### PR TITLE
18MS: Update private companies handling

### DIFF
--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -481,7 +481,10 @@ module Engine
          "tiles":[
             "yellow"
          ],
-         "operating_rounds":2
+         "operating_rounds":2,
+         "status":[
+            "can_buy_companies_operation_round_one"
+         ]
       },
       {
          "name":"3",

--- a/lib/engine/step/g_18_ms/buy_company.rb
+++ b/lib/engine/step/g_18_ms/buy_company.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../buy_company'
+
+module Engine
+  module Step
+    module G18MS
+      class BuyCompany < BuyCompany
+        def can_buy_company?(entity)
+          companies = @game.purchasable_companies
+
+          entity == current_entity &&
+            companies.any? &&
+            companies.map(&:min_price).min <= entity.cash
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make it possible for companies to buy P1/P2 during OR1.

AGS (P1) and BS (P2) can be bought by companies during OR1, but
only at face value. Otherwise buy of companies is as usual, can
be done for 50%-150% of face value during green phase. In 18MS
brown phase are triggered when 1st 6 train is bought.

Only private companies owned by the president may be bought