### PR TITLE
1846 - Small receivership/bankruptcy enhancements

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -372,7 +372,9 @@ module Engine
       end
 
       def active_players
-        @round.active_entities.map(&:player).compact
+        players_ = @round.active_entities.map(&:player).compact
+
+        players_.empty? ? @players.reject(&:bankrupt) : players_
       end
 
       def active_step

--- a/lib/engine/step/bankrupt.rb
+++ b/lib/engine/step/bankrupt.rb
@@ -24,7 +24,7 @@ module Engine
       def process_bankrupt(action)
         player = action.entity.owner
 
-        @log << "#{player.name} goes bankrupt and sells remaining shares"
+        @log << "-- #{player.name} goes bankrupt and sells remaining shares --"
 
         player.shares_by_corporation.each do |corporation, _|
           next unless corporation.share_price # if a corporation has not parred

--- a/lib/engine/step/g_1846/bankrupt.rb
+++ b/lib/engine/step/g_1846/bankrupt.rb
@@ -10,7 +10,7 @@ module Engine
           corp = action.entity
           player = corp.owner
 
-          @log << "#{player.name} goes bankrupt and sells remaining shares"
+          @log << "-- #{player.name} goes bankrupt and sells remaining shares --"
 
           # first, the corporation issues as many shares as they can
           if (bundle = @game.emergency_issuable_bundles(corp).max_by(&:num_shares))
@@ -42,7 +42,7 @@ module Engine
             @game.sell_shares_and_change_price(bundle)
 
             if corporation.owner == player
-              @log << "#{corporation.name} enters receivership (it has no president)"
+              @log << "-- #{corporation.name} enters receivership (it has no president) --"
               corporation.owner = @game.share_pool
             end
           end

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -17,6 +17,14 @@ module Engine
         'Run Routes'
       end
 
+      def help
+        return super unless current_entity.receivership?
+
+        "#{current_entity.name} is in receivership (it has no president). Most of its "\
+        'actions are automated, but it must have a player manually run its trains. '\
+        "Please enter the best route you see for #{current_entity.name}."
+      end
+
       def process_run_routes(action)
         entity = action.entity
         @round.routes = action.routes


### PR DESCRIPTION
- add help text for running routes when corporation is in receivership

- when `@round.active_entities.map(&:player)` is empty (e.g., active corporation
  is in receivership), mark all players as active so that they are alerted about
  whatever action needs to be taken

- make bankruptcy and receivership "events" in the logs so they are not as
  easily overlooked

[Fixes #1380]
[Fixes #1408]

![Screenshot from 2020-09-12 18-41-43](https://user-images.githubusercontent.com/1045173/93007592-b0628e00-f527-11ea-85d4-203d1db2f909.png)
