### PR TITLE
order/last run bg = holdings_bg

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -61,6 +61,8 @@ module View
               grid: '1fr / repeat(2, max-content)',
               gap: '2rem',
               justifyContent: 'center',
+              backgroundColor: color_for(:bg2),
+              color: color_for(:font2),
             },
           }
 
@@ -325,7 +327,10 @@ module View
 
       def render_revenue_history
         last_run = @corporation.operating_history[@corporation.operating_history.keys.max].revenue
-        h('div.bold', "Last Run: #{@game.format_currency(last_run)}")
+        h(:div, { style: { display: 'inline' } }, [
+          'Last Run: ',
+          h('span.bold', @game.format_currency(last_run)),
+        ])
       end
 
       def render_operating_order
@@ -333,8 +338,11 @@ module View
 
         round = @game.round
         if (n = @game.round.entities.find_index(@corporation))
-          div_class = '.bold' if n >= round.entities.find_index(round.current_entity)
-          [h("div#{div_class}", "Order: #{n + 1}")]
+          span_class = '.bold' if n >= round.entities.find_index(round.current_entity)
+          [h(:div, { style: { display: 'inline' } }, [
+            'Order: ',
+            h("span#{span_class}", n + 1),
+          ])]
         else
           []
         end


### PR DESCRIPTION
Another part of #1416 
![image](https://user-images.githubusercontent.com/33390595/90011362-c1f31480-dca1-11ea-889d-6dcadea56c39.png)

No zebra-style because it’s a minute detail not worth the time and code it would take because of user-defined colors, several possible combinations of abilities & company table plus maybe others in the long run.
Color on user-defined bg like in the screenshot is also not the best idea. Given we use bold in the holdings section and other places I’ll keep it here, too:
![image](https://user-images.githubusercontent.com/33390595/90011383-ce776d00-dca1-11ea-8b88-eb35ed2215c2.png)
![image](https://user-images.githubusercontent.com/33390595/90011389-d0d9c700-dca1-11ea-97fe-7310b89b14ca.png)
