### PR TITLE
par price buttons: cleaner look

### DIFF
--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -21,11 +21,20 @@ module View
             ))
           end
 
-          h('button.button', { on: { click: par } }, @game.format_currency(share_price.price))
+          props = {
+            style: {
+              width: '2.8rem',
+              marginLeft: '0',
+              padding: '0.2rem 0',
+            },
+            on: { click: par },
+          }
+          h('button.button', props, @game.format_currency(share_price.price))
         end
 
+        div_class = par_values.size < 5 ? '.inline' : ''
         h(:div, [
-          h(:div, 'Par Price:'),
+          h("div#{div_class}", 'Par Price: '),
           *par_values.reverse,
         ])
       end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -60,7 +60,7 @@ module View
 
         def render_input
           input = @selected_corporation.ipoed ? render_ipoed : render_pre_ipo
-          h(:div, { style: { 'margin-top': '0.5rem', width: '320px' } }, [input].compact)
+          h(:div, { style: { margin: '0.5rem 0', width: '20rem' } }, [input].compact)
         end
 
         def buy_share(entity, share)


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/33390595/88481576-96abbe00-cf5c-11ea-9780-01c4deeca05e.png)

after
![image](https://user-images.githubusercontent.com/33390595/88481581-9ad7db80-cf5c-11ea-809d-3b01b551c940.png)

< 5 buttons
![image](https://user-images.githubusercontent.com/33390595/88482077-50a42980-cf5f-11ea-95e7-283e0a8c4530.png)

5+ buttons
![image](https://user-images.githubusercontent.com/33390595/88482079-539f1a00-cf5f-11ea-87be-adaa0dcd05f1.png)

reduced padding and 0.5rem horizontal margin between buttons works for me on mobile, but might be a problem for fat fingers. Revert to previous values is no problem, just adds a row in most cases.