### PR TITLE
fix route colors on towns

### DIFF
--- a/assets/app/view/game/part/towns.rb
+++ b/assets/app/view/game/part/towns.rb
@@ -7,8 +7,6 @@ module View
   module Game
     module Part
       class Towns < Snabberb::Component
-        ROUTE_COLORS = %i[red blue green purple].freeze
-
         needs :tile
         needs :region_use
         needs :routes
@@ -31,7 +29,7 @@ module View
               p.town == town
             end
           end
-          index ? self.class::ROUTE_COLORS[index] : 'black'
+          index ? Part::Track::ROUTE_COLORS[index] : 'black'
         end
       end
     end


### PR DESCRIPTION
blue and green were mixed up (=> blue towns on green routes and vice versa). Likely better to have only one constant anyway.