### PR TITLE
1846 - disallow expensive train variant if corp can only afford cheaper

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -130,7 +130,10 @@ module View
 
       def from_depot(depot_trains)
         depot_trains.flat_map do |train|
-          train.variants.sort_by { |_, v| v[:price] }.flat_map do |name, variant|
+          train.variants
+            .select { |_, v| @game.round.active_step.buyable_train_variants(train).include?(v) }
+            .sort_by { |_, v| v[:price] }
+            .flat_map do |name, variant|
             price = variant[:price]
 
             buy_train = lambda do

--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -39,7 +39,7 @@ module Engine
     end
 
     def min_depot_price
-      min_depot_train.price
+      min_depot_train.variants.map { |_, v| v[:price] }.min
     end
 
     def unshift_train(train)

--- a/lib/engine/step/g_1846/train.rb
+++ b/lib/engine/step/g_1846/train.rb
@@ -72,6 +72,17 @@ module Engine
 
           @round.emergency_issued = true
         end
+
+        def buyable_train_variants(train)
+          variants = super
+          return variants if variants.size < 2
+
+          cash = current_entity.cash
+          min, max = variants.sort_by { |v| v[:price] }
+          return [min] if (min[:price] <= cash) && (cash < max[:price])
+
+          variants
+        end
       end
     end
   end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -63,7 +63,7 @@ module Engine
         @game.phase.buying_train!(entity, train)
 
         # Check if the train is actually buyable in the current situation
-        raise GameError, 'Not a buyable train' unless buyable_trains.include?(train)
+        raise GameError, 'Not a buyable train' unless buyable_train_variants(train).include?(train.variant)
 
         remaining = price - entity.cash
         if remaining.positive? && must_buy_train?(entity)
@@ -152,6 +152,10 @@ module Engine
           end
         end
         depot_trains + other_trains
+      end
+
+      def buyable_train_variants(train)
+        buyable_trains.include?(train) ? train.variants.values : []
       end
 
       def setup


### PR DESCRIPTION
[Fixes #1235]

This will break any games like 5112; IC could afford a 6 but bought 7/8 with a little help from the president - https://www.18xx.games/game/5112?action=520