### PR TITLE
change font to Lato; improve legibility of numbers on map

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -162,7 +162,7 @@ class Api < Roda
             <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, minimum-scale=1.0, user-scalable=0">
             <title>18xx.games (#{desc})</title>
             <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css">
-            <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&amp;display=swap">
+            <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&amp;display=swap">
             <link rel="icon" type="image/svg+xml" href="/images/icon.svg">
             <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
             <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">

--- a/assets/app/index.rb
+++ b/assets/app/index.rb
@@ -14,7 +14,7 @@ class Index < Snabberb::Layout
         h(:title, '18xx.games'),
         # rubocop:disable Layout/LineLength
         h(:link, attrs: { rel: 'stylesheet', href: 'https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css' }),
-        h(:link, attrs: { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&display=swap' }),
+        h(:link, attrs: { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap' }),
         h(:link, attrs: { rel: 'icon', type: 'image/svg+xml', href: '/images/icon.svg' }),
         h(:link, attrs: { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/images/favicon-32x32.png' }),
         h(:link, attrs: { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/images/favicon-16x16.png' }),

--- a/assets/app/view/game/part/borders.rb
+++ b/assets/app/view/game/part/borders.rb
@@ -7,6 +7,8 @@ module View
   module Game
     module Part
       class Borders < Base
+        include Lib::Color
+
         needs :tile
         needs :region_use, default: nil
         needs :user, default: nil, store: true
@@ -72,9 +74,19 @@ module View
           x = [edges[:x1], edges[:x2]].sum / 2.0
           y = [edges[:y1], edges[:y2]].sum / 2.0
 
+          stroke_color = contrast_on(color(border))
+          text_props = {
+            attrs: {
+              stroke: stroke_color,
+              fill: stroke_color,
+              'dominant-baseline': 'central',
+              transform: 'translate(0 1)',
+            },
+          }
+
           h(:g, { attrs: { transform: "translate(#{x} #{y}), #{rotation_for_layout}" } }, [
-            h(:circle, attrs: { stroke: 'none', fill: color(border), r: '15' }),
-            h('text.tile__text', { attrs: { stroke: 'white' }, style: { fill: 'white' } }, border.cost.to_s),
+            h(:circle, attrs: { stroke: 'none', fill: color(border), r: '18' }),
+            h('text.tile__text.number', text_props, border.cost.to_s),
           ])
         end
 

--- a/assets/app/view/game/part/location_name.rb
+++ b/assets/app/view/game/part/location_name.rb
@@ -62,7 +62,7 @@ module View
 
           rendered_name = @name_segments.map.with_index do |segment, index|
             x = 0
-            y = index * LINE_HEIGHT
+            y = index * LINE_HEIGHT + 1
             h(:text, { attrs: { transform: "translate(#{x} #{y})" } }, segment)
           end
 

--- a/assets/app/view/game/part/multi_revenue.rb
+++ b/assets/app/view/game/part/multi_revenue.rb
@@ -24,7 +24,7 @@ module View
 
             {
               text: text,
-              width: text.size * 13,
+              width: text.size * 16,
               color: phase == :diesel ? :gray : phase,
             }
           end
@@ -37,27 +37,28 @@ module View
           children = computed_revenues.flat_map.with_index do |rev, index|
             fill = COLOR[rev['color']]
             width = rev['width']
-            t_x = (26 * index) - (total_width * 0.5)
+            t_x = (32 * index) - (total_width * 0.5)
 
             rect_attrs = {
               fill: fill,
               transform: "translate(#{t_x} 0)",
-              height: 24,
+              height: 27,
               width: width,
               x: 0,
               y: -12,
             }
 
-            text_attrs = {
-              transform: "translate(#{t_x + (width * 0.5)} -1)",
-              fill: 'black',
-              'dominant-baseline': 'central',
-              'font-size': 20,
+            text_props = {
+              attrs: {
+                transform: "translate(#{t_x + (width * 0.5)} 0)",
+                fill: 'black',
+                'dominant-baseline': 'central',
+              },
             }
 
             [
               h(:rect, attrs: rect_attrs),
-              h(:text, { attrs: text_attrs }, rev['text']),
+              h('text.number', text_props, rev['text']),
             ]
           end
 

--- a/assets/app/view/game/part/single_revenue.rb
+++ b/assets/app/view/game/part/single_revenue.rb
@@ -13,17 +13,29 @@ module View
         def render
           return h(:g) if @revenue.zero?
 
-          text_attrs = {
-            fill: 'black',
-            transform: 'translate(0 6)',
+          circle_props = {
+            attrs: {
+              r: 15,
+              fill: 'white',
+            },
+            style: {
+              stroke: '#777777',
+            },
+          }
+          text_props = {
+            attrs: {
+              fill: 'black',
+              'dominant-baseline': 'central',
+              transform: 'translate(0 -1)'
+            },
           }
 
           h(
             :g,
             { attrs: { transform: @transform } },
             [
-              h(:circle, attrs: { r: 14, fill: 'white' }),
-              h(:text, { attrs: text_attrs }, @revenue),
+              h(:circle, circle_props),
+              h('text.number', text_props, @revenue),
             ]
           )
         end

--- a/assets/app/view/game/part/single_revenue.rb
+++ b/assets/app/view/game/part/single_revenue.rb
@@ -15,7 +15,7 @@ module View
 
           circle_props = {
             attrs: {
-              r: 15,
+              r: @revenue > 99 ? 17 : 15,
               fill: 'white',
             },
             style: {
@@ -27,6 +27,9 @@ module View
               fill: 'black',
               'dominant-baseline': 'central',
               transform: 'translate(0 -1)',
+            },
+            style: {
+              fontSize: @revenue > 99 ? '18px' : '',
             },
           }
 

--- a/assets/app/view/game/part/single_revenue.rb
+++ b/assets/app/view/game/part/single_revenue.rb
@@ -26,7 +26,7 @@ module View
             attrs: {
               fill: 'black',
               'dominant-baseline': 'central',
-              transform: 'translate(0 -1)'
+              transform: 'translate(0 -1)',
             },
           }
 

--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -46,8 +46,7 @@ module View
         end
 
         def render_part
-          text_attrs = { fill: 'black', transform: 'scale(1.5)' }
-          cost = h(:text, { attrs: text_attrs }, @cost)
+          cost = h('text.number', { attrs: { fill: 'black' } }, @cost)
 
           delta_x = -10
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -184,7 +184,6 @@ module View
         store(:app_route, "#{@app_route.split('#').first}#{anchor}")
       end
 
-      a_class = route_anchor == anchor[1..-1] ? 'active' : ''
       a_props = {
         attrs: {
           href: anchor,
@@ -195,6 +194,7 @@ module View
         },
         on: { click: change_anchor },
       }
+      route_anchor == anchor[1..-1] ? a_props[:style][:textDecoration] = 'underline' : ''
       li_props = {
         style: {
           float: 'left',
@@ -203,7 +203,7 @@ module View
         },
       }
 
-      h(:li, li_props, [h("a.#{a_class}", a_props, name)])
+      h(:li, li_props, [h(:a, a_props, name)])
     end
 
     def route_anchor

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -184,6 +184,7 @@ module View
         store(:app_route, "#{@app_route.split('#').first}#{anchor}")
       end
 
+      a_class = route_anchor == anchor[1..-1] ? 'active' : ''
       a_props = {
         attrs: {
           href: anchor,
@@ -191,7 +192,6 @@ module View
         },
         style: {
           'color': color_for(:font2),
-          'text-decoration': route_anchor == anchor[1..-1] ? '' : 'none',
         },
         on: { click: change_anchor },
       }
@@ -203,7 +203,7 @@ module View
         },
       }
 
-      h(:li, li_props, [h(:a, a_props, name)])
+      h(:li, li_props, [h("a.#{a_class}", a_props, name)])
     end
 
     def route_anchor

--- a/assets/app/view/logo.rb
+++ b/assets/app/view/logo.rb
@@ -38,7 +38,7 @@ module View
       h('h1#logo', h1_props, [
         h(:a, a_props, [
           h(:span, logo_props, '18xx'),
-          h(:span, '.Games'),
+          h(:span, ' . Games'),
         ]),
       ])
     end

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -1,11 +1,17 @@
-* { font-family: 'Inconsolata', monospace; }
+* { font-family: Lato, sans; }
 
 a {
   color: currentColor;
   text-underline-offset: 0.2em;
 }
+nav a {
+  text-decoration: none;
+}
+nav a.active {
+  text-decoration: underline;
+}
 nav a:focus, nav a:hover {
-  font-weight: bold;
+  text-decoration: underline dotted;
   outline: 0;
 }
 
@@ -217,6 +223,11 @@ nav#game_menu {
   padding: 0;
 }
 
+text.number {
+  font-size: 21px;
+  font-weight: 300;
+}
+
 .small_font {
   font-size: 90%;
 }
@@ -244,7 +255,6 @@ nav#game_menu {
 .tile__text {
   fill: black;
   text-anchor: middle;
-  alignment-baseline: middle;
   dominant-baseline: middle;
   pointer-events: none;
 }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -10,9 +10,6 @@ a {
 nav a {
   text-decoration: none;
 }
-nav a.active {
-  text-decoration: underline;
-}
 nav a:focus, nav a:hover {
   text-decoration: underline dotted;
   outline: 0;

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -1,4 +1,7 @@
-* { font-family: Lato, sans; }
+* {
+  font-family: Lato, sans;
+  word-spacing: 1px;
+}
 
 a {
   color: currentColor;


### PR DESCRIPTION
Except for the logo margins (around .) and bold on game menu hover Lato worked out of the box for text, too.
Logo: Keep old one / use Lato, too?