### PR TITLE
fix stock price adjustments at end of stock round

### DIFF
--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -197,7 +197,7 @@ module Engine
             end
           price_drops.times { @stock_market.move_down(corp) }
 
-          log_share_price(corp, prev) if prev != corp.share_price.price
+          log_share_price(corp, prev)
         end
       end
 

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -188,12 +188,12 @@ module Engine
           @stock_market.move_up(corp) if sold_out?(corp)
 
           price_drops =
-            if @pool_share_drop == :none
+            if (@pool_share_drop == :none) || (shares_in_pool = corp.num_market_shares).zero?
               0
-            elsif (shares_in_pool = @share_pool.shares_by_corporation[corp].size).positive?
-              @pool_share_drop == :one ? 1 : shares_in_pool
+            elsif @pool_share_drop == :one
+              1
             else
-              0
+              shares_in_pool
             end
           price_drops.times { @stock_market.move_down(corp) }
 


### PR DESCRIPTION
- add new `sold_out?` method so that other games can easily override it (e.g.,
  1817 where more than 100% is also sold out, 18Chesapeake 2p where shares can
  be removed from the game but a corporation can still be sold out)

- use `move_down` instead of `move_left` for decreasing the price; 2D market
  games that drop prices for share in the market move down (e.g., 1849), and
  `move_down` will be correctly translated to `move_left` for 1D games like 1846

- count the number of shares instead of adding up their values and dividing by
  10--same result for 10-share corporations but with less computation, and for
  smaller corporations (e.g., 2-share and 5-share in 1817), the adjustment is
  based on number of shares in the pool rather than percentage

- adjust prices in descending corporation order for correct operating order when
  two corporations end up on the same space from different directions [Fixes #1069]