### PR TITLE
Consistent header styling / form headers

### DIFF
--- a/assets/app/view/about.rb
+++ b/assets/app/view/about.rb
@@ -4,7 +4,7 @@ module View
   class About < Snabberb::Component
     def render
       message = <<~MESSAGE
-        <div class="card_header">About 18xx.Games</div>
+        <h2>About 18xx.Games</h2>
         <p>18xx.Games is created and maintained by Toby Mao. It is an open source project, and you can find the
         code on <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>.</p>
 

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -35,10 +35,11 @@ module View
       props = {
         on: { keyup: enter },
       }
+      h2_props = { style: { marginBottom: '0.3rem' } }
 
       id = name.gsub(/\s/, '-').downcase
       h(:form, props, [
-        h(:legend, name),
+        h(:h2, h2_props, name),
         h("div##{id}", inputs),
         h(:input, attrs: { type: :text }, style: { display: 'none' }),
       ])

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -35,7 +35,7 @@ module View
       props = {
         on: { keyup: enter },
       }
-      h2_props = { style: { marginBottom: '0.3rem' } }
+      h2_props = { style: { margin: '0 0 0.5rem 0' } }
 
       id = name.gsub(/\s/, '-').downcase
       h(:form, props, [

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -39,7 +39,7 @@ module View
 
       id = name.gsub(/\s/, '-').downcase
       h(:form, props, [
-        h(:h2, h2_props, name),
+        h(:legend, [h(:h2, h2_props, name)]),
         h("div##{id}", inputs),
         h(:input, attrs: { type: :text }, style: { display: 'none' }),
       ])

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -130,10 +130,6 @@ nav#game_menu {
   font-weight: bold;
 }
 
-#profile-settings {
-  margin-top: 1rem;
-}
-
 #profile-settings > div {
   margin: 0.2rem 0;
 }


### PR DESCRIPTION
Right now all forms are on dedicated pages => form legend == content header. At least as long as that’s the case legend should contain h2, because of page semantics and consistent styling.