### PR TITLE
Fixes 1846 token teleport and discount powers.

### DIFF
--- a/lib/engine/config/game/g_1836_jr30.rb
+++ b/lib/engine/config/game/g_1836_jr30.rb
@@ -321,7 +321,8 @@ module Engine
                 ],
                "hexes":[
                   "J8"
-               ]
+               ],
+               "token_price": 0
             }
          ]
       },

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -285,7 +285,8 @@ module Engine
           "hexes": [
             "E11"
           ],
-          "token_price": 60
+          "token_price": 60,
+          "track_optional": true
         },
         {
           "type": "discounted_token",
@@ -330,7 +331,8 @@ module Engine
           "hexes": [
             "H12"
           ],
-          "token_price": 100
+          "token_price": 100,
+          "track_optional": true
         },
         {
           "type": "discounted_token",

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -280,10 +280,17 @@ module Engine
       ],
       "abilities": [
         {
-          "type": "token",
+          "type": "teleport",
+          "tiles": ["5", "6", "57"],
           "hexes": [
             "E11"
-          ]
+          ],
+          "token_price": 60
+        },
+        {
+          "type": "discounted_token",
+          "hex": "E11",
+          "price": 40
         }
       ],
       "coordinates": "F20",
@@ -318,11 +325,17 @@ module Engine
       ],
       "abilities": [
         {
-          "type": "token",
-          "tiles": [],
+          "type": "teleport",
+          "tiles": ["291", "292", "293"],
           "hexes": [
             "H12"
-          ]
+          ],
+          "token_price": 100
+        },
+        {
+          "type": "discounted_token",
+          "hex": "H12",
+          "price": 40
         }
       ],
       "coordinates": "G19",
@@ -384,7 +397,14 @@ module Engine
         0,
         80,
         80,
-        0
+        80
+      ],
+      "abilities": [
+        {
+          "type": "discounted_token",
+          "hex": "I5",
+          "price": 40
+        }
       ],
       "abilities": [
          {

--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -339,7 +339,8 @@ module Engine
           ],
           "hexes": [
             "D2"
-          ]
+          ],
+          "token_price": 0
         }
       ]
     },

--- a/lib/engine/round/g_1846/operating.rb
+++ b/lib/engine/round/g_1846/operating.rb
@@ -74,31 +74,6 @@ module Engine
           @step == :token_or_track && !skip_token
         end
 
-        def connected_hexes
-          hexes = {}
-
-          @current_entity.abilities(:token) do |ability, _|
-            ability[:hexes].each do |id|
-              hex = @game.hex_by_id(id)
-              hexes[hex] = hex.neighbors.keys
-            end
-          end
-
-          super.merge(hexes)
-        end
-
-        def connected_nodes
-          nodes = {}
-
-          @current_entity.abilities(:token) do |ability, _|
-            ability[:hexes].each do |id|
-              @game.hex_by_id(id).tile.cities.each { |c| nodes[c] = true }
-            end
-          end
-
-          super.merge(nodes)
-        end
-
         private
 
         def ignore_action?(action)
@@ -186,39 +161,9 @@ module Engine
         end
 
         def potential_tiles(hex)
-          return [] if used_teleport(hex) && !connected(hex)
+          return [] unless connected_hexes[hex]
 
           super
-        end
-
-        def place_token(action)
-          hex = action.city.hex
-
-          if used_teleport(hex)
-            higher =
-              case @current_entity.id
-              when 'B&O'
-                100
-              when 'PRR'
-                60
-              end
-            action.token.price = connected(hex) ? 40 : higher
-            @current_entity.remove_ability(:token)
-          end
-
-          super
-        end
-
-        def connected(hex)
-          @graph.connected_hexes(@current_entity)[hex]
-        end
-
-        def used_teleport(hex)
-          @current_entity.abilities(:token) do |ability, _|
-            return true if ability[:hexes].include?(hex.id)
-          end
-
-          false
         end
 
         def change_share_price(revenue = 0)

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -67,11 +67,7 @@ module Engine
         @current_routes = []
         @current_actions = []
         @teleported = false
-<<<<<<< HEAD
         @ambiguous_hex_token = []
-=======
-        @teleport_token_price = 0
->>>>>>> 5e5eed3... Fixes 1846 token teleport and discount powers.
 
         payout_companies
         @entities.each { |c| place_home_token(c) } if @home_token_timing == :operating_round
@@ -314,7 +310,6 @@ module Engine
         @current_entity.abilities(:teleport) do |ability, _|
           if ability[:hexes].include?(hex_id) && ability[:tiles].include?(action.tile.name)
             @teleported = true
-            @teleport_token_price = ability[:token_price] || 0
           end
         end
 
@@ -596,7 +591,14 @@ module Engine
           return ability[:price] if ability[:hex] == hex.id && reachable_hexes[hex]
         end
 
-        return @teleport_token_price if @teleported
+        @current_entity.abilities(:teleport) do |ability, _|
+          next unless ability[:track_optional] || @teleported # Teleported is true if a track was laid.
+
+          if ability[:hexes].include?(hex.id)
+            @teleported = true
+            return ability[:token_price] || 0
+          end
+        end
 
         token.price || 0
       end


### PR DESCRIPTION
Changes 1846 to use the already existing teleport ability for tokens. Adds a price to the ability that 46 can set for each company and other games (Ches, 36jr) can set to 0 to make the teleport token free. This leads to a lot of cleanup in the 1846 operating round subclass.

Adds a discounted_token ability to cover to cover the 1846 token discounts for being connected to special hexes.

#748 #755 