### PR TITLE
Add sortable columns to spreadsheet view, closes #291

### DIFF
--- a/assets/app/view/spreadsheet.rb
+++ b/assets/app/view/spreadsheet.rb
@@ -8,8 +8,6 @@ require 'lib/storage'
 module View
   class Spreadsheet < Snabberb::Component
     needs :game
-    needs :spreadsheet_sort_by, default: nil
-    needs :spreadsheet_sort_order, default: nil
 
     def render
       @spreadsheet_sort_by = Lib::Storage['spreadsheet_sort_by']
@@ -91,9 +89,9 @@ module View
           h(:th, props, 'IPO'),
           h(:th, props, 'Market'),
           h(:th, props, 'IPO'),
-          render_sort_link(props, 'Market', 'SHARE-PRICE'),
+          render_sort_link(props, 'Market', 'SHARE_PRICE'),
           render_sort_link(props, 'Cash', 'CASH'),
-          render_sort_link(props, 'Operating Order', 'OPERATING-ORDER'),
+          render_sort_link(props, 'Operating Order', 'OPERATING_ORDER'),
           h(:th, props, 'Trains'),
           h(:th, props, 'Tokens'),
           h(:th, props, 'Privates'),
@@ -138,31 +136,29 @@ module View
     def render_corporations
       current_round = @game.round.turn_round_num
 
-      ordered_corporations = sorted_corporations
-      ordered_corporations.map do |c|
+      sorted_corporations.map do |c|
         render_corporation(c[1], c[0], current_round)
       end
     end
 
     def sorted_corporations
-      result = []
       floated_corporations = @game.round.entities
 
-      @game.corporations.map do |c|
+      result = @game.corporations.map do |c|
         operating_order = (floated_corporations.find_index(c) || -1) + 1
-        result << [operating_order, c]
+        [operating_order, c]
       end
 
-      result = result.sort_by do |c|
+      result.sort_by! do |operating_order, corporation|
         case @spreadsheet_sort_by
-        when 'OPERATING-ORDER'
-          c[0]
+        when 'OPERATING_ORDER'
+          operating_order
         when 'CASH'
-          c[1].cash
-        when 'SHARE-PRICE'
-          c[1].share_price.nil? ? 0 : c[1].share_price.price
+          corporation.cash
+        when 'SHARE_PRICE'
+          corporation.share_price&.price || 0
         else
-          c[1].id
+          corporation.id
         end
       end
 

--- a/assets/app/view/spreadsheet.rb
+++ b/assets/app/view/spreadsheet.rb
@@ -86,58 +86,14 @@ module View
           h(:th, { attrs: { colspan: or_history_titles.size } }, 'OR History'),
           ]),
         h(:tr, [
-          h(:th, { style: { width: '20px' } }, [
-            h(
-              Link,
-              href: '',
-              click: lambda {
-                mark_sort_column('ID')
-                toggle_sort_order
-              },
-              children: 'SYM' + (@spreadsheet_sort_by == 'ID' ? ' ' + sort_order_icon : ''),
-              class: ''
-            ),
-          ]),
+          render_sort_link({ style: { width: '20px' } }, 'SYM', 'ID'),
           *@game.players.map { |p| h(:th, props, p.name) },
           h(:th, props, 'IPO'),
           h(:th, props, 'Market'),
           h(:th, props, 'IPO'),
-          h(:th, props, [
-            h(
-              Link,
-              href: '',
-              click: lambda {
-                mark_sort_column('SHARE-PRICE')
-                toggle_sort_order
-              },
-              children: 'Market' + (@spreadsheet_sort_by == 'SHARE-PRICE' ? ' ' + sort_order_icon : ''),
-              class: ''
-            ),
-          ]),
-          h(:th, props, [
-            h(
-              Link,
-              href: '',
-              click: lambda {
-                mark_sort_column('CASH')
-                toggle_sort_order
-              },
-              children: 'Cash' + (@spreadsheet_sort_by == 'CASH' ? ' ' + sort_order_icon : ''),
-              class: ''
-            ),
-          ]),
-          h(:th, props, [
-            h(
-              Link,
-              href: '',
-              click: lambda {
-                mark_sort_column('OPERATING-ORDER')
-                toggle_sort_order
-              },
-              children: 'Operating Order' + (@spreadsheet_sort_by == 'OPERATING-ORDER' ? ' ' + sort_order_icon : ''),
-              class: ''
-            ),
-          ]),
+          render_sort_link(props, 'Market', 'SHARE-PRICE'),
+          render_sort_link(props, 'Cash', 'CASH'),
+          render_sort_link(props, 'Operating Order', 'OPERATING-ORDER'),
           h(:th, props, 'Trains'),
           h(:th, props, 'Tokens'),
           h(:th, props, 'Privates'),
@@ -145,6 +101,21 @@ module View
           *or_history_titles,
         ]),
       ]
+    end
+
+    def render_sort_link(props, title, sort_by)
+      h(:th, props, [
+        h(
+          Link,
+          href: '',
+          click: lambda {
+            mark_sort_column(sort_by)
+            toggle_sort_order
+          },
+          children: title + (@spreadsheet_sort_by == sort_by ? ' ' + sort_order_icon : ''),
+          class: ''
+        ),
+      ])
     end
 
     def sort_order_icon


### PR DESCRIPTION
This PR allows sorting columns in the spreadsheet view. At the moment the following 3 columns are supported:
- Operating Order
- Cash
- Market price

The default is to sort by company symbol in ascending order (current view). The sort preferences are locally stored so they should be maintained over sessions :).

See screencast: [https://streamable.com/oobcg6](https://streamable.com/oobcg6)