### PR TITLE
Add config option for only allowing the cheapest depot train on EMR

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -129,6 +129,7 @@ module Engine
 
       EBUY_PRES_SWAP = true # allow presidential swaps of other corps when ebuying
       EBUY_OTHER_VALUE = true # allow ebuying other corp trains for up to face
+      EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = true
 
       # when is the home token placed? on...
       # operate

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -32,6 +32,7 @@ module Engine
       SELL_BUY_ORDER = :sell_buy
       SELL_MOVEMENT = :left_block_pres
       EBUY_OTHER_VALUE = false
+      EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
       HOME_TOKEN_TIMING = :float
       MUST_BUY_TRAIN = :always
 

--- a/lib/engine/step/g_1846/buy_train.rb
+++ b/lib/engine/step/g_1846/buy_train.rb
@@ -46,8 +46,6 @@ module Engine
           super
         end
 
-        private
-
         def can_issue?(entity)
           return false if @round.emergency_issued
           return false unless entity.corporation?

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -89,7 +89,8 @@ module Engine
         # If the corporation cannot buy a train, then it can only buy the cheapest available (if there is any...)
         min_depot_train = @depot.min_depot_train
         if min_depot_train && min_depot_train.price > entity.cash
-          depot_trains = [min_depot_train]
+
+          depot_trains = [min_depot_train] if @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST
 
           if @last_share_sold_price
             # 1889, a player cannot contribute to buy a train from another corporation


### PR DESCRIPTION
Once the President is contributing cash in 1846, any train can be bought

[Fixes #1497]