### PR TITLE
Enable password protection for private games.

### DIFF
--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -66,8 +66,8 @@ module GameManager
     end
   end
 
-  def join_game(game)
-    @connection.safe_post(url(game, '/join')) do |data|
+  def join_game(game, password = nil)
+    @connection.safe_post(url(game, '/join'), password: password) do |data|
       update_game(data)
     end
   end

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -11,6 +11,8 @@ module View
     needs :num_players, default: 3, store: true
     needs :flash_opts, default: {}, store: true
     needs :user, default: nil, store: true
+    needs :access, default: :public, store: true
+    needs :password, default: nil, store: true
 
     def render_content
       inputs = [
@@ -37,6 +39,11 @@ module View
             display: 'block',
           },
         )
+      end
+
+      if @mode == :multi
+        inputs << access_selector
+        inputs << password_input if @access == :private
       end
 
       description = [h(:a, { attrs: { href: '/signup' } }, 'Signup'), ' or ',
@@ -107,6 +114,29 @@ module View
         attrs: { name: 'mode_options', checked: @mode == mode },
         on: { click: click_handler },
       )]
+    end
+
+    def access_selector
+      h(:div, { style: { margin: '1rem 0' } }, [
+          render_input(
+            'Public',
+            id: :public,
+            type: 'radio',
+            attrs: { name: 'access_options', checked: @access == :public },
+            on: { click: -> { store(:access, :public) } },
+          ),
+          render_input(
+            'Private',
+            id: :private,
+            type: 'radio',
+            attrs: { name: 'access_options', checked: @access == :private },
+            on: { click: -> { store(:access, :private) } },
+          ),
+        ])
+    end
+
+    def password_input
+      h(:div, [render_input('Password', placeholder: 'For private games', id: :password)])
     end
 
     def submit

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -22,7 +22,10 @@ module View
       @inputs.map do |key, input|
         input = Native(input)
         elm = input['elm']
-        [key, elm['type'] == 'checkbox' ? elm['checked'] : elm['value']]
+        [
+          key,
+          elm['type'] == 'checkbox' || elm['type'] == 'radio' ? elm['checked'] : elm['value'],
+        ]
       end.to_h
     end
 


### PR DESCRIPTION
Implement simple password protection for private games. Addresses issue #169 

## Game creation

When game is set to multiplayer, a Public/Private option is shown. When `private` is selected, a password field appears.

![Screen Shot 2020-07-09 at 23 49 15](https://user-images.githubusercontent.com/147/87125464-6fa47b00-c23f-11ea-8713-064d46b8c22a.png)
![Screen Shot 2020-07-09 at 23 49 24](https://user-images.githubusercontent.com/147/87125469-7206d500-c23f-11ea-95e3-f6585de29b1e.png)

## State of game in "Your Games" list

All players who have joined the game will see the password in plaintext. This is to facilitate easy sharing of the password by anyone who has already joined the game.

![Screen Shot 2020-07-09 at 23 49 41](https://user-images.githubusercontent.com/147/87125572-92cf2a80-c23f-11ea-8b55-4364f9b2f18f.png)

## Joining the game

The `Join` button reads `Join (private)` for private games. Clicking the button yields a textbox and a new join button. Incorrect passwords result in an error across the notification section in the header. After successfully joining, the password is displayed again in plaintext.


![Screen Shot 2020-07-09 at 23 49 53](https://user-images.githubusercontent.com/147/87125643-b1cdbc80-c23f-11ea-8348-5c2fd403965c.png)
![Screen Shot 2020-07-09 at 23 50 04](https://user-images.githubusercontent.com/147/87125649-b3978000-c23f-11ea-89ff-f090f987f973.png)
![Screen Shot 2020-07-09 at 23 50 16](https://user-images.githubusercontent.com/147/87125662-bb572480-c23f-11ea-8bb5-67bd42241181.png)
