### PR TITLE
1836jr: Implement ports

### DIFF
--- a/lib/engine/config/game/g_1836_jr30.rb
+++ b/lib/engine/config/game/g_1836_jr30.rb
@@ -629,13 +629,13 @@ module Engine
          ]
       },
       "blue":{
-         "offboard=revenue:yellow_20|brown_30;path=a:4,b:_0;path=a:5,b:_0":[
+         "offboard=revenue:yellow_20|brown_30,groups:port;path=a:4,b:_0;path=a:5,b:_0":[
             "E3",
             "G1"
          ]
       },
       "green":{
-         "offboard=revenue:yellow_20|brown_30;path=a:3,b:_0;path=a:4,b:_0":[
+         "offboard=revenue:yellow_20|brown_30,groups:port;path=a:3,b:_0;path=a:4,b:_0":[
             "J2"
          ]
       }


### PR DESCRIPTION
A train that includes one of these three locations at one end of its run increases the total of its run by F20 per station
token (not City) on the route in the green phase, and F30 per station token (not City) in the brown phase. As with
Off-Map Locations, only one Paris/Port Location may be scored (either at the beginning or the end of the run). Such
a run must include at least two other scoring locations (e.g., a run from Lille to Paris is not legal) and thus requires at
least a 3 train. A train may include both an Off-Map Location and a Paris/Port Location in its run, one at each end.