### PR TITLE
Special tile should not be available for corporation that do not own …

### DIFF
--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -29,6 +29,10 @@ module Engine
       end
 
       def process_lay_tile(action)
+        unless allowed_to_lay_tile?(action.entity)
+          @game.game_error("#{@game.current_entity.name} does not own #{action.entity.name}")
+        end
+
         lay_tile(action)
         check_connect(action)
         ability(action.entity).use!
@@ -77,6 +81,19 @@ module Engine
 
       def setup
         @company = nil
+      end
+
+      private
+
+      def allowed_to_lay_tile?(entity)
+        # If corporation owns the company, this is allowed
+        return true if @game.current_entity.corporation? && entity.owner == @game.current_entity
+
+        # This is if tile lay is a continuation of a special tile lay
+        return true if @game.current_entity == entity
+
+        # Player owned company can be used
+        ability(entity).owner_type == :player && entity.owner == @game.current_entity.player
       end
     end
   end


### PR DESCRIPTION
…company

This is a general fix that affects all special tile laying abilities.
By checking owner of the company, the step is skipped if missmatch.

Fixes #1284.

@tobymao I wonder if this is the right way to solve this? Yes, I do think it stops someone doing a tile-lay when not controlling the ability, but isn't the basic problem that abilities you do not control are shown?
When "Show Others" are clicked, should it not just show companies owned by the acting player? And only companies that have an ability that is owner_type == :player?

Also, even if this PR is accepted, I wonder if this does not need to be done for more types of actions? Maybe it is possible to put down a token using the ability that one does not control?