### PR TITLE
allow complete set of upgradeable checks for special tile lay abilities

### DIFF
--- a/lib/engine/ability/tile_lay.rb
+++ b/lib/engine/ability/tile_lay.rb
@@ -5,13 +5,14 @@ require_relative 'base'
 module Engine
   module Ability
     class TileLay < Base
-      attr_reader :hexes, :tiles, :free, :discount
+      attr_reader :hexes, :tiles, :free, :discount, :special_lay
 
-      def setup(hexes:, tiles:, free: false, discount: nil)
+      def setup(hexes:, tiles:, free: false, discount: nil, special_lay: true)
         @hexes = hexes
         @tiles = tiles
         @free = free
         @discount = discount || 0
+        @special_lay = special_lay
       end
     end
   end

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -291,6 +291,7 @@ module Engine
               "295",
               "296"
             ],
+           "special_lay": false,
            "when":"track",
            "count": 1
         }

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -32,11 +32,12 @@ module Engine
       end
 
       def potential_tiles(entity, hex)
+        special_lay = ability(entity)&.special_lay.nil? || ability(entity)&.special_lay
         colors = @game.phase.tiles
         (ability(entity)&.tiles || [])
           .map { |name| @game.tiles.find { |t| t.name == name } }
           .compact
-          .select { |t| colors.include?(t.color) && hex.tile.upgrades_to?(t, true) }
+          .select { |t| colors.include?(t.color) && hex.tile.upgrades_to?(t, special_lay) }
       end
 
       def ability(entity)


### PR DESCRIPTION
By default, special tile lay abilities skip the check for matching labels and matching number of cities/towns. One consequence of this is that the LSL private ability in 1846 allows upgrading Cleveland to a non-Z city or Toledo to a Z-city. This PR introduces a parameter to the ability configuration which will restore the full set of checks. Setting this parameter for LSL prevents the illegal upgrade.

Fixes #1285 