### PR TITLE
Add reservation ability for token reservations.

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -39,7 +39,7 @@ module View
           h(
             :text,
             { attrs: { fill: 'black', transform: 'translate(0 9) scale(1.75)' } },
-            @reservation,
+            @reservation.sym,
           )
         end
 

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -39,7 +39,7 @@ module View
           h(
             :text,
             { attrs: { fill: 'black', transform: 'translate(0 9) scale(1.75)' } },
-            @reservation.sym,
+            @reservation.id,
           )
         end
 

--- a/assets/app/view/map_page.rb
+++ b/assets/app/view/map_page.rb
@@ -10,12 +10,12 @@ module View
 
     def render
       game_title = @route.match(ROUTE_FORMAT)[1]
-      game_class = Engine::GAMES_BY_TITLE[game_title]
+      game = Engine::GAMES_BY_TITLE[game_title]
 
-      return h(:p, "Bad game title: #{game_title}") unless game_class
+      return h(:p, "Bad game title: #{game_title}") unless game
 
-      names = %w[p1 p2 p3 p4]
-      h(Game::Map, game: game_class.new(names))
+      players = Game.player_range(game).max.times.map { |n| "Player #{n + 1}" }
+      h(Game::Map, game: game.new(players))
     end
   end
 end

--- a/assets/app/view/map_page.rb
+++ b/assets/app/view/map_page.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_tree 'engine'
 require 'view/game/map'
 
 module View
@@ -14,7 +15,7 @@ module View
 
       return h(:p, "Bad game title: #{game_title}") unless game
 
-      players = Game.player_range(game).max.times.map { |n| "Player #{n + 1}" }
+      players = Engine.player_range(game).max.times.map { |n| "Player #{n + 1}" }
       h(Game::Map, game: game.new(players))
     end
   end

--- a/lib/engine/abilities.rb
+++ b/lib/engine/abilities.rb
@@ -48,6 +48,7 @@ module Engine
     end
 
     def remove_ability(type)
+      @abilities[type]&.teardown
       @abilities.delete(type)
     end
 

--- a/lib/engine/ability/base.rb
+++ b/lib/engine/ability/base.rb
@@ -9,14 +9,16 @@ module Engine
       include Helper::Type
       include Ownable
 
-      attr_reader :type, :owner_type, :when, :count
+      attr_reader :type, :owner_type, :remove, :when, :count
 
-      def initialize(type:, owner_type: nil, count: nil, **opts)
+      def initialize(type:, owner_type: nil, count: nil, remove: nil, **opts)
         @type = type&.to_sym
         @owner_type = owner_type&.to_sym
         @when = opts.delete(:when)&.to_s
         @count = count
         @used = false
+        @remove = remove&.to_s
+
         setup(**opts)
       end
 
@@ -33,6 +35,8 @@ module Engine
       end
 
       def setup(**_opts); end
+
+      def teardown; end
     end
   end
 end

--- a/lib/engine/ability/reservation.rb
+++ b/lib/engine/ability/reservation.rb
@@ -8,10 +8,10 @@ module Engine
       attr_accessor :city, :tile
       attr_reader :hex, :slot
 
-      def setup(hex:, city: 0, slot: 0)
+      def setup(hex:, city: nil, slot: nil)
         @hex = hex
-        @city = city
-        @slot = slot
+        @city = city || 0
+        @slot = slot || 0
         @tile = nil
       end
 

--- a/lib/engine/ability/reservation.rb
+++ b/lib/engine/ability/reservation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Ability
+    class Reservation < Base
+      attr_accessor :city, :tile
+      attr_reader :hex, :slot
+
+      def setup(hex:, city: 0, slot: 0)
+        @hex = hex
+        @city = city
+        @slot = slot
+        @tile = nil
+      end
+
+      def teardown
+        tile.cities[@city].reservations.delete(owner) if tile
+      end
+    end
+  end
+end

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -35,6 +35,8 @@ module Engine
 
     def close!
       @closed = true
+
+      @abilities.each { |t, _| remove_ability(t) }
       return unless owner
 
       owner.companies.delete(self)

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -36,7 +36,7 @@ module Engine
     def close!
       @closed = true
 
-      @abilities.each { |t, _| remove_ability(t) }
+      @abilities.keys.each { |a| remove_ability(a) }
       return unless owner
 
       owner.companies.delete(self)

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -715,7 +715,7 @@ module Engine
       "offboard=revenue:yellow_30|brown_50,groups:E;icon=image:1846/20;path=a:1,b:_0;label=E;border=edge:1,type:mountain,cost:40 ": [
         "B18"
       ],
-      "offboard=revenue:yellow_20|brown_40;icon=image:1846/50;path=a:5,b:_0;label=W;icon=image:port;icon=image:port": [
+      "offboard=revenue:yellow_20|brown_40;icon=image:1846/50;path=a:5,b:_0;label=W;icon=image:port": [
         "C5"
       ],
       "offboard=revenue:yellow_40|brown_60,groups:E;icon=image:1846/30;path=a:1,b:_0;label=E;border=edge:1,type:mountain,cost:60": [

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -181,6 +181,12 @@ module Engine
           "price": 0,
           "teleport_price": 0,
           "extra": true
+        },
+        {
+          "type": "reservation",
+          "hex": "D6",
+          "city": 3,
+          "when": "sold"
         }
       ]
     },
@@ -369,6 +375,11 @@ module Engine
           ],
           "price": 40,
           "teleport_price": 60
+        },
+        {
+          "type": "reservation",
+          "hex": "E11",
+          "remove": "4"
         }
       ],
       "coordinates": "F20",
@@ -409,6 +420,11 @@ module Engine
           ],
           "price": 40,
           "teleport_price": 100
+        },
+        {
+          "type": "reservation",
+          "hex": "H12",
+          "remove": "4"
         }
       ],
       "coordinates": "G19",
@@ -441,6 +457,21 @@ module Engine
         80,
         80,
         0
+      ],
+      "abilities": [
+        {
+          "type": "token",
+          "hexes": [
+            "D20"
+          ],
+          "price": 40
+        },
+        {
+          "type": "reservation",
+          "hex": "D20",
+          "slot": 1,
+          "remove": "4"
+        }
       ],
       "coordinates": "E21",
       "color": "yellow",
@@ -495,6 +526,11 @@ module Engine
             "I5"
           ],
           "price": 40
+        },
+        {
+          "type": "reservation",
+          "hex": "I5",
+          "remove": "4"
         }
       ],
       "coordinates": "K3",

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -21,11 +21,12 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :share_price
-    attr_reader :capitalization, :companies, :min_price, :name, :full_name
+    attr_reader :capitalization, :companies, :min_price, :name, :full_name, :sym
     attr_writer :par_price
 
     def initialize(sym:, name:, **opts)
       @name = sym
+      @sym = sym
       @full_name = name
       [
         Share.new(self, president: true, percent: 20),

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -21,12 +21,11 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :share_price
-    attr_reader :capitalization, :companies, :min_price, :name, :full_name, :sym
+    attr_reader :capitalization, :companies, :min_price, :name, :full_name
     attr_writer :par_price
 
     def initialize(sym:, name:, **opts)
       @name = sym
-      @sym = sym
       @full_name = name
       [
         Share.new(self, president: true, percent: 20),

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -143,7 +143,7 @@ module Engine
     def abilities(type, time = nil)
       abilities = []
 
-      if (ability = super)
+      if (ability = super(type, time, &nil))
         abilities << ability
         yield ability, self if block_given?
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -559,13 +559,29 @@ module Engine
 
       def init_hexes(companies, corporations)
         blockers = {}
-
         companies.each do |company|
           company.abilities(:blocks_hexes) do |ability|
             ability.hexes.each do |hex|
               blockers[hex] = company
             end
           end
+        end
+
+        reservations = Hash.new { |k, v| k[v] = [] }
+        corporations.each do |c|
+          reservations[c.coordinates] << { entity: c,
+                                           city: c.city }
+        end
+        (corporations + companies).each do |c|
+          abilities = c.abilities(:reservation)
+          next if abilities.nil? || (abilities == [])
+
+          ability = abilities.is_a?(Array) ? abilities.first : abilities
+
+          reservations[ability.hex] << { entity: c,
+                                         city: ability.city.to_i,
+                                         slot: ability.slot.to_i,
+                                         ability: ability }
         end
 
         self.class::HEXES.map do |color, hexes|
@@ -578,14 +594,13 @@ module Engine
                   Tile.from_code(coord, color, tile_string, preprinted: true, index: index)
                 end
 
-              # add private companies that block tile lays on this hex
               if (blocker = blockers[coord])
                 tile.add_blocker!(blocker)
               end
 
-              # reserve corporation home spots
-              corporations.select { |c| c.coordinates == coord }.each do |c|
-                tile.add_reservation!(c.name, c.city)
+              reservations[coord].each do |res|
+                res[:ability].tile = tile if res[:ability]
+                tile.add_reservation!(res[:entity], res[:city], res[:slot])
               end
 
               # name the location (city/town)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -573,15 +573,12 @@ module Engine
                                            city: c.city }
         end
         (corporations + companies).each do |c|
-          abilities = c.abilities(:reservation)
-          next if abilities.nil? || (abilities == [])
-
-          ability = abilities.is_a?(Array) ? abilities.first : abilities
-
-          reservations[ability.hex] << { entity: c,
-                                         city: ability.city.to_i,
-                                         slot: ability.slot.to_i,
-                                         ability: ability }
+          c.abilities(:reservation) do |ability|
+            reservations[ability.hex] << { entity: c,
+                                           city: ability.city.to_i,
+                                           slot: ability.slot.to_i,
+                                           ability: ability }
+          end
         end
 
         self.class::HEXES.map do |color, hexes|

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -100,9 +100,11 @@ module Engine
 
       def setup
         remove_from_group!(ORANGE_GROUP, @companies) do |company|
+          company.close!
           @round.companies.delete(company)
         end
         remove_from_group!(BLUE_GROUP, @companies) do |company|
+          company.close!
           @round.companies.delete(company)
         end
         remove_from_group!(GREEN_GROUP, @corporations) do |corporation|

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -109,6 +109,9 @@ module Engine
         end
         remove_from_group!(GREEN_GROUP, @corporations) do |corporation|
           @round.place_home_token(corporation)
+          corporation.abilities(:reservation) do |ability|
+            corporation.remove_ability(ability.type)
+          end
         end
 
         @companies.each do |company|

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -113,15 +113,13 @@ module Engine
 
       # when upgrading, preserve reservations on previous tile
       city_map.each do |old_city, new_city|
-        old_city.reservations.each do |res|
-          abilities = res.abilities(:reservation)
-          next if abilities.nil? || (abilities == [])
+        old_city.reservations.each do |entity|
+          entity.abilities(:reservation) do |ability|
+            next unless ability.hex == coordinates
 
-          ability = abilities.is_a?(Array) ? abilities.first : abilities
-          next unless ability.hex == coordinates
-
-          ability.tile = new_city.tile
-          ability.city = new_city.index
+            ability.tile = new_city.tile
+            ability.city = new_city.index
+          end
         end
 
         new_city.reservations.concat(old_city.reservations)

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -113,6 +113,17 @@ module Engine
 
       # when upgrading, preserve reservations on previous tile
       city_map.each do |old_city, new_city|
+        old_city.reservations.each do |res|
+          abilities = res.abilities(:reservation)
+          next if abilities.nil? || (abilities == [])
+
+          ability = abilities.is_a?(Array) ? abilities.first : abilities
+          next unless ability.hex == coordinates
+
+          ability.tile = new_city.tile
+          ability.city = new_city.index
+        end
+
         new_city.reservations.concat(old_city.reservations)
         old_city.reservations.clear
       end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -33,8 +33,12 @@ module Engine
         @tokens.any? { |t| t&.corporation == corporation }
       end
 
+      def find_reservation(corporation)
+        @reservations.find_index { |r| [r, r.owner].include?(corporation) }
+      end
+
       def reserved_by?(corporation)
-        @reservations.any? { |r| [r, r.owner].include?(corporation) }
+        !!find_reservation(corporation)
       end
 
       def add_reservation!(entity, slot = nil)
@@ -57,7 +61,7 @@ module Engine
           next false unless get_slot(t.corporation)
           next false if !free && t.price > corporation.cash
           next false if @tile.cities.any? { |c| c.tokened_by?(t.corporation) }
-          next true if @reservations.any? { |r| [r, r.owner].include?(corporation) }
+          next true if reserved_by?(corporation)
           next false if @tile.token_blocked_by_reservation?(corporation)
 
           true
@@ -69,7 +73,7 @@ module Engine
       end
 
       def get_slot(corporation)
-        reservation = @reservations.find_index { |r| [r, r.owner].include?(corporation) }
+        reservation = find_reservation(corporation)
         reservation || @tokens.find_index.with_index do |t, i|
           t.nil? && @reservations[i].nil?
         end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -34,11 +34,15 @@ module Engine
       end
 
       def reserved_by?(corporation)
-        @reservations.any? { |r| r == corporation.name }
+        @reservations.any? { |r| [r, r.owner].include?(corporation) }
       end
 
-      def add_reservation!(corporation_sym)
-        @reservations << corporation_sym
+      def add_reservation!(entity, slot = nil)
+        if slot
+          @reservations.insert(slot, entity)
+        else
+          @reservations << entity
+        end
       end
 
       def city?
@@ -53,7 +57,7 @@ module Engine
           next false unless get_slot(t.corporation)
           next false if !free && t.price > corporation.cash
           next false if @tile.cities.any? { |c| c.tokened_by?(t.corporation) }
-          next true if @reservations.index(corporation.name)
+          next true if @reservations.any? { |r| [r, r.owner].include?(corporation) }
           next false if @tile.token_blocked_by_reservation?(corporation)
 
           true
@@ -65,7 +69,8 @@ module Engine
       end
 
       def get_slot(corporation)
-        @reservations.index(corporation.name) || @tokens.find_index.with_index do |t, i|
+        reservation = @reservations.find_index { |r| [r, r.owner].include?(corporation) }
+        reservation || @tokens.find_index.with_index do |t, i|
           t.nil? && @reservations[i].nil?
         end
       end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -68,6 +68,12 @@ module Engine
           company.close!
         end
       end
+
+      (@game.companies + @game.corporations).each do |c|
+        c.all_abilities.each do |ability|
+          c.remove_ability(ability.type) if ability.remove == @name
+        end
+      end
     end
 
     def close_companies_on_train!(entity)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -247,17 +247,17 @@ module Engine
     end
 
     def reserved_by?(corporation)
-      @reservations.any? { |r| r == corporation.name }
+      @reservations.any? { |r| [r, r.owner].include?(corporation) }
     end
 
-    def add_reservation!(name, city)
+    def add_reservation!(entity, city, slot = 0)
       # Single city, assume the first
       city = 0 if @cities.one?
 
       if city
-        @cities[city].add_reservation!(name)
+        @cities[city].add_reservation!(entity, slot)
       else
-        @reservations << name
+        @reservations << entity
       end
     end
 
@@ -265,9 +265,9 @@ module Engine
       return false if @reservations.empty?
 
       if @reservation_blocks
-        !@reservations.include?(corporation.name)
+        !@reservations.include?(corporation)
       else
-        @reservations.count { |x| corporation.name != x } >= @cities.sum(&:available_slots)
+        @reservations.count { |x| corporation != x } >= @cities.sum(&:available_slots)
       end
     end
 

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -40,10 +40,10 @@ module Engine
         end
 
         it 'preserves a token reservation' do
-          subject.tile.cities[0].reservations = ['AR']
+          subject.tile.cities[0].reservations = [corp_1]
 
           subject.lay(green_tile)
-          expect(subject.tile.cities[0].reservations).to eq(['AR'])
+          expect(subject.tile.cities[0].reservations).to eq([corp_1])
         end
       end
 
@@ -82,14 +82,14 @@ module Engine
         end
 
         it 'preserves a placed token and a reservation' do
-          subject.tile.cities[0].reservations = ['AR']
+          subject.tile.cities[0].reservations = [corp_1]
           subject.tile.cities[0].place_token(corp_2, corp_2.next_token)
 
           subject.lay(brown_tile)
 
           expect(subject.tile.cities[0].tokens[0]).to be_nil
           expect(subject.tile.cities[0].tokens[1]).to have_attributes(corporation: corp_2)
-          expect(subject.tile.cities[0].reservations).to eq(['AR'])
+          expect(subject.tile.cities[0].reservations).to eq([corp_1])
         end
       end
 

--- a/spec/lib/engine/part/city_spec.rb
+++ b/spec/lib/engine/part/city_spec.rb
@@ -54,24 +54,24 @@ module Engine
           expect(subject.tokenable?(corporation)).to be true
         end
         it 'disallows with different corp reservation' do
-          subject.add_reservation!(corporation2.name)
+          subject.add_reservation!(corporation2)
           subject.place_token(corporation3, corporation3.next_token, free: true)
           expect(subject.tokenable?(corporation)).to be false
         end
         it 'allows with same corp reservation' do
-          subject.add_reservation!(corporation.name)
+          subject.add_reservation!(corporation)
           subject.place_token(corporation3, corporation3.next_token, free: true)
           expect(subject.tokenable?(corporation)).to be true
         end
         context '2 city tile' do
           subject { Tile.for('128', index: 0).cities[0] } # 2 city tile
           it 'disallows with different corp reservation on tile' do
-            subject.tile.add_reservation!(corporation2.name, nil)
+            subject.tile.add_reservation!(corporation2, nil)
             subject.tile.cities[1].place_token(corporation3, corporation3.next_token, free: true)
             expect(subject.tokenable?(corporation)).to be false
           end
           it 'allows with same corp reservation on tile' do
-            subject.tile.add_reservation!(corporation.name, nil)
+            subject.tile.add_reservation!(corporation, nil)
             subject.tile.cities[1].place_token(corporation3, corporation3.next_token, free: true)
             expect(subject.tokenable?(corporation)).to be true
           end
@@ -79,11 +79,11 @@ module Engine
         context '2 city tile with 1830/1836Jr30 rules' do
           subject { Tile.for('128', index: 0, reservation_blocks: true).cities[0] } # 2 city tile
           it 'disallows with different corp reservation on tile' do
-            subject.tile.add_reservation!(corporation2.name, nil)
+            subject.tile.add_reservation!(corporation2, nil)
             expect(subject.tokenable?(corporation)).to be false
           end
           it 'allows with same corp reservation on tile' do
-            subject.tile.add_reservation!(corporation.name, nil)
+            subject.tile.add_reservation!(corporation, nil)
             expect(subject.tokenable?(corporation)).to be true
           end
         end


### PR DESCRIPTION
1846

    - Give relevant corporations and C&WI the reservation ability.
    - Add Erie's token ability.
    - Close private companies that are removed from the game before deleti
      them. This keeps O&I and MC from blocking tiles if they're not in play.

Abilities

- Add teardown method to token abilities; called when the ability is being
  removed.
- Add `remove` key to abilities to indicate the phase in which that ability
  is removed; check for these at every phase change.
- When a company is closed, remove all of its abilities.

Reservations

- Reservations are the actual corp/company now rather than their short name.
- Reservation ability has tile and city properties that can be updated in order
  to handle tile upgrades.
- If a slot is reserved by a company, it also counts as being reserved by the
  owning corp.
- Reservations are more efficiently initialized, following pattern of blockers:
  build hash of hexes => reservations rather than looping through all the
  corp/company abilities on every hex.

Notes on things that could use refactoring (maybe after 1846 is done):

- `Engine::Corporation` now has `attr_reader :sym`; we want the sym/short name
  for both corporations *and* companies when rendering a reservation, so
  corporations/companies need a common interface for that (called in
  `View::Game::Part::CitySlot#reservation`; currently, corp.name returns the
  short name, company.name returns the long name)
- `corporation#abilities` returns an Array of abilities, but `company#abilities`
  returns `nil` or the ability; a consistent interface there would be
  nice. `lib/engine/game/base.rb` and `lib/engine/hex.rb` use the same logic to
  get to a single ability, or return if there isn't one.