### PR TITLE
Add company operating order to spreadsheet

### DIFF
--- a/assets/app/view/spreadsheet.rb
+++ b/assets/app/view/spreadsheet.rb
@@ -97,8 +97,7 @@ module View
     end
 
     def render_corporations
-      current_round = [@game.turn]
-      current_round << @game.round.round_num if @game.round.name == 'Operating Round'
+      current_round = @game.round.turn_round_num
 
       floated_corporations = @game.round.entities
       @game.corporations.map do |c|
@@ -128,7 +127,9 @@ module View
       operating_order_text = ''
       if operating_order.positive?
         operating_order_text = operating_order.to_s
-        operating_order_text += '*' if corporation_operated?(corporation, current_round)
+        corporation.operating_history.each do |history|
+          operating_order_text += '*' if history[0] == current_round
+        end
       end
 
       h(:tr, props, [
@@ -182,13 +183,6 @@ module View
         h(:th, 'Certs'),
         *@game.players.map { |p| h(:td, p.num_certs) },
       ])
-    end
-
-    def corporation_operated?(corporation, current_round)
-      corporation.operating_history.each do |history|
-        return true if history[0] == current_round
-      end
-      false
     end
   end
 end

--- a/assets/app/view/spreadsheet.rb
+++ b/assets/app/view/spreadsheet.rb
@@ -98,14 +98,11 @@ module View
 
     def render_corporations
       current_round = [@game.turn]
-      current_round += [@game.round.round_num] if @game.round.name == 'Operating Round'
+      current_round << @game.round.round_num if @game.round.name == 'Operating Round'
 
       floated_corporations = @game.round.entities
       @game.corporations.map do |c|
-        operating_order = -1
-        operating_index = floated_corporations.find_index(c)
-        operating_order = operating_index + 1 if operating_index
-
+        operating_order = (floated_corporations.find_index(c) || -1) + 1
         render_corporation(c, operating_order, current_round)
       end
     end
@@ -189,8 +186,8 @@ module View
 
     def corporation_operated?(corporation, current_round)
       current_round_s = current_round.join('.')
-      hist = corporation.operating_history
 
+      hist = corporation.operating_history
       hist.each do |x|
         history_key_s = x[0].join('.')
         return true if history_key_s == current_round_s

--- a/assets/app/view/spreadsheet.rb
+++ b/assets/app/view/spreadsheet.rb
@@ -185,14 +185,9 @@ module View
     end
 
     def corporation_operated?(corporation, current_round)
-      current_round_s = current_round.join('.')
-
-      hist = corporation.operating_history
-      hist.each do |x|
-        history_key_s = x[0].join('.')
-        return true if history_key_s == current_round_s
+      corporation.operating_history.each do |history|
+        return true if history[0] == current_round
       end
-
       false
     end
   end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -15,6 +15,7 @@ module Engine
         @log = game.log
         @current_entity = @entities.first
         @end_game = false
+        @round_num = 1
       end
 
       def log_new_round
@@ -44,6 +45,10 @@ module Engine
       def next_entity
         index = @entities.find_index(@current_entity) + 1
         index < @entities.size ? @entities[index] : @entities[0]
+      end
+
+      def turn_round_num
+        [@game.turn, @round_num]
       end
 
       def pass(action)


### PR DESCRIPTION
So this is part of #291 where we first implement an operating order column for the spreadsheet tab. Companies that have already operated are marked with an `*`. Unfloated companies do not have an order and neither do companies in a stock/auction round.

See screenshots:

[https://postimg.cc/SYz8Lhrf](https://postimg.cc/SYz8Lhrf)
[https://postimg.cc/BLzH16xv](https://postimg.cc/BLzH16xv)

In the next iteration we could tackle sorting on the UI :)