### PR TITLE
18TN: Privates should not block assigned hexes. (#1419)

### DIFF
--- a/lib/engine/config/game/g_18_tn.rb
+++ b/lib/engine/config/game/g_18_tn.rb
@@ -201,15 +201,8 @@ module Engine
          "name":"Tennessee Copper Co.",
          "value":20,
          "revenue":5,
-         "desc":"Blocks H17. Corporation owner may lay a free yellow tile in H17. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
+         "desc":"Corporation owner may lay a free yellow tile in H17. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
          "abilities":[
-            {
-               "type":"blocks_hexes",
-               "owner_type":"player",
-               "hexes":[
-                  "H17"
-               ]
-            },
             {
                "type":"tile_lay",
                "free":true,
@@ -231,15 +224,8 @@ module Engine
          "name":"East Tennessee & Western Carolina Railroad",
          "value":40,
          "revenue":10,
-         "desc":"Blocks F19. Corporation owner may lay a free yellow tile in F19. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
+         "desc":"Corporation owner may lay a free yellow tile in F19. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
          "abilities":[
-            {
-               "type":"blocks_hexes",
-               "owner_type":"player",
-               "hexes":[
-                  "F19"
-               ]
-            },
             {
                "type":"tile_lay",
                "free":true,
@@ -261,15 +247,8 @@ module Engine
          "name":"Memphis & Charleston Railroad",
          "value":70,
          "revenue":15,
-         "desc":"Blocks H3. Corporation owner may lay a free yellow tile in H3. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
+         "desc":"Corporation owner may lay a free yellow tile in H3. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
          "abilities":[
-            {
-               "type":"blocks_hexes",
-               "owner_type":"player",
-               "hexes":[
-                  "H3"
-               ]
-            },
             {
                "type":"tile_lay",
                "free":true,
@@ -291,15 +270,8 @@ module Engine
          "name":"Oneida & Western Railroad",
          "value":100,
          "revenue":20,
-         "desc":"Blocks E16. Corporation owner may lay a free yellow tile in E16. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
+         "desc":"Corporation owner may lay a free yellow tile in E16. It need not be connected to an existing station token of the corporation. It does not count toward the corporation's normal limit of two yellow tile lays per turn.",
          "abilities":[
-            {
-               "type":"blocks_hexes",
-               "owner_type":"player",
-               "hexes":[
-                  "E16"
-               ]
-            },
             {
                "type":"tile_lay",
                "free":true,

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -105,34 +105,13 @@ module Engine
       end
 
       def upgrades_to?(from, to, special = false)
-        # correct color progression?
-        return false unless Engine::Tile::COLORS.index(to.color) == (Engine::Tile::COLORS.index(from.color) + 1)
+        return true if super
 
-        # honors pre-existing track?
-        return false unless from.paths_are_subset_of?(to.paths)
-
-        # If special ability then remaining checks is not applicable
-        return true if special
-
-        # correct label?
-        return false if from.label != to.label && !allowed_upgrade_to_p_label?(from, to)
-
-        # honors existing town/city counts?
-        # - allow labelled cities to upgrade regardless of count; they're probably
-        #   fine (e.g., 18Chesapeake's OO cities merge to one city in brown)
-        # - TODO: account for games that allow double dits to upgrade to one town
-        return false if from.towns.size != to.towns.size
-        return false if !from.label && from.cities.size != to.cities.size
-
-        true
-      end
-
-      def allowed_upgrade_to_p_label?(from, to)
         # When upgrading from green to brown:
         #   Memphis (H3) has no label. P label or no label is OK.
         #   Chattanooga (H15) has C label. Only P label is OK.
         #   Nashville (F11) has N label. Only P label is OK.
-        HEX_WITH_P_LABEL.include?(from.hex.name) && to.color == :brown && to.label.to_s == 'P'
+        from.color == :green && HEX_WITH_P_LABEL.include?(from.hex.name) && to.color == :brown && to.label.to_s == 'P'
       end
     end
   end


### PR DESCRIPTION
Privates do not block their home hex.

Also did a minor refactoring to improve maintanability of upgrades_to?