### PR TITLE
Render revenue for each stop on OO/double-dits, various other changes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,22 +21,22 @@ Some app routes that may be of interest to developers:
 * `/tiles/all` - renders all of the track tiles (and generic map hex "tiles")
   defined in `lib/engine/tile.rb`
 * `/tiles/<game_title>` - renders all of the track tiles (and map hex "tiles")
-  for the given game
+  for the given game. Multiple game titles can be given, separated by `+`.
 * `/tiles/<tile_name>` - renders a single tile at large scale (tile must be
   defined in `lib/engine/tile.rb`)
-* `/tiles/<game_title>/<hex_coord>` - renders a single hex from the game's map
-  at large scale
-* `/tiles/<game_title>/<tile_name>` - renders a single tile from a game at large
-  scale
+* `/tiles/<game_title>/<hex_coord_or_tile_name>` - renders a single hex or tile
+  the given game at large scale. Multiple hex coords or tile names can be given,
+  separated by `+`.
 
-Additionally, where the above routes take a `<hex_coord>` or `<tile_name>`,
-multiple can be given by separating them with `+`, and hex coords and tile names
-can be mix and matched with `+`. Those routes also accept URL params `r` and
-`n`. `r` sets the rotation to render; `all` can be given, or multiple numbers
-can be given, separated by `+`. `n` specifies the location name to render on the
-tile, but this will not override an existing location name (e.g.,
-`/tiles/1889/I4?n=Exampleville` will always display "Kotohira" instead of
-"Exampleville")
+Optional URL params for above routes:
+
+* `r=<rotation(s)>` - specify the rotation with an `Integer`, multiple rotations
+    with `+`-separated `Integer`s, or `all` to see all 6. Preprinted tiles are
+    not rotated. This param is ignored at `/tiles/all`.
+* `n=<location_name>` - specify a location name to render for tiles that have at
+    least one stop. Preprinted tiles with location names are not
+    overridden. This param is ignored at `/tiles/all`.
+* `grid` - show the triangular grid on the hexes to identify regions on the tile
 
 ### Docker
 

--- a/assets/app/view/game.rb
+++ b/assets/app/view/game.rb
@@ -25,7 +25,6 @@ module View
     needs :game_data, store: true
     needs :game, default: nil, store: true
     needs :connection
-    needs :show_grid, default: false, store: true
     needs :selected_company, default: nil, store: true
     needs :app_route, store: true
     needs :user
@@ -117,7 +116,6 @@ module View
 
       destroy = lambda do
         @connection.unsubscribe(game_path)
-        store(:show_grid, false, skip: true)
         store(:selected_company, nil, skip: true)
       end
 

--- a/assets/app/view/hex.rb
+++ b/assets/app/view/hex.rb
@@ -30,7 +30,6 @@ module View
     needs :hex
     needs :round, default: nil
     needs :tile_selector, default: nil, store: true
-    needs :show_grid, default: false, store: true
     needs :role, default: :map
     needs :opacity, default: nil
 
@@ -41,7 +40,7 @@ module View
       @tile = @selected && @round.can_lay_track? && @tile_selector&.tile ? @tile_selector.tile : @hex.tile
 
       children << h(Tile, tile: @tile) if @tile
-      children << h(View::TriangularGrid) if @show_grid
+      children << h(View::TriangularGrid) if Lib::Params['grid']
       layable = @round.connected_hexes[@hex] if @round
 
       clickable = layable || @role == :tile_selector

--- a/assets/app/view/part/base.rb
+++ b/assets/app/view/part/base.rb
@@ -129,9 +129,13 @@ module View
         region_weights = { region_weights => 1.0 } if region_weights.is_a?(Array)
 
         region_weights.each do |regions, weight|
-          regions.each do |region|
-            @region_use[region] += weight
-          end
+          increment_weight_for_regions(regions, weight)
+        end
+      end
+
+      def increment_weight_for_regions(regions, weight = 1)
+        regions.each do |region|
+          @region_use[region] += weight
         end
       end
 

--- a/assets/app/view/part/blocker.rb
+++ b/assets/app/view/part/blocker.rb
@@ -27,7 +27,7 @@ module View
       }.freeze
 
       def preferred_render_locations
-        if @tile.parts.size == 1
+        if @tile.parts.one?
           [
             P_CENTER
           ]

--- a/assets/app/view/part/blocker.rb
+++ b/assets/app/view/part/blocker.rb
@@ -14,15 +14,10 @@ module View
         scale: 1.5,
       }.freeze
       P_LEFT_CORNER = {
-        region_weights: LEFT_CORNER + [13],
+        region_weights_in: LEFT_CORNER + [13],
+        region_weights_out: LEFT_CORNER,
         x: -65,
         y: 5,
-      }.freeze
-      P_BOTTOM_LEFT = {
-        region_weights_in: [13, 19, 20],
-        region_weights_out: [19, 20],
-        x: -35,
-        y: 60,
       }.freeze
       P_BOTTOM_RIGHT = {
         region_weights_in: [17, 22, 23],
@@ -39,7 +34,6 @@ module View
         else
           [
             P_LEFT_CORNER,
-            P_BOTTOM_LEFT,
             P_BOTTOM_RIGHT,
           ]
         end

--- a/assets/app/view/part/city.rb
+++ b/assets/app/view/part/city.rb
@@ -92,7 +92,7 @@ module View
 
       def preferred_render_locations
         edge_a, edge_b = @city.exits
-        if @tile.cities.size > 1 && (edge_a || edge_b)
+        if @num_cities > 1 && (edge_a || edge_b)
           return [
             {
               region_weights: EDGE_TRACK_REGIONS[@edge] + EDGE_CITY_REGIONS[@edge],
@@ -128,7 +128,7 @@ module View
 
       def load_from_tile
         @edge = @tile.preferred_city_town_edges[@city]
-        @cities = @tile.cities.size
+        @num_cities = @tile.cities.size
       end
 
       def render_part
@@ -162,15 +162,15 @@ module View
       end
 
       def render_revenue
-        revenues = @city.revenue.values.uniq
-        return if revenues.uniq.size > 1
+        revenues = @city.uniq_revenues
+        return if revenues.size > 1
 
         revenue = revenues.first
         return if revenue.zero?
 
         # let View::Tile worry about rendering revenue if there are too many
         # individual cities (eg, Chi in 1846)
-        return if @tile.cities.size > 2
+        return if @num_cities > 2
 
         angle = 0
         displacement = 42
@@ -180,7 +180,7 @@ module View
 
         # if there are more than 2 cities on the tile (e.g., Chi in 1846), the
         # revenue should be handled by View::Tile
-        case @cities
+        case @num_cities
         when 1
           x = 0
           y = 0

--- a/assets/app/view/part/city.rb
+++ b/assets/app/view/part/city.rb
@@ -79,6 +79,10 @@ module View
         }],
       }.freeze
 
+      # value at index 0 is used as default in render_revenue
+      # other indexes correspond to number of slots in the city
+      DISPLACEMENT = [42, 42, 67, 65, 67, 0, 0].freeze
+
       OO_REVENUE_ANGLES = [175, -135, 145, -5, 45, -45].freeze
 
       OO_REVENUE_REGIONS = [
@@ -173,10 +177,11 @@ module View
         return if @num_cities > 2
 
         angle = 0
-        displacement = 42
         x = render_location[:x]
         y = render_location[:y]
         regions = []
+
+        displacement = DISPLACEMENT[0]
 
         # if there are more than 2 cities on the tile (e.g., Chi in 1846), the
         # revenue should be handled by View::Tile
@@ -186,16 +191,9 @@ module View
           y = 0
           regions = [11, 18]
 
-          case @city.slots
-          when 1
-            regions = [9, 16]
-          when 2
-            displacement = 67
-          when 3
-            displacement = 65
-          when 4
-            displacement = 67
-          end
+          displacement = DISPLACEMENT[@city.slots]
+
+          regions = [9, 16] if @city.slots == 1
         when 2
           if @edge
             angle = OO_REVENUE_ANGLES[@edge]

--- a/assets/app/view/part/label.rb
+++ b/assets/app/view/part/label.rb
@@ -61,8 +61,8 @@ module View
       ].freeze
 
       def preferred_render_locations
-        if (@tile.cities + @tile.towns).size == 1
-          if (@tile.cities.size == 1) && (@tile.cities.first.slots > 1)
+        if (@tile.cities + @tile.towns).one?
+          if @tile.cities.one? && (@tile.cities.first.slots > 1)
             SINGLE_CITY_MULTI_SLOT
           else
             SINGLE_CITY_ONE_SLOT

--- a/assets/app/view/part/label.rb
+++ b/assets/app/view/part/label.rb
@@ -6,65 +6,72 @@ module View
   module Part
     # letter label, like "Z", "H", "OO"
     class Label < Base
-      CENTERED_LOCATIONS = [
-        {
-          region_weights: { (LEFT_MID + LEFT_CORNER) => 1, LEFT_CENTER => 0.5 },
-          x: -55,
-          y: 0,
-        },
-        {
-          region_weights: { (RIGHT_MID + RIGHT_CORNER) => 1, RIGHT_CENTER => 0.5 },
-          x: 55,
-          y: 0,
-        },
-        {
-          region_weights: { LEFT_CORNER => 1.0, (LEFT_CENTER + LEFT_MID) => 0.5 },
-          x: -28.5 * 2.5,
-          y: 0,
+      # left of center
+      SINGLE_CITY_ONE_SLOT = [{
+        region_weights: { (LEFT_MID + LEFT_CORNER) => 1, LEFT_CENTER => 0.5 },
+        x: -55,
+        y: 0,
+      }].freeze
 
-        },
-        {
-          region_weights: { RIGHT_CORNER => 1.0, (RIGHT_CENTER + RIGHT_MID) => 0.5 },
-          x: 28.5 * 2.5,
-          y: 0,
-        },
-      ].freeze
+      P_LEFT_CORNER = {
+        region_weights: { LEFT_CORNER => 1.0, (LEFT_CENTER + LEFT_MID) => 0.5 },
+        x: -71.25,
+        y: 0,
+      }.freeze
 
-      OFFSET_LOCATIONS = [
-        {
-          region_weights: { [6] => 1.0, [5, 7] => 0.5 },
-          x: -55,
-          y: -25,
-        },
-        {
-          region_weights: { [13] => 1.0, [12, 14] => 0.5 },
-          x: -55,
-          y: 25,
-        },
-        {
-          region_weights: { [10] => 1.0, [9, 11] => 0.5 },
-          x: 55,
-          y: -25,
-        },
+      SINGLE_CITY_MULTI_SLOT = [P_LEFT_CORNER].freeze
+
+      MULTI_CITY_LOCATIONS = [
+        # top center
         {
           region_weights: { [2] => 1.0, [1, 3] => 0.5 },
           x: 0,
           y: -60,
         },
+        # edge 2
+        {
+          region_weights: { [6] => 1.0, [5, 7] => 0.5 },
+          x: -50,
+          y: -31,
+        },
+        # edge 5
         {
           region_weights: { [17] => 1.0, [16, 18] => 0.5 },
-          x: 55,
-          y: 25,
+          x: 50,
+          y: 37,
         },
+        # top left corner
         {
-          region_weights: { [9, 16] => 1.0, [10, 17] => 0.25 },
-          x: 35,
-          y: 0,
+          region_weights: { [0, 1] => 1.0 },
+          x: -30,
+          y: -65,
+        },
+        # top right corner
+        {
+          region_weights: { [3, 4] => 1.0 },
+          x: 30,
+          y: -65,
+        },
+        # bottom left corner
+        {
+          region_weights: { [19, 20] => 1.0 },
+          x: -30,
+          y: 65,
         },
       ].freeze
 
       def preferred_render_locations
-        @tile.cities.size > 1 ? OFFSET_LOCATIONS : CENTERED_LOCATIONS
+        if (@tile.cities + @tile.towns).size == 1
+          if (@tile.cities.size == 1) && (@tile.cities.first.slots > 1)
+            SINGLE_CITY_MULTI_SLOT
+          else
+            SINGLE_CITY_ONE_SLOT
+          end
+        elsif @tile.cities.size > 1
+          MULTI_CITY_LOCATIONS
+        else
+          [P_LEFT_CORNER]
+        end
       end
 
       def load_from_tile

--- a/assets/app/view/part/location_name.rb
+++ b/assets/app/view/part/location_name.rb
@@ -98,7 +98,7 @@ module View
           ]
         end
 
-        if @tile.towns.size == 1
+        if @tile.towns.one?
           return [
             center,
             up40,
@@ -106,7 +106,7 @@ module View
           ]
         end
 
-        if @tile.cities.size == 1
+        if @tile.cities.one?
           return case @tile.cities.first.slots
                  when 3
                    [
@@ -130,14 +130,14 @@ module View
         if (@tile.towns + @tile.cities).size > 1
           # if top and bottom edges are both used, we might end up rendering in
           # the middle, so try to shift out of the way of track
-          if [0, 3].all? { |e| @tile.exits.include?(e) }
+          if ([0, 3] - @tile.exits).empty?
             width, = box_dimensions
             shift = 79 - (width / 2)
             delta_x =
-              if [1, 2].all? { |e| @tile.exits.include?(e) }
+              if ([1, 2] - @tile.exits).empty?
                 # track on both left edges, so shift to the right
                 shift
-              elsif [4, 5].all? { |e| @tile.exits.include?(e) }
+              elsif ([4, 5] - @tile.exits).empty?
                 # track on both right edges, so shift to the left
                 -shift
               end

--- a/assets/app/view/part/revenue.rb
+++ b/assets/app/view/part/revenue.rb
@@ -6,23 +6,16 @@ require 'view/part/multi_revenue'
 module View
   module Part
     class Revenue < Base
+      P_LEFT_CORNER = {
+        region_weights_in: LEFT_CORNER + LEFT_MID,
+        region_weights_out: LEFT_CORNER,
+        x: -75,
+        y: 0,
+      }.freeze
+
       def preferred_render_locations
-        left_corner = {
-          region_weights_in: LEFT_CORNER + LEFT_MID,
-          region_weights_out: LEFT_CORNER,
-          x: -75,
-          y: 0,
-        }
-
-        right_corner = {
-          region_weights_in: RIGHT_CORNER + RIGHT_MID,
-          region_weights_out: RIGHT_CORNER,
-          x: 75,
-          y: 0,
-        }
-
         if multi_revenue?
-          return [
+          [
             {
               region_weights: CENTER,
               x: 0,
@@ -49,90 +42,8 @@ module View
               y: 48,
             },
           ]
-        end
-
-        case @slots
-        when 1
-          [
-            {
-              # left-center
-              region_weights_in: { LEFT_MID => 1.0, LEFT_CENTER => 0.4 },
-              region_weights_out: { LEFT_CORNER => 0.1, LEFT_MID => 0.2, LEFT_CENTER => 1.0 },
-              x: -45,
-              y: 0,
-            },
-            {
-              # right-center
-              region_weights_in: { RIGHT_MID => 1.0, RIGHT_CENTER => 0.4 },
-              region_weights_out: { RIGHT_CORNER => 0.1, RIGHT_MID => 0.2, RIGHT_CENTER => 1.0 },
-              x: 45,
-              y: 0,
-            },
-            {
-              # between center and edge1
-              region_weights: [13, 14],
-              x: -45,
-              y: 25,
-            },
-            {
-              # between center and edge2
-              region_weights: [6, 7],
-              x: -45,
-              y: -25,
-            },
-            {
-              # between center and lower left corner
-              region_weights_in: { [13, 14, 15, 21] => 0.4, [19, 20] => 1.0 },
-              region_weights_out: [13, 14, 15, 19, 20, 21],
-              x: -28,
-              y: 45,
-            },
-            {
-              # between center and lower right corner
-              region_weights_in: { [15, 16, 17, 21] => 0.4, [22, 23] => 1.0 },
-              region_weights_out: [15, 16, 17, 21, 22, 34],
-              x: 28,
-              y: 45,
-            },
-          ]
-        when (2..4)
-          if @cities == 2
-            [
-              left_corner,
-              right_corner,
-              # top right corner
-              {
-                region_weights: [3, 4],
-                x: 40,
-                y: -68,
-              },
-              # lower left corner
-              {
-                region_weights: [19, 20],
-                x: -40,
-                y: 68,
-              }
-            ]
-          else
-            [
-              left_corner,
-              right_corner,
-              {
-                # between center and edge1
-                region_weights: [13, 14],
-                x: -45,
-                y: 25,
-              },
-            ]
-          end
         else
-          [
-            {
-              region_weights: [7, 8, 9, 14, 15, 16],
-              x: 0,
-              y: 0,
-            }
-          ]
+          [P_LEFT_CORNER]
         end
       end
 
@@ -169,28 +80,12 @@ module View
       end
 
       def render_part
-        text_attrs = {
-          fill: 'black',
-          transform: 'translate(0 6)',
-          'text-anchor': 'middle',
-        }
-
         if multi_revenue?
           h(Part::MultiRevenue, revenues: @revenue, translate: translate)
         else
-          attrs = {
-            'stroke-width': 1,
-            transform: translate,
-          }
-
-          h(
-            :g,
-            { attrs: attrs },
-            [
-              h(:circle, attrs: { r: 14, fill: 'white' }),
-              h(:text, { attrs: text_attrs }, @revenue),
-            ]
-          )
+          h(Part::SingleRevenue,
+            revenue: @revenue,
+            transform: translate,)
         end
       end
     end

--- a/assets/app/view/part/revenue.rb
+++ b/assets/app/view/part/revenue.rb
@@ -65,7 +65,7 @@ module View
 
         @revenue =
           if revenues.values.uniq.one?
-            revenues.values.uniq.first
+            revenues.values.first
           else
             revenues
           end

--- a/assets/app/view/part/revenue.rb
+++ b/assets/app/view/part/revenue.rb
@@ -55,7 +55,7 @@ module View
 
         return if revenues.empty?
 
-        if revenues.size == 1
+        if revenues.one?
           revenues = revenues.first
         else
           puts "WARNING: encountered multiple different revenues on tile #{@tile.name}"
@@ -64,7 +64,7 @@ module View
         end
 
         @revenue =
-          if revenues.values.uniq.size == 1
+          if revenues.values.uniq.one?
             revenues.values.uniq.first
           else
             revenues

--- a/assets/app/view/part/single_revenue.rb
+++ b/assets/app/view/part/single_revenue.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'view/part/base'
+require 'view/part/multi_revenue'
+
+module View
+  module Part
+    class SingleRevenue < Snabberb::Component
+      needs :revenue
+      needs :transform, default: 'translate(0 0)'
+
+      def render
+        text_attrs = {
+          fill: 'black',
+          transform: 'translate(0 6)',
+          'text-anchor': 'middle',
+        }
+
+        attrs = {
+          'stroke-width': 1,
+          transform: @transform,
+        }
+
+        h(
+          :g,
+          { attrs: attrs },
+          [
+            h(:circle, attrs: { r: 14, fill: 'white' }),
+            h(:text, { attrs: text_attrs }, @revenue),
+          ]
+        )
+      end
+    end
+  end
+end

--- a/assets/app/view/part/town_rect.rb
+++ b/assets/app/view/part/town_rect.rb
@@ -2,6 +2,7 @@
 
 require 'view/hit_box'
 require 'view/part/base'
+require 'view/part/city'
 require 'view/runnable'
 
 module View
@@ -11,111 +12,171 @@ module View
 
       needs :town
       needs :color, default: 'black'
+      needs :tile
 
       HEIGHT = 8
       WIDTH = 32
 
-      EDGE_TRACK_LOCATIONS = [
-        TRACK_TO_EDGE_0,
-        TRACK_TO_EDGE_1,
-        TRACK_TO_EDGE_2,
-        TRACK_TO_EDGE_3,
-        TRACK_TO_EDGE_4,
-        TRACK_TO_EDGE_5,
-      ].freeze
+      SINGLE_TOWN_REGIONS = {
+        straight: [CENTER] * 6,
+        sharp: [
+          [14, 15],
+          [7, 14],
+          [7, 8],
+          [8, 9],
+          [9, 16],
+          [15, 16]
+        ],
+        gentle: [
+          [14],
+          [7],
+          [8],
+          [9],
+          [16],
+          [15]
+        ],
+      }.freeze
 
-      SHARP_TRACK_LOCATIONS = [
-        [13, 14, 15, 19, 20, 21],
-        [5, 6, 7, 12, 13, 14],
-        [0, 1, 2, 6, 7, 8],
-        [2, 3, 4, 8, 9, 10],
-        [9, 10, 11, 16, 17, 18],
-        [15, 16, 17, 21, 22, 23],
-      ].freeze
+      EDGE_TOWN_REGIONS = {
+        straight: View::Part::City::EDGE_CITY_REGIONS,
+        sharp: View::Part::City::EDGE_CITY_REGIONS,
+        gentle: View::Part::City::EDGE_CITY_REGIONS,
+      }.freeze
 
-      # Returns the two edges so that a < b and b - a is 1, 2 or 3.
+      # absolute value of angle (in degrees) to tilt the town rectangle relative
+      # to a straight line from edge_a to the opposite edge
+      RECTANGLE_TILT = {
+        sharp: 10,
+        gentle: 10,
+      }.freeze
+
+      # from center of the hex, how many degrees of offset to apply to
+      # positioning the town rectangle; this value will be added/subtracted to
+      # (edge_a * 60)
+      POSITIONAL_ANGLE = {
+        sharp: 2,
+        gentle: 2,
+      }.freeze
+
+      DOUBLE_DIT_REVENUE_ANGLES = [10, -130, 130, -10, 50, -50].freeze
+      DOUBLE_DIT_REVENUE_REGIONS = View::Part::City::OO_REVENUE_REGIONS
+
+      # Returns the two edges so that a is the edge to render close to, and
+      # (a - b).abs is 1, 2 or 3.
       def normalized_edges
         @normalized_edges ||=
           begin
-            edge_a, edge_b = @town.exits
-            edge_a, edge_b = edge_b, edge_a if edge_b < edge_a
-            edge_a += 6 if (edge_b - edge_a).abs > 3
-            edge_a, edge_b = edge_b, edge_a if edge_b < edge_a
-            [edge_a, edge_b]
+            edge_a = @tile.preferred_city_town_edges[@town]
+            edge_b = (@town.exits - [edge_a]).first
+            edges = [edge_a, edge_b]
+            edges[edges.index(edges.min)] += 6 if (edge_a - edge_b).abs > 3
+            edges
           end
       end
 
-      # Takes the difference in normalized edges and returns a symbol of
-      # :straight, :gentle or :sharp
+      def min_edge
+        @min_edge ||= normalized_edges.min
+      end
+
+      # Returns a symbol of :straight, :gentle or :sharp based on the absolute
+      # difference of the normalized edges
       def track_type
         @track_type ||=
           begin
             edge_a, edge_b = normalized_edges
+            [nil, :sharp, :gentle, :straight][(edge_a - edge_b).abs]
+          end
+      end
 
-            case edge_b - edge_a
-            when 3
+      # Returns a symbol of :left, :right, or :straight based on the direction
+      # the track curves starting from edge_a
+      def track_direction
+        @track_direction ||=
+          begin
+            edge_a, edge_b = normalized_edges
+
+            if (edge_a - edge_b).abs == 3
               :straight
-            when 2
-              :gentle
-            else
-              :sharp
+            elsif edge_a > edge_b
+              :right
+            elsif edge_a < edge_b
+              :left
             end
           end
       end
 
       # Returns an array of options for track positions
       def track_location
-        edge_a, edge_b = normalized_edges
+        edge_a, = normalized_edges
 
-        case track_type
-        when :sharp
-          [SHARP_TRACK_LOCATIONS[edge_a % 6]]
-        else
-          [CENTER,
-           EDGE_TRACK_LOCATIONS[edge_a % 6],
-           EDGE_TRACK_LOCATIONS[edge_b % 6]]
-        end
+        loc =
+          if @tile.towns.size == 1
+            SINGLE_TOWN_REGIONS[track_type][min_edge]
+          else
+            EDGE_TOWN_REGIONS[track_type][edge_a % 6]
+          end
+        [loc]
       end
 
       # Returns an array of rotation options for the town rectangle that
       # corresponds to the positions given from track_location
       def rotation_angles
         edge_a, = normalized_edges
-        case track_type
-        when :sharp
-          [(edge_a + 2) * 60]
-        when :gentle
-          [(edge_a * 60) - 30,
-           (edge_a * 60) - 10,
-           (edge_a * 60) - 50]
+
+        if @tile.towns.size == 1
+          {
+            straight: [min_edge * 60],
+            sharp: [(min_edge + 2) * 60],
+            gentle: [(min_edge * 60) - 30],
+          }[track_type]
         else
-          [edge_a * 60] * 3
+
+          tilt = RECTANGLE_TILT[track_type] || 0
+
+          delta = {
+            left: -tilt,
+            right: tilt,
+            straight: 0,
+          }[track_direction]
+
+          [(edge_a * 60) + delta]
         end
       end
 
       # Returns an array of weights, location and rotations
       def position
-        edge_a, edge_b = normalized_edges
-        angles = case track_type
-                 when :sharp
-                   [(edge_a + 0.5) * 60]
-                 when :gentle
-                   [(edge_a + 1) * 60,
-                    (edge_a * 60) + 2,
-                    (edge_b * 60) - 2]
-                 else
-                   [edge_a * 60] * 3
-                 end
-        radians = angles.map { |a| a / 180 * Math::PI }
+        edge_a, = normalized_edges
 
-        positions = case track_type
-                    when :sharp
-                      [43.5]
-                    when :gentle
-                      [20, 53.375, 53.375]
-                    else
-                      [0, 40, -40]
-                    end
+        if @tile.towns.size == 1
+          angles = {
+            straight: [edge_a * 60],
+            sharp: [(min_edge + 0.5) * 60],
+            gentle: [(min_edge + 1) * 60],
+          }[track_type]
+
+          positions = {
+            straight: [0],
+            sharp: [43.5],
+            gentle: [20],
+          }[track_type]
+
+        else
+          positional_angle = POSITIONAL_ANGLE[track_type] || 0
+          delta = {
+            left: positional_angle,
+            right: -positional_angle,
+            straight: 0,
+          }[track_direction]
+          angles = [(edge_a * 60) + delta]
+
+          positions = {
+            straight: [40],
+            sharp: [60],
+            gentle: [53.375],
+          }[track_type]
+        end
+
+        radians = angles.map { |a| a / 180 * Math::PI }
 
         xs = positions.zip(radians).map { |p, r| -Math.sin(r) * p }
         ys = positions.zip(radians).map { |p, r| Math.cos(r) * p }
@@ -136,7 +197,12 @@ module View
         end
       end
 
-      def render
+      def load_from_tile
+        @edge = @tile.preferred_city_town_edges[@town]
+        @towns = @tile.towns.size
+      end
+
+      def render_part
         children = [h(:rect, attrs: {
             transform: "#{translate} #{rotation}",
             x: -WIDTH / 2,
@@ -147,9 +213,57 @@ module View
             stroke: 'none',
           })]
 
+        if (revenue = render_revenue)
+          children << revenue
+        end
+
         children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
 
         h(:g, children)
+      end
+
+      def render_revenue
+        revenues = @town.revenue.values.uniq
+        return if revenues.uniq.size > 1
+
+        revenue = revenues.first
+        return if revenue.zero?
+
+        angle = 0
+        displacement = 38
+        x = render_location[:x]
+        y = render_location[:y]
+        reverse_side = false
+        regions = []
+
+        # AFAIK no tiles have more than 2 towns
+        case @towns
+        when 1
+          angle = rotation_angles[0]
+          reverse_side = track_type == :sharp
+
+          # for gentle and straight, exact regions vary, but it's always in
+          # CENTER; close enough to always use CENTER and not worry about rotations
+          regions = CENTER
+        when 2
+          angle = DOUBLE_DIT_REVENUE_ANGLES[@edge]
+          displacement = 35
+          regions = DOUBLE_DIT_REVENUE_REGIONS[@edge]
+        end
+
+        increment_weight_for_regions(regions)
+
+        angle += 180 if reverse_side
+
+        h(:g, { attrs: { transform: "translate(#{x} #{y})" } }, [
+            h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+                h(:g, { attrs: { transform: "translate(#{displacement} 0)" } }, [
+                    h(Part::SingleRevenue,
+                      revenue: revenue,
+                      transform: "rotate(#{-angle})")
+                  ])
+              ])
+          ])
       end
     end
   end

--- a/assets/app/view/part/towns.rb
+++ b/assets/app/view/part/towns.rb
@@ -17,7 +17,7 @@ module View
           if @tile.lawson? || @tile.paths.empty?
             h(Part::TownDot, town: town, tile: @tile, region_use: @region_use, color: color_for(town))
           else
-            h(Part::TownRect, tile: @tile, town: town, region_use: @region_use, color: color_for(town))
+            h(Part::TownRect, town: town, region_use: @region_use, color: color_for(town))
           end
         end
       end

--- a/assets/app/view/part/towns.rb
+++ b/assets/app/view/part/towns.rb
@@ -17,7 +17,7 @@ module View
           if @tile.lawson? || @tile.paths.empty?
             h(Part::TownDot, town: town, tile: @tile, region_use: @region_use, color: color_for(town))
           else
-            h(Part::TownRect, town: town, region_use: @region_use, color: color_for(town))
+            h(Part::TownRect, tile: @tile, town: town, region_use: @region_use, color: color_for(town))
           end
         end
       end

--- a/assets/app/view/part/track.rb
+++ b/assets/app/view/part/track.rb
@@ -27,7 +27,7 @@ module View
             h(TrackOffboard, offboard: path.offboard, region_use: @region_use, path: path, color: color_for(path))
           end
         elsif @tile.lawson?
-          @tile.paths.select { |path| path.edges.size == 1 }.map do |path|
+          @tile.paths.select { |path| path.edges.one? }.map do |path|
             h(TrackLawsonPath, region_use: @region_use, path: path, color: color_for(path))
           end
         elsif @tile.towns.any?

--- a/assets/app/view/part/upgrade.rb
+++ b/assets/app/view/part/upgrade.rb
@@ -21,16 +21,16 @@ module View
           y: -60,
         }
 
-        top_center = {
-          region_weights: [2],
-          x: 0,
-          y: -60,
+        edge2 = {
+          region_weights: [0, 5, 6],
+          x: -50,
+          y: -45,
         }
 
         [
           center,
           top_right_corner,
-          top_center,
+          edge2,
         ]
       end
 

--- a/assets/app/view/tile.rb
+++ b/assets/app/view/tile.rb
@@ -51,7 +51,7 @@ module View
 
       # cities and towns render revenue, unless there are more than 2 cities on
       # the tile, or the revenue varies by phase
-      if (@tile.cities.size > 2) || @tile.stops.any? { |s| s.revenue.values.uniq.size > 1 }
+      if (@tile.cities.size > 2) || @tile.stops.any? { |s| s.uniq_revenues.size > 1 }
         children << render_tile_part(Part::Revenue)
       end
 

--- a/assets/app/view/tile.rb
+++ b/assets/app/view/tile.rb
@@ -47,15 +47,18 @@ module View
       children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 
       # OO tiles have different rules...
-      children << render_tile_part(Part::LocationName) if @tile.cities.size > 1 && @tile.location_name
+      children << render_tile_part(Part::LocationName) if @tile.location_name && @tile.cities.size > 1
+
+      # cities and towns render revenue, unless there are more than 2 cities on
+      # the tile, or the revenue varies by phase
+      if (@tile.cities.size > 2) || @tile.stops.any? { |s| s.revenue.values.uniq.size > 1 }
+        children << render_tile_part(Part::Revenue)
+      end
 
       children << render_tile_part(Part::Label) if @tile.label
-      children << render_tile_part(Part::Revenue) if @tile.stops.any?
       children << render_tile_part(Part::Upgrades) if @tile.upgrades
-
-      children << render_tile_part(Part::LocationName) if @tile.cities.count <= 1 && @tile.location_name
-
       children << render_tile_part(Part::Blocker) if should_render_blocker?
+      children << render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
 
       children.flatten!
 

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -16,10 +16,10 @@ module View
       }
 
       tile ||= Engine::Tile.for(name)
-      location_name ||= tile.location_name
 
-      # setting [0] as default value in function arg doesn't work
-      rotations ||= [0]
+      loc_name = location_name || tile.location_name if tile.stops.any?
+
+      rotations = [0] if tile.preprinted || rotations.nil?
 
       rotations.map do |rotation|
         tile.rotate!(rotation)
@@ -36,7 +36,7 @@ module View
                   Hex,
                   hex: Engine::Hex.new('A1',
                                        layout: 'flat',
-                                       location_name: location_name,
+                                       location_name: loc_name,
                                        tile: tile),
                   role: :tile_page,
                   opacity: opacity,

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -19,7 +19,7 @@ module View
 
       loc_name = location_name || tile.location_name if tile.stops.any?
 
-      rotations = [0] if tile.preprinted || rotations.nil?
+      rotations = [0] if tile.preprinted || !rotations
 
       rotations.map do |rotation|
         tile.rotate!(rotation)

--- a/assets/app/view/tiles_page.rb
+++ b/assets/app/view/tiles_page.rb
@@ -58,12 +58,15 @@ module View
         rendered = hex_or_tile_ids.flat_map { |id| render_individual_tile_from_game(game_title, id) }
         h('div#tiles', rendered)
 
-      # everything for one game
-      elsif Engine::GAMES_BY_TITLE.keys.include?(dest)
-        game_class = Engine::GAMES_BY_TITLE[dest]
-        h('div#tiles', [
-            map_hexes_and_tile_manifest_for(game_class)
-          ])
+      # everything for one or more games
+      elsif (game_titles = dest.split('+')).all? { |g| Engine::GAMES_BY_TITLE.keys.include?(g) }
+
+        rendered = game_titles.flat_map do |g|
+          game_class = Engine::GAMES_BY_TITLE[g]
+          map_hexes_and_tile_manifest_for(game_class)
+        end
+
+        h('div#tiles', rendered)
 
       # common tile(s)
       else
@@ -144,7 +147,13 @@ module View
       end
 
       rendered_tiles = game.tiles.sort.group_by(&:name).flat_map do |name, tiles_|
-        render_tile_blocks(name, tile: tiles_.first, num: tiles_.size)
+        render_tile_blocks(
+          name,
+          tile: tiles_.first,
+          num: tiles_.size,
+          rotations: @rotations,
+          location_name: @location_name,
+        )
       end
 
       h("div#hexes_and_tiles_#{game_class.title}", [

--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -545,7 +545,7 @@ module Engine
       "o=r:yellow_30|green_40|brown_50|gray_60;c=r:0,s:2;p=a:4,b:_0;p=a:5,b:_0": [
         "D9"
       ],
-      "p=a:3,b:j;p=a:4,b:j;p=a:5,b=j": [
+      "p=a:3,b:j;p=a:4,b:j;p=a:5,b:j": [
         "F1"
       ]
     },

--- a/lib/engine/part/revenue_center.rb
+++ b/lib/engine/part/revenue_center.rb
@@ -26,6 +26,10 @@ module Engine
 
         phase.tiles.reverse.each { |color| return @revenue[color] if @revenue[color] }
       end
+
+      def uniq_revenues
+        @uniq_revenues ||= revenue.values.uniq
+      end
     end
   end
 end

--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -191,7 +191,7 @@ module Engine
         while (bids = @bids[@companies.first])
           break if bids.empty?
 
-          if bids.size == 1
+          if bids.one?
             accept_bid(bids.first)
           else
             if @auctioning_company != @companies.first

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -25,7 +25,7 @@ module Engine
 
       return unless (first = connections[0])
 
-      if connections.size == 1
+      if connections.one?
         @connections << { left: first.nodes[0], right: first.nodes[-1], connection: first }
       else
         connections.each_cons(2) do |a, b|

--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -6,7 +6,7 @@ module Engine
 
     def initialize(shares, percent = nil)
       shares = Array(shares)
-      raise 'All shares must be from the same corporation' unless shares.map(&:corporation).uniq.size == 1
+      raise 'All shares must be from the same corporation' unless shares.map(&:corporation).uniq.one?
 
       @shares = shares
       @percent = percent || @shares.sum(&:percent)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -124,7 +124,7 @@ module Engine
       @blockers = []
       @preprinted = preprinted
       @index = index
-      @preferred_city_edges = {}
+      @preferred_city_town_edges = {}
 
       separate_parts
     end
@@ -216,51 +216,53 @@ module Engine
       "<#{self.class.name}: #{name}, hex: #{@hex&.name}>"
     end
 
-    # returns hash where keys are cities, and values are the edge the city
-    # should be rendered at
-    def preferred_city_edges
+    # returns hash where keys are cities, and values are the edge the city or
+    # town should be rendered at
+    #
+    # "ct" for "city or town"
+    def preferred_city_town_edges
       # cache per rotation
-      @preferred_city_edges[@rotation] ||=
+      @preferred_city_town_edges[@rotation] ||=
         begin
-          # city => nums of edges it is connected to
-          city_edges = Hash.new { |h, k| h[k] = [] }
+          # ct => nums of edges it is connected to
+          ct_edges = Hash.new { |h, k| h[k] = [] }
 
-          # edge => how many tracks/cities are on that edge, plus 0.1
-          # for each track/city on neighboring edges
+          # edge => how many tracks/cts are on that edge, plus 0.1
+          # for each track/ct on neighboring edges
           edge_count = Hash.new(0)
 
           # slightly prefer to keep room along bottom to render location name
           edge_count[0] += 0.1
 
-          # populate city_edges and edge_count as described in above comments
+          # populate ct_edges and edge_count as described in above comments
           paths.each do |path|
-            next unless (city = path.city)
+            next unless (ct = path.city || path.town)
 
             path.exits.each do |edge|
-              city_edges[city] << edge
+              ct_edges[ct] << edge
               edge_count[edge] += 1
               edge_count[(edge + 1) % 6] += 0.1
               edge_count[(edge - 1) % 6] += 0.1
             end
           end
 
-          # sort city_edges so that the lowest edge with any paths will be
+          # sort ct_edges so that the lowest edge with any paths will be
           # handled first
-          sorted = city_edges.each { |_, e| e.sort! }.sort_by { |_, e| e }
+          sorted = ct_edges.each { |_, e| e.sort! }.sort_by { |_, e| e }
 
           # construct the final hash to return, updating edge_count along the
           # way
-          sorted.map do |city, edges_|
+          sorted.map do |ct, edges_|
             edge = edges_.min_by { |e| edge_count[e] }
 
             # since this edge is being used, increase its count (and that of its
             # neighbors) to influence what edges will be used for the remaining
-            # cities
+            # cts
             edge_count[edge] += 1
             edge_count[(edge + 1) % 6] += 0.1
             edge_count[(edge - 1) % 6] += 0.1
 
-            [city, edge]
+            [ct, edge]
           end.to_h
         end
     end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -124,7 +124,6 @@ module Engine
       @blockers = []
       @preprinted = preprinted
       @index = index
-      @preferred_city_town_edges = {}
 
       separate_parts
     end
@@ -146,6 +145,7 @@ module Engine
       @nodes.each(&:clear!)
       @_paths = nil
       @_exits = nil
+      @preferred_city_town_edges = nil
       self
     end
 
@@ -164,8 +164,8 @@ module Engine
     def lawson?
       @lawson ||=
         @junctions.any? ||
-        (@cities.size == 1 && @towns.empty?) ||
-        ((cities.empty? && towns.size == 1) && edges.size > 2)
+        (@cities.one? && @towns.empty?) ||
+        ((cities.empty? && towns.one?) && edges.size > 2)
     end
 
     def upgrade_cost(abilities)
@@ -222,7 +222,7 @@ module Engine
     # "ct" for "city or town"
     def preferred_city_town_edges
       # cache per rotation
-      @preferred_city_town_edges[@rotation] ||=
+      @preferred_city_town_edges ||=
         begin
           # ct => nums of edges it is connected to
           ct_edges = Hash.new { |h, k| h[k] = [] }

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -36,6 +36,10 @@ describe 'Assets' do
       expect(x2_x3).to include('X2')
       expect(x2_x3).to include('X3')
 
+      multiple_games = render(app_route: '/tiles/1889+18Chesapeake')
+      expect(multiple_games).to include('Kouchi')
+      expect(multiple_games).to include('Delmarva')
+
       %w[1830 1889 18Chesapeake].each do |title|
         expect(render(app_route: "/tiles/#{title}")).to include("#{title} Map Hexes")
         expect(render(app_route: "/tiles/#{title}")).to include("#{title} Tile Manifest")
@@ -53,6 +57,12 @@ describe 'Assets' do
 
     context '/map' do
       {
+        # games with config but not full implementation; just do a quick spot check
+        '1817' => %w[Pittsburgh],
+        '1830' => %w[New York],
+        '1846' => %w[Chicago],
+
+        # games with full implementation; verify every string on the map
         '1889' => %w[
           1 10 11 12 13 14 2 20 3 30 4 40 5 6 60 7 8 80 9 A AR Anan Awaji B C D
           D100 D80 E ER F G H I IR Ikeda Imabari J K KO Komatsujima Kotohira
@@ -69,7 +79,7 @@ describe 'Assets' do
           Norfolk OO Ohio PLE PRR Peninsula Philadelphia Pittsburgh Princeton
           Richmond SRR Spring Strasburg Trenton Virginia Washington West
           Wilmington York
-        ]
+        ],
       }.each do |game_title, expected_strings|
         context game_title do
           it 'renders map' do

--- a/spec/lib/engine/tile_spec.rb
+++ b/spec/lib/engine/tile_spec.rb
@@ -115,7 +115,7 @@ module Engine
       end
     end
 
-    describe '#preferred_city_edges' do
+    describe '#preferred_city_town_edges' do
       [
         {
           desc: "18Chesapeake's X3",
@@ -174,7 +174,7 @@ module Engine
           spec[:expected].each do |rotation, expected|
             it "selects #{expected} for rotation #{rotation}" do
               tile.rotate!(rotation)
-              actual = tile.preferred_city_edges
+              actual = tile.preferred_city_town_edges
 
               expected_h = expected.map.with_index do |edge, index|
                 [tile.cities[index], edge]


### PR DESCRIPTION
This started as fix for town names getting in the way on the 1889 port tile and
other town tiles, especially double dit tiles in 18Chesapeake. The revenue was
the most troublesome tile part for rendering, and it wasn't long before I
decided to address the town problem by going after a revenue rendering idea I've
had for a while but hadn't acted on--render the revenue in a position relative
to the city/town, and do so for each city/town on OO/double-dits.

This imgur album has some screenshots showing the OO/double-dit work and the new
/tiles page - https://imgur.com/a/p46E9iJ

OO and Double Dits:

- all cities and towns render revenue circles right next to them; OO and double
  dits now render two revenue circles on the tile
- create a Part::SingleRevenue class; View::Tile still uses Part::Revenue, which
  in turn delegates to either Part::SingleRevenue or Part::MultiRevenue, but
  Part::City and Part::Town directly use Part::SingleRevenue; this
  simplifies/removes some of Part::Revenue#preferred_render_locations
- Engine::Tile#preferred_city_edges has been renamed to
  Engine::Tile#preferred_city_town_edges and works for cities or towns now; all
  of the logic is the same
- in Part::TownRect, use most of the existing logic for placing and positioning
  the rectangles; extract some constants

Location Name and Label Rendering (mainly done in service of above)

- fewer options for where to render Part::Label, unless it's a double OO tile;
  now label and revenue locations are more consistent for city tiles with lots
  of track
- remove a few render locations for location name

Single-Town Tiles:

- always center the town on the track
- better positioning--good examples are 1889's B3 and G14

Updates to `/tiles/` pages:
- `/tiles/<game_title>` can take multiple game titles, separated by +
- allow `/tiles/<game_title>` to accept `r` and `n` URL params
- add URL param `grid` to show the hex grid (related: remove show_grid from
  `assets/app/view/game.rb`)
- don't do rotations for preprinted tiles
- update docs in DEVELOPMENT.md for these changes
- add spec for loading 1889 and 18Chesapeake with all rotations and a given
  location name

Unrelated Fixes:

- "Ritsurin Kouen" was rendering past the top of the hex; this is fixed
- /map/1817 failed to load; this was caused by broken config for the hex F1;
  this is fixed and tests have been added in assets_spec to make sure maps for
  1817, 1830, and 1846 all render (just one expected string is checked, instead
  of all expected strings like for 89 and Chessie)
- the box for cities with three slots had a thinner border than the other lines;
  this was caused by scaling the whole shape down to size instead of calculating
  the scaled down points, and is now fixed

Miscellaneous Changes (done for the OO/double-dit stuff, but less directly
related):

- add method View::Part::Base#increment_weight_for_regions to allow Part::City
  and Part::Town to update the weights when they render their revenue circles
- adjust weights/locations for Part::Blocker, remove bottom left from render
  locations
- in Part::City and Part::Town, rename some constants from LOCATIONS to REGIONS
- move where the upgrade cost for 18Chesapeake H6 (Baltimore) is rendered to
  work better with the new label placement

[Fixes #501]