### PR TITLE
Render non-home token reservations

### DIFF
--- a/assets/app/view/map_page.rb
+++ b/assets/app/view/map_page.rb
@@ -14,7 +14,7 @@ module View
 
       return h(:p, "Bad game title: #{game_title}") unless game_class
 
-      names = %w[p1 p2 p3 p4]
+      names = %w[p1 p2 p3 p4 p5]
       h(Game::Map, game: game_class.new(names))
     end
   end

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -359,6 +359,15 @@ module Engine
         80,
         0
       ],
+      "abilities": [
+        {
+          "type": "token",
+          "hexes": [
+            "D20"
+          ],
+          "price": 40
+        }
+      ],
       "coordinates": "E21",
       "color": "yellow",
       "text_color": "black",


### PR DESCRIPTION
Also:
- add Erie's token ability
- fix a bug with the static 1846 map page where Erie's home token is rendered

![Screenshot from 2020-06-22 21-29-02](https://user-images.githubusercontent.com/1045173/85358170-4c07d380-b4d0-11ea-8df2-65f5087b1c2b.png)

![Screenshot from 2020-06-22 21-24-46](https://user-images.githubusercontent.com/1045173/85358176-51651e00-b4d0-11ea-8707-5df12b41b02a.png)
