### PR TITLE
18MS: Implement Mississippi Central Railway private

### DIFF
--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -304,7 +304,7 @@ module Engine
             }
          ],
          "price":80,
-         "num":4
+         "num":5
       },
       {
          "name":"3+",

--- a/lib/engine/step/g_18_ms/buy_company.rb
+++ b/lib/engine/step/g_18_ms/buy_company.rb
@@ -13,6 +13,16 @@ module Engine
             companies.any? &&
             companies.map(&:min_price).min <= entity.cash
         end
+
+        def process_buy_company(action)
+          super
+
+          company = action.company
+          return unless company.id == 'MC'
+
+          entity = action.entity
+          @game.add_free_train(entity)
+        end
       end
     end
   end

--- a/lib/engine/step/special_buy_train.rb
+++ b/lib/engine/step/special_buy_train.rb
@@ -27,7 +27,7 @@ module Engine
         from_depot = action.train.from_depot?
         buy_train_action(action, corporation)
 
-        @round.bought_trains << corporation if from_depot
+        @round.bought_trains << corporation if from_depot && @round.respond_to?(:bought_trains)
 
         ability.use! if action.price < action.train.price &&
           ability.discounted_price(action.train, action.train.price) == action.price


### PR DESCRIPTION
Implements Mississippi Central Railway. This works as a free extra 2+ train. Cannot be bought after 2+ has been rusted or if train locked.

Also fixed a bug with Mobile and Ohio Railway caused by 18MS not using train buy limit.