### PR TITLE
18MS: Handle emergency buy

### DIFF
--- a/assets/app/view/game/emergency_money.rb
+++ b/assets/app/view/game/emergency_money.rb
@@ -24,7 +24,7 @@ module View
           children << h(:div, props, corp)
         end
 
-        children << render_bankruptcy
+        children << render_bankruptcy if @game.round.steps.find { |s| s.respond_to?(:process_bankrupt) }
         children
       end
 

--- a/assets/app/view/game/emergency_money.rb
+++ b/assets/app/view/game/emergency_money.rb
@@ -24,13 +24,13 @@ module View
           children << h(:div, props, corp)
         end
 
-        children << render_bankruptcy if @game.round.steps.find { |s| s.respond_to?(:process_bankrupt) }
+        children << render_bankruptcy if @game.round.actions_for(entity).include?('bankrupt')
         children
       end
 
       def render_bankruptcy
         resign = lambda do
-          process_action(Engine::Action::Bankrupt.new(@game.round.active_step.current_entity))
+          process_action(Engine::Action::Bankrupt.new(entity))
         end
 
         props = {
@@ -41,6 +41,12 @@ module View
         }
 
         h(:button, props, 'Declare Bankruptcy')
+      end
+
+      private
+
+      def entity
+        @game.round.active_step.current_entity
       end
     end
   end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -70,12 +70,21 @@ module Engine
           @phase.next! if @turn == 1 && round_num == 2
         end
 
+        if round_num == 1
+          @players.each do |p|
+            next unless p.cash.negative?
+
+            debt = -p.cash
+            interest = (debt / 2.0 + 0.5).floor
+            p.spend(interest, @bank, check_cash: false)
+            @log << "#{p.name} has to borrow another #{format_currency(interest)} as being in debt at end of SR"
+          end
+        end
         super
       end
 
       def operating_round(round_num)
         Round::Operating.new(self, [
-          Step::Bankrupt,
           Step::Exchange,
           Step::DiscardTrain,
           Step::SpecialTrack,

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -75,7 +75,7 @@ module Engine
             next unless p.cash.negative?
 
             debt = -p.cash
-            interest = (debt / 2.0 + 0.5).floor
+            interest = (debt / 2.0).ceil
             p.spend(interest, @bank, check_cash: false)
             @log << "#{p.name} has to borrow another #{format_currency(interest)} as being in debt at end of SR"
           end

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -22,7 +22,36 @@ module Engine
             @log << "#{player.name} pays #{assist} and an additional #{fee} fee to assist buying a #{train.name} train"
           end
 
+          emergency_buy_with_loan = false
+
+          if train == @depot.min_depot_train &&
+            price > entity.cash + player.cash &&
+            must_buy_train?(entity) &&
+            @game.liquidity(player, emergency: true) == player.cash # Nothing more to sell
+
+            # Prepare to take a loan
+            emergency_buy_with_loan = true
+            corporation_cash = entity.cash
+            player_cash = player.cash
+            player_cash = 0 if player_cash.negative?
+            # Add temporary money in the corporation to pay for the train
+            @game.bank.spend(price, entity)
+          end
+
           super
+
+          return unless emergency_buy_with_loan
+
+          # Corporation should have no money left
+          entity.spend(entity.cash, @game.bank)
+
+          # The player borrows the missing amount, and add a $50 interest
+          debt = price - corporation_cash - player_cash
+          interest = 50
+          player.spend(player_cash + debt + interest, @game.bank, check_cash: false)
+          @log << "#{player.name} has to borrow #{@game.format_currency(debt)} to pay for the train"
+          @log << "An extra #{@game.format_currency(interest)} is added to the debt"
+          pass!
         end
       end
     end


### PR DESCRIPTION
Fix bug #1553.

If player is missing resources during emergency buy, the player must borrow the needed money.