### PR TITLE
Edge doesn't seem to support x & y, but left and top are aliases for it

### DIFF
--- a/assets/app/lib/tile_selector.rb
+++ b/assets/app/lib/tile_selector.rb
@@ -14,7 +14,7 @@ module Lib
 
     def get_coordinates(event)
       rect = event.JS['currentTarget'].JS.getBoundingClientRect
-      [`window.pageXOffset` + rect.JS['x'], `window.pageYOffset` + rect.JS['y']]
+      [`window.pageXOffset` + rect.JS['left'], `window.pageYOffset` + rect.JS['top']]
     end
 
     def tile=(new_tile)


### PR DESCRIPTION
fixes #41 
tested the fix on Edge, Chrome and Firefox