### PR TITLE
enforce player numbers on game creation

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -65,7 +65,7 @@ module View
         max = range.max = @max_p[title]
         val = range.value.to_i
         range.value = (min..max).include?(val) ? val : max
-        store(:num_players, range.value.to_i)
+        store(:num_players, val)
       end
 
       inputs = [

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -65,7 +65,7 @@ module View
         max = range.max = @max_p[title]
         val = range.value.to_i
         range.value = (min..max).include?(val) ? val : max
-        store(:num_players, val)
+        store(:num_players, range.value.to_i)
       end
 
       inputs = [

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -59,11 +59,13 @@ module View
       end
 
       limit_range = lambda do
-        min = Native(@inputs[:max_players]).elm.min = @min_p[Native(@inputs[:title]).elm.value]
-        max = Native(@inputs[:max_players]).elm.max = @max_p[Native(@inputs[:title]).elm.value]
-        val = Native(@inputs[:max_players]).elm.value.to_i
-        Native(@inputs[:max_players]).elm.value = (val < min || val > max ? max : val)
-        store(:num_players, Native(@inputs[:max_players]).elm.value.to_i)
+        range = Native(@inputs[:max_players]).elm
+        title = Native(@inputs[:title]).elm.value
+        min = range.min = @min_p[title]
+        max = range.max = @max_p[title]
+        val = range.value.to_i
+        range.value = (min..max).include?(val) ? val : max
+        store(:num_players, range.value.to_i)
       end
 
       inputs = [

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -94,7 +94,7 @@ module View
 
     def mode_input(mode, text)
       click_handler = lambda do
-        store(:mode, mode)
+        store(:mode, mode, skip: true)
         store(:num_players, Native(@inputs[:max_players]).elm.value.to_i)
       end
 

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -45,19 +45,23 @@ module View
     end
 
     # rubocop:disable Layout/LineLength
-    def render_input(label, placeholder: '', id:, el: 'input', type: 'text', attrs: {}, container_style: {}, label_style: {}, input_style: {}, children: [])
+    def render_input(label, placeholder: '', id:, el: 'input', type: 'text', attrs: {}, on: {}, container_style: {}, label_style: {}, input_style: {}, children: [])
       # rubocop:enable Layout/LineLength
       label_props = {
-        style: label_style,
-        attrs: { for: id },
+        style: {
+          cursor: 'pointer',
+          **label_style,
+        },
+        attrs: { for: id.gsub(/\s/, '-').downcase },
       }
       input_props = {
         style: input_style,
         attrs: {
-          id: id,
+          id: id.gsub(/\s/, '-').downcase,
           type: type,
           **attrs,
         },
+        on: { **on },
       }
       input_props[:attrs][:placeholder] = placeholder if placeholder != ''
       input = h(el, input_props, children)
@@ -69,9 +73,15 @@ module View
       )
     end
 
-    def render_button(text, &block)
+    def render_button(text, style: {}, &block)
       props = {
-        attrs: { type: :button },
+        attrs: {
+          id: text.gsub(/\s/, '-').downcase,
+          type: :button,
+        },
+        style: {
+          **style,
+        },
         on: { click: block },
       }
 

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -52,12 +52,12 @@ module View
           cursor: 'pointer',
           **label_style,
         },
-        attrs: { for: id.gsub(/\s/, '-').downcase },
+        attrs: { for: id },
       }
       input_props = {
         style: input_style,
         attrs: {
-          id: id.gsub(/\s/, '-').downcase,
+          id: id,
           type: type,
           **attrs,
         },
@@ -76,7 +76,6 @@ module View
     def render_button(text, style: {}, &block)
       props = {
         attrs: {
-          id: text.gsub(/\s/, '-').downcase,
           type: :button,
         },
         style: {

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -59,7 +59,7 @@ input, select, textarea {
   cursor: pointer;
   margin: 0.5rem;
 }
-input:not([type="checkbox"]), select {
+input:not([type=radio]):not([type=checkbox]), select {
   height: 2rem;
 }
 input + label, select + label {


### PR DESCRIPTION
fixes #698 
+ min/max player numbers taken from config file / cert_limit
+ inputs for names get created/removed on change of player number
+ +/- player buttons removed
+ player number changes to max allowed if illegal (< min || > max) on title switch
+ player number doesn’t change when changing modes

Caveat: [Safari doesn’t respect min/max of input=number](https://caniuse.com/#feat=input-number) (yet?).
