### PR TITLE
Switch enter button to link to allow opening in a new tab, closes #156

### DIFF
--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -134,11 +134,11 @@ module GameManager
     game['status'] == 'active' && game['acting'].include?(user&.dig('id'))
   end
 
-  protected
-
   def url(game, path = '')
     "/game/#{game['id']}#{path}"
   end
+
+  protected
 
   def hs_url(game, game_data)
     pin = game_data&.dig('settings', 'pin')

--- a/assets/app/index.rb
+++ b/assets/app/index.rb
@@ -17,13 +17,28 @@ class Index < Snabberb::Layout
         margin: 1rem 0;
       }
 
-      .button {
+      .button, .button-link {
         font-size: 14px;
         border: solid 1px black;
         border-radius: 5px;
         padding: 0.2rem 1rem;
         cursor: pointer;
         outline-style: none;
+      }
+
+      .button-link {
+        text-decoration: none;
+        color: initial;
+        background: whitesmoke;
+
+        -webkit-appearance: button;
+        -moz-appearance: button;
+        appearance: button;
+      }
+
+      .button-link:hover {
+        background: black;
+        color: white;
       }
 
       .button:hover {

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'view/game_row'
+require 'view/link'
 
 module View
   class GameCard < Snabberb::Component
@@ -75,10 +76,10 @@ module View
           end
           JOIN_YELLOW
         when 'active'
-          buttons << render_button('Enter', -> { enter_game(@gdata) })
+          buttons << render_link(url(@gdata), -> { enter_game(@gdata) }, 'Enter')
           acting?(@user) ? YOUR_TURN_ORANGE : ENTER_GREEN
         when 'finished'
-          buttons << render_button('Review', -> { enter_game(@gdata) })
+          buttons << render_link(url(@gdata), -> { enter_game(@gdata) }, 'Enter')
           FINISHED_GREY
         end
 
@@ -124,6 +125,23 @@ module View
       }
 
       h('button.button', props, text)
+    end
+
+    def render_link(href, click, text)
+      h(
+        Link,
+        href: href,
+        click: click,
+        children: text,
+        style: {
+          top: '1rem',
+          float: 'right',
+          'border-radius': '5px',
+          'margin': '0 0.3rem',
+          padding: '0.2rem 0.5rem',
+        },
+        class: '.button-link'
+      )
     end
 
     def render_body


### PR DESCRIPTION
This switches the `enter` button to use a Link class with an `href` attribute which can then be used to right-click and open the game in a new window/tab.