### PR TITLE
18GA: Let Bank own the neutral tokens

### DIFF
--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -33,6 +33,7 @@ module Engine
           logo: 'open_city',
           tokens: [0, 0],
         )
+        neutral.owner = @bank
 
         neutral.tokens.each { |token| token.type = :neutral }
 


### PR DESCRIPTION
During testing I experienced a crash sometimes that indicated
that owner was not always set. This might be the cause, so
just in case I added bank as owner to the neutral tokens.