### PR TITLE
18GA: Do not reserve any home city in Atlanta for W&A (fixes #1495, #…

### DIFF
--- a/lib/engine/config/game/g_18_ga.rb
+++ b/lib/engine/config/game/g_18_ga.rb
@@ -342,8 +342,7 @@ module Engine
             40
          ],
          "coordinates":"D4",
-         "color":"purple",
-         "city":0
+         "color":"purple"
       },
       {
          "float_percent":60,


### PR DESCRIPTION
…1517)

By removing the city reservation in the triple O tile of Atlanta
it behaves much better. If W&A do put out a token in Atlanta the
reservation does not remain. It wont block any other corporation
from tokening.