### PR TITLE
Abilities finetuning & left of map in ORs

### DIFF
--- a/assets/app/lib/truncate.rb
+++ b/assets/app/lib/truncate.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# https://apidock.com/rails/String/truncate
+
+class String
+  def truncate(truncate_at, options = {})
+    return dup unless length > truncate_at
+
+    omission = options[:omission] || '...'
+    length_with_room_for_omission = truncate_at - omission.length
+    stop = if options[:separator]
+             rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission
+           else
+             length_with_room_for_omission
+           end
+
+    "#{self[0, stop]}#{omission}"
+  end
+end

--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lib/truncate'
+
 module View
   module Game
     class Abilities < Snabberb::Component
@@ -72,19 +74,8 @@ module View
           }
           props[:style][:textDecoration] = 'underline' if @selected_company == company
 
-          company_name = company.name
-          owner_name = company.owner.id
-          c_size = company_name.size
-          o_size = owner_name.size
-          limit = 36
-          if c_size + o_size > limit
-            if o_size < 5
-              company_name = company_name[0..(limit - 7)] + '…' if c_size > (limit - 3)
-            else
-              company_name = company_name[0..(limit - 17)] + '…' if c_size > (limit - 13)
-              owner_name = owner_name[0..9] + '…' if o_size > 13
-            end
-          end
+          company_name = company.name.truncate(company.owner.id.size < 5 ? 32 : 19)
+          owner_name = company.owner.id.truncate(15)
 
           [h(:a, props, "#{company_name} (#{owner_name})"),
            @show_action && company == @selected_company ? render_company_action : '']

--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -8,16 +8,15 @@ module View
       needs :selected_company, default: nil, store: true
       needs :show_other_abilities, default: false, store: true
 
-      ABILITIES = %i[tile_lay teleport assign_hexes assign_corporation token exchange].freeze
-
       def render
         companies = @game.companies.select { |company| !company.closed? && actions_for(company).any? }
         return h(:div) if companies.empty? || @game.round.current_entity.company?
 
         current, others = companies.partition { |company| @game.current_entity.owner == company.owner.owner }
 
+        props = { style: { marginRight: '1rem' } }
         children = [
-          h('div.inline.margined.bold', 'Abilities:'),
+          h('h3.inline', props, 'Abilities:'),
           *render_companies(current),
         ]
 
@@ -29,16 +28,27 @@ module View
             store(:show_other_abilities, !@show_other_abilities)
           end
 
-          children << h('button.button', { on: { click: toggle_show } }, @show_other_abilities ? 'Hide' : 'Show')
+          props = {
+            style: { margin: '0.5rem 0.5rem 0 0' },
+            on: { click: toggle_show },
+          }
+          children << h('button.button', props, @show_other_abilities ? 'Hide' : 'Show Others')
           children.concat(render_companies(others)) if @show_other_abilities
         end
 
         if companies.include?(@selected_company)
-          children << h(:div, { style: { margin: '0.5rem 0' } }, @selected_company.desc)
+          props = {
+            style: {
+              maxWidth: '80rem',
+              margin: '0.3rem 0 0.5rem 0',
+            },
+          }
+          children << h(:div, props, @selected_company.desc)
           children.concat(render_actions)
         end
 
-        h(:div, children)
+        props = { style: { marginBottom: '0.5rem' } }
+        h(:div, props, children)
       end
 
       def render_companies(companies)
@@ -50,18 +60,26 @@ module View
             style: {
               cursor: 'pointer',
               display: 'inline-block',
-              padding: '0.5rem',
+              padding: '0.5rem 1rem 0 0',
             },
           }
           props[:style][:textDecoration] = 'underline' if @selected_company == company
 
           company_name = company.name
-          company_name = company_name[0..15] + '...' if company_name.size > 15
-
           owner_name = company.owner.id
-          owner_name = owner_name[0..10] + '...' if owner_name.size > 10
+          c_size = company_name.size
+          o_size = owner_name.size
+          limit = 36
+          if c_size + o_size > limit
+            if o_size < 5
+              company_name = company_name[0..(limit - 7)] + '…' if c_size > (limit - 3)
+            else
+              company_name = company_name[0..(limit - 17)] + '…' if c_size > (limit - 13)
+              owner_name = owner_name[0..9] + '…' if o_size > 13
+            end
+          end
 
-          h(:div, props, "#{company_name} (#{owner_name})")
+          h(:a, props, "#{company_name} (#{owner_name})")
         end.compact
       end
 

--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -13,12 +13,16 @@ module View
         return h(:div) if companies.empty? || @game.round.current_entity.company?
 
         op_round = @game.round.is_a?(Engine::Round::Operating)
-
         current, others = companies.partition { |company| @game.current_entity.owner == company.owner.owner }
 
-        props = { style: { marginRight: '1rem' } }
+        props = {
+          style: {
+            margin: '0 1rem 0 0',
+            display: op_round && current.any? ? '' : 'inline-block',
+          },
+        }
         children = [
-          h('h3.inline', props, 'Abilities'),
+          h(:h3, props, 'Abilities'),
           *render_companies(current, op_round),
         ]
 
@@ -31,7 +35,10 @@ module View
           end
 
           props = {
-            style: { margin: '0.5rem 0.5rem 0 0' },
+            style: {
+              margin: '0.5rem 0.5rem 0 0',
+              width: '7.3rem',
+            },
             on: { click: toggle_show },
           }
           children << h('button.button', props, @show_other_abilities ? 'Hide Others' : 'Show Others')
@@ -52,7 +59,7 @@ module View
           },
         }
 
-        h(:div, [h(:div, props, @selected_company.desc), *render_actions])
+        h(:div, props, [h(:div, @selected_company.desc), *render_actions])
       end
 
       def render_companies(companies, op_round)
@@ -64,7 +71,7 @@ module View
             style: {
               cursor: 'pointer',
               display: 'inline-block',
-              padding: '0.5rem 1rem 0 0',
+              padding: '0.3rem 1rem 0 0',
             },
           }
           props[:style][:textDecoration] = 'underline' if @selected_company == company

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -22,7 +22,8 @@ module View
           @current_actions = round.actions_for(entity)
           entity = entity.owner if entity.company?
 
-          left = [h(Game::Abilities, user: @user, game: @game), h(UndoAndPass, pass: @current_actions.include?('pass'))]
+          left = [h(Game::Abilities, user: @user, game: @game),
+                  h(UndoAndPass, pass: @current_actions.include?('pass'))]
           left << h(RouteSelector) if @current_actions.include?('run_routes')
           left << h(Dividend) if @current_actions.include?('dividend')
           if @current_actions.include?('buy_train')

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -22,8 +22,7 @@ module View
           @current_actions = round.actions_for(entity)
           entity = entity.owner if entity.company?
 
-          left = [h(Game::Abilities, user: @user, game: @game)]
-          left << h(UndoAndPass, pass: @current_actions.include?('pass'))
+          left = [h(Game::Abilities, user: @user, game: @game), h(UndoAndPass, pass: @current_actions.include?('pass'))]
           left << h(RouteSelector) if @current_actions.include?('run_routes')
           left << h(Dividend) if @current_actions.include?('dividend')
           if @current_actions.include?('buy_train')

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -22,7 +22,8 @@ module View
           @current_actions = round.actions_for(entity)
           entity = entity.owner if entity.company?
 
-          left = [h(UndoAndPass, pass: @current_actions.include?('pass'))]
+          left = [h(Game::Abilities, user: @user, game: @game)]
+          left << h(UndoAndPass, pass: @current_actions.include?('pass'))
           left << h(RouteSelector) if @current_actions.include?('run_routes')
           left << h(Dividend) if @current_actions.include?('dividend')
           if @current_actions.include?('buy_train')

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -146,7 +146,7 @@ module View
       }
 
       p_elm = players.map.with_index do |player, index|
-        short_name = player['name'].length > 19 ? player['name'][0...15] + '…' : player['name']
+        short_name = player['name'].length > 19 ? player['name'][0..15] + '…' : player['name']
         if owner? && new? && player['id'] != @user['id']
           button_props = {
             on: { click: -> { kick(@gdata, player) } },
@@ -187,7 +187,7 @@ module View
       elsif @gdata['status'] == 'finished'
         result = @gdata['result']
           .sort_by { |_, v| -v }
-          .map { |k, v| "#{k.length > 15 ? k[0...11] + '…' : k} #{v}" }
+          .map { |k, v| "#{k.length > 15 ? k[0..11] + '…' : k} #{v}" }
           .join(', ')
 
         children << h(:div, [

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'lib/truncate'
 require 'view/game_row'
 require 'view/link'
 
@@ -146,7 +147,7 @@ module View
       }
 
       p_elm = players.map.with_index do |player, index|
-        short_name = player['name'].length > 19 ? player['name'][0..15] + '…' : player['name']
+        short_name = player['name'].truncate(19)
         if owner? && new? && player['id'] != @user['id']
           button_props = {
             on: { click: -> { kick(@gdata, player) } },
@@ -187,7 +188,7 @@ module View
       elsif @gdata['status'] == 'finished'
         result = @gdata['result']
           .sort_by { |_, v| -v }
-          .map { |k, v| "#{k.length > 15 ? k[0..11] + '…' : k} #{v}" }
+          .map { |k, v| "#{k.truncate(15)} #{v}" }
           .join(', ')
 
         children << h(:div, [

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -146,7 +146,7 @@ module View
       }
 
       p_elm = players.map.with_index do |player, index|
-        short_name = player['name'].length > 19 ? player['name'][0...18] + '…' : player['name']
+        short_name = player['name'].length > 19 ? player['name'][0...15] + '…' : player['name']
         if owner? && new? && player['id'] != @user['id']
           button_props = {
             on: { click: -> { kick(@gdata, player) } },
@@ -187,7 +187,7 @@ module View
       elsif @gdata['status'] == 'finished'
         result = @gdata['result']
           .sort_by { |_, v| -v }
-          .map { |k, v| "#{k.length > 15 ? k[0...14] + '…' : k} #{v}" }
+          .map { |k, v| "#{k.length > 15 ? k[0...11] + '…' : k} #{v}" }
           .join(', ')
 
         children << h(:div, [

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -256,7 +256,7 @@ module View
         h(Game::GameLog, user: @user),
         h(Game::HistoryControls, num_actions: @num_actions),
         h(Game::EntityOrder, round: @round),
-        h(Game::Abilities, user: @user, game: @game),
+        @round.is_a?(Engine::Round::Operating) ? '' : h(Game::Abilities, user: @user, game: @game),
         render_action,
       ])
     end

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -23,7 +23,7 @@ h2 {
 }
 h3 {
   font-size: 1.1rem;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.3rem;
 }
 
 p {


### PR DESCRIPTION
- Abilities in h3 to fit with other action headers
- Abilities in ORs on top for consistency. I’d move them below actions or even below corp, but that’s your decision.
- Description of company rendered right below the name in ORs (before: below last company).
- Truncation on names improved to cut at least 4 chars (=> no "Mitsubishi Ferr…" etc.) and show more chars of company names. Imposed limit should work fine with 20rem width, current company names and font. For names with many wide chars (CAPS, m, w etc.) this may become a problem later on, but then it’s an easy change.

might resolve #1201
