### PR TITLE
Contrasting colors

### DIFF
--- a/assets/app/lib/color.rb
+++ b/assets/app/lib/color.rb
@@ -27,23 +27,24 @@ module Lib
 
     # helper functions to calc contrasting bg, font and logo colors
     # https://www.w3.org/TR/AERT/#color-contrast
-    def self.brightness(hexcolor)
+    def brightness(hexcolor)
       m = hexcolor.match(/#(..)(..)(..)/)
       red = m[1].to_i(16)
       green = m[2].to_i(16)
       blue = m[3].to_i(16)
-      Math.sqrt(
-        0.299 * red**2 +
-        0.587 * green**2 +
-        0.114 * blue**2
-      ).to_i
+      Math.sqrt((0.299 * red)**2 + (0.587 * green)**2 + (0.114 * blue)**2) / 1000
     end
 
     # https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
-    def self.contrast(color1, color2)
+    def contrast(color1, color2)
       brightest = [brightness(color1), brightness(color2)].max
       darkest = [brightness(color1), brightness(color2)].min
       (brightest + 0.05) / (darkest + 0.05)
+    end
+
+    def contrast_on(color)
+      # *1.8 to skew towards white on color => black only on really light colors
+      contrast('#ffffff', color) * 1.8 > contrast('#000000', color) ? '#ffffff' : '#000000'
     end
   end
 end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -256,7 +256,8 @@ module View
 
         if player_rows.any?
           if !@corporation.counts_for_limit && (color = StockMarket::COLOR_MAP[@corporation.share_price.color])
-            market_tr_props[:style]['background-color'] = Lib::Color.convert_hex_to_rgba(color, 0.4)
+            market_tr_props[:style][:backgroundColor] = color
+            market_tr_props[:style][:color] = contrast_on(color)
           end
 
           pool_rows << h('tr.market', market_tr_props, [

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -9,6 +9,7 @@ require 'view/game/stock_market'
 module View
   module Game
     class Spreadsheet < Snabberb::Component
+      include Lib::Color
       needs :game
 
       def render
@@ -184,9 +185,11 @@ module View
         market_props = { style: {} }
 
         if !corporation.floated?
-          props[:style]['background-color'] = 'rgba(220,220,220,0.4)'
+          props[:style][:backgroundColor] = '#c6c6c6'
+          props[:style][:color] = 'black'
         elsif !corporation.counts_for_limit && (color = StockMarket::COLOR_MAP[corporation.share_price.color])
-          market_props[:style]['background-color'] = Lib::Color.convert_hex_to_rgba(color, 0.4)
+          market_props[:style][:backgroundColor] = color
+          market_props[:style][:color] = contrast_on(color)
         end
 
         operating_order_text = ''
@@ -201,7 +204,8 @@ module View
           h(:th, name_props, corporation.name),
           *@game.players.map do |p|
             sold_props = { style: {} }
-            sold_props[:style]['background-color'] = 'rgba(225,0,0,0.4)' if @game.round.did_sell?(corporation, p)
+            sold_props[:style][:backgroundColor] = '#9e0000' if @game.round.did_sell?(corporation, p)
+            sold_props[:style][:color] = 'white' if @game.round.did_sell?(corporation, p)
             h(:td, sold_props, p.num_shares_of(corporation).to_s + (corporation.president?(p) ? '*' : ''))
           end,
           h(:td, corporation.num_shares_of(corporation)),

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -185,7 +185,7 @@ module View
         market_props = { style: {} }
 
         if !corporation.floated?
-          props[:style][:backgroundColor] = '#c6c6c6'
+          props[:style][:backgroundColor] = '#777777'
           props[:style][:color] = 'black'
         elsif !corporation.counts_for_limit && (color = StockMarket::COLOR_MAP[corporation.share_price.color])
           market_props[:style][:backgroundColor] = color

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -204,8 +204,10 @@ module View
           h(:th, name_props, corporation.name),
           *@game.players.map do |p|
             sold_props = { style: {} }
-            sold_props[:style][:backgroundColor] = '#9e0000' if @game.round.did_sell?(corporation, p)
-            sold_props[:style][:color] = 'white' if @game.round.did_sell?(corporation, p)
+            if @game.round.did_sell?(corporation, p)
+              sold_props[:style][:backgroundColor] = '#9e0000'
+              sold_props[:style][:color] = 'white'
+            end
             h(:td, sold_props, p.num_shares_of(corporation).to_s + (corporation.president?(p) ? '*' : ''))
           end,
           h(:td, corporation.num_shares_of(corporation)),


### PR DESCRIPTION
fixes #942
I don’t see a need for opacity on the bg colors. They aren’t as harsh as [expected](https://github.com/tobymao/18xx/issues/942#issuecomment-653387231) on black bg and hex-colors are easier to deal with anyway.