### PR TITLE
Add special case for rendering location name with one town on tile, fixes tile 437 and 58

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,7 +31,12 @@ Some app routes that may be of interest to developers:
 
 Additionally, where the above routes take a `<hex_coord>` or `<tile_name>`,
 multiple can be given by separating them with `+`, and hex coords and tile names
-can be mix and matched with `+`.
+can be mix and matched with `+`. Those routes also accept URL params `r` and
+`n`. `r` sets the rotation to render; `all` can be given, or multiple numbers
+can be given, separated by `+`. `n` specifies the location name to render on the
+tile, but this will not override an existing location name (e.g.,
+`/tiles/1889/I4?n=Exampleville` will always display "Kotohira" instead of
+"Exampleville")
 
 ### Docker
 

--- a/assets/app/view/part/location_name.rb
+++ b/assets/app/view/part/location_name.rb
@@ -121,6 +121,8 @@ module View
             down55,
             up56,
           ]
+        elsif @tile.towns.size == 1
+          default + [up63, down55]
         else
           default
         end

--- a/assets/app/view/tile_manifest.rb
+++ b/assets/app/view/tile_manifest.rb
@@ -10,10 +10,10 @@ module View
     def render
       remaining = @tiles.group_by(&:name)
 
-      children = @all_tiles.sort.group_by(&:name).map do |name, tiles|
+      children = @all_tiles.sort.group_by(&:name).flat_map do |name, tiles|
         num = remaining[name]&.size || 0
         opacity = num.positive? ? 1.0 : 0.5
-        render_tile_block(name, tile: tiles.first, num: num, opacity: opacity)
+        render_tile_blocks(name, tile: tiles.first, num: num, opacity: opacity)
       end
 
       h('div#tile_manifest', children)

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -2,7 +2,7 @@
 
 module View
   class Tiles < Snabberb::Component
-    def render_tile_block(name, num: nil, tile: nil, location_name: nil, scale: 1.0, opacity: 1.0)
+    def render_tile_blocks(name, num: nil, tile: nil, location_name: nil, scale: 1.0, opacity: 1.0, rotations: nil)
       props = {
         style: {
           display: 'inline-block',
@@ -15,24 +15,36 @@ module View
         },
       }
 
-      text = num ? "##{name} × #{num}" : name
+      tile ||= Engine::Tile.for(name)
+      location_name ||= tile.location_name
 
-      h(:div, props, [
-          h(:div, { style: { 'text-align': 'center', 'font-size': '12px' } }, text),
-          h(:svg, { style: { width: '100%', height: '100%' } }, [
-            h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
-              h(
-                Hex,
-                hex: Engine::Hex.new('A1',
-                                     layout: 'flat',
-                                     location_name: location_name,
-                                     tile: tile || Engine::Tile.for(name)),
-                role: :tile_page,
-                opacity: opacity,
-              )
+      # setting [0] as default value in function arg doesn't work
+      rotations ||= [0]
+
+      rotations.map do |rotation|
+        tile.rotate!(rotation)
+
+        text = name.dup
+        text += "-#{rotation}" if rotations.size > 1
+        text += " × #{num}" if num
+
+        h(:div, props, [
+            h(:div, { style: { 'text-align': 'center', 'font-size': '12px' } }, text),
+            h(:svg, { style: { width: '100%', height: '100%' } }, [
+              h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
+                h(
+                  Hex,
+                  hex: Engine::Hex.new('A1',
+                                       layout: 'flat',
+                                       location_name: location_name,
+                                       tile: tile),
+                  role: :tile_page,
+                  opacity: opacity,
+                )
+              ])
             ])
-          ])
-      ])
+        ])
+      end
     end
   end
 end

--- a/assets/app/view/tiles_page.rb
+++ b/assets/app/view/tiles_page.rb
@@ -2,6 +2,7 @@
 
 require_tree 'engine'
 
+require 'lib/params'
 require 'view/tile_manifest'
 require 'view/tiles'
 
@@ -25,12 +26,27 @@ module View
       dest = match[1]
       hexes_or_tiles = match[2]
 
+      # parse URL params 'r' and 'n'; but don't apply them to /tiles/all, are
+      # you trying to kill your browser?
+      @rotations =
+        case (r = Lib::Params['r'])
+        when nil
+          [0]
+        when 'all'
+          (0..5).to_a
+        else
+          # apparently separating rotations in URL with '+' works by passing ' '
+          # to split here
+          r.split(' ').map(&:to_i)
+        end
+      @location_name = Lib::Params['n']
+
       # all common hexes/tiles
       if dest == 'all'
         h('div#tiles', [
             h('div#all_tiles', [
                 h(:h1, 'Generic Map Hexes and Common Track Tiles'),
-                *TILE_IDS.map { |t| render_tile_block(t) }
+                *TILE_IDS.flat_map { |t| render_tile_blocks(t) }
               ]),
 
           ])
@@ -39,7 +55,7 @@ module View
       elsif hexes_or_tiles
         game_title = dest
         hex_or_tile_ids = hexes_or_tiles.split('+')
-        rendered = hex_or_tile_ids.map { |id| render_individual_tile(game_title, id) }
+        rendered = hex_or_tile_ids.flat_map { |id| render_individual_tile_from_game(game_title, id) }
         h('div#tiles', rendered)
 
       # everything for one game
@@ -52,12 +68,19 @@ module View
       # common tile(s)
       else
         tile_ids = dest.split('+')
-        rendered = tile_ids.map { |id| render_tile_block(id, scale: 3.0) }
+        rendered = tile_ids.flat_map do |id|
+          render_tile_blocks(
+            id,
+            scale: 3.0,
+            rotations: @rotations,
+            location_name: @location_name,
+          )
+        end
         h('div#tiles', rendered)
       end
     end
 
-    def render_individual_tile(game_title, dest)
+    def render_individual_tile_from_game(game_title, dest)
       game = Engine::GAMES_BY_TITLE[game_title].new(%w[p1 p2 p3])
 
       # TODO?: handle case with big map and uses X for game-specific tiles
@@ -71,11 +94,12 @@ module View
           [t, dest]
         end
 
-      render_tile_block(
+      render_tile_blocks(
         name,
         tile: tile,
-        location_name: tile.location_name,
-        scale: 3.0
+        location_name: tile.location_name || @location_name,
+        scale: 3.0,
+        rotations: @rotations,
       )
     end
 
@@ -111,16 +135,16 @@ module View
         tile
       end
 
-      rendered_map_hexes = map_hexes.sort.map do |tile|
-        render_tile_block(
+      rendered_map_hexes = map_hexes.sort.flat_map do |tile|
+        render_tile_blocks(
           tile.name,
           tile: tile,
           location_name: tile.location_name
         )
       end
 
-      rendered_tiles = game.tiles.sort.group_by(&:name).map do |name, tiles_|
-        render_tile_block(name, tile: tiles_.first, num: tiles_.size)
+      rendered_tiles = game.tiles.sort.group_by(&:name).flat_map do |name, tiles_|
+        render_tile_blocks(name, tile: tiles_.first, num: tiles_.size)
       end
 
       h("div#hexes_and_tiles_#{game_class.title}", [


### PR DESCRIPTION
Also allow the `/tiles` routes that render one or more `+`-separated tiles to take URL params `r` and `n` to specify rotation and location name. `r` can be `all` or `+`-separated integers, and `n` will be applied to all tiles that do not already have a location name (e.g., `/tiles/1889/I4` will always render "Kotohira")

![Screenshot from 2020-05-24 17-28-01](https://user-images.githubusercontent.com/1045173/82767313-f4e4e500-9de3-11ea-9956-b4afc6c541f3.png)

437 with rotation 3 still isn't ideal, but better than the current situation.

[Fixes #383]
[Fixes #404]
[Fixes #480]

