### PR TITLE
Support for blue hexes

### DIFF
--- a/assets/app/view/hex.rb
+++ b/assets/app/view/hex.rb
@@ -25,6 +25,7 @@ module View
       brown: '#cb7745',
       gray: '#bcbdc0',
       red: '#ec232a',
+      blue: '#00f',
     }.freeze
 
     needs :hex

--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -645,6 +645,11 @@ module Engine
       "c=r:30;c=r:30;p=a:0,b:_0;p=a:3,b:_1;l=OO": [
         "J4"
       ]
+    },
+    "blue": {
+      "": [
+        "H8", "H10", "I11"
+      ]
     }
   },
   "phases": [

--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -13,7 +13,7 @@ module Engine
         'city' => 'c=r:0',
       }.freeze
 
-      # Red tiles don't exist yet
+      BLUE = {}.freeze
       RED = {}.freeze
 
       YELLOW = {

--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -511,7 +511,7 @@ module Engine
         '469' => 'p=a:0,b:1,t:n',
       }.freeze
 
-      COLORS = %i[white yellow green brown gray greenbrown browngray none red].freeze
+      COLORS = %i[white yellow green brown blue gray greenbrown browngray none red].freeze
     end
   end
 end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -42,6 +42,8 @@ module Engine
         color = :gray
       elsif (code = RED[name])
         color = :red
+      elsif (code = BLUE[name])
+        color = :blue
       else
         raise Engine::GameError, "Tile '#{name}' not found"
       end


### PR DESCRIPTION
Necessary for 1846, useful for 18Chesapeake--render impassable water hexes instead of having an apparent gap in the map.

Probably necessary for the offboard port hex in 1882 (conceivably it could be a normal red offboard with some other indicator that it's a special port thing, but that would be suboptimal).

For 1846 and 18Chesapeake, routes should not be allowed to point to blue hexes, but they will have to in 1882.

What I've pushed here only draws the blue hex, it doesn't prevent track from being pointed to it, or prevent the hex from being clicked on during the track laying step (and doing so completely breaks the game)

![Screenshot from 2020-05-27 10-37-27](https://user-images.githubusercontent.com/1045173/83048686-3903ff80-a007-11ea-823d-a71e32b0c45b.png)
