### PR TITLE
18MEX: Add towns to Mexico City et.al.

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -98,7 +98,7 @@ module Engine
       "470":{
          "count":1,
          "color":"yellow",
-         "code":"junction=lawson:false;town=revenue:20;path=a:0,b:_1;path=a:3,b:_0;path=a:3,b:4;path=a:4,b:_0;path=a:_0,b:_1;label=CC"
+         "code":"town=revenue:20,loc:0;path=a:0,b:_0;path=a:3,b:_0;path=a:3,b:4;path=a:4,b:_0;label=CC"
       }
    },
    "market":[
@@ -771,13 +771,13 @@ module Engine
          "town=revenue:0;upgrade=cost:20,terrain:desert":[
             "K8"
          ],
-         "city=revenue:20;path=a:1,b:_0;upgrade=cost:20,terrain:water":[
+         "city=revenue:20,loc:center;town=revenue:10,loc:1;path=a:_1,b:_0;upgrade=cost:20,terrain:water":[
             "K6"
          ],
-         "city=revenue:20;path=a:4,b:_0;upgrade=cost:40,terrain:swamp":[
+         "city=revenue:20,loc:center;town=revenue:10,loc:4;path=a:_0,b:_1;upgrade=cost:40,terrain:swamp":[
             "M12"
          ],
-         "city=revenue:0;upgrade=cost:40,terrain:swamp":[
+         "city=revenue:0,loc:center;town=revenue:0,loc:5;upgrade=cost:40,terrain:swamp":[
             "P13"
          ],
          "town=revenue:0;upgrade=cost:120,terrain:mountain":[
@@ -791,7 +791,7 @@ module Engine
          "city=revenue:20;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0":[
             "E6"
          ],
-         "city=revenue:20;path=a:3,b:_0;path=a:5,b:_0":[
+         "city=revenue:20,loc:center;town=revenue:0,loc:2;path=a:3,b:_0;path=a:5,b:_0":[
             "O10"
          ],
          "town=revenue:10;path=a:2,b:_0;path=a:_0,b:5;upgrade=cost:60,terrain:mountain":[


### PR DESCRIPTION
Updating four tiles on map to include both town and city. Two tiles have them connected.

Result:
![18MEXmap](https://user-images.githubusercontent.com/8494213/91785109-cf752d80-ebc1-11ea-99c6-bd6ea946d077.png)

Also fixed tile 470:
![18MEX_470](https://user-images.githubusercontent.com/8494213/91785208-1105d880-ebc2-11ea-8eb0-2712f36fd835.png)
