### PR TITLE
18MS: Fix route bonus calculation for New Orleans (fixes #1600)

### DIFF
--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -137,7 +137,7 @@ module Engine
         revenue *= 2 if route.train.name.end_with?('D')
 
         route.corporation.abilities(:hexes_bonus) do |ability|
-          revenue += stops.sum { |stop| ability.hexes.include?(stop.hex.id) ? ability.amount : 0 }
+          revenue += stops.map { |s| s.hex.id }.uniq.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
         end
 
         revenue


### PR DESCRIPTION
After map change New Orleans hex can now appear twice in a route
(city + town).