### PR TITLE
(fixes #1450) Privates in auction now show discount

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -100,7 +100,7 @@ module View
             h(:div, { style: header_style }, 'PRIVATE COMPANY'),
             h(:div, @company.name),
             h(:div, { style: description_style }, @company.desc),
-            h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value-@company.discount)}"),
+            h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value - @company.discount)}"),
             h(:div, { style: revenue_style }, "Revenue: #{@game.format_currency(@company.revenue)}"),
           ]
 

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -100,7 +100,7 @@ module View
             h(:div, { style: header_style }, 'PRIVATE COMPANY'),
             h(:div, @company.name),
             h(:div, { style: description_style }, @company.desc),
-            h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
+            h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value-@company.discount)}"),
             h(:div, { style: revenue_style }, "Revenue: #{@game.format_currency(@company.revenue)}"),
           ]
 


### PR DESCRIPTION
I have fixed the issue #1450 and the company cards when auctioned now indicate the proper discount instead of only showing the initial value. 
![image](https://user-images.githubusercontent.com/69726608/91998705-77f6cf00-ed33-11ea-8680-77d7c7da3b80.png)
as seen the card now matches the new value that is shown in chat.
