### PR TITLE
WIP Initial attempt to change Enter button to a link

### DIFF
--- a/assets/js/view/game_card.rb
+++ b/assets/js/view/game_card.rb
@@ -66,7 +66,7 @@ module View
           end
           JOIN_YELLOW
         when 'active'
-          buttons << render_button('Enter', -> { enter_game(@gdata) })
+          buttons << h('a.button', { style: { top: '1rem', float: 'right', 'text-decoration': 'none', }, attrs: { href: url(@gdata) } }, 'Enter')
           acting?(@user) ? YOUR_TURN_ORANGE : ENTER_GREEN
         when 'finished'
           buttons << render_button('Review', -> { enter_game(@gdata) })


### PR DESCRIPTION
Changing it to a link was easy. Styling that link to look just like the buttons, not so much. It might be easier to define styles for both of them together, and override all the default styles on the buttons at the same time.

RESOLVES #156