### PR TITLE
Added styling to important log messages

### DIFF
--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -49,12 +49,12 @@ module View
       end
 
       lines = @log.map do |line|
+        line_props = { style: {} }
         if line.is_a?(String)
           if line.start_with?('--')
-            h('div.chatlog-important', line)
-          else
-            h(:div, line)
+            line_props[:style][:fontWeight] = 'bold'
           end
+          h(:div, line_props, line)
         elsif line.is_a?(Engine::Action::Message)
           h(:div, { style: { fontWeight: 'bold' } }, "#{line.entity.name}: #{line.message}")
         end

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -50,7 +50,11 @@ module View
 
       lines = @log.map do |line|
         if line.is_a?(String)
-          h(:div, line)
+          if line.start_with?('--')
+            h(:div, { style: { fontWeight: 'bold', color: 'green' } }, line)
+          else
+            h(:div, line)
+          end
         elsif line.is_a?(Engine::Action::Message)
           h(:div, { style: { fontWeight: 'bold' } }, "#{line.entity.name}: #{line.message}")
         end

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -51,7 +51,7 @@ module View
       lines = @log.map do |line|
         if line.is_a?(String)
           if line.start_with?('--')
-            h(:div, { style: { fontWeight: 'bold', color: 'green' } }, line)
+            h('div.chatlog-important', line)
           else
             h(:div, line)
           end

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -341,6 +341,18 @@ table.center {
 #chatlog {
   height: 200px;
 }
+.chatlog-important {
+  font-weight: bold;
+  border-top: dashed 1px #999;
+  border-bottom: dashed 1px #999;
+}
+.chatlog-important:not(:first-child) {
+  margin-top: 1em;
+}
+.chatlog-important + .chatlog-important {
+  border-top: none;
+  margin-top: 0;
+}
 @media only screen and (min-width: 900px) {
   #homepage #chatlog {
     height: 350px;

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -341,18 +341,6 @@ table.center {
 #chatlog {
   height: 200px;
 }
-.chatlog-important {
-  font-weight: bold;
-  border-top: dashed 1px #999;
-  border-bottom: dashed 1px #999;
-}
-.chatlog-important:not(:first-child) {
-  margin-top: 1em;
-}
-.chatlog-important + .chatlog-important {
-  border-top: none;
-  margin-top: 0;
-}
 @media only screen and (min-width: 900px) {
   #homepage #chatlog {
     height: 350px;


### PR DESCRIPTION
Similar to #1265 this is to very simply, for now, make it harder to miss the important automated log messages and make the overall log a bit easier to parse when looking through history. Admittedly a brittle solution, but simple enough for now and will work across games in history.