### PR TITLE
catch PG::UniqueViolation errors on username and email

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -22,6 +22,10 @@ class User < Base
     self[Sequel.function(:lower, :email) => email.downcase]
   end
 
+  def self.by_name(name)
+    self[Sequel.function(:lower, :name) => name.downcase]
+  end
+  
   def reset_hashes
     now = Time.now.to_i / RESET_WINDOW
     (0..1).map { |i| Digest::MD5.hexdigest("#{password}#{now + i}") }

--- a/models/user.rb
+++ b/models/user.rb
@@ -25,7 +25,7 @@ class User < Base
   def self.by_name(name)
     self[Sequel.function(:lower, :name) => name.downcase]
   end
-  
+
   def reset_hashes
     now = Time.now.to_i / RESET_WINDOW
     (0..1).map { |i| Digest::MD5.hexdigest("#{password}#{now + i}") }

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -22,6 +22,9 @@ class Api
             password: r['password'],
           }.reject { |_, v| v.empty? }
 
+          halt(400, 'User Name already registered') if User.by_name(r['name'])
+          halt(400, 'Email already registered') if User.by_email(r['email'])
+
           login_user(User.create(params))
         end
 


### PR DESCRIPTION
Flash pretty error message instead of
`PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "users_lower(name)_index" DETAIL: Key (lower(name))=(duplicate_username) already exists.`
when user name is already registered. Dito for email.