### PR TITLE
Add game name and round info to game page title

### DIFF
--- a/assets/js/view/game.rb
+++ b/assets/js/view/game.rb
@@ -157,18 +157,18 @@ module View
     end
 
     def round_info
-      name = @round.class.name.split(':').last
-      num = @round.operating? ? "#{@game.turn}.#{@round.round_num}" : @game.turn
+      name = @game.round.class.name.split(':').last
+      num = @game.round.operating? ? "#{@game.turn}.#{@game.round.round_num}" : @game.turn
       [name, num]
     end
 
     def render_round
       name, num = round_info
-      h(:div, { style: { 'font-weight': 'bold' } }, "#{name} Round #{num} - #{@round.description}")
+      h(:div, { style: { 'font-weight': 'bold' } }, "#{name} Round #{num} - #{@game.round.description}")
     end
 
     def render_action
-      case @round
+      case @game.round
       when Engine::Round::Auction
         h(AuctionRound, game: @game)
       when Engine::Round::Stock
@@ -179,12 +179,10 @@ module View
     end
 
     def render_game
-      @round = @game.round
-
       h('div.game', [
         render_round,
         h(GameLog, user: @user),
-        h(EntityOrder, round: @round),
+        h(EntityOrder, round: @game.round),
         h(Exchange),
         render_action,
       ])

--- a/assets/js/view/game.rb
+++ b/assets/js/view/game.rb
@@ -78,6 +78,11 @@ module View
         store(:selected_company, nil, skip: true)
       end
 
+      round_name, round_num = round_info
+      game_description = @game_data['description']
+      page_title = "#{game_description} - #{round_name} #{round_num} | 18xx.games"
+      `document.title = #{page_title}`
+
       props = {
         key: 'game_page',
         hook: {
@@ -151,11 +156,15 @@ module View
       @app_route.split('#')[1]
     end
 
-    def render_round
+    def round_info
       name = @round.class.name.split(':').last
-      description = @round.operating? ? "#{@game.turn}.#{@round.round_num}" : @game.turn
-      description = "#{description} - #{@round.description}"
-      h(:div, { style: { 'font-weight': 'bold' } }, "#{name} Round #{description}")
+      num = @round.operating? ? "#{@game.turn}.#{@round.round_num}" : @game.turn
+      [name, num]
+    end
+
+    def render_round
+      name, num = round_info
+      h(:div, { style: { 'font-weight': 'bold' } }, "#{name} Round #{num} - #{@round.description}")
     end
 
     def render_action


### PR DESCRIPTION
Changes "18xx.games" to "gamedescription - roundtype roundnum | 18xx.games" when viewing a game page

Needs testing.

RESOLVES #157