### PR TITLE
18AL/18GA/18MEX/18TN: Limit depot train buy to one before phase 4 (#961)

### DIFF
--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -19,6 +19,21 @@ module Engine
       def setup
         setup_company_price_50_to_150_percent
       end
+
+      def operating_round(round_num)
+        Round::Operating.new(self, [
+          Step::Bankrupt,
+          Step::DiscardTrain,
+          Step::BuyCompany,
+          Step::HomeToken,
+          Step::Track,
+          Step::Token,
+          Step::Route,
+          Step::Dividend,
+          Step::SingleDepotTrainBuyBeforePhase4,
+          [Step::BuyCompany, blocks: true],
+        ], round_num: round_num)
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -18,6 +18,21 @@ module Engine
       def setup
         setup_company_price_50_to_150_percent
       end
+
+      def operating_round(round_num)
+        Round::Operating.new(self, [
+          Step::Bankrupt,
+          Step::DiscardTrain,
+          Step::BuyCompany,
+          Step::HomeToken,
+          Step::Track,
+          Step::Token,
+          Step::Route,
+          Step::Dividend,
+          Step::SingleDepotTrainBuyBeforePhase4,
+          [Step::BuyCompany, blocks: true],
+        ], round_num: round_num)
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -28,6 +28,21 @@ module Engine
           hex.tile.cities[0].place_token(minor, minor.next_token)
         end
       end
+
+      def operating_round(round_num)
+        Round::Operating.new(self, [
+          Step::Bankrupt,
+          Step::DiscardTrain,
+          Step::BuyCompany,
+          Step::HomeToken,
+          Step::Track,
+          Step::Token,
+          Step::Route,
+          Step::Dividend,
+          Step::SingleDepotTrainBuyBeforePhase4,
+          [Step::BuyCompany, blocks: true],
+        ], round_num: round_num)
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -18,6 +18,21 @@ module Engine
       def setup
         setup_company_price_50_to_150_percent
       end
+
+      def operating_round(round_num)
+        Round::Operating.new(self, [
+          Step::Bankrupt,
+          Step::DiscardTrain,
+          Step::BuyCompany,
+          Step::HomeToken,
+          Step::Track,
+          Step::Token,
+          Step::Route,
+          Step::Dividend,
+          Step::SingleDepotTrainBuyBeforePhase4,
+          [Step::BuyCompany, blocks: true],
+        ], round_num: round_num)
+      end
     end
   end
 end

--- a/lib/engine/step/g_1836jr30/train.rb
+++ b/lib/engine/step/g_1836jr30/train.rb
@@ -21,7 +21,7 @@ module Engine
         end
 
         def process_buy_train(action)
-          # Since the train won't be in the depot after being bougth store the state now.
+          # Since the train won't be in the depot after being bought store the state now.
           from_depot = action.train.from_depot?
           super
 

--- a/lib/engine/step/single_depot_train_buy_before_phase4.rb
+++ b/lib/engine/step/single_depot_train_buy_before_phase4.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../train'
+
+module Engine
+  module Step
+    class SingleDepotTrainBuyBeforePhase4 < Train
+      def buyable_trains
+        super.reject { |x| x.from_depot? && @depot_trains_bought.any? && !@game.phase.available?('4') }
+      end
+
+      def setup
+        super
+        @depot_trains_bought = []
+      end
+
+      def unpass!
+        super
+        setup
+      end
+
+      def process_buy_train(action)
+        # Since the train won't be in the depot after being bought store the state now.
+        from_depot = action.train.from_depot?
+        super
+
+        return unless from_depot
+
+        @depot_trains_bought << action.train.sym
+
+        pass! unless buyable_trains.any?
+      end
+    end
+  end
+end


### PR DESCRIPTION
This applies to the following 18xx:
  - 18AL
  - 18GA
  - 18MEX
  - 18TN

When buying train from depot in phase 2 and phase 3
only one train can be bought.