### PR TITLE
Corps token scroll

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -98,7 +98,7 @@ module View
       def render_holdings
         holdings_row_props = {
           style: {
-            grid: '1fr / auto auto minmax(4rem, max-content)',
+            grid: '1fr / max-content auto minmax(4rem, max-content)',
             gap: '0 0.3rem',
             padding: '0.2rem 0.2rem 0.2rem 0.4rem',
             backgroundColor: color_for(:bg2),

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -98,8 +98,8 @@ module View
       def render_holdings
         holdings_row_props = {
           style: {
-            grid: '1fr / auto auto auto',
-            gap: '0 0.2rem',
+            grid: '1fr / auto auto minmax(4rem, max-content)',
+            gap: '0 0.3rem',
             padding: '0.2rem 0.2rem 0.2rem 0.4rem',
             backgroundColor: color_for(:bg2),
             color: color_for(:font2),
@@ -139,14 +139,14 @@ module View
       end
 
       def render_trains
-        train_value = @corporation.trains.empty? ? 'None' : @corporation.trains.map(&:name).join(',')
+        train_value = @corporation.trains.empty? ? 'None' : @corporation.trains.map(&:name).join(' ')
         render_header_segment(train_value, 'Trains')
       end
 
       def render_header_segment(value, key)
         segment_props = {
           style: {
-            grid: '3fr 2fr / 1fr',
+            grid: '25px auto / 1fr',
           },
         }
         value_props = {
@@ -172,11 +172,14 @@ module View
             grid: '1fr / auto-flow',
             justifySelf: 'right',
             gap: '0 0.2rem',
+            width: '100%',
+            overflow: 'auto',
           },
         }
         token_column_props = {
           style: {
-            grid: '3fr 2fr / 1fr',
+            grid: '25px auto / 1fr',
+            justifyItems: 'center',
           },
         }
         token_text_props = {

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -33,12 +33,12 @@ module View
         card_style = {
           cursor: 'pointer',
         }
-        card_style['border'] = '4px solid' if @game.round.can_act?(@corporation)
-        card_style['display'] = @display
+        card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
+        card_style[:display] = @display
 
         if selected?
-          card_style['background-color'] = 'lightblue'
-          card_style['color'] = 'black'
+          card_style[:backgroundColor] = 'lightblue'
+          card_style[:color] = 'black'
         end
 
         children = [render_title, render_holdings]
@@ -75,17 +75,17 @@ module View
             height: '1.6rem',
             width: '1.6rem',
             padding: '1px',
-            'align-self': 'center',
-            'justify-self': 'start',
+            alignSelf: 'center',
+            justifySelf: 'start',
             border: '2px solid currentColor',
-            'border-radius': '0.5rem',
+            borderRadius: '0.5rem',
           },
         }
         name_props = {
           style: {
             color: 'currentColor',
             display: 'inline-block',
-            'justify-self': 'start',
+            justifySelf: 'start',
           },
         }
 
@@ -107,9 +107,9 @@ module View
         }
         sym_props = {
           style: {
-            'font-size': '1.5rem',
-            'font-weight': 'bold',
-            'justify-self': 'start',
+            fontSize: '1.5rem',
+            fontWeight: 'bold',
+            justifySelf: 'start',
           },
         }
         holdings_props = {
@@ -151,13 +151,13 @@ module View
         }
         value_props = {
           style: {
-            'max-width': '7.5rem',
-            'font-weight': 'bold',
+            maxWidth: '7.5rem',
+            fontWeight: 'bold',
           },
         }
         key_props = {
           style: {
-            'align-self': 'end',
+            alignSelf: 'end',
           },
         }
         h(:div, segment_props, [
@@ -170,7 +170,7 @@ module View
         token_list_props = {
           style: {
             grid: '1fr / auto-flow',
-            'justify-self': 'right',
+            justifySelf: 'right',
             gap: '0 0.2rem',
           },
         }
@@ -181,7 +181,7 @@ module View
         }
         token_text_props = {
           style: {
-            'align-self': 'end',
+            alignSelf: 'end',
           },
         }
 
@@ -232,7 +232,7 @@ module View
 
         shares_props = {
           style: {
-            'padding-right': '1.5rem',
+            paddingRight: '1.5rem',
           },
         }
 
@@ -258,7 +258,7 @@ module View
 
         market_tr_props = {
           style: {
-            'border-bottom': player_rows.any? ? '1px solid currentColor' : '0',
+            borderBottom: player_rows.any? ? '1px solid currentColor' : '0',
           },
         }
 
@@ -282,7 +282,7 @@ module View
           *player_rows,
         ]
 
-        props = { style: { 'border-collapse': 'collapse' } }
+        props = { style: { borderCollapse: 'collapse' } }
 
         h('table.center', props, [
           h(:thead, [


### PR DESCRIPTION
fixes #1133 
The gist is in the 2nd commit. `scrollLeft = width` not implemented, because it’s just not that necessary now and even counter-productive early in games. (Maybe later when we actually have games with 6+ tokens.)

