### PR TITLE
Display owned trains that were rusted in log (fixes #1575)

### DIFF
--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -92,7 +92,7 @@ module Engine
     def rust_trains!(train, entity)
       obsolete_trains = []
       rusted_trains = []
-      owners = []
+      owners = Hash.new(0)
 
       @game.trains.each do |t|
         next if t.obsolete || t.obsolete_on != train.sym
@@ -108,13 +108,14 @@ module Engine
         next unless should_rust
 
         rusted_trains << t.name
-        owners << t.owner.name
+        owners[t.owner.name] += 1
         entity.rusted_self = true if entity && entity == t.owner
         t.rust!
       end
 
       @log << "-- Event: #{obsolete_trains.uniq.join(', ')} trains are obsolete --" if obsolete_trains.any?
-      @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust (#{owners.group_by(&:itself).map{|c,t| "#{c} x#{t.count}"}.join(', ')}) --" if rusted_trains.any?       
+      @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust " \
+        "( #{owners.map { |c, t| "#{c} x#{t}" }.join(', ')}) --" if rusted_trains.any?
     end
 
     def next!

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -92,17 +92,7 @@ module Engine
     def rust_trains!(train, entity)
       obsolete_trains = []
       rusted_trains = []
-      rusted_corporation_trains = {}
-
-      @game.corporations.each do |c|
-        c.trains.each do |t|
-          should_rust = t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
-          next unless should_rust
-
-          rusted_corporation_trains[t.owner.name] = 0 if !rusted_corporation_trains.has_key?(t.owner.name)
-          rusted_corporation_trains[t.owner.name] +=1
-        end
-      end
+      owners = []
 
       @game.trains.each do |t|
         next if t.obsolete || t.obsolete_on != train.sym
@@ -113,17 +103,18 @@ module Engine
 
       @game.trains.each do |t|
         next if t.rusted
-        
+
         should_rust = t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
         next unless should_rust
 
         rusted_trains << t.name
+        owners << t.owner.name
         entity.rusted_self = true if entity && entity == t.owner
         t.rust!
       end
 
       @log << "-- Event: #{obsolete_trains.uniq.join(', ')} trains are obsolete --" if obsolete_trains.any?
-      @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust (#{rusted_corporation_trains.map{|c,t| "#{c} x#{t}"}.join(', ')}) --" if rusted_trains.any?       
+      @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust (#{owners.group_by(&:itself).map{|c,t| "#{c} x#{t.count}"}.join(', ')}) --" if rusted_trains.any?       
     end
 
     def next!

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -92,6 +92,17 @@ module Engine
     def rust_trains!(train, entity)
       obsolete_trains = []
       rusted_trains = []
+      rusted_corporation_trains = {}
+
+      @game.corporations.each do |c|
+        c.trains.each do |t|
+          should_rust = t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
+          next unless should_rust
+
+          rusted_corporation_trains[t.owner.name] = 0 if !rusted_corporation_trains.has_key?(t.owner.name)
+          rusted_corporation_trains[t.owner.name] +=1
+        end
+      end
 
       @game.trains.each do |t|
         next if t.obsolete || t.obsolete_on != train.sym
@@ -102,7 +113,7 @@ module Engine
 
       @game.trains.each do |t|
         next if t.rusted
-
+        
         should_rust = t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
         next unless should_rust
 
@@ -112,7 +123,7 @@ module Engine
       end
 
       @log << "-- Event: #{obsolete_trains.uniq.join(', ')} trains are obsolete --" if obsolete_trains.any?
-      @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust --" if rusted_trains.any?
+      @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust (#{rusted_corporation_trains.map{|c,t| "#{c} x#{t}"}.join(', ')}) --" if rusted_trains.any?       
     end
 
     def next!


### PR DESCRIPTION
Log now displays:

```
-- Phase 6 (Operating Rounds: 3, Train Limit: 2, Available Tiles: Yellow, Green, Brown ) --
-- Event: 3 trains rust (The Depot x2, N&W x2, C&A x2) --
PRR buys a 6 train for $630 from The Depot
PRR skips buy companies
Player 2 operates B&O
```

![image](https://user-images.githubusercontent.com/17951/92318562-1f962a80-efdc-11ea-8fc1-f1ad62949c49.png)
