### PR TITLE
If blocker company also has tile laying ability, when it is bought in, remove barbell but keep sym

### DIFF
--- a/assets/app/view/game/part/blocker.rb
+++ b/assets/app/view/game/part/blocker.rb
@@ -83,7 +83,7 @@ module View
           children << render_company_sym if should_render_company_sym?
           children << render_barbell if should_render_barbell?
 
-          h(:g, { attrs: { transform: "#{translate} #{scale}" } }, children)
+          h(:g, { attrs: { transform: "#{translate} #{scale} #{rotation_for_layout}" } }, children)
         end
       end
     end

--- a/assets/app/view/game/part/blocker.rb
+++ b/assets/app/view/game/part/blocker.rb
@@ -44,21 +44,46 @@ module View
           @blocker = @tile.blockers.first
         end
 
+        def should_render?
+          should_render_company_sym?
+        end
+
+        def should_render_company_sym?
+          blocker_open? && (!@blocker.owned_by_corporation? || @blocker.abilities(:tile_lay))
+        end
+
+        def should_render_barbell?
+          blocker_open? && !@blocker.owned_by_corporation?
+        end
+
+        def blocker_open?
+          !(@blocker.nil? || @blocker.closed?)
+        end
+
+        def render_company_sym
+          h(:text, { attrs: {
+                       fill: 'black',
+                       'dominant-baseline': 'baseline',
+                       x: 0,
+                       y: -5,
+                     } },
+            @blocker.sym)
+        end
+
+        def render_barbell
+          h(:g, [
+            h(:path, attrs: { fill: 'white', d: 'M -11 6 A 44 44 0 0 0 11 6' }),
+            h(:circle, attrs: { fill: 'white', r: 6, cx: 11, cy: 6 }),
+            h(:circle, attrs: { fill: 'white', r: 6, cx: -11, cy: 6 }),
+          ])
+        end
+
         def render_part
-          h(:g,
-            { attrs: { transform: "#{translate} #{scale}" } },
-            [
-              h(:text, { attrs: {
-                fill: 'black',
-                'dominant-baseline': 'baseline',
-                x: 0,
-                y: -5,
-} },
-                @blocker.sym),
-              h(:path, attrs: { fill: 'white', d: 'M -11 6 A 44 44 0 0 0 11 6' }),
-              h(:circle, attrs: { fill: 'white', r: 6, cx: 11, cy: 6 }),
-              h(:circle, attrs: { fill: 'white', r: 6, cx: -11, cy: 6 }),
-            ])
+          children = []
+          children << render_company_sym if should_render_company_sym?
+          children << render_barbell if should_render_barbell?
+
+          h(:g, { attrs: { transform: "#{translate} #{scale}" } }, children)
         end
       end
     end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -21,21 +21,6 @@ module View
         h(part_class, region_use: @region_use, tile: @tile, **kwargs)
       end
 
-      def should_render_blocker?
-        blocker = @tile.blockers.first
-
-        # blocking company should exist...
-        return false if blocker.nil?
-
-        # ...and be open
-        return false if blocker.closed?
-
-        # ...and not have been sold into a corporation yet
-        return false if blocker.owned_by_corporation?
-
-        true
-      end
-
       # if false, then the revenue is rendered by Part::Cities or Part::Towns
       def should_render_revenue?
         revenue = @tile.revenue_to_render
@@ -71,7 +56,7 @@ module View
         children << render_tile_part(Part::Label) if @tile.label
 
         children << render_tile_part(Part::Upgrades) if @tile.upgrades.any?
-        children << render_tile_part(Part::Blocker) if should_render_blocker?
+        children << render_tile_part(Part::Blocker)
         children << render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
         @tile.reservations.each { |x| children << render_tile_part(Part::Reservation, reservation: x) }
         children << h(Part::Borders, tile: @tile) if @tile.borders.any?


### PR DESCRIPTION
Also fix rotation of blockers for pointy orientation (ie 1846)

[Fixes #493]
[Fixes #575]

orientation before:
![orientation before](https://user-images.githubusercontent.com/1045173/85216093-03b8ac00-b33e-11ea-9d68-93ffe6a71059.png)

orientation after:
![orientation after](https://user-images.githubusercontent.com/1045173/85216097-074c3300-b33e-11ea-85e3-b4f26de3315d.png)

18Chesapeake after C-P was bought in:
![chessie c-p](https://user-images.githubusercontent.com/1045173/85216106-116e3180-b33e-11ea-8cc3-3a80d629da89.png)

1889 before buying in both TR and ER:
![before buying in](https://user-images.githubusercontent.com/1045173/85216114-25b22e80-b33e-11ea-905b-929da8f71412.png)


1889 after buying in both (ER has tile lay ability, TR does not)
![after buying in](https://user-images.githubusercontent.com/1045173/85216110-1b903000-b33e-11ea-98dd-112d99fe81d7.png)
