### PR TITLE
Remove the button, players can exchange via the abilities menu out of turn

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -97,13 +97,9 @@ module View
             @game.companies.each do |company|
               company.abilities(:exchange) do |ability|
                 next unless ability.corporation == @selected_corporation.name
+                next unless company.owner == @current_entity
 
-                prefix =
-                  if company.owner == @current_entity
-                    "Exchange #{company.sym} for "
-                  else
-                    "#{company.owner&.name} exchanges #{company.sym} for"
-                  end
+                prefix = "Exchange #{company.sym} for "
 
                 if ability.from.include?(:ipo) && @step.can_gain?(company.owner, ipo_share)
                   children << h(:button, { on: { click: -> { buy_share(company, ipo_share) } } },


### PR DESCRIPTION
fixes #430

Since we now have the abilities menu, this is no longer needed