### PR TITLE
Add per train route information while selecting routes

### DIFF
--- a/assets/app/view/part/track.rb
+++ b/assets/app/view/part/track.rb
@@ -8,7 +8,8 @@ require 'view/part/track_offboard'
 module View
   module Part
     class Track < Snabberb::Component
-      ROUTE_COLORS = %i[red blue green purple].freeze
+      # http://mkweb.bcgsc.ca/colorblind/ 13 color palette
+      ROUTE_COLORS = %i[#AA0A3C #0A9B4B #005AC8 #8214A0].freeze
 
       needs :tile
       needs :region_use
@@ -81,7 +82,7 @@ module View
             path == p
           end
         end
-        index ? self.class::ROUTE_COLORS[index] : 'black'
+        index ? self.class::ROUTE_COLORS[index] : '#000000'
       end
     end
   end

--- a/assets/app/view/route_selector.rb
+++ b/assets/app/view/route_selector.rb
@@ -14,7 +14,7 @@ module View
     # Due to the way this and the map hook up routes needs to have
     # an entry, but that route is not valid at zero length
     def active_routes
-      @routes.map { |i| i unless i.hexes.empty? }.compact
+      @routes.select { |r| r.hexes.any? }
     end
 
     def render
@@ -40,9 +40,9 @@ module View
           padding: '0.5rem',
         }
 
-        route = @routes.find { |t| t.train == train }
+        route = active_routes.find { |t| t.train == train }
         children = []
-        if route && !route.hexes.empty?
+        if route
           revenue, invalid = begin
                                [@game.format_currency(route.revenue), nil]
                              rescue Engine::GameError => e
@@ -51,7 +51,7 @@ module View
 
           style['background-color'] = Part::Track::ROUTE_COLORS[@routes.index(route)]
           style['color'] = 'white'
-          children << h(:td, route.stops.length)
+          children << h(:td, route.stops.size)
           children << h(:td, revenue)
           children << h(:td, if invalid
                                "#{route.hexes.map(&:name).join(', ')} (#{invalid})"

--- a/assets/app/view/route_selector.rb
+++ b/assets/app/view/route_selector.rb
@@ -33,7 +33,7 @@ module View
         selected = @selected_route&.train == train
 
         style = {
-          border: "solid #{selected ? '3px' : '1px'} rgba(0,0,0,0.2)",
+          border: "solid #{selected ? '4px' : '1px'} rgba(0,0,0,0.2)",
           display: 'inline-block',
           cursor: selected ? 'default' : 'pointer',
           margin: '0.5rem 0.5rem 0.5rem 0',

--- a/assets/app/view/route_selector.rb
+++ b/assets/app/view/route_selector.rb
@@ -10,6 +10,13 @@ module View
     needs :routes, store: true, default: []
     needs :selected_route, store: true, default: nil
 
+    # Get routes that have a length greater than zero
+    # Due to the way this and the map hook up routes needs to have
+    # an entry, but that route is not valid at zero length
+    def active_routes
+      @routes.map { |i| i unless i.hexes.empty? }.compact
+    end
+
     def render
       round = @game.round
 
@@ -28,36 +35,75 @@ module View
         style = {
           border: "solid #{selected ? '3px' : '1px'} rgba(0,0,0,0.2)",
           display: 'inline-block',
-          cursor: selected ? 'none' : 'pointer',
+          cursor: selected ? 'default' : 'pointer',
           margin: '0.5rem 0.5rem 0.5rem 0',
           padding: '0.5rem',
         }
 
-        h(:div, { style: style, on: { click: onclick } }, "Train: #{train.name}")
+        route = @routes.find { |t| t.train == train }
+        children = []
+        if route && !route.hexes.empty?
+          revenue, invalid = begin
+                               [@game.format_currency(route.revenue), nil]
+                             rescue Engine::GameError => e
+                               ['N/A', e.to_s]
+                             end
+
+          style['background-color'] = Part::Track::ROUTE_COLORS[@routes.index(route)]
+          style['color'] = 'white'
+          children << h(:td, route.stops.length)
+          children << h(:td, revenue)
+          children << h(:td, if invalid
+                               "#{route.hexes.map(&:name).join(', ')} (#{invalid})"
+                             else
+                               route.hexes.map(&:name).join(', ')
+                             end)
+        end
+        h(:tr, [h(:td, { style: style, on: { click: onclick } }, "Train: #{train.name}"), *children])
       end
 
       h(:div, [
         h(UndoAndPass, pass: false),
-        *trains,
+        h(:table, { style: { 'text-align': 'left' } }, [
+          h(:tr, [
+           h(:th, 'Train'),
+           h(:th, 'Stops'),
+           h(:th, 'Revenue'),
+           h(:th, 'Route')
+          ]),
+          *trains
+        ]),
         actions,
       ])
     end
 
     def actions
       submit = lambda do
-        process_action(Engine::Action::RunRoutes.new(@game.current_entity, @routes))
+        process_action(Engine::Action::RunRoutes.new(@game.current_entity, active_routes))
         store(:routes, [], skip: true)
         store(:selected_route, nil, skip: true)
       end
 
       reset = lambda do
-        @selected_route.reset!
+        @selected_route&.reset!
         store(:selected_route, @selected_route)
       end
 
+      reset_all = lambda do
+        @selected_route = nil
+        store(:selected_route, @selected_route)
+        store(:routes, [])
+      end
+
+      revenue = begin
+                  @game.format_currency(active_routes.sum(&:revenue))
+                rescue Engine::GameError
+                  '(Invalid Route)'
+                end
       h(:div, [
-        h(:button, { on: { click: submit } }, 'Submit'),
-        h(:button, { style: { 'margin-left': '1rem' }, on: { click: reset } }, 'Reset'),
+        h(:button, { on: { click: submit } }, 'Submit ' + revenue),
+        h(:button, { style: { 'margin-left': '1rem' }, on: { click: reset } }, 'Reset Train'),
+        h(:button, { style: { 'margin-left': '1rem' }, on: { click: reset_all } }, 'Reset All'),
       ])
     end
   end


### PR DESCRIPTION
Give more information about the route while the user is selecting it
Also makes the route colours colourblind safe

Valid route example

![Screenshot from 2020-05-05 22-24-42](https://user-images.githubusercontent.com/71923/81117650-5c172400-8f1f-11ea-8b2d-dc4b83c3babe.png)

Invalid route example
![Screenshot from 2020-05-05 22-25-00](https://user-images.githubusercontent.com/71923/81117654-5e797e00-8f1f-11ea-97f1-cc53401a0907.png)

fixes #98