### PR TITLE
halfpay fix for Safari

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -79,7 +79,8 @@ module View
                            else
                              '1.0'
                            end,
-                  textDecoration: hist[x].dividend.kind == 'half' ? 'underline dotted' : '',
+                  textDecorationLine: hist[x].dividend.kind == 'half' ? 'underline' : '',
+                  textDecorationStyle: hist[x].dividend.kind == 'half' ? 'dotted' : '',
                   padding: '0 0.15rem',
                 },
               }


### PR DESCRIPTION
fixes #1119 
Safari doesn’t support text-decoration shorthand (=> -webkit-prefix or split into -line and -style)