### PR TITLE
18MS: Modify Atlanta off-board hexes

### DIFF
--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -41,7 +41,7 @@ module Engine
       "E5":"Meridian",
       "E9":"Selma",
       "E11":"Montgomery",
-      "E13":"Atlanta",
+      "E15":"Atlanta",
       "G3":"Hattiesburg",
       "H4":"Gulfport",
       "H6":"Mobile",
@@ -465,14 +465,17 @@ module Engine
          "path=a:1,b:5":[
             "A3"
          ],
-         "offboard=revenue:yellow_40|brown_50,hide:1,groups:Atlanta;path=a:0,b:_0;border=edge:5":[
+         "path=a:0,b:5":[
             "D12"
          ],
-         "offboard=revenue:yellow_40|brown_50,groups:Atlanta;path=a:1,b:_0;border=edge:2;border=edge:0":[
+         "path=a:0,b:4;path=a:1,b:4;path=a:2,b:4":[
             "E13"
          ],
-         "offboard=revenue:yellow_40|brown_50,hide:1,groups:Atlanta;path=a:2,b:_0;border=edge:3":[
+         "path=a:2,b:3":[
             "F12"
+         ],
+         "offboard=revenue:yellow_40|brown_50;path=a:1,b:_0":[
+            "E15"
          ]
       },
       "gray":{

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -32,7 +32,6 @@ module Engine
 
       HEXES_FOR_GRAY_TILE = %w[C9 E11].freeze
       COMPANY_1_AND_2 = %w[AGS BS].freeze
-      ATLANTA_HEXES = %w[D12 E13 F12].freeze
 
       include CompanyPrice50To150Percent
 
@@ -145,9 +144,6 @@ module Engine
       end
 
       def routes_revenue(routes)
-        atlanta_stops = routes.count { |r| r.stops.any? { |s| ATLANTA_HEXES.include?(s.hex.id) } }
-        game_error('Atlanta may only be visited once per run') if atlanta_stops > 1
-
         active_step.current_entity.trains.each do |t|
           next unless t.name == "#{@turn}+"
 


### PR DESCRIPTION
Use the track restriction instead of specific code, to stop
multiple visits to Atlanta in a run.

Before:

![image](https://user-images.githubusercontent.com/2631151/92996598-21e11300-f50d-11ea-9514-6d9a0f78cb36.png)

After:

![image](https://user-images.githubusercontent.com/2631151/92996614-345b4c80-f50d-11ea-8db0-c87ed229b293.png)

And here is how parts of it looks like on the physical map:
![image](https://user-images.githubusercontent.com/2631151/92996665-813f2300-f50d-11ea-9476-406c0dc64688.png)
