### PR TITLE
route selection styling: prevent map wrapping

### DIFF
--- a/assets/app/view/game/issue_shares.rb
+++ b/assets/app/view/game/issue_shares.rb
@@ -40,7 +40,7 @@ module View
       def render_button(bundle, &block)
         h(
           'button.button',
-          { on: { click: block } },
+          { style: { padding: '0.2rem 0.5rem' }, on: { click: block } },
           "#{bundle.num_shares} (#{@game.format_currency(bundle.price)})",
         )
       end

--- a/assets/app/view/game/issue_shares.rb
+++ b/assets/app/view/game/issue_shares.rb
@@ -31,9 +31,9 @@ module View
 
         return nil if shares.empty?
 
-        h(:div, [
-          h('div.inline-block.margined', description),
-          *shares,
+        h('div.margined', [
+          h('div.inline-block', description),
+          h('div.inline-block', shares),
         ])
       end
 

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -93,11 +93,9 @@ module View
             children << h('td.right', td_props, route.distance)
             children << h('td.right', td_props, revenue)
             children << h(:td, route.hexes.map(&:name).join(' '))
-          else
-            unless selected
-              style[:border] = '1px solid'
-              style[:padding] = '5px 8px'
-            end
+          elsif !selected
+            style[:border] = '1px solid'
+            style[:padding] = '5px 8px'
           end
 
           invalid_props = {
@@ -135,8 +133,8 @@ module View
         h(:div, div_props, [
           h(UndoAndPass, pass: false),
           h(:h2, { style: { margin: '0.5rem 0 0.2rem' } }, 'Select Routes'),
-          h('div.smallfont', description),
-          h('div.smallfont', 'Click revenue centers, again to cycle paths.'),
+          h('div.small_font', description),
+          h('div.small_font', 'Click revenue centers, again to cycle paths.'),
           h(:table, table_props, [
             h(:thead, [
               h(:tr, [
@@ -146,9 +144,7 @@ module View
                 h(:th, th_route_props, 'Route'),
               ]),
             ]),
-            h(:tbody, [
-              *trains,
-            ]),
+            h(:tbody, trains),
           ]),
           actions,
         ])

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -195,7 +195,7 @@ p:last-child {
   padding: 1rem;
 }
 
-.smallfont {
+.small_font {
   font-size: 90%;
 }
 

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -268,14 +268,11 @@ p:last-child {
   max-width: 12rem;
 }
 
-.corp div, .player div {
+.corp div {
   display: grid;
-}
-.corp__title div, .corp__holdings div {
   align-self: center;
   justify-self: center;
 }
-
 table.center {
   margin: 0.2rem auto;
 }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -153,7 +153,7 @@ p:last-child {
   font-weight: bold;
   margin: 1rem 0;
 }
-.card_header h2 {
+.card_header h2, #left h2 {
   margin: 0;
   font-size: 1.2rem;
 }
@@ -193,6 +193,10 @@ p:last-child {
 
 .padded {
   padding: 1rem;
+}
+
+.smallfont {
+  font-size: 90%;
 }
 
 .tile {
@@ -239,13 +243,14 @@ p:last-child {
   border-radius: 0.7rem;
 }
 @media only screen and (max-width: 420px) {
-  .card {
-    width: 95vw;
+  .card, #left {
+    width: 96vw;
   }
 }
 
 @media only screen and (min-width: 421px) {
   #left {
+    width: 20rem;
     margin-right: 1rem;
   }
 }
@@ -263,11 +268,14 @@ p:last-child {
   max-width: 12rem;
 }
 
-.corp div {
+.corp div, .player div {
   display: grid;
+}
+.corp__title div, .corp__holdings div {
   align-self: center;
   justify-self: center;
 }
+
 table.center {
   margin: 0.2rem auto;
 }


### PR DESCRIPTION
- prevent map wrapping due to changes of routes, error msg etc.
- #left = fixed width => breakpoint on Chesapeake and 1889 ~1360px, 1846 ~1480px
- error message outsourced to separate tr
- prevent width changes of train "buttons"
- paddings, margins. nowrap etc.

Temporary fix for #921. It’s (still) not ideal for widths between 420 and ~1360px (with most maps).

Screenshots:
prod
PR

![image](https://user-images.githubusercontent.com/33390595/86016019-97ffce80-ba22-11ea-9cd8-cce97aff6ff1.png)
![image](https://user-images.githubusercontent.com/33390595/86016032-9c2bec00-ba22-11ea-864c-546f63e3e286.png)

![image](https://user-images.githubusercontent.com/33390595/86016046-a0580980-ba22-11ea-9b8b-126670b6a565.png)
![image](https://user-images.githubusercontent.com/33390595/86016058-a2ba6380-ba22-11ea-9b49-cd99f33e1d95.png)