### PR TITLE
Add 1882 Initial auction rules, fix 18Chesapeake train export during initial auction

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -605,6 +605,8 @@ module Engine
         end
       end
 
+      def or_set_finished; end
+
       def place_home_token(corporation)
         return unless corporation.next_token # 1882
 
@@ -943,8 +945,6 @@ module Engine
       end
 
       def action_processed(_action); end
-
-      def or_set_finished; end
 
       def priority_deal_player
         if @round.current_entity&.player?

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -35,6 +35,13 @@ module Engine
       # Two lays or one upgrade, second tile costs 20
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false, cost: 20 }].freeze
 
+      def new_auction_round
+        Round::Auction.new(self, [
+          Step::CompanyPendingPar,
+          Step::G1882::WaterfallAuction,
+        ])
+      end
+
       def operating_round(round_num)
         Round::Operating.new(self, [
           Step::Bankrupt,

--- a/lib/engine/step/g_1882/waterfall_auction.rb
+++ b/lib/engine/step/g_1882/waterfall_auction.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../waterfall_auction'
+
+module Engine
+  module Step
+    module G1882
+      class WaterfallAuction < WaterfallAuction
+        def buy_company(player, company, price)
+          super
+
+          # Update cheapest so that passing causes it's price to drop
+          @cheapest = @companies.first
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -132,6 +132,7 @@ module Engine
           end
         else
           @game.payout_companies
+          @game.or_set_finished
         end
 
         entities.each(&:unpass!)


### PR DESCRIPTION
Fixes #1092

Also implements 1882
The first available company reduces by $5, not just the first.