### PR TITLE
Assign steamboats before the private company is bought in

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -7,6 +7,7 @@ module View
       needs :bids, default: nil
       needs :selected_company, default: nil, store: true
       needs :game, store: true
+      needs :round, default: nil, store: true
       needs :tile_selector, default: nil, store: true
       needs :display, default: 'inline-block'
       needs :layout, default: nil
@@ -28,8 +29,10 @@ module View
       def select_company(event)
         event.JS.stopPropagation
         selected_company = (purchasable? || ability_usable?) && !selected? ? @company : nil
+        round = selected_company ? @game.special : @game.round
         store(:tile_selector, nil, skip: true)
         store(:selected_company, selected_company)
+        store(:round, round)
       end
 
       def render_bidders

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -7,7 +7,6 @@ module View
       needs :bids, default: nil
       needs :selected_company, default: nil, store: true
       needs :game, store: true
-      needs :round, default: nil, store: true
       needs :tile_selector, default: nil, store: true
       needs :display, default: 'inline-block'
       needs :layout, default: nil
@@ -29,10 +28,9 @@ module View
       def select_company(event)
         event.JS.stopPropagation
         selected_company = (purchasable? || ability_usable?) && !selected? ? @company : nil
-        round = selected_company ? @game.special : @game.round
+        
         store(:tile_selector, nil, skip: true)
         store(:selected_company, selected_company)
-        store(:round, round)
       end
 
       def render_bidders

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -28,7 +28,6 @@ module View
       def select_company(event)
         event.JS.stopPropagation
         selected_company = (purchasable? || ability_usable?) && !selected? ? @company : nil
-        
         store(:tile_selector, nil, skip: true)
         store(:selected_company, selected_company)
       end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -9,22 +9,24 @@ module View
       include Actionable
       include Lib::Color
       needs :corporation
-      needs :round, default: nil, store: true
+      needs :selected_company, default: nil, store: true
       needs :selected_corporation, default: nil, store: true
       needs :game, store: true
       needs :display, default: 'inline-block'
 
       def render
         select_corporation = lambda do
-          if @round&.can_assign_corporation?
-            puts "Assigning corporation"
-            process_action(Engine::Action::Assign.new(@round.current_entity, target: @corporation))
-            #store(:selected_corporation, nil)
-            puts "Done assigning corporation"
-          else
-            selected_corporation = selected? ? nil : @corporation
-            store(:selected_corporation, selected_corporation)
-          end
+          selected_corporation = selected? ? nil : @corporation
+          store(:selected_corporation, selected_corporation)
+
+          puts "#{@round.inspect}"
+
+
+          if selected_corporation && @selected_company && @game.special.can_assign_corporation?
+            process_action(Engine::Action::Assign.new(@selected_company, target: @corporation))
+            store(:selected_corporation, nil)
+            store(:selected_company, nil)
+          end       
         end
 
         card_style = {

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -6,7 +6,6 @@ require 'view/game/companies'
 module View
   module Game
     class Corporation < Snabberb::Component
-      include Actionable
       include Lib::Color
       needs :corporation
       needs :selected_company, default: nil, store: true

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -19,14 +19,11 @@ module View
           selected_corporation = selected? ? nil : @corporation
           store(:selected_corporation, selected_corporation)
 
-          puts "#{@round.inspect}"
-
-
-          if selected_corporation && @selected_company && @game.special.can_assign_corporation?
+          if can_assign_corporation?
             process_action(Engine::Action::Assign.new(@selected_company, target: @corporation))
             store(:selected_corporation, nil)
             store(:selected_company, nil)
-          end       
+          end
         end
 
         card_style = {
@@ -301,6 +298,10 @@ module View
 
       def selected?
         @corporation == @selected_corporation
+      end
+
+      def can_assign_corporation?
+        @selected_corporation && @selected_company && @game.special.can_assign_corporation?
       end
     end
   end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -1,20 +1,30 @@
 # frozen_string_literal: true
 
+require 'view/game/actionable'
 require 'view/game/companies'
 
 module View
   module Game
     class Corporation < Snabberb::Component
+      include Actionable
       include Lib::Color
       needs :corporation
+      needs :round, default: nil, store: true
       needs :selected_corporation, default: nil, store: true
       needs :game, store: true
       needs :display, default: 'inline-block'
 
       def render
         select_corporation = lambda do
-          selected_corporation = selected? ? nil : @corporation
-          store(:selected_corporation, selected_corporation)
+          if @round&.can_assign_corporation?
+            puts "Assigning corporation"
+            process_action(Engine::Action::Assign.new(@round.current_entity, target: @corporation))
+            #store(:selected_corporation, nil)
+            puts "Done assigning corporation"
+          else
+            selected_corporation = selected? ? nil : @corporation
+            store(:selected_corporation, selected_corporation)
+          end
         end
 
         card_style = {

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -103,7 +103,9 @@ module View
 
         case @role
         when :map
-          return process_action(Engine::Action::Assign.new(@round.current_entity, target: @hex)) if @round&.can_assign_hex?
+          if @round&.can_assign_hex?
+            return process_action(Engine::Action::Assign.new(@round.current_entity, target: @hex))
+          end
           return unless @round&.can_lay_track?
 
           if @selected && (tile = @tile_selector&.tile)

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -44,7 +44,7 @@ module View
           if @round.ambiguous_token
             opaque = @round.reachable_hexes[@hex]
             clickable ||= opaque
-          elsif @round.can_assign? || @round.can_lay_track?
+          elsif @round.can_assign_hex? || @round.can_lay_track?
             opaque = @round.connected_hexes[@hex]
             clickable ||= opaque
           elsif @round.can_place_token? || @round.can_run_routes?
@@ -103,7 +103,7 @@ module View
 
         case @role
         when :map
-          return process_action(Engine::Action::Assign.new(@round.current_entity, target: @hex)) if @round&.can_assign?
+          return process_action(Engine::Action::Assign.new(@round.current_entity, target: @hex)) if @round&.can_assign_hex?
           return unless @round&.can_lay_track?
 
           if @selected && (tile = @tile_selector&.tile)

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -16,7 +16,7 @@ module View
       class Operating < Snabberb::Component
         needs :game
 
-        ABILITIES = %i[tile_lay teleport assign_hexes token].freeze
+        ABILITIES = %i[tile_lay teleport assign_hexes assign_corporation token].freeze
 
         def render
           round = @game.round

--- a/lib/engine/assignable.rb
+++ b/lib/engine/assignable.rb
@@ -19,14 +19,12 @@ module Engine
     end
 
     def self.remove_from_all!(assignables, key)
-      unassigned = []
       assignables.each do |assignable|
         if assignable.assigned?(key)
-          unassigned << assignable.name
+          yield assignable if block_given?
           assignable.remove_assignment!(key)
         end
       end
-      unassigned
     end
   end
 end

--- a/lib/engine/assignable.rb
+++ b/lib/engine/assignable.rb
@@ -21,8 +21,8 @@ module Engine
     def self.remove_from_all!(assignables, key)
       assignables.each do |assignable|
         if assignable.assigned?(key)
-          yield assignable if block_given?
           assignable.remove_assignment!(key)
+          yield assignable if block_given?
         end
       end
     end

--- a/lib/engine/assignable.rb
+++ b/lib/engine/assignable.rb
@@ -17,5 +17,16 @@ module Engine
     def remove_assignment!(key)
       assignments.delete(key)
     end
+
+    def self.remove_from_all!(assignables, key)
+      unassigned = []
+      assignables.each do |assignable|
+        if assignable.assigned?(key)
+          unassigned << assignable
+          assignable.remove_assignment(key)
+        end
+      end
+      unassigned
+    end
   end
 end

--- a/lib/engine/assignable.rb
+++ b/lib/engine/assignable.rb
@@ -22,8 +22,8 @@ module Engine
       unassigned = []
       assignables.each do |assignable|
         if assignable.assigned?(key)
-          unassigned << assignable
-          assignable.remove_assignment(key)
+          unassigned << assignable.name
+          assignable.remove_assignment!(key)
         end
       end
       unassigned

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -94,7 +94,11 @@ module Engine
         false
       end
 
-      def can_assign?
+      def can_assign_corporation?
+        false
+      end
+
+      def can_assign_hex?
         false
       end
 

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -545,12 +545,12 @@ module Engine
         entity.companies.delete(company)
 
         company.abilities(:assign_corporation) do |ability|
-          Assignable.remove_from_all!(@game.corporations, company.sym) do |unassigned|
+          Assignable.remove_from_all!(@game.corporations, company.id) do |unassigned|
             unless unassigned.name == @current_entity.name
               log_later << "#{company.name} is unassigned from #{unassigned.name}"
             end
           end
-          @current_entity.assign!(company.sym)
+          @current_entity.assign!(company.id)
           ability.use!
           log_later << "#{company.name} is assigned to #{@current_entity.name}"
         end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -545,11 +545,13 @@ module Engine
         entity.companies.delete(company)
 
         company.abilities(:assign_corporation) do |ability|
-          unassigned = Assignable.remove_from_all!(@game.corporations, company.sym)
-          unassigned.delete(@current_entity.name)
+          Assignable.remove_from_all!(@game.corporations, company.sym) do |unassigned|
+            unless unassigned.name == @current_entity.name
+              log_later << "#{company.name} is unassigned from #{unassigned.name}"
+            end
+          end
           @current_entity.assign!(company.sym)
           ability.use!
-          log_later << "#{company.name} is unassigned from #{unassigned.join(', ')}" unless unassigned.empty?
           log_later << "#{company.name} is assigned to #{@current_entity.name}"
         end
         remove_just_sold_company_abilities

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -544,8 +544,11 @@ module Engine
         entity.companies.delete(company)
 
         company.abilities(:assign_corporation) do |ability|
+          unassigned = Assignable.remove_from_all!(@corporations, company.sym)
           @current_entity.assign!(company.sym)
           ability.use!
+          @log << "#{company.name} has been removed from #{unassigned}"
+          @log << "#{company.name} is assigned to #{@current_entity.name}"
         end
         remove_just_sold_company_abilities
         @just_sold_company = company

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -99,9 +99,10 @@ module Engine
             @game.log << "#{company.name} is assigned to #{target.name}"
           end
           if target.is_a?(Corporation) && company.abilities(:assign_corporation)
-            unassigned = Assignable.remove_from_all!(@game.corporations, company.id)
+            Assignable.remove_from_all!(@game.corporations, company.id) do |unassigned|
+              @game.log << "#{company.name} is unassigned from #{unassigned.name}"
+            end
             target.assign!(company.id)
-            @game.log << "#{company.name} is unassigned from #{unassigned.join(', ')}" unless unassigned.empty?
             @game.log << "#{company.name} is assigned to #{target.name}"
           end
         when Action::PlaceToken

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -97,8 +97,7 @@ module Engine
             target.assign!(company.id)
             company.abilities(:assign_hexes, &:use!)
             @game.log << "#{company.name} is assigned to #{target.name}"
-          end
-          if target.is_a?(Corporation) && company.abilities(:assign_corporation)
+          elsif target.is_a?(Corporation) && company.abilities(:assign_corporation)
             Assignable.remove_from_all!(@game.corporations, company.id) do |unassigned|
               @game.log << "#{company.name} is unassigned from #{unassigned.name}"
             end

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -94,12 +94,12 @@ module Engine
           if target.is_a?(Hex) && company.abilities(:assign_hexes)
             target.assign!(company.id)
             company.abilities(:assign_hexes, &:use!)
-            @game.log << "#{company.name} is assigned to #{hex.name}"
+            @game.log << "#{company.name} is assigned to #{target.name}"
           end
-          if target.is_a?(Corportation) && company.abilities(:assign_corporation)
+          if target.is_a?(Corporation) && company.abilities(:assign_corporation)
             target.assign!(company.id)
             company.abilities(:assign_corporation, &:use!)
-            @game.log << "#{company.name} is assigned to #{hex.name}"
+            @game.log << "#{company.name} is assigned to #{target.name}"
           end
         when Action::PlaceToken
           city = action.city

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -91,6 +91,8 @@ module Engine
           company.close!
         when Action::Assign
           target = action.target
+          raise GameError, "#{company.name} is already assigned to #{target.name}" if target.assigned?(company.id)
+
           if target.is_a?(Hex) && company.abilities(:assign_hexes)
             target.assign!(company.id)
             company.abilities(:assign_hexes, &:use!)
@@ -98,7 +100,6 @@ module Engine
           end
           if target.is_a?(Corporation) && company.abilities(:assign_corporation)
             target.assign!(company.id)
-            company.abilities(:assign_corporation, &:use!)
             @game.log << "#{company.name} is assigned to #{target.name}"
           end
         when Action::PlaceToken

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -99,7 +99,9 @@ module Engine
             @game.log << "#{company.name} is assigned to #{target.name}"
           end
           if target.is_a?(Corporation) && company.abilities(:assign_corporation)
+            unassigned = Assignable.remove_from_all!(@game.corporations, company.id)
             target.assign!(company.id)
+            @game.log << "#{company.name} is unassigned from #{unassigned.join(', ')}" unless unassigned.empty?
             @game.log << "#{company.name} is assigned to #{target.name}"
           end
         when Action::PlaceToken


### PR DESCRIPTION
How to use: Click Steamboat Company then click the corporation. 

- Removes previous assignment when clicked again
- Removes previous assignment when purchased

![image](https://user-images.githubusercontent.com/1228912/86530175-5b413680-be6b-11ea-9b7e-4df915fea70c.png)

Fixes #851 