### PR TITLE
Fix render of tile #62, fix town revenue on pointy

### DIFF
--- a/assets/app/view/game/part/base.rb
+++ b/assets/app/view/game/part/base.rb
@@ -24,7 +24,11 @@ module View
         RIGHT_MID = [10, 17].freeze
 
         LEFT_CORNER = [5, 12].freeze
+        UPPER_LEFT_CORNER = [0, 1].freeze
+        UPPER_RIGHT_CORNER = [3, 4].freeze
         RIGHT_CORNER = [11, 18].freeze
+        BOTTOM_RIGHT_CORNER = [22, 23].freeze
+        BOTTOM_LEFT_CORNER = [19, 20].freeze
 
         TRACK_TO_EDGE_0 = [15, 21].freeze
         TRACK_TO_EDGE_1 = [13, 14].freeze

--- a/assets/app/view/game/part/cities.rb
+++ b/assets/app/view/game/part/cities.rb
@@ -6,9 +6,10 @@ module View
   module Game
     module Part
       class Cities < Base
+        needs :should_render_revenue
         def render
           @tile.cities.map do |city|
-            h(City, region_use: @region_use, tile: @tile, city: city)
+            h(City, should_render_revenue: @should_render_revenue, region_use: @region_use, tile: @tile, city: city)
           end
         end
       end

--- a/assets/app/view/game/part/cities.rb
+++ b/assets/app/view/game/part/cities.rb
@@ -6,10 +6,10 @@ module View
   module Game
     module Part
       class Cities < Base
-        needs :should_render_revenue
+        needs :show_revenue
         def render
           @tile.cities.map do |city|
-            h(City, should_render_revenue: @should_render_revenue, region_use: @region_use, tile: @tile, city: city)
+            h(City, show_revenue: @show_revenue, region_use: @region_use, tile: @tile, city: city)
           end
         end
       end

--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -16,7 +16,7 @@ module View
 
         needs :tile
         needs :city
-        needs :should_render_revenue
+        needs :show_revenue
 
         # key is how many city slots are part of the city; value is the offset for
         # the first city slot
@@ -106,7 +106,7 @@ module View
         def preferred_render_locations
           if @num_cities > 1 && @edge
             weights = EDGE_TRACK_REGIONS[@edge] + EDGE_CITY_REGIONS[@edge]
-            weights += EXTRA_SLOT_REGIONS[@edge] if @city.slots != 1
+            weights += EXTRA_SLOT_REGIONS[@edge] unless @city.slots == 1
             return [
               {
                 region_weights: weights,
@@ -154,7 +154,7 @@ module View
             # rotation
             x, y = CITY_SLOT_POSITION[@city.slots]
             revert_angle = render_location[:angle]
-            revert_angle += angle_for_layout unless @num_cities > 1 && @edge
+            revert_angle -= angle_for_layout if @num_cities == 1 || !@edge
             h(:g, { attrs: { transform: "rotate(#{slot_rotation})" } }, [
               h(:g, { attrs: { transform: "translate(#{x.round(2)} #{y.round(2)}) rotate(#{-revert_angle})" } }, [
                 h(CitySlot, city: @city,
@@ -173,7 +173,7 @@ module View
           children << render_box(slots.size) if slots.size.between?(2, 6)
           children.concat(slots)
 
-          if @should_render_revenue && (revenue = render_revenue)
+          if @show_revenue && (revenue = render_revenue)
             children << revenue
           end
 
@@ -210,7 +210,7 @@ module View
           when 2
             if @edge
               regions, negative_displacement = OO_REVENUE_REGIONS[@edge]
-              displacement = - displacement if negative_displacement
+              displacement *= -1 if negative_displacement
             end
           end
 

--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -16,12 +16,12 @@ module View
 
         P_LEFT_CORNER = {
           flat: {
-            region_weights: { LEFT_CORNER => 1.0, (LEFT_CENTER + LEFT_MID) => 0.5 },
+            region_weights: { LEFT_CORNER => 1.0, LEFT_MID => 0.25 },
             x: -71.25,
             y: 0,
           },
           pointy: {
-            region_weights: { LEFT_CORNER => 1.0, (LEFT_CENTER + LEFT_MID) => 0.5 },
+            region_weights: { LEFT_CORNER => 1.0, LEFT_MID => 0.25 },
             x: -67,
             y: 0,
           },
@@ -29,12 +29,12 @@ module View
 
         P_BOTTOM_LEFT_CORNER = {
           flat: {
-            region_weights: { [19, 20] => 1.0, [21] => 0.5 },
+            region_weights: { BOTTOM_LEFT_CORNER => 1.0, [21] => 0.5 },
             x: -30,
             y: 65,
           },
           pointy: {
-            region_weights: { [19, 20] => 1.0, [21] => 0.5 },
+            region_weights: { BOTTOM_LEFT_CORNER => 1.0, [21] => 0.5 },
             x: -30,
             y: 61,
           },
@@ -61,16 +61,17 @@ module View
           },
           # top left corner
           {
-            region_weights: { [0, 1] => 1.0, [2] => 0.5 },
+            region_weights: { UPPER_LEFT_CORNER => 1.0, [2] => 0.5 },
             x: -30,
             y: -65,
           },
           # top right corner
           {
-            region_weights: { [2] => 0.5, [3, 4] => 1.0 },
+            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
             x: 30,
             y: -65,
           },
+          P_LEFT_CORNER[:flat],
           # bottom left corner
           P_BOTTOM_LEFT_CORNER[:flat],
           # edge 1

--- a/assets/app/view/game/part/revenue.rb
+++ b/assets/app/view/game/part/revenue.rb
@@ -8,10 +8,33 @@ module View
     module Part
       class Revenue < Base
         P_RIGHT_CORNER = {
-          region_weights_in: LEFT_CORNER + LEFT_MID,
-          region_weights_out: LEFT_CORNER,
+          region_weights: RIGHT_CORNER,
           x: 75,
           y: 0,
+        }.freeze
+
+        P_LEFT_CORNER = {
+          region_weights: LEFT_CORNER,
+          x: -75,
+          y: 0,
+        }.freeze
+
+        P_UPPER_LEFT_CORNER = {
+          region_weights: UPPER_LEFT_CORNER,
+          x: -35,
+          y: -60.62,
+        }.freeze
+
+        P_BOTTOM_LEFT_CORNER = {
+          region_weights: BOTTOM_LEFT_CORNER,
+          x: -35,
+          y: 60.62,
+        }.freeze
+
+        P_BOTTOM_RIGHT_CORNER = {
+          region_weights: BOTTOM_RIGHT_CORNER,
+          x: 35,
+          y: 60.62,
         }.freeze
 
         def preferred_render_locations
@@ -44,7 +67,7 @@ module View
               },
             ]
           else
-            [P_RIGHT_CORNER]
+            [P_RIGHT_CORNER, P_LEFT_CORNER, P_BOTTOM_RIGHT_CORNER, P_UPPER_LEFT_CORNER, P_BOTTOM_LEFT_CORNER]
           end
         end
 

--- a/assets/app/view/game/part/town_rect.rb
+++ b/assets/app/view/game/part/town_rect.rb
@@ -269,7 +269,7 @@ module View
 
           h(:g, { attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
             h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
-              h(:g, { attrs: { transform: "translate(#{displacement} 0)" } }, [
+              h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
                 h(SingleRevenue,
                   revenue: revenue,
                   transform: "rotate(#{-angle})"),

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -46,8 +46,7 @@ module View
 
         return false if revenue.uniq.size > 1
 
-        total_slots = @tile.cities.sum(&:slots)
-        return false if total_slots < 3 && revenue.size == 2
+        return false if @tile.cities.sum(&:slots) < 3 && revenue.size == 2
 
         true
       end
@@ -63,7 +62,7 @@ module View
         render_revenue = should_render_revenue?
         children << h(Part::Borders, tile: @tile) if @tile.borders.any?
         children << render_tile_part(Part::Track, routes: @routes) if @tile.exits.any?
-        children << render_tile_part(Part::Cities, should_render_revenue: !render_revenue) if @tile.cities.any?
+        children << render_tile_part(Part::Cities, show_revenue: !render_revenue) if @tile.cities.any?
         children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 
         # OO tiles have different rules...

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -46,7 +46,8 @@ module View
 
         return false if revenue.uniq.size > 1
 
-        return false if revenue.size == 2
+        total_slots = @tile.cities.sum(&:slots)
+        return false if total_slots < 3 && revenue.size == 2
 
         true
       end
@@ -59,17 +60,18 @@ module View
 
         children = []
 
+        render_revenue = should_render_revenue?
         children << h(Part::Borders, tile: @tile) if @tile.borders.any?
         children << render_tile_part(Part::Track, routes: @routes) if @tile.exits.any?
-        children << render_tile_part(Part::Cities) if @tile.cities.any?
+        children << render_tile_part(Part::Cities, should_render_revenue: !render_revenue) if @tile.cities.any?
         children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 
         # OO tiles have different rules...
         children << render_tile_part(Part::LocationName) if @tile.location_name && @tile.cities.size > 1
 
-        children << render_tile_part(Part::Revenue) if should_render_revenue?
-
+        children << render_tile_part(Part::Revenue) if render_revenue
         children << render_tile_part(Part::Label) if @tile.label
+
         children << render_tile_part(Part::Upgrades) if @tile.upgrades.any?
         children << render_tile_part(Part::Blocker) if should_render_blocker?
         children << render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)


### PR DESCRIPTION
Fixes rendering of tile #62 to
![Screenshot from 2020-06-17 17-24-18](https://user-images.githubusercontent.com/71923/84926538-7407c900-b0c3-11ea-8a20-6c7d8ede72c9.png)

This also improves the rendering of multi-city multi-slot tiles generally

Town revenues are now not rotated by 30 degrees