### PR TITLE
settings: alternative colors

### DIFF
--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -27,8 +27,8 @@ class App < Snabberb::Component
     props = {
       props: { id: 'app' },
       style: {
-        'background-color': @user&.dig(:settings, :bg_color) || 'inherit',
-        color: @user&.dig(:settings, :font_color) || 'currentColor',
+        'background-color': @user&.dig(:settings, :bg) || 'inherit',
+        color: @user&.dig(:settings, :font) || 'currentColor',
         margin: :auto,
         'min-height': '98vh',
         padding: '0.5rem',

--- a/assets/app/lib/color.rb
+++ b/assets/app/lib/color.rb
@@ -1,7 +1,25 @@
 # frozen_string_literal: true
 
+require 'lib/hex'
+
 module Lib
   module Color
+    COLORS = {
+      bg: '#ffffff',
+      bg2: '#dcdcdc',
+      font: '#000000',
+      font2: '#000000',
+    }.freeze
+    COLORS.merge!(Lib::Hex::COLOR)
+
+    def self.included(base)
+      base.needs :user, default: nil, store: true
+    end
+
+    def color_for(category)
+      @user&.dig(:settings, category) || COLORS[category]
+    end
+
     def self.convert_hex_to_rgba(color, alpha)
       m = color.match(/#(..)(..)(..)/)
       "rgba(#{m[1].hex},#{m[2].hex},#{m[3].hex},#{alpha})"

--- a/assets/app/view/chat.rb
+++ b/assets/app/view/chat.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'lib/color'
 require 'view/log'
 
 module View
   class Chat < Snabberb::Component
+    include Lib::Color
     needs :user
     needs :connection
     needs :log, default: [], store: true
@@ -48,10 +50,14 @@ module View
           margin: '0',
           'box-sizing': 'border-box',
           padding: '0 0.5rem',
+          'border-radius': '0',
+          background: color_for(:bg2),
+          color: color_for(:font2),
         },
+        on: { keyup: enter },
       }
 
-      children << h('textarea#chatbar', chatbar_props, on: { keyup: enter }) if @user
+      children << h('textarea#chatbar', chatbar_props) if @user
 
       props = {
         key: 'global_chat',

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -29,7 +29,7 @@ module View
           el: :textarea,
           attrs: {
             placeholder: 'Paste JSON Game Data. Will override settings',
-            rows: 50,
+            rows: 35,
             cols: 50,
           },
           container_style: {
@@ -56,7 +56,13 @@ module View
       h(:div, [
         render_input('Game Title', id: :title, el: 'select', children: games),
         render_input('Description', id: :description),
-        render_input('Max Players', id: :max_players, type: :number, attrs: { value: 6 }),
+        render_input(
+          'Max Players',
+          id: :max_players,
+          type: :number,
+          attrs: { value: 6 },
+          input_style: { width: '2.5rem' },
+        ),
       ])
     end
 

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -3,6 +3,7 @@
 module View
   module Game
     class Corporation < Snabberb::Component
+      include Lib::Color
       needs :corporation
       needs :selected_corporation, default: nil, store: true
       needs :game, store: true
@@ -85,8 +86,8 @@ module View
             grid: '1fr / auto auto auto',
             gap: '0 0.2rem',
             padding: '0.2rem 0.5rem',
-            'background-color': @game.round.can_act?(@corporation) ? '#99bb99' : 'gainsboro',
-            color: 'black',
+            'background-color': @game.round.can_act?(@corporation) ? '#99bb99' : color_for(:bg2),
+            color: @game.round.can_act?(@corporation) ? 'black' : color_for(:font2),
           },
         }
         sym_props = {

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -3,6 +3,7 @@
 module View
   module Game
     class Player < Snabberb::Component
+      include Lib::Color
       needs :player
       needs :game
 
@@ -33,8 +34,8 @@ module View
           style: {
             'max-width': '20rem',
             padding: '0.4rem',
-            'background-color': @game.round.can_act?(@player) ? '#9b9' : 'gainsboro',
-            color: 'black',
+            'background-color': @game.round.can_act?(@player) ? '#9b9' : color_for(:bg2),
+            color: @game.round.can_act?(@player) ? 'black' : color_for(:font2),
           },
         }
 

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -5,6 +5,7 @@ require 'view/game/token'
 module View
   module Game
     class StockMarket < Snabberb::Component
+      include Lib::Color
       needs :game
       needs :show_bank, default: false
 
@@ -43,13 +44,13 @@ module View
           width: "#{WIDTH_TOTAL - 2 * PAD - 2 * BORDER}px",
           height: "#{HEIGHT_TOTAL - 2 * PAD - 2 * BORDER}px",
           border: "solid #{BORDER}px rgba(0,0,0,0.2)",
-          color: 'black',
+          color: color_for(:font2),
         )
 
         grid = @game.stock_market.market.flat_map do |prices|
           rows = prices.map do |price|
             if price
-              style = box_style.merge('background-color' => price.color ? COLOR_MAP[price.color] : 'white')
+              style = box_style.merge('background-color' => price.color ? COLOR_MAP[price.color] : color_for(:bg2))
 
               corporations = price.corporations
               num = corporations.size

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -6,6 +6,7 @@ require_tree './game'
 
 module View
   class GamePage < Snabberb::Component
+    include Lib::Color
     needs :game_data, store: true
     needs :game, default: nil, store: true
     needs :connection
@@ -151,7 +152,7 @@ module View
           padding: '1.5rem',
           margin: '-16px -1.5rem 1.5rem -1.5rem',
           top: '0',
-          'background-color': 'gainsboro',
+          'background-color': color_for(:bg2),
           'font-size': 'large',
           'z-index': '9999',
         },
@@ -191,7 +192,7 @@ module View
         },
         style: {
           'margin': '0 1rem 1rem 0',
-          'color': 'black',
+          'color': color_for(:font2),
           'text-decoration': route_anchor == anchor[1..-1] ? '' : 'none',
         },
         on: { click: change_anchor },

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -2,6 +2,7 @@
 
 module View
   class Log < Snabberb::Component
+    include Lib::Color
     needs :log
     needs :negative_pad, default: false
     needs :follow_scroll, default: true, store: true
@@ -31,9 +32,10 @@ module View
         style: {
           overflow: 'auto',
           height: '200px',
+          width: '100%',
           padding: '0.5rem',
-          color: 'black',
-          'background-color': 'lightgray',
+          'background-color': color_for(:bg2),
+          color: color_for(:font2),
           'word-break': 'break-word',
         },
       }

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -8,6 +8,7 @@ require 'view/form'
 
 module View
   class User < Form
+    include Lib::Color
     include GameManager
     include UserManager
 
@@ -36,19 +37,15 @@ module View
           ['Profile Settings', [
             render_notifications(@user&.dig(:settings, :notifications)),
             h('div#settings__colors', [
-              render_color(
-                :bg_color,
-                'Background',
-                @user&.dig(:settings, :bg_color),
-                dark ? '#000000' : '#ffffff'
-              ),
-              render_color(
-                :font_color,
-                'Font Color',
-                @user&.dig(:settings, :font_color),
-                dark ? '#ffffff' : '#000000'
-              ),
               render_logo_color(@user&.dig(:settings, :red_logo)),
+              h(:div, [
+                render_color(:bg, 'Main Background', color_for(:bg), dark ? '#000000' : '#ffffff'),
+                render_color(:font, 'Main Font Color', color_for(:font), dark ? '#ffffff' : '#000000'),
+              ]),
+              h(:div, [
+                render_color(:bg2, 'Alternative Background', color_for(:bg2), dark ? '#dcdcdc' : '#d3d3d3'),
+                render_color(:font2, 'Alternative Font Color', color_for(:font2), '#000000'),
+              ]),
             ]),
             render_tile_colors,
             h('div#settings__buttons', [
@@ -82,8 +79,10 @@ module View
 
     def reset_settings
       dark = `window.matchMedia('(prefers-color-scheme: dark)').matches`
-      Native(@inputs[:bg_color]).elm.value = dark ? '#000000' : '#ffffff'
-      Native(@inputs[:font_color]).elm.value = dark ? '#dcdcdc' : '#000000'
+      Native(@inputs[:bg]).elm.value = dark ? '#000000' : '#ffffff'
+      Native(@inputs[:font]).elm.value = dark ? '#dcdcdc' : '#000000'
+      Native(@inputs[:bg2]).elm.value = dark ? '#dcdcdc' : '#d3d3d3'
+      Native(@inputs[:font2]).elm.value = '#000000'
       Native(@inputs[:red_logo]).elm.checked = false
       Lib::Hex::COLOR.each do |color, hex_color|
         Native(@inputs[color]).elm.value = hex_color
@@ -119,12 +118,12 @@ module View
     def render_tile_colors
       h('div#settings__tiles', [
         h(:label, 'Map & Tile Colors'),
-        h('div#settings__tiles__buttons', Lib::Hex::COLOR.map do |color, hex_color|
+        h('div#settings__tiles__buttons', Lib::Hex::COLOR.map do |color, _hex_color|
           render_input(
             '',
             id: color,
             type: :color,
-            attrs: { title: color, value: @user&.dig(:settings, color) || hex_color },
+            attrs: { title: color == 'white' ? 'plain' : color, value: color_for(color) },
           )
         end),
       ])

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -42,7 +42,7 @@ module View
 
       props = {
         style: {
-          'background-color': '#FFEC46',
+          background: 'rgb(240, 229, 140)',
           color: 'black',
           'padding': '1em',
           'margin': '1rem 0',

--- a/models/user.rb
+++ b/models/user.rb
@@ -10,7 +10,9 @@ class User < Base
 
   RESET_WINDOW = 60 * 15 # 15 minutes
 
-  SETTINGS = %w[notifications bg_color font_color red_logo white yellow green brown gray red blue].freeze
+  SETTINGS = %w[
+    notifications bg font bg2 font2 red_logo white yellow green brown gray red blue
+  ].freeze
 
   def update_settings(params)
     SETTINGS.each { |setting| settings[setting] = params[setting] }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -40,6 +40,7 @@ button {
     background: black;
     border-color: gainsboro;
     color: gainsboro;
+    text-decoration: none;
   }
   .button, .button-link {
     outline: 0;
@@ -50,9 +51,15 @@ button {
   }
 }
 
-input, select {
+input, select, textarea {
+  background: whitesmoke;
+  border-radius: 5px;
+  padding: 0 0.5rem;
   cursor: pointer;
   margin: 0.5rem;
+}
+input, select {
+  height: 2rem;
 }
 input + label, select + label {
   margin-left: 0.5rem;
@@ -64,6 +71,17 @@ label.right {
 .input-container {
   display: inline-block;
   margin-right: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: black;
+    color: gainsboro;
+  }
+  
+  button, .button, .button-link, input, select, textarea {
+    background-color: gainsboro;
+  }
 }
 
 .nowrap {
@@ -86,13 +104,6 @@ label.right {
 }
 .bold {
   font-weight: bold;
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: black;
-    color: gainsboro;
-  }
 }
 
 #profile-settings {


### PR DESCRIPTION
colors are in effect for
- chat/gamelogs
- game navigation
- company holdings
- player card titles
- stock market

=> main part of #666 is done

additional changes:
+ button bg slightly darker when ```prefers-color-scheme: dark``` is set
+ welcome message bg color
+ create_game: json textarea and max players smaller

in app.rb color_for intentionally not used (wouldn’t work with pcs:dark)