### PR TITLE
18AL: Add support for buying companies between players

### DIFF
--- a/assets/app/view/game/buy_company_from_other_player.rb
+++ b/assets/app/view/game/buy_company_from_other_player.rb
@@ -25,9 +25,9 @@ module View
           size: max,
         })
         children = [input]
-        @game.round.active_step.purchasable_companies_from_others(@game.current_entity).each do |company|
+        @game.round.active_step.purchasable_companies(@game.current_entity).each do |company|
           children << render_company_buy(input, company)
-        end if @game.round.active_step.can_buy_any_company?(@game.current_entity)
+        end
         h(:div, props, children)
       end
 

--- a/assets/app/view/game/buy_company_from_other_player.rb
+++ b/assets/app/view/game/buy_company_from_other_player.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative 'actionable'
+
+module View
+  module Game
+    class BuyCompanyFromOtherPlayer < Snabberb::Component
+      include Actionable
+
+      def render
+        props = {
+          style: {
+            grid: '1fr / 5rem 4rem',
+            alignItems: 'center',
+            margin: '1rem 0 1.5rem 0',
+          },
+        }
+
+        max = @game.current_entity.cash.to_s.size
+        input = h(:input, style: { marginBottom: '0.5rem', marginRight: '1rem' }, props: {
+          value: 1,
+          type: 'number',
+          min: 1,
+          max: max,
+          size: max,
+        })
+        children = [input]
+        @game.round.active_step.purchasable_companies_from_others(@game.current_entity).each do |company|
+          children << render_company_buy(input, company)
+        end if @game.round.active_step.can_buy_any_company?(@game.current_entity)
+        h(:div, props, children)
+      end
+
+      private
+
+      def render_company_buy(input, company)
+        buy_company = lambda do
+          price = Native(input).elm.value.to_i
+          process_action(Engine::Action::BuyCompany.new(
+            @game.current_entity,
+            company: company,
+            price: price,
+          ))
+        end
+        h(:button, { on: { click: buy_company } }, "Buy #{company.id} from #{company.owner.name}")
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -46,14 +46,10 @@ module View
 
           children.concat(render_corporations)
           children << h(Players, game: @game)
-          children << h(BuyCompanyFromOtherPlayer, game: @game) if buy_any_company?
+          children << h(BuyCompanyFromOtherPlayer, game: @game) if @step.purchasable_companies(@current_entity).any?
           children << h(StockMarket, game: @game)
 
           h(:div, children)
-        end
-
-        def buy_any_company?
-          @step.can_buy_any_company?(@current_entity) && @step.purchasable_companies_from_others(@current_entity).any?
         end
 
         def render_corporations

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -46,9 +46,14 @@ module View
 
           children.concat(render_corporations)
           children << h(Players, game: @game)
+          children << h(BuyCompanyFromOtherPlayer, game: @game) if buy_any_company?
           children << h(StockMarket, game: @game)
 
           h(:div, children)
+        end
+
+        def buy_any_company?
+          @step.can_buy_any_company?(@current_entity) && @step.purchasable_companies_from_others(@current_entity).any?
         end
 
         def render_corporations

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -699,6 +699,7 @@ module Engine
          ],
          "operating_rounds": 1,
          "status":[
+            "can_buy_companies_from_other_players",
             "limited_train_buy"
          ]
       },
@@ -712,6 +713,7 @@ module Engine
          ],
          "status":[
             "can_buy_companies",
+            "can_buy_companies_from_other_players",
             "limited_train_buy"
          ],
          "operating_rounds": 2
@@ -726,6 +728,7 @@ module Engine
          ],
          "status":[
             "can_buy_companies",
+            "can_buy_companies_from_other_players",
             "limited_train_buy"
          ],
          "operating_rounds": 2

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -490,9 +490,9 @@ module Engine
         self.class::CURRENCY_FORMAT_STR % val
       end
 
-      def purchasable_companies
+      def purchasable_companies(entity = nil)
         @companies.select do |company|
-          company.owner&.player? && !company.abilities(:no_buy)
+          company.owner&.player? && entity != company.owner && !company.abilities(:no_buy)
         end
       end
 

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -26,6 +26,8 @@ module Engine
       ).freeze
 
       STATUS_TEXT = Base::STATUS_TEXT.merge(
+        'can_buy_companies_from_other_players' => ['Interplayer Company Buy', 'Companies can be bought between players']
+      ).merge(
         Step::SingleDepotTrainBuyBeforePhase4::STATUS_TEXT
       ).freeze
 

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -10,7 +10,7 @@ module Engine
     class BuySellParShares < Base
       include ShareBuying
 
-      PURCHASE_ACTIONS = [Action::BuyShares, Action::Par].freeze
+      PURCHASE_ACTIONS = [Action::BuyCompany, Action::BuyShares, Action::Par].freeze
 
       def actions(entity)
         return [] unless entity == current_entity
@@ -19,6 +19,7 @@ module Engine
         actions = []
         actions << 'buy_shares' if can_buy_any?(entity)
         actions << 'par' if can_ipo_any?(entity)
+        actions << 'buy_company' if can_buy_any_company?(entity)
         actions << 'sell_shares' if can_sell_any?(entity)
 
         actions << 'pass' if actions.any?
@@ -188,6 +189,17 @@ module Engine
         !bought? && @game.corporations.any? { |c| c.can_par?(entity) && can_buy?(entity, c.shares.first&.to_bundle) }
       end
 
+      def purchasable_companies_from_others(entity)
+        @game.purchasable_companies.reject { |c| c.owner == entity }
+      end
+
+      def can_buy_any_company?(entity)
+        !bought? &&
+        entity.cash.positive? &&
+        @game.phase.status.include?('can_buy_companies_from_other_players') &&
+        purchasable_companies_from_others(entity).any?
+      end
+
       def get_par_prices(entity, _corp)
         @game
           .stock_market
@@ -203,7 +215,24 @@ module Engine
       end
 
       def bought?
-        @current_actions.any? { |x| PURCHASE_ACTIONS.include?(x.class) }
+        @current_actions.any? { |x| self.class::PURCHASE_ACTIONS.include?(x.class) }
+      end
+
+      def process_buy_company(action)
+        entity = action.entity
+        company = action.company
+        price = action.price
+        owner = company.owner
+
+        @game.game_error("Cannot buy #{company.name} from #{owner.name}") unless owner.player?
+
+        company.owner = entity
+        owner.companies.delete(company)
+
+        entity.companies << company
+        entity.spend(price, owner)
+        @current_actions << action
+        @log << "-- #{entity.name} buys #{company.name} from #{owner.name} for #{@game.format_currency(price)}"
       end
     end
   end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -19,7 +19,7 @@ module Engine
         actions = []
         actions << 'buy_shares' if can_buy_any?(entity)
         actions << 'par' if can_ipo_any?(entity)
-        actions << 'buy_company' if can_buy_any_company?(entity)
+        actions << 'buy_company' if purchasable_companies(entity).any?
         actions << 'sell_shares' if can_sell_any?(entity)
 
         actions << 'pass' if actions.any?
@@ -189,15 +189,12 @@ module Engine
         !bought? && @game.corporations.any? { |c| c.can_par?(entity) && can_buy?(entity, c.shares.first&.to_bundle) }
       end
 
-      def purchasable_companies_from_others(entity)
-        @game.purchasable_companies.reject { |c| c.owner == entity }
-      end
+      def purchasable_companies(entity)
+        return [] if bought? ||
+          !entity.cash.positive? ||
+          !@game.phase.status.include?('can_buy_companies_from_other_players')
 
-      def can_buy_any_company?(entity)
-        !bought? &&
-        entity.cash.positive? &&
-        @game.phase.status.include?('can_buy_companies_from_other_players') &&
-        purchasable_companies_from_others(entity).any?
+        @game.purchasable_companies(entity)
       end
 
       def get_par_prices(entity, _corp)

--- a/spec/fixtures/18_al/4714.json
+++ b/spec/fixtures/18_al/4714.json
@@ -209,6 +209,22 @@
       ]
     },
     {
+      "type": "buy_company",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 20.1,
+      "company": "NDY",
+      "price": 1
+    },
+    {
+      "type": "buy_company",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 20.2,
+      "company": "NDY",
+      "price": 1
+    },
+    {
       "type": "buy_shares",
       "entity": "Daisy",
       "entity_type": "player",
@@ -227,6 +243,18 @@
       ]
     },
     {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 22.1
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 22.2
+    },
+    {
       "type": "buy_shares",
       "entity": "Daisy",
       "entity_type": "player",
@@ -234,6 +262,30 @@
       "shares": [
         "ATN_4"
       ]
+    },
+    {
+      "type": "pass",
+      "entity": "Bertil",
+      "entity_type": "player",
+      "id": 23.1
+    },
+    {
+      "type": "pass",
+      "entity": "Adam",
+      "entity_type": "player",
+      "id": 23.2
+    },
+    {
+      "type": "pass",
+      "entity": "Cecilia",
+      "entity_type": "player",
+      "id": 23.3
+    },
+    {
+      "type": "pass",
+      "entity": "Daisy",
+      "entity_type": "player",
+      "id": 23.4
     },
     {
       "type": "lay_tile",


### PR DESCRIPTION
This feature makes it possible for a player to buy a private company from another player during the stock round.

This should maybe be a draft instead?

There are two things remaining:
- The layout did not look good if a player buys the first company of two. So need help to get that correct.
- Need to fit this buy together with other so a player cannot buy more than one thing during an SR