### PR TITLE
Fix OO token teleporting issue when laying green OO tile

### DIFF
--- a/assets/app/view/hex.rb
+++ b/assets/app/view/hex.rb
@@ -26,7 +26,6 @@ module View
 
     needs :hex
     needs :round, default: nil
-    needs :selected_route, default: nil, store: true
     needs :tile_selector, default: nil, store: true
     needs :show_grid, default: false, store: true
     needs :role, default: :map
@@ -35,7 +34,7 @@ module View
     def render
       children = [h(:polygon, attrs: { points: Lib::Hex::POINTS })]
 
-      @selected = @hex == @tile_selector&.hex || @hex == @selected_route&.last_hex
+      @selected = @hex == @tile_selector&.hex
       @tile = @selected && @round.can_lay_track? && @tile_selector&.tile ? @tile_selector.tile : @hex.tile
 
       children << h(Tile, tile: @tile) if @tile
@@ -71,12 +70,6 @@ module View
     end
 
     def on_hex_click(event)
-      if @round&.can_run_routes? && @selected_route
-        @selected_route.touch_hex(@hex)
-        store(:selected_route, @selected_route)
-        return
-      end
-
       return @tile_selector.rotate! if @selected && @tile_selector.tile
 
       case @role

--- a/assets/app/view/hit_box.rb
+++ b/assets/app/view/hit_box.rb
@@ -9,7 +9,7 @@ module View
     def render
       h(:circle,
         on: { click: @click },
-        style: { 'pointer-events': 'bounding-box' },
+        style: { cursor: 'pointer', 'pointer-events': 'bounding-box' },
         attrs: {
           stroke: 'none',
           transform: @transform,

--- a/assets/app/view/hit_box.rb
+++ b/assets/app/view/hit_box.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module View
+  class HitBox < Snabberb::Component
+    needs :click
+    needs :transform
+    needs :r, default: 30
+
+    def render
+      h(:circle,
+        on: { click: @click },
+        style: { 'pointer-events': 'bounding-box' },
+        attrs: {
+          stroke: 'none',
+          transform: @transform,
+          r: @r,
+        })
+    end
+  end
+end

--- a/assets/app/view/map.rb
+++ b/assets/app/view/map.rb
@@ -30,7 +30,7 @@ module View
         end
 
       # move the selected hex to the back so it renders highest in z space
-      selected_hex = @tile_selector&.hex || @selected_route&.last_hex
+      selected_hex = @tile_selector&.hex
       @hexes << @hexes.delete(selected_hex) if @hexes.include?(selected_hex)
 
       @hexes.map! do |hex|

--- a/assets/app/view/part/blocker.rb
+++ b/assets/app/view/part/blocker.rb
@@ -51,7 +51,7 @@ module View
 
       def render_part
         h(:g,
-          { attrs: { transform: "#{translate} #{scale}", class: 'blocker', } },
+          { attrs: { transform: "#{translate} #{scale}" } },
           [
             h(:text,
               { attrs: { fill: 'black',

--- a/assets/app/view/part/cities.rb
+++ b/assets/app/view/part/cities.rb
@@ -7,8 +7,7 @@ module View
     class Cities < Base
       def render
         @tile.cities.map do |city|
-          edges = @tile.paths.select { |path| path.city.equal?(city) }.flat_map(&:exits)
-          h(Part::City, region_use: @region_use, tile: @tile, city: city, edges: edges)
+          h(Part::City, region_use: @region_use, tile: @tile, city: city)
         end
       end
     end

--- a/assets/app/view/part/city.rb
+++ b/assets/app/view/part/city.rb
@@ -149,7 +149,7 @@ module View
 
         children.concat(slots)
 
-        h('g.city', { on: { click: -> { touch_node(@city) } } }, children)
+        h(:g, { on: { click: -> { touch_node(@city) } } }, children)
       end
 
       # TODOS:

--- a/assets/app/view/part/city.rb
+++ b/assets/app/view/part/city.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'lib/hex'
+require 'view/runnable'
 require 'view/part/base'
 require 'view/part/city_slot'
 
 module View
   module Part
     class City < Base
+      include Runnable
+
       SLOT_RADIUS = 25
       SLOT_DIAMETER = 2 * SLOT_RADIUS
 
@@ -144,9 +147,9 @@ module View
 
         children << render_box(slots.size) if slots.size.between?(2, 6)
 
-        children += slots
+        children.concat(slots)
 
-        h('g.city', children)
+        h('g.city', { on: { click: -> { touch_node(@city) } } }, children)
       end
 
       # TODOS:

--- a/assets/app/view/part/city.rb
+++ b/assets/app/view/part/city.rb
@@ -14,7 +14,6 @@ module View
       SLOT_DIAMETER = 2 * SLOT_RADIUS
 
       needs :tile
-      needs :edges
       needs :city
 
       # key is how many city slots are part of the city; value is the offset for
@@ -89,7 +88,7 @@ module View
       }.freeze
 
       def preferred_render_locations
-        edge_a, edge_b = @edges
+        edge_a, edge_b = @city.exits
         if @tile.cities.size > 1 && (edge_a || edge_b)
           edge = @tile.preferred_city_edges[@city]
           return [
@@ -157,7 +156,7 @@ module View
       #   scaling the full-size hexagon
       def render_box(slots)
         element, attrs = BOX_ATTRS[slots]
-        h("#{element}.city_box", attrs: attrs)
+        h(element, attrs: attrs)
       end
     end
   end

--- a/assets/app/view/part/city_slot.rb
+++ b/assets/app/view/part/city_slot.rb
@@ -23,7 +23,7 @@ module View
         children << reservation if @reservation
         children << h(Token, corporation: @token.corporation, radius: @radius) if @token
 
-        h(:g, { on: { click: -> { on_click } }, attrs: { class: 'city_slot' } }, children)
+        h(:g, { on: { click: -> { on_click } } }, children)
       end
 
       def reservation

--- a/assets/app/view/part/label.rb
+++ b/assets/app/view/part/label.rb
@@ -85,7 +85,7 @@ module View
           'dominant-baseline': 'middle',
         }
 
-        h('g.label', { attrs: attrs }, [
+        h(:g, { attrs: attrs }, [
           h(:text, { attrs: text_attrs }, @label)
         ])
       end

--- a/assets/app/view/part/label.rb
+++ b/assets/app/view/part/label.rb
@@ -6,84 +6,65 @@ module View
   module Part
     # letter label, like "Z", "H", "OO"
     class Label < Base
-      def preferred_render_locations
-        left_center = {
+      CENTERED_LOCATIONS = [
+        {
           region_weights: { (LEFT_MID + LEFT_CORNER) => 1, LEFT_CENTER => 0.5 },
           x: -55,
           y: 0,
-        }
-
-        right_center = {
+        },
+        {
           region_weights: { (RIGHT_MID + RIGHT_CORNER) => 1, RIGHT_CENTER => 0.5 },
           x: 55,
           y: 0,
-        }
-
-        left_corner = {
+        },
+        {
           region_weights: { LEFT_CORNER => 1.0, (LEFT_CENTER + LEFT_MID) => 0.5 },
           x: -28.5 * 2.5,
           y: 0,
-        }
 
-        right_corner = {
+        },
+        {
           region_weights: { RIGHT_CORNER => 1.0, (RIGHT_CENTER + RIGHT_MID) => 0.5 },
           x: 28.5 * 2.5,
           y: 0,
-        }
+        },
+      ].freeze
 
-        edge1 = {
-          region_weights: { [13] => 1.0, [12, 14] => 0.5 },
-          x: -55,
-          y: 25,
-        }
-
-        edge2 = {
+      OFFSET_LOCATIONS = [
+        {
           region_weights: { [6] => 1.0, [5, 7] => 0.5 },
           x: -55,
           y: -25,
-        }
-
-        edge4 = {
+        },
+        {
+          region_weights: { [13] => 1.0, [12, 14] => 0.5 },
+          x: -55,
+          y: 25,
+        },
+        {
           region_weights: { [10] => 1.0, [9, 11] => 0.5 },
           x: 55,
           y: -25,
-        }
-
-        edge5 = {
-          region_weights: { [17] => 1.0, [16, 18] => 0.5 },
-          x: 55,
-          y: 25,
-        }
-
-        top_center = {
+        },
+        {
           region_weights: { [2] => 1.0, [1, 3] => 0.5 },
           x: 0,
           y: -60,
-        }
-
-        right_of_center = {
+        },
+        {
+          region_weights: { [17] => 1.0, [16, 18] => 0.5 },
+          x: 55,
+          y: 25,
+        },
+        {
           region_weights: { [9, 16] => 1.0, [10, 17] => 0.25 },
           x: 35,
           y: 0,
-        }
+        },
+      ].freeze
 
-        if @tile.cities.size > 1
-          [
-            edge2,
-            edge1,
-            edge4,
-            top_center,
-            edge5,
-            right_of_center,
-          ]
-        else
-          [
-            left_center,
-            right_center,
-            left_corner,
-            right_corner,
-          ]
-        end
+      def preferred_render_locations
+        @tile.cities.size > 1 ?  OFFSET_LOCATIONS : CENTERED_LOCATIONS
       end
 
       def load_from_tile
@@ -93,6 +74,7 @@ module View
       def render_part
         attrs = {
           transform: translate,
+          'pointer-events': 'none',
         }
 
         text_attrs = {
@@ -104,8 +86,8 @@ module View
         }
 
         h('g.label', { attrs: attrs }, [
-            h(:text, { attrs: text_attrs }, @label)
-          ])
+          h(:text, { attrs: text_attrs }, @label)
+        ])
       end
     end
   end

--- a/assets/app/view/part/label.rb
+++ b/assets/app/view/part/label.rb
@@ -64,7 +64,7 @@ module View
       ].freeze
 
       def preferred_render_locations
-        @tile.cities.size > 1 ?  OFFSET_LOCATIONS : CENTERED_LOCATIONS
+        @tile.cities.size > 1 ? OFFSET_LOCATIONS : CENTERED_LOCATIONS
       end
 
       def load_from_tile

--- a/assets/app/view/part/location_name.rb
+++ b/assets/app/view/part/location_name.rb
@@ -132,7 +132,6 @@ module View
 
       def render_part
         attrs = {
-          class: 'location_name',
           fill: 'black',
           transform: "scale(1.1) #{translate}",
           'text-anchor': 'middle',
@@ -147,7 +146,7 @@ module View
           h(:text, { attrs: { transform: "translate(#{x} #{y})" } }, segment)
         end
 
-        h('g.location_name', { attrs: attrs }, [
+        h('g.location_name', { style: { 'pointer-events': 'none' }, attrs: attrs }, [
             render_background_box,
             *rendered_name
           ])

--- a/assets/app/view/part/location_name.rb
+++ b/assets/app/view/part/location_name.rb
@@ -146,7 +146,7 @@ module View
           h(:text, { attrs: { transform: "translate(#{x} #{y})" } }, segment)
         end
 
-        h('g.location_name', { style: { 'pointer-events': 'none' }, attrs: attrs }, [
+        h(:g, { style: { 'pointer-events': 'none' }, attrs: attrs }, [
             render_background_box,
             *rendered_name
           ])

--- a/assets/app/view/part/multi_revenue.rb
+++ b/assets/app/view/part/multi_revenue.rb
@@ -61,12 +61,7 @@ module View
           ]
         end
 
-        attrs = {
-          class: 'multi_revenue',
-          transform: @translate,
-        }
-
-        h(:g, { attrs: attrs }, children)
+        h(:g, { attrs: { transform: @translate } }, children)
       end
     end
   end

--- a/assets/app/view/part/revenue.rb
+++ b/assets/app/view/part/revenue.rb
@@ -179,7 +179,6 @@ module View
           h(Part::MultiRevenue, revenues: @revenue, translate: translate)
         else
           attrs = {
-            class: 'revenue',
             'stroke-width': 1,
             transform: translate,
           }

--- a/assets/app/view/part/town_dot.rb
+++ b/assets/app/view/part/town_dot.rb
@@ -45,7 +45,7 @@ module View
       ].freeze
 
       def preferred_render_locations
-        @tile.towns.size > 1 ?  OFFSET_TOWNS : CENTER_TOWN
+        @tile.towns.size > 1 ? OFFSET_TOWNS : CENTER_TOWN
       end
 
       def render_part

--- a/assets/app/view/part/town_dot.rb
+++ b/assets/app/view/part/town_dot.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
+require 'view/hit_box'
 require 'view/part/base'
+require 'view/runnable'
 
 module View
   module Part
     class TownDot < Base
+      include Runnable
+
       needs :color, default: 'black'
       needs :tile
+      needs :town
 
       CENTER_TOWN = [
         {
@@ -40,24 +45,14 @@ module View
       ].freeze
 
       def preferred_render_locations
-        if @tile.towns.size > 1
-          OFFSET_TOWNS
-        else
-          CENTER_TOWN
-        end
+        @tile.towns.size > 1 ?  OFFSET_TOWNS : CENTER_TOWN
       end
 
       def render_part
-        attrs = {
-          class: 'town_dot',
-          transform: translate,
-          fill: @color,
-          cx: '0',
-          cy: '0',
-          r: '10',
-        }
-
-        h(:circle, attrs: attrs)
+        h(:g, [
+          h(:circle, attrs: { transform: translate, fill: @color, r: 10 }),
+          h(HitBox, click: -> { touch_node(@town) }, transform: translate),
+        ])
       end
     end
   end

--- a/assets/app/view/part/town_rect.rb
+++ b/assets/app/view/part/town_rect.rb
@@ -9,7 +9,6 @@ module View
     class TownRect < Base
       include Runnable
 
-      needs :edges
       needs :town
       needs :color, default: 'black'
 
@@ -38,7 +37,7 @@ module View
       def normalized_edges
         @normalized_edges ||=
           begin
-            edge_a, edge_b = @edges
+            edge_a, edge_b = @town.exits
             edge_a, edge_b = edge_b, edge_a if edge_b < edge_a
             edge_a += 6 if (edge_b - edge_a).abs > 3
             edge_a, edge_b = edge_b, edge_a if edge_b < edge_a

--- a/assets/app/view/part/town_rect.rb
+++ b/assets/app/view/part/town_rect.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
+require 'view/hit_box'
 require 'view/part/base'
+require 'view/runnable'
 
 module View
   module Part
     class TownRect < Base
+      include Runnable
+
       needs :edges
+      needs :town
       needs :color, default: 'black'
 
       HEIGHT = 8
       WIDTH = 32
+      HIT = 60
 
       EDGE_TRACK_LOCATIONS = [
         TRACK_TO_EDGE_0,
@@ -31,115 +37,121 @@ module View
 
       # Returns the two edges so that a < b and b - a is 1, 2 or 3.
       def normalized_edges
-        @normalized_edges ||= begin
-                                edge_a, edge_b = @edges
-                                edge_a, edge_b = edge_b, edge_a if edge_b < edge_a
-                                edge_a += 6 if (edge_b - edge_a).abs > 3
-                                edge_a, edge_b = edge_b, edge_a if edge_b < edge_a
-                                [edge_a, edge_b]
-                              end
+        @normalized_edges ||=
+          begin
+            edge_a, edge_b = @edges
+            edge_a, edge_b = edge_b, edge_a if edge_b < edge_a
+            edge_a += 6 if (edge_b - edge_a).abs > 3
+            edge_a, edge_b = edge_b, edge_a if edge_b < edge_a
+            [edge_a, edge_b]
+          end
       end
 
       # Takes the difference in normalized edges and returns a symbol of
       # :straight, :gentle or :sharp
       def track_type
-        @track_type ||= begin
-                          edge_a, edge_b = normalized_edges
+        @track_type ||=
+          begin
+            edge_a, edge_b = normalized_edges
 
-                          case edge_b - edge_a
-                          when 3
-                            :straight
-                          when 2
-                            :gentle
-                          else
-                            :sharp
-                          end
-                        end
+            case edge_b - edge_a
+            when 3
+              :straight
+            when 2
+              :gentle
+            else
+              :sharp
+            end
+          end
       end
 
       # Returns the angle that the town rect needs to be based on the rotation
       # of the tile
       def position_angle
-        @position_angle ||= begin
-                              edge_a, = normalized_edges
-                              angle = case track_type
-                                      when :sharp
-                                        (edge_a + 0.5) * 60
-                                      when :gentle
-                                        (edge_a * 60) + 5
-                                      else
-                                        edge_a * 60
-                                      end
-                              radians = (angle / 180) * Math::PI
+        @position_angle ||=
+          begin
+            edge_a, = normalized_edges
+            angle = case track_type
+                    when :sharp
+                      (edge_a + 0.5) * 60
+                    when :gentle
+                      (edge_a * 60) + 5
+                    else
+                      edge_a * 60
+                    end
+            radians = (angle / 180) * Math::PI
 
-                              [angle, -Math.sin(radians), Math.cos(radians)]
-                            end
+            [angle, -Math.sin(radians), Math.cos(radians)]
+          end
       end
 
       # Returns an array of options for track positions
       def track_location
-        @track_location ||= begin
-                              edge_a, edge_b = normalized_edges
+        @track_location ||=
+          begin
+            edge_a, edge_b = normalized_edges
 
-                              case track_type
-                              when :sharp
-                                [SHARP_TRACK_LOCATIONS[edge_a % 6]]
-                              else
-                                [CENTER,
-                                 EDGE_TRACK_LOCATIONS[edge_a % 6],
-                                 EDGE_TRACK_LOCATIONS[edge_b % 6]]
-                              end
-                            end
+            case track_type
+            when :sharp
+              [SHARP_TRACK_LOCATIONS[edge_a % 6]]
+            else
+              [CENTER,
+               EDGE_TRACK_LOCATIONS[edge_a % 6],
+               EDGE_TRACK_LOCATIONS[edge_b % 6]]
+            end
+          end
       end
 
       # Returns an array of rotation options for the town rectangle that
       # corresponds to the positions given from track_location
       def rotation_angles
-        @rotation_angles ||= begin
-                               edge_a, = normalized_edges
-                               case track_type
-                               when :sharp
-                                 [(edge_a + 2) * 60]
-                               when :gentle
-                                 [(edge_a * 60) - 30,
-                                  (edge_a * 60) - 10,
-                                  (edge_a * 60) - 50]
-                               else
-                                 [edge_a * 60] * 3
-                               end
-                             end
+        @rotation_angles ||=
+          begin
+            edge_a, = normalized_edges
+            case track_type
+            when :sharp
+              [(edge_a + 2) * 60]
+            when :gentle
+              [(edge_a * 60) - 30,
+               (edge_a * 60) - 10,
+               (edge_a * 60) - 50]
+            else
+              [edge_a * 60] * 3
+            end
+          end
       end
 
       # Returns an array of weights, location and rotations
       def position
-        @position ||= begin
-                        edge_a, edge_b = normalized_edges
-                        angles = case track_type
-                                 when :sharp
-                                   [(edge_a + 0.5) * 60]
-                                 when :gentle
-                                   [(edge_a + 1) * 60,
-                                    (edge_a * 60) + 2,
-                                    (edge_b * 60) - 2]
-                                 else
-                                   [edge_a * 60] * 3
-                                 end
-                        radians = angles.map { |a| a / 180 * Math::PI }
+        @position ||=
+          begin
+            edge_a, edge_b = normalized_edges
+            angles = case track_type
+                     when :sharp
+                       [(edge_a + 0.5) * 60]
+                     when :gentle
+                       [(edge_a + 1) * 60,
+                        (edge_a * 60) + 2,
+                        (edge_b * 60) - 2]
+                     else
+                       [edge_a * 60] * 3
+                     end
+            radians = angles.map { |a| a / 180 * Math::PI }
 
-                        positions = case track_type
-                                    when :sharp
-                                      [43.5]
-                                    when :gentle
-                                      [20, 53.375, 53.375]
-                                    else
-                                      [0, 40, -40]
-                                    end
+            positions = case track_type
+                        when :sharp
+                          [43.5]
+                        when :gentle
+                          [20, 53.375, 53.375]
+                        else
+                          [0, 40, -40]
+                        end
 
-                        xs = positions.zip(radians).map { |p, r| -Math.sin(r) * p }
-                        ys = positions.zip(radians).map { |p, r| Math.cos(r) * p }
+            xs = positions.zip(radians).map { |p, r| -Math.sin(r) * p }
+            ys = positions.zip(radians).map { |p, r| Math.cos(r) * p }
 
-                        track_location.zip(xs, ys, rotation_angles)
-                      end
+            track_location.zip(xs, ys, rotation_angles)
+          end
       end
 
       # Maps the position method into the required format for
@@ -156,18 +168,18 @@ module View
       end
 
       def render
-        attrs = {
-          class: 'town_rect',
-          transform: "#{translate} #{rotation}",
-          x: -WIDTH / 2,
-          y: -HEIGHT / 2,
-          height: HEIGHT,
-          width: WIDTH,
-          fill: @color,
-          stroke: 'none'
-        }
-
-        h(:rect, attrs: attrs)
+        h(:g, [
+          h(:rect, attrs: {
+            transform: "#{translate} #{rotation}",
+            x: -WIDTH / 2,
+            y: -HEIGHT / 2,
+            width: WIDTH,
+            height: HEIGHT,
+            fill: @color,
+            stroke: 'none',
+          }),
+          h(HitBox, click: -> { touch_node(@town) }, transform: translate),
+        ])
       end
     end
   end

--- a/assets/app/view/part/town_rect.rb
+++ b/assets/app/view/part/town_rect.rb
@@ -15,7 +15,6 @@ module View
 
       HEIGHT = 8
       WIDTH = 32
-      HIT = 60
 
       EDGE_TRACK_LOCATIONS = [
         TRACK_TO_EDGE_0,
@@ -65,93 +64,64 @@ module View
           end
       end
 
-      # Returns the angle that the town rect needs to be based on the rotation
-      # of the tile
-      def position_angle
-        @position_angle ||=
-          begin
-            edge_a, = normalized_edges
-            angle = case track_type
-                    when :sharp
-                      (edge_a + 0.5) * 60
-                    when :gentle
-                      (edge_a * 60) + 5
-                    else
-                      edge_a * 60
-                    end
-            radians = (angle / 180) * Math::PI
-
-            [angle, -Math.sin(radians), Math.cos(radians)]
-          end
-      end
-
       # Returns an array of options for track positions
       def track_location
-        @track_location ||=
-          begin
-            edge_a, edge_b = normalized_edges
+        edge_a, edge_b = normalized_edges
 
-            case track_type
-            when :sharp
-              [SHARP_TRACK_LOCATIONS[edge_a % 6]]
-            else
-              [CENTER,
-               EDGE_TRACK_LOCATIONS[edge_a % 6],
-               EDGE_TRACK_LOCATIONS[edge_b % 6]]
-            end
-          end
+        case track_type
+        when :sharp
+          [SHARP_TRACK_LOCATIONS[edge_a % 6]]
+        else
+          [CENTER,
+           EDGE_TRACK_LOCATIONS[edge_a % 6],
+           EDGE_TRACK_LOCATIONS[edge_b % 6]]
+        end
       end
 
       # Returns an array of rotation options for the town rectangle that
       # corresponds to the positions given from track_location
       def rotation_angles
-        @rotation_angles ||=
-          begin
-            edge_a, = normalized_edges
-            case track_type
-            when :sharp
-              [(edge_a + 2) * 60]
-            when :gentle
-              [(edge_a * 60) - 30,
-               (edge_a * 60) - 10,
-               (edge_a * 60) - 50]
-            else
-              [edge_a * 60] * 3
-            end
-          end
+        edge_a, = normalized_edges
+        case track_type
+        when :sharp
+          [(edge_a + 2) * 60]
+        when :gentle
+          [(edge_a * 60) - 30,
+           (edge_a * 60) - 10,
+           (edge_a * 60) - 50]
+        else
+          [edge_a * 60] * 3
+        end
       end
 
       # Returns an array of weights, location and rotations
       def position
-        @position ||=
-          begin
-            edge_a, edge_b = normalized_edges
-            angles = case track_type
-                     when :sharp
-                       [(edge_a + 0.5) * 60]
-                     when :gentle
-                       [(edge_a + 1) * 60,
-                        (edge_a * 60) + 2,
-                        (edge_b * 60) - 2]
-                     else
-                       [edge_a * 60] * 3
-                     end
-            radians = angles.map { |a| a / 180 * Math::PI }
+        edge_a, edge_b = normalized_edges
+        angles = case track_type
+                 when :sharp
+                   [(edge_a + 0.5) * 60]
+                 when :gentle
+                   [(edge_a + 1) * 60,
+                    (edge_a * 60) + 2,
+                    (edge_b * 60) - 2]
+                 else
+                   [edge_a * 60] * 3
+                 end
+        radians = angles.map { |a| a / 180 * Math::PI }
 
-            positions = case track_type
-                        when :sharp
-                          [43.5]
-                        when :gentle
-                          [20, 53.375, 53.375]
-                        else
-                          [0, 40, -40]
-                        end
+        positions = case track_type
+                    when :sharp
+                      [43.5]
+                    when :gentle
+                      [20, 53.375, 53.375]
+                    else
+                      [0, 40, -40]
+                    end
 
-            xs = positions.zip(radians).map { |p, r| -Math.sin(r) * p }
-            ys = positions.zip(radians).map { |p, r| Math.cos(r) * p }
+        xs = positions.zip(radians).map { |p, r| -Math.sin(r) * p }
+        ys = positions.zip(radians).map { |p, r| Math.cos(r) * p }
 
-            track_location.zip(xs, ys, rotation_angles)
-          end
+        track_location.zip(xs, ys, rotation_angles)
       end
 
       # Maps the position method into the required format for

--- a/assets/app/view/part/towns.rb
+++ b/assets/app/view/part/towns.rb
@@ -17,8 +17,7 @@ module View
           if @tile.lawson? || @tile.paths.empty?
             h(Part::TownDot, town: town, tile: @tile, region_use: @region_use, color: color_for(town))
           else
-            edges = @tile.paths.select { |path| path.town.equal?(town) }.flat_map(&:exits)
-            h(Part::TownRect, town: town, region_use: @region_use, color: color_for(town), edges: edges)
+            h(Part::TownRect, town: town, region_use: @region_use, color: color_for(town))
           end
         end
       end

--- a/assets/app/view/part/towns.rb
+++ b/assets/app/view/part/towns.rb
@@ -15,10 +15,10 @@ module View
       def render
         @tile.towns.map do |town|
           if @tile.lawson? || @tile.paths.empty?
-            h(Part::TownDot, tile: @tile, region_use: @region_use, color: color_for(town))
+            h(Part::TownDot, town: town, tile: @tile, region_use: @region_use, color: color_for(town))
           else
             edges = @tile.paths.select { |path| path.town.equal?(town) }.flat_map(&:exits)
-            h(Part::TownRect, region_use: @region_use, color: color_for(town), edges: edges)
+            h(Part::TownRect, town: town, region_use: @region_use, color: color_for(town), edges: edges)
           end
         end
       end

--- a/assets/app/view/part/track.rb
+++ b/assets/app/view/part/track.rb
@@ -44,10 +44,10 @@ module View
       private
 
       def render_track_for_curvilinear_city
-        @tile.paths.select(&:city).group_by(&:city).flat_map do |_, paths|
-          exits = paths.flat_map(&:exits)
+        @tile.cities.flat_map do |city|
+          exits = city.exits
 
-          paths.map do |path|
+          city.paths.map do |path|
             h(
               Part::TrackCurvilinearHalfPath,
               region_use: @region_use,
@@ -60,10 +60,10 @@ module View
       end
 
       def render_track_for_curvilinear_town
-        @tile.paths.select(&:town).group_by(&:town).flat_map do |_, paths|
-          exits = paths.flat_map(&:exits)
+        @tile.towns.flat_map do |town|
+          exits = town.exits
 
-          paths.map do |path|
+          town.paths.map do |path|
             h(
               Part::TrackCurvilinearHalfPath,
               region_use: @region_use,

--- a/assets/app/view/part/track.rb
+++ b/assets/app/view/part/track.rb
@@ -23,22 +23,21 @@ module View
         @routes_paths = @routes.map { |route| route.paths_for(@tile.paths) }
 
         if @tile.offboards.any?
-          track_class = Part::TrackOffboard
-          paths = @tile.paths.select(&:offboard)
+          @tile.paths.select(&:offboard).map do |path|
+            h(TrackOffboard, offboard: path.offboard, region_use: @region_use, path: path, color: color_for(path))
+          end
         elsif @tile.lawson?
-          track_class = Part::TrackLawsonPath
-          paths = @tile.paths.select { |path| path.edges.size == 1 }
+          @tile.paths.select { |path| path.edges.size == 1 }.map do |path|
+            h(TrackLawsonPath, region_use: @region_use, path: path, color: color_for(path))
+          end
         elsif @tile.towns.any?
-          return render_track_for_curvilinear_town
+          render_track_for_curvilinear_town
         elsif @tile.cities.any?
-          return render_track_for_curvilinear_city
+          render_track_for_curvilinear_city
         else
-          track_class = Part::TrackCurvilinearPath
-          paths = @tile.paths.select { |path| path.edges.size == 2 }
-        end
-
-        paths.map do |path|
-          h(track_class, region_use: @region_use, path: path, color: color_for(path))
+          @tile.paths.select { |path| path.edges.size == 2 }.map do |path|
+            h(TrackCurvilinearPath, region_use: @region_use, path: path, color: color_for(path))
+          end
         end
       end
 

--- a/assets/app/view/part/track_curvilinear_half_path.rb
+++ b/assets/app/view/part/track_curvilinear_half_path.rb
@@ -86,7 +86,6 @@ module View
       def render_part
         props = {
           attrs: {
-            class: 'curvilinear_path',
             transform: "rotate(#{@rotation})",
             d: SVG_PATH_STRINGS[[@curvilinear_type, @direction]],
             stroke: @color,

--- a/assets/app/view/part/track_curvilinear_path.rb
+++ b/assets/app/view/part/track_curvilinear_path.rb
@@ -82,7 +82,6 @@ module View
       def render_part
         props = {
           attrs: {
-            class: 'curvilinear_path',
             transform: "rotate(#{@rotation})",
             d: SVG_PATH_STRINGS[@curvilinear_type],
             stroke: @color,

--- a/assets/app/view/part/track_lawson_path.rb
+++ b/assets/app/view/part/track_lawson_path.rb
@@ -36,7 +36,6 @@ module View
 
         props = {
           attrs: {
-            class: 'lawson_path',
             transform: "rotate(#{rotation})",
             d: 'M 0 87 L 0 0',
             stroke: @color,

--- a/assets/app/view/part/track_offboard.rb
+++ b/assets/app/view/part/track_offboard.rb
@@ -1,30 +1,35 @@
 # frozen_string_literal: true
 
+require 'view/hit_box'
 require 'view/part/base'
+require 'view/runnable'
 
 module View
   module Part
     class TrackOffboard < Base
+      include Runnable
+
       needs :path
+      needs :offboard
       needs :color, default: 'black'
 
-      def edge_num
-        @edge_num ||= @path.edges.first.num
+      REGIONS = {
+        0 => [21],
+        1 => [13],
+        2 => [6],
+        3 => [2],
+        4 => [10],
+        5 => [17],
+      }.freeze
+
+      def edge
+        @edge ||= @path.exits[0]
       end
 
       def preferred_render_locations
-        regions = {
-          0 => [21],
-          1 => [13],
-          2 => [6],
-          3 => [2],
-          4 => [10],
-          5 => [17],
-        }[edge_num]
-
         [
           {
-            region_weights: regions,
+            region_weights: REGIONS[edge],
             x: 0,
             y: 0,
           }
@@ -32,11 +37,10 @@ module View
       end
 
       def render_part
-        rotate = 60 * edge_num
+        rotate = 60 * edge
 
         props = {
           attrs: {
-            class: 'track',
             transform: "rotate(#{rotate})",
             d: 'M6 75 L 6 85 L -6 85 L -6 75 L 0 48 Z',
             fill: @color,
@@ -47,7 +51,13 @@ module View
           }
         }
 
-        h(:path, props)
+        radians = (edge * 60) / 180 * Math::PI
+        translate = "translate(#{-Math.sin(radians) * 60}, #{Math.cos(radians) * 60})"
+
+        h(:g, [
+          h(:path, props),
+          h(HitBox, click: -> { touch_node(@offboard) }, transform: translate),
+        ])
       end
     end
   end

--- a/assets/app/view/runnable.rb
+++ b/assets/app/view/runnable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module View
+  module Runnable
+    def self.included(base)
+      base.needs :game, store: true, default: nil
+      base.needs :selected_route, store: true, default: nil
+    end
+
+    def touch_node(node)
+      return if !@game&.round&.can_run_routes? || !@selected_route
+
+      @selected_route.touch_node(node)
+      store(:selected_route, @selected_route)
+    end
+  end
+end

--- a/assets/app/view/tile.rb
+++ b/assets/app/view/tile.rb
@@ -47,17 +47,13 @@ module View
       children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 
       # OO tiles have different rules...
-      if @tile.cities.count > 1
-        children << render_tile_part(Part::LocationName) if @tile.location_name
-      end
+      children << render_tile_part(Part::LocationName) if @tile.cities.size > 1 && @tile.location_name
 
       children << render_tile_part(Part::Label) if @tile.label
       children << render_tile_part(Part::Revenue) if @tile.stops.any?
       children << render_tile_part(Part::Upgrades) if @tile.upgrades
 
-      if @tile.cities.count <= 1
-        children << render_tile_part(Part::LocationName) if @tile.location_name
-      end
+      children << render_tile_part(Part::LocationName) if @tile.cities.count <= 1 && @tile.location_name
 
       children << render_tile_part(Part::Blocker) if should_render_blocker?
 

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -29,8 +29,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        I rewrote the routing code so it should hopefully be more intuitive. If there are any issues please let me know.
-        I'm purposefully not explaining it here to see if it's intuitive to figure out.
+        The routing code has been changed again!!! You must now click nodes (cities towns and offboards). If there are any issues please let me know.
 
         You can now end games early. The owner of the game has an option in the tools tab to end the game if it is finished.
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -451,7 +451,7 @@ module Engine
             count.times.map { |i| Tile.for(name, index: i) }
           else
             count = val['count']
-            color = val['color']
+            color = val['color'].to_sym
             code = val['code']
             count.times.map { |i| Tile.from_code(name, color, code, index: i) }
           end

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -66,17 +66,14 @@ module Engine
       # map old cities to new based on edges they are connected to
       city_map =
         # if @tile is blank, map cities by index
-        if @tile.cities.flat_map(&:connected_edges).empty? && (@tile.cities.size == tile.cities.size)
+        if @tile.cities.flat_map(&:exits).empty? && (@tile.cities.size == tile.cities.size)
           @tile.cities.zip(tile.cities).to_h
-
         # if @tile is not blank, ensure connectivity is maintained
         else
           @tile.cities.map do |old_city|
             new_city = tile.cities.find do |city|
               # we want old_edges to be subset of new_edges
-              old_edges = old_city.connected_edges
-              new_edges = city.connected_edges
-              old_edges & new_edges == old_edges
+              (old_city.exits - city.exits).empty?
             end
             [old_city, new_city]
           end.to_h

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -72,21 +72,13 @@ module Engine
         # if @tile is not blank, ensure connectivity is maintained
         else
           @tile.cities.map do |old_city|
-            cities = tile.cities.select do |new_city|
+            new_city = tile.cities.find do |city|
               # we want old_edges to be subset of new_edges
               old_edges = old_city.connected_edges
-              new_edges = new_city.connected_edges
+              new_edges = city.connected_edges
               old_edges & new_edges == old_edges
-            end.compact
-
-            unless cities.one?
-              err_msg = "City #{old_city.index} on old tile maps to "\
-                        "cities #{cities.map(&:index)} on new tile; expected "\
-                        'exactly one city on new tile'
-              raise GameError, err_msg
             end
-
-            [old_city, cities.first]
+            [old_city, new_city]
           end.to_h
         end
 

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -60,16 +60,46 @@ module Engine
     end
 
     def lay(tile)
+      # key: city on @tile (AKA old_city)
+      # values: city on tile (AKA new_city)
+      #
+      # map old cities to new based on edges they are connected to
+      city_map =
+        # if @tile is blank, map cities by index
+        if @tile.cities.flat_map(&:connected_edges).empty? && (@tile.cities.size == tile.cities.size)
+          @tile.cities.zip(tile.cities).to_h
+
+        # if @tile is not blank, ensure connectivity is maintained
+        else
+          @tile.cities.map do |old_city|
+            cities = tile.cities.select do |new_city|
+              # we want old_edges to be subset of new_edges
+              old_edges = old_city.connected_edges
+              new_edges = new_city.connected_edges
+              old_edges & new_edges == old_edges
+            end.compact
+
+            unless cities.one?
+              err_msg = "City #{old_city.index} on old tile maps to "\
+                        "cities #{cities.map(&:index)} on new tile; expected "\
+                        'exactly one city on new tile'
+              raise GameError, err_msg
+            end
+
+            [old_city, cities.first]
+          end.to_h
+        end
+
       # when upgrading, preserve tokens (both reserved and actually placed) on
       # previous tile
-      @tile.cities.each_with_index do |city, i|
-        tile.cities[i].reservations = city.reservations.dup
+      city_map.each do |old_city, new_city|
+        new_city.reservations = old_city.reservations.dup
 
-        city.tokens.each do |token|
-          tile.cities[i].exchange_token(token) if token
+        old_city.tokens.each do |token|
+          new_city.exchange_token(token) if token
         end
-        city.remove_tokens!
-        city.reservations.clear
+        old_city.remove_tokens!
+        old_city.reservations.clear
       end
 
       @tile.hex = nil

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -77,7 +77,7 @@ module Engine
 
       # returns Array[Integer] of all edges that this city are connected to
       def connected_edges
-        @connected_edges[tile.rotation] ||= tile.paths.select { |p| p.city == self }.flat_map(&:edges).map(&:num).sort
+        @connected_edges[tile.rotation] ||= tile.paths.select { |p| p.city == self }.flat_map(&:exits).sort
       end
     end
   end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -2,12 +2,14 @@
 
 require_relative '../game_error'
 require_relative 'base'
+require_relative 'node'
 require_relative 'revenue_center'
 
 module Engine
   module Part
     class City < Base
-      include Part::RevenueCenter
+      include RevenueCenter
+      include Node
 
       attr_accessor :reservations
       attr_reader :slots, :tokens, :revenue
@@ -17,7 +19,6 @@ module Engine
         @slots = slots.to_i
         @tokens = Array.new(@slots)
         @reservations = []
-        @connected_edges = {}
       end
 
       def remove_tokens!
@@ -73,11 +74,6 @@ module Engine
 
       def exchange_token(token)
         @tokens[get_slot(token.corporation)] = token
-      end
-
-      # returns Array[Integer] of all edges that this city are connected to
-      def connected_edges
-        @connected_edges[tile.rotation] ||= tile.paths.select { |p| p.city == self }.flat_map(&:exits).sort
       end
     end
   end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -17,6 +17,7 @@ module Engine
         @slots = slots.to_i
         @tokens = Array.new(@slots)
         @reservations = []
+        @connected_edges = {}
       end
 
       def remove_tokens!
@@ -72,6 +73,11 @@ module Engine
 
       def exchange_token(token)
         @tokens[get_slot(token.corporation)] = token
+      end
+
+      # returns Array[Integer] of all edges that this city are connected to
+      def connected_edges
+        @connected_edges[tile.rotation] ||= tile.paths.select { |p| p.city == self }.flat_map(&:edges).map(&:num).sort
       end
     end
   end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -63,7 +63,7 @@ module Engine
       end
 
       def place_token(corporation)
-        raise GameError, 'Cannot lay token' unless tokenable?(corporation)
+        raise GameError, "Cannot lay token on #{id}" unless tokenable?(corporation)
 
         token = corporation.next_token
         token.use!

--- a/lib/engine/part/junction.rb
+++ b/lib/engine/part/junction.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'node'
 
 module Engine
   module Part
     class Junction < Base
+      include Node
+
       def junction?
         true
       end

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Engine
+  module Part
+    module Node
+      def clear!
+        @paths = nil
+        @exits = nil
+      end
+
+      def paths
+        @paths ||= @tile.paths.select { |p| p.node == self }
+      end
+
+      def exits
+        @exits ||= paths.flat_map(&:exits)
+      end
+    end
+  end
+end

--- a/lib/engine/part/offboard.rb
+++ b/lib/engine/part/offboard.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'node'
 require_relative 'revenue_center'
 
 module Engine
   module Part
     class Offboard < Base
-      include Part::RevenueCenter
+      include Node
+      include RevenueCenter
 
       def initialize(revenue)
         @revenue = parse_revenue(revenue)

--- a/lib/engine/part/town.rb
+++ b/lib/engine/part/town.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'node'
 require_relative 'revenue_center'
 
 module Engine
   module Part
     class Town < Base
-      include Part::RevenueCenter
+      include Node
+      include RevenueCenter
 
       attr_reader :revenue
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -180,7 +180,7 @@ module Engine
 
     def upgrades_to?(other)
       # correct color progression?
-      return false unless COLORS.index(other.color.to_sym) == (COLORS.index(@color.to_sym) + 1)
+      return false unless COLORS.index(other.color) == (COLORS.index(@color) + 1)
 
       # correct label?
       return false if label != other.label
@@ -189,8 +189,8 @@ module Engine
       # - allow labelled cities to upgrade regardless of count; they're probably
       #   fine (e.g., 18Chesapeake's OO cities merge to one city in brown)
       # - TODO: account for games that allow double dits to upgrade to one town
-      return false unless @towns.size == other.towns.size
-      return false unless label || (@cities.size == other.cities.size)
+      return false if @towns.size != other.towns.size
+      return false if !label && @cities.size != other.cities.size
 
       # honors pre-existing track?
       return false unless paths_are_subset_of?(other.paths)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -112,11 +112,13 @@ module Engine
       @cities = []
       @paths = []
       @towns = []
-      @branches = []
-      @edges = nil
-      @junctions = nil
       @upgrades = []
       @offboards = []
+      @branches = nil
+      @nodes = nil
+      @stops = nil
+      @edges = nil
+      @junctions = nil
       @location_name = location_name
       @legal_rotations = []
       @blockers = []
@@ -124,7 +126,6 @@ module Engine
       @index = index
       @preferred_city_edges = {}
 
-      tag_parts
       separate_parts
     end
 
@@ -142,6 +143,7 @@ module Engine
         @legal_rotations.first ||
         @rotation
       @rotation = new_rotation
+      @nodes.each(&:clear!)
       @_paths = nil
       @_exits = nil
       self
@@ -161,11 +163,9 @@ module Engine
 
     def lawson?
       @lawson ||=
-        [
-          @junctions.any?,
-          [cities.size, towns.size] == [1, 0],
-          ([cities.size, towns.size] == [0, 1]) && ![1, 2].include?(exits.size),
-        ].any?
+        @junctions.any? ||
+        (@cities.size == 1 && @towns.empty?) ||
+        ((cities.empty? && towns.size == 1) && edges.size > 2)
     end
 
     def upgrade_cost(abilities)
@@ -267,15 +267,6 @@ module Engine
 
     private
 
-    def tag_parts
-      @parts.each.group_by(&:class).values.each do |parts|
-        parts.each.with_index do |part, index|
-          part.index = index
-          part.tile = self
-        end
-      end
-    end
-
     def separate_parts
       @parts.each do |part|
         if part.city?
@@ -295,11 +286,18 @@ module Engine
         end
       end
 
-      @nodes = @paths.map(&:node)
-      @branches = @paths.map(&:branch)
-      @junctions = @paths.map(&:junction)
-      @edges = @paths.flat_map(&:edges)
-      @stops = @paths.map(&:stop).compact
+      @parts.each.group_by(&:class).values.each do |parts|
+        parts.each.with_index do |part, index|
+          part.index = index
+          part.tile = self
+        end
+      end
+
+      @nodes = @paths.map(&:node).compact.uniq
+      @branches = @paths.map(&:branch).compact.uniq
+      @junctions = @paths.map(&:junction).compact.uniq
+      @stops = @paths.map(&:stop).compact.uniq
+      @edges = @paths.flat_map(&:edges).compact.uniq
     end
   end
 end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -180,7 +180,7 @@ module Engine
 
     def upgrades_to?(other)
       # correct color progression?
-      return false unless COLORS.index(other.color) == (COLORS.index(@color) + 1)
+      return false unless COLORS.index(other.color.to_sym) == (COLORS.index(@color.to_sym) + 1)
 
       # correct label?
       return false if label != other.label

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -186,10 +186,11 @@ module Engine
       return false if label != other.label
 
       # honors existing town/city counts?
-      # TODO: this is not true for some OO upgrades, or some tiles where
-      # double-town can be upgraded into a single town
+      # - allow labelled cities to upgrade regardless of count; they're probably
+      #   fine (e.g., 18Chesapeake's OO cities merge to one city in brown)
+      # - TODO: account for games that allow double dits to upgrade to one town
       return false unless @towns.size == other.towns.size
-      return false unless @cities.size == other.cities.size
+      return false unless label || (@cities.size == other.cities.size)
 
       # honors pre-existing track?
       return false unless paths_are_subset_of?(other.paths)

--- a/spec/lib/engine/connection_spec.rb
+++ b/spec/lib/engine/connection_spec.rb
@@ -70,9 +70,15 @@ module Engine
     context 'with iyo' do
       subject { game.hex_by_id('E2') }
 
+      # broken; tile #6 rot 4 (edges [0,4]) cannot upgrade to tile #12 rot5
+      # (edges [0,1,5]); if not meant to be an upgrade, can we split those two
+      # lays into separate tests?
       it 'connects the upgrade' do
         subject.lay(game.tile_by_id('6-0').rotate!(4))
         expect(subject.connections[4][0].hexes.map(&:name)).to eq(%w[E2 F1])
+
+        # tile #12 with rotation 5 has edges 0, 1, 5; if laid on E2 how can it
+        # connect to F1? E2-F1 is on E2's edge 4
         subject.lay(game.tile_by_id('12-0').rotate!(5))
         expect(subject.connections[4][0].hexes.map(&:name)).to eq(%w[E2 F1])
       end
@@ -81,9 +87,15 @@ module Engine
     context 'with ko and sr' do
       subject { game.hex_by_id('J3') }
 
+      # broken; tile #6 rot 4 (edges [0,4]) cannot upgrade to tile #12 rot5
+      # (edges [0,1,5]); if not meant to be an upgrade, can we split those two
+      # lays into separate tests?
       it 'can upgrade fork to 3 stops' do
+        # why are these two lays happening? they appear to be overridden by
+        # the next two lays
         game.hex_by_id('I2').lay(game.tile_by_id('6-0').rotate!(4))
         subject.lay(game.tile_by_id('8-0').rotate!(3))
+
         game.hex_by_id('I2').lay(game.tile_by_id('12-0').rotate!(5))
         subject.lay(game.tile_by_id('23-0').rotate!(5))
         subject.lay(game.tile_by_id('47-0').rotate!(2))

--- a/spec/lib/engine/connection_spec.rb
+++ b/spec/lib/engine/connection_spec.rb
@@ -70,16 +70,10 @@ module Engine
     context 'with iyo' do
       subject { game.hex_by_id('E2') }
 
-      # broken; tile #6 rot 4 (edges [0,4]) cannot upgrade to tile #12 rot5
-      # (edges [0,1,5]); if not meant to be an upgrade, can we split those two
-      # lays into separate tests?
       it 'connects the upgrade' do
         subject.lay(game.tile_by_id('6-0').rotate!(4))
         expect(subject.connections[4][0].hexes.map(&:name)).to eq(%w[E2 F1])
-
-        # tile #12 with rotation 5 has edges 0, 1, 5; if laid on E2 how can it
-        # connect to F1? E2-F1 is on E2's edge 4
-        subject.lay(game.tile_by_id('12-0').rotate!(5))
+        subject.lay(game.tile_by_id('12-0').rotate!(4))
         expect(subject.connections[4][0].hexes.map(&:name)).to eq(%w[E2 F1])
       end
     end
@@ -87,20 +81,11 @@ module Engine
     context 'with ko and sr' do
       subject { game.hex_by_id('J3') }
 
-      # broken; tile #6 rot 4 (edges [0,4]) cannot upgrade to tile #12 rot5
-      # (edges [0,1,5]); if not meant to be an upgrade, can we split those two
-      # lays into separate tests?
       it 'can upgrade fork to 3 stops' do
-        # why are these two lays happening? they appear to be overridden by
-        # the next two lays
-        game.hex_by_id('I2').lay(game.tile_by_id('6-0').rotate!(4))
-        subject.lay(game.tile_by_id('8-0').rotate!(3))
-
         game.hex_by_id('I2').lay(game.tile_by_id('12-0').rotate!(5))
         subject.lay(game.tile_by_id('23-0').rotate!(5))
         subject.lay(game.tile_by_id('47-0').rotate!(2))
         expect(subject.connections.size).to eq(4)
-        # expect(subject.connections).to eq({})
         expect(subject.connections[0].size).to eq(2)
         expect(subject.connections[2].size).to eq(2)
         connections3 = subject.connections[3]

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -110,7 +110,7 @@ module Engine
         let(:old_city) { old_tile.cities.find { |c| c.tokenable?(c_and_a) } }
         let(:old_edge) do
           old_path = old_tile.paths.find { |p| p.city == old_city }
-          old_path.edges.first.num
+          old_path.exits.first
         end
 
         before(:each) do
@@ -142,7 +142,7 @@ module Engine
 
               # expect the connection between the edge and the bottom city
               # from the preprinted OO tile to still be present
-              edges = tile.paths.select { |p| p.city == city }.flat_map(&:edges).map(&:num)
+              edges = tile.paths.select { |p| p.city == city }.flat_map(&:exits)
               expect(edges.size).to eq(2)
               expect(edges).to include(old_edge)
             end

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -142,7 +142,7 @@ module Engine
 
               # expect the connection between the edge and the bottom city
               # from the preprinted OO tile to still be present
-              edges = tile.paths.select { |p| p.city == city }.flat_map(&:exits)
+              edges = city.exits
               expect(edges.size).to eq(2)
               expect(edges).to include(old_edge)
             end

--- a/spec/lib/engine/part/city_spec.rb
+++ b/spec/lib/engine/part/city_spec.rb
@@ -21,16 +21,16 @@ module Engine
         end
       end
 
-      describe '#connected_edges' do
+      describe '#exits' do
         it "returns the correct edges for 18Chesapeake's tile X3" do
           game = GAMES_BY_TITLE['18Chesapeake'].new(%w[a b c])
           x3 = game.tile_by_id('X3-0')
-          expect(x3.cities[0].connected_edges).to eq([0, 2])
-          expect(x3.cities[1].connected_edges).to eq([3, 5])
+          expect(x3.cities[0].exits.sort).to eq([0, 2])
+          expect(x3.cities[1].exits.sort).to eq([3, 5])
 
           x3.rotate!(1)
-          expect(x3.cities[0].connected_edges).to eq([1, 3])
-          expect(x3.cities[1].connected_edges).to eq([0, 4])
+          expect(x3.cities[0].exits.sort).to eq([1, 3])
+          expect(x3.cities[1].exits.sort).to eq([0, 4])
         end
       end
     end

--- a/spec/lib/engine/part/city_spec.rb
+++ b/spec/lib/engine/part/city_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
+require 'engine'
 require 'engine/corporation'
 require 'engine/part/city'
 require 'engine/token'
@@ -17,6 +18,19 @@ module Engine
       describe '#initialize' do
         it 'starts with no tokens' do
           expect(subject.tokens).to eq([nil])
+        end
+      end
+
+      describe '#connected_edges' do
+        it "returns the correct edges for 18Chesapeake's tile X3" do
+          game = GAMES_BY_TITLE['18Chesapeake'].new(%w[a b c])
+          x3 = game.tile_by_id('X3-0')
+          expect(x3.cities[0].connected_edges).to eq([0, 2])
+          expect(x3.cities[1].connected_edges).to eq([3, 5])
+
+          x3.rotate!(1)
+          expect(x3.cities[0].connected_edges).to eq([1, 3])
+          expect(x3.cities[1].connected_edges).to eq([0, 4])
         end
       end
     end

--- a/spec/lib/engine/tile_spec.rb
+++ b/spec/lib/engine/tile_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
+require 'engine'
 require 'engine/game/g_1889'
 require 'engine/tile'
 
@@ -37,8 +38,14 @@ module Engine
     end
 
     describe '#upgrades_to?' do
-      context '1889' do
-        EXPECTED_TILE_UPGRADES = {
+      EXPECTED_TILE_UPGRADES = {
+        '18Chesapeake' => {
+          'X3' => %w[X7],
+          'X4' => %w[X7],
+          'X5' => %w[X7],
+          'X7' => %w[],
+        },
+        '1889' => {
           'blank' => %w[7 8 9],
           'city' => %w[5 6 57],
           'town' => %w[3 58],
@@ -82,16 +89,26 @@ module Engine
           '466' => %w[],
           '492' => %w[],
           '611' => %w[],
-        }.freeze
+        },
+      }.freeze
 
-        EXPECTED_TILE_UPGRADES.keys.each do |t|
-          EXPECTED_TILE_UPGRADES.keys.each do |u|
-            tile = Tile.for(t)
-            upgrade = Tile.for(u)
-            included = EXPECTED_TILE_UPGRADES[t].include?(u)
+      EXPECTED_TILE_UPGRADES.each do |game_title, upgrades|
+        context game_title do
+          game = Engine::GAMES_BY_TITLE[game_title].new(%w[p1 p2 p3])
 
-            it "#{t} can#{included ? '' : 'not'} upgrade to #{u}" do
-              expect(tile.upgrades_to?(upgrade)).to eq(included)
+          upgrades.keys.each do |t|
+            tile = game.tile_by_id("#{t}-0") || Tile.for(t)
+
+            context "tile \"#{t}\"" do
+              upgrades.keys.each do |u|
+                upgrade = game.tile_by_id("#{u}-0") || Tile.for(t)
+
+                included = upgrades[t].include?(u)
+
+                it "can#{included ? '' : 'not'} upgrade to tile \"#{u}\"" do
+                  expect(tile.upgrades_to?(upgrade)).to eq(included)
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
This breaks a couple connection tests, but I don't entirely understand what's happening in those tests; added some questions in comments in aa40d57.

Still need to make green OO tiles upgradable to brown, so I'm marking this as a Draft PR. Additionally I now seem to be unable to run a route through both cities on a OO tile.

In this flie, it is C&A's turn, they cannot upgrade J4 or run through it twice, though both should be possible.
[cannot_run_or_upgrade_oo.json.txt](https://github.com/tobymao/18xx/files/4654826/cannot_run_or_upgrade_oo.json.txt)
