### PR TITLE
implement event for removal of MPC/SBC tokens in 1846

### DIFF
--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -264,7 +264,27 @@ module Engine
       end
 
       def event_remove_tokens!
-        # to be implemented
+        removals = Hash.new { |h, k| h[k] = {} }
+
+        @corporations.each do |corp|
+          corp.assignments.each do |company, _|
+            removals[company][:corporation] = corp.name
+            corp.remove_assignment!(company)
+          end
+        end
+
+        @hexes.each do |hex|
+          hex.assignments.each do |company, _|
+            removals[company][:hex] = hex.name
+            hex.remove_assignment!(company)
+          end
+        end
+
+        removals.each do |company, removal|
+          hex = removal[:hex]
+          corp = removal[:corporation]
+          @log << "-- Event: #{corp}'s #{company} token removed from #{hex} --"
+        end
       end
     end
   end

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -19,9 +19,9 @@ module Engine
         'kino111' => 4863,
       },
       2987 => {
-        'Saintis' => 6059,
-        'steak' => 7425,
-        'tomdidiot' => 7670,
+        'Saintis' => 6050,
+        'steak' => 7371,
+        'tomdidiot' => 7643,
       },
     },
     GAMES_BY_TITLE['18Chesapeake'] => {


### PR DESCRIPTION
tested with the game data shared in #918 at action 342

test game 2987 has final values change a little, but does not break, implying
that the illegal bonus revenue in that game did not lead to an extra share or
train purchase

[Fixes #918]

Screenshot showing new log output:

![Screenshot from 2020-07-01 23-22-43](https://user-images.githubusercontent.com/1045173/86319688-558cec00-bbf2-11ea-95ed-1f3087c046f6.png)
