### PR TITLE
add default operating info, closes #618

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -111,6 +111,10 @@ module Engine
       @operating_history[[turn, round_num]] = info
     end
 
+    def operating_info(turn, round_num)
+      @operating_history[[turn, round_num]]
+    end
+
     def inspect
       "<#{self.class.name}: #{id}>"
     end

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -107,14 +107,6 @@ module Engine
       true
     end
 
-    def add_operating_info!(turn, round_num, info)
-      @operating_history[[turn, round_num]] = info
-    end
-
-    def operating_info(turn, round_num)
-      @operating_history[[turn, round_num]]
-    end
-
     def inspect
       "<#{self.class.name}: #{id}>"
     end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -235,9 +235,7 @@ module Engine
 
       def _process_action(action)
         entity = action.entity
-        # default operating action is to payout 0, i.e. withhold
-        or_info = OperatingInfo.new([], Action::Dividend.new(@game.current_entity, 'withhold'), 0)
-
+        
         case action
         when Action::LayTile
           hex_id = action.hex.id
@@ -272,6 +270,7 @@ module Engine
         when Action::Dividend
           revenue = @current_routes.sum(&:revenue)
           or_info = OperatingInfo.new(@current_routes, action, revenue)
+          @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
           @current_routes = []
 
           case action.kind
@@ -297,14 +296,15 @@ module Engine
         when Action::Bankrupt
           liquidate(entity.owner)
         end
-
-        @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
       end
 
       def start_operating
         return if finished?
 
         log_operation(@current_entity)
+        # default operating action is to payout 0, i.e. withhold
+        or_info = OperatingInfo.new([], Action::Dividend.new(@game.current_entity, 'withhold'), 0)
+        @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
         place_home_token(@current_entity) if @home_token_timing == :operate
       end
 

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -235,6 +235,8 @@ module Engine
 
       def _process_action(action)
         entity = action.entity
+        # default operating action is to payout 0, i.e. withhold
+        or_info = OperatingInfo.new([], Action::Dividend.new(@game.current_entity, 'withhold'), 0)
 
         case action
         when Action::LayTile
@@ -270,7 +272,6 @@ module Engine
         when Action::Dividend
           revenue = @current_routes.sum(&:revenue)
           or_info = OperatingInfo.new(@current_routes, action, revenue)
-          @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
           @current_routes = []
 
           case action.kind
@@ -296,6 +297,8 @@ module Engine
         when Action::Bankrupt
           liquidate(entity.owner)
         end
+
+        @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
       end
 
       def start_operating

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -269,8 +269,11 @@ module Engine
           end
         when Action::Dividend
           revenue = @current_routes.sum(&:revenue)
-          or_info = OperatingInfo.new(@current_routes, action, revenue)
-          @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
+          @current_entity.operating_history[[@game.turn, @round_num]] = OperatingInfo.new(
+            @current_routes,
+            action,
+            revenue
+          )
           @current_routes = []
 
           case action.kind
@@ -308,11 +311,12 @@ module Engine
       def change_entity(_action)
         return unless @current_entity.passed?
 
-        unless @current_entity.operating_info(@game.turn, @round_num)
-          # default operating action is to payout 0, i.e. withhold
-          or_info = OperatingInfo.new([], Action::Dividend.new(@game.current_entity, 'withhold'), 0)
-          @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
-        end
+        # default operating action is to payout 0, i.e. withhold
+        @current_entity.operating_history[[@game.turn, @round_num]] ||= OperatingInfo.new(
+          [],
+          Action::Dividend.new(@game.current_entity, 'withhold'),
+          0
+        )
 
         if @teleported
           @teleported = false

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -235,7 +235,7 @@ module Engine
 
       def _process_action(action)
         entity = action.entity
-        
+
         case action
         when Action::LayTile
           hex_id = action.hex.id
@@ -302,14 +302,17 @@ module Engine
         return if finished?
 
         log_operation(@current_entity)
-        # default operating action is to payout 0, i.e. withhold
-        or_info = OperatingInfo.new([], Action::Dividend.new(@game.current_entity, 'withhold'), 0)
-        @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
         place_home_token(@current_entity) if @home_token_timing == :operate
       end
 
       def change_entity(_action)
         return unless @current_entity.passed?
+
+        unless @current_entity.operating_info(@game.turn, @round_num)
+          # default operating action is to payout 0, i.e. withhold
+          or_info = OperatingInfo.new([], Action::Dividend.new(@game.current_entity, 'withhold'), 0)
+          @current_entity.add_operating_info!(@game.turn, @round_num, or_info)
+        end
 
         if @teleported
           @teleported = false


### PR DESCRIPTION
This fix adds a default operating information for any company that is operating.

The default is to withhold with a revenue of 0. This allows one to identify if a company has operated its turn or not. This is especially relevant for the spreadsheet view.