### PR TITLE
change upgrades_to? specs to one test per game title

### DIFF
--- a/spec/lib/engine/tile_spec.rb
+++ b/spec/lib/engine/tile_spec.rb
@@ -93,21 +93,23 @@ module Engine
       }.freeze
 
       EXPECTED_TILE_UPGRADES.each do |game_title, upgrades|
-        context game_title do
+        it "correctly upgrades tiles for #{game_title}" do
           game = Engine::GAMES_BY_TITLE[game_title].new(%w[p1 p2 p3])
 
-          upgrades.keys.each do |t|
-            tile = game.tile_by_id("#{t}-0") || Tile.for(t)
+          aggregate_failures 'tile upgrades' do
+            upgrades.keys.each do |t|
+              tile = game.tile_by_id("#{t}-0") || Tile.for(t)
 
-            context "tile \"#{t}\"" do
               upgrades.keys.each do |u|
-                upgrade = game.tile_by_id("#{u}-0") || Tile.for(t)
+                upgrade = game.tile_by_id("#{u}-0") || Tile.for(u)
 
-                included = upgrades[t].include?(u)
+                expected_included = upgrades[t].include?(u)
+                expected_string = "#{t} #{expected_included ? '<' : '!<'} #{u}"
 
-                it "can#{included ? '' : 'not'} upgrade to tile \"#{u}\"" do
-                  expect(tile.upgrades_to?(upgrade)).to eq(included)
-                end
+                actual_included = tile.upgrades_to?(upgrade)
+                actual_string = "#{t} #{actual_included ? '<' : '!<'} #{u}"
+
+                expect(actual_string).to eq(expected_string)
               end
             end
           end


### PR DESCRIPTION
These specs were originally written as one test per upgrade to ensure the rspec
output would be useful, but the number of tests that created is not so useful.

Using aggregate_failures to group upgrades_to? tests by game gets the number of
tests to something more reasonable.

Using expected/actual strings instead of just the return value of
`upgrades_to?` (`true`/`false`) keeps the rspec output useful.

For these tests, `A < B` means "A upgrades to B" and `A !< B` means "A does not
upgrade to B"