### PR TITLE
18MS: Correct phases

### DIFF
--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -479,14 +479,10 @@ module Engine
          "tiles":[
             "yellow"
          ],
-         "operating_rounds":2,
-         "status":[
-            "can_buy_companies"
-         ]
+         "operating_rounds":2
       },
       {
          "name":"3",
-         "on":"3",
          "train_limit":3,
          "tiles":[
             "yellow",
@@ -496,30 +492,6 @@ module Engine
          "status":[
             "can_buy_companies"
          ]
-      },
-      {
-         "name":"4",
-         "on":"4",
-         "train_limit":3,
-         "tiles":[
-            "yellow",
-            "green"
-         ],
-         "operating_rounds":2,
-         "status":[
-            "can_buy_companies"
-         ]
-      },
-      {
-         "name":"5",
-         "on":"5",
-         "train_limit":3,
-         "tiles":[
-            "yellow",
-            "green",
-            "brown"
-         ],
-         "operating_rounds":2
       },
       {
          "name":"6",


### PR DESCRIPTION
Removed phase 4 and 5 - does not exist in 18MS.

General buy private companies only allowed in phase 3.

Phase 3 is not triggered by any train buy.