### PR TITLE
Fix issue of tile selector stuck onscreen, improve tile selector code

### DIFF
--- a/assets/app/lib/tile_selector.rb
+++ b/assets/app/lib/tile_selector.rb
@@ -4,17 +4,12 @@ module Lib
   class TileSelector
     attr_reader :entity, :hex, :tile, :x, :y
 
-    def initialize(hex, tile, event, root, entity)
+    def initialize(hex, tile, coordinates, root, entity)
       @hex = hex
       @tile = tile
-      @x, @y = get_coordinates(event)
+      @x, @y = coordinates
       @root = root
       @entity = entity
-    end
-
-    def get_coordinates(event)
-      rect = event.JS['currentTarget'].JS.getBoundingClientRect
-      [`window.pageXOffset` + rect.JS['left'], `window.pageYOffset` + rect.JS['top']]
     end
 
     def tile=(new_tile)

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -12,6 +12,7 @@ module View
         base.needs :flash_opts, default: {}, store: true
         base.needs :connection, store: true, default: nil
         base.needs :user, store: true, default: nil
+        base.needs :tile_selector, default: nil, store: true
       end
 
       def process_action(action)
@@ -62,6 +63,7 @@ module View
         end
 
         store(:game, game)
+        store(:tile_selector, nil, skip: true)
       rescue StandardError => e
         store(:game, @game.clone(@game.actions), skip: true)
         store(:flash_opts, e.message)

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -7,6 +7,7 @@ module View
       needs :bids, default: nil
       needs :selected_company, default: nil, store: true
       needs :game, store: true
+      needs :tile_selector, default: nil, store: true
 
       def selected?
         @company == @selected_company
@@ -26,6 +27,7 @@ module View
       def render
         onclick = lambda do
           selected_company = selected? ? nil : @company
+          store(:tile_selector, nil)
           store(:selected_company, selected_company)
         end
 

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -66,15 +66,8 @@ module View
         props[:attrs][:cursor] = 'pointer' if clickable
 
         props[:on] = { click: ->(e) { on_hex_click(e) } } if clickable
-        if @selected
-          props[:attrs]['stroke-width'] = 5
-          props[:hook] = { destroy: -> { cleanup } }
-        end
+        props[:attrs]['stroke-width'] = 5 if @selected
         h(:g, props, children)
-      end
-
-      def cleanup
-        store(:tile_selector, nil, skip: true)
       end
 
       def translation
@@ -91,7 +84,7 @@ module View
         "#{translation}#{@hex.layout == :pointy ? ' rotate(30)' : ''}"
       end
 
-      def on_hex_click(_event)
+      def on_hex_click
         nodes = @hex.tile.nodes
 
         if @round&.can_run_routes?

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -44,27 +44,28 @@ module View
         children = [render_map]
 
         if @tile_selector
-          selector = if @tile_selector.hex.tile != @tile_selector.tile
-                       h(TileConfirmation)
-                     else
-                       begin
-                         tiles = round.upgradeable_tiles(@tile_selector.hex)
+          begin
+            tiles = round.upgradeable_tiles(@tile_selector.hex)
+            selector = if @tile_selector.hex.tile != @tile_selector.tile
+                         h(TileConfirmation)
+                       else
                          h(TileSelector, layout: @layout, tiles: tiles)
-                       rescue StandardError
-                         nil
                        end
-                     end
-
-          # Move the position to the middle of the hex
-          props = {
-            style: {
-              position: 'relative',
-              left: "#{(@tile_selector.x + map_x) * SCALE}px",
-              top: "#{(@tile_selector.y + map_y) * SCALE}px",
-            },
-          }
-          # This needs to be before the map, so that the relative positioning works
-          children.unshift(h(:div, props, [selector])) if selector
+            # Move the position to the middle of the hex
+            props = {
+             style: {
+               position: 'relative',
+               left: "#{(@tile_selector.x + map_x) * SCALE}px",
+               top: "#{(@tile_selector.y + map_y) * SCALE}px",
+             },
+            }
+            # This needs to be before the map, so that the relative positioning works
+            children.unshift(h(:div, props, [selector])) if selector
+          rescue StandardError
+            # If the tile selector is left up when undo occurs an exception can occur, clear
+            store(:tile_selector, nil)
+            nil
+          end
         end
 
         props = {

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -44,28 +44,22 @@ module View
         children = [render_map]
 
         if @tile_selector
-          begin
-            tiles = round.upgradeable_tiles(@tile_selector.hex)
-            selector = if @tile_selector.hex.tile != @tile_selector.tile
-                         h(TileConfirmation)
-                       else
-                         h(TileSelector, layout: @layout, tiles: tiles)
-                       end
-            # Move the position to the middle of the hex
-            props = {
-             style: {
-               position: 'relative',
-               left: "#{(@tile_selector.x + map_x) * SCALE}px",
-               top: "#{(@tile_selector.y + map_y) * SCALE}px",
-             },
-            }
-            # This needs to be before the map, so that the relative positioning works
-            children.unshift(h(:div, props, [selector])) if selector
-          rescue StandardError
-            # If the tile selector is left up when undo occurs an exception can occur, clear
-            store(:tile_selector, nil)
-            nil
-          end
+          selector = if @tile_selector.hex.tile != @tile_selector.tile
+                       h(TileConfirmation)
+                     else
+                       tiles = round.upgradeable_tiles(@tile_selector.hex)
+                       h(TileSelector, layout: @layout, tiles: tiles)
+                     end
+          # Move the position to the middle of the hex
+          props = {
+           style: {
+             position: 'relative',
+             left: "#{(@tile_selector.x + map_x) * SCALE}px",
+             top: "#{(@tile_selector.y + map_y) * SCALE}px",
+           },
+          }
+          # This needs to be before the map, so that the relative positioning works
+          children.unshift(h(:div, props, [selector]))
         end
 
         props = {

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -44,17 +44,24 @@ module View
         children = [render_map]
 
         if @tile_selector
+          left = (@tile_selector.x + map_x) * SCALE
           selector = if @tile_selector.hex.tile != @tile_selector.tile
                        h(TileConfirmation)
                      else
+                       # Selecting column A can cause tiles to go off the edge of the map
+                       if (left - (TileSelector::DISTANCE + (TileSelector::TILE_SIZE / 2))).negative?
+                         left = TileSelector::DISTANCE + (TileSelector::TILE_SIZE / 2)
+                       end
+
                        tiles = round.upgradeable_tiles(@tile_selector.hex)
                        h(TileSelector, layout: @layout, tiles: tiles)
                      end
+
           # Move the position to the middle of the hex
           props = {
            style: {
              position: 'relative',
-             left: "#{(@tile_selector.x + map_x) * SCALE}px",
+             left: "#{left}px",
              top: "#{(@tile_selector.y + map_y) * SCALE}px",
            },
           }

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -14,7 +14,9 @@ module View
       needs :selected_company, default: nil, store: true
       needs :opacity, default: nil
 
+      FONT_SIZE = 25
       GAP = 25 # GAP between the row/col labels and the map hexes
+      SCALE = 0.5 # Scale for the map
 
       def render
         @hexes = @game.hexes.dup
@@ -41,11 +43,28 @@ module View
 
         children = [render_map]
 
-        if @tile_selector && @tile_selector.hex.tile != @tile_selector.tile
-          children << h(TileConfirmation)
-        elsif @tile_selector
-          tiles = round.upgradeable_tiles(@tile_selector.hex)
-          children << h(TileSelector, layout: @layout, tiles: tiles)
+        if @tile_selector
+          selector = if @tile_selector.hex.tile != @tile_selector.tile
+                       h(TileConfirmation)
+                     else
+                       begin
+                         tiles = round.upgradeable_tiles(@tile_selector.hex)
+                         h(TileSelector, layout: @layout, tiles: tiles)
+                       rescue StandardError
+                         nil
+                       end
+                     end
+
+          # Move the position to the middle of the hex
+          props = {
+            style: {
+              position: 'relative',
+              left: "#{(@tile_selector.x + map_x) * SCALE}px",
+              top: "#{(@tile_selector.y + map_y) * SCALE}px",
+            },
+          }
+          # This needs to be before the map, so that the relative positioning works
+          children.unshift(h(:div, props, [selector])) if selector
         end
 
         props = {
@@ -58,11 +77,15 @@ module View
         h(:div, props, children)
       end
 
-      def render_map
-        font_size = 25
-        map_x = GAP + font_size
-        map_y = GAP + (@layout == :flat ? (font_size / 2) : font_size)
+      def map_x
+        GAP + FONT_SIZE
+      end
 
+      def map_y
+        GAP + (@layout == :flat ? (FONT_SIZE / 2) : FONT_SIZE)
+      end
+
+      def render_map
         w_size, h_size = @layout == :flat ? [85, 50] : [50, 85]
         width = (@cols.size * w_size) + GAP
         height = (@rows.size * h_size) + GAP
@@ -75,14 +98,14 @@ module View
         }
 
         h(:svg, props, [
-          h(:g, { attrs: { transform: 'scale(0.5)' } }, [
+          h(:g, { attrs: { transform: "scale(#{SCALE})" } }, [
             h(:g, { attrs: { id: 'map-hexes', transform: "translate(#{map_x} #{map_y})" } }, @hexes),
             h(Axis,
               cols: @cols,
               rows: @rows,
               axes: @game.axes,
               layout: @layout,
-              font_size: font_size,
+              font_size: FONT_SIZE,
               gap: GAP,
               map_x: map_x,
               map_y: map_y),

--- a/assets/app/view/game/tile_confirmation.rb
+++ b/assets/app/view/game/tile_confirmation.rb
@@ -11,19 +11,13 @@ module View
       needs :tile_selector, store: true
 
       def render
-        style = {
-          position: 'absolute',
-          left: @tile_selector.x,
-          top: @tile_selector.y,
-        }
-
         confirm = {
           props: { innerHTML: '☑' },
           style: {
             position: 'absolute',
             cursor: 'pointer',
-            left: '75px',
-            top: '40px',
+            left: '-26px',
+            top: '-50px',
             color: 'black',
             'font-size': '35px',
           },
@@ -31,19 +25,19 @@ module View
         }
 
         delete = {
-          props: { innerHTML: '⌫' },
+          props: { innerHTML: '☒' },
           style: {
             position: 'absolute',
             cursor: 'pointer',
-            left: '103px',
-            top: '44px',
+            left: '0px',
+            top: '-50px',
             color: 'black',
             'font-size': '35px',
           },
           on: { click: -> { store(:tile_selector, nil) } },
         }
 
-        h(:div, { style: style }, [
+        h(:div, [
           h(:div, confirm),
           h(:div, delete),
         ])

--- a/assets/app/view/game/tile_confirmation.rb
+++ b/assets/app/view/game/tile_confirmation.rb
@@ -29,7 +29,7 @@ module View
           style: {
             position: 'absolute',
             cursor: 'pointer',
-            left: '0px',
+            left: '6px',
             top: '-50px',
             color: 'black',
             'font-size': '35px',

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -9,6 +9,7 @@ module View
       needs :layout
       needs :tiles
       SCALE = 0.3
+      SIZE = Hex::SIZE * SCALE
 
       def render
         hexes = @tiles.map do |tile|
@@ -18,12 +19,11 @@ module View
 
         theta = 360.0 / hexes.size * Math::PI / 180
 
-        size = Hex::SIZE * SCALE
         hexes = hexes.map.with_index do |hex, index|
           style = {
             position: 'absolute',
-            left: "#{Hex::SIZE * Math.cos(index * theta) - size}px",
-            bottom: "#{Hex::SIZE * Math.sin(index * theta) - size}px",
+            left: "#{Hex::SIZE * Math.cos(index * theta) - SIZE}px",
+            bottom: "#{Hex::SIZE * Math.sin(index * theta) - SIZE}px",
             width: '60px',
             height: '60px',
             filter: 'drop-shadow(5px 5px 2px #888)',

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -9,7 +9,9 @@ module View
       needs :layout
       needs :tiles
       SCALE = 0.3
+      TILE_SIZE = 60
       SIZE = Hex::SIZE * SCALE
+      DISTANCE = Hex::SIZE
 
       def render
         hexes = @tiles.map do |tile|
@@ -22,10 +24,10 @@ module View
         hexes = hexes.map.with_index do |hex, index|
           style = {
             position: 'absolute',
-            left: "#{Hex::SIZE * Math.cos(index * theta) - SIZE}px",
-            bottom: "#{Hex::SIZE * Math.sin(index * theta) - SIZE}px",
-            width: '60px',
-            height: '60px',
+            left: "#{DISTANCE * Math.cos(index * theta) - SIZE}px",
+            bottom: "#{DISTANCE * Math.sin(index * theta) - SIZE}px",
+            width: "#{TILE_SIZE}px",
+            height: "#{TILE_SIZE}px",
             filter: 'drop-shadow(5px 5px 2px #888)',
             'pointer-events' => 'auto',
           }

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -8,6 +8,7 @@ module View
       needs :tile_selector, store: true
       needs :layout
       needs :tiles
+      SCALE = 0.3
 
       def render
         hexes = @tiles.map do |tile|
@@ -17,29 +18,21 @@ module View
 
         theta = 360.0 / hexes.size * Math::PI / 180
 
+        size = Hex::SIZE * SCALE
         hexes = hexes.map.with_index do |hex, index|
           style = {
             position: 'absolute',
-            left: "#{Hex::SIZE * Math.cos(index * theta) + 70}px",
-            bottom: "#{Hex::SIZE * Math.sin(index * theta) + 80}px",
+            left: "#{Hex::SIZE * Math.cos(index * theta) - size}px",
+            bottom: "#{Hex::SIZE * Math.sin(index * theta) - size}px",
             width: '60px',
             height: '60px',
             filter: 'drop-shadow(5px 5px 2px #888)',
             'pointer-events' => 'auto',
           }
-          h(:svg, { style: style }, [h(:g, { attrs: { transform: 'scale(0.3)' } }, [hex])])
+          h(:svg, { style: style }, [h(:g, { attrs: { transform: "scale(#{SCALE})" } }, [hex])])
         end
 
-        style = {
-          position: 'absolute',
-          left: "#{@tile_selector.x - 50}px",
-          top: "#{@tile_selector.y - 50}px",
-          width: '200px',
-          height: '200px',
-          'pointer-events' => 'none',
-        }
-
-        h(:div, { style: style }, hexes)
+        h(:div, hexes)
       end
     end
   end


### PR DESCRIPTION
fixes #28 
fixes #517 
fixes #679

also fixes the ☑' and ⌫ not lining up
and make the radial selector align a bit nicer (and get rid of the magic numbers)