### PR TITLE
Add button to open game in new link, closes #156

### DIFF
--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -134,11 +134,11 @@ module GameManager
     game['status'] == 'active' && game['acting'].include?(user&.dig('id'))
   end
 
-  protected
-
   def url(game, path = '')
     "/game/#{game['id']}#{path}"
   end
+
+  protected
 
   def hs_url(game, game_data)
     pin = game_data&.dig('settings', 'pin')

--- a/assets/app/index.rb
+++ b/assets/app/index.rb
@@ -17,13 +17,28 @@ class Index < Snabberb::Layout
         margin: 1rem 0;
       }
 
-      .button {
+      .button, .button-link {
         font-size: 14px;
         border: solid 1px black;
         border-radius: 5px;
         padding: 0.2rem 1rem;
         cursor: pointer;
         outline-style: none;
+      }
+
+      .button-link {
+        text-decoration: none;
+        color: initial;
+        background: whitesmoke;
+
+        -webkit-appearance: button;
+        -moz-appearance: button;
+        appearance: button;
+      }
+
+      .button-link:hover {
+        background: black;
+        color: white;
       }
 
       .button:hover {

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -58,7 +58,7 @@ module View
       buttons = []
       if owner?
         buttons << if @confirm_delete != @gdata['id']
-                     render_button('Delete', -> { store(:confirm_delete, @gdata['id']) })
+                     render_button('🗑️', -> { store(:confirm_delete, @gdata['id']) })
                    else
                      render_button('Confirm', -> { delete_game(@gdata) })
                    end
@@ -76,7 +76,9 @@ module View
           JOIN_YELLOW
         when 'active'
           buttons << render_button('Enter', -> { enter_game(@gdata) })
-          buttons << render_button_as_link('↗️', url(@gdata))
+          if @confirm_delete != @gdata['id']
+            buttons << render_button_as_link('↗️', url(@gdata))
+          end
           acting?(@user) ? YOUR_TURN_ORANGE : ENTER_GREEN
         when 'finished'
           buttons << render_button('Review', -> { enter_game(@gdata) })

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -76,9 +76,11 @@ module View
           JOIN_YELLOW
         when 'active'
           buttons << render_button('Enter', -> { enter_game(@gdata) })
+          buttons << render_button_as_link('↗️', url(@gdata))
           acting?(@user) ? YOUR_TURN_ORANGE : ENTER_GREEN
         when 'finished'
           buttons << render_button('Review', -> { enter_game(@gdata) })
+          buttons << render_button_as_link('↗️', url(@gdata))
           FINISHED_GREY
         end
 
@@ -124,6 +126,23 @@ module View
       }
 
       h('button.button', props, text)
+    end
+
+    def render_button_as_link(text, href)
+      props = {
+        style: {
+          top: '1rem',
+          float: 'right',
+          'margin': '0 0.3rem',
+          padding: '0.2rem 0.5rem',
+        },
+        attrs: {
+          href: href,
+          target: '_blank',
+        },
+      }
+
+      h('a.button-link', props, text)
     end
 
     def render_body


### PR DESCRIPTION
This PR adds a link to allow opening a game in a new window:

- The current `enter` functionality is unchanged.
- The `delete` button has now been changed to a `trash can emoji` in order to accomodate the extra button
- The new link button will not be displayed if the `confirm` button is active

Please see screenshots below:

[https://postimg.cc/75MbF4Vh](https://postimg.cc/75MbF4Vh)
[https://postimg.cc/CdB2mxhG](https://postimg.cc/CdB2mxhG)
[https://postimg.cc/Tpn4vNWh](https://postimg.cc/Tpn4vNWh)