### PR TITLE
18MS: Handle emergency buy with insufficient resources

### DIFF
--- a/assets/app/view/game/emergency_money.rb
+++ b/assets/app/view/game/emergency_money.rb
@@ -24,13 +24,13 @@ module View
           children << h(:div, props, corp)
         end
 
-        children << render_bankruptcy
+        children << render_bankruptcy if @game.round.actions_for(entity).include?('bankrupt')
         children
       end
 
       def render_bankruptcy
         resign = lambda do
-          process_action(Engine::Action::Bankrupt.new(@game.round.active_step.current_entity))
+          process_action(Engine::Action::Bankrupt.new(entity))
         end
 
         props = {
@@ -41,6 +41,12 @@ module View
         }
 
         h(:button, props, 'Declare Bankruptcy')
+      end
+
+      private
+
+      def entity
+        @game.round.active_step.current_entity
       end
     end
   end

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -507,7 +507,6 @@ module Engine
       },
       {
          "name":"6",
-         "on":"6",
          "train_limit":3,
          "tiles":[
             "yellow",
@@ -518,7 +517,6 @@ module Engine
       },
       {
          "name":"D",
-         "on":"2D",
          "train_limit":3,
          "tiles":[
             "yellow",

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -67,15 +67,24 @@ module Engine
         # When OR1.2 is to start setup company prices and switch to green phase
         if @turn == 1 && round_num == 2
           setup_company_price_50_to_150_percent
-          @phase.next! if @turn == 1 && round_num == 2
+          @phase.next!
         end
 
+        if round_num == 1
+          @players.each do |p|
+            next unless p.cash.negative?
+
+            debt = -p.cash
+            interest = (debt / 2.0).ceil
+            p.spend(interest, @bank, check_cash: false)
+            @log << "#{p.name} has to borrow another #{format_currency(interest)} as being in debt at end of SR"
+          end
+        end
         super
       end
 
       def operating_round(round_num)
         Round::Operating.new(self, [
-          Step::Bankrupt,
           Step::Exchange,
           Step::DiscardTrain,
           Step::SpecialTrack,

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -22,7 +22,45 @@ module Engine
             @log << "#{player.name} pays #{assist} and an additional #{fee} fee to assist buying a #{train.name} train"
           end
 
+          emergency_buy_with_loan = false
+
+          if train == @depot.min_depot_train &&
+            price > entity.cash + player.cash &&
+            must_buy_train?(entity) &&
+            @game.liquidity(player, emergency: true) == player.cash # Nothing more to sell
+
+            name, variant = train.variants.min_by { |_, v| v[:price] }
+            @game.game_error("Must buy cheapest train, and #{name} is cheaper than #{action.variant}") if name &&
+              name != action.variant &&
+              variant[:price] < price
+
+            # Prepare to take a loan
+            emergency_buy_with_loan = true
+            corporation_cash = entity.cash
+            player_cash = player.cash
+            player_cash = 0 if player_cash.negative?
+            # Add temporary money in the corporation to pay for the train
+            @game.bank.spend(price, entity)
+          end
+
           super
+
+          # Phase change triggered here to avoid problems that 2D is cheaper than 6 train (see issue #1553)
+          @game.phase.next! if train.name == '6' && !@game.phase.available?('6')
+          @game.phase.next! if train.name.include?('D') && !@game.phase.available?('D')
+
+          return unless emergency_buy_with_loan
+
+          # Corporation should have no money left
+          entity.spend(entity.cash, @game.bank)
+
+          # The player borrows the missing amount, and add a $50 interest
+          debt = price - corporation_cash - player_cash
+          interest = 50
+          player.spend(player_cash + debt + interest, @game.bank, check_cash: false)
+          @log << "#{player.name} has to borrow #{@game.format_currency(debt)} to pay for the train"
+          @log << "An extra #{@game.format_currency(interest)} is added to the debt"
+          pass!
         end
       end
     end


### PR DESCRIPTION
In 18MS a player that is president for a corporation doing an
emergency buy cannot declare bankrupcy. Instead the player
must buy the cheapest train in the depot and borrow the amount
missing (+ $50 interest).

Debt is represented by negative cash (which is an existing
"feature). This stops the debtee to spend any cash (except
further loans)

If player has negative cash at the end of another loan is added
to the debt, which means that the debt is increased by 50% of
the remaining debt.

The final score in the game is share value plus cash, so this
means that any remaining debt after OR5.2 is automatically
deducted from the final score.

The display of the "Declare Bankruptcy" button during emergency
buy has been changed. If the active step(s) does not support
the 'bankrupt' action the button is not displayed.
In 18MS you cannot declare bankruptcy - you need to manually
end the game if a player has given up, so therefor no button.

Have removed automatic phase change in 18MS for 6 and D trains.
Instead this is checked directly after buy train action in
18MS module. The reason for this is to avoid the problem that
a cheaper train made available by the phase triggered by trying
to buy the train of the new phase. This is reported in issue
1553 and affected 18MS before the change.
Now the phase change in 18MS does not rust any trains so doing
phase change when buy train completed should be an OK way of doing
it in 18MS.
Note that doing phase change to D (gray) would probably not
cause any problems but it is done in the same place in the code
as change to brown (6) phase to make it consistent.
From before the phase change to green (3) is handled in g_18_ms.rb
when we enter OR1.2.