### PR TITLE
1882 Allow neutral and corp lays on same tile

### DIFF
--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -45,13 +45,16 @@ module Engine
         true
       end
 
-      def tokenable?(corporation, free: false)
-        return false unless get_slot(corporation)
-        return false unless (token = corporation.next_token)
-        return false if !free && token.price > corporation.cash
-        return false if @tile.cities.any? { |c| c.tokened_by?(corporation) }
+      def tokenable?(corporation, free: false, tokens: corporation.next_tokens_by_type)
+        return false unless tokens
 
-        true
+        tokens.any? do |t|
+          next false unless get_slot(t.corporation)
+          next false if !free && t.price > corporation.cash
+          next false if @tile.cities.any? { |c| c.tokened_by?(t.corporation) }
+
+          true
+        end
       end
 
       def get_slot(corporation)
@@ -61,7 +64,9 @@ module Engine
       end
 
       def place_token(corporation, token, free: false)
-        raise GameError, "#{corporation.name} cannot lay token on #{id}" unless tokenable?(corporation, free: free)
+        unless tokenable?(corporation, free: free, tokens: [token])
+          raise GameError, "#{corporation.name} cannot lay token on #{id}"
+        end
 
         token.use!
         exchange_token(token)

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -45,7 +45,8 @@ module Engine
         true
       end
 
-      def tokenable?(corporation, free: false, tokens: corporation.next_tokens_by_type)
+      def tokenable?(corporation, free: false, token: nil)
+        tokens = Array(token || corporation.next_tokens_by_type)
         return false unless tokens
 
         tokens.any? do |t|
@@ -64,7 +65,7 @@ module Engine
       end
 
       def place_token(corporation, token, free: false)
-        unless tokenable?(corporation, free: free, tokens: [token])
+        unless tokenable?(corporation, free: free, token: token)
           raise GameError, "#{corporation.name} cannot lay token on #{id}"
         end
 

--- a/spec/lib/engine/part/city_spec.rb
+++ b/spec/lib/engine/part/city_spec.rb
@@ -9,15 +9,48 @@ require 'engine/token'
 module Engine
   module Part
     describe City do
-      subject { described_class.new('20') }
+      subject { Tile.for('57', index: 0).cities[0] }
 
-      let(:corporation) { Engine::Corporation.new('AS', name: 'Aperture Science', tokens: 2) }
-      let(:placed_token) { Engine::Token.new(corporation, true) }
-      let(:unplaced_token) { Engine::Token.new(corporation) }
+      let(:corporation) { Engine::Corporation.new(sym: 'AS', name: 'Aperture Science', tokens: [0, 40]) }
+      let(:corporation2) { Engine::Corporation.new(sym: 'BM', name: 'Black Mesa', tokens: []) }
+      let(:unplaced_token) { corporation.next_token }
+      let(:neutral_token) { Engine::Token.new(corporation2, type: :neutral) }
 
       describe '#initialize' do
         it 'starts with no tokens' do
           expect(subject.tokens).to eq([nil])
+        end
+      end
+
+      describe '#blocks?' do
+        it 'unblocked with no tokens' do
+          expect(subject.blocks?(corporation)).to be false
+        end
+        it 'unblocked with same corporation token' do
+          subject.place_token(corporation, unplaced_token, free: true)
+          expect(subject.blocks?(corporation)).to be false
+        end
+        it 'blocked with different corporation token' do
+          subject.place_token(corporation, unplaced_token, free: true)
+          expect(subject.blocks?(corporation2)).to be true
+        end
+        it 'unblocked with neutral token' do
+          corporation2.tokens << neutral_token
+          subject.place_token(corporation2, neutral_token, free: true)
+          expect(subject.blocks?(corporation)).to be false
+        end
+      end
+
+      describe '#tokenable?' do
+        subject { Tile.for('14', index: 0).cities[0] }
+        it 'disallows two tokens of the same corp' do
+          subject.place_token(corporation, unplaced_token, free: true)
+          expect(subject.tokenable?(corporation)).to be false
+        end
+        it 'allows neutral token' do
+          corporation.tokens << neutral_token
+          subject.place_token(corporation, unplaced_token, free: true)
+          expect(subject.tokenable?(corporation)).to be true
         end
       end
 


### PR DESCRIPTION
This covers the last two parts of CN for 1882

* It is allowed for a company to place a neutral station marker in a city where that company already has a station.
* There may only be one neutral station marker in a hex