### PR TITLE
18AL: Lumber Terminal (Tile 445) cannot be upgraded

### DIFF
--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -140,6 +140,9 @@ module Engine
       end
 
       def upgrades_to?(from, to, special = false)
+        # Lumber terminal cannot be upgraded
+        return false if from.name == '445'
+
         # If upgrading Montgomery (L5) to green, only M tile #443a is allowed
         return to.name == '443a' if from.color == :yellow && from.hex.name == 'L5'
 


### PR DESCRIPTION
As it is now you will get an option to upgrade tile 445 but it should not be allowed.

If anyone have upgrades Lumber Terminal to green this will break the game. But it cannot be saved.