### PR TITLE
18AL: Minor fixes related to phases

### DIFF
--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -321,7 +321,7 @@ module Engine
          "name":"4",
          "distance":4,
          "price":300,
-         "rusts_on":"7",
+         "obsolete_on":"7",
          "num":3
       },
       {
@@ -478,6 +478,7 @@ module Engine
       },
       {
          "name":"3",
+         "on":"3",
          "train_limit":4,
          "tiles":[
             "yellow",
@@ -488,6 +489,7 @@ module Engine
       },
       {
          "name":"4",
+         "on":"4",
          "train_limit":3,
          "tiles":[
             "yellow",
@@ -498,6 +500,7 @@ module Engine
       },
       {
          "name":"5",
+         "on":"5",
          "train_limit":2,
          "tiles":[
             "yellow",
@@ -531,11 +534,13 @@ module Engine
       },
       {
          "name":"4D",
+         "on":"4D",
          "train_limit":2,
          "tiles":[
             "yellow",
             "green",
-            "brown"
+            "brown",
+            "gray"
          ],
          "operating_rounds": 3
       }


### PR DESCRIPTION
- Add "on" attribute to denote on which train phase change occur (Table I)
- Add gray tiles available on 4D train buy (Table I)
- 4T are now obsoleted on 7T buy, not rusted (Rule 4.5.2.1)