### PR TITLE
settings: route colors, width & dash

### DIFF
--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -5,6 +5,15 @@ require 'lib/hex'
 module Lib
   module Settings
     DARK = `window.matchMedia('(prefers-color-scheme: dark)').matches`.freeze
+    # http://mkweb.bcgsc.ca/colorblind/ 12 color palette
+    ROUTE_COLORS = %i[#A40122 #008DF9 #00FCCF #FF5AAF].freeze
+
+    routes = {}
+    ROUTE_COLORS.each_with_index do |color, n|
+      routes["r#{n}_color"] = color
+      routes["r#{n}_dash"] = '0'
+      routes["r#{n}_width"] = 8
+    end
 
     SETTINGS = {
       notifications: true,
@@ -14,6 +23,7 @@ module Lib
       font: DARK ? '#ffffff' : '#000000',
       font2: '#000000',
       **Lib::Hex::COLOR,
+      **routes,
     }.freeze
 
     def self.included(base)

--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -8,8 +8,8 @@ module Lib
     # http://mkweb.bcgsc.ca/colorblind/ 12 color palette
     ROUTE_COLORS = %i[#A40122 #008DF9 #00FCCF #FF5AAF].freeze
 
-    ROUTES = ROUTE_COLORS.flat_map.with_index do |color, n|
-      [["r#{n}_color", color], ["r#{n}_dash", '0'], ["r#{n}_width", 8]]
+    ROUTES = ROUTE_COLORS.flat_map.with_index do |color, index|
+      [["r#{index}_color", color], ["r#{index}_dash", '0'], ["r#{index}_width", 8]]
     end.to_h
 
     SETTINGS = {
@@ -37,8 +37,12 @@ module Lib
 
     alias color_for setting_for
 
-    def route_prop(n, prop)
-      setting_for("r#{n}_#{prop}")
+    def route_prop(index, prop)
+      setting_for(route_prop_string(index, prop))
+    end
+
+    def route_prop_string(index, prop)
+      "r#{index}_#{prop}"
     end
   end
 end

--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -8,12 +8,9 @@ module Lib
     # http://mkweb.bcgsc.ca/colorblind/ 12 color palette
     ROUTE_COLORS = %i[#A40122 #008DF9 #00FCCF #FF5AAF].freeze
 
-    routes = {}
-    ROUTE_COLORS.each_with_index do |color, n|
-      routes["r#{n}_color"] = color
-      routes["r#{n}_dash"] = '0'
-      routes["r#{n}_width"] = 8
-    end
+    ROUTES = ROUTE_COLORS.flat_map.with_index do |color, n|
+      [["r#{n}_color", color], ["r#{n}_dash", '0'], ["r#{n}_width", 8]]
+    end.to_h
 
     SETTINGS = {
       notifications: true,
@@ -23,7 +20,7 @@ module Lib
       font: DARK ? '#ffffff' : '#000000',
       font2: '#000000',
       **Lib::Hex::COLOR,
-      **routes,
+      **ROUTES,
     }.freeze
 
     def self.included(base)
@@ -39,5 +36,9 @@ module Lib
     end
 
     alias color_for setting_for
+
+    def route_prop(n, prop)
+      setting_for("r#{n}_#{prop}")
+    end
   end
 end

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -13,6 +13,7 @@ module View
         needs :color, default: 'black'
         needs :tile
         needs :town
+        needs :width, default: 8
 
         REVENUE_DISPLACEMENT = 42
         REVENUE_ANGLE = -60
@@ -76,7 +77,7 @@ module View
         end
 
         def render_part
-          children = [h(:circle, attrs: { transform: translate, fill: @color, r: 10 })]
+          children = [h(:circle, attrs: { transform: translate, fill: @color, r: 10 * (0.8 + @width.to_i / 40) })]
           children << render_revenue
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, children)

--- a/assets/app/view/game/part/town_rect.rb
+++ b/assets/app/view/game/part/town_rect.rb
@@ -13,9 +13,7 @@ module View
 
         needs :town
         needs :color, default: 'black'
-
-        HEIGHT = 8
-        WIDTH = 32
+        needs :width, default: 8
 
         SINGLE_TOWN_REGIONS = {
           straight: [CENTER] * 6,
@@ -215,12 +213,14 @@ module View
         end
 
         def render_part
+          height = @width.to_i / 2 + 4
+          width = height * 4
           children = [h(:rect, attrs: {
             transform: "#{translate} #{rotation}",
-            x: -WIDTH / 2,
-            y: -HEIGHT / 2,
-            width: WIDTH,
-            height: HEIGHT,
+            x: -width / 2,
+            y: -height / 2,
+            width: width,
+            height: height,
             fill: @color,
             stroke: 'none',
           })]

--- a/assets/app/view/game/part/towns.rb
+++ b/assets/app/view/game/part/towns.rb
@@ -34,7 +34,7 @@ module View
               p.town == town
             end
           end
-          index ? setting_for("r#{index}_#{prop}") : Track::TRACK[prop]
+          index ? route_prop(index, prop) : Track::TRACK[prop]
         end
       end
     end

--- a/assets/app/view/game/part/towns.rb
+++ b/assets/app/view/game/part/towns.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'lib/settings'
 require 'view/game/part/town_dot'
 require 'view/game/part/town_rect'
 
@@ -7,6 +8,8 @@ module View
   module Game
     module Part
       class Towns < Snabberb::Component
+        include Lib::Settings
+
         needs :tile
         needs :region_use
         needs :routes
@@ -14,14 +17,16 @@ module View
         def render
           @tile.towns.map do |town|
             if @tile.lawson? || @tile.paths.empty?
-              h(TownDot, town: town, tile: @tile, region_use: @region_use, color: color_for(town))
+              h(TownDot, town: town, tile: @tile, region_use: @region_use,
+                         color: prop_for(town, :color), width: prop_for(town, :width))
             else
-              h(TownRect, town: town, region_use: @region_use, color: color_for(town))
+              h(TownRect, town: town, region_use: @region_use,
+                          color: prop_for(town, :color), width: prop_for(town, :width))
             end
           end
         end
 
-        def color_for(town)
+        def prop_for(town, prop)
           @routes_paths = @routes.map { |route| route.paths_for(@tile.paths) }
 
           index = @routes_paths.find_index do |route_paths|
@@ -29,7 +34,7 @@ module View
               p.town == town
             end
           end
-          index ? Part::Track::ROUTE_COLORS[index] : 'black'
+          index ? setting_for("r#{index}_#{prop}") : Track::TRACK[prop]
         end
       end
     end

--- a/assets/app/view/game/part/towns.rb
+++ b/assets/app/view/game/part/towns.rb
@@ -18,15 +18,15 @@ module View
           @tile.towns.map do |town|
             if @tile.lawson? || @tile.paths.empty?
               h(TownDot, town: town, tile: @tile, region_use: @region_use,
-                         color: prop_for(town, :color), width: prop_for(town, :width))
+                         color: value_for(town, :color), width: value_for(town, :width))
             else
               h(TownRect, town: town, region_use: @region_use,
-                          color: prop_for(town, :color), width: prop_for(town, :width))
+                          color: value_for(town, :color), width: value_for(town, :width))
             end
           end
         end
 
-        def prop_for(town, prop)
+        def value_for(town, prop)
           @routes_paths = @routes.map { |route| route.paths_for(@tile.paths) }
 
           index = @routes_paths.find_index do |route_paths|

--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -32,14 +32,14 @@ module View
           if @tile.offboards.any?
             @tile.paths.select(&:offboard).map do |path|
               h(TrackOffboard, offboard: path.offboard, path: path, region_use: @region_use,
-                               color: prop_for(path, :color), width: prop_for(path, :width),
-                               dash: prop_for(path, :dash),)
+                               color: value_for(path, :color), width: value_for(path, :width),
+                               dash: value_for(path, :dash),)
             end
           elsif @tile.lawson?
             @tile.paths.select { |path| path.edges.one? }.map do |path|
               h(TrackLawsonPath, path: path, region_use: @region_use,
-                                 color: prop_for(path, :color), width: prop_for(path, :width),
-                                 dash: prop_for(path, :dash),)
+                                 color: value_for(path, :color), width: value_for(path, :width),
+                                 dash: value_for(path, :dash),)
             end
           elsif @tile.towns.any?
             render_track_for_curvilinear_town
@@ -50,8 +50,8 @@ module View
             .map { |path| [path, index_for(path)] }
             .sort_by { |_, index| index || -1 }
             .map do |path, index|
-              h(TrackCurvilinearPath, region_use: @region_use, path: path, color: prop_for_index(index, :color),
-                                      width: prop_for(path, :width), dash: prop_for(path, :dash),)
+              h(TrackCurvilinearPath, region_use: @region_use, path: path, color: value_for_index(index, :color),
+                                      width: value_for(path, :width), dash: value_for(path, :dash),)
             end
           end
         end
@@ -64,8 +64,8 @@ module View
 
             city.paths.map do |path|
               h(TrackCurvilinearHalfPath, exits: exits, path: path, region_use: @region_use,
-                                          color: prop_for(path, :color), width: prop_for(path, :width),
-                                          dash: prop_for(path, :dash),)
+                                          color: value_for(path, :color), width: value_for(path, :width),
+                                          dash: value_for(path, :dash),)
             end
           end
         end
@@ -76,8 +76,8 @@ module View
 
             town.paths.map do |path|
               h(TrackCurvilinearHalfPath, exits: exits, path: path, region_use: @region_use,
-                                          color: prop_for(path, :color), width: prop_for(path, :width),
-                                          dash: prop_for(path, :dash),)
+                                          color: value_for(path, :color), width: value_for(path, :width),
+                                          dash: value_for(path, :dash),)
             end
           end
         end
@@ -88,12 +88,12 @@ module View
           end
         end
 
-        def prop_for_index(index, prop)
+        def value_for_index(index, prop)
           index ? setting_for("r#{index}_#{prop}") : TRACK[prop]
         end
 
-        def prop_for(path, prop)
-          prop_for_index(index_for(path), prop)
+        def value_for(path, prop)
+          value_for_index(index_for(path), prop)
         end
       end
     end

--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -89,7 +89,7 @@ module View
         end
 
         def value_for_index(index, prop)
-          index ? setting_for("r#{index}_#{prop}") : TRACK[prop]
+          index ? route_prop(index, prop) : TRACK[prop]
         end
 
         def value_for(path, prop)

--- a/assets/app/view/game/part/track_curvilinear_half_path.rb
+++ b/assets/app/view/game/part/track_curvilinear_half_path.rb
@@ -8,6 +8,9 @@ module View
     module Part
       class TrackCurvilinearHalfPath < TrackCurvilinearPath
         needs :exits
+        needs :color, default: 'black'
+        needs :width, default: 8
+        needs :dash, default: '0'
 
         REGIONS = {
           [STOP, :none] => [15, 21],
@@ -90,7 +93,8 @@ module View
               transform: "rotate(#{@rotation})",
               d: SVG_PATH_STRINGS[[@curvilinear_type, @direction]],
               stroke: @color,
-              'stroke-width' => 8,
+              'stroke-width': @width,
+              'stroke-dasharray': @dash,
             },
           }
 

--- a/assets/app/view/game/part/track_curvilinear_path.rb
+++ b/assets/app/view/game/part/track_curvilinear_path.rb
@@ -34,6 +34,8 @@ module View
 
         needs :path
         needs :color, default: 'black'
+        needs :width, default: 8
+        needs :dash, default: '0'
 
         # returns SHARP, GENTLE, or STRAIGHT
         def compute_curvilinear_type(edge_a, edge_b)
@@ -86,7 +88,8 @@ module View
               transform: "rotate(#{@rotation})",
               d: SVG_PATH_STRINGS[@curvilinear_type],
               stroke: @color,
-              'stroke-width' => 8,
+              'stroke-width': @width,
+              'stroke-dasharray': @dash,
             },
           }
 

--- a/assets/app/view/game/part/track_lawson_path.rb
+++ b/assets/app/view/game/part/track_lawson_path.rb
@@ -8,6 +8,8 @@ module View
       class TrackLawsonPath < Base
         needs :path
         needs :color, default: 'black'
+        needs :width, default: 8
+        needs :dash, default: '0'
 
         def load_from_tile
           @edge_num = @path.edges.first.num
@@ -40,7 +42,8 @@ module View
               transform: "rotate(#{rotation})",
               d: 'M 0 87 L 0 0',
               stroke: @color,
-              'stroke-width' => 8,
+              'stroke-width': @width,
+              'stroke-dasharray': @dash,
             },
           }
 

--- a/assets/app/view/game/part/track_offboard.rb
+++ b/assets/app/view/game/part/track_offboard.rb
@@ -9,6 +9,8 @@ module View
         needs :path
         needs :offboard
         needs :color, default: 'black'
+        needs :width, default: 8
+        needs :dash, default: '0'
 
         REGIONS = {
           0 => [21],
@@ -44,7 +46,8 @@ module View
               stroke: 'none',
               'stroke-linecap': 'butt',
               'stroke-linejoin': 'miter',
-              'stroke-width': 6,
+              'stroke-width': @width.to_i * 0.75,
+              'stroke-dasharray': @dash,
             },
           }
 

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -88,7 +88,7 @@ module View
                                  ['N/A', e.to_s]
                                end
 
-            bg_color = setting_for("r#{@routes.index(route)}_color")
+            bg_color = route_prop(@routes.index(route), :color)
             style[:backgroundColor] = bg_color
             style[:color] = contrast_on(bg_color)
 

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'lib/color'
 require 'lib/settings'
 require 'view/game/actionable'
 require 'view/game/undo_and_pass'
@@ -8,6 +9,7 @@ module View
   module Game
     class RouteSelector < Snabberb::Component
       include Actionable
+      include Lib::Color
       include Lib::Settings
 
       needs :routes, store: true, default: []
@@ -67,7 +69,7 @@ module View
           selected = @selected_route&.train == train
 
           style = {
-            border: "solid 3px #{selected ? 'currentColor' : color_for(:bg)}",
+            border: "solid 3px #{selected ? color_for(:font) : color_for(:bg)}",
             display: 'inline-block',
             cursor: selected ? 'default' : 'pointer',
             margin: '0.1rem 0rem',
@@ -86,8 +88,9 @@ module View
                                  ['N/A', e.to_s]
                                end
 
-            style['background-color'] = Part::Track::ROUTE_COLORS[@routes.index(route)]
-            style['color'] = 'white'
+            bg_color = setting_for("r#{@routes.index(route)}_color")
+            style[:backgroundColor] = bg_color
+            style[:color] = contrast_on(bg_color)
 
             td_props = { style: { paddingRight: '0.8rem' } }
 

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -153,7 +153,7 @@ module View
           render_color(
             '',
             "r#{index}_color",
-            setting_for("r#{index}_color"),
+            route_prop(index, :color),
             attrs: { title: 'color of train and route on map' },
           ),
           render_input(
@@ -164,7 +164,7 @@ module View
               title: 'width of route on map',
               min: 6,
               max: 24,
-              value: setting_for("r#{index}_width"),
+              value: route_prop(index, :width),
             },
             input_style: { width: '2.5rem' },
           ),
@@ -174,7 +174,7 @@ module View
             type: :text,
             attrs: {
               title: 'dash/gap lengths of route on map, for help hover/click header',
-              value: setting_for("r#{index}_dash"),
+              value: route_prop(index, :dash),
             },
             input_style: { width: '2.5rem' },
           ),

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -81,6 +81,10 @@ module View
       h(:div, children)
     end
 
+    def route_prop_string(index, prop)
+      "r#{index}_#{prop}"
+    end
+
     def input_elm(setting)
       Native(@inputs[setting]).elm
     end
@@ -97,9 +101,9 @@ module View
       end
 
       ROUTE_COLORS.each_with_index do |hex_color, index|
-        input_elm("r#{index}_color").value = hex_color
-        input_elm("r#{index}_dash").value = '0'
-        input_elm("r#{index}_width").value = 8
+        input_elm(route_prop_string(index, :color)).value = hex_color
+        input_elm(route_prop_string(index, :dash)).value = '0'
+        input_elm(route_prop_string(index, :width)).value = 8
       end
 
       submit
@@ -152,13 +156,13 @@ module View
           h(:label, "Route #{index + 1}"),
           render_color(
             '',
-            "r#{index}_color",
+            route_prop_string(index, :color),
             route_prop(index, :color),
             attrs: { title: 'color of train and route on map' },
           ),
           render_input(
             '',
-            id: "r#{index}_width",
+            id: route_prop_string(index, :width),
             type: :number,
             attrs: {
               title: 'width of route on map',
@@ -170,7 +174,7 @@ module View
           ),
           render_input(
             '',
-            id: "r#{index}_dash",
+            id: route_prop_string(index, :dash),
             type: :text,
             attrs: {
               title: 'dash/gap lengths of route on map, for help hover/click header',

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -16,6 +16,7 @@ module View
     needs :type
 
     TILE_COLORS = Lib::Hex::COLOR.freeze
+    ROUTE_COLORS = Lib::Settings::ROUTE_COLORS.freeze
 
     def render_content
       title, inputs =
@@ -50,6 +51,7 @@ module View
               ]),
             ]),
             render_tile_colors,
+            render_route_colors,
             h('div#settings__buttons', [
               render_button('Save Changes') { submit },
               render_button('Reset to Defaults') { reset_settings },
@@ -89,9 +91,17 @@ module View
       input_elm(:bg2).value = default_for(:bg2)
       input_elm(:font2).value = default_for(:font2)
       input_elm(:red_logo).checked = false
+
       TILE_COLORS.each do |color, hex_color|
         input_elm(color).value = hex_color
       end
+
+      ROUTE_COLORS.each_with_index do |hex_color, index|
+        input_elm("r#{index}_color").value = hex_color
+        input_elm("r#{index}_dash").value = '0'
+        input_elm("r#{index}_width").value = 8
+      end
+
       submit
     end
 
@@ -106,8 +116,8 @@ module View
       ])
     end
 
-    def render_color(label, id, hex_color, attrs = {})
-      render_input(label, id: id, type: :color, attrs: { value: hex_color, **attrs },)
+    def render_color(label, id, hex_color, attrs: {})
+      render_input(label, id: id, type: :color, attrs: { value: hex_color, **attrs })
     end
 
     def render_logo_color(red_logo)
@@ -121,10 +131,82 @@ module View
 
     def render_tile_colors
       h('div#settings__tiles', [
-        h(:label, 'Map & Tile Colors'),
+        h(:h3, 'Map & Tile Colors'),
         h('div#settings__tiles__buttons', TILE_COLORS.map do |color, _|
           render_color('', color, setting_for(color), attrs: { title: color == 'white' ? 'plain' : color })
         end),
+      ])
+    end
+
+    def render_route_colors
+      grid_props = {
+        style: {
+          display: 'grid',
+          grid: '1fr / 5rem 4rem 5rem 5rem',
+          alignItems: 'center',
+        },
+      }
+
+      children = ROUTE_COLORS.map.with_index do |_, index|
+        h(:div, grid_props, [
+          h(:label, "Route #{index + 1}"),
+          render_color(
+            '',
+            "r#{index}_color",
+            setting_for("r#{index}_color"),
+            attrs: { title: 'color of train and route on map' },
+          ),
+          render_input(
+            '',
+            id: "r#{index}_width",
+            type: :number,
+            attrs: {
+              title: 'width of route on map',
+              min: 6,
+              max: 24,
+              value: setting_for("r#{index}_width"),
+            },
+            input_style: { width: '2.5rem' },
+          ),
+          render_input(
+            '',
+            id: "r#{index}_dash",
+            type: :text,
+            attrs: {
+              title: 'dash/gap lengths of route on map, for help hover/click header',
+              value: setting_for("r#{index}_dash"),
+            },
+            input_style: { width: '2.5rem' },
+          ),
+        ])
+      end
+
+      header_props = { style: { marginLeft: '0.5rem' } }
+
+      help_message = <<~MESSAGE
+        5 = dash 5, gap 5, [repeat]
+        15 5 7.5 5 = dash 15, gap 5, dash 7.5, gap 5, [repeat]
+        hex width (side to side) = 174
+      MESSAGE
+      link_props = {
+        props: {
+          href: 'https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray',
+          title: help_message,
+        },
+        style: {
+          marginLeft: '0.5rem',
+        },
+      }
+
+      h('div#routes', [
+        h(:h3, 'Trains & Routes'),
+        h(:div, grid_props, [
+          h(:div, ''),
+          h(:div, header_props, 'Color'),
+          h(:div, header_props, 'Width'),
+          h(:a, link_props, 'Dash'),
+        ]),
+        *children,
       ])
     end
 

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -81,10 +81,6 @@ module View
       h(:div, children)
     end
 
-    def route_prop_string(index, prop)
-      "r#{index}_#{prop}"
-    end
-
     def input_elm(setting)
       Native(@inputs[setting]).elm
     end

--- a/models/user.rb
+++ b/models/user.rb
@@ -10,9 +10,13 @@ class User < Base
 
   RESET_WINDOW = 60 * 15 # 15 minutes
 
-  SETTINGS = %w[
-    notifications bg font bg2 font2 red_logo white yellow green brown gray red blue
-  ].freeze
+  opts = %w[notifications red_logo bg font bg2 font2 white yellow green brown gray red blue]
+  4.times do |n|
+    %w[color dash width].each do |prop|
+      opts << "r#{n}_#{prop}"
+    end
+  end
+  SETTINGS = opts.freeze
 
   def update_settings(params)
     SETTINGS.each { |setting| settings[setting] = params[setting] }

--- a/models/user.rb
+++ b/models/user.rb
@@ -10,13 +10,12 @@ class User < Base
 
   RESET_WINDOW = 60 * 15 # 15 minutes
 
-  opts = %w[notifications red_logo bg font bg2 font2 white yellow green brown gray red blue]
-  4.times do |n|
-    %w[color dash width].each do |prop|
-      opts << "r#{n}_#{prop}"
+  SETTINGS = Array.new(4) do |n|
+    %w[color dash width].map do |prop|
+      "r#{n}_#{prop}"
     end
   end
-  SETTINGS = opts.freeze
+  SETTINGS.concat(%w[notifications red_logo bg font bg2 font2 white yellow green brown gray red blue]).flatten!.freeze
 
   def update_settings(params)
     SETTINGS.each { |setting| settings[setting] = params[setting] }

--- a/models/user.rb
+++ b/models/user.rb
@@ -10,12 +10,11 @@ class User < Base
 
   RESET_WINDOW = 60 * 15 # 15 minutes
 
-  SETTINGS = 4.times.flat_map do |n|
+  SETTINGS = (4.times.flat_map do |index|
     %w[color dash width].map do |prop|
-      "r#{n}_#{prop}"
+      "r#{index}_#{prop}"
     end
-  end
-  SETTINGS.concat(%w[notifications red_logo bg font bg2 font2 white yellow green brown gray red blue]).freeze
+  end + %w[notifications red_logo bg font bg2 font2 white yellow green brown gray red blue]).freeze
 
   def update_settings(params)
     SETTINGS.each { |setting| settings[setting] = params[setting] }

--- a/models/user.rb
+++ b/models/user.rb
@@ -10,12 +10,12 @@ class User < Base
 
   RESET_WINDOW = 60 * 15 # 15 minutes
 
-  SETTINGS = Array.new(4) do |n|
+  SETTINGS = 4.times.flat_map do |n|
     %w[color dash width].map do |prop|
       "r#{n}_#{prop}"
     end
   end
-  SETTINGS.concat(%w[notifications red_logo bg font bg2 font2 white yellow green brown gray red blue]).flatten!.freeze
+  SETTINGS.concat(%w[notifications red_logo bg font bg2 font2 white yellow green brown gray red blue]).freeze
 
   def update_settings(params)
     SETTINGS.each { |setting| settings[setting] = params[setting] }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -23,8 +23,6 @@ h2 {
 }
 h3 {
   font-size: 1.1rem;
-}
-#game_info h3 {
   margin-bottom: 0.4rem;
 }
 
@@ -79,10 +77,6 @@ input:not([type=radio]):not([type=checkbox]), select {
 }
 input + label, select + label {
   margin-left: 0.5rem;
-}
-label.right {
-  margin-left: 0;
-  margin-right: 1rem;
 }
 .input-container {
   display: inline-block;
@@ -163,6 +157,11 @@ nav#game_menu {
 
 #profile-settings > #settings__notifications {
   height: 2rem;
+}
+
+#settings__colors .input-container label {
+    display: inline-block;
+    width: 11.5rem;
 }
 
 #settings__tiles > label {


### PR DESCRIPTION
I’m no fan of dasharray, but if we’re serious about making the site friendlier to people with visual impairments color and width very likely won’t suffice.

width.to_i because user-settings from inputs are saved as string afaik. I don’t know where/how exactly I could change this for specific inputs.
`4.times` in models/user.rb is ugly – couldn’t figure out how to access Lib::Settings::ROUTE_COLORS there.
no hash with route settings because of problems with settings-array in models/user.rb and accessing values with color_for/settings_for. I wouldn’t mind rewriting these parts, but would likely need a lot of help.