### PR TITLE
Minor bugs, 1882 -> alpha, 1836jr30 -> production

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -320,6 +320,8 @@ module View
       end
 
       def render_operating_order
+        return [] unless @game.round.current_entity.operator?
+
         round = @game.round
         if (n = @game.round.entities.find_index(@corporation))
           div_class = '.bold' if n >= round.entities.find_index(round.current_entity)

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -16,8 +16,10 @@ module View
     def render_notification
       message = <<~MESSAGE
         <p>Using abilities has now changed and hopefully is more intuitive.</p>
-        <p>1836Jr30 is now available for beta.</p>
+        <p>1836Jr30 has finished beta and is now in production.</p>
+        <p>1882 is now available for alpha.</p>
         <p>1846 is now available for alpha.</p>
+
 
         <p>Please file issues <a href='https://github.com/tobymao/18xx/issues'>here</a>. And if you have any questions, check out the
         <a href='https://docs.google.com/document/d/1nCYnzNMQLrFLZtWdbjfuSx5aIcaOyi27lMYkJxcGayw/edit'>FAQ!</a>

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -58,7 +58,7 @@ module View
     def render_introduction
       message = <<~MESSAGE
         <p>18xx.games is a website where you can play async or real-time 18xx games (based on the system originally devised by the brilliant Francis Tresham)!
-        <p>Right now, 1889 and 18Chesapeake are fully implemented, with 1836Jr30 being in beta but I'm planning on doing many more in the future.
+        <p>Right now, 1889, 18Chesapeake and 1836Jr30 are fully implemented but I'm planning on doing many more in the future.
         If you are new to 18xx games then 1889 or 18Chesapeake are good games to begin with.</p>
 
         <p>You can play locally with hot seat mode without an account. If you want to play multiplayer, you'll need to create an account.</p>

--- a/lib/engine/game/g_1836_jr30.rb
+++ b/lib/engine/game/g_1836_jr30.rb
@@ -8,7 +8,7 @@ module Engine
     class G1836Jr30 < Base
       load_from_json(Config::Game::G1836Jr30::JSON)
 
-      DEV_STAGE = :beta
+      DEV_STAGE = :production
       GAME_LOCATION = 'Netherlands'
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/114572/1836jr-30-rules'
       GAME_DESIGNER = 'David G. D. Hecht'

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -13,6 +13,8 @@ module Engine
                       yellow: '#FFF500',
                       brown: '#7b352a')
 
+      DEV_STAGE = :alpha
+
       AXES = { x: :number, y: :letter }.freeze
       CORPORATIONS_WITHOUT_NEUTRAL = %w[CPR CN].freeze
 
@@ -167,6 +169,9 @@ module Engine
           hex.lay(hex.original_tile)
           tiles << old_tile
         end
+
+        # Some companies might no longer have valid routes
+        @graph.clear_graph_for_all
       end
 
       def revenue_for(route)

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -30,6 +30,12 @@ module Engine
       @routes.delete(corporation)
     end
 
+    def clear_graph_for_all
+      # warning: this is very costly
+      clear
+      @routes.clear
+    end
+
     def route_info(corporation)
       compute(corporation) unless @routes[corporation]
       @routes[corporation]


### PR DESCRIPTION
Two minor bugs
* The operating order change caused it to crash as soon as you used NWR
* Make sure to clear the state of the graph after the NWR destroys tiles.

Update the status.