### PR TITLE
18MS: Implement private P1 and P2 + general tile lay anywhere

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -78,10 +78,10 @@ Exchange this company for a share of a corporation.
 
 ## hex_bonus
 
-????
+Give a route bonus if at least one of the hexes are included in the route.
 
-- `hexes`:
-- `amount`:
+- `hexes`: Name of hexes that gives a bonus.
+- `amount`: Revenue bonus.
 
 ## no_buy
 
@@ -156,14 +156,17 @@ normal tile lay actions.
   connect to each other. Default true.
 - `blocks`: If true and `count` is greater than 1, all tile lays must
   be performed at once.
+- `reachable`: If true, when tile layed, a check is done if one of the
+  controlling corporation's station tokens are reachable; if not a game
+  error is triggered. Default false.
 
 ## token
 
-Modified station token placment
+Modified station token placement
 
 - `hexes`: Array of hex coordinates where this ability may be used
 - `price`: Price for placing token
 - `teleport_price`: If present, this ability may be used to place a
   token without connectivity, for the given price.
 - `extra`: If true, this ability may be used in addition to the turn's
-  normal token placment step. Default false.
+  normal token placement step. Default false.

--- a/lib/engine/ability/tile_lay.rb
+++ b/lib/engine/ability/tile_lay.rb
@@ -5,10 +5,10 @@ require_relative 'base'
 module Engine
   module Ability
     class TileLay < Base
-      attr_reader :hexes, :tiles, :free, :discount, :special, :connect, :blocks
+      attr_reader :hexes, :tiles, :free, :discount, :special, :connect, :blocks, :reachable
 
       def setup(hexes:, tiles:, free: false, discount: nil, special: nil,
-                connect: nil, blocks: nil)
+                connect: nil, blocks: nil, reachable: nil)
         @hexes = hexes
         @tiles = tiles
         @free = free
@@ -16,6 +16,7 @@ module Engine
         @special = special.nil? ? true : special
         @connect = connect.nil? ? true : connect
         @blocks = blocks.nil? ? true : blocks
+        @reachable = !!reachable
       end
     end
   end

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -160,18 +160,48 @@ module Engine
    ],
    "companies":[
       {
-         "name":"Atlanta Great Southern Railroad",
+         "name":"Alabama Great Southern Railroad",
          "value":30,
          "revenue":10,
          "desc":"The owning Major Company may lay an extra yellow tile for free. This extra tile must extend existing track and could be used to extend from a yellow or green tile played as a company’s  normal tile lay. This ability can only be used once, and using it does not close the company.",
-         "sym":"AGS"
-      },
+         "sym":"AGS",
+         "abilities": [
+           {
+             "type": "tile_lay",
+             "owner_type": "corporation",
+             "count": 1,
+             "free": true,
+             "special": false,
+             "reachable": true,
+             "hexes": [
+             ],
+             "tiles": [
+             ],
+             "when":"track"
+           }
+         ]
+        },
       {
          "name":"Birmingham Southern Railroad",
          "value":40,
          "revenue":10,
          "desc":"The owning Major Company may lay one or two extra yellow tiles for free. This extra tile lay must extend existing track and could be used to extend from a yellow or green tile played as a company’s normal tile lay. This ability can only be used once during a single operating round, and using it does not close the company.",
-         "sym":"BS"
+         "sym":"BS",
+         "abilities": [
+           {
+             "type": "tile_lay",
+             "owner_type": "corporation",
+             "count": 2,
+             "free": true,
+             "special": false,
+             "reachable": true,
+             "hexes": [
+             ],
+             "tiles": [
+             ],
+             "when":"track"
+           }
+         ]
       },
       {
          "name":"Meridian and Memphis Railway",

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -34,6 +34,10 @@ module Engine
       COMPANY_1_AND_2 = %w[AGS BS].freeze
       ATLANTA_HEXES = %w[D12 E13 F12].freeze
 
+      def p2_company
+        @p2_company ||= company_by_id('BS')
+      end
+
       include CompanyPrice50To150Percent
 
       def setup
@@ -78,7 +82,7 @@ module Engine
           Step::Bankrupt,
           Step::Exchange,
           Step::DiscardTrain,
-          Step::SpecialTrack,
+          Step::G18MS::SpecialTrack,
           Step::G18MS::SpecialToken,
           Step::G18MS::BuyCompany,
           Step::G18MS::Track,

--- a/lib/engine/step/g_18_ms/special_track.rb
+++ b/lib/engine/step/g_18_ms/special_track.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../special_track'
+
+module Engine
+  module Step
+    module G18MS
+      class SpecialTrack < SpecialTrack
+        def unpass!
+          super
+
+          # If private P2 was used once it cannot be used again
+          tile_lay = @game.p2_company.abilities(:tile_lay)
+          tile_lay.use! if tile_lay&.count == 1
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -29,13 +29,13 @@ module Engine
       end
 
       def process_lay_tile(action)
-        lay_tile(action)
+        lay_tile(action, spender: action.entity.owner)
         check_connect(action)
         ability(action.entity).use!
       end
 
       def available_hex(entity, hex)
-        return unless ability(entity).hexes.include?(hex.id)
+        return if ability(entity).hexes.any? && !ability(entity).hexes.include?(hex.id)
 
         @game.hex_by_id(hex.id).neighbors.keys
       end
@@ -43,9 +43,10 @@ module Engine
       def potential_tiles(entity, hex)
         return [] unless (tile_ability = ability(entity))
 
-        tile_ability
-          .tiles
-          .map { |name| @game.tiles.find { |t| t.name == name } }
+        tiles = tile_ability.tiles.map { |name| @game.tiles.find { |t| t.name == name } }
+        tiles = @game.tiles.uniq(&:name) if tile_ability.tiles.empty?
+
+        tiles
           .compact
           .select { |t| @game.phase.tiles.include?(t.color) && @game.upgrades_to?(hex.tile, t, tile_ability.special) }
       end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -72,7 +72,15 @@ module Engine
         discount = 0
 
         entity.abilities(:tile_lay) do |ability|
-          next if !ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name)
+          next if ability.hexes.any? && (!ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name))
+
+          if ability.reachable &&
+            !@game.loading &&
+            !@game.graph.reachable_hexes(spender)[hex] &&
+            hex.name != spender.coordinates
+
+            @game.game_error("Track laid must be connected to one of #{spender.id}'s stations")
+          end
 
           free = ability.free
           discount = ability.discount

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -74,13 +74,10 @@ module Engine
         entity.abilities(:tile_lay) do |ability|
           next if ability.hexes.any? && (!ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name))
 
-          if ability.reachable &&
+          @game.game_error("Track laid must be connected to one of #{spender.id}'s stations") if ability.reachable &&
+            hex.name != spender.coordinates &&
             !@game.loading &&
-            !@game.graph.reachable_hexes(spender)[hex] &&
-            hex.name != spender.coordinates
-
-            @game.game_error("Track laid must be connected to one of #{spender.id}'s stations")
-          end
+            !@game.graph.reachable_hexes(spender)[hex]
 
           free = ability.free
           discount = ability.discount


### PR DESCRIPTION
This PR implements private P1 and P2 in 18MS, which are privates that can lay extra yellow tiles during tile lay.
This require the possibility to specify empty hexes and tiles for the ability, so supporting this in the general code has been added.