### PR TITLE
1817 privates

### DIFF
--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -338,7 +338,8 @@ module Engine
         0,
         0
       ],
-      "color": "yellow"
+      "color": "yellow",
+      "text_color": "black"
     },
     {
       "float_percent": 20,
@@ -364,12 +365,13 @@ module Engine
         0,
         0
       ],
-      "color": "white"
+      "color": "white",
+      "text_color": "black"
     },
     {
       "float_percent": 20,
       "sym": "PSNR",
-      "name": "Pittsburg, Shawmut and Northern Railroad",
+      "name": "Pittsburgh, Shawmut and Northern Railroad",
       "logo": "1817/PSNR",
       "tokens": [
         0,
@@ -382,7 +384,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "PLE",
-      "name": "Pittsburg and Lake Erie Railroad",
+      "name": "Pittsburgh and Lake Erie Railroad",
       "logo": "1817/PLE",
       "tokens": [
         0,
@@ -408,7 +410,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "R",
-      "name": "Rutland Railraod",
+      "name": "Rutland Railroad",
       "logo": "1817/R",
       "tokens": [
         0,
@@ -429,7 +431,8 @@ module Engine
         0,
         0
       ],
-      "color": "natural"
+      "color": "natural",
+      "text_color": "black"
     },
     {
       "float_percent": 20,
@@ -681,6 +684,7 @@ module Engine
     },
     {
       "name": "2+",
+      "on": "2+",
       "train_limit": 4,
       "tiles": [
         "yellow"
@@ -689,6 +693,7 @@ module Engine
     },
     {
       "name": "3",
+      "on": "3",
       "train_limit": 4,
       "tiles": [
         "yellow",
@@ -698,6 +703,7 @@ module Engine
     },
     {
       "name": "4",
+      "on": "4",
       "train_limit": 3,
       "tiles": [
         "yellow",
@@ -707,6 +713,7 @@ module Engine
     },
     {
       "name": "5",
+      "on": "5",
       "train_limit": 3,
       "tiles": [
         "yellow",
@@ -717,6 +724,7 @@ module Engine
     },
     {
       "name": "6",
+      "on": "6",
       "train_limit": 2,
       "tiles": [
         "yellow",
@@ -727,6 +735,7 @@ module Engine
     },
     {
       "name": "7",
+      "on": "7",
       "train_limit": 2,
       "tiles": [
         "yellow",
@@ -738,6 +747,7 @@ module Engine
     },
     {
       "name": "8",
+      "on": "8",
       "train_limit": 2,
       "tiles": [
         "yellow",

--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -130,7 +130,85 @@ module Engine
       "600"
     ]
   ],
-  "companies": [],
+  "companies": [
+    {
+       "name" : "Pittsburgh Steel Mill",
+       "value" : 40,
+       "revenue" : 0,
+       "desc" : "Owning corp may place special Pittsburgh yellow tile during tile-laying, regardless of connectivity.  The hex is not reserved, and the power is lost if another company builds there first.",
+       "sym" : "PSM"
+    },
+    {
+      "name" : "Mountain Engineers",
+      "value" : 40,
+      "revenue" : 0,
+      "desc" : "Owning company receives $20 after laying a yellow tile in a mountain hex.  Any fees must be paid first.",
+      "sym" : "ME"
+    },
+    {
+      "name" : "Ohio Bridge Company",
+      "value" : 40,
+      "revenue" : 0,
+      "desc" : "Comes with one $10 bridge token that may be placed by the owning corp in Louisville, Cincinnati, or Charleston, max one token per city, regardless of connectivity..  Allows owning corp to skip $10 river fee when placing yellow tiles.",
+      "sym" : "OBC"
+    },
+    {
+      "name" : "Union Bridge Company",
+      "value" : 80,
+      "revenue" : 0,
+      "desc" : "Comes with two $10 bridge token that may be placed by the owning corp in Louisville, Cincinnati, or Charleston, max one token per city, regardless of connectivity..  Allows owning corp to skip $10 river fee when placing yellow tiles.",
+      "sym" : "UBC"
+    },
+    {
+      "name" : "Train Station",
+      "value" : 80,
+      "revenue" : 0,
+      "desc" : "Provides an additional station marker for the owning corp, awarded at time of purchase",
+      "sym" : "TS"
+    },
+    {
+      "name" : "Minor Coal Mine",
+      "value" : 30,
+      "revenue" : 0,
+      "desc" : "Comes with one coal mine marker.  When placing a yellow tile in a mountain hex, can place token to avoid $15 terrain fee.  Marked yellow hexes cannot be upgraded.  Hexes pay $10 extra.  May not start or end a route at a coal mine.",
+      "sym" : "MINC"
+    },
+    {
+      "name" : "Coal Mine",
+      "value" : 60,
+      "revenue" : 0,
+      "desc" : "Comes with two coal mine markers.  When placing a yellow tile in a mountain hex, can place token to avoid $15 terrain fee.  Marked yellow hexes cannot be upgraded.  Hexes pay $10 extra.  May not start or end a route at a coal mine.",
+      "sym" : "CM"
+    },
+    {
+      "name" : "Major Coal Mine",
+      "value" : 90,
+      "revenue" : 0,
+      "desc" : "Comes with three coal mine markers.  When placing a yellow tile in a mountain hex, can place token to avoid $15 terrain fee.  Marked yellow hexes cannot be upgraded.  Hexes pay $10 extra.  May not start or end a route at a coal mine.",
+      "sym" : "MAJC"
+    },
+    {
+      "name" : "Minor Mail Contract",
+      "value" : 60,
+      "revenue" : 0,
+      "desc" : "Pays owning corp $10 at the start of each operating round, as long as the company has at least one train.",
+      "sym" : "MINM"
+    },
+    {
+      "name" : "Mail Contract",
+      "value" : 90,
+      "revenue" : 0,
+      "desc" : "Pays owning corp $15 at the start of each operating round, as long as the company has at least one train.",
+      "sym" : "MAIL"
+    },
+    {
+      "name" : "Major Mail Contract",
+      "value" : 120,
+      "revenue" : 0,
+      "desc" : "Pays owning corp $20 at the start of each operating round, as long as the company has at least one train.",
+      "sym" : "MAJM"
+    }
+  ],
   "corporations": [
     {
       "float_percent": 20,


### PR DESCRIPTION
Adds a rough draft of privates for 1817.  No abilities yet, and the descriptions need cleaned up.

Fixes for trains so that the game will start properly.  The "on" condition of phase "2+" is wrong: it should trigger on the export of a 2T, which also zeroes the inventory of 2T's  but doesn't rust/obsolete them.

Fixed spelling of "Pittsburgh" in Corp names.

Added contrasting text_color to corps as needed.