### PR TITLE
Adjust multi_revenue placement; Add support for terminal paths for off-board cities fixes #1290

### DIFF
--- a/TILES.md
+++ b/TILES.md
@@ -59,6 +59,7 @@ game config/code:
       be integer to indicate edge number, or an underscore followed by an
       integer to refer by index to a city/town/offboard/junction defined earlier
       on the tile
+    - **terminal** - 1 - indicates that path is part of a non-passthru path, typically for off-board cities. Tapered track will be drawn.
     - **track** - broad/narrow/dual/line/dashed; this option is not yet
       implemented, so track is always broad
 - **label** - large letter(s) on tile (e.g., "Chi", "OO", or "Z")

--- a/assets/app/view/game/part/revenue.rb
+++ b/assets/app/view/game/part/revenue.rb
@@ -31,12 +31,12 @@ module View
               {
                 region_weights: TOP_ROW,
                 x: 0,
-                y: -48,
+                y: -72,
               },
               {
                 region_weights: BOTTOM_ROW,
                 x: 0,
-                y: 48,
+                y: 69,
               },
             ]
           else

--- a/assets/app/view/game/part/revenue.rb
+++ b/assets/app/view/game/part/revenue.rb
@@ -14,30 +14,30 @@ module View
           if multi_revenue?
             [
               {
-                region_weights: CENTER,
+                region_weights: { CENTER => 1.5 },
                 x: 0,
                 y: 0,
               },
               {
-                region_weights: TOP_MIDDLE_ROW,
+                region_weights: { TOP_MIDDLE_ROW => 1.5 },
                 x: 0,
-                y: -24,
+                y: -48,
               },
               {
-                region_weights: BOTTOM_MIDDLE_ROW,
+                region_weights: { BOTTOM_MIDDLE_ROW => 1.5 },
                 x: 0,
-                y: 24,
+                y: 45,
               },
-              {
-                region_weights: TOP_ROW,
-                x: 0,
-                y: -72,
-              },
-              {
-                region_weights: BOTTOM_ROW,
-                x: 0,
-                y: 69,
-              },
+              # {
+              #   region_weights: { TOP_ROW => 1.5 },
+              #   x: 0,
+              #   y: -72,
+              # },
+              # {
+              #   region_weights: { BOTTOM_ROW => 1.5 },
+              #   x: 0,
+              #   y: 69,
+              # },
             ]
           else
             SMALL_ITEM_LOCATIONS

--- a/assets/app/view/game/part/track_lawson_path.rb
+++ b/assets/app/view/game/part/track_lawson_path.rb
@@ -38,31 +38,25 @@ module View
         def render_part
           rotation = 60 * @edge_num
 
-          props =
-            if @terminal == 1
-              {
-                attrs: {
-                  transform: "rotate(#{rotation})",
-                  d: 'M6 60 L 6 85 L -6 85 L -6 60 L 0 25 Z',
-                  fill: @color,
-                  stroke: 'none',
-                  'stroke-linecap': 'butt',
-                  'stroke-linejoin': 'miter',
-                  'stroke-width': @width.to_i * 0.75,
-                  'stroke-dasharray': @dash,
-                 },
-              }
-            else
-              {
-                attrs: {
-                  transform: "rotate(#{rotation})",
-                  d: 'M 0 87 L 0 0',
-                  stroke: @color,
-                  'stroke-width': @width,
-                  'stroke-dasharray': @dash,
-                },
-              }
-            end
+          props = {
+            attrs: {
+              transform: "rotate(#{rotation})",
+              d: 'M 0 87 L 0 0',
+              stroke: @color,
+              'stroke-width': @width,
+              'stroke-dasharray': @dash,
+            },
+          }
+
+          props[:attrs].merge!(
+            d: 'M6 60 L 6 85 L -6 85 L -6 60 L 0 25 Z',
+            fill: @color,
+            stroke: 'none',
+            'stroke-linecap': 'butt',
+            'stroke-linejoin': 'miter',
+            'stroke-width': @width.to_i * 0.75,
+            'stroke-dasharray': @dash,
+          ) if @terminal
 
           [
             h(:path, props),

--- a/assets/app/view/game/part/track_lawson_path.rb
+++ b/assets/app/view/game/part/track_lawson_path.rb
@@ -38,31 +38,31 @@ module View
         def render_part
           rotation = 60 * @edge_num
 
-          if (@terminal == 1)
-            # half-way between standard track and off-board track
-            props = {
-              attrs: {
-                transform: "rotate(#{rotation})",
-                d: 'M6 60 L 6 85 L -6 85 L -6 60 L 0 25 Z',
-                fill: @color,
-                stroke: 'none',
-                'stroke-linecap': 'butt',
-                'stroke-linejoin': 'miter',
-                'stroke-width': @width.to_i * 0.75,
-                'stroke-dasharray': @dash,
-              },
-            }
-          else
-            props = {
-              attrs: {
-                transform: "rotate(#{rotation})",
-                d: 'M 0 87 L 0 0',
-                stroke: @color,
-                'stroke-width': @width,
-                'stroke-dasharray': @dash,
-              },
-            }
-          end
+          props =
+            if @terminal == 1
+              {
+                attrs: {
+                  transform: "rotate(#{rotation})",
+                  d: 'M6 60 L 6 85 L -6 85 L -6 60 L 0 25 Z',
+                  fill: @color,
+                  stroke: 'none',
+                  'stroke-linecap': 'butt',
+                  'stroke-linejoin': 'miter',
+                  'stroke-width': @width.to_i * 0.75,
+                  'stroke-dasharray': @dash,
+                 },
+              }
+            else
+              {
+                attrs: {
+                  transform: "rotate(#{rotation})",
+                  d: 'M 0 87 L 0 0',
+                  stroke: @color,
+                  'stroke-width': @width,
+                  'stroke-dasharray': @dash,
+                },
+              }
+            end
 
           [
             h(:path, props),

--- a/assets/app/view/game/part/track_lawson_path.rb
+++ b/assets/app/view/game/part/track_lawson_path.rb
@@ -13,6 +13,7 @@ module View
 
         def load_from_tile
           @edge_num = @path.edges.first.num
+          @terminal = @path.terminal
         end
 
         def preferred_render_locations
@@ -37,15 +38,31 @@ module View
         def render_part
           rotation = 60 * @edge_num
 
-          props = {
-            attrs: {
-              transform: "rotate(#{rotation})",
-              d: 'M 0 87 L 0 0',
-              stroke: @color,
-              'stroke-width': @width,
-              'stroke-dasharray': @dash,
-            },
-          }
+          if (@terminal == 1)
+            # half-way between standard track and off-board track
+            props = {
+              attrs: {
+                transform: "rotate(#{rotation})",
+                d: 'M6 60 L 6 85 L -6 85 L -6 60 L 0 25 Z',
+                fill: @color,
+                stroke: 'none',
+                'stroke-linecap': 'butt',
+                'stroke-linejoin': 'miter',
+                'stroke-width': @width.to_i * 0.75,
+                'stroke-dasharray': @dash,
+              },
+            }
+          else
+            props = {
+              attrs: {
+                transform: "rotate(#{rotation})",
+                d: 'M 0 87 L 0 0',
+                stroke: @color,
+                'stroke-width': @width,
+                'stroke-dasharray': @dash,
+              },
+            }
+          end
 
           [
             h(:path, props),

--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -645,7 +645,7 @@ module Engine
          ]
       },
       "red":{
-         "city=revenue:yellow_40|brown_50;path=a:0,b:_0;path=a:1,b:_0":[
+         "city=revenue:yellow_40|brown_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1":[
             "A4"
          ],
          "offboard=revenue:yellow_40|brown_30;path=a:5,b:_0":[
@@ -660,7 +660,7 @@ module Engine
          "offboard=revenue:yellow_30|brown_40;path=a:2,b:_0;path=a:3,b:_0":[
             "P7"
          ],
-         "city=revenue:yellow_40|brown_50;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0":[
+         "city=revenue:yellow_40|brown_50;path=a:2,b:_0,terminal:1;path=a:3,b:_0,terminal:1;path=a:4,b:_0,terminal:1":[
             "Q2"
          ]
       },

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -5,12 +5,13 @@ require_relative 'base'
 module Engine
   module Part
     class Path < Base
-      attr_reader :a, :b, :branch, :city, :edges, :junction, :node, :offboard, :stop, :town
+      attr_reader :a, :b, :branch, :city, :edges, :junction, :node, :offboard, :stop, :town, :terminal
 
-      def initialize(a, b)
+      def initialize(a, b, terminal = 0)
         @a = a
         @b = b
         @edges = []
+        @terminal = terminal
 
         separate_parts
       end
@@ -64,7 +65,7 @@ module Engine
       end
 
       def rotate(ticks)
-        path = Path.new(@a.rotate(ticks), @b.rotate(ticks))
+        path = Path.new(@a.rotate(ticks), @b.rotate(ticks), @terminal)
         path.index = index
         path.tile = @tile
         path

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -7,11 +7,11 @@ module Engine
     class Path < Base
       attr_reader :a, :b, :branch, :city, :edges, :junction, :node, :offboard, :stop, :town, :terminal
 
-      def initialize(a, b, terminal = 0)
+      def initialize(a, b, terminal: nil)
         @a = a
         @b = b
         @edges = []
-        @terminal = terminal
+        @terminal = !!terminal
 
         separate_parts
       end
@@ -65,7 +65,7 @@ module Engine
       end
 
       def rotate(ticks)
-        path = Path.new(@a.rotate(ticks), @b.rotate(ticks), @terminal)
+        path = Path.new(@a.rotate(ticks), @b.rotate(ticks), terminal: @terminal)
         path.index = index
         path.tile = @tile
         path

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -63,15 +63,20 @@ module Engine
       case type
       when 'path'
         params = params.map do |k, v|
-          case v[0]
-          when '_'
-            [k, cache[v[1..-1].to_i]]
+        case k
+          when 'terminal'
+            [k, v.to_i]
           else
-            [k, Part::Edge.new(v)]
+            case v[0]
+            when '_'
+              [k, cache[v[1..-1].to_i]]
+            else
+              [k, Part::Edge.new(v)]
+            end
           end
         end.to_h
 
-        Part::Path.new(params['a'], params['b'])
+        Part::Path.new(params['a'], params['b'], params['terminal'])
       when 'city'
         city = Part::City.new(params['revenue'],
                               slots: params['slots'],

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -63,7 +63,7 @@ module Engine
       case type
       when 'path'
         params = params.map do |k, v|
-        case k
+          case k
           when 'terminal'
             [k, v.to_i]
           else

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -65,7 +65,7 @@ module Engine
         params = params.map do |k, v|
           case k
           when 'terminal'
-            [k, v.to_i]
+            [k, v]
           else
             case v[0]
             when '_'
@@ -76,7 +76,7 @@ module Engine
           end
         end.to_h
 
-        Part::Path.new(params['a'], params['b'], params['terminal'])
+        Part::Path.new(params['a'], params['b'], terminal: params['terminal'])
       when 'city'
         city = Part::City.new(params['revenue'],
                               slots: params['slots'],


### PR DESCRIPTION
Fixes #1290 
Adjusted multi_revenue placement when in tow or bottom row.
Added support for "terminal:1" parameter to path in tile definition. Will create tapered track to city.