### PR TITLE
render non-home reservations as grey instead of black

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -48,8 +48,12 @@ module View
         def reservation
           text = @reservation.id
 
+          non_home = @reservation.corporation? && (@reservation.coordinates != @city.hex.coordinates)
+          color = non_home ? '#808080' : 'black'
+
           attrs = {
-            fill: 'black',
+            fill: color,
+            stroke: color,
             'font-size': "#{RESERVATION_FONT_SIZE[text.size]}px",
             'dominant-baseline': 'central',
           }

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -12,7 +12,8 @@ module View
       location_name: nil,
       scale: 1.0,
       opacity: 1.0,
-      rotations: nil
+      rotations: nil,
+      hex_coordinates: nil
     )
       props = {
         style: {
@@ -35,16 +36,20 @@ module View
         text += "-#{rotation}" unless rotations == [0]
         text += " × #{num}" if num
 
+        hex = Engine::Hex.new(hex_coordinates || 'A1',
+                              layout: layout,
+                              location_name: loc_name,
+                              tile: tile)
+        hex.x = 0
+        hex.y = 0
+
         h('div.tile__block', props, [
             h(:div, { style: { 'text-align': 'center', 'font-size': '12px' } }, text),
             h(:svg, { style: { width: '100%', height: '100%' } }, [
               h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
                 h(
                   Game::Hex,
-                  hex: Engine::Hex.new('A1',
-                                       layout: layout,
-                                       location_name: loc_name,
-                                       tile: tile),
+                  hex: hex,
                   role: :tile_page,
                   opacity: opacity,
                 ),

--- a/assets/app/view/tiles_page.rb
+++ b/assets/app/view/tiles_page.rb
@@ -87,20 +87,22 @@ module View
     end
 
     def render_individual_tile_from_game(game_title, hex_or_tile_id)
-      game = Engine::GAMES_BY_TITLE[game_title].new(%w[p1 p2 p3])
+      game_class = Engine::GAMES_BY_TITLE[game_title]
+      players = Engine.player_range(game_class).max.times.map { |n| "Player #{n + 1}" }
+      game = game_class.new(players)
 
       id, rotation = hex_or_tile_id.split('-')
       rotations = rotation ? [rotation.to_i] : @rotations
 
       # TODO?: handle case with big map and uses X for game-specific tiles
       # (i.e., "X1" is the name of a tile *and* a hex)
-      tile, name =
+      tile, name, hex_coordinates =
         if game.class::TILES.include?(id)
           t = game.tile_by_id("#{id}-0")
-          [t, t.name]
+          [t, t.name, nil]
         else
           t = game.hex_by_id(id).tile
-          [t, id]
+          [t, id, id]
         end
 
       render_tile_blocks(
@@ -110,11 +112,13 @@ module View
         location_name: tile.location_name || @location_name,
         scale: 3.0,
         rotations: rotations,
+        hex_coordinates: hex_coordinates,
       )
     end
 
     def map_hexes_and_tile_manifest_for(game_class)
-      game = game_class.new(%w[p1 p2 p3])
+      players = Engine.player_range(game_class).max.times.map { |n| "Player #{n + 1}" }
+      game = game_class.new(players)
 
       # map_tiles: hash; key is hex ID, value is the Tile there
       map_tiles = game.hexes.map { |h| [h.name, h.tile] }.to_h
@@ -150,7 +154,8 @@ module View
           tile.name,
           layout: game.layout,
           tile: tile,
-          location_name: tile.location_name
+          location_name: tile.location_name,
+          hex_coordinates: tile.name,
         )
       end
 

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -7,7 +7,8 @@ module Engine
   class Hex
     include Assignable
 
-    attr_reader :connections, :coordinates, :layout, :neighbors, :tile, :x, :y, :location_name, :original_tile
+    attr_accessor :x, :y
+    attr_reader :connections, :coordinates, :layout, :neighbors, :tile, :location_name, :original_tile
 
     DIRECTIONS = {
       flat: {


### PR DESCRIPTION
* on /tiles/ pages, use real hex coordinates instead of A1 where applicable;
  without this, all reservations are grey except when the corporation's home
  happens to be A1

[Fixes #1071]

![Screenshot from 2020-07-11 18-48-59](https://user-images.githubusercontent.com/1045173/87236629-b95ca500-c3a8-11ea-9b70-1dc8f064ac1b.png)

![Screenshot from 2020-07-11 18-51-23](https://user-images.githubusercontent.com/1045173/87236630-bbbeff00-c3a8-11ea-86d0-02aa81eb1b8c.png)
