### PR TITLE
Removed a visual error with limited train buying in 18AL (fixes #1625) 

### DIFF
--- a/lib/engine/config/game/g_18_al.rb
+++ b/lib/engine/config/game/g_18_al.rb
@@ -728,8 +728,7 @@ module Engine
          ],
          "status":[
             "can_buy_companies",
-            "can_buy_companies_from_other_players",
-            "limited_train_buy"
+            "can_buy_companies_from_other_players"
          ],
          "operating_rounds": 2
       },


### PR DESCRIPTION
Removed the visual error. This was just done in config and does not affect game play.