### PR TITLE
Enforce hex and city restrictions for token abilities

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -162,3 +162,5 @@ Modified station token placment
   token without connectivity, for the given price.
 - `extra`: If true, this ability may be used in addition to the turn's
   normal token placment step. Default false.
+- `city`: If present, the ability may only be used to token the city
+  with the corresponding index. Integer, default nil.

--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -5,13 +5,20 @@ require_relative 'base'
 module Engine
   module Ability
     class Token < Base
-      attr_reader :hexes, :price, :teleport_price, :extra
+      attr_reader :hexes, :price, :teleport_price, :extra, :city
 
-      def setup(hexes:, price:, teleport_price: nil, extra: nil)
+      def setup(hexes:, price:, teleport_price: nil, extra: nil, city: nil)
         @hexes = hexes
         @price = price
         @teleport_price = teleport_price
         @extra = extra || false
+        @city = city
+      end
+
+      def check_target(city)
+        match_hex_id = @hexes.include?(city.hex.id)
+        match_city = @city.nil? || city == city.tile.cities[@city]
+        match_hex_id && match_city
       end
     end
   end

--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -15,10 +15,8 @@ module Engine
         @city = city
       end
 
-      def check_target(city)
-        match_hex_id = @hexes.include?(city.hex.id)
-        match_city = @city.nil? || city == city.tile.cities[@city]
-        match_hex_id && match_city
+      def check_city(city)
+        @hexes.include?(city.hex.id) && (!@city || city == city.tile.cities[@city])
       end
     end
   end

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -179,6 +179,7 @@ module Engine
           "hexes": [
             "D6"
           ],
+          "city": 3,
           "price": 0,
           "teleport_price": 0,
           "count": 1,

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -40,6 +40,7 @@ module Engine
     "C9": "South Bend",
     "C15": "Detroit",
     "C17": "Windsor",
+    "D6": "Chicago",
     "D14": "Toledo",
     "D20": "Erie",
     "D22": "Buffalo",

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -2,6 +2,7 @@
 
 require_relative 'base'
 require_relative 'tokener'
+require_relative '../game_error'
 
 module Engine
   module Step
@@ -22,13 +23,20 @@ module Engine
 
       def process_place_token(action)
         entity = action.entity
+        token_ability = ability(entity)
 
-        place_token(
-          entity.owner,
-          action.city,
-          action.token,
-          teleport: ability(entity).teleport_price,
-        )
+        if token_ability.check_target(action.city)
+          place_token(
+            entity.owner,
+            action.city,
+            action.token,
+            teleport: token_ability.teleport_price,
+          )
+        else
+          raise GameError,
+                "#{entity.name} ability can not be used to place token " \
+                "in #{action.city.hex.id}."
+        end
       end
 
       def available_hex(entity, hex)

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -25,7 +25,7 @@ module Engine
         entity = action.entity
         token_ability = ability(entity)
 
-        if token_ability.check_target(action.city)
+        if token_ability.check_city(action.city)
           place_token(
             entity.owner,
             action.city,
@@ -33,9 +33,8 @@ module Engine
             teleport: token_ability.teleport_price,
           )
         else
-          raise GameError,
-                "#{entity.name} ability can not be used to place token " \
-                "in #{action.city.hex.id}."
+          @game.gate_error("#{entity.name} ability can not be used to place token " \
+                "in #{action.city.hex.id}.")
         end
       end
 

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -72,7 +72,7 @@ module Engine
         end
 
         entity.abilities(:token) do |ability, _|
-          next unless ability.check_target(city)
+          next unless ability.check_city(city)
 
           # check if this is correct or should be a corporation
           token = Engine::Token.new(entity) if ability.extra

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -29,7 +29,7 @@ module Engine
 
         @game.game_error('Token is already used') if token.used
 
-        token, ability = adjust_token_price_ability!(entity, token, hex)
+        token, ability = adjust_token_price_ability!(entity, token, city)
         entity.remove_ability(ability) if ability
         free = !token.price.positive?
         city.place_token(entity, token, free: free)
@@ -37,6 +37,7 @@ module Engine
           entity.spend(token.price, @game.bank)
           price_log = " for #{@game.format_currency(token.price)}"
         end
+        location_log = "(#{hex.location_name})" if hex.location_name
 
         case token.type
         when :neutral
@@ -44,7 +45,7 @@ module Engine
           token.corporation.tokens << token
           @log << "#{entity.name} places a neutral token on #{hex.name}#{price_log}"
         else
-          @log << "#{entity.name} places a token on #{hex.name} (#{hex.location_name})#{price_log}"
+          @log << "#{entity.name} places a token on #{hex.name} #{location_log}#{price_log}"
         end
 
         @game.graph.clear
@@ -64,19 +65,19 @@ module Engine
         prices.compact.min
       end
 
-      def adjust_token_price_ability!(entity, token, hex)
+      def adjust_token_price_ability!(entity, token, city)
         if (teleport = @round.teleported?(entity))
           token.price = 0
           return [token, teleport]
         end
 
         entity.abilities(:token) do |ability, _|
-          next unless ability.hexes.include?(hex.id)
+          next unless ability.check_target(city)
 
           # check if this is correct or should be a corporation
           token = Engine::Token.new(entity) if ability.extra
           token.price = ability.teleport_price if ability.teleport_price
-          token.price = ability.price if @game.graph.reachable_hexes(entity)[hex]
+          token.price = ability.price if @game.graph.reachable_hexes(entity)[city.hex]
           return [token, ability]
         end
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -157,7 +157,7 @@ module Engine
       end
 
       def check_track_restrictions!(entity, old_tile, new_tile)
-        return if @game.loading || !entity.corporation?
+        return if @game.loading || !(entity.corporation? || entity.minor?)
 
         old_paths = old_tile.paths
         changed_city = false


### PR DESCRIPTION
Also includes a little fix-up for the token log messages for cases where the hex has no location name.

Fixes #1228
Fixes #1461 