### PR TITLE
18AL: Implement M&C RR and S&NA companies

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -192,7 +192,7 @@ module View
         }
 
         revenue = begin
-                    @game.format_currency(active_routes.sum(&:revenue))
+                    @game.format_currency(@game.routes_revenue(active_routes))
                   rescue Engine::GameError
                     '(Invalid Route)'
                   end

--- a/lib/engine/ability/hex_bonus.rb
+++ b/lib/engine/ability/hex_bonus.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Ability
+    class HexBonus < Base
+      attr_reader :hexes, :amount
+
+      def setup(hexes:, amount:)
+        @hexes = hexes
+        @amount = amount
+      end
+    end
+  end
+end

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -202,7 +202,21 @@ module Engine
          "name":"South & North Alabama Railroad",
          "value":40,
          "revenue":10,
-         "desc":"Comes with a Warrior Coal Field token. The owning corporation may place it in Gadsden Anniston Oxmoor Birmingham or Tuscaloosa provided that the corporation owns a train that can reach that city on existing track. Placing the token does NOT close the S&NA. The token makes that city worth an extra $10 (when run to) for that corporation only. The token remains on the board until the first 6 Train is purchased."
+         "desc":"Comes with a Warrior Coal Field token. The owning corporation may place it in one of the city hexes with a mining symbol (Gadsden, Anniston, Oxmoor, Birmingham, or Tuscaloosa) provided that the corporation owns a train that can reach that city on existing track. Placing the token does NOT close the S&NA. The token makes that city worth an extra $10 (when run to) for that corporation only. The token remains on the board until the first 6 Train is purchased.",
+         "abilities": [
+            {
+               "type": "assign_hexes",
+               "hexes": [
+                 "H3",
+                 "G4",
+                 "H5",
+                 "G6",
+                 "E6"
+               ],
+               "count": 1,
+               "owner_type": "corporation"
+            }
+         ]
       },
       {
          "sym":"BLC",
@@ -490,7 +504,10 @@ module Engine
             }
          ],
          "price":630,
-         "num":1
+         "num":1,
+         "events": [
+            {"type": "remove_tokens"}
+         ]
       },
       {
          "name":"7",

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -249,7 +249,7 @@ module Engine
          "name":"Memphis & Charleston Railroad",
          "value":100,
          "revenue":20,
-         "desc":"When a corporation purchases the Memphis & Charleston, it receives the two train name chits. The corporation may place either or both of these on any trains it owns. Getting or placing the name chits does not close the Memphis & Charleston. Any train which has a name chit, and which makes a run that includes both of the locations named on the chit, has its revenue increased by the amount stated on the chit. The corporation may, on its turn, move the name chits freely among its trains, but each train is limited to at most one name at a time, and each chit may give its bonus to at most one train in each operating turn. The chits last for the rest of the game, unless that corporation changes presidents, in which case both chits are immediately removed from play."
+         "desc":"When a corporation purchases the Memphis & Charleston, it receives the ability to get revenue bonus if certain pair of cities is part of any routes. If any route include Atlanta AND Birmingham (Robert E Lee) a bonus of $20 is added to the revenue. If any run include Nashville AND Mobile (Pan American) a bonus of $40 is added to the revenue. The ability last for the rest of the game, unless that corporation changes presidents, in which it is removed from play."
       },
       {
          "sym":"NDY",

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -568,6 +568,10 @@ module Engine
         route.stops.sum { |stop| stop.route_revenue(route.phase, route.train) }
       end
 
+      def routes_revenue(routes)
+        routes.sum(&:revenue)
+      end
+
       def get(type, id)
         send("#{type}_by_id", id)
       end

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -19,9 +19,15 @@ module Engine
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge('remove_tokens' => ['Remove Tokens', 'Coal Field token removed']).freeze
 
+      ROUTE_BONUSES = %i[atlanta_birmingham mobile_nashville].freeze
+
       include CompanyPrice50To150Percent
       include Revenue4D
       include TerminusCheck
+
+      def route_bonuses
+        ROUTE_BONUSES
+      end
 
       def setup
         setup_company_price_50_to_150_percent
@@ -38,7 +44,7 @@ module Engine
           Step::Bankrupt,
           Step::DiscardTrain,
           Step::G18AL::Assign,
-          Step::BuyCompany,
+          Step::G18AL::BuyCompany,
           Step::HomeToken,
           Step::SpecialTrack,
           Step::G18AL::Track,
@@ -48,6 +54,13 @@ module Engine
           Step::SingleDepotTrainBuyBeforePhase4,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
+      end
+
+      def stock_round
+        Round::Stock.new(self, [
+          Step::DiscardTrain,
+          Step::G18AL::BuySellParShares,
+        ])
       end
 
       def revenue_for(route)
@@ -60,7 +73,23 @@ module Engine
           revenue += route.stops.sum { |stop| ability.hexes.include?(stop.hex.id) ? ability.amount : 0 }
         end
 
+        route_bonuses.each do |type|
+          revenue += route_bonus(route, type)
+        end
+
         revenue
+      end
+
+      def routes_revenue(routes)
+        # Ensure we only get each route_bonus at most one time
+        total_revenue = super
+        route_bonuses.each do |type|
+          bonus_amount = routes.first.corporation.abilities(&:amount)
+          times_received = routes.count { |r| route_bonus(r, type).positive? }
+
+          total_revenue -= bonus_amount * (times_received - 1) if times_received > 1
+        end if routes.any?
+        total_revenue
       end
 
       def event_remove_tokens!
@@ -74,6 +103,14 @@ module Engine
 
       def get_location_name(hex_name)
         @hexes.find { |h| h.name == hex_name }.location_name
+      end
+
+      private
+
+      def route_bonus(route, type)
+        route.corporation.abilities(type).sum do |ability|
+          ability.hexes == (ability.hexes & route.hexes.map(&:name)) ? ability.amount : 0
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -26,8 +26,7 @@ module Engine
 
         @corporations.each do |corporation|
           corporation.abilities(:assign_hexes) do |ability|
-            historical_objective_city_name = @hexes.find { |h| h.name == ability.hexes.first }.location_name
-            ability.description = "Historical objective: #{historical_objective_city_name}"
+            ability.description = "Historical objective: #{get_location_name(ability.hexes.first)}"
           end
         end
       end
@@ -53,6 +52,10 @@ module Engine
         ensure_termini_not_passed_through(route, %w[A4 Q2])
 
         adjust_revenue_for_4d_train(route, super)
+      end
+
+      def get_location_name(hex_name)
+        @hexes.find { |h| h.name == hex_name }.location_name
       end
     end
   end

--- a/lib/engine/step/g_18_al/assign.rb
+++ b/lib/engine/step/g_18_al/assign.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../assign'
+
+module Engine
+  module Step
+    module G18AL
+      class Assign < Assign
+        def process_assign(action)
+          company = action.entity
+          @game.game_error("#{company.owner.name} owns no trains") if company.owner.trains.empty?
+
+          target = action.target
+          hexes = company.abilities(:assign_hexes)&.hexes
+          if !@game.loading && @game.graph.reachable_hexes(company.owner).find { |h, _| h.id == target.id }.nil?
+            @game.game_error("#{@game.get_location_name(target.id)} is not reachable")
+          end
+
+          super
+
+          # Add a revenue bonus for the corporation
+          # that will be removed in phase 6
+          ability = Engine::Ability::HexBonus.new(
+            type: :hexes_bonus,
+            description: "Coal Field token: #{@game.get_location_name(target.id)}",
+            hexes: [target.id],
+            amount: 10
+          )
+          company.owner.add_ability(ability)
+          @game
+            .hexes
+            .select { |hex| hexes.include?(hex.name) }
+            .each { |hex| hex.tile.icons = [] }
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_al/buy_company.rb
+++ b/lib/engine/step/g_18_al/buy_company.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../buy_company'
+
+module Engine
+  module Step
+    module G18AL
+      class BuyCompany < BuyCompany
+        def process_buy_company(action)
+          super
+
+          return unless action.company.sym == 'M&C'
+
+          rob_bonus, pan_bonus = @game.route_bonuses
+          action.entity.add_ability(create_hexes_bonus_ability(rob_bonus, 'Robert E. Lee', %w[G8 G4], 20))
+          action.entity.add_ability(create_hexes_bonus_ability(pan_bonus, 'Pan American', %w[Q2 A4], 40))
+        end
+
+        private
+
+        def create_hexes_bonus_ability(type, name, hex_names, amount)
+          terminus1, terminus2 = hex_names.map { |n| @game.get_location_name(n) }
+          description = "#{name}: #{terminus1}-#{terminus2} (#{@game.format_currency(amount)})"
+          Engine::Ability::HexBonus.new(type: type, description: description, hexes: hex_names, amount: amount)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_al/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_al/buy_sell_par_shares.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../buy_sell_par_shares'
+
+module Engine
+  module Step
+    module G18AL
+      class BuySellParShares < BuySellParShares
+        def setup
+          super
+          @controller_at_start = current_controller
+        end
+
+        def process_pass(action)
+          super
+          return if @controller_at_start.nil? || @controller_at_start == current_controller
+
+          @log << "#{route_bonus_ability.owner.name} removes route bonuses as presidency changed"
+          president_changed(route_bonus_ability.owner)
+          @controller_at_start = nil
+        end
+
+        private
+
+        def current_controller
+          route_bonus_ability&.player
+        end
+
+        def route_bonus_ability
+          @game.corporations.each do |corporation|
+            corporation.abilities(@game.route_bonuses.first) do |ability|
+              return ability
+            end
+          end
+
+          nil
+        end
+
+        def president_changed(corporation)
+          @game.route_bonuses.each do |type|
+            corporation.abilities(type) do |ability|
+              corporation.remove_ability(ability)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/minor_half_pay.rb
+++ b/lib/engine/step/minor_half_pay.rb
@@ -12,7 +12,7 @@ module Engine
       def skip!
         return super if current_entity.corporation?
 
-        revenue = routes.sum(&:revenue)
+        revenue = @game.routes_revenue(routes)
         process_dividend(Action::Dividend.new(
           current_entity,
           kind: revenue.positive? ? 'payout' : 'withhold',


### PR DESCRIPTION
Added route_bonus ability that can be used to give revenue
bonus if a route include the specified hexes.

Although generic, the use of ability implemented in 18AL only.

Configure ability for company Memphis & Charleston RR.