### PR TITLE
Add drop shadow to tile selector

### DIFF
--- a/assets/js/view/tile_selector.rb
+++ b/assets/js/view/tile_selector.rb
@@ -25,7 +25,7 @@ module View
           bottom: Hex::SIZE * Math.sin(index * theta) + 80,
           width: 60,
           height: 60,
-          filter: "drop-shadow( 5px 5px 2px #888)",
+          filter: 'drop-shadow(5px 5px 2px #888)',
           'pointer-events' => 'auto',
         }
         h(:svg, { style: style }, [h(:g, { attrs: { transform: 'scale(0.3)' } }, [hex])])

--- a/assets/js/view/tile_selector.rb
+++ b/assets/js/view/tile_selector.rb
@@ -25,6 +25,7 @@ module View
           bottom: Hex::SIZE * Math.sin(index * theta) + 80,
           width: 60,
           height: 60,
+          filter: "drop-shadow( 5px 5px 2px #888)",
           'pointer-events' => 'auto',
         }
         h(:svg, { style: style }, [h(:g, { attrs: { transform: 'scale(0.3)' } }, [hex])])


### PR DESCRIPTION
Makes the tiles being chosen hover a little over the background map, making it more clear that they're temporary.