### PR TITLE
margins/paddings revised (header/home/content/game/companies)

### DIFF
--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -29,9 +29,8 @@ class App < Snabberb::Component
       style: {
         'background-color': @user&.dig(:settings, :bg) || 'inherit',
         color: @user&.dig(:settings, :font) || 'currentColor',
-        margin: :auto,
         'min-height': '98vh',
-        padding: '0.5rem',
+        padding: '0.75vmin 2vmin 2vmin 2vmin',
         transition: 'background-color 1s ease',
       },
     }
@@ -75,13 +74,7 @@ class App < Snabberb::Component
         h(View::Home, user: @user)
       end
 
-    props = {
-      style: {
-        margin: '0 1rem',
-      },
-    }
-
-    h('div#content', props, [page])
+    h('div#content', [page])
   end
 
   def render_game

--- a/assets/app/view/game/buy_companies.rb
+++ b/assets/app/view/game/buy_companies.rb
@@ -13,7 +13,7 @@ module View
 
       def render
         @corporation = @game.current_entity
-        props = @limit_width ? { style: { flexGrow: '1', width: '0' } } : {}
+        props = @limit_width ? { style: { flexGrow: '1', width: '0', marginRight: '-1rem' } } : {}
 
         h(:div, props, [
           *render_companies,

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -17,6 +17,7 @@ module View
       def render_bidders
         bidders_style = {
           'font-weight': 'normal',
+          margin: '0 0.5rem',
         }
         names = @bids
           .sort_by(&:price)
@@ -42,40 +43,35 @@ module View
         }
 
         description_style = {
-          margin: '0.5rem 0 0.5rem 0',
+          margin: '0.5rem 0',
           'font-size': '80%',
           'text-align': 'left',
           'font-weight': 'normal',
         }
 
         value_style = {
-          display: 'inline-block',
-          width: '50%',
-          'text-align': 'left',
+          float: 'left',
         }
 
         revenue_style = {
-          display: 'inline-block',
-          width: '50%',
-          'text-align': 'right',
+          float: 'right',
         }
 
         bidders_style = {
-          'margin-top': '1rem',
+          'margin-top': '0.5rem',
+          display: 'inline-block',
+          clear: 'both',
+          width: '100%',
         }
 
         props = {
           style: {
             cursor: 'pointer',
-            border: 'solid 1px gainsboro',
-            'border-radius': '10px',
-            overflow: 'hidden',
+            boxSizing: 'border-box',
             padding: '0.5rem',
             margin: '0.5rem 0.5rem 0 0',
-            width: '19rem',
             'text-align': 'center',
             'font-weight': 'bold',
-            'vertical-align': 'top',
           },
           on: { click: onclick },
         }
@@ -83,16 +79,14 @@ module View
           props[:style]['background-color'] = 'lightblue'
           props[:style]['color'] = 'black'
         end
-        props[:style][:display] = 'inline-block' if @inline
+        props[:style][:display] = 'block' unless @inline
 
         children = [
           h(:div, { style: header_style }, 'PRIVATE COMPANY'),
           h(:div, @company.name),
           h(:div, { style: description_style }, @company.desc),
-          h(:div, [
-            h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
-            h(:div, { style: revenue_style }, "Revenue: #{@game.format_currency(@company.revenue)}"),
-          ]),
+          h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
+          h(:div, { style: revenue_style }, "Revenue: #{@game.format_currency(@company.revenue)}"),
         ]
 
         if @bids&.any?
@@ -100,9 +94,9 @@ module View
           children << render_bidders
         end
 
-        children << h(:div, { style: bidders_style }, "Owner: #{@company.owner.name}") if @company.owner
+        children << h('div.nowrap', { style: bidders_style }, "Owner: #{@company.owner.name}") if @company.owner
 
-        h(:div, props, children)
+        h('div.company.card', props, children)
       end
     end
   end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -16,7 +16,6 @@ module View
 
         card_style = {
           cursor: 'pointer',
-          width: '20rem',
         }
 
         if @game.round.can_act?(@corporation)

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -32,13 +32,13 @@ module View
 
         if @player
           children << h(:div, { style: {
-            'margin-top': '0.5rem',
+            margin: '1vmin 0',
             'display': 'flex',
             'flex-direction': 'row',
           } }, [
             h(:span, { style: {
               'font-weight': 'bold',
-              'margin-top': '4px',
+              margin: 'auto 0',
             } }, [@user['name'] + ':']),
             h(:input,
               style: {
@@ -53,7 +53,6 @@ module View
           style: {
             display: 'inline-block',
             width: '100%',
-            margin: '1rem 0 1rem 0',
           },
         }
 

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -78,7 +78,7 @@ module View
         props = {
           style: {
             overflow: 'auto',
-            margin: '1rem -1rem',
+            margin: '1rem 0',
           },
         }
 

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -10,7 +10,6 @@ module View
       def render
         card_style = {
           border: '1px solid gainsboro',
-          width: '20rem',
         }
 
         if @game.round.can_act?(@player)
@@ -32,7 +31,6 @@ module View
       def render_title
         props = {
           style: {
-            'max-width': '20rem',
             padding: '0.4rem',
             'background-color': @game.round.can_act?(@player) ? '#9b9' : color_for(:bg2),
             color: @game.round.can_act?(@player) ? 'black' : color_for(:font2),

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -54,7 +54,7 @@ module View
 
           left_props = {
             style: {
-              marginRight: '2rem',
+              marginRight: '1rem',
               verticalAlign: 'top',
             },
           }

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -19,7 +19,6 @@ module View
     def render
       props = {
         style: {
-          width: '320px',
           'margin': '0 0.5rem 0.5rem 0',
         },
       }

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -154,8 +154,9 @@ module View
         style: {
           overflow: 'auto',
           position: 'sticky',
-          padding: '1.5rem',
-          margin: '-16px -1.5rem 1.5rem -1.5rem',
+          padding: '2vmin',
+          margin: '-2vmin -2vmin 2vmin -2vmin',
+          borderBottom: "1px solid #{color_for(:font2)}",
           top: '0',
           'background-color': color_for(:bg2),
           'font-size': 'large',
@@ -196,7 +197,7 @@ module View
           onclick: 'return false',
         },
         style: {
-          'margin': '0 1rem 1rem 0',
+          'margin': '0 2vmin 2vmin 0',
           'color': color_for(:font2),
           'text-decoration': route_anchor == anchor[1..-1] ? '' : 'none',
         },
@@ -218,7 +219,7 @@ module View
       game_end = @game.game_ending_description
       description += " - #{game_end}" if game_end
       description += " - Pinned to Version: #{@pin}" if @pin
-      h(:div, { style: { 'font-weight': 'bold' } }, description)
+      h(:div, { style: { 'font-weight': 'bold', margin: '2vmin 0' } }, description)
     end
 
     def render_action

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -39,8 +39,8 @@ module View
       }
 
       if @negative_pad
-        props[:style][:padding] = '0.5rem 1.5rem'
-        props[:style][:margin] = '0 -1.5rem'
+        props[:style][:padding] = '0.5rem 2vmin'
+        props[:style][:margin] = '0 -2vmin'
       else
         props[:style]['box-sizing'] = 'border-box'
       end

--- a/assets/app/view/logo.rb
+++ b/assets/app/view/logo.rb
@@ -7,6 +7,14 @@ module View
     needs :user, default: nil, store: true
 
     def render
+      h1_props = {
+        style: {
+          margin: '0',
+          fontSize: '1rem',
+          lineHeight: '3rem',
+          whiteSpace: 'nowrap',
+        },
+      }
       a_props = {
         attrs: { href: '/', title: '18xx.Games' },
         style: {
@@ -27,7 +35,7 @@ module View
         },
       }
 
-      h('h1#logo', { style: { margin: '0', fontSize: '1rem' } }, [
+      h('h1#logo', h1_props, [
         h(:a, a_props, [
           h(:span, logo_props, '18xx'),
           h(:span, '.Games'),

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -21,15 +21,14 @@ module View
       props = {
         style: {
           display: 'flex',
-          marginBottom: '1rem',
-          padding: '0 1rem 0.5rem 1rem',
+          marginBottom: '1.5vmin',
+          paddingBottom: '1vmin',
           'box-shadow': '0 2px 0 0 gainsboro',
           'justify-content': 'space-between',
-          'line-height': '3rem',
         },
       }
 
-      h('div#nav', props, [
+      h('div#header', props, [
         h(Logo),
         render_other_links(other_links),
       ])
@@ -41,7 +40,7 @@ module View
           href: href,
         },
         style: {
-          margin: '0 1rem',
+          margin: '0 2vmin',
         },
       }
       h(:a, props, name)
@@ -52,7 +51,12 @@ module View
         link
       end
 
-      h(:div, children)
+      nav_props = {
+        style: {
+          margin: 'auto 0',
+        },
+      }
+      h('div#nav', nav_props, children)
     end
   end
 end

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -59,7 +59,7 @@ input, select, textarea {
   margin: 0.5rem;
 }
 input:not([type=radio]):not([type=checkbox]), select {
-  height: 2rem;
+  height: 1.5rem;
 }
 input + label, select + label {
   margin-left: 0.5rem;
@@ -225,11 +225,19 @@ p:last-child {
 
 .card {
   display: inline-block;
+  box-sizing: border-box;
+  width: 20rem;
+  min-width: 240px;
   overflow: hidden;
   vertical-align: top;
   margin: 0.5rem 0.5rem 0 0;
   border: 1px solid gainsboro;
   border-radius: 0.7rem;
+}
+@media only screen and (max-width: 420px) {
+  .card {
+    width: 95vw;
+  }
 }
 .card table {
   line-height: 1.25rem;


### PR DESCRIPTION
rem => vmin for most margins/paddings between/of boxes/divs
companies: (at least) 3 inline below most maps
company cards share props with corps, players and game cards
cards stretch on mobile (<= 420px) to fill the width (95vw leaves some padding)
player card header fixed (bg stretches to fill width)
bottom border to game menu to diff from log content

looks good on Safari/iOS 13 on browserstack, too – but again: please check locally on hardware