### PR TITLE
Show wiki page as game info link if such exists (#1251)

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -44,6 +44,10 @@ module View
           children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_RULES_URL } }, 'Rules')])
         end
 
+        if @game.class::GAME_INFO_URL
+          children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_INFO_URL } }, 'More info')])
+        end
+
         children
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -42,6 +42,7 @@ module Engine
       GAME_RULES_URL = nil
       GAME_DESIGNER = nil
       GAME_PUBLISHER = nil
+      GAME_INFO_URL = nil
 
       # Game end check is described as a dictionary
       # with reason => after

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -33,6 +33,7 @@ module Engine
       GAME_RULES_URL = 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view'
       GAME_DESIGNER = 'Craig Bartell, Tim Flowers'
       GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817'
     end
   end
 end

--- a/lib/engine/game/g_1836_jr30.rb
+++ b/lib/engine/game/g_1836_jr30.rb
@@ -12,6 +12,7 @@ module Engine
       GAME_LOCATION = 'Netherlands'
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/114572/1836jr-30-rules'
       GAME_DESIGNER = 'David G. D. Hecht'
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1836Jr-30'
 
       SELL_BUY_ORDER = :sell_buy_sell
       TRACK_RESTRICTION = :permissive

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -25,6 +25,7 @@ module Engine
       GAME_RULES_URL = 'https://s3-us-west-2.amazonaws.com/gmtwebsiteassets/1846/1846-RULES-GMT.pdf'
       GAME_DESIGNER = 'Thomas Lehmann'
       GAME_PUBLISHER = Publisher::INFO[:gmt_games]
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1846'
 
       POOL_SHARE_DROP = :one
       SELL_AFTER = :p_any_operate

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -24,6 +24,7 @@ module Engine
       GAME_RULES_URL = 'https://boardgamegeek.com/thread/2389239/article/35386441#35386441'
       GAME_DESIGNER = 'Marc Voyer'
       GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1882'
 
       SELL_BUY_ORDER = :sell_buy_sell
       TRACK_RESTRICTION = :permissive

--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -22,6 +22,7 @@ module Engine
       GAME_RULES_URL = 'http://dl.deepthoughtgames.com/1889-Rules.pdf'
       GAME_DESIGNER = 'Yasutaka Ikeda (池田 康隆)'
       GAME_PUBLISHER = Publisher::INFO[:grand_trunk_games]
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1889'
 
       EBUY_PRES_SWAP = false # allow presidential swaps of other corps when ebuying
       EBUY_OTHER_VALUE = false # allow ebuying other corp trains for up to face

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -17,6 +17,8 @@ module Engine
       GAME_LOCATION = 'Alabama, USA'
       GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
       GAME_DESIGNER = 'Mark Derrick'
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18AL'
+
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(

--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -22,6 +22,7 @@ module Engine
       GAME_RULES_URL = 'https://www.dropbox.com/s/x0dsehrxqr1tl6w/18Chesapeake_Rules.pdf'
       GAME_DESIGNER = 'Scott Petersen'
       GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
 
       SELL_BUY_ORDER = :sell_buy
 


### PR DESCRIPTION
If the GAME_INFO_URL is set, do show that as a link under
Game Info part of the Info page. Do not show any other Game
Info parts.