### PR TITLE
Map axes: allow letters to be rows or columns

### DIFF
--- a/assets/app/view/axis.rb
+++ b/assets/app/view/axis.rb
@@ -7,6 +7,7 @@ module View
     needs :cols
     needs :rows
     needs :layout
+    needs :axes
 
     needs :font_size, default: 25
     needs :text_length, default: 25
@@ -40,9 +41,15 @@ module View
     def col_labels
       hex_x, hex_y = hex_size
 
-      labels = @cols.map do |c|
-        x = hex_x * (c.to_i - 1)
-        label = ('A'..'Z').to_a[c - 1]
+      labels = @cols.map do |col|
+        x = hex_x * (col.to_i - 1)
+
+        label =
+          if @axes[:x] == :letter
+            ('A'..'Z').to_a[col - 1]
+          else
+            col
+          end
         h(:text, { attrs: { x: x } }, label)
       end
 
@@ -74,7 +81,13 @@ module View
         multiplier -= 0.5 if @layout == :pointy
         y = hex_y * multiplier
 
-        label = row
+        label =
+          if @axes[:y] == :letter
+            ('A'..'Z').to_a[row - 1]
+          else
+            row
+          end
+
         h(:text, { attrs: { y: y } }, label)
       end
 

--- a/assets/app/view/map.rb
+++ b/assets/app/view/map.rb
@@ -78,6 +78,7 @@ module View
           h(Axis,
             cols: @cols,
             rows: @rows,
+            axes: @game.axes,
             layout: @layout,
             font_size: font_size,
             gap: GAP,

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -33,40 +33,43 @@ module Engine
   },
   "capitalization": "incremental",
   "layout": "pointy",
+  "axes": {
+    "rows": "numbers",
+    "columns": "letters"
+  },
   "mustSellInBlocks": false,
   "locationNames": {
-    "H2": "Holland",
-    "P2": "Port Huron",
-    "R2": "Sarnia",
-    "E3": "Chicago Connections",
-    "I3": "South Bend",
-    "O3": "Detroit",
-    "Q3": "Windsor",
-    "N4": "Toledo",
-    "T4": "Erie",
-    "U3": "Buffalo",
-    "V4": "Buffalo",
-    "K5": "Fort Wayne",
-    "Q5": "Cleveland",
-    "U5": "Salamanca",
-    "W5": "Binghamton",
-    "C7": "Springfield",
+    "B8": "Holland",
+    "B16": "Port Huron",
+    "B18": "Sarnia",
+    "C5": "Chicago Connections",
+    "C9": "South Bend",
+    "C15": "Detroit",
+    "C17": "Windsor",
+    "D14": "Toledo",
+    "D20": "Erie",
+    "C23": "Buffalo",
+    "D22": "Buffalo",
+    "E11": "Fort Wayne",
+    "E17": "Cleveland",
+    "E21": "Salamanca",
+    "E23": "Binghamton",
+    "G3": "Springfield",
     "G7": "Terre Haute",
-    "I7": "Indianapolis",
-    "M7": "Dayton",
-    "O7": "Columbus",
-    "S7": "Wheeling",
-    "U7": "Pittsburgh",
-    "V6": "Pittsburgh",
-    "L8": "Cincinnati",
-    "T6": "Homewood",
-    "T8": "Cumberland",
-    "A9": "St. Louis",
-    "E9": "Centralia",
-    "O9": "Huntington",
-    "Q9": "Charleston",
+    "G9": "Indianapolis",
+    "G13": "Dayton",
+    "G15": "Columbus",
+    "G19": "Wheeling",
+    "G21": "Pittsburgh",
+    "G21": "Pittsburgh",
+    "H12": "Cincinnati",
+    "H20": "Cumberland",
+    "I1": "St. Louis",
+    "I5": "Centralia",
+    "I15": "Huntington",
+    "I17": "Charleston",
     "J10": "Louisville",
-    "C11": "Cairo"
+    "K3": "Cairo"
   },
   "tiles": {
     "5": 3,
@@ -159,20 +162,20 @@ module Engine
       "value": 60,
       "discount": -80,
       "revenue": 0,
-      "desc": "Starts with $60 in treasury, a 2 train, and a token in Detroit (O3). Splits revenue evenly with owner. Buyer pays an extra $80 (\"debt\")."
+      "desc": "Starts with $60 in treasury, a 2 train, and a token in Detroit (C15). Splits revenue evenly with owner. Buyer pays an extra $80 (\"debt\")."
     },
     {
       "name": "Big 4",
       "value": 40,
       "discount": -60,
       "revenue": 0,
-      "desc": "Starts with $40 in treasury, a 2 train, and a token in Indianapolis (I7). Splits revenue evenly with owner. Buyer pays an extra $60 (\"debt\")."
+      "desc": "Starts with $40 in treasury, a 2 train, and a token in Indianapolis (G9). Splits revenue evenly with owner. Buyer pays an extra $60 (\"debt\")."
     },
     {
       "name": "Chicago and Western Indiana",
       "value": 60,
       "revenue": 10,
-      "desc": "Reserves a token slot in Chicago (F4), in which the owning corporation may place an extra token at no cost."
+      "desc": "Reserves a token slot in Chicago (D6), in which the owning corporation may place an extra token at no cost."
     },
     {
       "name": "Mail Contract",
@@ -190,31 +193,31 @@ module Engine
       "name": "Meat Packing Company",
       "value": 60,
       "revenue": 15,
-      "desc": "The owning corporation may place a $30 marker in either St. Louis (A9) or Chicago (F4), to add $30 to all routes run to this location."
+      "desc": "The owning corporation may place a $30 marker in either St. Louis (I1) or Chicago (D6), to add $30 to all routes run to this location."
     },
     {
       "name": "Steamboat Company",
       "value": 40,
       "revenue": 10,
-      "desc": "Place or shift the port marker among port locations (H2, E3, N4, S7, A9). Add $20 per port symbol to all routes run to this location by the owning (or assigned) company."
+      "desc": "Place or shift the port marker among port locations (B8, C5, D14, G19, I1). Add $20 per port symbol to all routes run to this location by the owning (or assigned) company."
     },
     {
       "name": "Lake Shore Line",
       "value": 40,
       "revenue": 15,
-      "desc": "The owning corporation may make an extra $0 cost tile upgrade of either Cleveland (Q5) or Toledo (N4), but not both."
+      "desc": "The owning corporation may make an extra $0 cost tile upgrade of either Cleveland (E17) or Toledo (D14), but not both."
     },
     {
       "name": "Michigan Central",
       "value": 40,
       "revenue": 15,
-      "desc": "The owning corporation may lay up to two extra $0 cost yellow tiles in the MC's reserved hexes (J2, L2)."
+      "desc": "The owning corporation may lay up to two extra $0 cost yellow tiles in the MC's reserved hexes (B10, B12)."
     },
     {
       "name": "Ohio & Indiana",
       "value": 40,
       "revenue": 15,
-      "desc": "The owning corporation may lay up to two extra $0 cost yellow tiles in the O&I's reserved hexes (N6, P6)."
+      "desc": "The owning corporation may lay up to two extra $0 cost yellow tiles in the O&I's reserved hexes (F14, F16)."
     }
   ],
   "corporations": [
@@ -230,7 +233,7 @@ module Engine
         80,
         0
       ],
-      "coordinates": "T6",
+      "coordinates": "F20",
       "color": "red"
     },
     {
@@ -244,7 +247,7 @@ module Engine
         80,
         80
       ],
-      "coordinates": "T4",
+      "coordinates": "D20",
       "color": "black"
     },
     {
@@ -258,7 +261,7 @@ module Engine
         80,
         0
       ],
-      "coordinates": "S7",
+      "coordinates": "G19",
       "color": "blue"
     },
     {
@@ -272,7 +275,7 @@ module Engine
         80,
         80
       ],
-      "coordinates": "O9",
+      "coordinates": "I15",
       "color": "lightBlue",
       "text_color": "black"
     },
@@ -287,7 +290,7 @@ module Engine
         80,
         0
       ],
-      "coordinates": "U5",
+      "coordinates": "E21",
       "color": "yellow",
       "text_color": "black"
     },
@@ -301,7 +304,7 @@ module Engine
         80,
         80
       ],
-      "coordinates": "P2",
+      "coordinates": "B16",
       "color": "orange"
     },
     {
@@ -315,7 +318,7 @@ module Engine
         80,
         0
       ],
-      "coordinates": "C11",
+      "coordinates": "K3",
       "color": "green"
     }
   ],
@@ -392,117 +395,117 @@ module Engine
       "blank": [
         "E5",
         "F6",
-        "E7",
-        "F8",
-        "D10",
-        "N2",
-        "K3",
-        "M3",
-        "H4",
-        "J4",
-        "L4",
         "G5",
-        "I5",
-        "M5",
-        "O5",
-        "S5",
-        "D6",
         "H6",
-        "J6",
-        "L6",
-        "K7",
-        "B8",
+        "J4",
+        "B14",
+        "C11",
+        "C13",
         "D8",
+        "D10",
+        "D12",
+        "E7",
+        "E9",
+        "E13",
+        "E15",
+        "E19",
+        "F4",
+        "F8",
+        "F10",
+        "F12",
+        "G11",
+        "H2",
+        "H4",
         "H8",
-        "J8",
-        "C9",
-        "G9",
-        "I9",
         "H10",
-        "R4",
-        "J2",
-        "L2",
-        "N6",
-        "P6",
-        "K9",
-        "F10"
-      ],
-      "city": [
-        "P2",
         "I3",
-        "N4",
-        "K5",
-        "C7",
-        "G7",
         "I7",
-        "M7",
-        "O7"
+        "I9",
+        "J8",
+        "D18",
+        "B10",
+        "B12",
+        "F14",
+        "F16",
+        "I11",
+        "J6"
+      ],
+      "c=r:0": [
+        "B16",
+        "C9",
+        "D14",
+        "E11",
+        "G3",
+        "G7",
+        "G9",
+        "G13",
+        "G15"
       ],
       "c=r:0;l=Z": [
-        "Q5",
-        "L8"
+        "E17",
+        "H12"
       ],
       "u=c:40,t:mountain": [
-        "R6",
-        "Q7",
-        "P8"
+        "F18",
+        "G17",
+        "H16"
       ],
       "u=c:60,t:mountain": [
-        "N8"
+        "H14"
       ]
     },
     "gray": {
       "p=a:5,b:0": [
-        "O1",
-        "G3"
+        "A15",
+        "C7"
       ],
       "c=r:10;p=a:1,b:_0;p=a:2,b:_0;p=a:4,b:_0;p=a:5,b:_0": [
-        "T6"
+        "F20"
       ],
       "c=r:10,s:2;p=a:1,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:0,b:_0": [
-        "E9"
+        "I5"
       ],
       "c=r:20;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0": [
-        "O9"
+        "I15"
       ],
       "c=r:20;p=a:3,b:_0": [
-        "C11"
+        "K3"
       ]
     },
     "red": {
       "o=r:yellow_40|brown_10;p=a:4,b:_0": [
-        "H2"
+        "B8"
       ],
       "o=r:yellow_30|brown_50;p=a:1,b:_0;l=E": [
-        "R2"
+        "B18"
       ],
       "o=r:yellow_20|brown_40;p=a:5,b:_0;l=W": [
-        "E3"
+        "C5"
       ],
       "o=r:yellow_40|brown_60;p=a:1,b:_0;l=E": [
-        "Q3"
+        "C17"
       ],
-      "o=r:yellow_30|brown_60;p=a:0,b:_0;l=E": [
-        "U3"
+      "o=yellow_30|brown_60;p=a:0,b:_0;l=E": [
+        "C21"
       ],
-      "o=r:yellow_30|brown_60;p=a:1,b:_0;l=E": [
-        "V4"
+      "o=yellow_30|brown_60;p=a:1,b:_0;l=E": [
+        "D22"
       ],
       "o=r:yellow_20|brown_50;p=a:1,b:_0;l=E": [
-        "W5",
-        "Q9"
+        "E23",
+        "I17"
       ],
-      "o=r:yellow_30|brown_70;p=a:1,b:_0;l=E": [
-        "V6"
+      "o=yellow_30|brown_70;p=a:1,b:_0;l=E": [
+        "F22"
       ],
-      "o=r:yellow_30|brown_70;p=a:1,b:_0;p=a:2,b:_0;l=E": [
-        "U7"
+      "o=yellow_30|brown_70;p=a:1,b:_0;p=a:2,b:_0;l=E": [
+        "G21"
       ],
       "o=r:yellow_20|brown_40;p=a:2,b:_0;l=E": [
-        "T8"
+        "H20"
       ],
       "o=r:yellow_50|brown_70;p=a:3,b:_0;p=a:4,b:_0;l=W": [
-        "A9"
+        "I1"
       ],
       "o=r:yellow_50|brown_70;p=a:2,b:_0;p=a:3,b:_0": [
         "J10"
@@ -510,25 +513,25 @@ module Engine
     },
     "yellow": {
       "c=r:40,s:2;p=a:1,b:_0;p=a:3,b:_0;l=Z;u=c:40,t:water": [
-        "O3"
+        "C15"
       ],
       "c=r:10;c=r:10;c=r:10;c=r:10;p=a:3,b:_0;p=a:4,b:_1;p=a:5,b:_2;p=a:0,b:_3;l=Chi": [
-        "F4"
+        "D6"
       ],
       "c=r:10,s:2;p=a:1,b:_0;p=a:3,b:_0;p=a:0,b:_0": [
-        "T4"
+        "D20"
       ],
       "c=r:10;p=a:1,b:_0;p=a:2,b:_0;p=a:4,b:_0": [
-        "U5"
+        "E21"
       ],
       "c=r:10;p=a:5,b:_0": [
-        "S7"
+        "G19"
       ]
     },
     "blue": {
-      "blank": [
-        "S3",
-        "P4"
+      "": [
+        "C19",
+        "D16"
       ]
     }
   },

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -41,6 +41,8 @@ module Engine
 
       LAYOUT = nil
 
+      AXES = nil
+
       TRAINS = [].freeze
 
       CERT_LIMIT = {
@@ -365,6 +367,17 @@ module Engine
         self.class::LAYOUT
       end
 
+      def axes
+        @axes ||=
+          if (axes = self.class::AXES)
+            axes
+          elsif layout == :flat
+            { x: :letter, y: :number }
+          elsif layout == :pointy
+            { x: :number, y: :letter }
+          end
+      end
+
       def format_currency(val)
         self.class::CURRENCY_FORMAT_STR % val
       end
@@ -471,7 +484,7 @@ module Engine
               # name the location (city/town)
               location_name = self.class::LOCATION_NAMES[coord]
 
-              Hex.new(coord, layout: layout, tile: tile, location_name: location_name)
+              Hex.new(coord, layout: layout, axes: axes, tile: tile, location_name: location_name)
             end
           end
         end.flatten

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -27,18 +27,43 @@ module Engine
 
     LETTERS = ('A'..'Z').to_a
 
+    COORD_LETTER = /([A-Z]+)/.freeze
+    COORD_NUMBER = /([0-9]+)/.freeze
+
     def self.invert(dir)
       (dir + 3) % 6
+    end
+
+    def self.init_x_y(coordinates, axes_config)
+      axes_config ||= { x: :letter, y: :number }
+
+      letter = coordinates.match(COORD_LETTER)[1]
+      number = coordinates.match(COORD_NUMBER)[1].to_i
+
+      x =
+        if axes_config[:x] == :letter
+          LETTERS.index(letter)
+        else
+          number - 1
+        end
+
+      y =
+        if axes_config[:y] == :letter
+          LETTERS.index(letter)
+        else
+          number - 1
+        end
+
+      [x, y]
     end
 
     # Coordinates are of the form A1..Z99
     # x and y map to the double coordinate system
     # layout is :pointy or :flat
-    def initialize(coordinates, layout: nil, tile: Tile.for('blank'), location_name: nil)
+    def initialize(coordinates, layout: nil, axes: nil, tile: Tile.for('blank'), location_name: nil)
       @coordinates = coordinates
       @layout = layout
-      @x = LETTERS.index(@coordinates[0]).to_i
-      @y = @coordinates[1..-1].to_i - 1
+      @x, @y = self.class.init_x_y(@coordinates, axes)
       @neighbors = {}
       @connections = Hash.new { |h, k| h[k] = [] }
       @location_name = location_name


### PR DESCRIPTION
screenshot album - https://imgur.com/a/zG4xN6B

by default, for pointy maps letters are rows and for flat maps letters are
columns; this can be overriden by defining AXES in the game class; for example,
this is what was used to generate the wonky 1889 screenshot:

```
AXES = { x: :number, y: :letter }.freeze
```

* update 1846 config (TODO: contribute back to 18xx-maker)
  - no aliases, this allows the blue hexes to be blue
  - rotate track appropriately



![Screenshot from 2020-06-03 19-14-28](https://user-images.githubusercontent.com/1045173/83704590-b44d4e80-a5cf-11ea-890b-20d65bd6a57d.png)
