### PR TITLE
Make Pass be more descriptive (Pass for real passes, Don't or Done otherwise)

### DIFF
--- a/assets/js/view/pass_button.rb
+++ b/assets/js/view/pass_button.rb
@@ -15,7 +15,7 @@ module View
         },
       }
 
-      h(:button, props, 'Pass')
+      h(:button, props, @game.round.pass_description.to_s)
     end
   end
 end

--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -28,6 +28,10 @@ module Engine
         'Bid on Companies'
       end
 
+      def pass_description
+        'Pass on Bidding on Companies'
+      end
+
       def finished?
         @companies.empty?
       end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -28,6 +28,10 @@ module Engine
         raise NotImplementedError
       end
 
+      def pass_description
+        raise NotImplementedError
+      end
+
       def current_player
         @current_entity.player
       end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -61,7 +61,7 @@ module Engine
         @bankrupt = false
 
         @step = self.class::STEPS.first
-        @lastactionstep = self.class::STEPS.last
+        @last_action_step = self.class::STEPS.last
         @current_routes = []
 
         payout_companies
@@ -82,7 +82,7 @@ module Engine
 
       def pass_description
         # If the user is continuing an action change the phrasing from Don't to Done
-        if @step == @lastactionstep
+        if @step == @last_action_step
           return self.class::ACTIVE_PASS_DESCRIPTION[@step] if self.class::ACTIVE_PASS_DESCRIPTION.include?(@step)
         elsif self.class::INACTIVE_PASS_DESCRIPTION.include?(@step)
           return self.class::INACTIVE_PASS_DESCRIPTION[@step]
@@ -332,7 +332,7 @@ module Engine
       end
 
       def action_processed(action)
-        @lastactionstep = @step
+        @last_action_step = @step
         remove_just_sold_company_abilities unless action.is_a?(Action::BuyCompany)
         return if @bankrupt
         return if ignore_action?(action)

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -83,7 +83,9 @@ module Engine
       end
 
       def pass_description
-        self.class::ACTIVE_PASS_DESCRIPTION[@step == @last_action_step ? @step : nil] || self.class::INACTIVE_PASS_DESCRIPTION[@step] || 'Pass'
+        self.class::ACTIVE_PASS_DESCRIPTION[@step == @last_action_step ? @step : nil] ||
+        self.class::INACTIVE_PASS_DESCRIPTION[@step] ||
+        'Pass'
       end
 
       def pass(_action)

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -43,6 +43,8 @@ module Engine
 
       # Pass Descriptions for steps players can take more than one action
       ACTIVE_PASS_DESCRIPTION = {
+        track: 'Done Laying Track',
+        token: 'Done Placing a Token',
         train: 'Done Buying Trains',
         company: 'Done Purchasing Companies',
       }.freeze
@@ -81,13 +83,7 @@ module Engine
       end
 
       def pass_description
-        # If the user is continuing an action change the phrasing from Don't to Done
-        if @step == @last_action_step
-          return self.class::ACTIVE_PASS_DESCRIPTION[@step] if self.class::ACTIVE_PASS_DESCRIPTION.include?(@step)
-        elsif self.class::INACTIVE_PASS_DESCRIPTION.include?(@step)
-          return self.class::INACTIVE_PASS_DESCRIPTION[@step]
-        end
-        raise NotImplementedError
+        self.class::ACTIVE_PASS_DESCRIPTION[@step == @last_action_step ? @step : nil] || self.class::INACTIVE_PASS_DESCRIPTION[@step] || 'Pass'
       end
 
       def pass(_action)

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -34,6 +34,14 @@ module Engine
         'Buy and Sell Shares'
       end
 
+      def pass_description
+        if @current_actions.empty?
+          'Pass on Buying or Selling Shares'
+        else
+          'Done Buying or Selling Shares'
+        end
+      end
+
       def stock?
         true
       end


### PR DESCRIPTION
Pass has a specific game meaning in the initial stock round and in stock rounds.

Passing when in the operating round moves to the next step.

Use 'Pass' when this has the specific in game meaning
"Don't" when the user wishes to skip to the next action
"Done" when the user has taking an action in this step (Done Buying Trains)

Resolves #63 