### PR TITLE
Prevent duplicate Hotseat player names

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -95,7 +95,7 @@ module View
         players = params
           .select { |k, _| k.start_with?('player_') }
           .values
-          .map { |name| { name: name } }
+          .map { |name| name.gsub(/\s+/, ' ').strip }
 
         if players.any? { |name| players.count(name) > 1 }
           return store(:flash_opts, 'Cannot have duplicate player names')
@@ -114,7 +114,7 @@ module View
         end
 
         create_hotseat(
-          players: players,
+          players: players.map { |name| { name: name } },
           title: params[:title],
           description: params[:description],
           max_players: params[:max_players],

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -97,6 +97,10 @@ module View
           .values
           .map { |name| { name: name } }
 
+        if players.any? { |name| players.count(name) > 1 }
+          return store(:flash_opts, 'Cannot have duplicate player names')
+        end
+
         game_data = params['game_data']
 
         if game_data.empty?


### PR DESCRIPTION
Fixes tobymao/18xx#71

After I prevented strict duplicates, I realized it was still possible to add names that would appear identical such as `<space>Player<space>1` and `Player<space><space>1`. So I added a second commit to trim whitespace out of the name. That took the longest because I couldn't figure out why `.gsub(/[[:space:]]+/, " ")` wasn't working. Turns out it's not supported by Opel! 😢 

I haven't added any tests yet. I couldn't find anything existing in the `/spec` folder that mentioned the Hotseat feature or the CreateGame class. Let me know if that's a merge blocker.