### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+Please describe your idea and why we should consider it.

--- a/.github/ISSUE_TEMPLATE/game_related_issue.md
+++ b/.github/ISSUE_TEMPLATE/game_related_issue.md
@@ -1,0 +1,19 @@
+---
+name: Game-related issue
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Please provide**
+* Issue title including game title and concise description, e.g. [18Chesapeake]: C-P Private usable out of operating order
+* Multiplayer? Link to the game with action number: Game tab -> History, press < to go to the previous action, copy the link and paste here, e.g. https://www.18xx.games/game/4011?action=173
+* Hotseat? JSON: Tools -> Copy Game Data -> Create public gist on https://gist.github.com/ and paste link here, e.g. https://gist.github.com/username/07f4d5a2178...
+
+It really helps us having a sample game to reproduce the issue.
+
+**Describe the bug**
+A clear and concise description of what the bug is. Include steps to reproduce the behavior. If applicable, add screenshots to help explain your problem.
+e.g. In OR 2.1 B&O ran a 3 train from A to B to C. Revenue was $80 instead of $100.

--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -1,0 +1,15 @@
+---
+name: General issue
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is. Include steps to reproduce the behavior. If applicable, add screenshots to help explain your problem.
+
+**Please provide details about your system**
+ - OS [e.g. iOS13, Win10] & Device [e.g. iPhone XS]
+ - Browser & Version [e.g. Chrome 83]


### PR DESCRIPTION
"about" could need some differentiation.
Maybe labels "game" and "general" ("issue"?), with "game" to be changed into "18..." by mod and "bug" applied once confirmed. (Afaik there’s no way for issue creators to add a label.)
Wording might be off in some places, please check.

PS: There’s always an option to open an issue without using a template.