### PR TITLE
Fix dot-town revenues and double-city tiles where only one has paths

### DIFF
--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -14,6 +14,14 @@ module View
         needs :tile
         needs :town
 
+        REVENUE_DISPLACEMENT = 42
+        REVENUE_ANGLE = -60
+
+        REVENUE_REGIONS = {
+          flat: [9, 16],
+          pointy: [8, 9],
+        }.freeze
+
         CENTER_TOWN = [
           {
             region_weights: CENTER,
@@ -49,8 +57,27 @@ module View
           @tile.towns.size > 1 ? OFFSET_TOWNS : CENTER_TOWN
         end
 
+        def render_revenue
+          revenues = @tile.towns.first.revenue.values.uniq
+          return unless revenues.one?
+
+          revenue = revenues.first
+
+          angle = layout == :pointy ? -60 : 0
+
+          increment_weight_for_regions(REVENUE_REGIONS[layout])
+          h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+              h(:g, { attrs: { transform: "translate(#{REVENUE_DISPLACEMENT} 0) rotate(#{-angle})" } }, [
+                  h(Part::SingleRevenue,
+                    revenue: revenue,
+                    transform: rotation_for_layout),
+                ]),
+            ])
+        end
+
         def render_part
           children = [h(:circle, attrs: { transform: translate, fill: @color, r: 10 })]
+          children << render_revenue
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, children)
         end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -50,19 +50,21 @@ module View
         children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 
         # OO tiles have different rules...
-        children << render_tile_part(Part::LocationName) if @tile.location_name && @tile.cities.size > 1
+        rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && @tile.cities.size > 1
 
         children << render_tile_part(Part::Revenue) if render_revenue
         children << render_tile_part(Part::Label) if @tile.label
 
         children << render_tile_part(Part::Upgrades) if @tile.upgrades.any?
         children << render_tile_part(Part::Blocker)
-        children << render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
+        rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
         @tile.reservations.each { |x| children << render_tile_part(Part::Reservation, reservation: x) }
         children << render_tile_part(Part::Icons) if @tile.icons.any?
 
         # borders should always be the top layer
         children << h(Part::Borders, tile: @tile) if @tile.borders.any?
+
+        children << rendered_loc_name if rendered_loc_name
 
         children.flatten!
 

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -31,7 +31,7 @@ module View
 
         return false if revenue.uniq.size > 1
 
-        return false if @tile.cities.sum(&:slots) < 3 && revenue.size == 2
+        return false if @tile.cities.sum(&:slots) < 3 && @tile.cities.size == 2
 
         true
       end

--- a/assets/app/view/tiles_page.rb
+++ b/assets/app/view/tiles_page.rb
@@ -32,7 +32,7 @@ module View
         when nil
           [0]
         when 'all'
-          (0..5).to_a
+          Engine::Tile::ALL_EDGES
         else
           # apparently separating rotations in URL with '+' works by passing ' '
           # to split here

--- a/lib/engine/config/game/g_18_carolinas.rb
+++ b/lib/engine/config/game/g_18_carolinas.rb
@@ -191,6 +191,7 @@ module Engine
             100
          ],
          "coordinates":"G19",
+         "city": 0,
          "color":"deepPink"
       },
       {
@@ -233,6 +234,7 @@ module Engine
             100
          ],
          "coordinates":"G19",
+         "city": 1,
          "color":"yellow",
          "text_color":"black"
       },
@@ -435,7 +437,7 @@ module Engine
          "city=revenue:0;label=C;icon=image:18_carolinas/sc,sticky:1":[
             "J12"
          ],
-         "city=revenue:0;city=revenue:0;path=a:1,b:_0;label=C;icon=image:18_carolinas/ncsc,sticky:1":[
+         "city=revenue:30;city=revenue:0;path=a:1,b:_0;label=C;icon=image:18_carolinas/ncsc,sticky:1":[
             "G19"
          ]
       },

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -136,7 +136,7 @@ module Engine
       def legal_rotations(hex, tile)
         old_paths = hex.tile.paths
 
-        (0..5).select do |rotation|
+        Engine::Tile::ALL_EDGES.select do |rotation|
           tile.rotate!(rotation)
           new_paths = tile.paths
           new_exits = tile.exits

--- a/spec/lib/engine/tile_spec.rb
+++ b/spec/lib/engine/tile_spec.rb
@@ -169,6 +169,13 @@ module Engine
             0 => [0, 1, 4, 5],
           },
         },
+        {
+          desc: "18Carolina's G19 hex (Wilmington)",
+          code: 'city=revenue:30;city=revenue:0;path=a:1,b:_0;label=C',
+          expected: {
+            0 => [1, 4],
+          },
+        },
       ].each do |spec|
         describe "with #{spec[:desc]}" do
           tile = Tile.from_code('name', 'color', spec[:code])


### PR DESCRIPTION
- replace all occurrences of (0..5) with a constant
- fix config for 18Carolinas' G19 -- assign corp homes to specific cities, add
  missing revenue

town before:
![Screenshot from 2020-06-21 16-37-27](https://user-images.githubusercontent.com/1045173/85236731-aecc7280-b3dd-11ea-9734-9797a01d5e3d.png)

town after:
![Screenshot from 2020-06-21 16-37-42](https://user-images.githubusercontent.com/1045173/85236733-b3912680-b3dd-11ea-8d2e-024893b8a74e.png)

Wilmington before:
![Screenshot from 2020-06-21 16-37-18](https://user-images.githubusercontent.com/1045173/85236738-c1df4280-b3dd-11ea-87ef-c0f1b8d0dc21.png)

Wilmington after (still needs name position tweaking, will fix later):
![Screenshot from 2020-06-21 16-47-08](https://user-images.githubusercontent.com/1045173/85236848-e851ad80-b3de-11ea-92a4-ebf72d6f2d49.png)

