### PR TITLE
Center fields in corporation card header

### DIFF
--- a/assets/app/view/corporation.rb
+++ b/assets/app/view/corporation.rb
@@ -97,7 +97,7 @@ module View
         style: {
           display: 'inline-block',
           margin: '0.5em',
-          'text-align': 'right',
+          'text-align': 'center',
         },
       }
 


### PR DESCRIPTION
They used to be right-aligned; this looks much nicer (I claim).