### PR TITLE
[18Ches] Proposed private description changes 

### DIFF
--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -347,7 +347,7 @@ module Engine
       "name": "Baltimore & Ohio Railroad",
       "value": 100,
       "revenue": 0,
-      "desc": "During game setup place one share of the Baltimore & Ohio corporation with this certificate. The player purchasing this private immediately takes both the private company and the B&O share. This private company has no other special ability.",
+      "desc": "Purchasing player immediately takes a 10% share of the B&O (This does not close the private company). This private company has no other special ability.",
       "sym": "B&OR",
       "abilities": [
         {
@@ -360,7 +360,7 @@ module Engine
       "name": "Cornelius Vanderbilt",
       "value": 200,
       "revenue": 30,
-      "desc": "During game setup select a random president’s certificate and place it with this certificate. The player purchasing this private company takes both this certificate and the randomly selected president’s certificate. The player immediately sets the par value of the corporation. This private closes when the associated corporation buys its first train. It cannot be bought by a corporation.",
+      "desc": "This private closes when the associated corporation buys its first train. It cannot be bought by a corporation.",
       "sym": "CV",
       "abilities": [
         {

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -661,7 +661,7 @@ module Engine
             corporation = @corporations[rand % @corporations.size]
             share = corporation.shares[0]
             ability.share = share
-            company.desc = "#{company.desc} The random corporation in this game is #{corporation.name}."
+            company.desc = "Purchasing player takes a president's share (20%) #{corporation.name} and immediately sets its par value. #{company.desc}"
             @log << "#{company.name} comes with the president's share of #{corporation.name}"
           when 'random_share'
             corporations = ability.corporations&.map { |id| corporation_by_id(id) } || @corporations

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -661,7 +661,8 @@ module Engine
             corporation = @corporations[rand % @corporations.size]
             share = corporation.shares[0]
             ability.share = share
-            company.desc = "Purchasing player takes a president's share (20%) #{corporation.name} and immediately sets its par value. #{company.desc}"
+            company.desc = "Purchasing player takes a president's share (20%) of #{corporation.name} \
+            and immediately sets its par value. #{company.desc}"
             @log << "#{company.name} comes with the president's share of #{corporation.name}"
           when 'random_share'
             corporations = ability.corporations&.map { |id| corporation_by_id(id) } || @corporations


### PR DESCRIPTION
I don't want to trod on @scottredracecar , but wanted to propose some changes to the description of 18Ches privates

Specifically I wanted to surface the name of the company attached to the Vanderbilt (it felt a bit buried in the bottom of the description)

As well as trim out references to "game setup" that didn't seem relevant for this online implementation