### PR TITLE
Ensure special tile lay follows phase colors (#1130)

### DIFF
--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -38,6 +38,7 @@ module Engine
           Step::DiscardTrain,
           Step::BuyCompany,
           Step::HomeToken,
+          Step::SpecialTrack,
           Step::G18AL::Track,
           Step::G18AL::Token,
           Step::Route,

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -39,6 +39,7 @@ module Engine
           Step::DiscardTrain,
           Step::BuyCompany,
           Step::HomeToken,
+          Step::SpecialTrack,
           Step::Track,
           Step::Token,
           Step::Route,

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -32,10 +32,11 @@ module Engine
       end
 
       def potential_tiles(entity, hex)
+        colors = @game.phase.tiles
         (ability(entity)&.tiles || [])
           .map { |name| @game.tiles.find { |t| t.name == name } }
           .compact
-          .select { |t| hex.tile.upgrades_to?(t, true) }
+          .select { |t| colors.include?(t.color) && hex.tile.upgrades_to?(t, true) }
       end
 
       def ability(entity)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -204,6 +204,9 @@ module Engine
       # correct color progression?
       return false unless COLORS.index(other.color) == (COLORS.index(@color) + 1)
 
+      # honors pre-existing track?
+      return false unless paths_are_subset_of?(other.paths)
+
       # If special ability then remaining checks is not applicable
       return true if special_lay
 
@@ -216,9 +219,6 @@ module Engine
       # - TODO: account for games that allow double dits to upgrade to one town
       return false if @towns.size != other.towns.size
       return false if !label && @cities.size != other.cities.size
-
-      # honors pre-existing track?
-      return false unless paths_are_subset_of?(other.paths)
 
       true
     end


### PR DESCRIPTION
For special tile tile, restrict available tiles to
the ones that are allowed to lay during current phase.

Add special lay to 18AL and 18MEX so that they can lay
Copper Canyon and Lumber Terminal again.

Put check for honoring existing track before short cut
for special lay, so existing track is also honored by
special lay.
(This was a potential bug with the special lay short cut.
 It should have no change of existing functionality for
 non special lays as this was an existing check that
 has just been moved. The remaining checks are still
 skipped by special lay.)