### PR TITLE
Revert "18GA: Implement Waycross & Southern RR (fixes #1496) (#1498)"

### DIFF
--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -5,14 +5,13 @@ require_relative 'base'
 module Engine
   module Ability
     class Token < Base
-      attr_reader :hexes, :price, :teleport_price, :extra, :from_owner
+      attr_reader :hexes, :price, :teleport_price, :extra
 
-      def setup(hexes:, price:, teleport_price: nil, extra: nil, from_owner: false)
+      def setup(hexes:, price:, teleport_price: nil, extra: nil)
         @hexes = hexes
         @price = price
         @teleport_price = teleport_price
         @extra = extra || false
-        @from_owner = from_owner || false
       end
     end
   end

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -53,10 +53,8 @@ module Engine
       true
     end
 
-    def find_token_by_type(token_type)
+    def find_token_by_type(_token_type)
       raise GameError, "#{name} does not have a token" unless abilities(:token)
-
-      return @owner.find_token_by_type(token_type) if abilities(:token).from_owner
 
       Token.new(@owner)
     end

--- a/lib/engine/config/game/g_18_ga.rb
+++ b/lib/engine/config/game/g_18_ga.rb
@@ -226,16 +226,17 @@ module Engine
          "sym":"W&SR",
          "abilities":[
             {
-               "type": "token",
+               "type":"teleport",
                "owner_type":"corporation",
-               "hexes": [
-                 "I9"
+               "tiles":[
+                  "5",
+                  "6",
+                  "57"
                ],
-               "price": 0,
-               "teleport_price": 0,
-               "count": 1,
-               "from_owner": true
-             }
+               "hexes":[
+                  "I9"
+               ]
+            }
          ]
       },
       {

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -56,7 +56,6 @@ module Engine
         Round::Operating.new(self, [
           Step::Bankrupt,
           Step::DiscardTrain,
-          Step::SpecialToken,
           Step::G18GA::BuyCompany,
           Step::HomeToken,
           Step::SpecialTrack,


### PR DESCRIPTION
This reverts commit 071273e19d664ebecc56e81df80e862cfdc0bc2a.

Reverted due to bug in tokening.