### PR TITLE
forms: placeholder, label_props, for/id

### DIFF
--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -45,24 +45,33 @@ module View
     end
 
     # rubocop:disable Layout/LineLength
-    def render_input(label, id:, el: 'input', type: 'text', attrs: {}, container_style: {}, input_style: {}, children: [])
+    def render_input(label, placeholder: '', id:, el: 'input', type: 'text', attrs: {}, container_style: {}, label_style: {}, input_style: {}, children: [])
       # rubocop:enable Layout/LineLength
-      props = {
+      label_props = {
+        style: {
+          **label_style,
+        },
+        attrs: {
+          for: id,
+        },
+      }
+      input_props = {
         style: {
           **input_style,
         },
         attrs: {
-          placeholder: label,
+          placeholder: placeholder,
+          id: id,
           type: type,
           **attrs,
         },
       }
-      input = h(el, props, children)
+      input = h(el, input_props, children)
       @inputs[id] = input
       h(
         'div.input-container',
         { style: { **container_style } },
-        [h(:label, label), input]
+        [h(:label, label_props, label), input]
       )
     end
 


### PR DESCRIPTION
+ placeholder:
+ label_props
+ for on label
+ id on input

for + id connect label and input => click on label results in focus on input
dedicated placeholder to separate label/placeholder
render_input() is used in reset.rb, create_game.rb, forgot.rb and user.rb. I haven’t added placeholders there.

Without iOS device hard to test, but missing ids might have been the reason color inputs displayed standard color (black) on iOS. So this commit might fix this issue. Reports in regards to my [test-page](https://yzemaze.de/temp/18xx_profile_test.html) were positive.