### PR TITLE
Fix process_action not found when trying to assign_corporation

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -6,6 +6,7 @@ require 'view/game/companies'
 module View
   module Game
     class Corporation < Snabberb::Component
+      include Actionable
       include Lib::Color
       needs :corporation
       needs :selected_company, default: nil, store: true


### PR DESCRIPTION
Fixes the NOOP that is happening when trying to assign Steamboats to B&O.