### PR TITLE
18MS: Assisted permanent train buy

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -121,6 +121,7 @@ module View
             .sort_by { |_, v| v[:price] }
             .flat_map do |name, variant|
             price = variant[:price]
+            president_assist, _fee = @game.president_assisted_buy(@corporation, train, price)
             price = @ability&.discounted_price(train, price) || price
 
             buy_train = lambda do
@@ -137,7 +138,7 @@ module View
             [h(:div, name),
              h('div.nowrap', source),
              h('div.right', @game.format_currency(price)),
-             h('button.no_margin', { on: { click: buy_train } }, 'Buy')]
+             h('button.no_margin', { on: { click: buy_train } }, president_assist.positive? ? 'Assisted buy' : 'Buy')]
           end
         end
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1140,6 +1140,10 @@ module Engine
       end
 
       def interest_rate; end
+
+      def president_assisted_buy(_corporation, _train, _price)
+        [0, 0]
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -85,7 +85,7 @@ module Engine
           Step::Route,
           Step::Dividend,
           Step::SpecialBuyTrain,
-          Step::BuyTrain,
+          Step::G18MS::BuyTrain,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
       end
@@ -221,6 +221,22 @@ module Engine
         @hexes
           .select { |hex| hex_to_clear == hex.name }
           .each { |hex| hex.tile.icons = [] }
+      end
+
+      def president_assisted_buy(corporation, train, price)
+        # Can only assist if corporation cannot afford the train, but can pay at least 50%.
+        # Corporation also need to own at least one train, and the train need to be permanent.
+        if corporation.trains.size.positive? &&
+          !train.name.include?('+') &&
+          corporation.cash >= price / 2 &&
+          price > corporation.cash
+
+          fee = 50
+          president_assist = price - corporation.cash
+          return [president_assist, fee] unless corporation.owner.cash < president_assist + fee
+        end
+
+        super
       end
 
       private

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../buy_train'
+
+module Engine
+  module Step
+    module G18MS
+      class BuyTrain < BuyTrain
+        def process_buy_train(action)
+          entity ||= action.entity
+          price = action.price
+          train = action.train
+          player = entity.player
+
+          president_assist, fee_amount = @game.president_assisted_buy(entity, train, price)
+
+          if president_assist.positive?
+            player.spend(president_assist + fee_amount, @game.bank)
+            @game.bank.spend(president_assist, entity)
+            assist = @game.format_currency(president_assist).to_s
+            fee = @game.format_currency(fee_amount).to_s
+            @log << "#{player.name} pays #{assist} and an additional #{fee} fee to assist buying a #{train.name} train"
+          end
+
+          super
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If a corporation owns trains but cannot afford to buy an available
permanent train (but has at least 50% of its price) the president
can assist in the purchase buy spending the difference (and an
extra $50 "fee").

Have added a president_assisted_buy in the base class that can
be overridden if the game support this feature.