### PR TITLE
Modify engine to use playerid->username hash for future modifications to allow players to rename themselves.

### DIFF
--- a/assets/app/mail/turn.rb
+++ b/assets/app/mail/turn.rb
@@ -11,7 +11,7 @@ class Turn < Snabberb::Component
 
   def render
     @game = Engine::GAMES_BY_TITLE[@game_data['title']].new(
-      @game_data['players'].map { |p| p['name'] },
+      @game_data['players'].map { |p| [p['id'], p['name']] }.to_h,
       id: @game_data['id'],
       actions: @game_data['actions'],
     )

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -52,8 +52,10 @@ module View
       return if game_id == @game&.id &&
         ((!cursor && @game.actions.size == @num_actions) || (cursor == @game.actions.size))
 
+      # Hotseat doesn't have player ids, use names instead.
+      players = @game_data['players'].map { |p| [p['id'] || p['name'], p['name']] }.to_h
       @game = Engine::GAMES_BY_TITLE[@game_data['title']].new(
-        @game_data['players'].map { |p| p['name'] },
+        players,
         id: game_id,
         actions: cursor ? actions.take(cursor) : actions,
         pin: @pin,

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -313,8 +313,15 @@ module Engine
         @finished = false
         @log = []
         @actions = []
-        @names = names.freeze
-        @players = @names.map { |name| Player.new(name) }
+        @names = if names.is_a?(Hash)
+                   names.freeze
+                 else
+                   names.map { |n| [n, n] }.to_h
+                 end
+
+        # This intentionally ignores player id for now until the database is migrated.
+        @players = @names.map { |_playerid, name| Player.new(name, name) }
+
         @optional_rules = init_optional_rules(optional_rules)
 
         @seed = @id.to_s.scan(/\d+/).first.to_i % RAND_M

--- a/lib/engine/player.rb
+++ b/lib/engine/player.rb
@@ -13,9 +13,10 @@ module Engine
     include Spender
 
     attr_accessor :bankrupt
-    attr_reader :name, :companies
+    attr_reader :name, :companies, :id
 
-    def initialize(name)
+    def initialize(id, name)
+      @id = id
       @name = name
       @cash = 0
       @companies = []
@@ -23,10 +24,6 @@ module Engine
 
     def value
       @cash + shares.select { |s| s.corporation.ipoed }.sum(&:price) + @companies.sum(&:value)
-    end
-
-    def id
-      @name
     end
 
     def owner

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -80,9 +80,11 @@ class Api
 
                 game.save
               else
+                players = users.map { |u| [u.id, u.name] }.to_h
                 engine = Engine::GAMES_BY_TITLE[game.title].new(
-                  users.map(&:name),
+                  players,
                   id: game.id,
+                  settings: game.settings,
                   actions: actions_h(game),
                 )
 
@@ -145,7 +147,8 @@ class Api
 
           # POST '/api/game/<game_id>/start
           r.is 'start' do
-            engine = Engine::GAMES_BY_TITLE[game.title].new(users.map(&:name), id: game.id)
+            players = users.map { |u| [u.id, u.name] }.to_h
+            engine = Engine::GAMES_BY_TITLE[game.title].new(players, id: game.id)
             unless game.players.size.between?(*Engine.player_range(engine.class))
               halt(400, 'Player count not supported')
             end


### PR DESCRIPTION
Step 1 for #1135

Engine now takes a hash of players id's to names. This is currently ignored but lays the foundation for future fixes.
This can go in now, and more changes can come later.

Next steps
1. Clean up parts of the UI that use id rather than name. (I've seen a few)
2. Write migration script
3. Modify user settings to use id rather than name
4. Add UI to change player names

One thing I've spotted is that player names are used in the game results, my solution to this is to rerun unpinned games with that player in and store the new result.