### PR TITLE
18AL/18MS: Implement company that gives discount for some trains

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -54,6 +54,8 @@ module View
       def render
         step = @game.round.active_step
         @corporation = step.current_entity
+        @ability = @selected_company&.abilities(:train_discount, 'train') if @selected_company&.owner == @corporation
+
         @depot = @game.depot
 
         available = step.buyable_trains.group_by(&:owner)
@@ -135,10 +137,11 @@ module View
             .sort_by { |_, v| v[:price] }
             .flat_map do |name, variant|
             price = variant[:price]
+            price = @ability&.discounted_price(train, price) || price
 
             buy_train = lambda do
               process_action(Engine::Action::BuyTrain.new(
-                @corporation,
+                @ability ? @selected_company : @corporation,
                 train: train,
                 price: price,
                 variant: name,

--- a/lib/engine/ability/train_discount.rb
+++ b/lib/engine/ability/train_discount.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Ability
+    class TrainDiscount < Base
+      attr_reader :discount, :trains
+      def setup(discount:, trains:)
+        @discount = discount
+        @trains = trains
+      end
+
+      def discounted_price(train, price)
+        return price unless @trains.include?(train.name)
+
+        price - (discount > 1 ? discount : (price * discount))
+      end
+    end
+  end
+end

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -256,7 +256,21 @@ module Engine
          "name":"New Decatur Yards",
          "value":120,
          "revenue":20,
-         "desc":"A corporation which owns the New Decatur Yards may purchase any one new train from the bank for half the regular price. This action closes the New Decatur Yards."
+         "desc":"A corporation which owns the New Decatur Yards may during purchase of any one new train from the bank use this ability to reduce the regular price by 50%. This action closes the New Decatur Yards.",
+         "abilities": [
+            {
+              "type": "train_discount",
+              "discount": 0.50,
+              "owner_type": "corporation",
+              "trains": [
+                 "3",
+                 "4",
+                 "5"
+              ],
+              "count": 1,
+              "when": "train"
+            }
+         ]
       }
    ],
    "corporations":[

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -192,7 +192,20 @@ module Engine
          "value":70,
          "revenue":5,
          "desc":"The owning Major Company may purchase an available 3+ Train or 4+ Train from the bank for a discount of $100, which closes this Private Company. This purchase is subject to the normal rules governing train purchases - only during the train-buying step and train limits.",
-         "sym":"M&O"
+         "sym":"M&O",
+         "abilities": [
+            {
+              "type": "train_discount",
+              "discount": 100,
+              "owner_type": "corporation",
+              "trains": [
+                 "3+",
+                 "4+"
+              ],
+              "count": 1,
+              "when": "train"
+            }
+         ]
       }
    ],
    "corporations":[

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1030,7 +1030,7 @@ module Engine
           Step::Token,
           Step::Route,
           Step::Dividend,
-          Step::Train,
+          Step::BuyTrain,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
       end

--- a/lib/engine/game/g_1836_jr30.rb
+++ b/lib/engine/game/g_1836_jr30.rb
@@ -29,7 +29,7 @@ module Engine
           Step::Token,
           Step::Route,
           Step::Dividend,
-          Step::G1836Jr30::Train,
+          Step::G1836Jr30::BuyTrain,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
       end

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -301,7 +301,7 @@ module Engine
           Step::G1846::TrackAndToken,
           Step::Route,
           Step::G1846::Dividend,
-          Step::G1846::Train,
+          Step::G1846::BuyTrain,
           [Step::G1846::BuyCompany, blocks: true],
         ], round_num: round_num)
       end

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -62,7 +62,7 @@ module Engine
           Step::Token,
           Step::Route,
           Step::Dividend,
-          Step::Train,
+          Step::BuyTrain,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
       end

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -73,21 +73,16 @@ module Engine
           revenue += route.stops.sum { |stop| ability.hexes.include?(stop.hex.id) ? ability.amount : 0 }
         end
 
-        route_bonuses.each do |type|
-          revenue += route_bonus(route, type)
-        end
-
         revenue
       end
 
       def routes_revenue(routes)
-        # Ensure we only get each route_bonus at most one time
         total_revenue = super
         route_bonuses.each do |type|
-          bonus_amount = routes.first.corporation.abilities(&:amount)
-          times_received = routes.count { |r| route_bonus(r, type).positive? }
+          abilities = routes.first.corporation.abilities(type)
+          return total_revenue if abilities.empty?
 
-          total_revenue -= bonus_amount * (times_received - 1) if times_received > 1
+          total_revenue += routes.map { |r| route_bonus(r, type) }.max
         end if routes.any?
         total_revenue
       end

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -51,6 +51,7 @@ module Engine
           Step::G18AL::Token,
           Step::Route,
           Step::Dividend,
+          Step::SpecialBuyTrain,
           Step::SingleDepotTrainBuyBeforePhase4,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)

--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -51,7 +51,7 @@ module Engine
           Step::Token,
           Step::Route,
           Step::Dividend,
-          Step::Train,
+          Step::BuyTrain,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
       end

--- a/lib/engine/game/g_18_eu.rb
+++ b/lib/engine/game/g_18_eu.rb
@@ -30,7 +30,7 @@ module Engine
           Step::Token,
           Step::Route,
           Step::G18EU::Dividend,
-          Step::Train,
+          Step::BuyTrain,
           Step::IssueShares,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -25,6 +25,23 @@ module Engine
       def setup
         setup_company_price_50_to_150_percent
       end
+
+      def operating_round(round_num)
+        Round::Operating.new(self, [
+          Step::Bankrupt,
+          Step::Exchange,
+          Step::DiscardTrain,
+          Step::SpecialTrack,
+          Step::BuyCompany,
+          Step::Track,
+          Step::Token,
+          Step::Route,
+          Step::Dividend,
+          Step::SpecialBuyTrain,
+          Step::BuyTrain,
+          [Step::BuyCompany, blocks: true],
+        ], round_num: round_num)
+      end
     end
   end
 end

--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'train'
+
+module Engine
+  module Step
+    class BuyTrain < Base
+      include Train
+
+      def actions(entity)
+        # 1846 and a few others minors can't buy trains
+        return [] if entity.minor?
+
+        # TODO: This needs to check it actually needs to sell shares.
+        return ['sell_shares'] if entity == current_entity.owner
+
+        return [] if entity != current_entity
+        # TODO: Not sure this is right
+        return %w[sell_shares buy_train] if must_buy_train?(entity)
+        return %w[buy_train pass] if can_buy_train?(entity)
+
+        []
+      end
+
+      def description
+        'Buy Trains'
+      end
+
+      def pass_description
+        @acted ? 'Done (Trains)' : 'Skip (Trains)'
+      end
+
+      def sequential?
+        true
+      end
+
+      def pass!
+        @last_share_sold_price = nil
+        super
+      end
+
+      def process_buy_train(action)
+        buy_train_action(action)
+        pass! unless can_buy_train?(action.entity)
+      end
+    end
+  end
+end

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -29,7 +29,7 @@ module Engine
       end
 
       def dividend_options(entity)
-        revenue = routes.sum(&:revenue)
+        revenue = @game.routes_revenue(routes)
         dividend_types.map do |type|
           payout = send(type, entity, revenue)
           [type, payout.merge(share_price_change(entity, revenue - payout[:company]))]
@@ -38,7 +38,7 @@ module Engine
 
       def process_dividend(action)
         entity = action.entity
-        revenue = routes.sum(&:revenue)
+        revenue = @game.routes_revenue(routes)
         kind = action.kind.to_sym
         payout = dividend_options(entity)[kind]
 

--- a/lib/engine/step/g_1836jr30/buy_train.rb
+++ b/lib/engine/step/g_1836jr30/buy_train.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative '../train'
+require_relative '../buy_train'
 
 module Engine
   module Step
     module G1836Jr30
-      class Train < Train
+      class BuyTrain < BuyTrain
         def buyable_trains
           super.reject { |x| x.from_depot? && @depot_trains_bought.include?(x.sym) }
         end

--- a/lib/engine/step/g_1846/buy_train.rb
+++ b/lib/engine/step/g_1846/buy_train.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative '../train'
+require_relative '../buy_train'
 
 module Engine
   module Step
     module G1846
-      class Train < Train
+      class BuyTrain < BuyTrain
         def actions(entity)
           return [] if entity.receivership?
 

--- a/lib/engine/step/single_depot_train_buy_before_phase4.rb
+++ b/lib/engine/step/single_depot_train_buy_before_phase4.rb
@@ -6,24 +6,24 @@ module Engine
   module Step
     class SingleDepotTrainBuyBeforePhase4 < Train
       def buyable_trains
-        super.reject { |x| x.from_depot? && @depot_trains_bought.any? && !@game.phase.available?('4') }
-      end
-
-      def setup
-        super
-        @depot_trains_bought = []
+        super.reject { |x| x.from_depot? && !@game.phase.available?('4') && already_bought_from_depot? }
       end
 
       def process_buy_train(action)
-        # Since the train won't be in the depot after being bought store the state now.
         from_depot = action.train.from_depot?
         super
-
         return unless from_depot
 
-        @depot_trains_bought << action.train.sym
-
+        @round.trains_bought << {
+          entity: action.entity,
+        }
         pass! unless buyable_trains.any?
+      end
+
+      private
+
+      def already_bought_from_depot?
+        @round.trains_bought.find { |e| e[:entity].name == current_entity.name }
       end
     end
   end

--- a/lib/engine/step/single_depot_train_buy_before_phase4.rb
+++ b/lib/engine/step/single_depot_train_buy_before_phase4.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../train'
+require_relative 'buy_train'
 
 module Engine
   module Step
-    class SingleDepotTrainBuyBeforePhase4 < Train
+    class SingleDepotTrainBuyBeforePhase4 < BuyTrain
       def buyable_trains
         super.reject { |x| x.from_depot? && !@game.phase.available?('4') && already_bought_from_depot? }
       end

--- a/lib/engine/step/special_buy_train.rb
+++ b/lib/engine/step/special_buy_train.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'train'
+
+module Engine
+  module Step
+    class SpecialBuyTrain < Base
+      include Train
+
+      ACTIONS = %w[buy_train].freeze
+
+      def actions(entity)
+        return [] unless ability(entity)
+
+        ACTIONS
+      end
+
+      def blocks?
+        false
+      end
+
+      def process_buy_train(action)
+        actual_buyer = action.entity.owner
+
+        buy_train_action(action, actual_buyer)
+
+        @round.trains_bought << {
+          entity: actual_buyer,
+        } if action.train.from_depot?
+
+        ability = ability(action.entity)
+        ability.use! if action.price < action.train.price &&
+          ability.discounted_price(action.train, action.train.price) == action.price
+        action.entity.close! if ability.count.zero?
+
+        pass! unless can_buy_train?(actual_buyer)
+      end
+
+      def ability(entity)
+        return unless entity.company?
+
+        entity.abilities(:train_discount, 'train')
+      end
+    end
+  end
+end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -91,6 +91,7 @@ module Engine
 
         @log << "#{entity.name} #{verb} a #{train.name} train for "\
           "#{@game.format_currency(price)} from #{source}"
+
         entity.buy_train(train, price)
         pass! unless can_buy_train?(entity)
       end
@@ -166,6 +167,12 @@ module Engine
 
       def issuable_shares
         []
+      end
+
+      def round_state
+        {
+          trains_bought: [],
+        }
       end
     end
   end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -4,39 +4,7 @@ require_relative 'base'
 
 module Engine
   module Step
-    class Train < Base
-      def actions(entity)
-        # 1846 and a few others minors can't buy trains
-        return [] if entity.minor?
-
-        # TODO: This needs to check it actually needs to sell shares.
-        return ['sell_shares'] if entity == current_entity.owner
-
-        return [] if entity != current_entity
-        # TODO: Not sure this is right
-        return %w[sell_shares buy_train] if must_buy_train?(entity)
-        return %w[buy_train pass] if can_buy_train?(entity)
-
-        []
-      end
-
-      def description
-        'Buy Trains'
-      end
-
-      def pass_description
-        @acted ? 'Done (Trains)' : 'Skip (Trains)'
-      end
-
-      def sequential?
-        true
-      end
-
-      def pass!
-        @last_share_sold_price = nil
-        super
-      end
-
+    module Train
       def can_buy_train?(entity = nil)
         entity ||= current_entity
         can_buy_normal = room?(entity) &&
@@ -55,8 +23,8 @@ module Engine
         @game.must_buy_train?(entity)
       end
 
-      def process_buy_train(action)
-        entity = action.entity
+      def buy_train_action(action, entity = nil)
+        entity ||= action.entity
         train = action.train
         train.variant = action.variant
         price = action.price

--- a/migrate_game.rb
+++ b/migrate_game.rb
@@ -34,7 +34,7 @@ def repair(game, original_actions, actions, broken_action)
     broken_action['type'] = 'place_token'
     return [broken_action]
   elsif broken_action['type'] == 'pass'
-    if game.active_step.is_a?(Engine::Step::Route) || game.active_step.is_a?(Engine::Step::Train)
+    if game.active_step.is_a?(Engine::Step::Route) || game.active_step.is_a?(Engine::Step::BuyTrain)
       # Lay token sometimes needed pass when it shouldn't have
       actions.delete(broken_action)
       return
@@ -68,7 +68,7 @@ def repair(game, original_actions, actions, broken_action)
       actions.insert(action_idx, pass)
       return
     end
-    if game.active_step.is_a?(Engine::Step::Train) && game.active_step.actions(game.active_step.current_entity).include?('pass')
+    if game.active_step.is_a?(Engine::Step::BuyTrain) && game.active_step.actions(game.active_step.current_entity).include?('pass')
       pass = Engine::Action::Pass.new(game.active_step.current_entity).to_h
       actions.insert(action_idx, pass)
       return


### PR DESCRIPTION
Configurable attribute 'train_discount' added. When this is set
for a corporation, the trains that has been configured in the
attribute, will appear as extra lines in the BuyTrains view,
shown with the discounted price.

When train bought for a discounted price the company should close.

This attribute has been configured for:
- 18AL: New Decatur Yards (50% discount for 3, 4, 5 trains)
- 18MS: Mobile & Ohio Railway (100$ discount for 3+, 4+ trains)

This commit is for peer review. The close of companies when
used does not seem to work as it should.