### PR TITLE
Companies on cards

### DIFF
--- a/assets/app/view/game/companies.rb
+++ b/assets/app/view/game/companies.rb
@@ -7,22 +7,56 @@ module View
     class Companies < Snabberb::Component
       needs :game
       needs :user, default: nil
+      needs :owner, default: nil
+      needs :table, default: false
 
       def render
-        children = @game
-          .companies
-          .select(&:owner)
-          .group_by(&:owner)
-          .sort_by { |owner, _| owner.name == @user&.dig(:name) ? '' : owner.name }
-          .map { |owner, companies| render_companies(owner, companies) }
+        if @table
+          render_companies_table(@owner)
+        else
+          children = @game
+            .companies
+            .select(&:owner)
+            .group_by(&:owner)
+            .sort_by { |owner, _| owner.name == @user&.dig(:name) ? '' : owner.name }
+            .map { |owner, companies| render_companies(owner, companies) }
 
-        h(:div, children)
+          h(:div, children)
+        end
       end
 
       def render_companies(owner, companies)
         h(:div, { style: { 'margin-bottom': '0.5rem' } }, [
           h(:div, { style: { 'border-bottom': '1px solid gainsboro' } }, owner.name),
           *companies.map { |c| h(Company, company: c) },
+        ])
+      end
+
+      def render_companies_table(owner)
+        companies = owner.companies.map do |c|
+          h(Company, company: c, table: true)
+        end
+
+        table_props = {
+          style: {
+            padding: '0 0.5rem',
+            justifySelf: 'stretch',
+          },
+        }
+        row_props = {
+          style: {
+            grid: owner.player? ? '1fr / 4fr 1fr 1fr' : '1fr / 5fr 1fr',
+            justifySelf: 'stretch',
+          },
+        }
+
+        h('div#company_table', table_props, [
+          h('div.bold', row_props, [
+            h(:div, 'Company'),
+            owner.player? ? h('div.right', 'Value') : '',
+            h('div.right', 'Income'),
+          ]),
+          h(:div, [*companies]),
         ])
       end
     end

--- a/assets/app/view/game/companies.rb
+++ b/assets/app/view/game/companies.rb
@@ -56,7 +56,7 @@ module View
             owner.player? ? h('div.right', 'Value') : '',
             h('div.right', 'Income'),
           ]),
-          h(:div, [*companies]),
+          h(:div, companies),
         ])
       end
     end

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -27,7 +27,7 @@ module View
 
       def select_company(event)
         event.JS.stopPropagation
-        selected_company = (ability_usable? || purchasable?) && !selected? ? @company : nil
+        selected_company = (purchasable? || ability_usable?) && !selected? ? @company : nil
         store(:tile_selector, nil, skip: true)
         store(:selected_company, selected_company)
       end

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -20,7 +20,6 @@ module View
       end
 
       def ability_usable?
-        puts @company.all_abilities.map(&:type)
         return if (@company.all_abilities.map(&:type) & Round::Operating::ABILITIES).empty?
 
         @game.round.can_act?(@company.owner) || @company.owner.player?

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -20,15 +20,15 @@ module View
       end
 
       def ability_usable?
-        return if (@company.all_abilities.map(&:type) & View::Game::Round::Operating::ABILITIES).empty?
+        return if (@company.all_abilities.map(&:type) & Round::Operating::ABILITIES).empty?
 
-        @game.round.can_act?(@company.owner)
+        @game.round.can_act?(@company.owner) || @company.owner.player?
       end
 
       def select_company(event)
         event.JS.stopPropagation
         selected_company = (ability_usable? || purchasable?) && !selected? ? @company : nil
-        store(:tile_selector, nil)
+        store(:tile_selector, nil, skip: true)
         store(:selected_company, selected_company)
       end
 
@@ -82,7 +82,7 @@ module View
 
           props = {
             style: {
-              cursor: ability_usable? || purchasable? ? 'pointer' : 'default',
+              cursor: purchasable? || ability_usable? ? 'pointer' : 'default',
               boxSizing: 'border-box',
               padding: '0.5rem',
               margin: '0.5rem 0.5rem 0 0',

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -20,7 +20,6 @@ module View
       end
 
       def ability_usable?
-        # TODO: add guard clause for already used abilities
         return if (@company.all_abilities.map(&:type) & View::Game::Round::Operating::ABILITIES).empty?
 
         @game.round.can_act?(@company.owner)

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -20,6 +20,7 @@ module View
       end
 
       def ability_usable?
+        puts @company.all_abilities.map(&:type)
         return if (@company.all_abilities.map(&:type) & Round::Operating::ABILITIES).empty?
 
         @game.round.can_act?(@company.owner) || @company.owner.player?

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -8,10 +8,29 @@ module View
       needs :selected_company, default: nil, store: true
       needs :game, store: true
       needs :tile_selector, default: nil, store: true
-      needs :inline, default: true
+      needs :display, default: 'inline-block'
+      needs :table, default: false
 
       def selected?
         @company == @selected_company
+      end
+
+      def purchasable?
+        !@company.owner || @game.round.operating? && @company.owner.player?
+      end
+
+      def ability_usable?
+        # TODO: add guard clause for already used abilities
+        return if (@company.all_abilities.map(&:type) & View::Game::Round::Operating::ABILITIES).empty?
+
+        @game.round.can_act?(@company.owner)
+      end
+
+      def select_company(event)
+        event.JS.stopPropagation
+        selected_company = (ability_usable? || purchasable?) && !selected? ? @company : nil
+        store(:tile_selector, nil)
+        store(:selected_company, selected_company)
       end
 
       def render_bidders
@@ -27,76 +46,121 @@ module View
       end
 
       def render
-        onclick = lambda do
-          selected_company = selected? ? nil : @company
-          store(:tile_selector, nil)
-          store(:selected_company, selected_company)
+        if @table
+          @hidden_divs = {}
+          render_company_on_card(@company)
+        else
+          header_style = {
+            background: 'yellow',
+            border: '1px solid',
+            'border-radius': '5px',
+            color: 'black',
+            'margin-bottom': '0.5rem',
+            'font-size': '90%',
+          }
+
+          description_style = {
+            margin: '0.5rem 0',
+            'font-size': '80%',
+            'text-align': 'left',
+            'font-weight': 'normal',
+          }
+
+          value_style = {
+            float: 'left',
+          }
+
+          revenue_style = {
+            float: 'right',
+          }
+
+          bidders_style = {
+            'margin-top': '0.5rem',
+            display: 'inline-block',
+            clear: 'both',
+            width: '100%',
+          }
+
+          props = {
+            style: {
+              cursor: ability_usable? || purchasable? ? 'pointer' : 'default',
+              boxSizing: 'border-box',
+              padding: '0.5rem',
+              margin: '0.5rem 0.5rem 0 0',
+              'text-align': 'center',
+              'font-weight': 'bold',
+            },
+            on: { click: ->(event) { select_company(event) } },
+          }
+          if selected?
+            props[:style]['background-color'] = 'lightblue'
+            props[:style]['color'] = 'black'
+          end
+          props[:style][:display] = @display
+
+          children = [
+            h(:div, { style: header_style }, 'PRIVATE COMPANY'),
+            h(:div, @company.name),
+            h(:div, { style: description_style }, @company.desc),
+            h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
+            h(:div, { style: revenue_style }, "Revenue: #{@game.format_currency(@company.revenue)}"),
+          ]
+
+          if @bids&.any?
+            children << h(:div, { style: bidders_style }, 'Bidders:')
+            children << render_bidders
+          end
+
+          children << h('div.nowrap', { style: bidders_style }, "Owner: #{@company.owner.name}") if @company.owner
+
+          h('div.company.card', props, children)
+        end
+      end
+
+      def render_company_on_card(company)
+        toggle_desc = lambda do
+          display = Native(@hidden_divs[company.sym]).elm.style.display
+          Native(@hidden_divs[company.sym]).elm.style.display = display == 'none' ? 'grid' : 'none'
         end
 
-        header_style = {
-          background: 'yellow',
-          border: '1px solid',
-          'border-radius': '5px',
-          color: 'black',
-          'margin-bottom': '0.5rem',
-          'font-size': '90%',
-        }
-
-        description_style = {
-          margin: '0.5rem 0',
-          'font-size': '80%',
-          'text-align': 'left',
-          'font-weight': 'normal',
-        }
-
-        value_style = {
-          float: 'left',
-        }
-
-        revenue_style = {
-          float: 'right',
-        }
-
-        bidders_style = {
-          'margin-top': '0.5rem',
-          display: 'inline-block',
-          clear: 'both',
-          width: '100%',
-        }
-
-        props = {
+        row_props = {
           style: {
+            grid: @company.owner.player? ? 'auto 1fr / 4fr 1fr 1fr [last]' : 'auto 1fr / 5fr 1fr [last]',
             cursor: 'pointer',
-            boxSizing: 'border-box',
-            padding: '0.5rem',
-            margin: '0.5rem 0.5rem 0 0',
-            'text-align': 'center',
-            'font-weight': 'bold',
           },
-          on: { click: onclick },
+        }
+        row_props[:on] = { click: ->(event) { select_company(event) } } unless @company.owner.player?
+
+        income_props = {
+          style: {
+            paddingRight: '0.3rem',
+          },
+        }
+
+        hidden_props = {
+          style: {
+            display: 'none',
+            gridColumnEnd: 'span 3',
+            marginBottom: '0.5rem',
+            padding: '0.1rem 0.2rem',
+            fontSize: '80%',
+            cursor: ability_usable? ? 'pointer' : 'default',
+          },
         }
         if selected?
-          props[:style]['background-color'] = 'lightblue'
-          props[:style]['color'] = 'black'
-        end
-        props[:style][:display] = 'block' unless @inline
-
-        children = [
-          h(:div, { style: header_style }, 'PRIVATE COMPANY'),
-          h(:div, @company.name),
-          h(:div, { style: description_style }, @company.desc),
-          h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
-          h(:div, { style: revenue_style }, "Revenue: #{@game.format_currency(@company.revenue)}"),
-        ]
-
-        if @bids&.any?
-          children << h(:div, { style: bidders_style }, 'Bidders:')
-          children << render_bidders
+          hidden_props[:style]['background-color'] = 'lightblue'
+          hidden_props[:style]['color'] = 'black'
+          hidden_props[:style][:borderRadius] = '0.2rem'
         end
 
-        children << h('div.nowrap', { style: bidders_style }, "Owner: #{@company.owner.name}") if @company.owner
+        @hidden_divs[company.sym] = h('div#hidden', hidden_props, company.desc)
 
-        h('div.company.card', props, children)
+        h(:div, row_props, [
+          h('span.name.nowrap', { on: { click: toggle_desc } }, company.name),
+          @company.owner.player? ? h('span.right', income_props, @game.format_currency(company.value)) : '',
+          h('span.right', income_props, @game.format_currency(company.revenue)),
+          @hidden_divs[company.sym],
+        ])
       end
     end
   end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'view/game/companies'
+
 module View
   module Game
     class Corporation < Snabberb::Component
@@ -7,9 +9,10 @@ module View
       needs :corporation
       needs :selected_corporation, default: nil, store: true
       needs :game, store: true
+      needs :display, default: 'inline-block'
 
       def render
-        onclick = lambda do
+        select_corporation = lambda do
           selected_corporation = selected? ? nil : @corporation
           store(:selected_corporation, selected_corporation)
         end
@@ -17,12 +20,8 @@ module View
         card_style = {
           cursor: 'pointer',
         }
-
-        if @game.round.can_act?(@corporation)
-          card_style['border'] = '1px solid black'
-          card_style['background-color'] = '#dfd'
-          card_style['color'] = 'black'
-        end
+        card_style['border'] = "4px solid #{color_for(:font)}" if @game.round.can_act?(@corporation)
+        card_style['display'] = @display
 
         if selected?
           card_style['background-color'] = 'lightblue'
@@ -33,7 +32,7 @@ module View
 
         unless @corporation.minor?
           children << render_shares
-          children << render_companies if @corporation.companies.any?
+          children << h(Companies, owner: @corporation, table: true, game: @game) if @corporation.companies.any?
         end
 
         if @corporation.owner
@@ -41,7 +40,7 @@ module View
           children << h('table.center', [h(:tr, subchildren)])
         end
 
-        h('div.corp.card', { style: card_style, on: { click: onclick } }, children)
+        h('div.corp.card', { style: card_style, on: { click: select_corporation } }, children)
       end
 
       def render_title
@@ -52,6 +51,9 @@ module View
             background: @corporation.color,
             color: @corporation.text_color,
             height: '2.4rem',
+            textDecoration: @game.round.can_act?(@corporation) ? 'underline' : 'none',
+            textDecorationThickness: @game.round.can_act?(@corporation) ? '0.2rem' : 'none',
+            textUnderlineOffset: @game.round.can_act?(@corporation) ? '0.1rem' : 'none',
           },
         }
         logo_props = {
@@ -86,8 +88,8 @@ module View
             grid: '1fr / auto auto auto',
             gap: '0 0.2rem',
             padding: '0.2rem 0.5rem',
-            'background-color': @game.round.can_act?(@corporation) ? '#99bb99' : color_for(:bg2),
-            color: @game.round.can_act?(@corporation) ? 'black' : color_for(:font2),
+            backgroundColor: color_for(:bg2),
+            color: color_for(:font2),
           },
         }
         sym_props = {
@@ -257,35 +259,6 @@ module View
           h(:tbody, [
             *rows,
           ]),
-        ])
-      end
-
-      def render_companies
-        companies = @corporation.companies.map do |company|
-          render_company(company)
-        end
-
-        h('table.center', [
-          h(:thead, [
-            h(:tr, [
-              h(:th, 'Company'),
-              h(:th, 'Income'),
-            ]),
-          ]),
-          h(:tbody, [
-            *companies,
-          ]),
-        ])
-      end
-
-      def render_company(company)
-        props = {
-          style: { 'max-width': '15rem' },
-        }
-
-        h(:tr, [
-          h('td.name.nowrap', props, company.name),
-          h('td.right', @game.format_currency(company.revenue)),
         ])
       end
 

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -20,7 +20,7 @@ module View
         card_style = {
           cursor: 'pointer',
         }
-        card_style['border'] = "4px solid #{color_for(:font)}" if @game.round.can_act?(@corporation)
+        card_style['border'] = '4px solid' if @game.round.can_act?(@corporation)
         card_style['display'] = @display
 
         if selected?

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -1,29 +1,28 @@
 # frozen_string_literal: true
 
+require 'view/game/companies'
+
 module View
   module Game
     class Player < Snabberb::Component
       include Lib::Color
       needs :player
       needs :game
+      needs :display, default: 'inline-block'
 
       def render
         card_style = {
-          border: '1px solid gainsboro',
+          border: @game.round.can_act?(@player) ? '4px solid' : '1px solid gainsboro',
+          paddingBottom: '0.2rem',
         }
-
-        if @game.round.can_act?(@player)
-          card_style['border'] = '1px solid black'
-          card_style['background-color'] = '#dfd'
-          card_style['color'] = 'black'
-        end
+        card_style[:display] = @display
 
         divs = [
           render_title,
           render_body,
         ]
 
-        divs << render_companies if @player.companies.any?
+        divs << h(Companies, owner: @player, table: true, game: @game) if @player.companies.any?
 
         h('div.player.card', { style: card_style }, divs)
       end
@@ -32,8 +31,11 @@ module View
         props = {
           style: {
             padding: '0.4rem',
-            'background-color': @game.round.can_act?(@player) ? '#9b9' : color_for(:bg2),
-            color: @game.round.can_act?(@player) ? 'black' : color_for(:font2),
+            backgroundColor: color_for(:bg2),
+            color: color_for(:font2),
+            textDecoration: @game.round.can_act?(@player) ? 'underline' : 'none',
+            textDecorationThickness: @game.round.can_act?(@player) ? '0.25rem' : 'none',
+            textUnderlineOffset: @game.round.can_act?(@player) ? '0.2rem' : 'none',
           },
         }
 
@@ -160,29 +162,6 @@ module View
           h('td.center', td_props, [h(:div, div_props, [h(:img, logo_props)])]),
           h(:td, td_props, corporation.name + president_marker),
           h('td.right', td_props, "#{shares.sum(&:percent)}%"),
-        ])
-      end
-
-      def render_companies
-        companies = @player.companies.map do |company|
-          render_company(company)
-        end
-
-        h('table.center', [
-          h(:tr, [
-            h(:th, 'Company'),
-            h(:th, 'Value'),
-            h(:th, 'Income'),
-          ]),
-          *companies,
-        ])
-      end
-
-      def render_company(company)
-        h(:tr, [
-          h('td.name.nowrap', company.name),
-          h('td.right', @game.format_currency(company.value)),
-          h('td.right', @game.format_currency(company.revenue)),
         ])
       end
     end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -42,10 +42,10 @@ module View
           left = [action]
           corporation = round.current_entity
           left << h(Corporation, corporation: corporation)
-          (corporation.companies + corporation.owner.companies).each do |c|
+          corporation.owner.companies.each do |c|
             next if (c.all_abilities.map(&:type) & ABILITIES).empty?
 
-            left << h(Company, inline: false, company: c)
+            left << h(Company, display: 'block', company: c, game: @game)
           end
 
           div_props = {

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -249,7 +249,8 @@ module Engine
           "tiles": [
             "437"
           ],
-          "owner_type": "player"
+          "owner_type": "player",
+          "count": 1
         }
       ]
     },
@@ -281,7 +282,8 @@ module Engine
             "206"
           ],
           "when": "sold",
-          "owner_type": "corporation"
+          "owner_type": "corporation",
+          "count": 1
         }
       ]
     },

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -263,11 +263,14 @@ p:last-child {
   max-width: 12rem;
 }
 
-.corp div {
+.corp div, .player div {
   display: grid;
+}
+.corp__title div, .corp__holdings div {
   align-self: center;
   justify-self: center;
 }
+
 table.center {
   margin: 0.2rem auto;
 }


### PR DESCRIPTION
- companies included on corp/player cards
- player owned companies with abilities during OR (e. g. Mitsubishi Ferry) are still rendered below active corp (alternative: render player card)
- toggle description by click/tap on company name
- click/tap to toggle selection (selected = light blue bg)
- prevent selection of not usable or not purchasable companies (should prevent using other corp’s companies from companies tab etc.)
- cursor: pointer only when selectable
- active corp/player highlighted with border and name underline instead of bg color
- (needs: display in part for later)

- still two selects needed when ability allows laying two tiles

I’m not convinced `@table` is the best method to choose which render method to use for corp/player. (… and results in annoying white-space changes. render as switch plus render_tab/page might be better.)
Logic in company ll. 18 – 34 does (should?!) work, but might not be flexible enough for other cases.