### PR TITLE
Adjust Paris and Channel Ports revenue boxes (#980)

### DIFF
--- a/lib/engine/config/game/g_1836_jr30.rb
+++ b/lib/engine/config/game/g_1836_jr30.rb
@@ -629,13 +629,13 @@ module Engine
          ]
       },
       "blue":{
-         "offboard=revenue:yellow_20|brown_30,groups:port;path=a:4,b:_0;path=a:5,b:_0":[
+         "offboard=revenue:green_20|brown_30,groups:port;path=a:4,b:_0;path=a:5,b:_0":[
             "E3",
             "G1"
          ]
       },
       "green":{
-         "offboard=revenue:yellow_20|brown_30,groups:port;path=a:3,b:_0;path=a:4,b:_0":[
+         "offboard=revenue:green_20|brown_30,groups:port;path=a:3,b:_0;path=a:4,b:_0":[
             "J2"
          ]
       }


### PR DESCRIPTION
Changed from yellow to green revenue as a 3T needed to use revenue
boxes.