### PR TITLE
WIP Attempt to move phase change after action

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -197,13 +197,15 @@ module Engine
 
         action = action_from_h(action) if action.is_a?(Hash)
         action.id = current_action_id
-        @phase.process_action(action)
         # company special power actions are processed by a different round handler
         if action.entity.is_a?(Company)
           @special.process_action(action)
         else
           @round.process_action(action)
         end
+        @phase.process_action(action)
+        @round.conditional_next_step! if round.respond_to? :conditional_next_step!
+        @round.conditional_change_entity! if round.respond_to? :conditional_change_entity!
         @actions << action
         next_round! while @round.finished? && !@finished
         self


### PR DESCRIPTION
This is a partial implementation of moving the phase change after the processing of a round action. The new conditional method calls are needed because the current logic expects new phase rules to be in place during the processing of an action. Unfortunately there are six test failures where existing games run into a player acting out of turn, due to turn order not being appropriately advanced. Further investigation is required.

resolves #332