### PR TITLE
fix dumping presidency when presidency is 30% instead of 20%

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -29,10 +29,13 @@ module Engine
     def initialize(sym:, name:, **opts)
       @name = sym
       @full_name = name
-      [
+      shares = [
         Share.new(self, president: true, percent: 20),
         *8.times.map { |index| Share.new(self, percent: 10, index: index + 1) },
-      ].each { |share| shares_by_corporation[self] << share }
+      ]
+      shares.each { |share| shares_by_corporation[self] << share }
+      @presidents_share = shares.first
+      @second_share = shares[1]
 
       @share_price = nil
       @par_price = nil
@@ -170,6 +173,14 @@ module Engine
 
     def available_share
       shares_by_corporation[self].find { |share| !share.president }
+    end
+
+    def presidents_percent
+      @presidents_share.percent
+    end
+
+    def share_percent
+      @second_share.percent
     end
   end
 end

--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -47,7 +47,9 @@ module Engine
     end
 
     def can_dump?(entity)
-      !presidents_share || (corporation.player_share_holders.reject { |k, _| k == entity }.values.max || 0) > 10
+      return true unless presidents_share
+
+      (corporation.player_share_holders.reject { |k, _| k == entity }.values.max || 0) >= presidents_share.percent
     end
 
     def to_bundle

--- a/lib/engine/share_holder.rb
+++ b/lib/engine/share_holder.rb
@@ -35,9 +35,18 @@ module Engine
         bundle = shares.take(index + 1)
         percent = bundle.sum(&:percent)
         bundles = [Engine::ShareBundle.new(bundle, percent)]
-        bundles.insert(0, Engine::ShareBundle.new(bundle, percent - 10)) if share.president
+        if share.president
+          normal_percent = corporation.share_percent
+          difference = corporation.presidents_percent - normal_percent
+          num_partial_bundles = difference / normal_percent
+          (1..num_partial_bundles).each do |n|
+            bundles.insert(0, Engine::ShareBundle.new(bundle, percent - (normal_percent * n)))
+          end
+        end
         bundles
       end
+
+      bundles
     end
 
     def dumpable_bundles(corporation)


### PR DESCRIPTION
The new code outside of Engine::Corporation#initialize should work for any size
of share corporations (e.g., 5 share corporations in 1817, 4 share corporations
in 18CZ), regardless of how many shares a president certificate is.

[Fixes #1376]