### PR TITLE
change the $0 space in 1846 to black, update legend

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -15,6 +15,7 @@ module View
         brown: '#8b4513',
         orange: '#ffbb55',
         yellow: '#ffff99',
+        black: '#000000',
       }.freeze
 
       PAD = 5                                     # between box contents and border
@@ -53,6 +54,7 @@ module View
           rows = prices.map do |price|
             if price
               style = box_style.merge('background-color' => price.color ? COLOR_MAP[price.color] : color_for(:bg2))
+              style['color'] = 'white' if price.color == :black
               colors_in_market << price.color unless colors_in_market.include?(price.color)
               corporations = price.corporations
               num = corporations.size
@@ -90,9 +92,10 @@ module View
         if @explain_colors
           colors_text = [
             [:red, 'PAR values'],
-            [:yellow, 'Company shares do not count towards cert limit'],
-            [:orange, 'Company shares can be held above 60%'],
-            [:brown, 'Can buy more than one share in the Company per turn'],
+            [:yellow, 'Corporation shares do not count towards cert limit'],
+            [:orange, 'Corporation shares can be held above 60%'],
+            [:brown, 'Can buy more than one share in the Corporation per turn'],
+            [:black, 'Corporation closes'],
           ]
           colors_text.each do |color, text|
             next unless colors_in_market.include?(color)

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -116,7 +116,7 @@ module Engine
   },
   "market": [
     [
-      "Closed",
+      "Closedblk",
       "10",
       "20",
       "30",

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -116,7 +116,7 @@ module Engine
   },
   "market": [
     [
-      "Closedblk",
+      "0blk",
       "10",
       "20",
       "30",

--- a/lib/engine/share_price.rb
+++ b/lib/engine/share_price.rb
@@ -13,6 +13,8 @@ module Engine
         case
         when can_par
           :red
+        when code.include?('blk')
+          :black
         when code.include?('b')
           :brown
         when code.include?('o')


### PR DESCRIPTION
* consistent wording in stock market legend: "Company" -> "Corporation"

[Fixes #945]

![Screenshot from 2020-07-01 23-42-29](https://user-images.githubusercontent.com/1045173/86320705-a867a300-bbf4-11ea-970c-1278bad90b51.png)

![Screenshot from 2020-07-01 23-44-19](https://user-images.githubusercontent.com/1045173/86320778-d0ef9d00-bbf4-11ea-9a7a-d37d1dec6357.png)
