### PR TITLE
18MEX: Changes to make Minors operatable

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -226,25 +226,58 @@ module Engine
         ]
       },
       {
-         "sym":"IR",
+         "sym":"A",
          "name":"Interoceanic Railroad",
          "value":50,
          "revenue":0,
-         "desc":"Minor company. Begins in Tampico (L13). Once closed owner receives a 5% share in NdM."
+         "desc":"Minor company C. Begins in Tampico (L13). Once closed owner receives a 5% share in NdM.",
+         "abilities": [
+            {
+              "type": "no_buy",
+              "owner_type": "player"
+            },
+            {
+               "type": "close",
+               "when": "3½",
+               "owner_type": "player"
+            }
+         ]
       },
       {
-         "sym":"SBCR",
+         "sym":"B",
          "name":"Sonora-Baja California Railway",
          "value":50,
          "revenue":0,
-         "desc":"Minor company. Begins in Mazatlán (F11). Once closed owner receives a 5% share in NdM."
+         "desc":"Minor company B. Begins in Mazatlán (F11). Once closed owner receives a 5% share in NdM.",
+         "abilities": [
+            {
+              "type": "no_buy",
+              "owner_type": "player"
+            },
+            {
+               "type": "close",
+               "when": "3½",
+               "owner_type": "player"
+            }
+         ]
       },
       {
-         "sym":"SR",
+         "sym":"C",
          "name":"Southeastern Railway",
          "value":50,
          "revenue":0,
-         "desc":"Minor company. Begins in Oaxaca (L19). Once closed owner receives a 10% share in UdY."
+         "desc":"Minor company C. Begins in Oaxaca (L19). Once closed owner receives a 10% share in UdY.",
+         "abilities": [
+            {
+              "type": "no_buy",
+              "owner_type": "player"
+            },
+            {
+               "type": "close",
+               "when": "3½",
+               "owner_type": "player"
+            }
+         ]
       },
       {
          "sym":"MIR",

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -47,10 +47,18 @@ module Engine
           Step::Track,
           Step::Token,
           Step::Route,
-          Step::Dividend,
+          Step::G18MEX::Dividend,
           Step::SingleDepotTrainBuyBeforePhase4,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
+      end
+
+      def new_stock_round
+        @minors.each do |minor|
+          matching_company = @companies.find { |company| company.sym == minor.name }
+          minor.owner = matching_company.owner
+        end if @turn == 1
+        super
       end
 
       def revenue_for(route)

--- a/lib/engine/step/g_18_mex/dividend.rb
+++ b/lib/engine/step/g_18_mex/dividend.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../dividend'
+require_relative '../minor_half_pay'
+
+module Engine
+  module Step
+    module G18MEX
+      class Dividend < Dividend
+        include MinorHalfPay
+      end
+    end
+  end
+end


### PR DESCRIPTION
Init owner for each minor after completed SR1.

Set corresponding companies as non-buyable and closing at phase 3½.

Use 50%-50% dividend for minors.