### PR TITLE
Believe Postgres is Requirement - Failing without

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,6 +10,7 @@ If configuring the droplet from scratch, these are the requirements:
 * `docker`
 * `docker-compose`
 * `make`
+* `postgres`
 * this repo (via `git clone`)
 
 ### Docker


### PR DESCRIPTION
Step 1/6 : FROM postgres:12.2
ERROR: Service 'db' failed to build: Get "https://registry-1.docker.io/v2/": dial tcp: lookup registry-1.docker.io on [::1]:53: read udp [::1]:41924->[::1]:53: read: connection refused
make: *** [Makefile:24: dev_up] Error 1

I assume this means that my box needs to have Postgres loaded.