### PR TITLE
[issue_474] game_card: comma-separate player names

### DIFF
--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -137,11 +137,11 @@ module View
 
       index = players.size
       p_elm = players.map do |player|
-        index = index - 1
+        index -= 1
         elm = h(
           acting?(player) ? :u : :span,
           { style: { 'margin-right': '0.5rem' } },
-          player['name'] + (index > 0 ? ',' : ''),
+          player['name'] + (index.positive? ? ',' : ''),
         )
 
         if owner? && new? && player['id'] != @user['id']
@@ -156,6 +156,7 @@ module View
 
         elm
       end
+      p_elm.join(',')
 
       children = [
         h(:div, [h(:b, 'Id: '), @gdata['id'].to_s]),

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -135,13 +135,12 @@ module View
         }
       }
 
-      index = players.size
-      p_elm = players.map do |player|
-        index -= 1
+      p_elm = []
+      players.each_with_index do |player, index|
         elm = h(
           acting?(player) ? :u : :span,
           { style: { 'margin-right': '0.5rem' } },
-          player['name'] + (index.positive? ? ',' : ''),
+          player['name'] + (index != (players.length - 1) ? ',' : ''),
         )
 
         if owner? && new? && player['id'] != @user['id']
@@ -154,7 +153,7 @@ module View
           elm = h('button.button', button_props, [elm])
         end
 
-        elm
+        p_elm << elm
       end
 
       children = [

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -135,8 +135,7 @@ module View
         }
       }
 
-      p_elm = []
-      players.each_with_index do |player, index|
+      p_elm = players.map.with_index do |player, index|
         elm = h(
           acting?(player) ? :u : :span,
           { style: { 'margin-right': '0.5rem' } },
@@ -153,7 +152,7 @@ module View
           elm = h('button.button', button_props, [elm])
         end
 
-        p_elm << elm
+        elm
       end
 
       children = [

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -156,7 +156,6 @@ module View
 
         elm
       end
-      p_elm.join(',')
 
       children = [
         h(:div, [h(:b, 'Id: '), @gdata['id'].to_s]),

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -135,11 +135,13 @@ module View
         }
       }
 
+      index = players.size
       p_elm = players.map do |player|
+        index = index - 1
         elm = h(
           acting?(player) ? :u : :span,
           { style: { 'margin-right': '0.5rem' } },
-          player['name'],
+          player['name'] + (index > 0 ? ',' : ''),
         )
 
         if owner? && new? && player['id'] != @user['id']


### PR DESCRIPTION
fixes #474

Please let me know if there's a more idiomatic way of doing this. I tried post-processing it, but this resulted in an extra space between the name and the succeeding comma:
`p_elm = p_elm.zip((',' * (p_elm.size - 1)).chars).flatten.compact`