### PR TITLE
18GA: Correct handling of free train (Fixes #1536)

### DIFF
--- a/lib/engine/config/game/g_18_ga.rb
+++ b/lib/engine/config/game/g_18_ga.rb
@@ -382,7 +382,7 @@ module Engine
          ],
          "price":100,
          "rusts_on":"4",
-         "num":5
+         "num":6
       },
       {
          "name":"3",

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -50,6 +50,12 @@ module Engine
         @green_s_tile ||= @tiles.find { |t| t.name == '454a' }
         @brown_b_tile ||= @tiles.find { |t| t.name == '457a' }
         @brown_m_tile ||= @tiles.find { |t| t.name == '458a' }
+
+        # The last 2 train will be used as free train for a private
+        # Store it in neutral corporation in the meantime
+        @free_2_train = train_by_id('2-5')
+        @free_2_train.buyable = false
+        neutral.buy_train(@free_2_train, :free)
       end
 
       def operating_round(round_num)
@@ -95,6 +101,13 @@ module Engine
         upgrades |= [@brown_m_tile] if @brown_m_tile && STANDARD_GREEN_CITY_TILES.include?(tile.name)
 
         upgrades
+      end
+
+      def add_free_two_train(corporation)
+        @free_2_train.buyable = true
+        corporation.buy_train(@free_2_train, :free)
+        @free_2_train.buyable = false
+        @log << "#{corporation.name} receives a bonus non sellable 2 train"
       end
     end
   end

--- a/lib/engine/step/g_18_ga/buy_company.rb
+++ b/lib/engine/step/g_18_ga/buy_company.rb
@@ -14,28 +14,7 @@ module Engine
           owner = action.company.owner
           return if owner.player? || owner.trains.size == @game.phase.train_limit || @game.phase.available?('4')
 
-          free_two_train = Engine::Train.new(
-            name: '2',
-            distance: [
-              {
-                nodes: %w[city offboard],
-                pay: 2,
-                visit: 2,
-              },
-              {
-                nodes: %w[town],
-                pay: 99,
-                visit: 99,
-              },
-            ],
-            price: 0,
-            rusts_on: '4'
-          )
-          free_two_train.buyable = false
-          free_two_train.owner = owner
-          owner.trains << free_two_train
-          @game.trains << free_two_train
-          @game.log << "#{owner.name} adds free 2 train"
+          @game.add_free_two_train(owner)
         end
       end
     end


### PR DESCRIPTION
The free train received when buying private Ocilla Souther RR
did not have the correct index. Changed so that the free train
is created as all other 2 trains, and then bought by neutral
corporation and set to buyable false. When Ocilla Southern RR
is bought the owning corporation makes a free buy of the free
2 train. The 2 train is set to not buyable otherwise so that
the owning corporation cannot sell it later.