### PR TITLE
Add desktop notifications to game and home pages

### DIFF
--- a/assets/app/lib/notification.rb
+++ b/assets/app/lib/notification.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Lib
+  module Notification
+    def self.notify(message)
+      %x{
+        if ("Notification" in window) {
+          if (Notification.permission === "granted") {
+            new Notification(#{message});
+          }
+          else if (Notification.permission !== "denied") {
+            Notification.requestPermission().then(function (permission) {
+              if (permission === "granted") {
+                new Notification(#{message});
+              }
+            });
+          }
+        }
+      }
+    end
+  end
+end

--- a/assets/app/view/game.rb
+++ b/assets/app/view/game.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lib/connection'
+require 'lib/notification'
 require 'lib/params'
 require 'view/auction_round'
 require 'view/companies'
@@ -73,6 +74,9 @@ module View
           @game_data['actions'] << data
           store(:game_data, @game_data, skip: true)
           store(:game, @game.process_action(data))
+          if @game.round.current_entity.name == @user['name']
+            Lib::Notification.notify('18xx - Game ' + @game.id.to_s + ' - Your turn')
+          end
         else
           @connection.get(game_path) do |new_data|
             store(:game_data, new_data, skip: true)

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'game_manager'
+require 'lib/notification'
 require 'lib/storage'
 require 'view/chat'
 require 'view/game_row'
@@ -46,6 +47,9 @@ module View
 
       @connection.subscribe('/games') do |data|
         update_game(data)
+        if data['acting']&.include?(@user['id'])
+          Lib::Notification.notify('18xx - Game ' + data['id'].to_s + ' - Your turn')
+        end
       end
 
       destroy = lambda do


### PR DESCRIPTION
This PR adds a desktop notification (through the Notification javascript API) when it becomes the current user's turn while viewing the game or home pages. These notifications are, as with all web site desktop notifications, optional and opt-in, and can be controlled by the the user's browser and/or OS.

This may leave a notification gap. I am unclear on whether or not the player will get email notifications while viewing the About or Profile (or hidden top level views like Tiles) pages, and since those pages have no event subscriptions they will also not get these desktop notifications.

This implementation also fails to deduplicate notifications. If the player has the same game open in two tabs/windows, or the game and the home page both open, they will get two notifications. It may be possible to resolve this with local storage, such as with a simple list of the most recent action number for which each game has issued a notification, although that would fail to account for the desired notification when a game encounters an undo and redo.

Resolves #176 