### PR TITLE
Apply company discount to border terrain, log terrain discounts

### DIFF
--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -64,6 +64,7 @@ module View
 
         def mountain(delta_x: 0, delta_y: 0)
           h(:polygon, attrs: { transform: "translate(#{delta_x} #{delta_y})",
+                               fill: "#cb7745",
                                points: TRIANGLE_PATH })
         end
 

--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -64,7 +64,7 @@ module View
 
         def mountain(delta_x: 0, delta_y: 0)
           h(:polygon, attrs: { transform: "translate(#{delta_x} #{delta_y})",
-                               fill: "#cb7745",
+                               fill: '#cb7745',
                                points: TRIANGLE_PATH })
         end
 

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -269,9 +269,9 @@ module Engine
           if free
             0
           else
-            border, border_types = border_cost(tile)
+            border, border_types = border_cost(tile, entity)
             terrain += border_types if border.positive?
-            tile_cost(old_tile, entity.all_abilities) + border
+            tile_cost(old_tile, entity, @game) + border
           end
 
         entity.spend(cost, @game.bank) if cost.positive?
@@ -294,7 +294,7 @@ module Engine
         end
       end
 
-      def border_cost(tile)
+      def border_cost(tile, entity)
         hex = tile.hex
         types = []
 
@@ -309,13 +309,24 @@ module Engine
           tile.borders.delete(border)
           neighbor.tile.borders.map! { |nb| nb.edge == hex.invert(edge) ? nil : nb }.compact!
 
-          cost
+          ability = entity.all_abilities.find do |a|
+            (a.type == :tile_discount) && (border.type == a.terrain)
+          end
+          discount = ability&.discount || 0
+
+          if discount.positive?
+            @log << "#{entity.name} receives a discount of "\
+                    "#{@game.format_currency(discount)} from "\
+                    "#{ability.owner.name}"
+          end
+
+          cost - discount
         end
         [total_cost, types]
       end
 
-      def tile_cost(tile, abilities)
-        tile.upgrade_cost(abilities)
+      def tile_cost(tile, entity, game)
+        tile.upgrade_cost(entity, game)
       end
 
       def payout_companies

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -271,7 +271,7 @@ module Engine
           else
             border, border_types = border_cost(tile, entity)
             terrain += border_types if border.positive?
-            tile_cost(old_tile, entity, @game) + border
+            tile_cost(old_tile, entity) + border
           end
 
         entity.spend(cost, @game.bank) if cost.positive?
@@ -325,8 +325,21 @@ module Engine
         [total_cost, types]
       end
 
-      def tile_cost(tile, entity, game)
-        tile.upgrade_cost(entity, game)
+      def tile_cost(tile, entity)
+        ability = entity.all_abilities.find { |a| a.type == :tile_discount }
+
+        tile.upgrades.sum do |upgrade|
+          discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
+
+          if discount.positive?
+            @log << "#{entity.name} receives a discount of "\
+                    "#{@game.format_currency(discount)} from "\
+                    "#{ability.owner.name}"
+          end
+
+          total_cost = upgrade.cost - discount
+          total_cost
+        end
       end
 
       def payout_companies

--- a/lib/engine/round/g_1846/operating.rb
+++ b/lib/engine/round/g_1846/operating.rb
@@ -157,8 +157,8 @@ module Engine
           super
         end
 
-        def tile_cost(tile, abilities)
-          [@game.class::TILE_COST, tile.upgrade_cost(abilities)].max
+        def tile_cost(tile, entity, game)
+          [@game.class::TILE_COST, tile.upgrade_cost(entity, game)].max
         end
 
         def change_share_price(revenue = 0)

--- a/lib/engine/round/g_1846/operating.rb
+++ b/lib/engine/round/g_1846/operating.rb
@@ -157,8 +157,8 @@ module Engine
           super
         end
 
-        def tile_cost(tile, entity, game)
-          [@game.class::TILE_COST, tile.upgrade_cost(entity, game)].max
+        def tile_cost(tile, entity)
+          [@game.class::TILE_COST, super(tile, entity)].max
         end
 
         def change_share_price(revenue = 0)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -190,23 +190,6 @@ module Engine
         ((cities.empty? && towns.one?) && edges.size > 2)
     end
 
-    def upgrade_cost(entity, game)
-      ability = entity.all_abilities.find { |a| a.type == :tile_discount }
-
-      @upgrades.sum do |upgrade|
-        discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
-
-        if discount.positive?
-          game.log << "#{entity.name} receives a discount of "\
-                      "#{game.format_currency(discount)} from "\
-                      "#{ability.owner.name}"
-        end
-
-        total_cost = upgrade.cost - discount
-        total_cost
-      end
-    end
-
     def terrain
       @upgrades.flat_map(&:terrains).uniq
     end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -190,11 +190,18 @@ module Engine
         ((cities.empty? && towns.one?) && edges.size > 2)
     end
 
-    def upgrade_cost(abilities)
-      ability = abilities.find { |a| a.type == :tile_discount }
+    def upgrade_cost(entity, game)
+      ability = entity.all_abilities.find { |a| a.type == :tile_discount }
 
       @upgrades.sum do |upgrade|
         discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
+
+        if discount.positive?
+          game.log << "#{entity.name} receives a discount of "\
+                      "#{game.format_currency(discount)} from "\
+                      "#{ability.owner.name}"
+        end
+
         total_cost = upgrade.cost - discount
         total_cost
       end


### PR DESCRIPTION
[Fixes #1001]
[Closes #877]

Example mentioned in #877:
![Screenshot from 2020-07-07 23-23-34](https://user-images.githubusercontent.com/1045173/86879945-363a0700-c0a9-11ea-90dd-249743a8b02d.png)

From the game data provided in #1001:
![Screenshot from 2020-07-07 23-22-58](https://user-images.githubusercontent.com/1045173/86879955-3b975180-c0a9-11ea-91cf-aacb5a1ec24d.png)
![Screenshot from 2020-07-07 23-23-14](https://user-images.githubusercontent.com/1045173/86880002-48b44080-c0a9-11ea-8c10-9ebcb3a882ac.png)

color mountains in middle of hex to match color of mountains on borders:
![Screenshot from 2020-07-07 23-33-34](https://user-images.githubusercontent.com/1045173/86880729-58805480-c0aa-11ea-80f5-508821a26629.png)



