### PR TITLE
Don't allow obsolete trains in pool (fixes #1438)

### DIFF
--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -35,7 +35,7 @@ module Engine
 
       train.owner.remove_train(train)
       train.owner = self
-      @discarded << train if @game.class::DISCARDED_TRAINS == :discard
+      @discarded << train if @game.class::DISCARDED_TRAINS == :discard && !train.obsolete
     end
 
     def min_price(corporation)

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -10,6 +10,7 @@ module Engine
       @index = 0
       @phases = phases
       @game = game
+      @depot = @game.depot
       @log = @game.log
       setup_phase!
     end
@@ -100,7 +101,8 @@ module Engine
       end
 
       @game.trains.each do |t|
-        next if t.rusted || t.rusts_on != train.sym
+        next if t.rusted
+        next unless t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
 
         rusted_trains << t.name
         entity.rusted_self = true if entity && entity == t.owner

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -102,7 +102,9 @@ module Engine
 
       @game.trains.each do |t|
         next if t.rusted
-        next unless t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
+
+        should_rust = t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
+        next unless should_rust
 
         rusted_trains << t.name
         entity.rusted_self = true if entity && entity == t.owner


### PR DESCRIPTION
Since this fix just adds another condition for rusting, it does generate a log message of the form `-- Event: 3/5 trains rust --`, even though the only 3/5 trains that have rusted are the ones in the pool. If this is too confusing I can break it out into separate check that doesn't trigger that event notice (or triggers a different one).