### PR TITLE
18AL: Implement company Brown & Sons Lumber Co

### DIFF
--- a/lib/engine/ability/tile_lay.rb
+++ b/lib/engine/ability/tile_lay.rb
@@ -5,12 +5,13 @@ require_relative 'base'
 module Engine
   module Ability
     class TileLay < Base
-      attr_reader :hexes, :tiles, :free
+      attr_reader :hexes, :tiles, :free, :discount
 
-      def setup(hexes:, tiles:, free: false)
+      def setup(hexes:, tiles:, free: false, discount: nil)
         @hexes = hexes
         @tiles = tiles
         @free = free
+        @discount = discount || 0
       end
     end
   end

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -209,7 +209,26 @@ module Engine
          "name":"Brown & Sons Lumber Co.",
          "value":70,
          "revenue":15,
-         "desc":"Owning corporation may lay the Lumber Terminal track tile (number 445) in an empty swamp hex. It need not be connected to an existing station of the corporation.  The corporation need not pay the $20 cost of the swamp hex.  And it does not count as the corporation's one tile lay per turn.  (But it still must be laid during the tile-laying step of the corporation's turn). Laying the tile does not close the B&SLC. The Lumber Terminal tile is permanent, and cannot be upgraded."
+         "desc":"Owning corporation may lay the Lumber Terminal track tile (number 445) in an empty swamp hex. It need not be connected to an existing station of the corporation.  The corporation need not pay the $20 cost of the swamp hex.  And it does not count as the corporation's one tile lay per turn.  (But it still must be laid during the tile-laying step of the corporation's turn). Laying the tile does not close the B&SLC. The Lumber Terminal tile is permanent, and cannot be upgraded.",
+         "abilities": [
+             {
+               "type": "tile_lay",
+               "free":true,
+               "owner_type": "corporation",
+               "tiles": [
+                  "445"
+               ],
+               "hexes": [
+                 "G2",
+                 "M2",
+                 "O4",
+                 "N5",
+                 "P5"
+               ],
+               "count": 1,
+               "when": "track"
+             }
+         ]
       },
       {
          "sym":"M&C",

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -201,8 +201,7 @@ module Engine
          "name":"Mexico City-Acapulco Railroad",
          "value":20,
          "revenue":5,
-         "desc":"No special abilities.",
-         "max_price":30
+         "desc":"No special abilities."
       },
       {
          "sym":"KCMO",
@@ -210,7 +209,21 @@ module Engine
          "value":40,
          "revenue":10,
          "desc":"Owning company may place the Copper Canyan tile in E6 for $60 unless that hex is already built.",
-         "max_price":60
+         "abilities": [
+            {
+              "type": "tile_lay",
+              "discount": 60,
+              "owner_type": "corporation",
+              "tiles": [
+                 "470"
+              ],
+              "hexes": [
+                "E6"
+              ],
+              "count": 1,
+              "when": "track"
+            }
+        ]
       },
       {
          "sym":"IR",
@@ -239,7 +252,6 @@ module Engine
          "value":100,
          "revenue":20,
          "desc":"Comes with a 10% share of the Chihuahua Pacific Railway (CHI).",
-         "max_price":150,
          "abilities":[
             {
                "type":"share",

--- a/lib/engine/round/special.rb
+++ b/lib/engine/round/special.rb
@@ -151,7 +151,7 @@ module Engine
           # this is shit
           @game.tiles.find { |t| t.name == name }
         end.compact
-        potentials.select { |t| hex.tile.upgrades_to?(t) }
+        potentials.select { |t| hex.tile.upgrades_to?(t, true) }
       end
 
       def check_track_restrictions!(_entity, _old_tile, _new_tile)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -54,7 +54,8 @@ module Engine
 
         tile.rotate!(rotation)
 
-        raise GameError, "#{old_tile.name} is not upgradeable to #{tile.name}" unless old_tile.upgrades_to?(tile)
+        raise GameError, "#{old_tile.name} is not upgradeable to #{tile.name}"\
+          unless old_tile.upgrades_to?(tile, entity.company?)
 
         @game.tiles.delete(tile)
         @game.tiles << old_tile unless old_tile.preprinted

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -65,11 +65,13 @@ module Engine
         @game.graph.clear
         check_track_restrictions!(entity, old_tile, tile) unless @game.loading
         free = false
+        discount = 0
 
         entity.abilities(:tile_lay) do |ability|
           next if !ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name)
 
           free = ability.free
+          discount = ability.discount
         end
 
         entity.abilities(:teleport) do |ability, _|
@@ -83,7 +85,7 @@ module Engine
           else
             border, border_types = border_cost(tile, entity)
             terrain += border_types if border.positive?
-            @game.tile_cost(old_tile, entity) + border + extra_cost
+            @game.tile_cost(old_tile, entity) + border + extra_cost - discount
           end
 
         entity.spend(cost, @game.bank) if cost.positive?

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -200,9 +200,12 @@ module Engine
       @upgrades.flat_map(&:terrains).uniq
     end
 
-    def upgrades_to?(other)
+    def upgrades_to?(other, special_lay = false)
       # correct color progression?
       return false unless COLORS.index(other.color) == (COLORS.index(@color) + 1)
+
+      # If special ability then remaining checks is not applicable
+      return true if special_lay
 
       # correct label?
       return false if label != other.label


### PR DESCRIPTION
Add the posibility to configure skip of feature check when
laying tile.

Add ability for Brown & Sons Lumber Co to lay tile 445
as a one of ability, for free.

Tile 445 does now ignore town count in the hex it is placed.
This tile will only be placed via the Brown & Sons Lumber
Co special ability.

A similar ability exists in 18MEX, but that will be implemented
later.