### PR TITLE
Allow exchange abilities to come from market

### DIFF
--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -9,21 +9,32 @@ module View
 
       needs :selected_company, default: nil, store: true
 
-      def render
-        return h(:div) unless (ability = @selected_company&.abilities(:exchange))
-
-        corporation = @game.corporation_by_id(ability.corporation)
-        share = corporation.shares.find { |s| !s.president }
-
-        return h(:div) unless share
-        return h(:div) unless @game.round.can_gain?(share, @selected_company.owner)
+      def render_exchange(share, share_origin)
+        return nil unless share
+        return nil unless @game.round.can_gain?(share, @selected_company.owner)
 
         exchange = lambda do
           process_action(Engine::Action::BuyShares.new(@selected_company, shares: share))
           store(:selected_company, nil, skip: true)
         end
 
-        h(:button, { on: { click: exchange } }, "Exchange for a share of #{corporation.name}")
+        h('button.button',
+          { on: { click: exchange } },
+          "Exchange #{@selected_company.sym} for a #{share_origin} share of #{share.corporation.name}")
+      end
+
+      def render
+        return h(:span) unless (ability = @selected_company&.abilities(:exchange))
+
+        corporation = @game.corporation_by_id(ability.corporation)
+        children = []
+        ipo_share = corporation.shares.find { |s| !s.president }
+        children << render_exchange(ipo_share, 'IPO') if ability.from.include?(:ipo)
+
+        pool_share = @game.share_pool.shares_by_corporation[corporation]&.first
+        children << render_exchange(pool_share, 'Market') if ability.from.include?(:market)
+
+        h(:span, children.compact)
       end
     end
   end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -56,16 +56,20 @@ module View
           h(:div, { style: { 'margin-top': '0.5rem', width: '320px' } }, [input].compact)
         end
 
+        def buy_share(entity, share)
+          process_action(Engine::Action::BuyShares.new(entity, shares: share))
+        end
+
         def render_ipoed
           ipo_share = @selected_corporation.shares.first
           pool_share = @round.share_pool.shares_by_corporation[@selected_corporation]&.first
 
           buy_ipo = lambda do
-            process_action(Engine::Action::BuyShares.new(@current_entity, shares: ipo_share))
+            buy_share(@current_entity, ipo_share)
           end
 
           buy_pool = lambda do
-            process_action(Engine::Action::BuyShares.new(@current_entity, shares: pool_share))
+            buy_share(@current_entity, pool_share)
           end
 
           children = []
@@ -79,26 +83,27 @@ module View
             end
 
             # Allow privates to be exchanged for shares
-            exchangable = @game.companies.select do |company|
-              can_exchange = false
+            @game.companies.each do |company|
               company.abilities(:exchange) do |ability|
-                can_exchange = ability.corporation == @selected_corporation.name &&
-                  @round.can_gain?(ipo_share, company.owner)
+                next unless ability.corporation == @selected_corporation.name
+
+                prefix =
+                  if company.owner == @current_entity
+                    "Exchange #{company.sym} for "
+                  else
+                    "#{company.owner&.name} exchanges #{company.sym} for"
+                  end
+
+                if ability.from.include?(:ipo) && @round.can_gain?(ipo_share, company.owner)
+                  children << h('button.button', { on: { click: -> { buy_share(company, ipo_share) } } },
+                                "#{prefix} an IPO share")
+                end
+
+                if ability.from.include?(:market) && @round.can_gain?(pool_share, company.owner)
+                  children << h('button.button', { on: { click: -> { buy_share(company, pool_share) } } },
+                                "#{prefix} a Market share")
+                end
               end
-              can_exchange
-            end
-            exchangable.each do |company|
-              exchange = lambda do
-                process_action(Engine::Action::BuyShares.new(company, shares: ipo_share))
-              end
-              children << if company.owner == @current_entity
-                            h('button.button', { on: { click: exchange } },
-                              "Exchange #{company.sym} for a share")
-                          else
-                            # This can be done outside of a players turn, but make it clear who owns it
-                            h('button.button', { on: { click: exchange } },
-                              "#{company.owner.name} exchanges #{company.name} for a share")
-                          end
             end
 
           end

--- a/lib/engine/ability/exchange.rb
+++ b/lib/engine/ability/exchange.rb
@@ -5,10 +5,11 @@ require_relative 'base'
 module Engine
   module Ability
     class Exchange < Base
-      attr_reader :corporation
+      attr_reader :corporation, :from
 
-      def setup(corporation:)
+      def setup(corporation:, from:)
         @corporation = corporation
+        @from = Array(from).map(&:to_sym)
       end
     end
   end

--- a/lib/engine/config/game/g_1836_jr30.rb
+++ b/lib/engine/config/game/g_1836_jr30.rb
@@ -335,7 +335,8 @@ module Engine
             {
                "type":"exchange",
                "corporation":"B",
-               "owner_type":"player"
+               "owner_type":"player",
+               "from":["ipo","market"]
             },
             {
                "type":"blocks_hexes",

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -309,7 +309,8 @@ module Engine
         {
           "type": "exchange",
           "corporation": "IR",
-          "owner_type": "player"
+          "owner_type": "player",
+          "from": "ipo"
         }
       ]
     },

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -10,6 +10,10 @@ module Engine
     class Special < Base
       attr_writer :current_entity
 
+      def change_entity(_action)
+        # Ignore change entity as special doesn't change entity
+      end
+
       def active_entities
         @entities
       end

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -38,17 +38,18 @@ module Engine
       share_str = "a #{bundle.percent}% share of #{corporation.name}"
       incremental = corporation.capitalization == :incremental
 
+      from = bundle.owner.corporation? ? 'the IPO' : 'the market'
       if exchange
         case exchange
         when :free
           @log << "#{entity.name} receives #{share_str}"
         when Company
-          @log << "#{entity.name} exchanges #{exchange.name} for #{share_str}"
+          @log << "#{entity.name} exchanges #{exchange.name} from #{from} for #{share_str}"
         end
         transfer_shares(bundle, entity)
       else
         @log << "#{entity.name} buys #{share_str} "\
-          "from #{bundle.owner.corporation? ? 'the IPO' : 'the market'} "\
+          "from #{from} "\
           "for #{@game.format_currency(price)}"
 
         transfer_shares(


### PR DESCRIPTION
Fixes:
1836Jr Allow GCB to trade for pool share issue
Fixes a problem where an error would occur if you used the special at the start of a stock round.