### PR TITLE
change arrows to wider supported glyphs

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -61,7 +61,7 @@ module View
           end
 
           h(:tr, [
-            h(:td, (current_phase == phase ? '⮕ ' : '') + phase[:name]),
+            h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
             h(:td, phase[:operating_rounds]),
             h(:td, phase[:train_limit]),
             h(:td, phase_props, phase_color.capitalize),
@@ -117,7 +117,7 @@ module View
         rows = @depot.upcoming.group_by(&:name).map do |name, trains|
           train = trains.first
           discounts = train.discount&.group_by { |_k, v| v }&.map do |price, price_discounts|
-            price_discounts.map(&:first).join(', ') + ' ⮕ ' + @game.format_currency(price)
+            price_discounts.map(&:first).join(', ') + ' → ' + @game.format_currency(price)
           end
           names_to_prices = train.names_to_prices
 

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -120,16 +120,16 @@ module View
               mark_sort_column(sort_by)
               toggle_sort_order
             },
-            children: title + (@spreadsheet_sort_by == sort_by ? ' ' + sort_order_icon : ''),
-            class: ''
+            children: title
           ),
+          h(:span, @spreadsheet_sort_by == sort_by ? sort_order_icon : ''),
         ])
       end
 
       def sort_order_icon
-        return '⬇️' if @spreadsheet_sort_order == 'ASC'
+        return '↓' if @spreadsheet_sort_order == 'ASC'
 
-        '⬆️'
+        '↑'
       end
 
       def mark_sort_column(sort_by)


### PR DESCRIPTION
fixes #1099 (… at least on Mojave/10.14 on browserstack – and prevents up/down arrow emoji there, too.)
Glyphs from the 2B block aren’t widely supported. Standard arrows work with many more fonts. [cf. http://www.alanwood.net/unicode/miscellaneous_symbols_and_arrows.html vs. http://www.alanwood.net/unicode/arrows.html]