### PR TITLE
Allow for purchasing the cheapest private if it has no bids

### DIFF
--- a/assets/js/view/auction_round.rb
+++ b/assets/js/view/auction_round.rb
@@ -31,6 +31,10 @@ module View
     def render_input
       input = h(:input, props: { value: @round.min_bid(@selected_company) })
 
+      buy = lambda do
+        process_action(Engine::Action::Bid.new(@current_entity, @selected_company, @round.min_bid(@selected_company)))
+      end
+
       create_bid = lambda do
         price = input.JS['elm'].JS['value'].to_i
         process_action(Engine::Action::Bid.new(@current_entity, @selected_company, price))
@@ -50,11 +54,18 @@ module View
         process_action(Engine::Action::Pass.new(@current_entity))
       end
 
+      company_actions = []
+      if @round.may_purchase?(@selected_company)
+        company_actions.push(h(:button, { on: { click: buy } }, 'Buy'))
+      elsif @selected_company
+        company_actions.push(input)
+        company_actions.push(h(:button, { on: { click: decrease_bid } }, '-'))
+        company_actions.push(h(:button, { on: { click: increase_bid } }, '+'))
+        company_actions.push(h(:button, { on: { click: create_bid } }, 'Place Bid'))
+      end
+
       h(:div, [
-        input,
-        h(:button, { on: { click: decrease_bid } }, '-'),
-        h(:button, { on: { click: increase_bid } }, '+'),
-        h(:button, { on: { click: create_bid } }, 'Place Bid'),
+        *company_actions,
         h(:button, { on: { click: pass } }, 'Pass'),
       ])
     end

--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -36,7 +36,7 @@ module Engine
 
       def min_bid(company)
         return unless company
-        return company.min_bid if !@auctioning_company && company == companies.first
+        return company.min_bid if may_purchase?(company)
 
         high_bid = @bids[company].max_by(&:price)
         (high_bid ? high_bid.price : company.min_bid) + @min_increment
@@ -49,6 +49,10 @@ module Engine
 
       def auction?
         true
+      end
+
+      def may_purchase?(company)
+        !@auctioning_company && company == companies.first
       end
 
       private

--- a/spec/lib/engine/round/auction_spec.rb
+++ b/spec/lib/engine/round/auction_spec.rb
@@ -20,6 +20,25 @@ module Engine
       bank.spend(100, player_2)
     end
 
+    describe '#may_purchase?' do
+      it 'is true for the cheapest, false for others' do
+        expect(subject.may_purchase?(private_1)).to be true
+        expect(subject.may_purchase?(private_2)).to be false
+      end
+
+      it 'is false if the cheapest has bids' do
+        subject.process_action(Action::Bid.new(player_1, private_2, 25))
+        subject.process_action(Action::Bid.new(player_2, private_2, 30))
+        subject.process_action(Action::Bid.new(player_1, private_1, 10))
+        expect(subject.may_purchase?(private_2)).to be false
+      end
+
+      it 'is true if the cheapest remaining has no bids' do
+        subject.process_action(Action::Bid.new(player_1, private_1, 10))
+        expect(subject.may_purchase?(private_2)).to be true
+      end
+    end
+
     describe '#process_action' do
       it 'buys the cheapest private' do
         subject.process_action(Action::Bid.new(player_1, private_1, 10))


### PR DESCRIPTION
Right now, you can bid on the cheapest private rather than buy it outright. The existing bid action is already designed to let you purchase the private in that situation, so this change is really just changing the way the action gets rendered.