### PR TITLE
Log when corporation operates, including president

### DIFF
--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -60,6 +60,7 @@ module Engine
 
         payout_companies
         place_home_stations
+        log_operation(@current_entity)
       end
 
       def log_new_round
@@ -317,6 +318,7 @@ module Engine
         return unless @current_entity.passed?
 
         @current_entity = next_entity
+        log_operation(@current_entity) unless finished?
       end
 
       def action_processed(action)
@@ -467,6 +469,10 @@ module Engine
         else
           super
         end
+      end
+
+      def log_operation(entity)
+        @log << "#{entity.owner.name} operates #{entity.name}"
       end
 
       def liquidate(player)


### PR DESCRIPTION
Log messages of the form `<president> operates <corporation>` at the beginning of each corporation's turn during the OR, making the gameflow in the log easier to follow.