### PR TITLE
[1846] implement tunnel blasting

### DIFF
--- a/lib/engine/ability/tile_discount.rb
+++ b/lib/engine/ability/tile_discount.rb
@@ -4,11 +4,11 @@ require_relative 'base'
 
 module Engine
   module Ability
-    class IgnoreTerrain < Base
-      attr_reader :terrain
-
-      def setup(terrain:)
+    class TileDiscount < Base
+      attr_reader :terrain, :discount
+      def setup(terrain:, discount:)
         @terrain = terrain.to_sym
+        @discount = discount
       end
     end
   end

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -209,7 +209,15 @@ module Engine
       "value": 60,
       "revenue": 20,
       "desc": "Reduces, for the owning corporation, the cost of laying all mountain tiles and tunnel/pass hexsides by $20.",
-      "sym": "TBC"
+      "sym": "TBC",
+      "abilities": [
+        {
+          "type":"tile_discount",
+          "discount" : "20",
+          "terrain": "mountain",
+          "owner_type": "corporation"
+        }
+      ]
     },
     {
       "name": "Meat Packing Company",

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -293,7 +293,8 @@ module Engine
       "sym": "SMR",
       "abilities": [
         {
-          "type": "ignore_terrain",
+          "type": "tile_discount",
+          "discount" : 80,
           "terrain": "mountain",
           "owner_type": "corporation"
         }

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -191,12 +191,12 @@ module Engine
     end
 
     def upgrade_cost(abilities)
-      ignore = abilities.find { |a| a.type == :ignore_terrain }
+      ability = abilities.find { |a| a.type == :tile_discount }
 
       @upgrades.sum do |upgrade|
-        cost = upgrade.cost
-        cost = 0 if ignore && upgrade.terrains.uniq == [ignore.terrain]
-        cost
+        discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
+        total_cost = upgrade.cost - discount
+        total_cost
       end
     end
 


### PR DESCRIPTION
fixes #894 

Refactors `ignore_terrain` into a generic `tile_discount` ability

I'm not 100% sure if this properly implements a discount for "mountain edges" in 1846 tiles, since I don't have a good grasp of [the code that determines that](https://github.com/tobymao/18xx/blob/master/lib/engine/round/base.rb#L274)