### PR TITLE
Set allowed purchase interval for companies in Mark Derrick games (#961)

### DIFF
--- a/lib/engine/game/company_price_50_to_150_percent.rb
+++ b/lib/engine/game/company_price_50_to_150_percent.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#
+# This module sets up so that the allowed price
+# for purchasing private companies are between
+# 50% and 150% of the face value.
+# This is used in e.g 18MEX and 18AL.
+#
+module CompanyPrice50To150Percent
+  def setup
+    @companies.each do |company|
+      company.min_price = company.value * 0.5
+      company.max_price = company.value * 1.5
+    end
+  end
+end

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -2,6 +2,7 @@
 
 require_relative '../config/game/g_18_al'
 require_relative 'base'
+require_relative 'company_price_50_to_150_percent'
 
 module Engine
   module Game
@@ -12,6 +13,8 @@ module Engine
       GAME_LOCATION = 'Alabama, USA'
       GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
       GAME_DESIGNER = 'Mark Derrick'
+
+      include CompanyPrice50To150Percent
 
       def operating_round(round_num)
         Round::G18AL::Operating.new(@corporations, game: self, round_num: round_num)

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -2,6 +2,7 @@
 
 require_relative '../config/game/g_18_ga'
 require_relative 'base'
+require_relative 'company_price_50_to_150_percent'
 
 module Engine
   module Game
@@ -11,6 +12,8 @@ module Engine
       GAME_LOCATION = 'Georgia, USA'
       GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18GA_Rules_v3_26.pdf'
       GAME_DESIGNER = 'Mark Derrick'
+
+      include CompanyPrice50To150Percent
     end
   end
 end

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -2,6 +2,7 @@
 
 require_relative '../config/game/g_18_mex'
 require_relative 'base'
+require_relative 'company_price_50_to_150_percent'
 
 module Engine
   module Game
@@ -13,6 +14,7 @@ module Engine
       GAME_RULES_URL = 'https://secure.deepthoughtgames.com/games/18MEX/rules.pdf'
       GAME_DESIGNER = 'Mark Derrick'
 
+      include CompanyPrice50To150Percent
       def setup
         @minors.each do |minor|
           train = @depot.upcoming[0]

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -2,6 +2,7 @@
 
 require_relative '../config/game/g_18_ms'
 require_relative 'base'
+require_relative 'company_price_50_to_150_percent'
 
 module Engine
   module Game
@@ -17,6 +18,8 @@ module Engine
       #      def init_round
       #        Round::G18MS::Draft.new(@players.reverse, game: self)
       #      end
+
+      include CompanyPrice50To150Percent
     end
   end
 end

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -2,6 +2,7 @@
 
 require_relative '../config/game/g_18_tn'
 require_relative 'base'
+require_relative 'company_price_50_to_150_percent'
 
 module Engine
   module Game
@@ -11,6 +12,8 @@ module Engine
       GAME_LOCATION = 'Tennessee, USA'
       GAME_RULES_URL = 'http://dl.deepthoughtgames.com/18TN-Rules.pdf'
       GAME_DESIGNER = 'Mark Derrick'
+
+      include CompanyPrice50To150Percent
     end
   end
 end


### PR DESCRIPTION
Update so that allowed purchase interval for companies is between
50% and 150% (inclusive) of face value.

This has been changed in the following games:
  - 18AL
  - 18GA
  - 18MEX
  - 18MS
  - 18TN