### PR TITLE
Fix typo in Mitsubishi Ferry description

### DIFF
--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -231,7 +231,7 @@ module Engine
       "name": "Mitsubishi Ferry",
       "value": 30,
       "revenue": 5,
-      "desc": "Player owner may place the port tile on a coastal town (B11, G10, I12, or J9) without a tile on it already, outside of the operating rounds of a company controller by another player. The player need not control a company or have connectivity to the placed tile from one of their companies. This does not close the company.",
+      "desc": "Player owner may place the port tile on a coastal town (B11, G10, I12, or J9) without a tile on it already, outside of the operating rounds of a company controlled by another player. The player need not control a company or have connectivity to the placed tile from one of their companies. This does not close the company.",
       "sym": "MF",
       "abilities": [
         {


### PR DESCRIPTION
Going through the 1889 tutorial, I'm pretty sure I found a typo.

This PR changes
"outside of the operating rounds of a company **controller** by another player"
to
"outside of the operating rounds of a company **controlled** by another player"