### PR TITLE
Pointy map rendering tweaks

### DIFF
--- a/assets/app/view/game/part/blocker.rb
+++ b/assets/app/view/game/part/blocker.rb
@@ -27,15 +27,46 @@ module View
           y: 60,
         }.freeze
 
+        PP_LEFT_CORNER = {
+          region_weights: LEFT_CORNER,
+          x: -65,
+          y: 5,
+        }.freeze
+        PP_BOTTOM_RIGHT = {
+          region_weights: [22, 23],
+          x: 35,
+          y: 60,
+        }.freeze
+        PP_EDGE_1 = {
+          region_weights_in: { [13] => 1, [12, 19] => 0.5 },
+          region_weights_out: [13],
+          x: -50,
+          y: 30,
+        }.freeze
+
+        PP_EDGE_4 = {
+          region_weights_in: { [10] => 1, [4, 11] => 0.5 },
+          region_weights_out: [10],
+          x: 50,
+          y: -30,
+        }.freeze
+
         def preferred_render_locations
           if @tile.parts.one?
             [
               P_CENTER,
             ]
-          else
+          elsif layout == :flat
             [
               P_LEFT_CORNER,
               P_BOTTOM_RIGHT,
+            ]
+          else
+            [
+              P_LEFT_CORNER,
+              PP_BOTTOM_RIGHT,
+              PP_EDGE_4,
+              PP_EDGE_1,
             ]
           end
         end

--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -202,12 +202,12 @@ module View
         ].freeze
 
         CENTER_REVENUE_REGIONS = [
-          [14, 15],
-          [17, 14],
-          [7, 8],
-          [8, 9],
-          [9, 16],
-          [15, 16],
+          { [14, 15] => 1.0, [13, 21] => 0.5, [19, 20] => 0.25 },
+          { [7, 14] => 1.0, [6, 13] => 0.5, [5, 12] => 0.25 },
+          { [7, 8] => 1.0, [2, 6] => 0.5, [0, 1] => 0.25 },
+          { [8, 9] => 1.0, [2, 10] => 0.5, [3, 4] => 0.25 },
+          { [9, 16] => 1.0, [10, 17] => 0.5, [11, 18] => 0.25 },
+          { [15, 16] => 1.0, [17, 21] => 0.5, [22, 23] => 0.25 },
         ].freeze
 
         CENTER_REVENUE_EDGE_PRIORITY = [1, 2, 3, 4, 0, 5].freeze
@@ -321,9 +321,9 @@ module View
             rotation = angle_for_layout
 
             regions = if layout == :flat
-                        @city.slots == 1 ? [9, 16] : [11, 18]
+                        @city.slots == 1 ? { [9, 16] => 1.0, [10, 17] => 0.5, [11, 18] => 0.25 } : [11, 18]
                       else
-                        @city.slots == 1 ? [8, 9] : [3, 4]
+                        @city.slots == 1 ? { [8, 9] => 1.0, [2, 10] => 0.5, [3, 4] => 0.25 } : [3, 4]
                       end
           elsif @edge && @city.slots == 1
             revenue_location = REVENUE_LOCATIONS_BY_EDGE[@edge].min_by { |loc| combined_cost(loc[:regions]) }
@@ -344,7 +344,11 @@ module View
             regions = CENTER_REVENUE_REGIONS[revenue_edge]
           end
 
-          increment_weight_for_regions(regions)
+          region_weights = regions
+          region_weights = { region_weights => 1.0 } if region_weights.is_a?(Array)
+          region_weights.each do |r, w|
+            increment_weight_for_regions(r, w)
+          end
 
           revert_angle = render_location[:angle] + rotation
           h(:g, { attrs: { transform: "rotate(#{rotation})" } }, [

--- a/assets/app/view/game/part/icons.rb
+++ b/assets/app/view/game/part/icons.rb
@@ -8,14 +8,49 @@ module View
     module Part
       class Icons < Base
         include SmallItem
+
+        P_WIDE_TOP_CORNER = {
+          region_weights: [0, 1, 2, 3, 4],
+          x: 0,
+          y: -65,
+        }.freeze
+
+        P_WIDE_BOTTOM_CORNER = {
+          region_weights: [19, 20, 21, 22, 23],
+          x: 0,
+          y: 65,
+        }.freeze
+
+        PP_WIDE_TOP_CORNER = {
+          region_weights: [0, 1, 2, 3, 5, 6],
+          x: 0,
+          y: -65,
+        }.freeze
+
+        PP_WIDE_BOTTOM_CORNER = {
+          region_weights: [17, 18, 20, 21, 22, 23],
+          x: 0,
+          y: 65,
+        }.freeze
+
+        WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
+                               PP_WIDE_BOTTOM_CORNER].freeze
+
+        POINTY_WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
+                                      PP_WIDE_BOTTOM_CORNER].freeze
+
         ICON_RADIUS = 16
         DELTA_X = (ICON_RADIUS * 2) + 2
 
         def preferred_render_locations
-          if layout == :pointy
+          if layout == :pointy && @icons.one?
             POINTY_SMALL_ITEM_LOCATIONS
-          elsif layout == :flat
+          elsif layout == :pointy
+            POINTY_WIDE_ITEM_LOCATIONS
+          elsif layout == :flat && @icons.one?
             SMALL_ITEM_LOCATIONS
+          else
+            WIDE_ITEM_LOCATIONS
           end
         end
 
@@ -29,7 +64,7 @@ module View
             h(:image,
               attrs: {
                 href: icon.image,
-                x: index * -DELTA_X,
+                x: ((index - (@icons.size - 1) / 2.0) * -DELTA_X).round(2),
                 width: "#{ICON_RADIUS * 2}px",
                 height: "#{ICON_RADIUS * 2}px",
               })

--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -8,11 +8,18 @@ module View
       # letter label, like "Z", "H", "OO"
       class Label < Base
         # left of center
-        SINGLE_CITY_ONE_SLOT = [{
-          region_weights: { (LEFT_MID + LEFT_CORNER) => 1, LEFT_CENTER => 0.5 },
-          x: -55,
-          y: 0,
-        }].freeze
+        SINGLE_CITY_ONE_SLOT = {
+          flat: {
+            region_weights: { (LEFT_MID + LEFT_CORNER) => 1, LEFT_CENTER => 0.5 },
+            x: -55,
+            y: 0,
+          },
+          pointy: {
+            region_weights: { [5, 6] => 1.0, [7, 12] => 0.25 },
+            x: -65,
+            y: 0,
+          },
+        }.freeze
 
         P_LEFT_CORNER = {
           flat: {
@@ -21,7 +28,7 @@ module View
             y: 0,
           },
           pointy: {
-            region_weights: { LEFT_CORNER => 1.0, LEFT_MID => 0.25 },
+            region_weights: { LEFT_CORNER => 1.0, [6] => 0.25 },
             x: -67,
             y: 0,
           },
@@ -82,15 +89,59 @@ module View
           },
         ].freeze
 
+        POINTY_MULTI_CITY_LOCATIONS = [
+          # top center
+          {
+            region_weights: { [2] => 1.0, [3] => 0.5 },
+            x: 0,
+            y: -60,
+          },
+          # edge 2
+          {
+            region_weights: { [6] => 1.0, [5] => 0.25 },
+            x: -50,
+            y: -31,
+          },
+          # edge 5
+          {
+            region_weights: { [17] => 1.0, [18, 23] => 0.25 },
+            x: 50,
+            y: 37,
+          },
+          # top left corner
+          {
+            region_weights: { UPPER_LEFT_CORNER => 1.0 },
+            x: -30,
+            y: -65,
+          },
+          # top right corner
+          {
+            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
+            x: 30,
+            y: -65,
+          },
+          P_LEFT_CORNER[:pointy],
+          # bottom left corner
+          P_BOTTOM_LEFT_CORNER[:pointy],
+          # edge 1
+          {
+            region_weights: { [13, 14] => 1.0 },
+            x: -50,
+            y: 25,
+          },
+        ].freeze
+
         def preferred_render_locations
           if @tile.city_towns.one?
             if @tile.cities.one? && (@tile.cities.first.slots > 1)
               [P_LEFT_CORNER[layout]]
             else
-              SINGLE_CITY_ONE_SLOT
+              [SINGLE_CITY_ONE_SLOT[layout]]
             end
-          elsif @tile.city_towns.size > 1
+          elsif @tile.city_towns.size > 1 && layout == :flat
             MULTI_CITY_LOCATIONS
+          elsif @tile.city_towns.size > 1
+            POINTY_MULTI_CITY_LOCATIONS
           elsif layout == :flat
             [P_LEFT_CORNER[layout]]
           else

--- a/assets/app/view/game/part/location_name.rb
+++ b/assets/app/view/game/part/location_name.rb
@@ -210,7 +210,7 @@ module View
             x: 0,
             y: -(24 + delta_y),
           }
-          loc[:region_weights] = layout == :flat ? TOP_MIDDLE_ROW : [4, 7, 8, 12]
+          loc[:region_weights] = layout == :flat ? TOP_MIDDLE_ROW : [2, 4, 6, 7, 8, 12]
           loc
         end
 
@@ -224,7 +224,7 @@ module View
 
         def l_down24
           loc = { x: 0, y: 24 }
-          loc[:region_weights] = layout == :flat ? BOTTOM_MIDDLE_ROW : [11, 15, 16, 19]
+          loc[:region_weights] = layout == :flat ? BOTTOM_MIDDLE_ROW : [11, 15, 16, 17, 19, 21]
           loc
         end
 

--- a/assets/app/view/game/part/revenue.rb
+++ b/assets/app/view/game/part/revenue.rb
@@ -42,8 +42,10 @@ module View
                 y: 45,
               },
             ]
-          else
+          elsif layout == :flat
             SMALL_ITEM_LOCATIONS
+          else
+            POINTY_SMALL_ITEM_LOCATIONS
           end
         end
 

--- a/assets/app/view/game/part/small_item.rb
+++ b/assets/app/view/game/part/small_item.rb
@@ -73,13 +73,13 @@ module View
         }.freeze
 
         PP_RIGHT_CORNER = {
-          region_weights: [10],
+          region_weights: [9, 10],
           x: 60,
           y: 0,
         }.freeze
 
         PP_LEFT_CORNER = {
-          region_weights: [13],
+          region_weights: [13, 14],
           x: -60,
           y: 0,
         }.freeze

--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -33,6 +33,18 @@ module View
           y: -45,
         }.freeze
 
+        P_RIGHT_CORNER = {
+          region_weights: [11, 18],
+          x: 70,
+          y: 0,
+        }.freeze
+
+        P_LEFT_CORNER = {
+          region_weights: [5, 12],
+          x: -70,
+          y: 0,
+        }.freeze
+
         SIZE = 20
         WATER_PATH = 'M -15 -7 Q -7.5 -15, 0 -7 S 7.5 1, 15 -7M -15 -2  Q -7.5 -10, 0 -2  S 7.5 6, 15 -2'
         TRIANGLE_PATH = '0,20 10,0 20,20'
@@ -43,6 +55,8 @@ module View
             P_TOP_RIGHT_CORNER,
             P_EDGE2,
             P_BOTTOM_LEFT_CORNER,
+            P_RIGHT_CORNER,
+            P_LEFT_CORNER,
           ]
         end
 


### PR DESCRIPTION
Fixes  #1622 
Fixes #1417 

Minor preferred_render_locations tweaks for pointy maps: location_name, icons, blockers, cities (revenue), labels, upgrades...
Old:
![1846_Chi](https://user-images.githubusercontent.com/8494213/92529227-62781e00-f1e7-11ea-8f9f-0597223405e1.png)

New:
![1846_Chi_new](https://user-images.githubusercontent.com/8494213/92529410-b125b800-f1e7-11ea-995c-45c48b5058f2.png)

