### PR TITLE
Handle empty depot smothly (fixes #1446)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -557,7 +557,7 @@ module Engine
       end
 
       def must_buy_train?(entity)
-        !entity.rusted_self && entity.trains.empty? &&
+        !entity.rusted_self && entity.trains.empty? && !depot.depot_trains.empty? &&
           (self.class::MUST_BUY_TRAIN == :always ||
            (self.class::MUST_BUY_TRAIN == :route && @graph.route_info(entity)&.dig(:route_train_purchase)))
       end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -105,10 +105,9 @@ module Engine
       def buyable_trains(entity)
         depot_trains = @depot.depot_trains
         other_trains = @depot.other_trains(entity)
-
-        # If the corporation cannot buy a train, then it can only buy the cheapest available
+        # If the corporation cannot buy a train, then it can only buy the cheapest available (if there is any...)
         min_depot_train = @depot.min_depot_train
-        if min_depot_train.price > entity.cash
+        if min_depot_train && min_depot_train.price > entity.cash
           depot_trains = [min_depot_train]
 
           if @last_share_sold_price

--- a/spec/fixtures/18_al/1446.json
+++ b/spec/fixtures/18_al/1446.json
@@ -1,0 +1,5307 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 1,
+      "company": "TR",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 2,
+      "company": "SNAR",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 3,
+      "company": "BLC",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 4,
+      "company": "M&C",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 5,
+      "company": "NDY",
+      "price": 120
+    },
+    {
+      "type": "par",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 6,
+      "corporation": "L&N",
+      "share_price": "60,2,2"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 7,
+      "shares": [
+        "L&N_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 8,
+      "shares": [
+        "L&N_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 9,
+      "shares": [
+        "L&N_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 10,
+      "shares": [
+        "L&N_4"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 11,
+      "shares": [
+        "L&N_5"
+      ]
+    },
+    {
+      "type": "par",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 12,
+      "corporation": "M&O",
+      "share_price": "105,0,6"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 13,
+      "shares": [
+        "M&O_1"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 14,
+      "shares": [
+        "M&O_2"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 15,
+      "shares": [
+        "M&O_3"
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 16,
+      "shares": [
+        "M&O_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 17
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 18
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 19
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 20
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 21,
+      "hex": "P1",
+      "tile": "8-0",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 22,
+      "train": "2-0",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 23,
+      "hex": "C4",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 24
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 25,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 26
+    },
+    {
+      "type": "par",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 27,
+      "corporation": "ABC",
+      "share_price": "105,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 28
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 29,
+      "shares": [
+        "ABC_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 30
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 31,
+      "shares": [
+        "ABC_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 32
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 33
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 34
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 35
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 36,
+      "shares": [
+        "ABC_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 37
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 38
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 39
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 40
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 41
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 42,
+      "shares": [
+        "L&N_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 43
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 44
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 45
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 46
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 47
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 48,
+      "hex": "N1",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 49
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 50,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 51,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 52,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 53
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 54,
+      "hex": "E4",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 55
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 56,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 57,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 58,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 59
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 60
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 61,
+      "shares": [
+        "L&N_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 62
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 63
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 64
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 65
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 66
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 67,
+      "hex": "K2",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 68,
+      "city": "57-1-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 69,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 70,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 71
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 72,
+      "hex": "G4",
+      "tile": "441a-0",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 73,
+      "city": "441a-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 74,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C4",
+              "E4",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 75,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 76
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 77
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 78,
+      "shares": [
+        "ABC_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 79
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 80
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 81,
+      "shares": [
+        "ABC_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 82
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 83,
+      "shares": [
+        "L&N_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 84
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 85
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 86
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 87
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 88
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 89,
+      "hex": "J3",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 90
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 91,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 92,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 93
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 94,
+      "hex": "G6",
+      "tile": "6-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 95
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 96,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 97
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 98
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 99
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 100,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C4",
+              "E4",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 101,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 102,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 103
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 104
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 105
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 106
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 107
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 108
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 109,
+      "hex": "I4",
+      "tile": "8-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 110
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 111,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 112,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 113,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 114
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 115
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 116,
+      "hex": "G4",
+      "tile": "442a-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 117
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 118
+    },
+    {
+      "type": "place_token",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 119,
+      "city": "442a-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 120,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 121,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 122,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 123
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 124
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 125,
+      "hex": "K2",
+      "tile": "14-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 126
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 127,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C4",
+              "E4",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 128,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 129,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 130
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 131,
+      "hex": "L3",
+      "tile": "8-2",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 132
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 133,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 134,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 135
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 136
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 137,
+      "hex": "H7",
+      "tile": "8-3",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 138,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 139,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 140
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 141
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 142,
+      "hex": "L5",
+      "tile": "6-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 143,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C4",
+              "E4",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ]
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 144,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 145
+    },
+    {
+      "type": "par",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 146,
+      "corporation": "WRA",
+      "share_price": "105,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 147
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 148,
+      "shares": [
+        "WRA_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 149
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 150,
+      "shares": [
+        "WRA_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 151
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 152,
+      "shares": [
+        "WRA_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 153
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 154,
+      "shares": [
+        "WRA_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 155
+    },
+    {
+      "type": "par",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 156,
+      "corporation": "ATN",
+      "share_price": "105,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 157
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 158,
+      "shares": [
+        "ATN_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 159
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 160,
+      "shares": [
+        "ATN_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 161
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 162
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 163
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 164,
+      "shares": [
+        "ATN_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 165
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 166
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 167
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 168
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 169
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 170,
+      "hex": "L5",
+      "tile": "443a-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_company",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 171,
+      "company": "BLC",
+      "price": 35
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BLC",
+      "entity_type": "company",
+      "id": 172,
+      "hex": "N5",
+      "tile": "445-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 173
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 174,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 175,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 176
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 177
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 178,
+      "hex": "G6",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 179,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 180,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 181
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 182
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 183,
+      "hex": "C4",
+      "tile": "14-2",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 184,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "G4",
+              "E4",
+              "C4"
+            ]
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ]
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 185,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 186
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 187,
+      "hex": "J5",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 188
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 189,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 190
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 191
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 192,
+      "hex": "O6",
+      "tile": "4-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 193
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 194,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 196,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 197
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 198
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 199,
+      "hex": "F7",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 200,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 201,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 202,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 203
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 204
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 205,
+      "hex": "E6",
+      "tile": "15-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 206,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ]
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 207,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 208
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 209
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 210
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 211
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 212,
+      "hex": "K4",
+      "tile": "14-3",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 213
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 214,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "L5",
+              "N5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 215,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 216,
+      "train": "5-0",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 217,
+      "shares": [
+        "ATN_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 218
+    },
+    {
+      "type": "par",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 219,
+      "corporation": "TAG",
+      "share_price": "105,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 220
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 221,
+      "shares": [
+        "TAG_1"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 222
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 223,
+      "shares": [
+        "TAG_2"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 224
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 225,
+      "shares": [
+        "TAG_3"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 226
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 227,
+      "shares": [
+        "TAG_4"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 228
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 229,
+      "shares": [
+        "M&O_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 230
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 231,
+      "shares": [
+        "M&O_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 232
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 233
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 234
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 235
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 236
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 237,
+      "hex": "K2",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 238
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 239,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G4",
+              "I4",
+              "J3",
+              "K2"
+            ],
+            [
+              "L1",
+              "K2"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "L5",
+              "N5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 240,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 241,
+      "hex": "G4",
+      "tile": "444b-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 242,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 243,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 244,
+      "hex": "H1",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 245,
+      "train": "5-1",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 246
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 247,
+      "hex": "J1",
+      "tile": "9-5",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 248
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 249,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 250,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 251,
+      "hex": "L5",
+      "tile": "444m-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 252
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 253,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ],
+            [
+              "K4",
+              "L5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 254,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 255,
+      "hex": "F5",
+      "tile": "9-6",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 256
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 257,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 258
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 259,
+      "hex": "F5",
+      "tile": "20-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 260
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 261,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 262,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 263
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 264,
+      "hex": "E4",
+      "tile": "24-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 265,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ],
+            [
+              "G4",
+              "E4",
+              "C4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 266,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 267
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 268,
+      "hex": "E4",
+      "tile": "42-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 269
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 270,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "K4",
+              "L3",
+              "K2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 271,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 272
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 273,
+      "hex": "K4",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 274
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 275,
+      "train": "4-0",
+      "price": 440
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 276,
+      "hex": "G6",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 277
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 278,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 279,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 280,
+      "train": "7-0",
+      "price": 700,
+      "variant": "7"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 281,
+      "hex": "I4",
+      "tile": "23-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 282
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 283,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 284,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 285
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 286,
+      "hex": "K6",
+      "tile": "9-7",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 287
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 288,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 289,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 290,
+      "train": "4D-0",
+      "price": 800,
+      "variant": "4D"
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 291
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 292,
+      "hex": "E6",
+      "tile": "63-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 293,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ],
+            [
+              "C4",
+              "E4",
+              "G4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 294,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 295,
+      "train": "4D-1",
+      "price": 800,
+      "variant": "4D"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 296
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 297,
+      "hex": "J7",
+      "tile": "57-2",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 298,
+      "city": "57-2-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 299,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 300,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 301,
+      "train": "4D-2",
+      "price": 800,
+      "variant": "4D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 302,
+      "hex": "C4",
+      "tile": "63-4",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 303,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "K4",
+              "I4",
+              "G4"
+            ],
+            [
+              "G4",
+              "E4",
+              "C4"
+            ],
+            [
+              "A4",
+              "C4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 304,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 305,
+      "train": "5-0",
+      "price": 1
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 306
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 307,
+      "train": "5-0",
+      "price": 179
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 308
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 309,
+      "hex": "J7",
+      "tile": "15-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 310
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 311,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 312,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 313,
+      "train": "4D-3",
+      "price": 800,
+      "variant": "4D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 314,
+      "hex": "F5",
+      "tile": "47-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 315
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 316,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 317,
+      "kind": "withhold"
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 318
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 319,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 320
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 321,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 322,
+      "train": "4D-4",
+      "price": 800,
+      "variant": "4D"
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 323
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 324
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 325
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 326
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 327
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 328
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 329,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 330,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 331,
+      "train": "5-0",
+      "price": 269
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 332
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 333,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 334,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 335
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 336
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 337
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 338
+    },
+    {
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 339
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 340,
+      "hex": "I8",
+      "tile": "8-5",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 341
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 342,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        },
+        {
+          "train": "4D-3",
+          "connections": [
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K6",
+              "J7"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 343,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 344,
+      "hex": "E2",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 345
+    },
+    {
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 346
+    },
+    {
+      "type": "undo",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 347
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 348,
+      "hex": "I6",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 349
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 350,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        },
+        {
+          "train": "4D-2",
+          "connections": [
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "J7",
+              "I6",
+              "G6"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 351,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 352
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 353
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 354
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 355
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 356
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 357
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 358
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 359,
+      "hex": "D5",
+      "tile": "9-8",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 360
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 361
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 362
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 363,
+      "hex": "C6",
+      "tile": "58-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 364
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 365,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "4D-4",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "G6",
+              "E6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 366,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 367,
+      "hex": "C6",
+      "tile": "144-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 368,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 369,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 370,
+      "hex": "B5",
+      "tile": "8-7",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 371,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 372,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 373
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 374,
+      "hex": "D3",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 375
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 376,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        },
+        {
+          "train": "4D-3",
+          "connections": [
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K6",
+              "J7"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 377,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 378,
+      "hex": "E2",
+      "tile": "9-9",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 379
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 380,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "F1",
+              "H1",
+              "J1",
+              "L1"
+            ]
+          ]
+        },
+        {
+          "train": "4D-2",
+          "connections": [
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "J7",
+              "I6",
+              "G6"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 381,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 382,
+      "hex": "J7",
+      "tile": "63-5",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 383
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 384,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "4D-4",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "G6",
+              "E6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 385,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 386
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 387
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 388
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 389
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 390,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 391,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 392
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 393,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 394,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 395
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 396
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 397
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 398,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "C4",
+              "B5",
+              "C6"
+            ],
+            [
+              "C4",
+              "E4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        },
+        {
+          "train": "4D-3",
+          "connections": [
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K6",
+              "J7"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 399,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 400
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 401
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 402,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "C4",
+              "B5",
+              "C6"
+            ],
+            [
+              "C4",
+              "D3",
+              "E2",
+              "F1"
+            ]
+          ]
+        },
+        {
+          "train": "4D-2",
+          "connections": [
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G6",
+              "I6",
+              "J7"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 403,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 404
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 405
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 406,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "4D-4",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "G6",
+              "E6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 407,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 408
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 409
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 410
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 411
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 412
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 413
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 414,
+      "shares": [
+        "WRA_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 415
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 416,
+      "shares": [
+        "WRA_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 417
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 418,
+      "shares": [
+        "WRA_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 419
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 420,
+      "shares": [
+        "WRA_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 421
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 422,
+      "shares": [
+        "TAG_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 423
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 424,
+      "shares": [
+        "TAG_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 425
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 426,
+      "shares": [
+        "TAG_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 427
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 428,
+      "shares": [
+        "TAG_8"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 429
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 430
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 431,
+      "shares": [
+        "ATN_5"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 432
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 433
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 434
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 435
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 436,
+      "shares": [
+        "ATN_6"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 437
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 438
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 439
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 440
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 441,
+      "shares": [
+        "ATN_7"
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 442
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 443
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 444
+    },
+    {
+      "type": "pass",
+      "entity": "Player 4",
+      "entity_type": "player",
+      "id": 445
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 446
+    },
+    {
+      "type": "pass",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 447
+    },
+    {
+      "type": "run_routes",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 448,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "K2",
+              "L3",
+              "K4"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "L1",
+              "N1",
+              "P1",
+              "Q2"
+            ],
+            [
+              "L1",
+              "K2"
+            ],
+            [
+              "K2",
+              "J3",
+              "I4",
+              "G4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "M&O",
+      "entity_type": "corporation",
+      "id": 449,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 450
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 451,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 452,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 453
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 454
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 455
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 456,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "C4",
+              "B5",
+              "C6"
+            ],
+            [
+              "C4",
+              "E4",
+              "F5",
+              "E6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "P7",
+              "O6"
+            ]
+          ]
+        },
+        {
+          "train": "4D-3",
+          "connections": [
+            [
+              "L5",
+              "K4"
+            ],
+            [
+              "L5",
+              "K6",
+              "J7"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 457,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 458
+    },
+    {
+      "type": "pass",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 459
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 460,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G8",
+              "H7",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "C4",
+              "B5",
+              "C6"
+            ],
+            [
+              "C4",
+              "D3",
+              "E2",
+              "F1"
+            ]
+          ]
+        },
+        {
+          "train": "4D-2",
+          "connections": [
+            [
+              "G6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G6",
+              "I6",
+              "J7"
+            ],
+            [
+              "G8",
+              "I8",
+              "J7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ATN",
+      "entity_type": "corporation",
+      "id": 461,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 462
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 463
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 464,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "P7",
+              "O6"
+            ],
+            [
+              "N5",
+              "O6"
+            ],
+            [
+              "N5",
+              "L5"
+            ],
+            [
+              "H5",
+              "J5",
+              "L5"
+            ],
+            [
+              "H5",
+              "G6"
+            ],
+            [
+              "D7",
+              "F7",
+              "G6"
+            ],
+            [
+              "D7",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "G4"
+            ]
+          ]
+        },
+        {
+          "train": "4D-4",
+          "connections": [
+            [
+              "B7",
+              "C6"
+            ],
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "G6",
+              "E6"
+            ],
+            [
+              "G8",
+              "H7",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 465,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 466
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 467
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 468
+    }
+  ],
+  "id": "1446",
+  "players": [
+    {
+      "name": "Player 1"
+    },
+    {
+      "name": "Player 2"
+    },
+    {
+      "name": "Player 3"
+    },
+    {
+      "name": "Player 4"
+    }
+  ],
+  "title": "18AL",
+  "description": "Game to show what happens when all trains sold",
+  "max_players": "4",
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2020-08-15",
+  "loaded": true,
+  "result": {
+    "Player 2": 4120,
+    "Player 4": 4057,
+    "Player 3": 3487,
+    "Player 1": 3362
+  }
+}

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -145,6 +145,16 @@ module Engine
         'Daisy' => 2522,
         'Cecilia' => 2498,
       },
+      # In this game all trains are bought from depot.
+      # One train is without trains, but as depot is
+      # empty it does not have to buy any trains.
+      # Fix of issue #1446
+      1446 => {
+        'Player 2' => 4120,
+        'Player 4' => 4057,
+        'Player 3' => 3487,
+        'Player 1' => 3362,
+      },
     },
     GAMES_BY_TITLE['18TN'] => {
       4715 => {


### PR DESCRIPTION
If the last train is bought the game does not try to use
the cheapest train in the depot.

And if no trains are in the depot then a corporation is not
forced to buy trains.

Included a test case for an 18AL game where all 9 permanent
trains are bought, and the trains distributed among the 6
corporations so that one corporation is left without. Game
runs to completion with L&N trainless.