### PR TITLE
A new attempt to make 18MS, first part 

### DIFF
--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -483,7 +483,7 @@ module Engine
          ],
          "operating_rounds":2,
          "status":[
-            "can_buy_companies"
+            "can_buy_companies_operation_round_one"
          ]
       },
       {

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -371,11 +371,11 @@ module Engine
          "variants":[
             {
                "name":"4D",
+               "price":750,
+               "available_on":"6",
                "distance":[
                   {
-                     "distance":4,
-                     "price":750,
-                     "available_on":"6"
+                     "visit":4
                   }
                ]
             }

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -213,6 +213,7 @@ module Engine
    "corporations":[
       {
          "float_percent":60,
+         "max_ownership_percent":70,
          "sym":"GMO",
          "name":"Gulf, Mobile and Ohio Railroad",
          "logo":"18_ms/GMO",
@@ -227,6 +228,7 @@ module Engine
       },
       {
          "float_percent":60,
+         "max_ownership_percent":70,
          "sym":"IC",
          "name":"Illinois Central Railroad",
          "logo":"18_ms/IC",
@@ -240,6 +242,7 @@ module Engine
       },
       {
          "float_percent":60,
+         "max_ownership_percent":70,
          "sym":"L&N",
          "name":"Louisville and Nashville Railroad",
          "logo":"18_ms/LN",
@@ -253,6 +256,7 @@ module Engine
       },
       {
          "float_percent":60,
+         "max_ownership_percent":70,
          "sym":"Fr",
          "name":"Frisco",
          "logo":"18_ms/Fr",
@@ -266,6 +270,7 @@ module Engine
       },
       {
          "float_percent":60,
+         "max_ownership_percent":70,
          "sym":"WRA",
          "name":"Western Railway of Alabama",
          "logo":"18_ms/WRA",

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -284,8 +284,7 @@ module Engine
             {
                "nodes":[
                   "city",
-                  "offboard",
-                  "town"
+                  "offboard"
                ],
                "pay":2,
                "visit":2
@@ -307,8 +306,7 @@ module Engine
             {
                "nodes":[
                   "city",
-                  "offboard",
-                  "town"
+                  "offboard"
                ],
                "pay":3,
                "visit":3
@@ -330,8 +328,7 @@ module Engine
             {
                "nodes":[
                   "city",
-                  "offboard",
-                  "town"
+                  "offboard"
                ],
                "pay":4,
                "visit":4
@@ -351,16 +348,16 @@ module Engine
          "name":"5",
          "distance":5,
          "price":500,
-         "num":2,
-         "events":[
-           {"type": "close_companies"}
-         ]
+         "num":2
       },
       {
          "name":"6",
          "distance":6,
          "price":550,
-         "num":2
+         "num":2,
+         "events":[
+           {"type": "close_companies"}
+         ]
       },
       {
          "name":"2D",
@@ -496,30 +493,6 @@ module Engine
          "status":[
             "can_buy_companies"
          ]
-      },
-      {
-         "name":"4",
-         "on":"4",
-         "train_limit":3,
-         "tiles":[
-            "yellow",
-            "green"
-         ],
-         "operating_rounds":2,
-         "status":[
-            "can_buy_companies"
-         ]
-      },
-      {
-         "name":"5",
-         "on":"5",
-         "train_limit":3,
-         "tiles":[
-            "yellow",
-            "green",
-            "brown"
-         ],
-         "operating_rounds":2
       },
       {
          "name":"6",

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -41,12 +41,14 @@ module Engine
       "E5":"Meridian",
       "E9":"Selma",
       "E11":"Montgomery",
+      "E13":"Atlanta",
       "G3":"Hattiesburg",
       "H4":"Gulfport",
       "H6":"Mobile",
       "H8":"Pensacola",
       "H10":"Tallahassee",
-      "I1":"New Orleans"
+      "I1":"New Orleans",
+      "J2":"Port Sulphur"
    },
    "tiles":{
       "1":1,
@@ -447,25 +449,28 @@ module Engine
          "city=revenue:yellow_40|brown_50;path=a:5,b:_0;path=a:4,b:_0":[
             "A1"
          ],
-         "city=revenue:yellow_51|brown_50;path=a:3,b:_0;path=a:4,b:_0":[
+         "city=revenue:yellow_50|brown_80;path=a:3,b:_0;path=a:5,b:_0":[
             "I1"
-         ],
-         "town=revenue:10":[
-            "I3"
          ],
          "path=a:1,b:5":[
             "A3"
          ],
-         "path=a:0,b:5":[
+         "offboard=revenue:yellow_40|brown_50,hide:1,groups:Atlanta;path=a:0,b:_0;border=edge:5":[
             "D12"
          ],
-         "path=a:2,b:3":[
+         "offboard=revenue:yellow_40|brown_50,groups:Atlanta;path=a:1,b:_0;border=edge:2;border=edge:0":[
+            "E13"
+         ],
+         "offboard=revenue:yellow_40|brown_50,hide:1,groups:Atlanta;path=a:2,b:_0;border=edge:3":[
             "F12"
          ]
       },
       "gray":{
          "city=revenue:yellow_30|brown_60,slots:2;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0":[
             "E1"
+         ],
+         "town=revenue:10;path=a:2,b:_0;path=a:5,b:_0":[
+            "J2"
          ]
       }
    },

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -45,6 +45,7 @@ module Engine
       @cash = 0
       @capitalization = opts[:capitalization] || :full
       @float_percent = opts[:float_percent] || 60
+      @max_ownership_percent = opts[:max_ownership_percent] || 60
       @min_price = opts[:min_price]
       @always_market_price = opts[:always_market_price] || false
       @needs_token_to_par = opts[:needs_token_to_par] || false
@@ -136,7 +137,7 @@ module Engine
     # Is it legal to hold percent shares in this corporation?
     def holding_ok?(share_holder, extra_percent = 0)
       percent = share_holder.percent_of(self) + extra_percent
-      %i[orange brown].include?(@share_price&.color) || percent <= 60
+      %i[orange brown].include?(@share_price&.color) || percent <= @max_ownership_percent
     end
 
     def all_abilities

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -601,6 +601,8 @@ module Engine
         end
       end
 
+      def sr_finished; end
+
       def or_round_finished; end
 
       def or_set_finished; end
@@ -932,6 +934,7 @@ module Engine
           when Round::Stock
             @operating_rounds = @phase.operating_rounds
             reorder_players
+            sr_finished
             new_operating_round
           when Round::Operating
             if @round.round_num < @operating_rounds

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -12,7 +12,9 @@ module Engine
       GAME_LOCATION = 'Mississippi, USA'
       GAME_DESIGNER = 'Mark Derrick'
       GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
-      GAME_END_CHECK = { final_or_set: 10 }.freeze
+
+      # Game ends after 5 * 2 ORs
+      GAME_END_CHECK = { final_or_set: 5 }.freeze
 
       HOME_TOKEN_TIMING = :operating_round
 
@@ -24,6 +26,12 @@ module Engine
 
       def setup
         setup_company_price_50_to_150_percent
+      end
+
+      def new_operating_round(round_num = 1)
+        # Switch to phase 3 if OR1.2 is to start
+        @phase.next! if @turn == 1 && round_num == 2
+        super
       end
 
       def operating_round(round_num)
@@ -41,6 +49,32 @@ module Engine
           Step::BuyTrain,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
+      end
+
+      def or_set_finished
+        case @turn
+        when 3 then rust('2+', 20)
+        when 4 then rust('3+', 30)
+        when 5 then rust('4+', 60)
+        end
+      end
+
+      private
+
+      def rust(train, salvage_value)
+        rusted_trains = []
+        trains.each do |t|
+          next if t.rusted || t.name != train
+
+          rusted_trains << t.name
+          @bank.spend(salvage_value, t.owner)
+          t.rust!
+        end
+
+        return unless rusted_trains.any?
+
+        @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust --"
+        @log << "Corporations received a salvage value of #{format_currency(salvage_value)} per rusted train"
       end
     end
   end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -12,6 +12,7 @@ module Engine
       GAME_LOCATION = 'Mississippi, USA'
       GAME_DESIGNER = 'Mark Derrick'
       GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18MS'
 
       # Game ends after 5 * 2 ORs
       GAME_END_CHECK = { final_or_set: 5 }.freeze

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -36,8 +36,13 @@ module Engine
         @previously_floated_corporations = []
       end
 
-      def purchasable_companies
-        companies = super
+      def purchasable_companies(entity = nil)
+        entity ||= current_entity
+        # Only companies owned by the president may be bought
+        companies = super.reject do |c|
+          entity.corporation? && entity.player == c.player
+        end
+
         return companies unless @phase.status.include?('can_buy_companies_operation_round_one')
 
         return [] if @turn > 1

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -39,8 +39,8 @@ module Engine
       def purchasable_companies(entity = nil)
         entity ||= current_entity
         # Only companies owned by the president may be bought
-        companies = super.reject do |c|
-          entity.corporation? && entity.player == c.player
+        companies = super.select do |c|
+          c.owned_by?(entity.player)
         end
 
         return companies unless @phase.status.include?('can_buy_companies_operation_round_one')

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -45,6 +45,7 @@ module Engine
 
       def new_operating_round(round_num = 1)
         # For OR 1, set company buy price to face value only
+
         @companies.each do |company|
           company.min_price = company.value
           company.max_price = company.value
@@ -86,16 +87,13 @@ module Engine
       private
 
       def rust(train, salvage_value)
-        rusted_trains = []
-        trains.each do |t|
-          next if t.rusted || t.name != train
+        rusted_trains = trains.select { |t| !t.rusted && t.name == train }
+        return if rusted_trains.empty?
 
-          rusted_trains << t.name
+        rusted_trains.each do |t|
           @bank.spend(salvage_value, t.owner)
           t.rust!
         end
-
-        return unless rusted_trains.any?
 
         @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust --"
         @log << "Corporations received a salvage value of #{format_currency(salvage_value)} per rusted train"

--- a/lib/engine/step/g_18_ms/buy_company.rb
+++ b/lib/engine/step/g_18_ms/buy_company.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../buy_company'
+
+module Engine
+  module Step
+    module G18MS
+      class BuyCompany < BuyCompany
+        def can_buy_company?(entity)
+          companies = @game.purchasable_companies
+
+          entity == current_entity &&
+            companies.any? &&
+            companies.map(&:min_price).min <= entity.cash
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Remaining are at least:

- [x] Implement 2+, 3+, 4+ trains
- [x] Rusting after OR 2.2, 3.2, 4.2
- [x] Game end after 10 ORs (actually after 5.2, as we use 1.1, 1.2, 2.1, 2.2, ... 5.1, 5.2 END
- [x] Fix map for New Orleans and Atlanta
- [ ] Private Alabama Great Southern Railroad
- [ ] Private Birmingham Southern Railroad
- [ ] Private Meridian & Memphis Railway
- [ ] Private Mississippi Central Railway
- [ ] President can (maybe) help when buying permanent trains
- [ ] Bonus for Atlanta tokenize
- [ ] Bonus for Chattanooga connection
- [ ] Restrict Atlanta revenue to once per run
- [ ] Loan during emergency buy
- [ ] Illegal to buy train that has run during OR, if it will rust at the end of the OR (idea: set them as obsolete and then rust obsoleted trains)
- [x] Corporations can lay 2 yellow tiles during its first OR
- [x] P1/P2 can be bought at face value OR 1
- [x] Purchase of private companies can only be done from those that the president own
- [ ] D phase should be triggered by purchase of any D train, not just 2D
- [x] 70% is max ownership in company
- [x] Update wiki page and add link to it
- [ ] Optional: Timeline presentation, for events and status