### PR TITLE
Correct tiles in 18AL (#961)

### DIFF
--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -97,7 +97,8 @@ module Engine
       "441a":1,
       "442a":1,
       "443a":1,
-      "444a":2
+      "444b":1,
+      "444m":1
    },
    "market":[
       [
@@ -404,15 +405,17 @@ module Engine
          "upgrade=cost:60,terrain:mountain":[
             "F7"
          ],
-         "city=revenue:0;upgrade=cost:60,terrain:mountain":[
+         "city=revenue:0;upgrade=cost:60,terrain:mountain;label=B;icon=image:18_al/coal,sticky:1":[
             "G4"
          ],
          "city=revenue:0":[
-            "G6",
-            "H3",
             "J7",
             "K2",
             "L5"
+         ],
+         "city=revenue:0;icon=image:18_al/coal,sticky:1":[
+            "G6",
+            "H3"
          ],
          "town=revenue:0":[
             "O6"
@@ -445,7 +448,7 @@ module Engine
          "city=revenue:30;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0":[
             "F1"
          ],
-         "city=revenue:30;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0":[
+         "city=revenue:30;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;icon=image:18_al/coal,sticky:1":[
             "H5"
          ],
          "city=revenue:yellow_30|brown_40,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0":[
@@ -456,7 +459,7 @@ module Engine
          ]
       },
       "yellow":{
-         "city=revenue:20;path=a:3,b:_0;path=a:4,b:_0":[
+         "city=revenue:20;path=a:3,b:_0;path=a:4,b:_0;icon=image:18_al/coal,sticky:1":[
             "E6"
          ],
          "city=revenue:20;path=a:1,b:_0;path=a:_0,b:5":[

--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -52,7 +52,7 @@ module Engine
         # '403' => 'city=revenue:30;town=revenue:30;path=a:0,b:_0;label=B;upgrade=cost:40',
         '437' => 'town=revenue:30;path=a:0,b:_0;path=a:_0,b:2;icon=image:port,blocks_lay:1',
         '438' => 'city=revenue:40;path=a:0,b:_0;path=a:2,b:_0;label=H;upgrade=cost:80',
-        '445' => 'town=revenue:10;path=a:0,b:_0;path=a:_0,b:2',
+        '445' => 'town=revenue:20;path=a:0,b:_0;path=a:_0,b:2;icon=image:18_al/tree,blocks_lay:1',
         # '601' => 'city=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:2,b:_1;label=V',
         '621' => 'city=revenue:30;path=a:0,b:_0;path=a:_0,b:3;label=Y',
         '630' => 'town=revenue:10;town=revenue:10;path=a:2,b:_0;path=a:_0,b:3;path=a:0,b:_1;path=a:_1,b:4',
@@ -442,7 +442,8 @@ module Engine
         '1067' => 'city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:2,b:_1;path=a:_1,b:4',
         '1068' => 'city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:4',
         '61Y' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y',
-        '444a' => 'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=B·M',
+        '444b' => 'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=B',
+        '444m' => 'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=M',
         '891Y' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=Y',
       }.freeze
 

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -12,6 +12,10 @@ module Engine
       GAME_LOCATION = 'Alabama, USA'
       GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
       GAME_DESIGNER = 'Mark Derrick'
+
+      def operating_round(round_num)
+        Round::G18AL::Operating.new(@corporations, game: self, round_num: round_num)
+      end
     end
   end
 end

--- a/lib/engine/round/g_18_al/operating.rb
+++ b/lib/engine/round/g_18_al/operating.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../operating'
+
+module Engine
+  module Round
+    module G18AL
+      class Operating < Operating
+        def process_lay_tile(action)
+          super
+
+          # Change Montgomery to use M tiles after first tile
+          # placed there. From beginning Montgomery is a regular
+          # city, but from "green" phase it has its own tiles.
+          action.tile.label = 'M' if action.tile.hex.name == 'L5'
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -328,6 +328,11 @@ module Engine
       @revenue_to_render ||= stops.map(&:revenue_to_render)
     end
 
+    # Used to set label for a recently placed tile
+    def label=(label_name)
+      @label = Part::Label.new(label_name)
+    end
+
     private
 
     def separate_parts

--- a/public/icons/18_al/coal.svg
+++ b/public/icons/18_al/coal.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="-12.5 -12.5 25 25">
+    <g class="color-main color-black color-stroke-main color-stroke-black" stroke="#000">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M-7 7L4-4"/>
+        <path stroke-linecap="miter" d="M-5-9Q12-12 9 5 8-8-5-9"/>
+    </g>
+</svg>

--- a/public/icons/18_al/tree.svg
+++ b/public/icons/18_al/tree.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="-12.5 -12.5 25 25">
+    <path class="color-mountain color-stroke-black" fill="#d1ae85" stroke="#000" stroke-linecap="round" stroke-linejoin="round" d="M-2 1h4v8h-4z"/>
+    <path class="color-land color-stroke-black" fill="#59b578" stroke="#000" stroke-linecap="round" stroke-linejoin="round" d="M-6 3l6-13L6 3z"/>
+</svg>


### PR DESCRIPTION
- Split 444a into two tiles with different labels (444b for Birmingham
  with label B, and 444m for Montgomery with label M)
- Block tile laying of tile 445 as can only be placed via company BLC
- Put icon of tile 445
  - to be able to use attribute for tile block
  - to separate it form normal gentle tile with town
- Add sticky coal icon for Warrior Coal token locations (5 hexes)
- When tile is placed in Montgomery ensure label is set to M to
  allow for a yellow tile to be put there and further tiles to be
  put there needing the label M.