### PR TITLE
Add NWR tile laying incentive and Tresle company, add revenue calculation for Hudson Bay

### DIFF
--- a/lib/engine/ability/tile_income.rb
+++ b/lib/engine/ability/tile_income.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Ability
+    class TileIncome < Base
+      attr_reader :terrain, :income
+      def setup(terrain:, income:)
+        @terrain = terrain.to_sym
+        @income = income
+      end
+    end
+  end
+end

--- a/lib/engine/config/game/g_1882.rb
+++ b/lib/engine/config/game/g_1882.rb
@@ -277,7 +277,7 @@ module Engine
       "name": "Trestle Bridge",
       "value": 140,
       "revenue": 0,
-      "desc": "Earns $10 every time a corporation adds track over a river. During setup, a 10% share certificate selected randomly from the corporations (excluding SC) is placed with this company. When purchased during the private auction, the player receives both the company and the certificate.",
+      "desc": "Blocks hex G9 while owned by a player. Earns $10 every time a corporation adds track over a river. During setup, a 10% share certificate selected randomly from the corporations (excluding SC) is placed with this company. When purchased during the private auction, the player receives both the company and the certificate.",
       "sym": "TB",
       "abilities": [
         {
@@ -297,6 +297,11 @@ module Engine
           "hexes": [
             "G9"
           ]
+        },
+        {
+            "type": "tile_income",
+            "income" : 10,
+            "terrain": "water"
         }
       ]
     },

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -498,6 +498,14 @@ module Engine
         send("#{type}_by_id", id)
       end
 
+      def all_companies_with_ability(ability)
+        @companies.each do |company|
+          if (found_ability = company.abilities(ability))
+            yield company, found_ability
+          end
+        end
+      end
+
       private
 
       def init_bank

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -31,6 +31,10 @@ module Engine
                   'Remove all yellow tiles from NWR-marked hexes. Station markers remain']
       ).freeze
 
+      def operating_round(round_num)
+        Round::G1882::Operating.new(@corporations, game: self, round_num: round_num)
+      end
+
       def init_phase
         phases = self.class::PHASES
         nwr_phases = %w[3 4 5 6]
@@ -67,7 +71,7 @@ module Engine
 
       def event_nwr!
         @log << '-- Event: North West Rebellion! --'
-        name = '1882/NWR'
+        name = 'NWR'
         @hexes.each do |hex|
           next unless hex.tile.icons.any? { |icon| icon.name == name }
 
@@ -79,6 +83,19 @@ module Engine
           hex.lay(hex.original_tile)
           tiles << old_tile
         end
+      end
+
+      def revenue_for(route)
+        revenue = super
+
+        stops = route.stops
+        # East offboards I1, B2
+        east = stops.find { |stop| %w[I1 B2].include?(stop.hex.name) }
+        # Hudson B12
+        west = stops.find { |stop| stop.hex.name == 'B12' }
+        revenue += 100 if east && west
+
+        revenue
       end
     end
   end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -256,11 +256,14 @@ module Engine
           free = ability.free
         end
 
+        terrain = old_tile.terrain
         cost =
           if free
             0
           else
-            tile_cost(old_tile, entity.all_abilities) + border_cost(tile)
+            border, border_types = border_cost(tile)
+            terrain += border_types if border.positive?
+            tile_cost(old_tile, entity.all_abilities) + border
           end
 
         entity.spend(cost, @game.bank) if cost.positive?
@@ -269,23 +272,38 @@ module Engine
           "#{cost.zero? ? '' : " spends #{@game.format_currency(cost)} and"}"\
           " lays tile ##{tile.name}"\
          " with rotation #{rotation} on #{hex.name}"
+
+        return unless terrain.any?
+
+        @game.all_companies_with_ability(:tile_income) do |company, ability|
+          if terrain.include?(ability.terrain)
+            # If multiple borders are connected bonus counts each individually
+            income = ability.income * terrain.find_all { |t| t == ability.terrain }.size
+            @bank.spend(income, company.owner)
+            @log << "#{company.owner.name} earns #{@game.format_currency(income)}"\
+            " for #{ability.terrain} tile with #{company.name}"
+          end
+        end
       end
 
       def border_cost(tile)
         hex = tile.hex
+        types = []
 
-        tile.borders.dup.sum do |border|
+        total_cost = tile.borders.dup.sum do |border|
           next 0 unless (cost = border.cost)
 
           edge = border.edge
           neighbor = hex.neighbors[edge]
           next 0 if !hex.targeting?(neighbor) || !neighbor.targeting?(hex)
 
+          types << border.type
           tile.borders.delete(border)
           neighbor.tile.borders.map! { |nb| nb.edge == hex.invert(edge) ? nil : nb }.compact!
 
           cost
         end
+        [total_cost, types]
       end
 
       def tile_cost(tile, abilities)

--- a/lib/engine/round/g_1882/operating.rb
+++ b/lib/engine/round/g_1882/operating.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../operating'
+
+module Engine
+  module Round
+    module G1882
+      class Operating < Operating
+        def lay_tile(action)
+          super
+
+          nwr_name = 'NWR'
+          nwr_tile = action.tile.icons.any? { |icon| icon.name == nwr_name }
+          return if !nwr_tile || action.tile.color != :yellow
+
+          @game.log << "#{action.entity.name} gains #{@game.format_currency(20)} for laying yellow tile in NWR area"
+          @bank.spend(20, action.entity)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -200,6 +200,10 @@ module Engine
       end
     end
 
+    def terrain
+      @upgrades.flat_map(&:terrains).uniq
+    end
+
     def upgrades_to?(other)
       # correct color progression?
       return false unless COLORS.index(other.color) == (COLORS.index(@color) + 1)


### PR DESCRIPTION
Covers the following of the 1882 list

* P4 pays revenue each time a bridge (river hexsides preprinted on the map) is crossed, $10 to its owner.
* If you lay in a NWR hex, you get $20 for each lay (must pay any extra costs before getting the $20). (possibly this can be a negative payment, the opposite of tile action payment in 1846)
* (alpha) A route gets a bonus $100 for running [A9 or B2] to L2. (probably can already implement this as using the new group function on tiles)