### PR TITLE
min-width: 1480px => display map inline

### DIFF
--- a/assets/app/view/map.rb
+++ b/assets/app/view/map.rb
@@ -50,11 +50,10 @@ module View
       props = {
          style: {
            overflow: 'auto',
-           margin: '1rem -1rem',
          },
       }
 
-      h(:div, props, children)
+      h('div.map', props, children)
     end
 
     def render_map

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -119,6 +119,16 @@ a.game__nav:focus {
   .half { width: 49%; }
 }
 
+div.map {
+  margin: 1rem -1rem;
+}
+@media only screen and (min-width: 1480px) {
+  div.map {
+    display: inline-block;
+    margin: -1.5rem 1rem 1rem 1rem;
+  }
+}
+
 .tile {
    fill: none;
    stroke-width: 1;


### PR DESCRIPTION
1480 is rather arbitrary, works for Chessie and 1889, but won’t be ideal for larger or smaller maps. Media query with calculated min-width = map-width + x would be the way to go. That would be a breeze with Stylus or another CSS-preprocessor ;) Another option would be JS of course.