### PR TITLE
Hide unaffordable par prices. 

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -48,6 +48,13 @@ module View
         unless @corporation.minor?
           children << render_shares
           children << h(Companies, owner: @corporation, game: @game) if @corporation.companies.any?
+          if @corporation.can_par?(@game.current_entity)
+            pars = @game.stock_market.par_prices.map do |pp|
+              pp.price if 2 * pp.price <= @game.current_entity.cash
+            end.compact.sort
+            div_content = pars.empty? ? 'Cannot afford to par' : "Par values: #{pars.join('/')}"
+            children << h('div.center', div_content)
+          end
         end
 
         abilities_to_display = @corporation.all_abilities.select do |ability|

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -48,13 +48,6 @@ module View
         unless @corporation.minor?
           children << render_shares
           children << h(Companies, owner: @corporation, game: @game) if @corporation.companies.any?
-          if @corporation.can_par?(@game.current_entity)
-            pars = @game.stock_market.par_prices.map do |pp|
-              pp.price if 2 * pp.price <= @game.current_entity.cash
-            end.compact.sort
-            div_content = pars.empty? ? 'Cannot afford to par' : "Par values: #{pars.join('/')}"
-            children << h('div.center', div_content)
-          end
         end
 
         abilities_to_display = @corporation.all_abilities.select do |ability|

--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -13,6 +13,8 @@ module View
         return h(:div, 'Cannot Par') unless @corporation.can_par?(@game.current_entity)
 
         par_values = @game.stock_market.par_prices.map do |share_price|
+          next unless share_price.price * 2 <= @game.current_entity.cash
+
           par = lambda do
             process_action(Engine::Action::Par.new(
               @game.current_entity,
@@ -29,13 +31,13 @@ module View
             on: { click: par },
           }
           h('button.small.par_price', props, @game.format_currency(share_price.price))
-        end
+        end.compact
 
         div_class = par_values.size < 5 ? '.inline' : ''
         h(:div, [
           h("div#{div_class}", { style: { marginTop: '0.5rem' } }, 'Par Price: '),
           *par_values.reverse,
-        ])
+        ]) unless par_values.empty?
       end
     end
   end

--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -12,9 +12,7 @@ module View
       def render
         return h(:div, 'Cannot Par') unless @corporation.can_par?(@game.current_entity)
 
-        par_values = @game.stock_market.par_prices.map do |share_price|
-          next unless share_price.price * 2 <= @game.current_entity.cash
-
+        par_buttons = @game.par_prices_for_entity.map do |share_price|
           par = lambda do
             process_action(Engine::Action::Par.new(
               @game.current_entity,
@@ -33,11 +31,11 @@ module View
           h('button.small.par_price', props, @game.format_currency(share_price.price))
         end.compact
 
-        div_class = par_values.size < 5 ? '.inline' : ''
+        div_class = par_buttons.size < 5 ? '.inline' : ''
         h(:div, [
           h("div#{div_class}", { style: { marginTop: '0.5rem' } }, 'Par Price: '),
-          *par_values.reverse,
-        ]) unless par_values.empty?
+          *par_buttons.reverse,
+        ]) unless par_buttons.empty?
       end
     end
   end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -36,6 +36,11 @@ module View
                           h('div.margined', 'Must sell stock: above 60% limit in corporation(s)')
                         end
           end
+          par_prices = @game.par_prices_for_entity.map(&:price)
+          par_label = h('div.inline.bold', 'Available par prices: ')
+          par_string = h('div.inline-block',
+                         par_prices.empty? ? 'Cannot afford to par' : par_prices.join('/'))
+          children << h('div.margined', [par_label, par_string])
           children += render_corporations
           children << h(Players, game: @game)
           children << h(StockMarket, game: @game)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1065,6 +1065,12 @@ module Engine
       def bankruptcy_limit_reached?
         @players.any?(&:bankrupt)
       end
+
+      def par_prices_for_entity(entity: current_entity)
+        @stock_market.par_prices.map do |p|
+          p if p.price * 2 <= entity.cash
+        end.compact.sort_by(&:price)
+      end
     end
   end
 end


### PR DESCRIPTION
The participants in the issue discussion concluded that it would be good to show the available par prices on the corporation card so they are visible without having to click on them. I did implement that, but to be honest I am somewhat ambivalent towards this choice. On the one hand, it is good to be able to see the par options at a glance. On the other hand, it's kind of the same information repeated in several places (unless there is some example of an 18xx game where available pars vary between corporations).

Fixes #671