### PR TITLE
Add two bold texts, and improve phase status

### DIFF
--- a/lib/engine/config/game/g_1836_jr30.rb
+++ b/lib/engine/config/game/g_1836_jr30.rb
@@ -661,7 +661,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+         "can_buy_companies"
+      ]
     },
     {
       "name": "4",
@@ -672,7 +674,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+         "can_buy_companies"
+      ]
     },
     {
       "name": "5",

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -821,7 +821,9 @@ module Engine
         "yellow"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "2",
@@ -832,7 +834,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "3",

--- a/lib/engine/config/game/g_1882.rb
+++ b/lib/engine/config/game/g_1882.rb
@@ -706,7 +706,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "4",
@@ -717,7 +719,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "5",
@@ -729,7 +733,9 @@ module Engine
         "brown"
       ],
       "operating_rounds": 3,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "6",

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -602,7 +602,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "4",
@@ -613,7 +615,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "5",

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -697,7 +697,10 @@ module Engine
          "tiles":[
             "yellow"
          ],
-         "operating_rounds": 1
+         "operating_rounds": 1,
+         "status":[
+            "limited_train_buy"
+         ]
       },
       {
          "name":"3",
@@ -708,7 +711,8 @@ module Engine
             "green"
          ],
          "status":[
-            "can_buy_companies"
+            "can_buy_companies",
+            "limited_train_buy"
          ],
          "operating_rounds": 2
       },
@@ -721,7 +725,8 @@ module Engine
             "green"
          ],
          "status":[
-            "can_buy_companies"
+            "can_buy_companies",
+            "limited_train_buy"
          ],
          "operating_rounds": 2
       },

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -707,7 +707,9 @@ module Engine
             "yellow",
             "green"
          ],
-         "buy_companies":true,
+         "status":[
+            "can_buy_companies"
+         ],
          "operating_rounds": 2
       },
       {
@@ -718,7 +720,9 @@ module Engine
             "yellow",
             "green"
          ],
-         "buy_companies":true,
+         "status":[
+            "can_buy_companies"
+         ],
          "operating_rounds": 2
       },
       {

--- a/lib/engine/config/game/g_18_carolinas.rb
+++ b/lib/engine/config/game/g_18_carolinas.rb
@@ -484,7 +484,9 @@ module Engine
             "green"
          ],
          "operating_rounds":2,
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"4",
@@ -495,7 +497,9 @@ module Engine
             "green"
          ],
          "operating_rounds":2,
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"5",

--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -672,7 +672,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "4",
@@ -683,7 +685,9 @@ module Engine
         "green"
       ],
       "operating_rounds": 2,
-      "buy_companies": true
+      "status":[
+        "can_buy_companies"
+      ]
     },
     {
       "name": "5",

--- a/lib/engine/config/game/g_18_ga.rb
+++ b/lib/engine/config/game/g_18_ga.rb
@@ -573,7 +573,10 @@ module Engine
          "tiles":[
             "yellow"
          ],
-         "operating_rounds":1
+         "operating_rounds":1,
+         "status":[
+            "limited_train_buy"
+         ]
       },
       {
          "name":"3",
@@ -585,7 +588,8 @@ module Engine
          ],
          "operating_rounds":2,
          "status":[
-            "can_buy_companies"
+            "can_buy_companies",
+            "limited_train_buy"
          ]
       },
       {

--- a/lib/engine/config/game/g_18_ga.rb
+++ b/lib/engine/config/game/g_18_ga.rb
@@ -584,7 +584,9 @@ module Engine
             "green"
          ],
          "operating_rounds":2,
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"4",
@@ -595,7 +597,9 @@ module Engine
             "green"
          ],
          "operating_rounds":2,
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"5",

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -724,6 +724,9 @@ module Engine
          "train_limit":3,
          "tiles":[
             "yellow"
+         ],
+         "status":[
+            "limited_train_buy"
          ]
       },
       {
@@ -734,7 +737,8 @@ module Engine
             "green"
          ],
          "status":[
-            "can_buy_companies"
+            "can_buy_companies",
+            "limited_train_buy"
          ]
       },
       {

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -724,8 +724,7 @@ module Engine
          "train_limit":3,
          "tiles":[
             "yellow"
-         ],
-         "buy_companies":true
+         ]
       },
       {
          "name":"3",
@@ -734,7 +733,9 @@ module Engine
             "yellow",
             "green"
          ],
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"4",
@@ -743,7 +744,9 @@ module Engine
             "yellow",
             "green"
          ],
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"5",

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -480,7 +480,9 @@ module Engine
             "yellow"
          ],
          "operating_rounds":2,
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"3",
@@ -491,7 +493,9 @@ module Engine
             "green"
          ],
          "operating_rounds":2,
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"4",
@@ -502,7 +506,9 @@ module Engine
             "green"
          ],
          "operating_rounds":2,
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"5",

--- a/lib/engine/config/game/g_18_tn.rb
+++ b/lib/engine/config/game/g_18_tn.rb
@@ -579,6 +579,9 @@ module Engine
          "train_limit":4,
          "tiles":[
             "yellow"
+         ],
+         "status":[
+            {"type": "limited_train_buy"}
          ]
       },
       {
@@ -589,7 +592,8 @@ module Engine
             "green"
          ],
          "status":[
-            "can_buy_companies"
+            "can_buy_companies",
+            "limited_train_buy"
          ]
       },
       {

--- a/lib/engine/config/game/g_18_tn.rb
+++ b/lib/engine/config/game/g_18_tn.rb
@@ -588,7 +588,9 @@ module Engine
             "yellow",
             "green"
          ],
-         "buy_companies":true
+         "status":[
+            "can_buy_companies"
+         ]
       },
       {
          "name":"4",

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -563,7 +563,7 @@ module Engine
 
         @finished = true
         scores = result.map { |name, value| "#{name} (#{format_currency(value)})" }
-        @log << "Game over: #{scores.join(', ')}"
+        @log << "-- Game over: #{scores.join(', ')} --"
         @round
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -148,6 +148,9 @@ module Engine
       EVENTS_TEXT = { 'close_companies' =>
                       ['Companies Close', 'All companies unless otherwise noted are discarded from the game'] }.freeze
 
+      STATUS_TEXT = { 'can_buy_companies' =>
+                      ['Can Buy Companies', 'All corporations can buy companies from players'] }.freeze
+
       IPO_NAME = 'IPO'
 
       CACHABLE = [

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -25,6 +25,10 @@ module Engine
         'remove_tokens' => ['Remove Tokens', 'Warrior Coal Field token removed']
       ).freeze
 
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        Step::SingleDepotTrainBuyBeforePhase4::STATUS_TEXT
+      ).freeze
+
       ROUTE_BONUSES = %i[atlanta_birmingham mobile_nashville].freeze
 
       include CompanyPrice50To150Percent

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -14,6 +14,10 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        Step::SingleDepotTrainBuyBeforePhase4::STATUS_TEXT
+      ).freeze
+
       include CompanyPrice50To150Percent
 
       def setup

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -16,6 +16,10 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        Step::SingleDepotTrainBuyBeforePhase4::STATUS_TEXT
+      ).freeze
+
       include CompanyPrice50To150Percent
       include Revenue4D
       include TerminusCheck

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -14,6 +14,10 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        Step::SingleDepotTrainBuyBeforePhase4::STATUS_TEXT
+      ).freeze
+
       include CompanyPrice50To150Percent
 
       def setup

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -4,7 +4,7 @@ require_relative 'action/buy_train'
 
 module Engine
   class Phase
-    attr_reader :buy_companies, :name, :operating_rounds, :train_limit, :tiles, :phases
+    attr_reader :name, :operating_rounds, :train_limit, :tiles, :phases, :status
 
     def initialize(phases, game)
       @index = 0
@@ -41,10 +41,10 @@ module Engine
 
       @name = phase[:name]
       @operating_rounds = phase[:operating_rounds]
-      @buy_companies = !!phase[:buy_companies]
       @train_limit = phase[:train_limit]
       @tiles = Array(phase[:tiles])
       @events = phase[:events] || []
+      @status = phase[:status] || []
       @next_on = @phases[@index + 1]&.dig(:on)
 
       @log << "-- Phase #{@name.capitalize} " \

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -20,7 +20,7 @@ module Engine
         companies = @game.purchasable_companies
 
         entity == current_entity &&
-          @game.phase.buy_companies &&
+          @game.phase.status.include?('can_buy_companies') &&
           companies.any? &&
           companies.map(&:min_price).min <= entity.cash
       end

--- a/lib/engine/step/g_18_al/assign.rb
+++ b/lib/engine/step/g_18_al/assign.rb
@@ -12,9 +12,9 @@ module Engine
 
           target = action.target
           hexes = company.abilities(:assign_hexes)&.hexes
-          target_location = @game.get_location_name(target.id)
+          location = @game.get_location_name(target.id)
           if !@game.loading && @game.graph.reachable_hexes(company.owner).find { |h, _| h.id == target.id }.nil?
-            @game.game_error("#{target_location} is not reachable")
+            @game.game_error("#{location} is not reachable")
           end
 
           super
@@ -23,17 +23,17 @@ module Engine
           # that will be removed in phase 6
           ability = Engine::Ability::HexBonus.new(
             type: :hexes_bonus,
-            description: "Warrior Coal Field token: #{target_location}",
+            description: "Warrior Coal Field token: #{location}",
             hexes: [target.id],
             amount: 10
           )
           company.owner.add_ability(ability)
           @game.remove_mining_icons(hexes, exclude: target.id)
 
-          @log << "Warrior Coal Field token is placed in #{target_location} (#{target.id})"
+          @log << "Warrior Coal Field token is placed in #{location} (#{target.id})"
           # TODO: the following note can be removed when this can be done automatically
-          @log << "Note! It is not verified that #{company.owner.name} owns a train that can run to #{target_location}"
-          @log << "Please undo the assign of Warrior Coal Field token to #{target_location} if it is not legal"
+          @log << "-- Note! It is not verified that #{company.owner.name} owns a train that can run to #{location}"
+          @log << "-- Please undo the assign of Warrior Coal Field token to #{location} if it is not legal"
         end
       end
     end

--- a/lib/engine/step/single_depot_train_buy_before_phase4.rb
+++ b/lib/engine/step/single_depot_train_buy_before_phase4.rb
@@ -5,6 +5,10 @@ require_relative 'buy_train'
 module Engine
   module Step
     class SingleDepotTrainBuyBeforePhase4 < BuyTrain
+      STATUS_TEXT = {
+        'limited_train_buy' => ['Limited Train Buy', 'Corporations can only buy one train from the bank per OR'],
+      }.freeze
+
       def buyable_trains(entity)
         super.reject do |train|
           train.from_depot? &&


### PR DESCRIPTION
Applied bold text to Game over message, and one Note! in 18AL.

Made it possible to show phase status, like e.g. Limited Train Buy in 18AL. See picture.

![Screenshot from 2020-08-04 13-34-46](https://user-images.githubusercontent.com/2631151/89290792-b2e4e480-d659-11ea-8391-f9b9b1c9392f.png)
