### PR TITLE
Fix tokens in OO upgrades [Fixes #464]

### DIFF
--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -79,16 +79,19 @@ module Engine
           end.to_h
         end
 
-      # when upgrading, preserve tokens (both reserved and actually placed) on
-      # previous tile
+      # when upgrading, preserve reservations on previous tile
       city_map.each do |old_city, new_city|
-        new_city.reservations = old_city.reservations.dup
+        new_city.reservations.concat(old_city.reservations)
+        old_city.reservations.clear
+      end
 
+      # when upgrading, preserve tokens on previous tile (must be handled after
+      # reservations are completely done due to OO weirdness)
+      city_map.each do |old_city, new_city|
         old_city.tokens.each do |token|
           new_city.exchange_token(token) if token
         end
         old_city.remove_tokens!
-        old_city.reservations.clear
       end
 
       @tile.hex = nil
@@ -98,6 +101,7 @@ module Engine
       # old one
       tile.location_name = @location_name
       @tile.location_name = nil
+
       @tile = tile
       clear_cache
       connect!

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -65,7 +65,7 @@ module Engine
       end
 
       def place_token(corporation)
-        raise GameError, "Cannot lay token on #{id}" unless tokenable?(corporation)
+        raise GameError, "#{corporation.name} cannot lay token on #{id}" unless tokenable?(corporation)
 
         token = corporation.next_token
         token.use!

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -115,6 +115,29 @@ module Engine
               'X5' => [0, 3],
             },
           },
+          {
+            game: '18Chesapeake',
+            desc: 'Baltimore green to brown w/ B&O and PRR tokens',
+            setup: {
+              hex: 'H6',
+              corporations: [
+                {
+                  name: 'B&O',
+                  token: 1,
+                  reservations_in_cities: nil,
+                },
+                {
+                  name: 'PRR',
+                  token: 0,
+                  reservations_in_cities: nil,
+                },
+              ],
+              tile: ['X3', 2],
+            },
+            tiles_with_rotations_to_lay: {
+              'X7' => [3],
+            },
+          },
         ].each do |spec|
           context "#{spec[:game]} #{spec[:desc]}" do
             let(:game) { GAMES_BY_TITLE[spec[:game]].new(%w[a b c]) }

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -158,9 +158,7 @@ module Engine
               # add initial corporation tokens
               spec[:setup][:corporations].each do |corp|
                 corporation = game.corporation_by_id(corp[:name])
-                unless corp[:token].nil?
-                  initial_tile.cities[corp[:token]].place_token(corporation)
-                end
+                initial_tile.cities[corp[:token]].place_token(corporation) unless corp[:token].nil?
               end
             end
 

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -135,6 +135,27 @@ module Engine
               'X7' => [3],
             },
           },
+          {
+            game: '18Chesapeake',
+            desc: 'Baltimore green to brown w/ PRR token and B&O reservation',
+            setup: {
+              hex: 'H6',
+              corporations: [
+                {
+                  name: 'B&O',
+                  token: nil,
+                },
+                {
+                  name: 'PRR',
+                  token: 0,
+                },
+              ],
+              tile: ['X3', 2],
+            },
+            tiles_with_rotations_to_lay: {
+              'X7' => [3],
+            },
+          },
         ].each do |spec|
           context "#{spec[:game]} #{spec[:desc]}" do
             let(:game) { GAMES_BY_TITLE[spec[:game]].new(%w[a b c]) }

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -217,22 +217,22 @@ module Engine
                   spec[:setup][:corporations].each do |corp|
                     corporation = game.corporation_by_id(corp[:name])
 
-                    if corp[:token]
-                      # check corp still has a token, grab the new city with
-                      # their token
-                      cities = tile.cities.select { |c| c.tokened_by?(corporation) }
-                      expect(cities.size).to eq(1)
-                      city = cities.first
+                    next unless corp[:token]
 
-                      # expect the connection between the edge and the bottom
-                      # city from the preprinted OO tile to still be present
-                      old_city = initial_tile.cities[corp[:token]]
-                      old_edges = old_city.exits
+                    # check corp still has a token, grab the new city with
+                    # their token
+                    cities = tile.cities.select { |c| c.tokened_by?(corporation) }
+                    expect(cities.size).to eq(1)
+                    city = cities.first
 
-                      # make sure all old edges are in the new city
-                      edges = city.exits
-                      expect(edges).to include(*old_edges)
-                    end
+                    # expect the connection between the edge and the bottom
+                    # city from the preprinted OO tile to still be present
+                    old_city = initial_tile.cities[corp[:token]]
+                    old_edges = old_city.exits
+
+                    # make sure all old edges are in the new city
+                    edges = city.exits
+                    expect(edges).to include(*old_edges)
                   end
                 end
               end

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -137,6 +137,27 @@ module Engine
           },
           {
             game: '18Chesapeake',
+            desc: 'Baltimore brown to gray w/ B&O and PRR tokens',
+            setup: {
+              hex: 'H6',
+              corporations: [
+                {
+                  name: 'B&O',
+                  token: 0,
+                },
+                {
+                  name: 'PRR',
+                  token: 0,
+                },
+              ],
+              tile: ['X7', 3],
+            },
+            tiles_with_rotations_to_lay: {
+              'X9' => [3],
+            },
+          },
+          {
+            game: '18Chesapeake',
             desc: 'Baltimore green to brown w/ PRR token and B&O reservation',
             setup: {
               hex: 'H6',

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -93,58 +93,92 @@ module Engine
         end
       end
 
-      context 'OO tile on 18Chesapeake J4 (Philadelphia)' do
-        let(:game) { GAMES_BY_TITLE['18Chesapeake'].new(%w[a b c]) }
+      context 'OO tiles' do
+        [
+          {
+            game: '18Chesapeake',
+            desc: 'Philadelphia yellow to green w/ C&A token in bottom city',
+            setup: {
+              hex: 'J4',
+              corporations: [
+                {
+                  name: 'C&A',
+                  token: 0,
+                  reservations_in_cities: nil,
+                },
+              ],
+              tile: ['preprinted', 0],
+            },
+            tiles_with_rotations_to_lay: {
+              'X3' => [0, 1, 3, 4],
+              'X4' => [0, 3],
+              'X5' => [0, 3],
+            },
+          },
+        ].each do |spec|
+          context "#{spec[:game]} #{spec[:desc]}" do
+            let(:game) { GAMES_BY_TITLE[spec[:game]].new(%w[a b c]) }
+            let(:hex) { game.hex_by_id(spec[:setup][:hex]) }
+            let(:initial_tile) do
+              tile_name, rotation = spec[:setup][:tile]
+              if tile_name == 'preprinted'
+                hex.tile
+              else
+                tile = game.tile_by_id("#{tile_name}-0")
+                tile.rotate!(rotation)
+                tile
+              end
+            end
 
-        # init C&A so it can token in Philly
-        let(:c_and_a) do
-          corp = game.corporation_by_id('C&A')
-          corp.cash = 40
-          corp
-        end
+            # setup
+            before(:each) do
+              # lay initial tile
+              hex.lay(initial_tile) unless hex.tile == initial_tile
 
-        subject { game.hex_by_id('J4') }
+              # add initial corporation tokens and reservations
+              spec[:setup][:corporations].each do |corp|
+                corporation = game.corporation_by_id(corp[:name])
 
-        # grab some properties form the preprinted OO tile
-        let(:old_tile) { subject.tile }
-        let(:old_city) { old_tile.cities.find { |c| c.tokenable?(c_and_a) } }
-        let(:old_edge) do
-          old_path = old_tile.paths.find { |p| p.city == old_city }
-          old_path.exits.first
-        end
+                initial_tile.cities[corp[:reservations]].add_reservation!(corporation.sym) unless corp[:reservations].nil?
 
-        before(:each) do
-          # place C&A's home token
-          game.hex_by_id('J6').tile.cities[0].place_token(c_and_a)
+                unless corp[:token].nil?
+                  initial_tile.cities[corp[:token]].place_token(corporation)
+                end
+              end
+            end
 
-          # place token on the preprinted OO tile
-          old_city.place_token(c_and_a)
-        end
+            spec[:tiles_with_rotations_to_lay].each do |tile_name, rotations|
+              rotations.each do |rotation|
+                it "correctly lays #{tile_name} with rotation #{rotation}" do
+                  # get the tile and rotate it
+                  tile = game.tile_by_id("#{tile_name}-0")
+                  tile.rotate!(rotation)
 
-        {
-          'X3' => [0, 1, 3, 4],
-          'X4' => [0, 3],
-          'X5' => [0, 3],
-        }.each do |tile_name, rotations|
-          rotations.each do |rotation|
-            it "correctly lays #{tile_name} with rotation #{rotation}" do
-              # get the tile and rotate it
-              tile = game.tile_by_id("#{tile_name}-0")
-              tile.rotate!(rotation)
+                  # lay it
+                  hex.lay(tile)
 
-              # lay it
-              subject.lay(tile)
+                  spec[:setup][:corporations].each do |corp|
+                    corporation = game.corporation_by_id(corp[:name])
 
-              # grab the city that C&A's token is on
-              cities = tile.cities.select { |c| c.tokened_by?(c_and_a) }
-              expect(cities.size).to eq(1)
-              city = cities.first
+                    if corp[:token]
+                      # check corp still has a token, grab the new city with
+                      # their token
+                      cities = tile.cities.select { |c| c.tokened_by?(corporation) }
+                      expect(cities.size).to eq(1)
+                      city = cities.first
 
-              # expect the connection between the edge and the bottom city
-              # from the preprinted OO tile to still be present
-              edges = city.exits
-              expect(edges.size).to eq(2)
-              expect(edges).to include(old_edge)
+                      # expect the connection between the edge and the bottom
+                      # city from the preprinted OO tile to still be present
+                      old_city = initial_tile.cities[corp[:token]]
+                      old_edges = old_city.exits
+
+                      # make sure all old edges are in the new city
+                      edges = city.exits
+                      expect(edges).to include(*old_edges)
+                    end
+                  end
+                end
+              end
             end
           end
         end

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -104,7 +104,6 @@ module Engine
                 {
                   name: 'C&A',
                   token: 0,
-                  reservations_in_cities: nil,
                 },
               ],
               tile: ['preprinted', 0],
@@ -124,12 +123,10 @@ module Engine
                 {
                   name: 'B&O',
                   token: 1,
-                  reservations_in_cities: nil,
                 },
                 {
                   name: 'PRR',
                   token: 0,
-                  reservations_in_cities: nil,
                 },
               ],
               tile: ['X3', 2],
@@ -158,12 +155,9 @@ module Engine
               # lay initial tile
               hex.lay(initial_tile) unless hex.tile == initial_tile
 
-              # add initial corporation tokens and reservations
+              # add initial corporation tokens
               spec[:setup][:corporations].each do |corp|
                 corporation = game.corporation_by_id(corp[:name])
-
-                initial_tile.cities[corp[:reservations]].add_reservation!(corporation.sym) unless corp[:reservations].nil?
-
                 unless corp[:token].nil?
                   initial_tile.cities[corp[:token]].place_token(corporation)
                 end


### PR DESCRIPTION
* fix how tokens and reservations are moved from cities on one tile to the upgrade tile
* add corporation name to `place_token` error
* rewrite existing OO specs such that additional specs can be added by adding hashes with the same structure to the list
* add spec exactly matching the scenario in #464 
* add spec for upgrading Baltimore from brown to gray
* add spec like #464, only with B&O only holding the reservation there, not having placed its token