### PR TITLE
18GA: Implement Waycross & Southern RR (fixes #1496)

### DIFF
--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -5,13 +5,14 @@ require_relative 'base'
 module Engine
   module Ability
     class Token < Base
-      attr_reader :hexes, :price, :teleport_price, :extra
+      attr_reader :hexes, :price, :teleport_price, :extra, :from_owner
 
-      def setup(hexes:, price:, teleport_price: nil, extra: nil)
+      def setup(hexes:, price:, teleport_price: nil, extra: nil, from_owner: false)
         @hexes = hexes
         @price = price
         @teleport_price = teleport_price
         @extra = extra || false
+        @from_owner = from_owner || false
       end
     end
   end

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -53,8 +53,10 @@ module Engine
       true
     end
 
-    def find_token_by_type(_token_type)
+    def find_token_by_type(token_type)
       raise GameError, "#{name} does not have a token" unless abilities(:token)
+
+      return @owner.find_token_by_type(token_type) if abilities(:token).from_owner
 
       Token.new(@owner)
     end

--- a/lib/engine/config/game/g_18_ga.rb
+++ b/lib/engine/config/game/g_18_ga.rb
@@ -226,17 +226,16 @@ module Engine
          "sym":"W&SR",
          "abilities":[
             {
-               "type":"teleport",
+               "type": "token",
                "owner_type":"corporation",
-               "tiles":[
-                  "5",
-                  "6",
-                  "57"
+               "hexes": [
+                 "I9"
                ],
-               "hexes":[
-                  "I9"
-               ]
-            }
+               "price": 0,
+               "teleport_price": 0,
+               "count": 1,
+               "from_owner": true
+             }
          ]
       },
       {

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -56,6 +56,7 @@ module Engine
         Round::Operating.new(self, [
           Step::Bankrupt,
           Step::DiscardTrain,
+          Step::SpecialToken,
           Step::G18GA::BuyCompany,
           Step::HomeToken,
           Step::SpecialTrack,


### PR DESCRIPTION
Had to change special token handling a bit to make the token placement
being performed by the company's owner, and use one of the tokens from
the owner.
(Did this by adding a from_owner atribute to the token ability.)

TODO: This works, almost... When the token is placed using the ability the corporation can still lay a token (have to Skip Token if not wanting to), but this is incorrect.

I tried to use a round state and store company.owner there, and then add a check in tokens_available? that the entity had not put out any token, but it did break an 1846 game where IC had been used to lay a token. Looking into that one it looked OK (id 150 for hs_cbxfbqwe_5779 it complained about).

So am I missing something obvious to get it to skip token automatically when having used company token ability to place token?