### PR TITLE
1817 Cash Crisis

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require 'view/game/actionable'
-require 'view/game/corporation'
-require 'view/game/sell_shares'
-require 'view/game/undo_and_pass'
+require 'view/game/emergency_money'
 
 module View
   module Game
     class BuyTrains < Snabberb::Component
       include Actionable
+      include EmergencyMoney
       needs :show_other_players, default: nil, store: true
       needs :selected_corporation, default: nil, store: true
 
@@ -24,24 +23,8 @@ module View
                         'To buy the cheapest train from the depot the president must raise '\
                         "#{@game.format_currency(funds_required)}, and can sell "\
                         "#{@game.format_currency(liquidity - player.cash)} in shares:")
-          props = {
-            style: {
-              display: 'inline-block',
-              verticalAlign: 'top',
-            },
-          }
 
-          player.shares_by_corporation.each do |corporation, shares|
-            next if shares.empty?
-
-            corp = [h(Corporation, corporation: corporation)]
-
-            corp << h(SellShares, player: @corporation.owner) if @selected_corporation == corporation
-
-            children << h(:div, props, corp)
-          end
-
-          children << render_bankruptcy
+          children.append(*render_emergency_money_raising(player))
         else
           children << h('div',
                         'To buy the cheapest train from the depot the president must contribute'\
@@ -245,21 +228,6 @@ module View
           h('div.bold', 'Qty'),
           *rows,
         ])
-      end
-
-      def render_bankruptcy
-        resign = lambda do
-          process_action(Engine::Action::Bankrupt.new(@corporation))
-        end
-
-        props = {
-          style: {
-            width: 'max-content',
-          },
-          on: { click: resign },
-        }
-
-        h(:button, props, 'Declare Bankruptcy')
       end
     end
   end

--- a/assets/app/view/game/cash_crisis.rb
+++ b/assets/app/view/game/cash_crisis.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+require 'view/game/emergency_money'
+
+module View
+  module Game
+    class CashCrisis < Snabberb::Component
+      include Actionable
+      include EmergencyMoney
+      needs :selected_corporation, default: nil, store: true
+
+      def render
+        player = @game.round.active_step.current_entity
+
+        children = []
+
+        funds_required = @game.round.active_step.needed_cash(player)
+        children << h('div',
+                      "Player owes the bank #{@game.format_currency(funds_required)} and must sell shares if possible.")
+
+        children.append(*render_emergency_money_raising(player))
+
+        h(:div, children)
+      end
+    end
+  end
+end

--- a/assets/app/view/game/emergency_money.rb
+++ b/assets/app/view/game/emergency_money.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'view/game/corporation'
+require 'view/game/sell_shares'
+
+module View
+  module Game
+    module EmergencyMoney
+      def render_emergency_money_raising(player)
+        children = []
+        props = {
+          style: {
+            display: 'inline-block',
+            verticalAlign: 'top',
+          },
+        }
+        player.shares_by_corporation.each do |corporation, shares|
+          next if shares.empty?
+
+          corp = [h(Corporation, corporation: corporation)]
+
+          corp << h(SellShares, player: player) if @selected_corporation == corporation
+
+          children << h(:div, props, corp)
+        end
+
+        children << render_bankruptcy
+        children
+      end
+
+      def render_bankruptcy
+        resign = lambda do
+          process_action(Engine::Action::Bankrupt.new(@game.round.active_step.current_entity))
+        end
+
+        props = {
+          style: {
+            width: 'max-content',
+          },
+          on: { click: resign },
+        }
+
+        h(:button, props, 'Declare Bankruptcy')
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -3,11 +3,12 @@
 require 'view/game/buy_companies'
 require 'view/game/buy_trains'
 require 'view/game/corporation'
+require 'view/game/player'
 require 'view/game/dividend'
 require 'view/game/issue_shares'
 require 'view/game/map'
-require 'view/game/undo_and_pass'
 require 'view/game/route_selector'
+require 'view/game/cash_crisis'
 
 module View
   module Game
@@ -18,19 +19,26 @@ module View
         def render
           round = @game.round
           @step = round.active_step
-          entity = round.current_entity
+          entity = @step.current_entity
           @current_actions = round.actions_for(entity)
           entity = entity.owner if entity.company?
 
           left = []
           left << h(RouteSelector) if @current_actions.include?('run_routes')
           left << h(Dividend) if @current_actions.include?('dividend')
+
           if @current_actions.include?('buy_train')
             left << h(IssueShares) if @current_actions.include?('sell_shares')
             left << h(BuyTrains)
+          elsif @current_actions.include?('sell_shares') && entity.player?
+            left << h(CashCrisis)
           end
           left << h(IssueShares) if @current_actions.include?('buy_shares')
-          left << h(Corporation, corporation: entity)
+          left << if entity.player?
+                    h(Player, player: entity, game: @game)
+                  else
+                    h(Corporation, corporation: entity)
+                  end
 
           div_props = {
             style: {

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -102,6 +102,7 @@ module Engine
       # down_block -- down one row per block
       # left_block_pres -- left one column per block if president
       # left_block -- one row per block
+      # none -- don't drop price
       SELL_MOVEMENT = :down_share
 
       # :sell_buy_or_buy_sell
@@ -538,10 +539,12 @@ module Engine
           bundle.num_shares.times { @stock_market.move_down(corporation) }
         when :left_block_pres
           stock_market.move_left(corporation) if was_president
+        when :none
+          nil
         else
           raise NotImplementedError
         end
-        log_share_price(corporation, price)
+        log_share_price(corporation, price) if self.class::SELL_MOVEMENT != :none
       end
 
       def log_share_price(entity, from)

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -36,6 +36,9 @@ module Engine
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817'
       SEED_MONEY = 200
       MUST_BUY_TRAIN = :never
+      EBUY_PRES_SWAP = false # allow presidential swaps of other corps when ebuying
+      POOL_SHARE_DROP = :one
+      SELL_MOVEMENT = :none
 
       def new_auction_round
         log << "Seed Money for initial auction is #{format_currency(SEED_MONEY)}"
@@ -57,8 +60,9 @@ module Engine
       end
 
       def operating_round(round_num)
-        Round::Operating.new(self, [
-          Step::Bankrupt,
+        Round::G1817::Operating.new(self, [
+          Step::Bankrupt, # @todo: needs customization
+          Step::G1817::CashCrisis,
           Step::BuyCompany, # @todo: remove
           Step::DiscardTrain,
           Step::G1817::Track,
@@ -66,6 +70,7 @@ module Engine
           Step::Route,
           Step::G1817::Dividend,
           Step::G1817::BuyTrain,
+
           # @todo: pay fees on loans, repay loans
           # @todo: check for liquidation
         ], round_num: round_num)

--- a/lib/engine/round/g_1817/operating.rb
+++ b/lib/engine/round/g_1817/operating.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../operating'
+
+module Engine
+  module Round
+    module G1817
+      class Operating < Operating
+        attr_accessor :last_player
+
+        def after_process(action)
+          # Keep track of last_player for Cash Crisis
+          @last_player = action.entity.player
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/spender.rb
+++ b/lib/engine/spender.rb
@@ -14,8 +14,8 @@ module Engine
       raise GameError, "#{amount} is not valid to spend" unless amount.positive?
     end
 
-    def spend(cash, receiver)
-      check_cash(cash)
+    def spend(cash, receiver, allow_overdraw = false)
+      check_cash(cash) unless allow_overdraw
       check_positive(cash)
       @cash -= cash
       receiver.cash += cash

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Step
+    module EmergencyMoney
+      def process_sell_shares(action)
+        unless can_sell?(action.entity, action.bundle)
+          @game.game_error("Cannot sell shares of #{action.bundle.corporation.name}")
+        end
+
+        @game.sell_shares_and_change_price(action.bundle)
+      end
+
+      def can_sell?(_entity, bundle)
+        player = bundle.owner
+        # Can't sell president's share
+        return false unless bundle.can_dump?(player)
+
+        # Can only sell as much as you need to afford the train
+        total_cash = bundle.price + available_cash(player)
+        return false if total_cash >= needed_cash(player) + bundle.price_per_share
+
+        # Can't swap presidency
+        corporation = bundle.corporation
+        if corporation.president?(player) &&
+            (!@game.class::EBUY_PRES_SWAP || corporation == current_entity)
+          share_holders = corporation.player_share_holders
+          remaining = share_holders[player] - bundle.percent
+          next_highest = share_holders.reject { |k, _| k == player }.values.max || 0
+          return false if remaining < next_highest
+        end
+
+        # Can't oversaturate the market
+        return false unless @game.share_pool.fit_in_bank?(bundle)
+
+        # Otherwise we're good
+        true
+      end
+
+      def issuable_shares
+        []
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1817/cash_crisis.rb
+++ b/lib/engine/step/g_1817/cash_crisis.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../emergency_money'
+
+module Engine
+  module Step
+    module G1817
+      class CashCrisis < Base
+        include EmergencyMoney
+
+        def actions(entity)
+          return [] unless entity == current_entity
+
+          ['sell_shares']
+        end
+
+        def description
+          'Cash Crisis'
+        end
+
+        def active?
+          active_entities.any?
+        end
+
+        def active_entities
+          return [] unless @round.last_player
+
+          # Rotate players to order starting with the current player
+          players = @game.players.rotate(@game.players.index(@round.last_player))
+          players.select { |p| p.cash.negative? }
+        end
+
+        def needed_cash(entity)
+          -entity.cash
+        end
+
+        def available_cash(_player)
+          0
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'emergency_money'
 
 module Engine
   module Step
     module Train
+      include EmergencyMoney
       def can_buy_train?(entity = nil)
         entity ||= current_entity
         can_buy_normal = room?(entity) &&
@@ -67,39 +69,18 @@ module Engine
       end
 
       def process_sell_shares(action)
-        unless can_sell?(action.entity, action.bundle)
-          @game.game_error("Cannot sell shares of #{action.bundle.corporation.name}")
-        end
+        super
 
         @last_share_sold_price = action.bundle.price_per_share
-        @game.sell_shares_and_change_price(action.bundle)
         @round.recalculate_order
       end
 
-      def can_sell?(_entity, bundle)
-        player = bundle.owner
-        # Can't sell president's share
-        return false unless bundle.can_dump?(player)
+      def needed_cash(_entity)
+        @depot.min_depot_price
+      end
 
-        # Can only sell as much as you need to afford the train
-        total_cash = bundle.price + player.cash + current_entity.cash
-        return false if total_cash >= @depot.min_depot_price + bundle.price_per_share
-
-        # Can't swap presidency
-        corporation = bundle.corporation
-        if corporation.president?(player) &&
-            (!@game.class::EBUY_PRES_SWAP || corporation == current_entity)
-          share_holders = corporation.player_share_holders
-          remaining = share_holders[player] - bundle.percent
-          next_highest = share_holders.reject { |k, _| k == player }.values.max || 0
-          return false if remaining < next_highest
-        end
-
-        # Can't oversaturate the market
-        return false unless @game.share_pool.fit_in_bank?(bundle)
-
-        # Otherwise we're good
-        true
+      def available_cash(player)
+        player.cash + current_entity.cash
       end
 
       def buyable_trains(entity)


### PR DESCRIPTION
Reuse the EMR from trains, temporarily allow players to go overdrawn and then have to sell shares to rectify it.

Also implement 1817 share price changes