### PR TITLE
Setup db user in an entrypoint script

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,13 +1,11 @@
 FROM postgres:12.2
 
-# use uid 1000 to (hopefully) match host user (ie, you)
-RUN useradd --uid 1000 --user-group --create-home --home-dir /home/db db
-
-RUN chown db:db /var/lib/postgresql/data && \
-    chown db:db /var/run/postgresql
-
-USER db:db
+USER root:root
 
 COPY ./postgresql.conf /etc/postgresql/postgresql.conf
 
+# entrypoint is used to create db user, chown the directories, then run as db
+COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/db/entrypoint.sh
+++ b/db/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Adapted from https://github.com/sudo-bmitch/jenkins-docker/blob/main/entrypoint.sh
+# Originally pointed out here: https://stackoverflow.com/a/44683248
+
+# Expectation: /var/lib/postgresql/data has been mounted into the container 
+# from the Docker Host
+
+set -x
+
+# configure script to go back to original postgres image's entrypoint
+set -- /docker-entrypoint.sh "$@"
+
+# match db user's uid to that of /var/lib/postgresql/data
+if [ "$(id -u)" = "0" ]; then
+  # get uid of mounted data dir
+  CONTAINER_RUNNER_UID=`ls -nud /var/lib/postgresql/data | cut -f3 -d' '`
+
+  if [ -z "$(getent passwd db)" ]; then
+    # Create user and group matching the UID found on /var/lib/postgresql/data
+    useradd --uid $CONTAINER_RUNNER_UID --user-group --create-home --home-dir /home/db db
+  fi
+
+  # Make sure db can write to these
+  chown db:db /var/lib/postgresql/data && \
+  chown db:db /var/run/postgresql
+
+  # Add call to gosu (installed by postgres 12.2 image) 
+  # to drop from root user to db user when running original entrypoint
+  set -- gosu db "$@"
+fi
+
+# replace the current pid 1 with original entrypoint or CMD
+exec "$@"

--- a/scripts/data_dir.sh
+++ b/scripts/data_dir.sh
@@ -11,7 +11,15 @@
 # - postgres requires the data dir to be empty when it initializes, so if a file
 #   like ./db/data/.keep is checked into the repo, it will error out instead of
 #   initializing properly
+# 
+# - if this script is run under one-shot sudo, $USER will be 'root', so 
+#   if user $SUDO_USER exists, use that instead
 
 mkdir -p db/data
 
-[ $(ls -l db/ | grep data | awk '{print $3}' | head -1) = 'root' ] && sudo chown -R $USER:$USER db/data || true
+usr="$SUDO_USER"
+if [ -z "$usr" ]; then
+  usr="$USER"
+fi 
+
+[ $(ls -l db/ | grep data | awk '{print $3}' | head -1) = 'root' ] && sudo chown -R $usr:$usr db/data || true


### PR DESCRIPTION
Trying to address #1105. I have tested this on Centos7, but not elsewhere. 

After this, should not have to edit db/Dockerfile to replace '1000' with your actual UID.

Overall I was trying to make the process of running "sudo make dev_up_b" from a fresh checkout as smooth as possible.  To that end, a new dev using Centos might still need to first disable selinux. 