### PR TITLE
Fix Mark Derrick games

### DIFF
--- a/lib/engine/game/company_price_50_to_150_percent.rb
+++ b/lib/engine/game/company_price_50_to_150_percent.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 #
-# This module sets up so that the allowed price
-# for purchasing private companies are between
-# 50% and 150% of the face value.
+# This module can be called from setup method
+# in the Engine::Game class for the game to
+# modify the allowed price for purchasing companies
+# to between 50% and 150% of the face value.
+#
 # This is used in e.g 18MEX and 18AL.
 #
 module CompanyPrice50To150Percent
-  def setup
+  def setup_company_price_50_to_150_percent
     @companies.each do |company|
       company.min_price = company.value * 0.5
       company.max_price = company.value * 1.5

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -16,8 +16,8 @@ module Engine
 
       include CompanyPrice50To150Percent
 
-      def operating_round(round_num)
-        Round::G18AL::Operating.new(@corporations, game: self, round_num: round_num)
+      def setup
+        setup_company_price_50_to_150_percent
       end
     end
   end

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -14,6 +14,10 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
 
       include CompanyPrice50To150Percent
+
+      def setup
+        setup_company_price_50_to_150_percent
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -15,7 +15,10 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
 
       include CompanyPrice50To150Percent
+
       def setup
+        setup_company_price_50_to_150_percent
+
         @minors.each do |minor|
           train = @depot.upcoming[0]
           train.buyable = false
@@ -24,10 +27,6 @@ module Engine
           hex = hex_by_id(minor.coordinates)
           hex.tile.cities[0].place_token(minor, minor.next_token)
         end
-      end
-
-      def operating_round(round_num)
-        Round::G18MEX::Operating.new(@minors + @corporations, game: self, round_num: round_num)
       end
     end
   end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -20,6 +20,10 @@ module Engine
       #      end
 
       include CompanyPrice50To150Percent
+
+      def setup
+        setup_company_price_50_to_150_percent
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -14,6 +14,10 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
 
       include CompanyPrice50To150Percent
+
+      def setup
+        setup_company_price_50_to_150_percent
+      end
     end
   end
 end


### PR DESCRIPTION
18MEX/18AL is broke right now on master; they stop after SR1. 
Also the "50-150%" change did not work with further additions to setup of the games.

This change is prioritized among the PRs for 18AL.