### PR TITLE
lib/truncate

### DIFF
--- a/assets/app/lib/truncate.rb
+++ b/assets/app/lib/truncate.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# https://apidock.com/rails/String/truncate
+
+class String
+  def truncate(truncate_at = 15, options = {})
+    return dup unless length > truncate_at
+
+    omission = options[:omission] || '...'
+    length_with_room_for_omission = truncate_at - omission.length
+    stop = if options[:separator]
+             rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission
+           else
+             length_with_room_for_omission
+           end
+
+    "#{self[0, stop]}#{omission}"
+  end
+end

--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lib/truncate'
+
 module View
   module Game
     class Abilities < Snabberb::Component
@@ -55,11 +57,8 @@ module View
           }
           props[:style][:textDecoration] = 'underline' if @selected_company == company
 
-          company_name = company.name
-          company_name = company_name[0..15] + '...' if company_name.size > 16
-
-          owner_name = company.owner.id
-          owner_name = owner_name[0..10] + '...' if owner_name.size > 11
+          company_name = company.name.truncate(company.owner.id.size < 5 ? 32 : 19)
+          owner_name = company.owner.id.truncate
 
           h(:div, props, "#{company_name} (#{owner_name})")
         end.compact

--- a/assets/app/view/game/entity_order.rb
+++ b/assets/app/view/game/entity_order.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lib/truncate'
+
 module View
   module Game
     class EntityOrder < Snabberb::Component
@@ -64,7 +66,7 @@ module View
             children << h(:span, logo_container_props, [h(:img, logo_props)])
           end
 
-          owner = " (#{entity.owner.name})" if !entity.player? && entity.owner
+          owner = " (#{entity.owner.name.truncate})" if !entity.player? && entity.owner
           children << h(:span, "#{entity.name}#{owner}")
 
           h(:div, entity_props, children)

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -2,6 +2,7 @@
 
 require 'lib/color'
 require 'lib/settings'
+require 'lib/truncate'
 require 'view/game_row'
 require 'view/link'
 
@@ -147,7 +148,7 @@ module View
       }
 
       p_elm = players.map.with_index do |player, index|
-        short_name = player['name'].length > 19 ? player['name'][0...18] + '…' : player['name']
+        short_name = player['name'].truncate
         if owner? && new? && player['id'] != @user['id']
           button_props = {
             on: { click: -> { store(:confirm_kick, [@gdata['id'], player['id']]) } },
@@ -191,7 +192,7 @@ module View
       elsif @gdata['status'] == 'finished'
         result = @gdata['result']
           .sort_by { |_, v| -v }
-          .map { |k, v| "#{k.length > 15 ? k[0...14] + '…' : k} #{v}" }
+          .map { |k, v| "#{k.truncate} #{v}" }
           .join(', ')
 
         children << h('div.inline', [


### PR DESCRIPTION
Default truncation at 15 chars (=> rendering: 12 + ...) seems useful in our case to render usernames the same in multiple places with less hassle.
It’s only necessary for elements where it’s not possible to rely on CSS (cf. `.nowrap`), because they aren’t contained in an element with a max-width.