### PR TITLE
Fix initialization of BuyTrain actions to prevent history from being changed

### DIFF
--- a/lib/engine/action/buy_train.rb
+++ b/lib/engine/action/buy_train.rb
@@ -5,13 +5,13 @@ require_relative 'base'
 module Engine
   module Action
     class BuyTrain < Base
-      attr_reader :train, :price, :exchange
+      attr_reader :train, :price, :exchange, :variant
 
       def initialize(entity, train:, price:, variant: nil, exchange: nil)
         @entity = entity
         @train = train
         @price = price
-        @train.variant = variant
+        @variant = variant
         @exchange = exchange
       end
 
@@ -28,7 +28,7 @@ module Engine
         {
           'train' => @train.id,
           'price' => @price,
-          'variant' => @train.variants.one? ? nil : @train.name,
+          'variant' => @variant,
           'exchange' => @exchange&.id,
         }
       end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -58,6 +58,7 @@ module Engine
       def process_buy_train(action)
         entity = action.entity
         train = action.train
+        train.variant = action.variant
         price = action.price
         exchange = action.exchange
         @game.phase.buying_train!(entity, train)


### PR DESCRIPTION
[Fixes #1233]

`variant` in `args_to_h` was checking `train`'s *current* `name` and `variants,` instead
of using whatever `variant` was passed in when the action was created

Also it seems better to modify the train object in `process_buy_train`, rather
than when creating the action
