### PR TITLE
1846 steamboat - allow "unlimited" hex assigning, unassign old hex

### DIFF
--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -260,7 +260,7 @@ module Engine
             "I1",
             "G19"
           ],
-          "count": 1
+          "count": 99
         },
         {
           "type": "assign_corporation",

--- a/lib/engine/step/assign.rb
+++ b/lib/engine/step/assign.rb
@@ -20,6 +20,10 @@ module Engine
         @game.game_error("#{company.name} is already assigned to #{target.name}") if target.assigned?(company.id)
 
         if target.is_a?(Hex) && (ability = company.abilities(:assign_hexes))
+          assignable_hexes = ability.hexes.map { |h| @game.hex_by_id(h) }
+          Assignable.remove_from_all!(assignable_hexes, company.id) do |unassigned|
+            @log << "#{company.name} is unassigned from #{unassigned.name}"
+          end
           target.assign!(company.id)
           ability.use!
           @log << "#{company.name} is assigned to #{target.name}"

--- a/spec/lib/engine/round/operating_spec.rb
+++ b/spec/lib/engine/round/operating_spec.rb
@@ -2,6 +2,8 @@
 
 require './spec/spec_helper'
 
+require 'engine'
+require 'engine/game/g_1846'
 require 'engine/game/g_1889'
 require 'engine/game/g_18_chesapeake'
 require 'engine/phase'
@@ -437,6 +439,39 @@ module Engine
           corporation.companies << company
           game.phase.next!
           subject.process_action(Action::LayTile.new(corporation, tile: Tile.for('440'), hex: hex_k4, rotation: 0))
+        end
+      end
+    end
+
+    context '1846' do
+      let(:players) { %w[a b c d e] }
+      let(:game) { Game::G1846.new(players) }
+      let(:corporation) { game.corporation_by_id('B&O') }
+      let(:company) { game.company_by_id('SC') }
+      let(:hex_b8) { game.hex_by_id('B8') }
+      let(:hex_d14) { game.hex_by_id('D14') }
+      let(:hex_g19) { game.hex_by_id('G19') }
+
+      subject { move_to_or! }
+
+      before :each do
+        game.stock_market.set_par(corporation, game.stock_market.par_prices[0])
+        corporation.cash = 80
+        corporation.owner = game.players.first
+        company.owner = game.players.first
+
+        subject.process_action(Action::Assign.new(company, target: hex_d14))
+      end
+
+      describe 'with steamboat company' do
+        it 'can be assigned to a new hex' do
+          expect(hex_d14.assigned?(company.id)).to eq(true)
+          expect(hex_g19.assigned?(company.id)).to eq(false)
+
+          subject.process_action(Action::Assign.new(company, target: hex_g19))
+
+          expect(hex_d14.assigned?(company.id)).to eq(false)
+          expect(hex_g19.assigned?(company.id)).to eq(true)
         end
       end
     end


### PR DESCRIPTION
While this allows the company to be reassigned more than the rules permit (I have opened #1359 to address this), it is better than the current situation which prevents the company from being reassigned once by the owning corporation.

[Fixes #1313]

The added unit test fails if either the 1846 config or added logic in `Step::Assign` is reverted.

Screenshots from a continuation of [the game data shared](https://gist.github.com/wcraigtrader/cb9b22291a2ee33fa61fabcb433aab75) on #1313:

![Screenshot from 2020-08-05 20-09-21](https://user-images.githubusercontent.com/1045173/89482800-dc843580-d757-11ea-9765-713a4c3a5bbe.png)

![Screenshot from 2020-08-05 20-09-32](https://user-images.githubusercontent.com/1045173/89482790-d9894500-d757-11ea-8de5-98ee30ce82c1.png)

