### PR TITLE
Add warnings about alpha and beta quality games on initialization

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -44,10 +44,12 @@ module View
     end
 
     def render_inputs
-      games = Engine::GAMES.map do |game|
-        next unless game.title == '1889'
-
-        h(:option, game.title)
+      games = (Lib::Params['all'] ? Engine::GAMES : Engine::VISIBLE_GAMES).map do |game|
+        if game::DEV_STAGE == :production
+          h(:option, { attrs: { value: game.title } }, game.title)
+        else
+          h(:option, { attrs: { value: game.title } }, "#{game.title} (#{game::DEV_STAGE})")
+        end
       end
       h(:div, [
         render_input('Game Title', id: :title, el: 'select', children: games),

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -15,5 +15,8 @@ module Engine
     klass
   end.compact
 
+  # Games that are alpha or above
+  VISIBLE_GAMES = GAMES.select { |game| %i[alpha beta production].include? game::DEV_STAGE }
+
   GAMES_BY_TITLE = GAMES.map { |game| [game.title, game] }.to_h
 end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -27,7 +27,7 @@ module Engine
       attr_reader :actions, :bank, :cert_limit, :cities, :companies, :corporations,
                   :depot, :finished, :hexes, :id, :log, :phase, :players, :round,
                   :share_pool, :special, :stock_market, :tiles, :turn, :undo_possible, :redo_possible
-
+      DEV_STAGE = :prealpha
       BANK_CASH = 12_000
 
       CURRENCY_FORMAT_STR = '$%d'
@@ -191,6 +191,23 @@ module Engine
         @actions = []
         @names = names.freeze
         @players = @names.map { |name| Player.new(name) }
+
+        case self.class::DEV_STAGE
+        when :prealpha
+          @log << "#{self.class.title} is in prealpha state, no support is provided at all"
+        when :alpha
+          @log << "#{self.class.title} is currently considered 'alpha',"\
+          ' the rules implementation is likely to not be complete.'
+          @log << 'As the implementation improves, games that are not compatible'\
+          ' with the latest version will be deleted.'
+          @log << 'We suggest that any alpha quality game is concluded within 7 days.'
+        when :beta
+          @log << "#{self.class.title} is currently considered 'beta',"\
+          ' the rules implementation may allow illegal moves.'
+          @log << 'As the implementation improves, games that are not compatible'\
+          ' with the latest version will be given 7 days to be completed before being deleted.'
+          @log << 'Because of this we suggest not playing games that may take months to complete.'
+        end
 
         @companies = init_companies(@players)
         @stock_market = init_stock_market

--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -7,6 +7,8 @@ module Engine
   module Game
     class G1889 < Base
       load_from_json(Config::Game::G1889::JSON)
+
+      DEV_STAGE = :beta
     end
   end
 end


### PR DESCRIPTION
I thought separating this out from the rest of the opal pinning would be sensible.

It adds the following messages to the top of the log

![Screenshot from 2020-05-16 11-31-48](https://user-images.githubusercontent.com/71923/82117591-eb66d780-9768-11ea-8974-06f0eabc0058.png)

For dev purposes if you do http://localhost:9292/new_game?all you can see all the games not just those marked alpha and above, 1889 is the only game visible at the moment.