### PR TITLE
pruning + token popup

### DIFF
--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -351,3 +351,26 @@ div.game.card em {
   font-style: normal;
   text-decoration: underline;
 }
+
+#stock_market .splayed {
+  display: flex;
+  flex-direction: row-reverse;
+  position: absolute;
+  left: 2px;
+  z-index: 1000;
+  padding: 2px;
+  height: 33px;
+  box-sizing: border-box;
+  border: 2px solid;
+  border-color: inherit;
+  border-radius: 5px;
+  box-shadow: 2px 2px #555555;
+  background-color: inherit;
+}
+#stock_market object {
+  position: absolute;
+}
+#stock_market .splayed object {
+  position: static;
+  padding-right: 1px;
+}


### PR DESCRIPTION
fixes #1122 (partially?)
on hover/tap:
![image](https://user-images.githubusercontent.com/33390595/88075378-0266e300-cb79-11ea-82c0-20b086a1fcae.png) => ![image](https://user-images.githubusercontent.com/33390595/88075404-0a268780-cb79-11ea-8bc0-c749cdd50a46.png)

Additionally some pruning. I could do more, but don’t know about your intentions regarding the load of CONSTs. If these values won’t be changed in the future we could eliminate at least some of them. (… and maybe even switch to .box and css to en passant eliminate the style mergings.)

What’s the purpose of empty boxes without borders? https://github.com/tobymao/18xx/blob/master/assets/app/view/game/stock_market.rb#L85

PS: How about reducing the width of empty boxes on pretty wide 1D markets like 1846?