### PR TITLE
Format currency based on game title

### DIFF
--- a/assets/js/view/buy_trains.rb
+++ b/assets/js/view/buy_trains.rb
@@ -53,7 +53,7 @@ module View
         buy_train = -> { process_action(Engine::Action::BuyTrain.new(@corporation, train, train.price)) }
 
         h(:div, [
-          "Train #{train.name} - $#{train.price}",
+          "Train #{train.name} - #{@game.format_currency(train.price)}",
           h(:button, { on: { click: buy_train } }, 'Buy'),
         ])
       end
@@ -89,7 +89,7 @@ module View
     def remaining_trains
       @depot.upcoming.group_by(&:name).map do |name, trains|
         train = trains.first
-        h(:div, "Train: #{name} - $#{train.price} x #{trains.size}")
+        h(:div, "Train: #{name} - #{@game.format_currency(train.price)} x #{trains.size}")
       end
     end
   end

--- a/assets/js/view/company.rb
+++ b/assets/js/view/company.rb
@@ -5,6 +5,7 @@ module View
     needs :company
     needs :bids, default: nil
     needs :selected_company, default: nil, store: true
+    needs :game, store: true
 
     def selected?
       @company == @selected_company
@@ -18,7 +19,7 @@ module View
       }
       names = @bids
         .sort_by(&:price)
-        .reverse.map { |bid| "#{bid.entity.name} ($#{bid.price})" }
+        .reverse.map { |bid| "#{bid.entity.name} (#{@game.format_currency(bid.price)})" }
         .join(', ')
       h(:div, { style: bidders_style }, names)
     end
@@ -82,8 +83,8 @@ module View
         h(:div, @company.name),
         h(:div, { style: description_style }, @company.desc),
         h(:div, [
-          h(:div, { style: value_style }, "Value: #{@company.value}"),
-          h(:div, { style: revenue_style }, "Revenue: #{@company.revenue}"),
+          h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
+          h(:div, { style: revenue_style }, "Revenue: #{@game.format_currency(@company.revenue)}"),
         ]),
         h(:div, { style: bidders_style }, 'Bidders:'),
         render_bidders,

--- a/assets/js/view/corporation.rb
+++ b/assets/js/view/corporation.rb
@@ -4,6 +4,7 @@ module View
   class Corporation < Snabberb::Component
     needs :corporation
     needs :selected_corporation, default: nil, store: true
+    needs :game, store: true
 
     def selected?
       @corporation == @selected_corporation
@@ -87,7 +88,7 @@ module View
         h(:div, { style: title_style }, @corporation.name),
         h(:div, { style: token_style }, render_tokens),
         render_trains,
-        h(:div, "Treasury: #{@corporation.cash}"),
+        h(:div, "Treasury: #{@game.format_currency(@corporation.cash)}"),
         render_private_companies,
         h(:div, "Available Shares: #{@corporation.shares.size}")
       ])

--- a/assets/js/view/player.rb
+++ b/assets/js/view/player.rb
@@ -3,6 +3,7 @@
 module View
   class Player < Snabberb::Component
     needs :player
+    needs :game, store: true
 
     def render
       style = {
@@ -17,7 +18,7 @@ module View
 
       h(:div, { style: style }, [
         h(:div, "name: #{@player.name}"),
-        h(:div, "cash: #{@player.cash}"),
+        h(:div, "cash: #{@game.format_currency(@player.cash)}"),
         h(:div, "companies: #{@player.companies.map(&:name)}"),
         *shares_div,
       ])

--- a/assets/js/view/sell_shares.rb
+++ b/assets/js/view/sell_shares.rb
@@ -24,7 +24,8 @@ module View
         num = bundle.size
         percent = bundle.sum(&:percent)
         sell = -> { process_action(Engine::Action::SellShares.new(@player, bundle)) }
-        text = "Sell #{num} share#{num > 1 ? 's' : ''} (%#{percent} - $#{Engine::Share.price(bundle)})"
+        text = "Sell #{num} share#{num > 1 ? 's' : ''} (#{percent}% - "\
+               "#{@game.format_currency(Engine::Share.price(bundle))})"
         h(:button, { on: { click: sell } }, text)
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -34,6 +34,8 @@ module Engine
 
       BANK_CASH = 12_000
 
+      CURRENCY_FORMAT_STR = '$%d'
+
       STARTING_CASH = {
         2 => 1200,
         3 => 800,
@@ -104,7 +106,7 @@ module Engine
 
         @depot = init_train_handler(@bank)
         init_starting_cash(@players, @bank)
-        @share_pool = SharePool.new(@corporations, @bank, @log)
+        @share_pool = SharePool.new(self)
         @hexes = init_hexes(@companies, @corporations)
 
         # call here to set up ids for all cities before any tiles from @tiles
@@ -204,6 +206,10 @@ module Engine
 
       def layout
         :flat
+      end
+
+      def format_currency(val)
+        self.class::CURRENCY_FORMAT_STR % val
       end
 
       private

--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -12,6 +12,8 @@ module Engine
     class G1889 < Base
       BANK_CASH = 7_000
 
+      CURRENCY_FORMAT_STR = '¥%d'
+
       CERT_LIMIT = {
         2 => 25,
         3 => 19,

--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -94,7 +94,8 @@ module Engine
           value = @cheapest.min_bid
           @cheapest.discount += 5
           new_value = @cheapest.min_bid
-          @log << "#{@cheapest.name} minimum bid decreases from $#{value} to $#{new_value}"
+          @log << "#{@cheapest.name} minimum bid decreases from "\
+                  "#{@game.format_currency(value)} to #{@game.format_currency(new_value)}"
 
           if new_value <= 0
             buy_company(@current_entity, @cheapest, 0)
@@ -154,7 +155,7 @@ module Engine
         price = bid.price
         raise GameError, 'Cannot afford bid' if bids_for_player(entity).sum(&:price) > entity.cash
 
-        @log << "#{entity.name} bids $#{price} for #{bid.company.name}"
+        @log << "#{entity.name} bids #{@game.format_currency(price)} for #{bid.company.name}"
       end
 
       def buy_company(player, company, price)
@@ -162,7 +163,7 @@ module Engine
         player.companies << company
         player.spend(price, @bank)
         @companies.delete(company)
-        @log << "#{player.name} buys #{company.name} for $#{price}"
+        @log << "#{player.name} buys #{company.name} for #{@game.format_currency(price)}"
       end
 
       def bids_for_player(player)

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -145,7 +145,7 @@ module Engine
         entity.spend(cost, @game.bank) unless cost.zero?
 
         @log << "#{action.entity.name}"\
-          "#{cost.zero? ? '' : "spends $#{cost} and"}"\
+          "#{cost.zero? ? '' : "spends #{@game.format_currency(cost)} and"}"\
           " lays tile #{tile.name}"\
          " with rotation #{rotation} on #{hex.name}"
       end
@@ -169,13 +169,16 @@ module Engine
           owner = company.owner
           revenue = company.revenue
           @game.bank.spend(revenue, owner)
-          @log << "#{owner.name} collects $#{revenue} from #{company.name}"
+          @log << "#{owner.name} collects #{@game.format_currency(revenue)} from #{company.name}"
         end
       end
 
       def log_share_price(entity, from)
         to = entity.share_price.price
-        @log << "#{entity.name}'s share price changes from $#{from} to $#{to}" if from != to
+        return unless from != to
+
+        @log << "#{entity.name}'s share price changes from #{@game.format_currency(from)} "\
+                "to #{@game.format_currency(to)}"
       end
 
       def log_pass(entity)

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -263,7 +263,8 @@ module Engine
           @current_routes = action.routes
           @current_routes.each do |route|
             hexes = route.hexes.map(&:name).join(', ')
-            @log << "#{entity.name} runs a #{route.train.name} train for $#{route.revenue} (#{hexes})"
+            @log << "#{entity.name} runs a #{route.train.name} train for "\
+                    "#{@game.format_currency(route.revenue)} (#{hexes})"
           end
         when Action::Dividend
           revenue = @current_routes.sum(&:revenue)
@@ -305,7 +306,7 @@ module Engine
       def withhold(revenue = 0)
         name = @current_entity.name
         if revenue.positive?
-          @log << "#{name} withholds $#{revenue}"
+          @log << "#{name} withholds #{@game.format_currency(revenue)}"
           @bank.spend(revenue, @current_entity)
         else
           @log << "#{name} does not run"
@@ -315,7 +316,8 @@ module Engine
 
       def payout(revenue)
         per_share = revenue / 10
-        @log << "#{@current_entity.name} pays out $#{revenue} - $#{per_share} per share"
+        @log << "#{@current_entity.name} pays out #{@game.format_currency(revenue)} - "\
+                "#{@game.format_currency(per_share)} per share"
         @players.each do |player|
           payout_entity(player, per_share)
         end
@@ -329,7 +331,8 @@ module Engine
         receiver ||= holder
         shares = percent / 10
         amount = shares * per_share
-        @log << "#{receiver.name} receives $#{amount} - $#{per_share} x #{shares}"
+        @log << "#{receiver.name} receives #{@game.format_currency(amount)} - "\
+                "#{@game.format_currency(per_share)} x #{shares}"
         @bank.spend(amount, receiver)
       end
 
@@ -353,9 +356,9 @@ module Engine
         if remaining.positive?
           player = entity.owner
           player.spend(remaining, entity)
-          @log << "#{player.name} contributes $#{remaining}"
+          @log << "#{player.name} contributes #{@game.format_currency(remaining)}"
         end
-        @log << "#{entity.name} buys a #{train.name} train for $#{price} from #{train.owner.name}"
+        @log << "#{entity.name} buys a #{train.name} train for #{@game.format_currency(price)} from #{train.owner.name}"
         entity.buy_train(train, price)
       end
 
@@ -375,7 +378,7 @@ module Engine
 
         @current_entity.companies << company
         @current_entity.spend(price, player)
-        @log << "#{@current_entity.name} buys #{company.name} from #{player.name} for $#{price}"
+        @log << "#{@current_entity.name} buys #{company.name} from #{player.name} for #{@game.format_currency(price)}"
       end
 
       def place_token(action)
@@ -389,7 +392,7 @@ module Engine
         action.city.place_token(entity)
         if price.positive?
           entity.spend(price, @bank)
-          price_log = " for $#{price}"
+          price_log = " for #{@game.format_currency(price)}"
         end
         @log << "#{entity.name} places a token on #{action.city.hex.name}#{price_log}"
         clear_route_cache

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -9,10 +9,11 @@ module Engine
     include ShareHolder
     attr_reader :corporations
 
-    def initialize(corporations, bank, log)
-      @corporations = corporations
-      @bank = bank
-      @log = log
+    def initialize(game)
+      @game = game
+      @corporations = game.corporations # used by View::StockRound::render_corporations
+      @bank = game.bank
+      @log = game.log
     end
 
     def name
@@ -29,15 +30,16 @@ module Engine
       transfer_share(share, entity, entity, @bank)
 
       if ipoed != corporation.ipoed
-        @log << "#{entity.name} pars #{corporation.name} at $#{price} and becomes the president"
+        @log << "#{entity.name} pars #{corporation.name} at #{@game.format_currency(price)} and becomes the president"
       end
 
-      @log << "#{entity.name} buys a #{share.percent}% share of #{corporation.name} for $#{price}"
+      @log << "#{entity.name} buys a #{share.percent}% share of #{corporation.name} for #{@game.format_currency(price)}"
 
       return if floated == corporation.floated?
 
       @bank.spend(price * 10, corporation)
-      @log << "#{corporation.name} floats with $#{corporation.cash} and tokens #{corporation.coordinates}"
+      @log << "#{corporation.name} floats with #{@game.format_currency(corporation.cash)} "\
+              "and tokens #{corporation.coordinates}"
     end
 
     def sell_shares(shares)
@@ -50,7 +52,7 @@ module Engine
       shares.each { |s| transfer_share(s, self, @bank, entity) }
 
       @log << "#{entity.name} sells #{num} share#{num > 1 ? 's' : ''} " \
-        "(%#{percent}) of #{corporation.name} and receives $#{Engine::Share.price(shares)}"
+        "(%#{percent}) of #{corporation.name} and receives #{@game.format_currency(Engine::Share.price(shares))}"
     end
 
     def player?

--- a/spec/lib/engine/share_pool_spec.rb
+++ b/spec/lib/engine/share_pool_spec.rb
@@ -4,6 +4,7 @@ require './spec/spec_helper'
 
 require 'engine/bank'
 require 'engine/corporation'
+require 'engine/game/g_1889'
 require 'engine/share'
 require 'engine/share_pool'
 require 'engine/share_price'
@@ -11,11 +12,12 @@ require 'engine/player'
 
 module Engine
   describe SharePool do
-    let(:bank) { Bank.new(1000) }
+    let(:game) { Game::G1889.new([]) }
+    let(:bank) { game.bank }
     let(:player) { Player.new('a') }
     let(:corporation) { Corporation.new(sym: 'a', name: 'a', tokens: [0]) }
     let(:share_price) { SharePrice.from_code('10', 0, 0) }
-    let(:subject) { SharePool.new([corporation], bank, []) }
+    let(:subject) { SharePool.new(game) }
     let(:share) { Share.new(corporation, owner: subject, president: true, percent: 20) }
 
     before :each do


### PR DESCRIPTION
Currency values are now printed as `$<val>` by default but can be customized per title (e.g., `¥<val>` for 1889).