### PR TITLE
Change logic for share pass wording

### DIFF
--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -169,7 +169,7 @@ module Engine
       def log_pass(entity)
         return super if @current_actions.empty?
 
-        action = @current_actions.include?(Action::SellShares) ? 'buying' : 'selling'
+        action = !(@current_actions.include?(Action::BuyShare) || @current_actions.include?(Action::Par))? 'buying' : 'selling'
         @log << "#{entity.name} passes #{action} shares"
       end
     end

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -169,7 +169,11 @@ module Engine
       def log_pass(entity)
         return super if @current_actions.empty?
 
-        action = !(@current_actions.include?(Action::BuyShare) || @current_actions.include?(Action::Par))? 'buying' : 'selling'
+        action = if @current_actions.include?(Action::BuyShare) || @current_actions.include?(Action::Par)
+                   'selling'
+                 else
+                   'buying'
+                 end
         @log << "#{entity.name} passes #{action} shares"
       end
     end


### PR DESCRIPTION
```
sparr buys a 10% share of UR from the IPO for ¥90
sparr sells 4 shares UR and receives ¥440
UR's share price changes from ¥110 to ¥80
sparr passes buying shares
```

This came up in a game recently and sounded wrong. I have changed the logic so that it says you are passing buying if you could still buy, passing selling if you have bought.