### PR TITLE
Make 18AL alpha

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -15,7 +15,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p>1882 is now in alpha and 1846 is now in beta.</p>
+        <p>1882 and 18AL is now in alpha and 1846 is now in beta.</p>
         <p>Please file issues <a href='https://github.com/tobymao/18xx/issues'>here</a>. And if you have any questions, check out the
         <a href='https://github.com/tobymao/18xx/wiki'>Wiki!</a>
         </p>

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -12,6 +12,8 @@ module Engine
       load_from_json(Config::Game::G18AL::JSON)
       AXES = { x: :number, y: :letter }.freeze
 
+      DEV_STAGE = :alpha
+
       GAME_LOCATION = 'Alabama, USA'
       GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
       GAME_DESIGNER = 'Mark Derrick'

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -17,7 +17,9 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
-      EVENTS_TEXT = Base::EVENTS_TEXT.merge('remove_tokens' => ['Remove Tokens', 'Coal Field token removed']).freeze
+      EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+        'remove_tokens' => ['Remove Tokens', 'Warrior Coal Field token removed']
+      ).freeze
 
       ROUTE_BONUSES = %i[atlanta_birmingham mobile_nashville].freeze
 

--- a/lib/engine/step/g_18_al/assign.rb
+++ b/lib/engine/step/g_18_al/assign.rb
@@ -12,8 +12,9 @@ module Engine
 
           target = action.target
           hexes = company.abilities(:assign_hexes)&.hexes
+          target_location = @game.get_location_name(target.id)
           if !@game.loading && @game.graph.reachable_hexes(company.owner).find { |h, _| h.id == target.id }.nil?
-            @game.game_error("#{@game.get_location_name(target.id)} is not reachable")
+            @game.game_error("#{target_location} is not reachable")
           end
 
           super
@@ -22,7 +23,7 @@ module Engine
           # that will be removed in phase 6
           ability = Engine::Ability::HexBonus.new(
             type: :hexes_bonus,
-            description: "Coal Field token: #{@game.get_location_name(target.id)}",
+            description: "Warrior Coal Field token: #{target_location}",
             hexes: [target.id],
             amount: 10
           )
@@ -31,6 +32,11 @@ module Engine
             .hexes
             .select { |hex| hexes.include?(hex.name) }
             .each { |hex| hex.tile.icons = [] }
+
+          @log << "Warrior Coal Field token is placed in #{target_location} (#{target.id})"
+          # TODO: the following note can be removed when this can be done automatically
+          @log << "Note! It is not verified that #{company.owner.name} owns a train that can run to #{target_location}"
+          @log << "Please undo the assign of Warrior Coal Field token to #{target_location} if it is not legal"
         end
       end
     end

--- a/lib/engine/step/special_buy_train.rb
+++ b/lib/engine/step/special_buy_train.rb
@@ -25,12 +25,15 @@ module Engine
         from_depot = action.train.from_depot?
         buy_train_action(action, corporation)
 
-        @round.trains_bought << corporation if from_depot
+        @round.bought_trains << corporation if from_depot
 
         ability = ability(action.entity)
         ability.use! if action.price < action.train.price &&
           ability.discounted_price(action.train, action.train.price) == action.price
-        action.entity.close! if ability.count.zero?
+        begin
+          action.entity.close!
+          @log << "#{action.entity.name} closes due to use of discount to buy train"
+        end if ability.count.zero?
 
         pass! unless can_buy_train?(corporation)
       end

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -155,6 +155,8 @@ describe 'Assets' do
       ['1846', 3099, 48, 'lay_track_or_token', '1846: Operating Round 1.1 (of 2) - Place a Token or Lay Track'],
       ['1846', 3099, 53, 'issue_shares', '1846: Operating Round 1.1 (of 2) - Issue or Redeem Shares'],
       ['1846', 3099, nil, 'endgame', '1846: Operating Round 6.2 (of 2) - Game Over - Bank Broken'],
+      ['18_al', 4711, nil, 'endgame', '18AL: Operating Round 6.3 (of 3) - Game Over - Bank Broken'],
+      ['18_al', 4712, nil, 'endgame', '18AL: Operating Round 8.1 (of 3) - Game Over - Bank Broken'],
     ].freeze
 
     def render_game(jsonfile, no_actions, string)

--- a/spec/fixtures/18_al/4711.json
+++ b/spec/fixtures/18_al/4711.json
@@ -1,0 +1,5722 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 1,
+      "company": "TR",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 2,
+      "company": "SNAR",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 3,
+      "company": "BLC",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 4,
+      "company": "M&C",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 5,
+      "company": "NDY",
+      "price": 120
+    },
+    {
+      "type": "par",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 6,
+      "corporation": "WRA",
+      "share_price": "60,2,2"
+    },
+    {
+      "type": "par",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 7,
+      "corporation": "TAG",
+      "share_price": "60,2,2"
+    },
+    {
+      "type": "par",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 8,
+      "corporation": "L&N",
+      "share_price": "60,2,2"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 9,
+      "shares": [
+        "WRA_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 10,
+      "shares": [
+        "TAG_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 11,
+      "shares": [
+        "L&N_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 12,
+      "shares": [
+        "WRA_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 13,
+      "shares": [
+        "TAG_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 14,
+      "shares": [
+        "L&N_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 15,
+      "shares": [
+        "WRA_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 16,
+      "shares": [
+        "TAG_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 17,
+      "shares": [
+        "L&N_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 18,
+      "shares": [
+        "WRA_4"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 19,
+      "shares": [
+        "TAG_4"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 20,
+      "shares": [
+        "L&N_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 21
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 22
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 23
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 24,
+      "hex": "L5",
+      "tile": "5-0",
+      "rotation": 2
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 25
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 26,
+      "hex": "L5",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 27
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 28,
+      "hex": "L5",
+      "tile": "5-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 29
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 30,
+      "train": "2-0",
+      "price": 100
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 31,
+      "hex": "C6",
+      "tile": "58-0",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 32,
+      "train": "2-1",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 33
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 34,
+      "hex": "B3",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 35,
+      "train": "2-2",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 36
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 37
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 38
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 39
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 40,
+      "hex": "J5",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 41
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 42,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H5",
+              "J5",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 43,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 44,
+      "train": "2-3",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 45
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 46,
+      "hex": "F7",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 47,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 48,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 49,
+      "train": "2-4",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 50
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 51,
+      "hex": "C2",
+      "tile": "58-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 52,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "B1",
+              "C2"
+            ],
+            [
+              "A4",
+              "B3",
+              "C2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 53,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 54,
+      "train": "3-0",
+      "price": 180
+    },
+    {
+      "type": "buy_company",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 55,
+      "company": "SNAR",
+      "price": 20
+    },
+    {
+      "type": "buy_company",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 56,
+      "company": "NDY",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 57
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 58
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 59,
+      "shares": [
+        "TAG_5"
+      ]
+    },
+    {
+      "type": "undo",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 60
+    },
+    {
+      "type": "par",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 61,
+      "corporation": "ABC",
+      "share_price": "90,0,5"
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 62
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 63,
+      "shares": [
+        "ABC_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 64
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 65,
+      "shares": [
+        "ABC_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 66
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 67
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 68,
+      "shares": [
+        "ABC_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 69
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 70,
+      "shares": [
+        "ABC_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 71
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 72
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 73
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 74
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 75,
+      "hex": "G6",
+      "tile": "6-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 76
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 77,
+      "train": "3-1",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 78
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 79
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 80,
+      "hex": "L5",
+      "tile": "443a-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 81
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 82,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H5",
+              "J5",
+              "L5"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "K4",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 83,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 84,
+      "train": "3-2",
+      "price": 180
+    },
+    {
+      "type": "buy_company",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 85,
+      "company": "BLC",
+      "price": 35
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 86
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 87
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 88,
+      "hex": "H7",
+      "tile": "7-0",
+      "rotation": 3
+    },
+    {
+      "type": "buy_company",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 89,
+      "company": "M&C",
+      "price": 50
+    },
+    {
+      "type": "buy_company",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 90,
+      "company": "TR",
+      "price": 10
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 91,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 92,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 93,
+      "train": "3-3",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 94
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 95,
+      "hex": "C4",
+      "tile": "4-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 96,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "B1",
+              "C2"
+            ],
+            [
+              "A4",
+              "B3",
+              "C2"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 97,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 98
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 99,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 100,
+      "train": "4-0",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 101
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 102,
+      "hex": "G4",
+      "tile": "441a-0",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 103,
+      "city": "441a-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 104,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 105,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 106,
+      "train": "4-1",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 107
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 108
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 109
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 110,
+      "hex": "M6",
+      "tile": "9-3",
+      "rotation": 2
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 111
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BLC",
+      "entity_type": "company",
+      "id": 112,
+      "hex": "N5",
+      "tile": "445-0",
+      "rotation": 3
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 113
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 114,
+      "hex": "N5",
+      "tile": "8-0",
+      "rotation": 3
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 115
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BLC",
+      "entity_type": "company",
+      "id": 116,
+      "hex": "N5",
+      "tile": "445-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 117,
+      "hex": "O6",
+      "tile": "4-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 118
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 119,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "L5",
+              "N5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 120,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 121,
+      "train": "4-2",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 122
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 123,
+      "hex": "E6",
+      "tile": "14-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 124,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 125,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 126
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 127,
+      "hex": "E4",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 128,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A4",
+              "B3",
+              "C2"
+            ],
+            [
+              "B1",
+              "C2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 129,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 130,
+      "train": "5-0",
+      "price": 225,
+      "ability": "train_discount"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 131
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 132,
+      "train": "5-0",
+      "price": 225,
+      "ability": "train_discount"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 133
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 134,
+      "train": "5-0",
+      "price": 225,
+      "ability": "train_discount"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 135
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 136
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 137
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 138
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 139
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 140
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 141
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 142
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 143
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 144
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 145
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 146
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 147
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 148
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 149
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 150
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 151
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 152
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 153
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 154
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 155
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 156
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 157
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 158,
+      "train": "4-0",
+      "price": 150,
+      "ability": "train_discount"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 159
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 160,
+      "train": "4-0",
+      "price": 150,
+      "ability": "train_discount"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 161
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 162,
+      "train": "4-0",
+      "price": 150,
+      "ability": "train_discount"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 163
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 164,
+      "train": "4-0",
+      "price": 150,
+      "ability": "train_discount"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 165
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 166,
+      "train": "4-0",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 167
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 168,
+      "hex": "G4",
+      "tile": "441a-0",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 169,
+      "city": "441a-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 170,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 171,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 172,
+      "train": "4-1",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 173
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BLC",
+      "entity_type": "company",
+      "id": 174,
+      "hex": "N5",
+      "tile": "445-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 175,
+      "hex": "O6",
+      "tile": "4-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 176
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 177,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "L5",
+              "N5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 178,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 179,
+      "train": "4-2",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 180
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 181,
+      "hex": "E6",
+      "tile": "14-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 182,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 183,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 184
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 185,
+      "hex": "E4",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 186,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "B1",
+              "C2"
+            ],
+            [
+              "A4",
+              "B3",
+              "C2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 187,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 188,
+      "train": "5-0",
+      "price": 225,
+      "ability": "train_discount"
+    },
+    {
+      "type": "discard_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 189,
+      "train": "3-0"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 190,
+      "shares": [
+        "L&N_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 191
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 192,
+      "shares": [
+        "ABC_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 193
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 194,
+      "shares": [
+        "TAG_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 195
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 196,
+      "shares": [
+        "L&N_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 197
+    },
+    {
+      "type": "undo",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 198
+    },
+    {
+      "type": "undo",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 199
+    },
+    {
+      "type": "undo",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 200
+    },
+    {
+      "type": "undo",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 201
+    },
+    {
+      "type": "undo",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 202
+    },
+    {
+      "type": "undo",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 203
+    },
+    {
+      "type": "undo",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 204
+    },
+    {
+      "type": "undo",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 205
+    },
+    {
+      "type": "undo",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 206
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 207
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 208
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 209,
+      "shares": [
+        "ABC_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 210
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 211,
+      "shares": [
+        "ABC_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 212
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 213,
+      "shares": [
+        "TAG_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 214
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 215,
+      "shares": [
+        "ABC_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 216
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 217,
+      "shares": [
+        "ABC_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 218
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 219
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 220
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 221
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 222,
+      "hex": "G4",
+      "tile": "442a-0",
+      "rotation": 1
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 223
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 224,
+      "hex": "H7",
+      "tile": "28-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 225,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "L5",
+              "N5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 226,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 227
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 228,
+      "hex": "K4",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 229
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 230
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 231
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 232,
+      "hex": "G6",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 233,
+      "city": "14-1-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 234,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "L5",
+              "N5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 235,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 236
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 237,
+      "hex": "F5",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 238,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 239,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 240
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 241,
+      "hex": "G4",
+      "tile": "442a-0",
+      "rotation": 1
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 242,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 243
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 244,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 245
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 246,
+      "city": "442a-0-0",
+      "slot": 1
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 247
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 248,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 249
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 250
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 251,
+      "hex": "G4",
+      "tile": "442a-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 252,
+      "city": "H5-0-0",
+      "slot": 0
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 253,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 254
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 255
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 256,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 257
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 258
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 259,
+      "hex": "G4",
+      "tile": "442a-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 260,
+      "city": "H5-0-0",
+      "slot": 0
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 261,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 262
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 263
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 264,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 265,
+      "city": "H5-0-0",
+      "slot": 0
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 266
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 267
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 268,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 269
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 270
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 271,
+      "hex": "G4",
+      "tile": "442a-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 272,
+      "city": "H5-0-0",
+      "slot": 0
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 273
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 274,
+      "city": "442a-0-0",
+      "slot": 1
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 275,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 276,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 277,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 278
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 279
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 280
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 281,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 282,
+      "train": "5-0",
+      "price": 225,
+      "ability": "train_discount"
+    },
+    {
+      "type": "discard_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 283,
+      "train": "3-0"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 284,
+      "hex": "G4",
+      "tile": "444b-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 285,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "L5",
+              "N5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 286,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 287,
+      "hex": "L5",
+      "tile": "444m-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 288
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 289,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 290,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 291,
+      "hex": "E6",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 292,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 293,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 294,
+      "train": "5-1",
+      "price": 450
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 295,
+      "hex": "H3",
+      "tile": "6-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 296
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 297,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 298,
+      "kind": "payout"
+    },
+    {
+      "type": "par",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 299,
+      "corporation": "ATN",
+      "share_price": "90,0,5"
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 300
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 301,
+      "shares": [
+        "L&N_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 302
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 303,
+      "shares": [
+        "L&N_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 304
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 305,
+      "shares": [
+        "ATN_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 306
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 307,
+      "shares": [
+        "L&N_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 308
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 309,
+      "shares": [
+        "L&N_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 310
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 311,
+      "shares": [
+        "ATN_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 312
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 313
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 314
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 315,
+      "shares": [
+        "ATN_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 316
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 317
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 318
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 319
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 320
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 321,
+      "shares": [
+        "ATN_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 322
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 323
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 324
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 325
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 326,
+      "hex": "G6",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 327,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 328,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 329,
+      "hex": "H1",
+      "tile": "9-5",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 330
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 331,
+      "hex": "H3",
+      "tile": "15-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 332
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 333,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 334,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 335,
+      "hex": "K4",
+      "tile": "15-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 336
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 337,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 338,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 339,
+      "hex": "H7",
+      "tile": "70-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 340,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ]
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E6",
+              "G6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 341,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 342,
+      "hex": "K4",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 343
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 344,
+      "hex": "K4",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 345,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 346,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 347,
+      "hex": "J1",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 348,
+      "city": "L1-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 349,
+      "train": "6-0",
+      "price": 630
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 350
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 351,
+      "hex": "H3",
+      "tile": "63-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 352
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 353,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 354,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 355,
+      "hex": "I6",
+      "tile": "9-7",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 356
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 357,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 358,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 359
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 360,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 361,
+      "train": "7-0",
+      "price": 700
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 362
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 363,
+      "hex": "J5",
+      "tile": "20-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 364
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 365,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 366,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 367
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 368,
+      "hex": "F5",
+      "tile": "23-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 369,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 370,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 371,
+      "train": "4D-0",
+      "price": 800
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 372
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 373,
+      "hex": "J3",
+      "tile": "8-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 374
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 375,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "K4",
+              "J3",
+              "H3"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 376,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 377
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 378,
+      "hex": "G2",
+      "tile": "9-8",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 379,
+      "city": "63-3-0",
+      "slot": 1
+    },
+    {
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 380
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 381
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 382,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "K4",
+              "J3",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2",
+              "F1"
+            ],
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 383,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 384
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 385
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 386
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 387,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 388
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 389
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 390
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 391,
+      "hex": "O6",
+      "tile": "142-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 392
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 393,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 394,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 395
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 396,
+      "hex": "N7",
+      "tile": "9-9",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 397,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 398,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 399
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 400,
+      "shares": [
+        "TAG_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 401
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 402,
+      "shares": [
+        "WRA_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 403
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 404,
+      "shares": [
+        "WRA_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 405
+    },
+    {
+      "type": "par",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 406,
+      "corporation": "M&O",
+      "share_price": "105,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 407
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 408,
+      "shares": [
+        "WRA_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 409
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 410,
+      "shares": [
+        "WRA_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 411
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 412,
+      "shares": [
+        "M&O_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 413
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 414,
+      "shares": [
+        "M&O_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 415
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 416
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 417,
+      "shares": [
+        "M&O_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 418
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 419,
+      "shares": [
+        "M&O_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 420
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 421
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 422,
+      "shares": [
+        "M&O_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 423
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 424
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 425
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 426
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 427,
+      "hex": "L7",
+      "tile": "7-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 428,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 429,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 430
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 431,
+      "hex": "P1",
+      "tile": "8-1",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 432,
+      "train": "4D-1",
+      "price": 800
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 433
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 434,
+      "hex": "K8",
+      "tile": "8-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 435
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 436,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "K4",
+              "J3",
+              "H3"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 437,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 438
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 439,
+      "hex": "N1",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 440
+    },
+    {
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 441
+    },
+    {
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 442
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 443,
+      "hex": "I8",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 444
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 445,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K4",
+              "J3",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2",
+              "F1"
+            ],
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 446,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 447
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 448
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 449
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 450,
+      "hex": "L3",
+      "tile": "8-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 451
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 452,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 453,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 454
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 455
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 456
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 457,
+      "hex": "F7",
+      "tile": "23-1",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 458,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G6",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 459,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 460
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 461,
+      "hex": "K2",
+      "tile": "6-2",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 462
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 463,
+      "hex": "J5",
+      "tile": "47-0",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 464
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 465,
+      "hex": "I6",
+      "tile": "24-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 466,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 467,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 468
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 469,
+      "hex": "K2",
+      "tile": "6-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 470
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 471,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "K4",
+              "J3",
+              "H3"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 472,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 473
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 474,
+      "hex": "N1",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 475,
+      "city": "63-2-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 476,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 477,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 478
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 479,
+      "hex": "J5",
+      "tile": "47-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 480
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 481,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 482,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 483
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 484,
+      "hex": "K2",
+      "tile": "15-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 485
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 486,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 487,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 488
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 489,
+      "hex": "K2",
+      "tile": "63-4",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 490,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G6",
+              "H7",
+              "I6",
+              "J5",
+              "K4"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 491,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 492
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 493,
+      "hex": "G4",
+      "tile": "446-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 494,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G8",
+              "H7",
+              "F7",
+              "D7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 495,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 496
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 497,
+      "hex": "I4",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 498
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 499,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "K4",
+              "J3",
+              "H3"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 500,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 501
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 502,
+      "hex": "P3",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 503
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 504,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 505,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 506
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 507,
+      "hex": "M4",
+      "tile": "8-5",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 508
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 509,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 510,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 511
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 512,
+      "hex": "N3",
+      "tile": "8-6",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 513,
+      "city": "446-0-0",
+      "slot": 2
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 514
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 515
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 516,
+      "hex": "N3",
+      "tile": "8-6",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 517,
+      "city": "63-3-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 518,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "Q2",
+              "P3",
+              "N3",
+              "M4",
+              "K4"
+            ],
+            [
+              "K4",
+              "J3",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 519,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 520
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 521
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 522,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G8",
+              "I8",
+              "K8",
+              "L7",
+              "M8"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G4",
+              "I4",
+              "K4"
+            ],
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 523,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 524
+    }
+  ],
+  "id": "4711",
+  "players": [
+    {
+      "name": "Adam"
+    },
+    {
+      "name": "Bertil"
+    },
+    {
+      "name": "Cecilia"
+    }
+  ],
+  "title": "18AL",
+  "description": "Game End in OR 8.1 due to bank break in that OR",
+  "max_players": "3",
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2020-07-19",
+  "loaded": true,
+  "result": {
+    "Bertil": 4874,
+    "Cecilia": 4435,
+    "Adam": 4209
+  }
+}

--- a/spec/fixtures/18_al/4712.json
+++ b/spec/fixtures/18_al/4712.json
@@ -1,0 +1,6211 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 1,
+      "company": "TR",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 2,
+      "company": "SNAR",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 3,
+      "company": "BLC",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 4,
+      "company": "M&C",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 5,
+      "company": "NDY",
+      "price": 120
+    },
+    {
+      "type": "par",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 6,
+      "corporation": "WRA",
+      "share_price": "60,2,2"
+    },
+    {
+      "type": "par",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 7,
+      "corporation": "ABC",
+      "share_price": "60,2,2"
+    },
+    {
+      "type": "par",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 8,
+      "corporation": "ATN",
+      "share_price": "60,2,2"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 9,
+      "shares": [
+        "WRA_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 10,
+      "shares": [
+        "ABC_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 11,
+      "shares": [
+        "ATN_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 12,
+      "shares": [
+        "WRA_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 13,
+      "shares": [
+        "ABC_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 14,
+      "shares": [
+        "ATN_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 15,
+      "shares": [
+        "WRA_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 16,
+      "shares": [
+        "ABC_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 17,
+      "shares": [
+        "ATN_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 18,
+      "shares": [
+        "WRA_4"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 19,
+      "shares": [
+        "ABC_4"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 20,
+      "shares": [
+        "ATN_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 21
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 22
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 23
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 24,
+      "hex": "L5",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 25
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 26,
+      "train": "2-0",
+      "price": 100
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 27,
+      "hex": "G6",
+      "tile": "6-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 28
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 29,
+      "train": "2-1",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 30
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 31,
+      "hex": "H1",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 32,
+      "train": "2-2",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 33
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 34
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 35
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 36
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 37,
+      "hex": "M6",
+      "tile": "8-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 38
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 39,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "K4",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 40,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 41,
+      "train": "2-3",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 42
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 43,
+      "hex": "H7",
+      "tile": "8-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 44
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 45,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 46,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 47,
+      "train": "2-4",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 48
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 49,
+      "hex": "J1",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 50
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 51,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 52,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 53,
+      "train": "3-0",
+      "price": 180
+    },
+    {
+      "type": "buy_company",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 54,
+      "company": "NDY",
+      "price": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 55,
+      "company": "SNAR",
+      "price": 60
+    },
+    {
+      "id": 56,
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 57,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 58
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 59
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 60
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 61
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 62
+    },
+    {
+      "id": 63,
+      "hex": "L7",
+      "tile": "8-2",
+      "type": "lay_tile",
+      "entity": "WRA",
+      "rotation": 1,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 64,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 65,
+      "hex": "L7",
+      "tile": "8-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 66
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 67,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "K4",
+              "L5"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "L5",
+              "M6",
+              "L7",
+              "M8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 68,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 69,
+      "train": "3-1",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 70
+    },
+    {
+      "type": "buy_company",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 71,
+      "company": "BLC",
+      "price": 105
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 72
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 73,
+      "hex": "G6",
+      "tile": "14-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 74
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 75,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 76,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 77,
+      "train": "3-2",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 78
+    },
+    {
+      "type": "buy_company",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 79,
+      "company": "TR",
+      "price": 30
+    },
+    {
+      "type": "buy_company",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 80,
+      "company": "M&C",
+      "price": 150
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 81,
+      "hex": "K2",
+      "tile": "6-1",
+      "rotation": 5
+    },
+    {
+      "id": 82,
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 83,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "place_token",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 84,
+      "city": "6-1-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 85,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 86,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 87
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 88,
+      "hex": "L5",
+      "tile": "443a-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 89
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 90,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "K4",
+              "L5"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 91,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BLC",
+      "entity_type": "company",
+      "id": 92,
+      "hex": "G2",
+      "tile": "445-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 93
+    },
+    {
+      "id": 94,
+      "hex": "G4",
+      "tile": "441a-0",
+      "type": "lay_tile",
+      "entity": "ABC",
+      "rotation": 5,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 95,
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 96,
+      "hex": "G4",
+      "tile": "441a-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 97,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 98,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 99
+    },
+    {
+      "id": 100,
+      "hex": "L3",
+      "tile": "8-3",
+      "type": "lay_tile",
+      "entity": "ATN",
+      "rotation": 0,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 101,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 102,
+      "hex": "L3",
+      "tile": "8-3",
+      "type": "lay_tile",
+      "entity": "ATN",
+      "rotation": 2,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 103,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 104,
+      "hex": "F3",
+      "tile": "8-3",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 105
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 106,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 107,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 108
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 109
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 110
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 111
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 112,
+      "hex": "J5",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 113
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 114,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "K4",
+              "L5"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 115,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 116
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 117,
+      "hex": "G4",
+      "tile": "442a-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 118,
+      "city": "442a-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 119,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G2",
+              "F3",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 120,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 121
+    },
+    {
+      "id": 122,
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 123,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 124,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "G4",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 125,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 126,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "E6",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 127,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 128,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "E6",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 129,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 130,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "G4",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 131,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 132,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "G6",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 133,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 134,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "G4",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 135,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 136,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "H5",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 137,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 138,
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "G6",
+      "entity_type": "company",
+      "target_type": "hex"
+    },
+    {
+      "id": 139,
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 140,
+      "target": "G4",
+      "target_type": "hex"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 141,
+      "hex": "F5",
+      "tile": "8-4",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 142
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 143,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "F1",
+              "G2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 144,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 145
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 146,
+      "hex": "L3",
+      "tile": "8-5",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 147
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 148,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "K4",
+              "L5"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 149,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 150
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 151,
+      "hex": "I4",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 152,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G2",
+              "F3",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 153,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 154
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 155,
+      "hex": "K2",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 156
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 157,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "F1",
+              "G2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 158,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 159
+    },
+    {
+      "type": "par",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 160,
+      "corporation": "L&N",
+      "share_price": "75,1,4"
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 161
+    },
+    {
+      "type": "par",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 162,
+      "corporation": "M&O",
+      "share_price": "105,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 163
+    },
+    {
+      "type": "par",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 164,
+      "corporation": "TAG",
+      "share_price": "75,1,4"
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 165
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 166,
+      "shares": [
+        "L&N_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 167
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 168,
+      "shares": [
+        "M&O_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 169
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 170,
+      "shares": [
+        "TAG_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 171
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 172,
+      "shares": [
+        "L&N_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 173
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 174,
+      "shares": [
+        "M&O_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 175
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 176,
+      "shares": [
+        "TAG_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 177
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 178,
+      "shares": [
+        "L&N_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 179
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 180,
+      "shares": [
+        "M&O_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 181
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 182,
+      "shares": [
+        "TAG_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 183
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 184,
+      "shares": [
+        "L&N_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 185
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 186,
+      "shares": [
+        "M&O_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 187
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 188,
+      "shares": [
+        "TAG_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 189
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 190,
+      "shares": [
+        "ATN_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 191
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 192
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 193,
+      "shares": [
+        "WRA_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 194
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 195
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 196
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 197
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 198,
+      "hex": "P1",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 199,
+      "train": "3-3",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 200
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 201,
+      "hex": "B3",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 202,
+      "train": "4-0",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 203
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 204,
+      "hex": "C6",
+      "tile": "58-0",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 205,
+      "train": "4-1",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 206
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 207,
+      "hex": "K4",
+      "tile": "15-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 208
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 209,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 210,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 211
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 212,
+      "hex": "I4",
+      "tile": "23-0",
+      "rotation": 3
+    },
+    {
+      "id": 213,
+      "type": "run_routes",
+      "entity": "ABC",
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation"
+    },
+    {
+      "id": 214,
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 215,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 216,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 217
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 218,
+      "hex": "J3",
+      "tile": "9-5",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 219
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 220,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "F1",
+              "G2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 221,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 222
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 223,
+      "hex": "N1",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 224,
+      "city": "14-1-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 225,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 226,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 227,
+      "train": "4-2",
+      "price": 300
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 228,
+      "train": "5-0",
+      "price": 450
+    },
+    {
+      "type": "discard_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 229,
+      "train": "3-3"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 230,
+      "hex": "C2",
+      "tile": "58-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 231,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A4",
+              "B3",
+              "C2"
+            ],
+            [
+              "B1",
+              "C2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 232,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 233,
+      "train": "3-3",
+      "price": 180
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 234,
+      "hex": "F7",
+      "tile": "8-7",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 235
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 236,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 237,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 238
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 239,
+      "hex": "E6",
+      "tile": "15-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 240
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 241,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 242,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 243,
+      "train": "5-1",
+      "price": 450
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 244,
+      "hex": "J3",
+      "tile": "27-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 245,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 246,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 247,
+      "train": "6-0",
+      "price": 630
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 248
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 249,
+      "hex": "G4",
+      "tile": "444b-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 250
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 251,
+      "train": "7-0",
+      "price": 700
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 252
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 253,
+      "shares": [
+        "ABC_1",
+        "ABC_2",
+        "ABC_3",
+        "ABC_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 254
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 255,
+      "shares": [
+        "TAG_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 256,
+      "shares": [
+        "ABC_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 257
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 258
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 259,
+      "shares": [
+        "ABC_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 260
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 261
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 262,
+      "shares": [
+        "ABC_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 263
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 264
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 265
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 266
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 267,
+      "hex": "E4",
+      "tile": "9-7",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 268
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 269,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 270,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 271
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 272,
+      "hex": "F5",
+      "tile": "23-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 273
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 274,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "B7",
+              "C6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 275,
+      "kind": "payout"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 276,
+      "shares": [
+        "WRA_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 277,
+      "shares": [
+        "TAG_2",
+        "TAG_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 278,
+      "shares": [
+        "ATN_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 279,
+      "train": "4D-0",
+      "price": 800
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 280,
+      "hex": "C4",
+      "tile": "4-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 281
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 282,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "E4",
+              "C4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 283,
+      "kind": "withhold"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 284,
+      "shares": [
+        "WRA_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 285,
+      "shares": [
+        "ATN_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 286,
+      "shares": [
+        "L&N_1",
+        "L&N_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 287,
+      "train": "4D-1",
+      "price": 800
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 288,
+      "hex": "G4",
+      "tile": "446-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 289,
+      "city": "15-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 290,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "K4",
+              "J3",
+              "I4",
+              "G4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 291,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 292
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 293,
+      "hex": "L5",
+      "tile": "444m-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 294,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 295,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 296
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 297,
+      "hex": "G6",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 298,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "K4",
+              "J3",
+              "I4",
+              "G4"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 299,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 300
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 301,
+      "hex": "N7",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 302
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 303,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 304,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 305
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 306,
+      "hex": "E6",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 307,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 308,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 309
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 310,
+      "hex": "O6",
+      "tile": "3-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 311
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 312,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "K4",
+              "J3",
+              "I4",
+              "G4"
+            ],
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 313,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 314
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 315,
+      "hex": "K2",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 316,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 317,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 318
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 319,
+      "hex": "K4",
+      "tile": "63-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 320,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 321,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 322
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 323,
+      "hex": "I6",
+      "tile": "9-9",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 324,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 325,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 326
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 327,
+      "hex": "K6",
+      "tile": "8-8",
+      "rotation": 1
+    },
+    {
+      "id": 328,
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 329,
+      "type": "undo",
+      "entity": "M&O",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "place_token",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 330,
+      "city": "446-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 331,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G6",
+              "I6",
+              "K6",
+              "L5"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 332,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 333
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 334,
+      "hex": "F7",
+      "tile": "23-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 335
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 336,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 337,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 338
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 339,
+      "hex": "H7",
+      "tile": "28-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 340
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 341,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 342,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 343
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 344
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 345
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 346,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G6",
+              "H7",
+              "G8"
+            ],
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 347,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 348
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 349
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 350
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 351,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 352,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 353
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 354
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 355,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 356,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 357
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 358,
+      "shares": [
+        "L&N_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 359
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 360,
+      "shares": [
+        "L&N_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 361
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 362,
+      "shares": [
+        "L&N_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 363
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 364,
+      "shares": [
+        "L&N_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 365
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 366,
+      "shares": [
+        "L&N_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 367
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 368,
+      "shares": [
+        "L&N_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 369
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 370,
+      "shares": [
+        "TAG_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 371
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 372,
+      "shares": [
+        "TAG_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 373
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 374,
+      "shares": [
+        "TAG_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 375
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 376,
+      "shares": [
+        "TAG_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 377
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 378,
+      "shares": [
+        "TAG_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 379
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 380,
+      "shares": [
+        "TAG_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 381
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 382,
+      "shares": [
+        "TAG_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 383
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 384,
+      "shares": [
+        "ATN_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 385
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 386,
+      "shares": [
+        "ATN_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 387
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 388,
+      "shares": [
+        "ATN_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 389
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 390,
+      "shares": [
+        "ATN_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 391
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 392,
+      "shares": [
+        "ATN_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 393
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 394,
+      "shares": [
+        "ABC_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 395
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 396,
+      "shares": [
+        "ABC_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 397
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 398,
+      "shares": [
+        "ABC_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 399
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 400,
+      "shares": [
+        "ABC_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 401
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 402,
+      "shares": [
+        "ABC_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 403
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 404,
+      "shares": [
+        "ABC_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 405
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 406,
+      "shares": [
+        "ABC_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 407
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 408,
+      "shares": [
+        "M&O_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 409
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 410,
+      "shares": [
+        "WRA_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 411
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 412,
+      "shares": [
+        "M&O_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 413
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 414,
+      "shares": [
+        "WRA_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 415
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 416,
+      "shares": [
+        "WRA_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 417
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 418,
+      "shares": [
+        "M&O_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 419
+    },
+    {
+      "id": 420,
+      "type": "sell_shares",
+      "entity": "Bertil",
+      "shares": [
+        "M&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "player"
+    },
+    {
+      "id": 421,
+      "type": "undo",
+      "entity": "Bertil",
+      "entity_type": "player"
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 422
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 423,
+      "shares": [
+        "WRA_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 424
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 425,
+      "shares": [
+        "M&O_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 426
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 427
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 428,
+      "shares": [
+        "WRA_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 429
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 430
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 431
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 432
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 433
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 434,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G6",
+              "I6",
+              "K6",
+              "L5"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 435,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 436
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 437
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 438
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 439,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 440,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 441
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 442
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 443
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 444,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 445,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 446
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 447
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 448
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 449,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G6",
+              "H7",
+              "G8"
+            ],
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 450,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 451
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 452
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 453
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 454,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 455,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 456
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 457
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 458,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 459,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 460
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 461
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 462,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G6",
+              "I6",
+              "K6",
+              "L5"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 463,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 464
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 465
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 466
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 467,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 468,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 469
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 470
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 471
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 472,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 473,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 474
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 475
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 476
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 477,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G6",
+              "H7",
+              "G8"
+            ],
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 478,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 479
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 480
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 481
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 482,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 483,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 484
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 485
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 486,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 487,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 488
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 489
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 490,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G6",
+              "I6",
+              "K6",
+              "L5"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 491,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 492
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 493
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 494
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 495,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 496,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 497
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 498
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 499
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 500,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 501,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 502
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 503
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 504
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 505,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G6",
+              "H7",
+              "G8"
+            ],
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 506,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 507
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 508
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 509
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 510,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 511,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 512
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 513
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 514,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 515
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 516
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 517
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 518
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 519
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 520
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 521
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 522,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 523,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 524
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 525
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 526,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "E6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 527,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 528
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 529,
+      "shares": [
+        "TAG_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 530,
+      "shares": [
+        "ATN_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 531,
+      "shares": [
+        "M&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 532,
+      "shares": [
+        "ABC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 533
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 534,
+      "shares": [
+        "M&O_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 535,
+      "shares": [
+        "WRA_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 536
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 537,
+      "shares": [
+        "ABC_3",
+        "ABC_7"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 538,
+      "shares": [
+        "ATN_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 539
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 540
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 541
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 542
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 543
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 544,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "G6",
+              "I6",
+              "K6",
+              "L5"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 545,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 546
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 547
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 548
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 549,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "G2",
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G6",
+              "F7",
+              "D7"
+            ],
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 550,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 551
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 552
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 553
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 554,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 555,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 556
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 557
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 558
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 559,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G6",
+              "H7",
+              "G8"
+            ],
+            [
+              "G4",
+              "F5",
+              "G6"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 560,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 561
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 562
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 563
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 564,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 565,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 566
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 567
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 568,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D7",
+              "F7",
+              "H7",
+              "G8"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K4"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "M8",
+              "L7",
+              "M6",
+              "L5"
+            ],
+            [
+              "M8",
+              "N7",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 569,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 570
+    }
+  ],
+  "id": "4712",
+  "players": [
+    {
+      "id": 7,
+      "name": "Cecilia"
+    },
+    {
+      "id": 5,
+      "name": "Adam"
+    },
+    {
+      "id": 6,
+      "name": "Bertil"
+    }
+  ],
+  "title": "18AL",
+  "description": "Game End in OR 6.3 due to bank break in OR 6.3",
+  "max_players": 3,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 2.385742159307854e+38
+  },
+  "turn": 7,
+  "round": "Operating Round",
+  "acting": [],
+  "result": {
+    "Adam": 5780,
+    "Cecilia": 5116,
+    "Bertil": 4718
+  },
+  "loaded": true,
+  "created_at": "2020-07-31",
+  "updated_at": 1595977620,
+  "mode": "hotseat"
+}

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -126,6 +126,18 @@ module Engine
         'ryu' => 2260,
       },
     },
+    GAMES_BY_TITLE['18AL'] => {
+      4711 => {
+        'Bertil' => 4874,
+        'Cecilia' => 4435,
+        'Adam' => 4209,
+      },
+      4712 => {
+        'Adam' => 5780,
+        'Cecilia' => 5116,
+        'Bertil' => 4718,
+      },
+    },
   }.freeze
 
   TEST_CASES.each do |game, results|


### PR DESCRIPTION
Contains 18AL related stuff:
- Put in alpha
- Fix bug and add log text for closing company in special_buy_train
- Improve log text when assigning Warrior Coal Field token
- Add fixtures  (2 bank broke games, one with full set and one that ends in OR 8.1)

fixes #961 961