### PR TITLE
special round: filter laid hexes from connected_hexes

### DIFF
--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -200,6 +200,11 @@ module Engine
         rotation = action.rotation
         old_tile = hex.tile
 
+        # at time of writing, this check is invalid for tile 437 in 1889; we
+        # need to remove the P label and properly implement ports to use this
+        # error
+        # raise GameError, "#{old_tile.name} cannot upgrade to #{tile.name}" unless old_tile.upgrades_to?(tile)
+
         @game.tiles.delete(tile)
         @game.tiles << old_tile unless old_tile.preprinted
 

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -25,10 +25,12 @@ module Engine
       end
 
       def connected_hexes
-        tile_laying_ability[:hexes]&.map do |coordinates|
+        (tile_laying_ability[:hexes] || []).map do |coordinates|
           hex = @game.hex_by_id(coordinates)
+          next unless hex.tile.preprinted
+
           [hex, hex.neighbors.keys]
-        end.to_h
+        end.compact.to_h
       end
 
       private


### PR DESCRIPTION
I tried adding a check in `Engine::Round::Base#lay_tile` for
`old_tile.upgrades_to?(tile)`, but that breaks in the case of 1889's port town
-> tile 437. Will need to add a "port" part to the appropriate towns and tile
437 for that to work correctly.

This now prevents the UI from allowing a private company to lay a tile on a hex
that already has a tile laid on it, but if that action sneaks in, it is not
caught, meaning past games that did this illegally should survive for now.

[Fixes #613]