### PR TITLE
Fix 1846 token powers

### DIFF
--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -5,11 +5,13 @@ require_relative 'base'
 module Engine
   module Ability
     class Token < Base
-      attr_reader :hexes, :free
+      attr_reader :hexes, :free, :price, :teleport_price
 
-      def setup(hexes:, free: nil)
+      def setup(hexes:, free: nil, price:, teleport_price: nil)
         @hexes = hexes
         @free = free || false
+        @price = price
+        @teleport_price = teleport_price
       end
     end
   end

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -283,7 +283,9 @@ module Engine
           "type": "token",
           "hexes": [
             "E11"
-          ]
+          ],
+          "price": 40,
+          "teleport_price": 60
         }
       ],
       "coordinates": "F20",
@@ -319,10 +321,11 @@ module Engine
       "abilities": [
         {
           "type": "token",
-          "tiles": [],
           "hexes": [
             "H12"
-          ]
+          ],
+          "price": 40,
+          "teleport_price": 100
         }
       ],
       "coordinates": "G19",
@@ -384,7 +387,7 @@ module Engine
         0,
         80,
         80,
-        0
+        80
       ],
       "abilities": [
          {
@@ -402,6 +405,13 @@ module Engine
               "8",
               "9"
             ]
+        },
+        {
+          "type": "token",
+          "hexes": [
+            "I5"
+          ],
+          "price": 40
         }
       ],
       "coordinates": "K3",

--- a/lib/engine/round/g_1846/operating.rb
+++ b/lib/engine/round/g_1846/operating.rb
@@ -79,7 +79,7 @@ module Engine
 
           @current_entity.abilities(:token) do |ability, _|
             next unless ability.teleport_price
-            
+
             ability.hexes.each do |id|
               hex = @game.hex_by_id(id)
               hexes[hex] = hex.neighbors.keys
@@ -94,7 +94,7 @@ module Engine
 
           @current_entity.abilities(:token) do |ability, _|
             next unless ability.teleport_price
-            
+
             ability.hexes.each do |id|
               @game.hex_by_id(id).tile.cities.each { |c| nodes[c] = true }
             end

--- a/lib/engine/round/g_1846/operating.rb
+++ b/lib/engine/round/g_1846/operating.rb
@@ -201,8 +201,8 @@ module Engine
 
           if used_token_ability(hex)
             @current_entity.abilities(:token) do |ability, _|
-              next action.token.price = ability[:price] if reachable_hexes[hex]
-              next action.token.price = ability[:teleport_price] if ability[:teleport_price]
+              next action.token.price = ability.price if reachable_hexes[hex]
+              next action.token.price = ability.teleport_price if ability.teleport_price
             end
           end
 


### PR DESCRIPTION
- Sets the price of the token ability in the config.
- Adds token ability for IC
- Uses teleport_price on the ability to determine if corp needs a route first to use power. This is needed for IC.
- Overrides skip_token? since the base class one relies on graph.skip_token? that doesn't hook into 1846 special logic for connected_hexes and connected_nodes.

#748 #755
