### PR TITLE
feat: ability to define colors for a game

### DIFF
--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -92,7 +92,40 @@ module Engine
     }
   },
   "market": [
-    []
+    [
+      "0",
+      "40",
+      "40",
+      "40",
+      "40",
+      "45",
+      "50",
+      "55",
+      "60",
+      "65",
+      "70",
+      "80",
+      "90",
+      "100",
+      "110",
+      "120",
+      "135",
+      "150",
+      "165",
+      "180",
+      "200",
+      "220",
+      "245",
+      "270",
+      "300",
+      "330",
+      "360",
+      "400",
+      "440",
+      "490",
+      "540",
+      "600"
+    ]
   ],
   "companies": [],
   "corporations": [
@@ -106,7 +139,7 @@ module Engine
         0,
         0
       ],
-      "color": "rgb(193,60,125)"
+      "color": "pink"
     },
     {
       "float_percent": 20,
@@ -118,7 +151,7 @@ module Engine
         0,
         0
       ],
-      "color": "#e09001"
+      "color": "gold"
     },
     {
       "float_percent": 20,
@@ -130,7 +163,7 @@ module Engine
         0,
         0
       ],
-      "color": "#f48221"
+      "color": "orange"
     },
     {
       "float_percent": 20,
@@ -142,7 +175,7 @@ module Engine
         0,
         0
       ],
-      "color": "#37383a"
+      "color": "black"
     },
     {
       "float_percent": 20,
@@ -154,7 +187,7 @@ module Engine
         0,
         0
       ],
-      "color": "#d81e3e"
+      "color": "red"
     },
     {
       "float_percent": 20,
@@ -166,7 +199,7 @@ module Engine
         0,
         0
       ],
-      "color": "#7b352a"
+      "color": "brown"
     },
     {
       "float_percent": 20,
@@ -178,7 +211,7 @@ module Engine
         0,
         0
       ],
-      "color": "#237333"
+      "color": "green"
     },
     {
       "float_percent": 20,
@@ -190,7 +223,7 @@ module Engine
         0,
         0
       ],
-      "color": "#7f528b"
+      "color": "violet"
     },
     {
       "float_percent": 20,
@@ -202,7 +235,7 @@ module Engine
         0,
         0
       ],
-      "color": "#37b2e2"
+      "color": "lightBlue"
     },
     {
       "float_percent": 20,
@@ -214,7 +247,7 @@ module Engine
         0,
         0
       ],
-      "color": "#f8c200"
+      "color": "yellow"
     },
     {
       "float_percent": 20,
@@ -226,7 +259,7 @@ module Engine
         0,
         0
       ],
-      "color": "#00a99e"
+      "color": "turquoise"
     },
     {
       "float_percent": 20,
@@ -238,7 +271,7 @@ module Engine
         0,
         0
       ],
-      "color": "#9a9a9d"
+      "color": "white"
     },
     {
       "float_percent": 20,
@@ -250,7 +283,7 @@ module Engine
         0,
         0
       ],
-      "color": "#76a042"
+      "color": "brightGreen"
     },
     {
       "float_percent": 20,
@@ -262,7 +295,7 @@ module Engine
         0,
         0
       ],
-      "color": "#bdbd00"
+      "color": "lime"
     },
     {
       "float_percent": 20,
@@ -274,7 +307,7 @@ module Engine
         0,
         0
       ],
-      "color": "#b58168"
+      "color": "lightBrown"
     },
     {
       "float_percent": 20,
@@ -286,7 +319,7 @@ module Engine
         0,
         0
       ],
-      "color": "#0189d1"
+      "color": "blue"
     },
     {
       "float_percent": 20,
@@ -298,7 +331,7 @@ module Engine
         0,
         0
       ],
-      "color": "#fbf4de"
+      "color": "natural"
     },
     {
       "float_percent": 20,
@@ -310,7 +343,7 @@ module Engine
         0,
         0
       ],
-      "color": "#004d95"
+      "color": "navy"
     },
     {
       "float_percent": 20,
@@ -322,7 +355,7 @@ module Engine
         0,
         0
       ],
-      "color": "#baa4cb"
+      "color": "lavender"
     },
     {
       "float_percent": 20,
@@ -334,7 +367,7 @@ module Engine
         0,
         0
       ],
-      "color": "#baa4cb"
+      "color": "lavender"
     }
   ],
   "trains": [

--- a/lib/engine/config/game/g_1830.rb
+++ b/lib/engine/config/game/g_1830.rb
@@ -349,7 +349,7 @@ module Engine
       "float_percent": 60,
       "sym": "B&O",
       "name": "Baltimore & Ohio Railroad",
-      "logo": "1830/B&O",
+      "logo": "1830/BO",
       "tokens": [
         0,
         40,
@@ -362,7 +362,7 @@ module Engine
       "float_percent": 60,
       "sym": "C&O",
       "name": "Chesapeake & Ohio Railroad",
-      "logo": "1830/C&O",
+      "logo": "1830/CO",
       "tokens": [
         0,
         40,
@@ -400,7 +400,7 @@ module Engine
       "float_percent": 60,
       "sym": "B&M",
       "name": "Boston & Maine Railroad",
-      "logo": "1830/B&M",
+      "logo": "1830/BM",
       "tokens": [
         0,
         40

--- a/lib/engine/config/game/g_1830.rb
+++ b/lib/engine/config/game/g_1830.rb
@@ -315,7 +315,7 @@ module Engine
         100
       ],
       "coordinates": "H12",
-      "color": "#237333"
+      "color": "green"
     },
     {
       "float_percent": 60,
@@ -329,7 +329,7 @@ module Engine
         100
       ],
       "coordinates": "E19",
-      "color": "#37383a"
+      "color": "black"
     },
     {
       "float_percent": 60,
@@ -343,33 +343,33 @@ module Engine
         100
       ],
       "coordinates": "A19",
-      "color": "#d81e3e"
+      "color": "red"
     },
     {
       "float_percent": 60,
       "sym": "B&O",
       "name": "Baltimore & Ohio Railroad",
-      "logo": "1830/BO",
+      "logo": "1830/B&O",
       "tokens": [
         0,
         40,
         100
       ],
       "coordinates": "I15",
-      "color": "#0189d1"
+      "color": "blue"
     },
     {
       "float_percent": 60,
       "sym": "C&O",
       "name": "Chesapeake & Ohio Railroad",
-      "logo": "1830/CO",
+      "logo": "1830/C&O",
       "tokens": [
         0,
         40,
         100
       ],
       "coordinates": "F6",
-      "color": "#37b2e2"
+      "color": "lightBlue"
     },
     {
       "float_percent": 60,
@@ -382,7 +382,7 @@ module Engine
         100
       ],
       "coordinates": "E11",
-      "color": "#f8c200"
+      "color": "yellow"
     },
     {
       "float_percent": 60,
@@ -394,19 +394,19 @@ module Engine
         40
       ],
       "coordinates": "G19",
-      "color": "#f48221"
+      "color": "orange"
     },
     {
       "float_percent": 60,
       "sym": "B&M",
       "name": "Boston & Maine Railroad",
-      "logo": "1830/BM",
+      "logo": "1830/B&M",
       "tokens": [
         0,
         40
       ],
       "coordinates": "E23",
-      "color": "#76a042"
+      "color": "brightGreen"
     }
   ],
   "trains": [

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -224,7 +224,7 @@ module Engine
         0
       ],
       "coordinates": "F20",
-      "color": "#d81e3e"
+      "color": "red"
     },
     {
       "float_percent": 20,
@@ -237,13 +237,13 @@ module Engine
         80
       ],
       "coordinates": "D20",
-      "color": "#37383a"
+      "color": "black"
     },
     {
       "float_percent": 20,
       "sym": "B&O",
       "name": "Baltimore & Ohio",
-      "logo": "1846/BO",
+      "logo": "1846/B&O",
       "tokens": [
         0,
         80,
@@ -251,20 +251,21 @@ module Engine
         0
       ],
       "coordinates": "G19",
-      "color": "#0189d1"
+      "color": "blue"
     },
     {
       "float_percent": 20,
       "sym": "C&O",
       "name": "Chesapeake & Ohio",
-      "logo": "1846/CO",
+      "logo": "1846/C&O",
       "tokens": [
         0,
         80,
         80,
         80
       ],
-      "coordinates": "I15"
+      "coordinates": "I15",
+      "color": "lightBlue"
     },
     {
       "float_percent": 20,
@@ -277,7 +278,7 @@ module Engine
         0
       ],
       "coordinates": "E21",
-      "color": "#f8c200"
+      "color": "yellow"
     },
     {
       "float_percent": 20,
@@ -289,7 +290,7 @@ module Engine
         80
       ],
       "coordinates": "B16",
-      "color": "#f48221"
+      "color": "orange"
     },
     {
       "float_percent": 20,
@@ -302,12 +303,12 @@ module Engine
         0
       ],
       "coordinates": "K3",
-      "color": "#237333"
+      "color": "green"
     }
   ],
   "trains": [
     {
-      "name": "2: Big 4",
+      "name": "2",
       "distance": 2,
       "price": 0,
       "rusts_on": [
@@ -317,7 +318,7 @@ module Engine
       "num": 1
     },
     {
-      "name": "2: MS",
+      "name": "2",
       "distance": 2,
       "price": 0,
       "rusts_on": [
@@ -520,14 +521,14 @@ module Engine
   },
   "phases": [
     {
-      "name": "Yellow",
+      "name": "1",
       "train_limit": 4,
       "tiles": [
         "yellow"
       ]
     },
     {
-      "name": "Green",
+      "name": "2",
       "train_limit": 4,
       "tiles": [
         "yellow",
@@ -535,23 +536,29 @@ module Engine
       ]
     },
     {
-      "name": "Brown",
+      "name": "3",
       "train_limit": 3,
       "tiles": [
         "yellow",
         "green",
         "brown"
-      ]
+      ],
+      "events": {
+        "close_companies": true
+      }
     },
     {
-      "name": "Gray",
+      "name": "4",
       "train_limit": 2,
       "tiles": [
         "yellow",
         "green",
         "brown",
         "gray"
-      ]
+      ],
+      "events": {
+        "remove_tokens": true
+      }
     }
   ]
 }

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -265,7 +265,8 @@ module Engine
         80
       ],
       "coordinates": "I15",
-      "color": "lightBlue"
+      "color": "lightBlue",
+      "text_color": "black"
     },
     {
       "float_percent": 20,
@@ -278,7 +279,8 @@ module Engine
         0
       ],
       "coordinates": "E21",
-      "color": "yellow"
+      "color": "yellow",
+      "text_color": "black"
     },
     {
       "float_percent": 20,

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -243,7 +243,7 @@ module Engine
       "float_percent": 20,
       "sym": "B&O",
       "name": "Baltimore & Ohio",
-      "logo": "1846/B&O",
+      "logo": "1846/BO",
       "tokens": [
         0,
         80,
@@ -257,7 +257,7 @@ module Engine
       "float_percent": 20,
       "sym": "C&O",
       "name": "Chesapeake & Ohio",
-      "logo": "1846/C&O",
+      "logo": "1846/CO",
       "tokens": [
         0,
         80,

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -231,7 +231,7 @@ module Engine
       "name": "Mitsubishi Ferry",
       "value": 30,
       "revenue": 5,
-      "desc": "Player owner may place the port tile on a coastal town (B11, G10, I12, or J9) without a tile on it already, outside of the operating rounds of a corporation controlled by another player. The player need not control a corporation or have connectivity to the placed tile from one of their corporations. This does not close the company.",
+      "desc": "Player owner may place the port tile on a coastal town (B11, G10, I12, or J9) without a tile on it already, outside of the operating rounds of a corporation controlled by another player. The player need not control a corporation or have connectivity to the placed tile from one of their corporations. This does not close the corporation.",
       "sym": "MF",
       "abilities": [
         {
@@ -344,7 +344,7 @@ module Engine
         40
       ],
       "coordinates": "K8",
-      "color": "#37383a"
+      "color": "black"
     },
     {
       "float_percent": 50,
@@ -356,7 +356,7 @@ module Engine
         40
       ],
       "coordinates": "E2",
-      "color": "#f48221"
+      "color": "orange"
     },
     {
       "float_percent": 50,
@@ -368,7 +368,7 @@ module Engine
         40
       ],
       "coordinates": "I2",
-      "color": "#76a042"
+      "color": "brightGreen"
     },
     {
       "float_percent": 50,
@@ -380,7 +380,7 @@ module Engine
         40
       ],
       "coordinates": "K4",
-      "color": "#d81e3e"
+      "color": "red"
     },
     {
       "float_percent": 50,
@@ -393,7 +393,7 @@ module Engine
         40
       ],
       "coordinates": "F9",
-      "color": "#00a99e"
+      "color": "turquoise"
     },
     {
       "float_percent": 50,
@@ -404,7 +404,7 @@ module Engine
         0
       ],
       "coordinates": "C10",
-      "color": "#0189d1"
+      "color": "blue"
     },
     {
       "float_percent": 50,
@@ -417,7 +417,7 @@ module Engine
         40
       ],
       "coordinates": "B7",
-      "color": "#7b352a"
+      "color": "brown"
     }
   ],
   "trains": [

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -231,7 +231,7 @@ module Engine
       "name": "Mitsubishi Ferry",
       "value": 30,
       "revenue": 5,
-      "desc": "Player owner may place the port tile on a coastal town (B11, G10, I12, or J9) without a tile on it already, outside of the operating rounds of a corporation controlled by another player. The player need not control a corporation or have connectivity to the placed tile from one of their corporations. This does not close the corporation.",
+      "desc": "Player owner may place the port tile on a coastal town (B11, G10, I12, or J9) without a tile on it already, outside of the operating rounds of a corporation controlled by another player. The player need not control a corporation or have connectivity to the placed tile from one of their corporations. This does not close the company.",
       "sym": "MF",
       "abilities": [
         {

--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -401,7 +401,7 @@ module Engine
       "float_percent": 60,
       "sym": "B&O",
       "name": "Baltimore & Ohio Railroad",
-      "logo": "18_chesapeake/B&O",
+      "logo": "18_chesapeake/BO",
       "tokens": [
         0,
         40,
@@ -414,7 +414,7 @@ module Engine
       "float_percent": 60,
       "sym": "C&O",
       "name": "Chesapeake & Ohio Railroad",
-      "logo": "18_chesapeake/C&O",
+      "logo": "18_chesapeake/CO",
       "tokens": [
         0,
         40,
@@ -442,7 +442,7 @@ module Engine
       "float_percent": 60,
       "sym": "C&A",
       "name": "Camden & Amboy Railroad",
-      "logo": "18_chesapeake/C&A",
+      "logo": "18_chesapeake/CA",
       "tokens": [
         0,
         40
@@ -454,7 +454,7 @@ module Engine
       "float_percent": 60,
       "sym": "N&W",
       "name": "Norfolk & Western Railway",
-      "logo": "18_chesapeake/N&W",
+      "logo": "18_chesapeake/NW",
       "tokens": [
         0,
         40,

--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -320,8 +320,12 @@ module Engine
         {
           "type": "teleport",
           "owner_type": "corporation",
-          "tiles": ["57"],
-          "hexes": ["D2"]
+          "tiles": [
+            "57"
+          ],
+          "hexes": [
+            "D2"
+          ]
         }
       ]
     },
@@ -347,7 +351,9 @@ module Engine
           "type": "share",
           "share": "random-president"
         },
-        { "type": "no_buy" }
+        {
+          "type": "no_buy"
+        }
       ]
     }
   ],
@@ -364,7 +370,7 @@ module Engine
         80
       ],
       "coordinates": "F2",
-      "color": "#237333"
+      "color": "green"
     },
     {
       "float_percent": 60,
@@ -389,7 +395,7 @@ module Engine
         40
       ],
       "coordinates": "H4",
-      "color": "#d81e3e"
+      "color": "red"
     },
     {
       "float_percent": 60,
@@ -402,7 +408,7 @@ module Engine
         60
       ],
       "coordinates": "H6",
-      "color": "#0189d1"
+      "color": "blue"
     },
     {
       "float_percent": 60,
@@ -416,7 +422,7 @@ module Engine
         80
       ],
       "coordinates": "G13",
-      "color": "#A2DCED",
+      "color": "lightBlue",
       "text_color": "black"
     },
     {
@@ -429,7 +435,7 @@ module Engine
         40
       ],
       "coordinates": "J2",
-      "color": "#FFF500",
+      "color": "yellow",
       "text_color": "black"
     },
     {
@@ -442,7 +448,7 @@ module Engine
         40
       ],
       "coordinates": "J6",
-      "color": "#f48221"
+      "color": "orange"
     },
     {
       "float_percent": 60,
@@ -455,7 +461,7 @@ module Engine
         60
       ],
       "coordinates": "C13",
-      "color": "#7b352a"
+      "color": "brown"
     }
   ],
   "trains": [
@@ -691,7 +697,8 @@ module Engine
       "tiles": [
         "yellow",
         "green",
-        "brown"
+        "brown",
+        "gray"
       ],
       "operating_rounds": 3
     }

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -79,6 +79,14 @@ module Engine
         name.split('::').last.slice(1..-1)
       end
 
+      def self.register_colors(colors)
+        colors.default_proc = proc do |_, key|
+          key
+        end
+
+        const_set(:COLORS, colors)
+      end
+
       def self.load_from_json(json)
         data = JSON.parse(json)
 
@@ -110,8 +118,12 @@ module Engine
           company
         end
 
-        data['corporations'].map! do |company|
-          company.transform_keys!(&:to_sym)
+        data['corporations'].map! do |corporation|
+          corporation.transform_keys!(&:to_sym)
+
+          corporation[:color] = const_get(:COLORS)[corporation[:color]] if const_defined?(:COLORS)
+
+          corporation
         end
 
         data['hexes'].transform_keys!(&:to_sym)

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -6,6 +6,27 @@ require_relative 'base'
 module Engine
   module Game
     class G1817 < Base
+      register_colors(black: '#0a0a0a',
+                      blue: '#0a70b3',
+                      brightGreen: '#7bb137',
+                      brown: '#881a1e',
+                      gold: '#e09001',
+                      gray: '#9a9a9d',
+                      green: '#008f4f',
+                      lavender: '#baa4cb',
+                      lightBlue: '#37b2e2',
+                      lightBrown: '#b58168',
+                      lime: '#bdbd00',
+                      navy: '#004d95',
+                      natural: '#fbf4de',
+                      orange: '#eb6f0e',
+                      pink: '#ec767c',
+                      red: '#dd0030',
+                      turquoise: '#235758',
+                      violet: '#4d2674',
+                      white: '#ffffff',
+                      yellow: '#fcea18')
+
       load_from_json(Config::Game::G1817::JSON)
     end
   end

--- a/lib/engine/game/g_1830.rb
+++ b/lib/engine/game/g_1830.rb
@@ -6,6 +6,15 @@ require_relative 'base'
 module Engine
   module Game
     class G1830 < Base
+      register_colors(red: '#d1232a',
+                      orange: '#f58121',
+                      black: '#110a0c',
+                      blue: '#025aaa',
+                      lightBlue: '#8dd7f6',
+                      yellow: '#ffe600',
+                      green: '#32763f',
+                      brightGreen: 'rgb(110,192,55)')
+
       load_from_json(Config::Game::G1830::JSON)
     end
   end

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -8,6 +8,14 @@ require_relative 'base'
 module Engine
   module Game
     class G1846 < Base
+      register_colors(red: '#d1232a',
+                      orange: '#f58121',
+                      black: '#110a0c',
+                      blue: '#025aaa',
+                      lightBlue: '#8dd7f6',
+                      yellow: '#ffe600',
+                      green: '#32763f')
+
       load_from_json(Config::Game::G1846::JSON)
     end
   end

--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -6,6 +6,14 @@ require_relative 'base'
 module Engine
   module Game
     class G1889 < Base
+      register_colors(black: '#37383a',
+                      orange: '#f48221',
+                      brightGreen: '#76a042',
+                      red: '#d81e3e',
+                      turquoise: '#00a993',
+                      blue: '#0189d1',
+                      brown: '#7b352a')
+
       load_from_json(Config::Game::G1889::JSON)
 
       DEV_STAGE = :beta

--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -6,6 +6,14 @@ require_relative 'base'
 module Engine
   module Game
     class G18Chesapeake < Base
+      register_colors(green: '#237333',
+                      red: '#d81e3e',
+                      blue: '#0189d1',
+                      lightBlue: '#a2dced',
+                      yellow: '#FFF500',
+                      orange: '#f48221',
+                      brown: '#7b352a')
+
       load_from_json(Config::Game::G18Chesapeake::JSON)
 
       DEV_STAGE = :alpha


### PR DESCRIPTION
This uses the colors names from 18xx-maker in the game definition, which WILL pass through if not defined. This means if we don't define colors the svg will just use `red` or `green` and the like. However now you can call `register_colors` to define the colors for this game in the game file. I did it for 1889 and 18Chesapeake.

For 1889 and 18Chesapeake I used the colors currently used.
For 1846 and 1830 I used the GMT color scheme from 18xx-maker.
For 1817 I used every Rails on Board token color (one for each of the 20), we will probably change this if you want to use AAG's colors of course.

At least now changing that is just on your side 👍 