### PR TITLE
Add spacing + user identification to game log/chat

### DIFF
--- a/assets/app/view/game_log.rb
+++ b/assets/app/view/game_log.rb
@@ -29,7 +29,24 @@ module View
         end
       end
 
-      children << h(:input, style: { width: '100%' }, on: { keyup: enter }) if @player
+      if @player
+        children << h(:div, { style: {
+            'margin-top': '0.5rem',
+            'display': 'flex',
+            'flex-direction': 'row',
+          } }, [
+            h(:span, { style: {
+              'font-weight': 'bold',
+              'margin-top': '4px',
+             } }, [@user['name'] + ':']),
+            h(:input,
+              style: {
+                'margin-left': '0.5rem',
+                'flex': 1,
+              },
+              on: { keyup: enter }),
+          ])
+      end
 
       props = {
         style: {


### PR DESCRIPTION
This PR enhances the game chat text box slightly to give it a bit more focus and fixes the input width :)

When I started a game, I did not realize that I could type in the box! See image:

[https://postimg.cc/K15Q4YLB](https://postimg.cc/K15Q4YLB)



