### PR TITLE
Restore # prefix to tile IDs

### DIFF
--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -24,7 +24,7 @@ module View
       rotations.map do |rotation|
         tile.rotate!(rotation)
 
-        text = name.dup
+        text = "##{name}"
         text += "-#{rotation}" if rotations.size > 1
         text += " × #{num}" if num
 


### PR DESCRIPTION
Was originally added with https://github.com/tobymao/18xx/commit/3af74892f41beed7cccec7c9894c7be80692dbdb, then accidentally (I presume) undone with https://github.com/tobymao/18xx/commit/f034cc3c3d07384ada590fb0dabc064d5fc9ab56.