### PR TITLE
Improve UI of emergency purchase

### DIFF
--- a/assets/app/view/corporation.rb
+++ b/assets/app/view/corporation.rb
@@ -25,12 +25,12 @@ module View
         'vertical-align': 'top',
       }
 
-      card_style['background-color'] = 'lightblue' if selected?
-
       if @game.round.can_act?(@corporation)
         card_style['border'] = 'solid 1px black'
         card_style['background-color'] = '#dfd'
       end
+
+      card_style['background-color'] = 'lightblue' if selected?
 
       children = [
         render_title,


### PR DESCRIPTION
* Show how much the player needs to get
* Only show declare bankrupcy if the player liquidate enough
* Align the shares sell buttons under the share
* Fix seeing other trains after selling shares
* Move shares above trains if player needs to contribute

fixes #551 and #565
![Screenshot from 2020-05-30 12-29-05](https://user-images.githubusercontent.com/71923/83327093-4290a000-a271-11ea-9aa3-a2af6bafcba7.png)
![Screenshot from 2020-05-30 12-28-20](https://user-images.githubusercontent.com/71923/83327094-43c1cd00-a271-11ea-8c25-e4d3ff633609.png)

