### PR TITLE
Intra-tile path routing support

### DIFF
--- a/lib/engine/connection.rb
+++ b/lib/engine/connection.rb
@@ -7,12 +7,10 @@ module Engine
     def self.connect!(hex)
       connections = {}
 
-      # FIXME: for intra-node paths
-      node_paths, paths = hex.tile.paths.partition { |p| p.nodes[0] }
+      node_paths, paths = hex.tile.paths.partition { |p| p.nodes.any? }
 
       paths.each do |path|
-        # FIXME: for intra-node paths
-        path.walk { |p| node_paths << p if p.nodes[0] }
+        path.walk { |p| node_paths << p if p.nodes.any? }
       end
 
       node_paths.uniq.each do |node_path|
@@ -21,16 +19,21 @@ module Engine
           hex = path.hex
           connection = connection.branch!(path)
           next if connection.paths.include?(path)
-          # FIXME: for intra-node paths
           next if connection.nodes.include?(path.nodes[0])
+          next if connection.nodes.include?(path.nodes[1])
           next if connection.paths.any? { |p| p.hex == hex && (p.exits & path.exits).any? }
 
           connections[connection] = true
           connection.add_path(path)
 
-          path.exits.each do |edge|
-            hex_connections = hex.connections[edge]
+          if path.exits.none?
+            hex_connections = hex.connections[:internal]
             hex_connections << connection unless hex_connections.include?(connection)
+          else
+            path.exits.each do |edge|
+              hex_connections = hex.connections[edge]
+              hex_connections << connection unless hex_connections.include?(connection)
+            end
           end
         end
       end
@@ -68,8 +71,7 @@ module Engine
           node_path = nil
 
           @paths.each do |path|
-            # FIXME: for intra-node paths
-            node_path = path if path.nodes[0]
+            node_path = path if path.nodes.any?
             path_map[path] = true
           end
 
@@ -94,8 +96,7 @@ module Engine
     end
 
     def nodes
-      # FIXME: for intra-tile paths
-      @nodes ||= @paths.map { |p| p.nodes[0] }.compact
+      @nodes ||= @paths.map(&:nodes).flatten
     end
 
     def hexes

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -120,8 +120,7 @@ module Engine
 
         node.walk(visited: visited, corporation: corporation) do |path|
           paths[path] = true
-          # FIXME: for intra-node paths
-          if (p_node = path.nodes[0])
+          path.nodes.each do |p_node|
             nodes[p_node] = true
             yield p_node if block_given?
             local_nodes[p_node] = true

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -43,17 +43,17 @@ module Engine
         paths.each do |node_path|
           node_path.walk(visited: visited_paths, on: on) do |path, vp|
             yield path
-            # FIXME: for intra-node paths
-            next unless (next_node = path.nodes[0])
-            next if next_node == self
-            next if corporation && next_node.blocks?(corporation)
+            path.nodes.each do |next_node|
+              next if next_node == self
+              next if corporation && next_node.blocks?(corporation)
 
-            next_node.walk(
-              visited: visited,
-              on: on,
-              corporation: corporation,
-              visited_paths: visited_paths.merge(vp),
-            ) { |p| yield p }
+              next_node.walk(
+                visited: visited,
+                on: on,
+                corporation: corporation,
+                visited_paths: visited_paths.merge(vp),
+              ) { |p| yield p }
+            end
           end
         end
       end

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -63,6 +63,10 @@ module Engine
         true
       end
 
+      def node?
+        @_node ||= @nodes.any?
+      end
+
       def exits
         @exits ||= @edges.map(&:num)
       end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -169,8 +169,9 @@ module Engine
 
           op = old_paths.find { |path| path <= np }
           used_new_track = true unless op
-          # FIXME: for intra-tile paths
-          changed_city = true if op && op.nodes[0] && op.nodes[0].max_revenue != np.nodes[0].max_revenue
+          old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
+          new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
+          changed_city = old_revenues != new_revenues
         end
 
         case @game.class::TRACK_RESTRICTION


### PR DESCRIPTION
Now supports routing for tiles with a single intra-tile path (i.e. 18TN, 18MEX).

A fully robust fix will require more substantial changes (and will likely break existing games without taking special action).