### PR TITLE
Fix OO tiles without paths on 1836jr/1882

### DIFF
--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -97,8 +97,7 @@ module View
         ].freeze
 
         def preferred_render_locations
-          edge_a, edge_b = @city.exits
-          if @num_cities > 1 && (edge_a || edge_b)
+          if @num_cities > 1 && @edge
             return [
               {
                 region_weights: EDGE_TRACK_REGIONS[@edge] + EDGE_CITY_REGIONS[@edge],


### PR DESCRIPTION
This changes tiles with multiple cities but no paths from rendering all cities in the middle
![1836_oos](https://user-images.githubusercontent.com/71923/84772350-b9989900-afd2-11ea-9487-65922a33072f.png)

to

![Screenshot from 2020-06-16 12-34-38](https://user-images.githubusercontent.com/71923/84772394-c917e200-afd2-11ea-96e2-39a1b766ebc9.png)

