### PR TITLE
Show position for layed token (#688)

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -189,7 +189,12 @@ module View
           }
           img_props[:style][:filter] = 'contrast(50%) grayscale(100%)' if token.used
 
-          token_text = i.zero? ? @corporation.coordinates : token.price
+          token_text =
+            if i.zero?
+              @corporation.coordinates
+            else
+              token.city.nil? ? token.price : token.city.hex.name
+            end
 
           h(:div, token_column_props, [
             h(:img, img_props),


### PR DESCRIPTION
When token is placed all tokens will show the
hex name instead of showing token cost for
non-home tokens.

This is the request as given in issue #688 
Pros:
- Easy to see where a token is placed
Cons:
- What did I pay for it? This you have to check the log for.
Might also cause problems in 18xx where a token can be returned, but I believe this problem is similar if showing cost.

This is my first contribution to this open source project so I am interested to know if I have missed anything?
Also, was not able to locate any unit test for this.
