### PR TITLE
Don't log presidency when setting par

### DIFF
--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -31,7 +31,7 @@ module Engine
 
       if ipoed != corporation.ipoed
         @log << "#{entity.name} pars #{corporation.name} at "\
-                "#{@game.format_currency(corporation.par_price.price)} and becomes the president"
+                "#{@game.format_currency(corporation.par_price.price)}"
       end
 
       if exchange


### PR DESCRIPTION
Remove redundant presidency announcement. Previously the log would look like
```
dfan pars TR at ¥65 and becomes the president
dfan buys a 20% share of TR from the IPO for ¥130
dfan becomes the president of TR
```
