### PR TITLE
1846 - corporation closure fixes

### DIFF
--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -231,10 +231,10 @@ module Engine
 
         hexes.each do |hex|
           hex.tile.cities.each do |city|
-            next unless city.tokened_by?(corporation) || city.reserved_by?(corporation)
-
-            city.tokens.map! { |token| token&.corporation == corporation ? nil : token }
-            city.reservations.delete(corporation)
+            if city.tokened_by?(corporation) || city.reserved_by?(corporation)
+              city.tokens.map! { |token| token&.corporation == corporation ? nil : token }
+              city.reservations.delete(corporation)
+            end
           end
         end
 


### PR DESCRIPTION
* fix removal of reservations
* prevent buying trains from closed corporations
* remove share price token
* close companies owned by the corporation, and log it; duplicate the array
  since `company.close!` removes it from its owner's `companies`, i.e., `dup` is
  needed to avoid modifying the array that is being iterated over

[Fixes #958]

This game is on PRR's turn at the train buying step, after ERIE closed at action 65 - [958_example.json.txt](https://github.com/tobymao/18xx/files/4874174/958_example.json.txt)