### PR TITLE
Operating round - don't move to next entity on messages

### DIFF
--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -58,8 +58,8 @@ module Engine
         end
         entity.trains.each { |train| train.operated = false }
         @game.place_home_token(entity) if @home_token_timing == :operate
-        skip_steps
         @game.log << "#{entity.owner.name} operates #{entity.name}" unless finished?
+        skip_steps
         next_entity! if finished?
       end
 

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -28,7 +28,9 @@ module Engine
         @just_sold_company = nil
       end
 
-      def after_process(_action)
+      def after_process(action)
+        return if action.type == 'message'
+
         if active_step
           return if @entities[@entity_index].owner&.player?
         end


### PR DESCRIPTION
[Fixes #1352]

Also fix order of log messages for corp in receivership to say

> Sharepool operates NYC
> NYC skips issue or redeem shares
> NYC skips place a token or lay track

instead of

> NYC skips issue or redeem shares
> NYC skips place a token or lay track
> Sharepool operates NYC