### PR TITLE
Implement 1836jr ports and Paris

### DIFF
--- a/lib/engine/config/game/g_1836_jr30.rb
+++ b/lib/engine/config/game/g_1836_jr30.rb
@@ -628,13 +628,13 @@ module Engine
          ]
       },
       "blue":{
-         "offboard=revenue:yellow_20|brown_30;path=a:4,b:_0;path=a:5,b:_0":[
+         "offboard=revenue:yellow_20|brown_30,revenue_mode:tokens;path=a:4,b:_0;path=a:5,b:_0":[
             "E3",
             "G1"
          ]
       },
       "green":{
-         "offboard=revenue:yellow_20|brown_30;path=a:3,b:_0;path=a:4,b:_0":[
+         "offboard=revenue:yellow_20|brown_30,revenue_mode:tokens;path=a:3,b:_0;path=a:4,b:_0":[
             "J2"
          ]
       }

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -9,8 +9,8 @@ module Engine
       attr_accessor :reservations
       attr_reader :slots, :tokens
 
-      def initialize(revenue, slots = 1, groups = nil, hide = false, visit_cost = nil)
-        super(revenue, groups, hide, visit_cost)
+      def initialize(revenue, slots = 1, groups = nil, hide = false, visit_cost = nil, revenue_mode = nil)
+        super(revenue, groups, hide, visit_cost, revenue_mode)
         @slots = slots.to_i
         @tokens = Array.new(@slots)
         @reservations = []

--- a/lib/engine/part/revenue_center.rb
+++ b/lib/engine/part/revenue_center.rb
@@ -5,22 +5,23 @@ require_relative 'node'
 module Engine
   module Part
     class RevenueCenter < Node
-      attr_reader :groups, :hide, :revenue, :revenue_to_render, :visit_cost
+      attr_reader :groups, :hide, :revenue, :revenue_to_render, :visit_cost, :revenue_mode
 
       PHASES = %i[yellow green brown gray diesel].freeze
 
-      def initialize(revenue, groups = nil, hide = false, visit_cost = nil)
+      def initialize(revenue, groups = nil, hide = false, visit_cost = nil, revenue_mode = nil)
         @revenue = parse_revenue(revenue)
         @groups = (groups || '').split('|')
         @hide = hide
         @visit_cost = (visit_cost || 1).to_i
+        @revenue_mode = (revenue_mode || :normal).to_sym
       end
 
       # number, or something like "yellow_30|green_40|brown_50|gray_70|diesel_90"
       def parse_revenue(revenue)
         @revenue =
           if revenue.include?('|')
-            rev = revenue.split('|').map { |s| s.split('_') }.map { |c, r| [c.to_sym, r.to_i] }.to_h
+            rev = revenue.split('|').map { |s| s.split('_') }.map { |c, r, _s| [c.to_sym, r.to_i] }.to_h
             @revenue_to_render = rev
             rev
           else

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -77,21 +77,24 @@ module Engine
                               params.fetch('slots', 1),
                               params['groups'],
                               params['hide'],
-                              params['visit_cost'])
+                              params['visit_cost'],
+                              params['revenue_mode'])
         cache << city
         city
       when 'town'
         town = Part::Town.new(params['revenue'],
                               params['groups'],
                               params['hide'],
-                              params['visit_cost'])
+                              params['visit_cost'],
+                              params['revenue_mode'])
         cache << town
         town
       when 'offboard'
         offboard = Part::Offboard.new(params['revenue'],
                                       params['groups'],
                                       params['hide'],
-                                      params['visit_cost'])
+                                      params['visit_cost'],
+                                      params['revenue_mode'])
         cache << offboard
         offboard
       when 'label'


### PR DESCRIPTION
A train that includes one of these three locations at one end of its run increases the total of its run by F20 per station
token (not City) on the route in the green phase, and F30 per station token (not City) in the brown phase. As with
Off-Map Locations, only one Paris/Port Location may be scored (either at the beginning or the end of the run). Such
a run must include at least two other scoring locations (e.g., a run from Lille to Paris is not legal) and thus requires at
least a 3 train. A train may include both an Off-Map Location and a Paris/Port Location in its run, one at each end.