### PR TITLE
zebra-style

### DIFF
--- a/assets/app/lib/color.rb
+++ b/assets/app/lib/color.rb
@@ -2,7 +2,7 @@
 
 module Lib
   module Color
-    def self.convert_hex_to_rgba(color, alpha)
+    def convert_hex_to_rgba(color, alpha)
       m = color.match(/#(..)(..)(..)/)
       "rgba(#{m[1].hex},#{m[2].hex},#{m[3].hex},#{alpha})"
     end

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lib/color'
+require 'lib/settings'
 require 'lib/storage'
 require 'view/link'
 require 'view/game/bank'
@@ -10,6 +11,7 @@ module View
   module Game
     class Spreadsheet < Snabberb::Component
       include Lib::Color
+      include Lib::Settings
 
       needs :game
 
@@ -29,6 +31,7 @@ module View
       def render_table
         h(:table, { style: {
           margin: '1rem 0 1.5rem 0',
+          borderCollapse: 'collapse',
           textAlign: 'center',
           whiteSpace: 'nowrap',
         } }, [
@@ -55,7 +58,7 @@ module View
       end
 
       def render_history_titles(corporations)
-        or_history(corporations).map { |turn, round| h('th.no_padding', "#{turn}.#{round}") }
+        or_history(corporations).map { |turn, round| h(:th, "#{turn}.#{round}") }
       end
 
       def render_history(corporation)
@@ -89,7 +92,15 @@ module View
       end
 
       def render_title
-        spacing = ->(cols) { { attrs: { colspan: cols }, style: { letterSpacing: '0.4rem' } } }
+        th_props = lambda do |cols, alt_bg = false, border_right = true|
+          props = zebra_props(alt_bg)
+          props[:attrs] = { colspan: cols }
+          props[:style][:padding] = '0.3rem'
+          props[:style][:borderRight] = "1px solid #{color_for(:font2)}" if border_right
+          props[:style][:fontSize] = '1.1rem'
+          props[:style][:letterSpacing] = '1px'
+          props
+        end
 
         or_history_titles = render_history_titles(@game.corporations)
 
@@ -97,35 +108,33 @@ module View
           style: {
             background: 'salmon',
             color: 'black',
-            borderRadius: '3px',
           },
         }
 
         [
           h(:tr, [
             h(:th, ''),
-            h(:th, spacing[@game.players.size], 'Players'),
-            h(:th, spacing[2], 'Bank'),
-            h(:th, spacing[2], 'Prices'),
-            h(:th, spacing[4], 'Corporation'),
+            h(:th, th_props[@game.players.size], 'Players'),
+            h(:th, th_props[2, true], 'Bank'),
+            h(:th, th_props[2], 'Prices'),
+            h(:th, th_props[5, true, false], 'Corporation'),
             h(:th, ''),
-            h(:th, ''),
-            h(:th, spacing[or_history_titles.size], 'OR History'),
+            h(:th, th_props[or_history_titles.size, false, false], 'OR History'),
           ]),
           h(:tr, [
-            h(:th, render_sort_link('SYM', :id)),
+            h(:th, { style: { paddingBottom: '0.3rem' } }, render_sort_link('SYM', :id)),
             *@game.players.map do |p|
               h('th.name.nowrap.right', p == @game.priority_deal_player ? pd_props : '', render_sort_link(p.name, p.id))
             end,
             h(:th, @game.class::IPO_NAME),
             h(:th, 'Market'),
             h(:th, @game.class::IPO_NAME),
-            h('th.no_padding', render_sort_link('Market', :share_price)),
+            h(:th, render_sort_link('Market', :share_price)),
             h(:th, render_sort_link('Cash', :cash)),
-            h('th.no_padding', render_sort_link('Order', :order)),
+            h(:th, render_sort_link('Order', :order)),
             h(:th, 'Trains'),
             h(:th, 'Tokens'),
-            h('th.no_padding', 'Companies'),
+            h(:th, 'Companies'),
             h(:th, ''),
             *or_history_titles,
           ]),
@@ -167,8 +176,8 @@ module View
       def render_corporations
         current_round = @game.turn_round_num
 
-        sorted_corporations.map do |order, corporation|
-          render_corporation(corporation, order, current_round)
+        sorted_corporations.map.with_index do |corp_array, index|
+          render_corporation(corp_array[1], corp_array[0], current_round, index)
         end
       end
 
@@ -199,7 +208,9 @@ module View
         result
       end
 
-      def render_corporation(corporation, operating_order, current_round)
+      def render_corporation(corporation, operating_order, current_round, index)
+        border_style = "1px solid #{color_for(:font2)}"
+
         name_props =
           {
             style: {
@@ -208,8 +219,8 @@ module View
             },
         }
 
-        tr_props = { style: {} }
-        market_props = { style: {} }
+        tr_props = zebra_props(index.odd?)
+        market_props = { style: { borderRight: border_style } }
         if !corporation.floated?
           tr_props[:style][:opacity] = '0.6'
         elsif !corporation.counts_for_limit && (color = StockMarket::COLOR_MAP[corporation.share_price.color])
@@ -235,8 +246,8 @@ module View
             end
             h('td.padded_number', sold_props, "#{corporation.president?(p) ? '*' : ''}#{p.num_shares_of(corporation)}")
           end,
-          h('td.padded_number', corporation.num_shares_of(corporation)),
-          h('td.padded_number',
+          h('td.padded_number', { style: { borderLeft: border_style } }, corporation.num_shares_of(corporation)),
+          h('td.padded_number', { style: { borderRight: border_style } },
             "#{corporation.receivership? ? '*' : ''}#{@game.share_pool.num_shares_of(corporation)}"),
           h('td.padded_number', corporation.par_price ? @game.format_currency(corporation.par_price.price) : ''),
           h('td.padded_number', market_props,
@@ -246,7 +257,7 @@ module View
           h(:td, corporation.trains.map(&:name).join(', ')),
           h(:td, "#{corporation.tokens.map { |t| t.used ? 0 : 1 }.sum}/#{corporation.tokens.size}"),
           render_companies(corporation),
-          h('th.no_padding', name_props, corporation.name),
+          h(:th, name_props, corporation.name),
           *render_history(corporation),
         ])
       end
@@ -256,36 +267,36 @@ module View
       end
 
       def render_player_companies
-        h(:tr, [
-          h('th.no_padding', 'Companies'),
+        h(:tr, zebra_props, [
+          h(:th, 'Companies'),
           *@game.players.map { |p| render_companies(p) },
         ])
       end
 
       def render_player_cash
-        h(:tr, [
-          h('th.left.no_padding', 'Cash'),
+        h(:tr, zebra_props, [
+          h('th.left', 'Cash'),
           *@game.players.map { |p| h('td.padded_number', @game.format_currency(p.cash)) },
         ])
       end
 
       def render_player_value
-        h(:tr, [
-          h('th.left.no_padding', 'Value'),
+        h(:tr, zebra_props(true), [
+          h('th.left', 'Value'),
           *@game.players.map { |p| h('td.padded_number', @game.format_currency(p.value)) },
         ])
       end
 
       def render_player_liquidity
-        h(:tr, [
-          h('th.left.no_padding', 'Liquidity'),
+        h(:tr, zebra_props, [
+          h('th.left', 'Liquidity'),
           *@game.players.map { |p| h('td.padded_number', @game.format_currency(@game.liquidity(p))) },
         ])
       end
 
       def render_player_shares
-        h(:tr, [
-          h('th.left.no_padding', 'Shares'),
+        h(:tr, zebra_props(true), [
+          h('th.left', 'Shares'),
           *@game.players.map { |p| h('td.padded_number', @game.corporations.sum { |c| p.num_shares_of(c) }) },
         ])
       end
@@ -293,10 +304,20 @@ module View
       def render_player_certs
         cert_limit = @game.cert_limit
         props = { style: { color: 'red' } }
-        h(:tr, [
-          h('th.left.no_padding', "Certs/#{cert_limit}"),
+        h(:tr, zebra_props(true), [
+          h('th.left', "Certs/#{cert_limit}"),
           *@game.players.map { |p| h('td.padded_number', p.num_certs > cert_limit ? props : '', p.num_certs) },
         ])
+      end
+
+      def zebra_props(alt_bg = false)
+        factor = Native(`window.matchMedia('(prefers-color-scheme: dark)').matches`) ? 0.9 : 0.5
+        {
+          style: {
+            backgroundColor: alt_bg ? convert_hex_to_rgba(color_for(:bg2), factor) : color_for(:bg2),
+            color: color_for(:font2),
+          },
+        }
       end
     end
   end

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -96,7 +96,7 @@ p:last-child {
 th, td {
   padding: 0 0.3rem;
 }
-#game_info tbody > tr:hover, #spreadsheet tbody > tr:hover {
+#game_info tbody > tr:hover {
   background-color: #CCCCCC;
   color: black;
 }


### PR DESCRIPTION
(resolves a part of  #1416)

@justinkwaugh ’s proposal:
![image](https://user-images.githubusercontent.com/33390595/90004799-8e5ebd00-dc96-11ea-8d6c-d37f342dac15.png)

To me that many borders just reduce my parse speed hence I added only a few. Withhold and half-pay conflict a bit with gray bg, but I’d just wait and see what people think.

FF dark
![image](https://user-images.githubusercontent.com/33390595/90005012-df6eb100-dc96-11ea-8574-afee8fe32fc4.png)

Chrome light
![image](https://user-images.githubusercontent.com/33390595/90005022-e39ace80-dc96-11ea-8b3d-58b288258dd4.png)
