### PR TITLE
City boxes, "all tiles" page, show company blocker on tile even before it is bought in the private auction

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -106,6 +106,10 @@ class Api < Roda
     on 'api' do |hr|
       hr.hash_routes :api
     end
+
+    on 'all_tiles' do
+      render(app_route: 'all_tiles')
+    end
   end
 
   route do |r|
@@ -126,10 +130,6 @@ class Api < Roda
     r.on 'game', Integer do |id|
       r.halt 404 unless (game = Game[id])
       render(game_data: game.to_h(include_actions: true))
-    end
-
-    r.on 'all_tiles' do
-      render(app_route: 'all_tiles')
     end
   end
 

--- a/api.rb
+++ b/api.rb
@@ -106,10 +106,6 @@ class Api < Roda
     on 'api' do |hr|
       hr.hash_routes :api
     end
-
-    on 'all_tiles' do
-      render(app_route: 'all_tiles')
-    end
   end
 
   route do |r|
@@ -123,7 +119,7 @@ class Api < Roda
       render_with_games
     end
 
-    r.on %w[/ about signup login profile] do
+    r.on %w[/ about signup login profile all_tiles] do
       render_with_games
     end
 

--- a/api.rb
+++ b/api.rb
@@ -127,6 +127,10 @@ class Api < Roda
       r.halt 404 unless (game = Game[id])
       render(game_data: game.to_h(include_actions: true))
     end
+
+    r.on 'all_tiles' do
+      render(app_route: 'all_tiles')
+    end
   end
 
   def render_with_games

--- a/assets/js/app.rb
+++ b/assets/js/app.rb
@@ -13,6 +13,7 @@ require 'view/home'
 require 'view/flash'
 require 'view/game'
 require 'view/navigation'
+require 'view/all_tiles'
 require 'view/user'
 
 class App < Snabberb::Component
@@ -58,6 +59,8 @@ class App < Snabberb::Component
         h(View::CreateGame)
       when 'about'
         h(View::About)
+      when 'all_tiles'
+        h(View::AllTiles)
       else
         store(:flash_opts, "Unknown path #{path}")
         store(:app_route, '/', skip: true)

--- a/assets/js/lib/hex.rb
+++ b/assets/js/lib/hex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lib
   class Hex
     POINTS = '100,0 50,-87 -50,-87 -100,-0 -50,87 50,87'

--- a/assets/js/lib/hex.rb
+++ b/assets/js/lib/hex.rb
@@ -1,0 +1,5 @@
+module Lib
+  class Hex
+    POINTS = '100,0 50,-87 -50,-87 -100,-0 -50,87 50,87'
+  end
+end

--- a/assets/js/lib/hex.rb
+++ b/assets/js/lib/hex.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Lib
-  class Hex
+  module Hex
     POINTS = '100,0 50,-87 -50,-87 -100,-0 -50,87 50,87'
   end
 end

--- a/assets/js/view/all_tiles.rb
+++ b/assets/js/view/all_tiles.rb
@@ -10,7 +10,7 @@ require 'view/tiles'
 module View
   class AllTiles < Tiles
     # TODO: can this automatically discover all defined games?
-    GAMES = %w[1889]
+    GAMES = %w[1889].freeze
 
     TILE_IDS = [
       Engine::Tile::WHITE.keys,
@@ -27,7 +27,7 @@ module View
               *TILE_IDS.map { |t| render_tile_block(t) }
             ]),
 
-          *GAMES.map { |g| map_hexes_for(g)}
+          *GAMES.map { |g| map_hexes_for(g) }
         ])
     end
 
@@ -41,8 +41,9 @@ module View
 
       rendered_tiles = game_hexes.map do |color, hexes|
         hexes.map do |coords, tile_string|
-          coords.map.with_index do |coord, index|
+          coords.map.with_index do |coord, _index|
             next if TILE_IDS.include?(tile_string)
+
             tile = Engine::Tile.from_code(
               coord,
               color,

--- a/assets/js/view/all_tiles.rb
+++ b/assets/js/view/all_tiles.rb
@@ -1,27 +1,63 @@
 # frozen_string_literal: true
 
+require 'engine/game/g_1889'
 require 'engine/tile'
 
 require 'view/tiles'
 
 module View
   class AllTiles < Tiles
+    # TODO: can this automatically discover all defined games?
+    GAMES = %w[1889]
+
+    TILE_IDS = [
+      Engine::Tile::WHITE.keys,
+      Engine::Tile::YELLOW.keys,
+      Engine::Tile::GREEN.keys,
+      Engine::Tile::BROWN.keys,
+      Engine::Tile::GRAY.keys,
+    ].reduce(&:+)
+
     def render
-      tile_ids = [
-        Engine::Tile::WHITE.keys,
-        Engine::Tile::YELLOW.keys,
-        Engine::Tile::GREEN.keys,
-        Engine::Tile::BROWN.keys,
-        Engine::Tile::GRAY.keys,
-      ].reduce(&:+)
+      h('div#tiles', [
+          h('div#all_tiles', [
+              h(:h1, 'Track Tiles and Generic Map Hexes'),
+              *TILE_IDS.map { |t| render_tile_block(t) }
+            ]),
 
-      generic_tiles, game_tiles = tile_ids.partition { |id| id =~ /;/ }
+          *GAMES.map { |g| map_hexes_for(g)}
+        ])
+    end
 
-      children = (generic_tiles + game_tiles).map do |tile|
-        render_tile_block(tile)
-      end
+    def map_hexes_for(game_name)
+      game_class = Object.const_get("Engine::Game::G#{game_name}")
+      game_hexes = game_class::HEXES
+      location_names = game_class::LOCATION_NAMES
 
-      h('div#tiles', children)
+      rendered_tiles = game_hexes.map do |color, hexes|
+        hexes.map do |coords, tile_string|
+          coords.map.with_index do |coord, index|
+            next if TILE_IDS.include?(tile_string)
+            tile = Engine::Tile.from_code(
+              coord,
+              color,
+              tile_string,
+              location_name: location_names[coord]
+            )
+
+            render_tile_block(
+              tile.name,
+              tile: tile,
+              location_name: tile.location_name
+            )
+          end.compact
+        end
+      end.flatten
+
+      h("div#map_hexes_#{game_name}", [
+          h(:h1, "#{game_name} Map Hexes"),
+          *rendered_tiles,
+        ])
     end
   end
 end

--- a/assets/js/view/all_tiles.rb
+++ b/assets/js/view/all_tiles.rb
@@ -53,14 +53,8 @@ module View
 
             # add private companies that block tile lays on this hex
             blocker = companies.find do |c|
-              if %w[C4 K4].include?(coord)
-                puts "#{c.name} hex: #{c.abilities(:blocks_hex)&.dig(:hex)}"
-                puts "coord: #{coord}"
-              end
-
               c.abilities(:blocks_hex)&.dig(:hex) == coord
             end
-            puts blocker unless blocker.nil?
             tile.add_blocker!(blocker) unless blocker.nil?
 
             # reserve corporation home spots

--- a/assets/js/view/hex.rb
+++ b/assets/js/view/hex.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'lib/hex'
 require 'lib/tile_selector'
 require 'view/tile'
 require 'view/triangular_grid'
@@ -10,7 +11,7 @@ require 'engine/route'
 module View
   class Hex < Snabberb::Component
     SIZE = 100
-    POINTS = '100,0 50,-87 -50,-87 -100,-0 -50,87 50,87'
+
     LAYOUT = {
       flat: [SIZE * 3 / 2, SIZE * Math.sqrt(3) / 2],
       pointy: [SIZE * Math.sqrt(3) / 2, SIZE * 3 / 2],
@@ -33,7 +34,7 @@ module View
     needs :role, default: :map
 
     def render
-      children = [h(:polygon, attrs: { points: self.class::POINTS })]
+      children = [h(:polygon, attrs: { points: Lib::Hex::POINTS })]
 
       @selected = @hex == @tile_selector&.hex
       @tile = @selected && @tile_selector.tile ? @tile_selector.tile : @hex.tile

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -67,7 +67,17 @@ module View
             ])
         end
 
-        h(:g, { attrs: { class: 'city' } }, slots)
+        children = []
+
+        children << render_box if slots.size > 1
+
+        children += slots
+
+        h(:g, { attrs: { class: 'city' } }, children)
+      end
+
+      def render_box
+        h(:g, {attrs: {class: 'city-box'}}, [])
       end
     end
   end

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -36,7 +36,7 @@ module View
           points: Lib::Hex::POINTS,
           transform: 'scale(0.458)',
         }]
-      }
+      }.freeze
 
       def preferred_render_locations
         region_weights =

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -73,7 +73,7 @@ module View
 
         children += slots
 
-        h(:g, { attrs: { class: 'city' } }, children)
+        h('g.city', children)
       end
 
       # TODOS:
@@ -105,9 +105,7 @@ module View
             )
           end
 
-        h(:g, { attrs: { class: 'city-box' } }, [
-            box
-          ])
+        h('g.city_box', [box])
       end
     end
   end

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'lib/hex'
 require 'view/part/base'
 require 'view/part/city_slot'
 
@@ -7,6 +8,7 @@ module View
   module Part
     class City < Base
       SLOT_RADIUS = 25
+      SLOT_DIAMETER = 2 * SLOT_RADIUS
 
       # key is how many city slots are part of the city; value is the offset for
       # the first city slot
@@ -18,6 +20,23 @@ module View
         5 => [0, -43],
         6 => [0, -50],
       }.freeze
+
+      # key: number of slots in city
+      # value: attrs for svg polygon (or rect, for 2 slots)
+      BOX_ATTRS = {
+        2 => [:rect, {
+          fill: 'white',
+          width: SLOT_DIAMETER,
+          height: SLOT_DIAMETER,
+          x: -SLOT_RADIUS,
+          y: -SLOT_RADIUS,
+        }],
+        3 => [:polygon, {
+          fill: 'white',
+          points: Lib::Hex::POINTS,
+          transform: 'scale(0.458)',
+        }]
+      }
 
       def preferred_render_locations
         region_weights =
@@ -48,7 +67,6 @@ module View
         @city = @tile.cities.first
       end
 
-      # TODO: render white "background" before slots
       def render_part
         slots = (0..(@city.slots - 1)).zip(@city.tokens).map do |slot_index, token|
           rotation = (360 / @city.slots) * slot_index
@@ -81,31 +99,8 @@ module View
       #   scaling the full-size hexagon
       # - implement for 4, 5, and 6 slot cities
       def render_box(slots)
-        box =
-          case slots
-          when 2
-            h(
-              :rect,
-              attrs: {
-                width: 2 * SLOT_RADIUS,
-                height: 2 * SLOT_RADIUS,
-                fill: 'white',
-                x: -SLOT_RADIUS,
-                y: -SLOT_RADIUS,
-              }
-            )
-          when 3
-            h(
-              :polygon,
-              attrs: {
-                points: '100,0 50,-87 -50,-87 -100,-0 -50,87 50,87',
-                fill: 'white',
-                transform: 'scale(0.458)',
-              }
-            )
-          end
-
-        h('g.city_box', [box])
+        element, attrs = BOX_ATTRS[slots]
+        h("#{element}.city_box", attrs: attrs)
       end
     end
   end

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -78,7 +78,7 @@ module View
         h(:g, { attrs: { class: 'city' } }, children)
       end
 
-      # TODO:
+      # TODOS:
       # - do actual math and get points for the 3-slot hexagon, rather than
       #   scaling the full-size hexagon
       # - implement for 4, 5, and 6 slot cities
@@ -105,11 +105,9 @@ module View
                 transform: 'scale(0.458)',
               }
             )
-          else
-            nil
           end
 
-        h(:g, {attrs: {class: 'city-box'}}, [
+        h(:g, { attrs: { class: 'city-box' } }, [
             box
           ])
       end

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -50,8 +50,6 @@ module View
 
       # TODO: render white "background" before slots
       def render_part
-        slot_radius = SLOT_RADIUS
-
         slots = (0..(@city.slots - 1)).zip(@city.tokens).map do |slot_index, token|
           rotation = (360 / @city.slots) * slot_index
 
@@ -63,7 +61,7 @@ module View
                   h(CitySlot, city: @city,
                               token: token,
                               slot_index: slot_index,
-                              radius: slot_radius,
+                              radius: SLOT_RADIUS,
                               reservation: @city.reservations[slot_index])
                 ])
             ])

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -6,13 +6,15 @@ require 'view/part/city_slot'
 module View
   module Part
     class City < Base
+      SLOT_RADIUS = 25
+
       # key is how many city slots are part of the city; value is the offset for
       # the first city slot
       CITY_SLOT_POSITION = {
         1 => [0, 0],
-        2 => [-25, 0],
+        2 => [-SLOT_RADIUS, 0],
         3 => [0, -29],
-        4 => [-25, -25],
+        4 => [-SLOT_RADIUS, -SLOT_RADIUS],
         5 => [0, -43],
         6 => [0, -50],
       }.freeze
@@ -48,7 +50,7 @@ module View
 
       # TODO: render white "background" before slots
       def render_part
-        slot_radius = 25
+        slot_radius = SLOT_RADIUS
 
         slots = (0..(@city.slots - 1)).zip(@city.tokens).map do |slot_index, token|
           rotation = (360 / @city.slots) * slot_index
@@ -69,15 +71,47 @@ module View
 
         children = []
 
-        children << render_box if slots.size > 1
+        children << render_box(slots.size) if slots.size > 1
 
         children += slots
 
         h(:g, { attrs: { class: 'city' } }, children)
       end
 
-      def render_box
-        h(:g, {attrs: {class: 'city-box'}}, [])
+      # TODO:
+      # - do actual math and get points for the 3-slot hexagon, rather than
+      #   scaling the full-size hexagon
+      # - implement for 4, 5, and 6 slot cities
+      def render_box(slots)
+        box =
+          case slots
+          when 2
+            h(
+              :rect,
+              attrs: {
+                width: 2 * SLOT_RADIUS,
+                height: 2 * SLOT_RADIUS,
+                fill: 'white',
+                x: -SLOT_RADIUS,
+                y: -SLOT_RADIUS,
+              }
+            )
+          when 3
+            h(
+              :polygon,
+              attrs: {
+                points: '100,0 50,-87 -50,-87 -100,-0 -50,87 50,87',
+                fill: 'white',
+                transform: 'scale(0.458)',
+              }
+            )
+          else
+            nil
+          end
+
+        h(:g, {attrs: {class: 'city-box'}}, [
+            box
+          ])
       end
     end
   end

--- a/assets/js/view/part/city.rb
+++ b/assets/js/view/part/city.rb
@@ -22,7 +22,7 @@ module View
       }.freeze
 
       # key: number of slots in city
-      # value: attrs for svg polygon (or rect, for 2 slots)
+      # value: [element name (sym), element attrs]
       BOX_ATTRS = {
         2 => [:rect, {
           fill: 'white',
@@ -87,7 +87,7 @@ module View
 
         children = []
 
-        children << render_box(slots.size) if slots.size > 1
+        children << render_box(slots.size) if (2..3).include?(slots.size)
 
         children += slots
 

--- a/assets/js/view/tile.rb
+++ b/assets/js/view/tile.rb
@@ -24,10 +24,11 @@ module View
     def should_render_blocker?
       blocker = @tile.blockers.first
 
+      # blocking company should exist...
       return false if blocker.nil?
 
       # ...and be open
-      return false unless blocker.owner
+      return false if blocker.closed?
 
       # ...and not have been sold into a corporation yet
       return false if blocker.owned_by_corporation?

--- a/assets/js/view/tiles.rb
+++ b/assets/js/view/tiles.rb
@@ -2,7 +2,7 @@
 
 module View
   class Tiles < Snabberb::Component
-    def render_tile_block(name, num: nil)
+    def render_tile_block(name, num: nil, tile: nil, location_name: nil)
       props = {
         style: {
           display: 'inline-block',
@@ -23,7 +23,10 @@ module View
           h(:g, { attrs: { transform: 'scale(0.4)' } }, [
             h(
               Hex,
-              hex: Engine::Hex.new('A1', layout: 'flat', tile: Engine::Tile.for(name)),
+              hex: Engine::Hex.new('A1',
+                                   layout: 'flat',
+                                   location_name: location_name,
+                                   tile: tile || Engine::Tile.for(name)),
               role: :tile_page
             )
           ])

--- a/assets/js/view/triangular_grid.rb
+++ b/assets/js/view/triangular_grid.rb
@@ -14,14 +14,13 @@ module View
       end
 
       attrs = {
-        class: 'triangular-grid',
         fill: 'none',
         opacity: 0.5,
         stroke: 'black',
         'stroke-width' => 2,
       }
 
-      h(:g, { attrs: attrs }, children)
+      h('g.triangular_grid', { attrs: attrs }, children)
     end
   end
 end

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -16,6 +16,7 @@ module Engine
       @revenue = revenue
       @sym = sym
       @discount = 0
+      @closed = false
 
       @abilities = abilities
         .group_by { |ability| ability[:type] }
@@ -69,10 +70,15 @@ module Engine
     end
 
     def close!
+      @closed = true
       return unless owner
 
       owner.companies.delete(self)
       @owner = nil
+    end
+
+    def closed?
+      @closed
     end
 
     def player?

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -186,7 +186,7 @@ module Engine
     end
 
     # rotation 0-5
-    def initialize(name, color:, parts:, rotation: 0, preprinted: false, index: 0)
+    def initialize(name, color:, parts:, rotation: 0, preprinted: false, index: 0, location_name: nil)
       @name = name
       @color = color
       @parts = parts
@@ -197,7 +197,7 @@ module Engine
       @edges = nil
       @junctions = nil
       @upgrades = []
-      @location_name = nil
+      @location_name = location_name
       @offboards = []
       @legal_rotations = []
       @blockers = []


### PR DESCRIPTION
* Cities with 2 or 3 slots have boxes now (per https://github.com/tobymao/18xx/issues/2#issuecomment-614425795)
  * the 3-slot solution is lazily scaling down the full-size hexagon
  * cities with 4+ slots still don't have a box, but 1889 doesn't use those
* add new route/page at `/all_tiles`, to show all defined tiles
  * also shows all custom starting hexes defined for 1889 (including corporations and company blockers)
* company blocker is now rendered on map even before it is bought during the private auction