### PR TITLE
18AL: Add support for historical objective (#961)

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -48,6 +48,9 @@ module View
           children << h(Companies, owner: @corporation, game: @game) if @corporation.companies.any?
         end
 
+        abilities = @corporation.all_abilities.select { |ability| ability.owner.corporation? }
+        children << render_abilities(abilities) if abilities&.any?
+
         if @corporation.owner
           subchildren = (@corporation.operating_history.empty? ? [] : [render_revenue_history])
           children << h('table.center', [h(:tr, subchildren)])
@@ -298,6 +301,29 @@ module View
       def render_revenue_history
         last_run = @corporation.operating_history[@corporation.operating_history.keys.max].revenue
         h('td.bold', "Last Run: #{@game.format_currency(last_run)}")
+      end
+
+      def render_abilities(abilities)
+        attribute_lines = []
+
+        abilities.each do |ability|
+          attribute_lines << h('div.name.nowrap', ability.name)
+          attribute_lines << h('div.right', ability.display_value || '')
+        end
+
+        table_props = {
+          style: {
+            padding: '0 0.5rem',
+            grid: 'auto / 3fr 2fr',
+            gap: '0 0.2rem',
+          },
+        }
+
+        h('div#company_table', table_props, [
+          h('div.bold', 'Attribute'),
+          h('div.bold.right', 'Value'),
+          *attribute_lines,
+        ])
       end
 
       def selected?

--- a/lib/engine/ability/base.rb
+++ b/lib/engine/ability/base.rb
@@ -9,14 +9,17 @@ module Engine
       include Helper::Type
       include Ownable
 
+      attr_accessor :name, :display_value
       attr_reader :type, :owner_type, :remove, :when, :count
 
-      def initialize(type:, owner_type: nil, count: nil, remove: nil, **opts)
+      def initialize(type:, name: nil, owner_type: nil, count: nil, remove: nil, display_value: nil, **opts)
         @type = type&.to_sym
+        @name = name&.to_s || @type
         @owner_type = owner_type&.to_sym
         @when = opts.delete(:when)&.to_s
         @count = count
         @used = false
+        @display_value = display_value&.to_s
         @remove = remove&.to_s
 
         setup(**opts)

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -238,7 +238,17 @@ module Engine
             100
          ],
          "coordinates":"A4",
-         "color":"blue"
+         "color":"blue",
+         "abilities": [
+            {
+              "type": "assign_hexes",
+              "name": "Historical objective",
+              "hexes": [
+                "G4"
+              ],
+              "count": 1
+            }
+         ]
       },
       {
          "sym":"M&O",
@@ -251,7 +261,17 @@ module Engine
             100
          ],
          "coordinates":"Q2",
-         "color":"orange"
+         "color":"orange",
+         "abilities": [
+            {
+               "type": "assign_hexes",
+               "name": "Historical objective",
+               "hexes": [
+                 "K2"
+               ],
+               "count": 1
+            }
+         ]
       },
       {
          "sym":"WRA",
@@ -264,7 +284,17 @@ module Engine
             100
          ],
          "coordinates":"L5",
-         "color":"red"
+         "color":"red",
+         "abilities": [
+            {
+               "type": "assign_hexes",
+               "name": "Historical objective",
+               "hexes": [
+                 "J7"
+               ],
+               "count": 1
+            }
+         ]
       },
       {
          "sym":"ATN",
@@ -276,7 +306,17 @@ module Engine
             100
          ],
          "coordinates":"F1",
-         "color":"black"
+         "color":"black",
+         "abilities": [
+            {
+               "type": "assign_hexes",
+               "name": "Historical objective",
+               "hexes": [
+                 "L1"
+               ],
+               "count": 1
+            }
+         ]
       },
       {
          "sym":"ABC",
@@ -287,7 +327,17 @@ module Engine
             40
          ],
          "coordinates":"G6",
-         "color":"green"
+         "color":"green",
+         "abilities": [
+            {
+               "type": "assign_hexes",
+               "name": "Historical objective",
+               "hexes": [
+                 "G4"
+               ],
+               "count": 1
+            }
+         ]
       },
       {
          "sym":"TAG",
@@ -299,7 +349,17 @@ module Engine
          ],
          "coordinates":"E6",
          "color":"yellow",
-         "text_color":"black"
+         "text_color":"black",
+         "abilities": [
+            {
+               "type": "assign_hexes",
+               "name": "Historical objective",
+               "hexes": [
+                 "G4"
+               ],
+               "count": 1
+            }
+         ]
       }
    ],
    "trains":[

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -27,7 +27,7 @@ module Engine
           Step::DiscardTrain,
           Step::BuyCompany,
           Step::HomeToken,
-          Step::Track,
+          Step::G18AL::Track,
           Step::Token,
           Step::Route,
           Step::Dividend,

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -3,6 +3,7 @@
 require_relative '../config/game/g_18_al'
 require_relative 'base'
 require_relative 'company_price_50_to_150_percent'
+require_relative 'revenue_4d'
 
 module Engine
   module Game
@@ -16,6 +17,7 @@ module Engine
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
       include CompanyPrice50To150Percent
+      include Revenue4D
 
       def setup
         setup_company_price_50_to_150_percent
@@ -43,15 +45,7 @@ module Engine
           raise GameError, "#{hex.location_name} must be first or last in route"
         end
 
-        revenue = super
-
-        if route.train.name == '4D'
-          revenue = 2 * revenue - route.stops
-            .select { |stop| stop.hex.tile.towns.any? }
-            .sum { |stop| stop.route_revenue(route.phase, route.train) }
-        end
-
-        revenue
+        adjust_revenue_for_4d_train(route, super)
       end
     end
   end

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -23,6 +23,12 @@ module Engine
 
       def setup
         setup_company_price_50_to_150_percent
+
+        @corporations.each do |corporation|
+          corporation.abilities(:assign_hexes) do |ability|
+            ability.display_value = @hexes.find { |h| h.name == ability.hexes.first }.location_name
+          end
+        end
       end
 
       def operating_round(round_num)
@@ -32,7 +38,7 @@ module Engine
           Step::BuyCompany,
           Step::HomeToken,
           Step::G18AL::Track,
-          Step::Token,
+          Step::G18AL::Token,
           Step::Route,
           Step::Dividend,
           Step::SingleDepotTrainBuyBeforePhase4,

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -4,6 +4,7 @@ require_relative '../config/game/g_18_al'
 require_relative 'base'
 require_relative 'company_price_50_to_150_percent'
 require_relative 'revenue_4d'
+require_relative 'terminus_check'
 
 module Engine
   module Game
@@ -18,6 +19,7 @@ module Engine
 
       include CompanyPrice50To150Percent
       include Revenue4D
+      include TerminusCheck
 
       def setup
         setup_company_price_50_to_150_percent
@@ -39,11 +41,8 @@ module Engine
       end
 
       def revenue_for(route)
-        route.hexes[1...-1].each do |hex|
-          next unless termini.include?(hex.name)
-
-          raise GameError, "#{hex.location_name} must be first or last in route"
-        end
+        # Mobile and Nashville should not be possible to pass through
+        ensure_termini_not_passed_through(route, %w[A4 Q2])
 
         adjust_revenue_for_4d_train(route, super)
       end

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -3,7 +3,8 @@
 require_relative '../config/game/g_18_mex'
 require_relative 'base'
 require_relative 'company_price_50_to_150_percent'
-
+require_relative 'revenue_4d'
+require_relative 'terminus_check'
 module Engine
   module Game
     class G18MEX < Base
@@ -16,6 +17,8 @@ module Engine
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
       include CompanyPrice50To150Percent
+      include Revenue4D
+      include TerminusCheck
 
       def setup
         setup_company_price_50_to_150_percent
@@ -43,6 +46,13 @@ module Engine
           Step::SingleDepotTrainBuyBeforePhase4,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
+      end
+
+      def revenue_for(route)
+        # Merida should not be possible to pass-through
+        ensure_termini_not_passed_through(route, %w[Q14])
+
+        adjust_revenue_for_4d_train(route, super)
       end
     end
   end

--- a/lib/engine/game/revenue_4d.rb
+++ b/lib/engine/game/revenue_4d.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#
+# This module can be included and then called from
+# the revenue_for method in a subclass to the Engine::Game class.
+#
+# It will double the revenue for all cities and off-board
+# hexes in the route.
+#
+# This is used in any games that uses 4D trains, e.g. 18AL.
+#
+module Revenue4D
+  def adjust_revenue_for_4d_train(route, revenue)
+    return revenue unless route.train.name == '4D'
+
+    2 * revenue - route.stops
+      .select { |stop| stop.hex.tile.towns.any? }
+      .sum { |stop| stop.route_revenue(route.phase, route.train) }
+  end
+end

--- a/lib/engine/game/terminus_check.rb
+++ b/lib/engine/game/terminus_check.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+#
+# This module can be included and then called from
+# the revenue_for method in a subclass to the Engine::Game class.
+#
+# It will ensure that cities that cannot be passed through are
+# only termini stops in the route.
+#
+# This is used in games that have off-board cities that does not
+# allow pass-through.
+#
+module TerminusCheck
+  def ensure_termini_not_passed_through(route, termini)
+    route.hexes[1...-1].each do |hex|
+      next unless termini.include?(hex.name)
+
+      raise GameError, "#{hex.location_name} must be first or last in route"
+    end
+  end
+end

--- a/lib/engine/step/g_18_al/token.rb
+++ b/lib/engine/step/g_18_al/token.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../token'
+
+module Engine
+  module Step
+    module G18AL
+      class Token < Token
+        def place_token(entity, city, token, teleport: false)
+          super
+
+          entity.abilities(:assign_hexes) do |ability|
+            next unless ability.name == 'Historical objective'
+
+            if city.hex.name == ability.hexes.first
+              @log << "#{entity.name} receives $100 - #{ability.name} reached in #{ability.display_value}"
+              entity.cash += 100
+              entity.remove_ability(ability)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_al/track.rb
+++ b/lib/engine/step/g_18_al/track.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../track'
+
+module Engine
+  module Step
+    module G18AL
+      class Track < Track
+        def process_lay_tile(action)
+          super
+
+          # Change Montgomery to use M tiles after first tile
+          # placed there. From beginning Montgomery is a regular
+          # city, but from "green" phase it has its own tiles.
+          action.tile.label ||= 'M' if action.tile.hex.name == 'L5'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce an ability Destination that can be used to specify
a destination hex. This ability can be used in e.g. 1822,
1844, 1856, 18AL.

Configure historical objective hex for all corporations in 18AL
using the destination ability. When a corporation places its
token in its destination hex, it receives $100 to treasury as
it has reached its historical objective.