### PR TITLE
Separate @auction_triggerer and @last_to_act

### DIFF
--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -17,8 +17,16 @@ module Engine
 
         @bids = Hash.new { |h, k| h[k] = [] }
         @bidders = Hash.new { |h, k| h[k] = [] }
-        @auctioning_company = nil
+
+        # The player after this one will have priority deal next round
+        # if everyone passes.
         @last_to_act = nil
+
+        # The company currently up for limited auction, or nil.
+        @auctioning_company = nil
+
+        # The player who kicked off the limited auction, or nil.
+        @auction_triggerer = nil
       end
 
       def name
@@ -63,24 +71,35 @@ module Engine
         @entities.all?(&:passed?)
       end
 
+      # Process a non-pass action.
       def _process_action(bid)
+        @last_to_act = @current_entity unless @auctioning_company
         if @auctioning_company
+          # We're in the middle of a limited auction.
           add_bid(bid)
         else
+          # We're in the outer loop, either placing advanced bids or buying the first company outright.
           placement_bid(bid)
         end
       end
 
+      # A non-pass action has been completed.
+      # Everybody has a chance to act in the future so we clear their passed flags.
       def action_processed(_action)
         @entities.each(&:unpass!)
       end
 
+      # An action (either pass or not) has been completed and we move on
+      # to the next player.
       def change_entity(_action)
         if (bids = @bids[@auctioning_company]).any?
+          # There are still remaining bids on a limited auction. The
+          # lowest-bidding remaining player goes next.
           @current_entity = bids.min_by(&:price).entity
         else
-          # if someone bought a share outright, then we find the next person who hasn't passed
-          @current_entity = @last_to_act if @last_to_act
+          # If we just exited a limited auction, move to the player after the
+          # one who triggered it.
+          @current_entity = @auction_triggerer if @auction_triggerer
 
           loop do
             @current_entity = next_entity
@@ -89,11 +108,15 @@ module Engine
         end
       end
 
+      # We've already moved on to the next player at this point and just
+      # need to clean up.
       def action_finalized(_action)
-        @last_to_act = nil if @bids[@companies.first].empty? && !finished?
+        @auction_triggerer = nil if @bids[@companies.first].empty? && !finished?
         return if !all_passed? || finished?
 
+        # Everyone has passed so we need to run a fake OR.
         if @companies.include?(@cheapest)
+          # No one has bought anything so we reduce the value of the cheapest company.
           value = @cheapest.min_bid
           @cheapest.discount += 5
           new_value = @cheapest.min_bid
@@ -101,6 +124,7 @@ module Engine
                   "#{@game.format_currency(value)} to #{@game.format_currency(new_value)}"
 
           if new_value <= 0
+            # It's now free so the current player is forced to take it.
             buy_company(@current_entity, @cheapest, 0)
             resolve_bids
             change_entity(nil)
@@ -112,6 +136,9 @@ module Engine
       end
 
       def pass_processed(_action)
+        return unless @auctioning_company
+
+        # Remove ourselves from the current bidding, but we can come back in.
         @bids[@auctioning_company]&.reject! do |bid|
           @current_entity.unpass!
           bid.entity == @current_entity
@@ -121,10 +148,12 @@ module Engine
 
       def placement_bid(bid)
         if @companies.first == bid.company
-          @last_to_act = bid.entity
+          # We're buying the first company.
+          @auction_triggerer = bid.entity
           accept_bid(bid)
           resolve_bids
         else
+          # We're placing a bid on a later company.
           add_bid(bid)
         end
       end
@@ -136,8 +165,10 @@ module Engine
           if bids.size == 1
             accept_bid(bids.first)
           else
-            @auctioning_company = @companies.first
-            @log << "#{@auctioning_company.name} goes up for auction"
+            if @auctioning_company != @companies.first
+              @auctioning_company = @companies.first
+              @log << "#{@auctioning_company.name} goes up for auction"
+            end
             break
           end
         end

--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -146,12 +146,10 @@ module Engine
 
       def placement_bid(bid)
         if @companies.first == bid.company
-          # We're buying the first company.
           @auction_triggerer = bid.entity
           accept_bid(bid)
           resolve_bids
         else
-          # We're placing a bid on a later company.
           add_bid(bid)
         end
       end

--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -73,12 +73,10 @@ module Engine
 
       # Process a non-pass action.
       def _process_action(bid)
-        @last_to_act = @current_entity unless @auctioning_company
         if @auctioning_company
-          # We're in the middle of a limited auction.
           add_bid(bid)
         else
-          # We're in the outer loop, either placing advanced bids or buying the first company outright.
+          @last_to_act = @current_entity
           placement_bid(bid)
         end
       end


### PR DESCRIPTION
The code for #337 (in an upcoming PR) wants `@last_to_act` on a round with players (auction, stock) to reliably refer to the player who most recently effectively passed the priority deal card to their left by taking a non-pass action. The auction code overloaded this instance variable in order to handle turn order both during top-level bidding and when coming out of set of limited auctions.

The state necessary to handle auction turn order has now been broken out into `@last_to_act` (which now has the desired meaning defined above) and `@auction_triggerer` (the player who triggered a set of limited auctions by buying the lowest company outright).

In passing I also fixed a bug where the "Company goes up for auction" message could get logged multiple times if there were more than two players bidding for it.

I added a bunch of comments to make it clearer to myself what was going on; if you don't like them cluttering up the code I can remove them, but I tried to be pretty terse.

I've verified that all games from the DB Toby gave me a couple of days ago are unaffected by this change.