### PR TITLE
Fix revenue position on pointy maps

### DIFF
--- a/TILES.md
+++ b/TILES.md
@@ -59,7 +59,7 @@ game config/code:
       be integer to indicate edge number, or an underscore followed by an
       integer to refer by index to a city/town/offboard/junction defined earlier
       on the tile
-    - **terminal** - 1 - indicates that path is part of a non-passthru path, typically for off-board cities. Tapered track will be drawn.
+    - **terminal** - `1` - indicates that path is part of a non-passthru path, typically for off-board cities. Tapered track will be drawn.
     - **track** - broad/narrow/dual/line/dashed; this option is not yet
       implemented, so track is always broad
 - **label** - large letter(s) on tile (e.g., "Chi", "OO", or "Z")
@@ -67,9 +67,11 @@ game config/code:
     - **cost** - *required* - integer
     - **terrain** - `mountain`/`water` - multiple terrain types separated by `|`
 - **border**
-    - **edge** - integer - which edge to hide from rendering; a line matching
-      the tile's color is drawn on top of the edge's normal black line so that
-      two adjacent tiles appear joined
+    - **edge** - *required* - integer - which edge to modify
+    - **type** - `mountain`/`water`/`impassible` - Border type. If not'
+      specified, a line matching the tile's color is drawn on top of the edge's
+      normal black line so that two adjacent tiles appear joined.
+    - **cost** - integer - cost to cross for mountain/water borders
 - **junction** - the center point of a Lawson-style tile
 - **icon**
     - **image** - *required* - name of image, will be rendered with file at

--- a/assets/app/view/game/part/revenue.rb
+++ b/assets/app/view/game/part/revenue.rb
@@ -12,6 +12,19 @@ module View
 
         def preferred_render_locations
           if multi_revenue?
+
+            top_weights = if layout == :flat
+                            { TOP_MIDDLE_ROW => 1.5 }
+                          else
+                            { [2, 6, 7, 8] => 1.5, [3, 5] => 0.5 }
+                          end
+
+            bottom_weights = if layout == :flat
+                               { BOTTOM_MIDDLE_ROW => 1.5 }
+                             else
+                               { [15, 16, 21, 17] => 1.5, [18, 20] => 0.5 }
+                             end
+
             [
               {
                 region_weights: { CENTER => 1.5 },
@@ -19,12 +32,12 @@ module View
                 y: 0,
               },
               {
-                region_weights: { TOP_MIDDLE_ROW => 1.5 },
+                region_weights: top_weights,
                 x: 0,
                 y: -48,
               },
               {
-                region_weights: { BOTTOM_MIDDLE_ROW => 1.5 },
+                region_weights: bottom_weights,
                 x: 0,
                 y: 45,
               },
@@ -52,7 +65,7 @@ module View
         end
 
         def render_part
-          transform = "#{translate} #{rotation_for_layout}"
+          transform = "#{rotation_for_layout} #{translate}"
 
           if multi_revenue?
             h(MultiRevenue, revenues: @revenue, transform: transform)


### PR DESCRIPTION
1. Swap transformation on revenue for pointy maps to allow revenue to be properly horizontally centered on tiles
2. Add correct multi_revenue preferred_render_location for pointy maps
3. Update TILES.md for border options and minor formatting issue with last edit

With old revenue position (on 18TN):
![Birmingham_old](https://user-images.githubusercontent.com/8494213/89724538-8e726a80-d9c1-11ea-964b-e5a25c1e516a.png)

With this change:
![Birmingham_new](https://user-images.githubusercontent.com/8494213/89724542-96320f00-d9c1-11ea-971b-4720300b1700.png)
