### PR TITLE
View::Log scrolls to bottom via JavaScript

### DIFF
--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -11,6 +11,7 @@ module View
       end
 
       props = {
+        key: 'log',
         hook: {
           postpatch: ->(_, vnode) { scroll_to_bottom.call(vnode) },
         },

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -5,18 +5,16 @@ module View
     needs :log
 
     def render
-      reverse_scroll = lambda do |event|
-        %x{
-          var e = #{event}
-          e.preventDefault()
-          e.currentTarget.scrollTop -= e.deltaY
-        }
+      scroll_to_bottom = lambda do |vnode|
+        elm = Native(vnode)['elm']
+        elm.scrollTop = elm.scrollHeight
       end
 
       props = {
-        on: { wheel: reverse_scroll },
+        hook: {
+          postpatch: ->(_, vnode) { scroll_to_bottom.call(vnode) },
+        },
         style: {
-          transform: 'scaleY(-1)',
           overflow: 'auto',
           height: '200px',
           padding: '0.5rem',
@@ -25,11 +23,11 @@ module View
         },
       }
 
-      lines = @log.reverse.map do |line|
+      lines = @log.map do |line|
         if line.is_a?(String)
-          h(:div, { style: { transform: 'scaleY(-1)' } }, line)
+          h(:div, line)
         elsif line.is_a?(Engine::Action::Message)
-          h(:div, { style: { 'font-weight': 'bold', transform: 'scaleY(-1)' } }, "#{line.entity.name}: #{line.message}")
+          h(:div, { style: { 'font-weight': 'bold' } }, "#{line.entity.name}: #{line.message}")
         end
       end
 

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -3,6 +3,7 @@
 module View
   class Log < Snabberb::Component
     needs :log
+    needs :follow_scroll, default: true, store: true
 
     def render
       scroll_to_bottom = lambda do |vnode|
@@ -10,10 +11,17 @@ module View
         elm.scrollTop = elm.scrollHeight
       end
 
+      scroll_handler = lambda do
+        # can't seem to access the target of the event here
+      end
+
       props = {
         key: 'log',
         hook: {
-          postpatch: ->(_, vnode) { scroll_to_bottom.call(vnode) },
+          postpatch: ->(_, vnode) { scroll_to_bottom.call(vnode) if @follow_scroll },
+        },
+        on: {
+          scroll: scroll_handler
         },
         style: {
           overflow: 'auto',


### PR DESCRIPTION
Log is used in both chat and gameplay logs. The existing code
implemented scroll-to-bottom through CSS, which caused
problems with keyboard scrolling and copy-paste.

This commit removes the scroll-specific CSS, and replaces it
with a scroll_to_bottom lambda that is called in the postpatch
hook.

I'm new to Opal, so I have no idea if this is a reasonable solution!

Fixes #298 
Fixes #346