### PR TITLE
1882 critical bugs

### DIFF
--- a/lib/engine/config/game/g_1882.rb
+++ b/lib/engine/config/game/g_1882.rb
@@ -367,7 +367,7 @@ module Engine
       "tokens": [
         0,
         40,
-        40
+        100
       ],
       "coordinates": "D8",
       "color": "green"
@@ -379,7 +379,7 @@ module Engine
       "tokens": [
         0,
         40,
-        40
+        100
       ],
       "coordinates": "G11",
       "color": "gold",
@@ -392,8 +392,8 @@ module Engine
       "tokens": [
         0,
         40,
-        40,
-        40
+        100,
+        100
       ],
       "coordinates": "I5",
       "color": "red"
@@ -405,7 +405,7 @@ module Engine
       "tokens": [
         0,
         40,
-        40
+        100
       ],
       "coordinates": "L8",
       "color": "black"

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -598,13 +598,13 @@ module Engine
 
       def place_home_token(corporation)
         return unless corporation.next_token # 1882
+        # If a corp has laid it's first token assume it's their home token
+        return if corporation.tokens.first&.used
 
         hex = hex_by_id(corporation.coordinates)
 
         tile = hex&.tile
         if !tile || (tile.reserved_by?(corporation) && tile.paths.any?)
-          # If a corp doesn't have an allocated tile, and the first token is used they have a home token.
-          return if corporation.tokens.first&.used && !tile
 
           # If the tile does not have any paths at the present time, clear up the ambiguity when the tile is laid
           # otherwise the entity must choose now.

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -170,6 +170,12 @@ module Engine
           tiles << old_tile
         end
 
+        # Temporary workaround, remove the routes from the last OR
+        # The tiles may be destroyed and connect to other hexes causing problems
+        @corporations.each do |c|
+          c.operating_history[c.operating_history.keys.max]&.routes&.clear if c.operating_history.any?
+        end
+
         # Some companies might no longer have valid routes
         @graph.clear_graph_for_all
       end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -63,6 +63,7 @@ module Engine
         end
 
         company.abilities(:close, @name) do
+          @log << "Company #{company.name} closes"
           company.close!
         end
       end

--- a/lib/engine/step/g_1882/special_nwr.rb
+++ b/lib/engine/step/g_1882/special_nwr.rb
@@ -101,15 +101,10 @@ module Engine
         end
 
         def process_lay_tile(action)
-          lay_tile(action)
+          lay_tile(action, entity: action.entity.owner)
           gain_nwr_bonus(action.tile, action.entity.owner)
           ability(action.entity).use!
           @state = nil
-
-          # Clean up pending tokens to be done by the corp rather than the company
-          @round.pending_tokens.each do |pending|
-            pending[:entity] = action.entity.owner if pending[:entity] == action.entity
-          end
         end
 
         # Can't lay neutral tokens, so just provide the next one.

--- a/lib/engine/step/g_1882/track.rb
+++ b/lib/engine/step/g_1882/track.rb
@@ -10,7 +10,7 @@ module Engine
       class Track < Track
         include NwrTrackBonus
 
-        def lay_tile(action, extra_cost = 0)
+        def lay_tile(action, extra_cost: 0)
           super
           gain_nwr_bonus(action.tile, action.entity)
         end

--- a/lib/engine/step/g_1882/track.rb
+++ b/lib/engine/step/g_1882/track.rb
@@ -10,9 +10,10 @@ module Engine
       class Track < Track
         include NwrTrackBonus
 
-        def lay_tile(action, extra_cost: 0)
+        def lay_tile(action, extra_cost: 0, entity: nil)
+          entity ||= action.entity
           super
-          gain_nwr_bonus(action.tile, action.entity)
+          gain_nwr_bonus(action.tile, entity)
         end
       end
     end

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -8,8 +8,8 @@ module Engine
     module Tokener
       def can_place_token?(entity)
         current_entity == entity &&
-          (token = entity.next_token) &&
-          min_token_price(token) <= entity.cash &&
+          (tokens = available_tokens).any? &&
+          min_token_price(tokens) <= entity.cash &&
           @game.graph.can_token?(entity)
       end
 
@@ -50,10 +50,11 @@ module Engine
         @game.graph.clear
       end
 
-      def min_token_price(token)
+      def min_token_price(tokens)
+        token = tokens.first
         return 0 if @round.teleported?(token.corporation)
 
-        prices = [token.price]
+        prices = tokens.map(&:price)
 
         token.corporation.abilities(:token) do |ability, _|
           prices << ability.price

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -33,13 +33,13 @@ module Engine
         raise GameError, 'Cannot lay an upgrade now' if tile.color != :yellow && !tile_lay[:upgrade]
         raise GameError, 'Cannot lay an yellow now' if tile.color == :yellow && !tile_lay[:lay]
 
-        lay_tile(action, tile_lay[:cost])
+        lay_tile(action, extra_cost: tile_lay[:cost])
         @upgraded = true if action.tile.color != :yellow
         @laid_track += 1
       end
 
-      def lay_tile(action, extra_cost = 0)
-        entity = action.entity
+      def lay_tile(action, extra_cost: 0, entity: nil)
+        entity ||= action.entity
         tile = action.tile
         hex = action.hex
         rotation = action.rotation

--- a/spec/fixtures/1882/4932.json
+++ b/spec/fixtures/1882/4932.json
@@ -1,0 +1,3280 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 1,
+      "company": "TB",
+      "price": 145
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 2,
+      "message": "Hi everyone!!! Good luck "
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 3,
+      "message": "let’s find bugs "
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 4,
+      "message": "I had one game need to pause for a bug already today "
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 5,
+      "message": "Good luck and have fun! Who else is playing 1882 for the first time (I guess not Jac)"
+    },
+    {
+      "type": "bid",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 6,
+      "company": "SC",
+      "price": 55
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 7,
+      "message": "Good luck! I've played it twice on Board18, but far from an expert."
+    },
+    {
+      "type": "bid",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 8,
+      "company": "SC",
+      "price": 60
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 9,
+      "message": "I’ve played 6 times? i’d have to check "
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 10,
+      "message": "I played a 2p game on board18 a month or so ago."
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 11,
+      "message": "Really excited about this one"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 12,
+      "message": "Yeah, it's a cool game."
+    },
+    {
+      "type": "bid",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 13,
+      "company": "TB",
+      "price": 150
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 14,
+      "message": "i’m not an expert "
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 15,
+      "message": "OK, so beat up on Jac, right? :D"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 16,
+      "message": "i’m okay with that "
+    },
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 17,
+      "company": "NWR",
+      "price": 85
+    },
+    {
+      "type": "bid",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 18,
+      "company": "NWR",
+      "price": 90
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 19,
+      "message": "This game is kinda brutal "
+    },
+    {
+      "id": 20,
+      "type": "bid",
+      "price": 65,
+      "entity": "Mkjanssen",
+      "company": "SC",
+      "entity_type": "player"
+    },
+    {
+      "id": 21,
+      "type": "undo",
+      "entity": "Jac",
+      "entity_type": "player"
+    },
+    {
+      "type": "bid",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 22,
+      "company": "NWR",
+      "price": 95
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 23,
+      "message": "the rebellion is on 4 btw"
+    },
+    {
+      "type": "bid",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 24,
+      "company": "HB",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 25,
+      "company": "SC",
+      "price": 65
+    },
+    {
+      "type": "bid",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 26,
+      "company": "SC",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 27,
+      "company": "SC",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 28,
+      "company": "SC",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 29
+    },
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 30,
+      "company": "NWR",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 31,
+      "company": "NWR",
+      "price": 105
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 32
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 33
+    },
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 34,
+      "company": "TB",
+      "price": 155
+    },
+    {
+      "type": "bid",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 35,
+      "company": "TB",
+      "price": 160
+    },
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 36,
+      "company": "TB",
+      "price": 165
+    },
+    {
+      "type": "bid",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 37,
+      "company": "TB",
+      "price": 170
+    },
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 38,
+      "company": "TB",
+      "price": 175
+    },
+    {
+      "type": "bid",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 39,
+      "company": "TB",
+      "price": 180
+    },
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 40,
+      "company": "TB",
+      "price": 185
+    },
+    {
+      "type": "bid",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 41,
+      "company": "TB",
+      "price": 190
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 42,
+      "message": "yours for 195"
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 43
+    },
+    {
+      "type": "bid",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 44,
+      "company": "CP",
+      "price": 180
+    },
+    {
+      "type": "par",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 45,
+      "corporation": "CPR",
+      "share_price": "100,0,3"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 46,
+      "shares": [
+        "CPR_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 47,
+      "shares": [
+        "CPR_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 48,
+      "shares": [
+        "CPR_4"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 49,
+      "shares": [
+        "CPR_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 50
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 51,
+      "shares": [
+        "CPR_6"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 52,
+      "shares": [
+        "CPR_7"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 53,
+      "shares": [
+        "CPR_8"
+      ]
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 54,
+      "message": "i’ve never seen any start like this lol"
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 55,
+      "message": "Well, I don't have a clue how to play these companies. I did start in an asynch game 20 minutes ago, but we are still in SR1, so I have no frame of reference how it should go."
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 56
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 57,
+      "message": "ya, I need to check, but I don’t have a great record at this game. at least 1 bankruptcy haha"
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 58
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 59,
+      "hex": "I5",
+      "tile": "57-0",
+      "rotation": 3
+    },
+    {
+      "id": 60,
+      "hex": "K5",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "CPR",
+      "rotation": 1,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 61,
+      "type": "undo",
+      "entity": "CPR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 62,
+      "hex": "K5",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "id": 63,
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-0",
+      "entity": "CPR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 64,
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 65,
+      "type": "undo",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player"
+    },
+    {
+      "id": 66,
+      "type": "undo",
+      "entity": "CPR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 67
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 68,
+      "message": "Sorry - just realized I don't \"have\" to buy a train yet."
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 69,
+      "message": "Still don't know if it is right, but..."
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 70,
+      "message": "i think it’s the best move "
+    },
+    {
+      "type": "par",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 71,
+      "corporation": "CNR",
+      "share_price": "82,2,3"
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 72
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 73,
+      "message": "Hmm... No bump from being sold out, huh?"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 74,
+      "message": "no room "
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 75,
+      "message": "Duh"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 76,
+      "shares": [
+        "CNR_1"
+      ]
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 77,
+      "message": "I had the same thought"
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 78
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 79,
+      "shares": [
+        "CPR_1",
+        "CPR_4",
+        "CPR_7"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 80,
+      "shares": [
+        "CNR_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 81
+    },
+    {
+      "type": "buy_shares",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 82,
+      "shares": [
+        "CNR_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 83
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 84,
+      "shares": [
+        "CNR_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 85
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 86,
+      "shares": [
+        "CPR_1"
+      ]
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 87,
+      "message": "why keep shares that won’t pay?"
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 88
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 89,
+      "shares": [
+        "CNR_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 90
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 91
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 92
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 93,
+      "shares": [
+        "CPR_3",
+        "CPR_6",
+        "CPR_1"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 94,
+      "shares": [
+        "CNR_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 95
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 96,
+      "shares": [
+        "CNR_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 97
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 98
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 99
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 100,
+      "shares": [
+        "CNR_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 101
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 102
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 103
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 104
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 105
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 106,
+      "message": "andrew: you know about the fishing spot right? you could run a 2 train to 2 cities AND the fishing "
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 107,
+      "message": "Boy I bet Andrew is glad I bought a share :D"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 108,
+      "message": "haha"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 109,
+      "message": "i would have liked it "
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 110,
+      "message": "Yeah, absolutely, Jac. Will try to set up for that."
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 111,
+      "hex": "E7",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 112,
+      "hex": "F6",
+      "tile": "7-0",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 113,
+      "train": "2-0",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 114
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 115,
+      "hex": "M5",
+      "tile": "8-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 116,
+      "hex": "M7",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 117,
+      "city": "N6-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 118,
+      "train": "2-1",
+      "price": 80
+    },
+    {
+      "type": "buy_train",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 119,
+      "train": "2-2",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 120
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 121,
+      "shares": [
+        "CPR_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 122
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 123
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 124
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 125,
+      "shares": [
+        "CPR_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 126
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 127
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 128
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 129
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 130
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 131,
+      "hex": "D6",
+      "tile": "57-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 132,
+      "hex": "F8",
+      "tile": "2-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 133
+    },
+    {
+      "type": "run_routes",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 134,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "B6",
+              "D6"
+            ],
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 135,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 136,
+      "train": "2-3",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 137
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 138,
+      "hex": "L8",
+      "tile": "57-2",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 139,
+      "hex": "K9",
+      "tile": "55-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 140,
+      "city": "J10-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 141,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "J10",
+              "K9"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "N6",
+              "M5",
+              "K5",
+              "I5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 142,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 143,
+      "train": "2-4",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 144
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 145,
+      "shares": [
+        "CPR_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 146
+    },
+    {
+      "type": "buy_shares",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 147,
+      "shares": [
+        "CPR_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 148
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 149,
+      "shares": [
+        "CPR_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 150
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 151,
+      "message": "I, for one, have always believed in your company, Monty:)"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 152,
+      "message": "lol"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 153,
+      "shares": [
+        "CPR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 154,
+      "shares": [
+        "CNR_1",
+        "CNR_6",
+        "CNR_8"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "par",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 155,
+      "corporation": "SC",
+      "share_price": "82,2,3"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 156,
+      "message": "(Although Jac's move of selling it and then buying it back cheaper was smarter.)"
+    },
+    {
+      "type": "place_token",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 157,
+      "city": "57-1-0",
+      "slot": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 158,
+      "shares": [
+        "CNR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 159,
+      "shares": [
+        "CPR_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 160
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 161,
+      "message": "I agree that it was smarter. Very different game."
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 162
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 163
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 164,
+      "shares": [
+        "SC_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 165
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 166,
+      "message": "I keep forgetting that I can sell after buying"
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 167,
+      "message": "Too used to Chesapeake and 46"
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 168
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 169,
+      "message": "It feels like starting a company early could be bad, but it is hard to tell..."
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 170
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 171,
+      "message": "game often ends in BK"
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 172
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 173,
+      "shares": [
+        "SC_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 174
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 175
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 176
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 177
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 178,
+      "shares": [
+        "SC_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 179
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 180
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 181
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 182
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 183,
+      "shares": [
+        "SC_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 184
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 185
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 186
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 187
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 188,
+      "message": "autopass unless any sells"
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 189
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 190
+    },
+    {
+      "type": "buy_train",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 191,
+      "train": "2-5",
+      "price": 80
+    },
+    {
+      "type": "buy_train",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 192,
+      "train": "3-0",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 193
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 194
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 195,
+      "hex": "D6",
+      "tile": "15-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 196,
+      "city": "15-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 197,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "B6",
+              "D6"
+            ],
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D8",
+              "F8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 198,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 199,
+      "company": "NWR",
+      "price": 160
+    },
+    {
+      "type": "buy_train",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 200,
+      "train": "3-1",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 201
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 202
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 203,
+      "hex": "J10",
+      "tile": "R1-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 204,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "K9",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "N6",
+              "M5",
+              "K5",
+              "I5"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "N6",
+              "M7",
+              "L8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 205,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 206
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 207
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 208,
+      "shares": [
+        "SC_5"
+      ]
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 209,
+      "shares": [
+        "SC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 210
+    },
+    {
+      "type": "buy_shares",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 211,
+      "shares": [
+        "SC_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 212
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 213,
+      "shares": [
+        "CNR_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 214
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 215
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 216,
+      "shares": [
+        "CNR_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 217
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 218
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 219,
+      "shares": [
+        "CNR_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 220
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 221
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 222
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 223,
+      "message": "autopass unless sells for me"
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 224
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 225,
+      "shares": [
+        "CNR_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 226
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 227
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 228
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 229
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 230
+    },
+    {
+      "id": 231,
+      "hex": "C5",
+      "tile": "7-1",
+      "type": "lay_tile",
+      "entity": "CNR",
+      "rotation": 5,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 232,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 233,
+      "hex": "C5",
+      "tile": "8-1",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 234,
+      "hex": "D4",
+      "tile": "57-3",
+      "rotation": 1
+    },
+    {
+      "id": 235,
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 236,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "remove_token",
+      "entity": "NWR",
+      "entity_type": "company",
+      "id": 237,
+      "city": "D8-0-0",
+      "slot": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "NWR",
+      "entity_type": "company",
+      "id": 238,
+      "city": "57-3-0",
+      "slot": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NWR",
+      "entity_type": "company",
+      "id": 239,
+      "hex": "D4",
+      "tile": "14-0",
+      "rotation": 1
+    },
+    {
+      "id": 240,
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 241,
+      "type": "run_routes",
+      "entity": "CNR",
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "B6",
+              "D6"
+            ],
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 242,
+      "message": "Huh, there's something weird going on with the NWR. I believe I got that move all fine, but now I'm getting issues running trains."
+    },
+    {
+      "id": 243,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 244,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 245,
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 246,
+      "type": "run_routes",
+      "entity": "CNR",
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "B6",
+              "D6"
+            ],
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation"
+    },
+    {
+      "id": 247,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 248,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 249,
+      "message": "It looks like I should be able to run for 260, but it's only counting 80 when I hit submit."
+    },
+    {
+      "id": 250,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 251,
+      "message": "I'll try refreshing and doing it again."
+    },
+    {
+      "id": 252,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 253
+    },
+    {
+      "id": 254,
+      "type": "run_routes",
+      "entity": "CNR",
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "B6",
+              "D6"
+            ],
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 255,
+      "message": "Yeah, I get a \"$80\" and a \"Cannot run another corporation's train. Refresh.\" error. Anyone else want to give it a try?"
+    },
+    {
+      "id": 256,
+      "type": "undo",
+      "entity": "CNR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 257,
+      "message": "sure "
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 258,
+      "message": "Awesome. Routes I had were Maidstone-Spiritwood, Fishing-Spiritwood (using the count fishing as a spot), and the 3 from Spiritwood-Prince Albert-10."
+    },
+    {
+      "type": "run_routes",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 259,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D6",
+              "C5",
+              "D4"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "D8",
+              "F8"
+            ],
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "B6",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 260,
+      "message": "Unless the count fishing as a spot doesn't work anymore..."
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 261,
+      "message": "it works "
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 262,
+      "message": "but i’m getting 180"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 263,
+      "message": "how do you get more than 180?"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 264,
+      "message": "Huh. Maybe I had the count wrong. It was showing 260. 180 is fine...much better than 80!"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 265,
+      "message": "180 is highest i could find "
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 266,
+      "message": "You’re right—i tried it in hot seat mode and it told me 260, but 60+70+50 is 180"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 267,
+      "message": "Yeah, adding it manually, 180 seems right. "
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 268,
+      "message": "Awesome. Thanks for the help. "
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 269,
+      "message": "It definitely says “Submit $260” though"
+    },
+    {
+      "type": "dividend",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 270,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 271
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 272
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 273,
+      "message": "team work :)"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 274,
+      "message": "All right, there we go. Thanks for getting it to work, Jac."
+    },
+    {
+      "id": 275,
+      "hex": "C3",
+      "tile": "57-1",
+      "type": "lay_tile",
+      "entity": "SC",
+      "rotation": 2,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 276,
+      "type": "undo",
+      "entity": "SC",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 277,
+      "hex": "E9",
+      "tile": "8-2",
+      "type": "lay_tile",
+      "entity": "SC",
+      "rotation": 1,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 278,
+      "type": "undo",
+      "entity": "SC",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 279,
+      "hex": "C3",
+      "tile": "57-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 280
+    },
+    {
+      "id": 281,
+      "city": "14-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "SC",
+      "token_type": "neutral",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 282,
+      "type": "undo",
+      "entity": "SC",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 283
+    },
+    {
+      "type": "run_routes",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 284,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D4",
+              "C3"
+            ],
+            [
+              "D6",
+              "C5",
+              "D4"
+            ],
+            [
+              "B6",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 285,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 286
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 287
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 288,
+      "hex": "L10",
+      "tile": "8-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 289
+    },
+    {
+      "type": "run_routes",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 290,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "K9",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "N6",
+              "M5",
+              "K5",
+              "I5"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "N6",
+              "M7",
+              "L8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 291,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 292,
+      "train": "3-2",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 293
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 294,
+      "hex": "E5",
+      "tile": "59-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 295
+    },
+    {
+      "type": "run_routes",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 296,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D4",
+              "E5"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "B2",
+              "C3"
+            ],
+            [
+              "D4",
+              "C3"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ],
+            [
+              "B6",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 297,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 298
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 299
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 300,
+      "hex": "F6",
+      "tile": "27-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 301
+    },
+    {
+      "type": "run_routes",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 302,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D4",
+              "E5"
+            ],
+            [
+              "D6",
+              "C5",
+              "D4"
+            ],
+            [
+              "B6",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 303,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 304,
+      "train": "3-3",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 305
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "corporation",
+      "id": 306
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 307,
+      "hex": "G5",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 308
+    },
+    {
+      "type": "place_token",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 309,
+      "city": "59-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 310,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "K9",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "N6",
+              "M5",
+              "K5",
+              "I5"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "N6",
+              "M7",
+              "L8"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E5",
+              "G5",
+              "I5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 311,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 312
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 313,
+      "shares": [
+        "SC_1",
+        "SC_2",
+        "SC_3",
+        "SC_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 314,
+      "corporation": "HBR",
+      "share_price": "90,1,3"
+    },
+    {
+      "type": "message",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 315,
+      "message": "Living on the edge"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 316,
+      "shares": [
+        "SC_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 317
+    },
+    {
+      "id": 318,
+      "type": "buy_shares",
+      "entity": "MontyBrewster71",
+      "shares": [
+        "SC_2"
+      ],
+      "entity_type": "player"
+    },
+    {
+      "id": 319,
+      "type": "undo",
+      "entity": "MontyBrewster71",
+      "entity_type": "player"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 320,
+      "message": "Sorry, Monty, my misclick there. Thought it was on me."
+    },
+    {
+      "type": "buy_shares",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 321,
+      "shares": [
+        "SC_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 322
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 323,
+      "message": "No worries"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 324,
+      "shares": [
+        "SC_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 325
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 326,
+      "shares": [
+        "HBR_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 327
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 328,
+      "shares": [
+        "SC_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 329
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 330
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 331
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 332,
+      "shares": [
+        "SC_0"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 333,
+      "shares": [
+        "HBR_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 334
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 335,
+      "shares": [
+        "SC_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 336
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 337
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 338
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 339,
+      "shares": [
+        "HBR_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 340
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 341,
+      "shares": [
+        "SC_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 342
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 343
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 344
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 345,
+      "shares": [
+        "HBR_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 346
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 347
+    },
+    {
+      "type": "sell_shares",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 348,
+      "shares": [
+        "SC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 349
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 350,
+      "message": "i’m at share limit lol"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 351,
+      "shares": [
+        "HBR_5"
+      ]
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 352,
+      "message": "Oh, wow. I've never seen anyone hit the cert limit because of privates before."
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 353
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 354
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 355,
+      "message": "i’ll buy them in "
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 356
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 357,
+      "message": "You could sell a CNR and get the 5th SC, though."
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 358
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 359,
+      "message": "nah"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 360,
+      "shares": [
+        "SC_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 361
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 362
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 363
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 364
+    },
+    {
+      "type": "buy_shares",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 365,
+      "shares": [
+        "HBR_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 366
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 367,
+      "message": "Just trying to be helpful ;p"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 368,
+      "message": "lol"
+    },
+    {
+      "type": "pass",
+      "entity": "Mkjanssen",
+      "entity_type": "player",
+      "id": 369
+    },
+    {
+      "type": "pass",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 370
+    },
+    {
+      "type": "pass",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 371
+    },
+    {
+      "type": "pass",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 372
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 373,
+      "message": "reminder "
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 374,
+      "hex": "C3",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 375,
+      "message": "the NWR will happen soo "
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 376,
+      "message": "soon"
+    },
+    {
+      "type": "message",
+      "entity": "Jac",
+      "entity_type": "player",
+      "id": 377,
+      "message": "so make your tiles green if you want to keep them"
+    },
+    {
+      "type": "message",
+      "entity": "AndrewBucholtz",
+      "entity_type": "player",
+      "id": 378,
+      "message": "Indeed. Those yellow tiles are set to vanish."
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 379
+    },
+    {
+      "type": "run_routes",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 380,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D4",
+              "E5"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "B2",
+              "C3"
+            ],
+            [
+              "D4",
+              "C3"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D8",
+              "E7",
+              "F6",
+              "D6"
+            ],
+            [
+              "B6",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 381,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 382
+    },
+    {
+      "type": "pass",
+      "entity": "CNR",
+      "entity_type": "corporation",
+      "id": 383
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HBR",
+      "entity_type": "corporation",
+      "id": 384,
+      "hex": "G11",
+      "tile": "57-3",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HBR",
+      "entity_type": "corporation",
+      "id": 385,
+      "hex": "D12",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "HBR",
+      "entity_type": "corporation",
+      "id": 386,
+      "train": "3-4",
+      "price": 180
+    },
+    {
+      "type": "buy_train",
+      "entity": "HBR",
+      "entity_type": "corporation",
+      "id": 387,
+      "train": "4-0",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "HBR",
+      "entity_type": "corporation",
+      "id": 388
+    },
+    {
+      "type": "pass",
+      "entity": "HBR",
+      "entity_type": "corporation",
+      "id": 389
+    },
+    {
+      "type": "message",
+      "entity": "MontyBrewster71",
+      "entity_type": "player",
+      "id": 390,
+      "message": "Soon :D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 391,
+      "hex": "L8",
+      "tile": "14-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 392,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "K9",
+              "L8"
+            ],
+            [
+              "K9",
+              "J10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 393,
+      "kind": "payout"
+    },
+    {
+      "type": "end_game",
+      "entity": "CPR",
+      "entity_type": "corporation",
+      "id": 394
+    }
+  ],
+  "id": "hs_bxdiohmi_4932",
+  "players": [
+    {
+      "id": 523,
+      "name": "MontyBrewster71"
+    },
+    {
+      "id": 1876,
+      "name": "AndrewBucholtz"
+    },
+    {
+      "id": 151,
+      "name": "Mkjanssen"
+    },
+    {
+      "id": 24,
+      "name": "Jac"
+    }
+  ],
+  "title": "1882",
+  "description": "Cloned from game hs_qozeyluo_4932",
+  "max_players": 5,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 1.225414129318569e+38
+  },
+  "turn": 9,
+  "round": "Operating Round",
+  "acting": [],
+  "result": {
+    "AndrewBucholtz": 1433,
+    "Jac": 1232,
+    "MontyBrewster71": 1040,
+    "Mkjanssen": 646
+  },
+  "loaded": true,
+  "created_at": "2020-07-27",
+  "updated_at": 1595825920,
+  "mode": "hotseat"
+}

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -115,6 +115,15 @@ module Engine
         'scottredracecar' => 5021,
       },
     },
+    GAMES_BY_TITLE['1882'] => {
+      # This is a partial game and will get replaced as soon as it gets more stable
+      4932 => {
+        'AndrewBucholtz' => 1433,
+        'Jac' => 1232,
+        'MontyBrewster71' => 1040,
+        'Mkjanssen' => 646,
+      },
+    },
   }.freeze
 
   TEST_CASES.each do |game, results|


### PR DESCRIPTION
Critical 1882 bugs:

fixes #1198 Wrong price for tokens
fixes #1192 Neutral token gets replaced with another home token from the NWR owning corp
fixes #1189 Corp using NWR power should be able to pay for terrain costs
fixes #1188 Skipping token lays when can't afford it

short term workaround for #1199