### PR TITLE
Fix descriptions for Independent Railroads.

### DIFF
--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -155,14 +155,14 @@ module Engine
       "value": 60,
       "debt": 80,
       "revenue": 0,
-      "desc": "Starts with $60 in treasury, a 2 train, and a token in Detroit (C15). Splits revenue evenly with owner."
+      "desc": "Starts with $60 in treasury, a 2 train, and a token in Detroit (C15). Splits revenue evenly with owner. $80 debt must be paid by purchaser."
     },
     {
       "name": "Big 4",
       "value": 40,
       "debt": 60,
       "revenue": 0,
-      "desc": "Starts with $60 in treasury, a 2 train, and a token in Indianapolis (G9). Splits revenue evenly with owner."
+      "desc": "Starts with $40 in treasury, a 2 train, and a token in Indianapolis (G9). Splits revenue evenly with owner. $60 debt must be paid by purchaser."
     },
     {
       "name": "Chicago and Western Indiana",


### PR DESCRIPTION
1. Big 4 starting treasury is $40 not $60
2. Mention debt that must be paid off when purchasing.