### PR TITLE
18MS: Fix some problems discovered during pre-alpha test

### DIFF
--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -224,7 +224,7 @@ module Engine
          "name":"Mississippi Central Railway",
          "value":60,
          "revenue":5,
-         "desc":"Converts to a 2+ train that cannot be salvaged when placed in a Major Company.",
+         "desc":"The owning Major Company exchanges this private for a special 2+ train when purchased. (This 2+ train may not be sold.) This exchange occurs immediately when purchased. If this exchange would place the Major Company over the train limit of 3, the purchase is not allowed. If this Private Company is not purchased by the end of OR 2.2, it may not be sold to a Major Company and counts against the owner's certificate limit until it closed upon the start of Phase 6.",
          "sym":"MC"
       },
       {

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -162,7 +162,7 @@ module Engine
       {
          "name":"Alabama Great Southern Railroad",
          "value":30,
-         "revenue":10,
+         "revenue":15,
          "desc":"The owning Major Company may lay an extra yellow tile for free. This extra tile must extend existing track and could be used to extend from a yellow or green tile played as a company’s  normal tile lay. This ability can only be used once, and using it does not close the company.",
          "sym":"AGS",
          "abilities": [

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -216,11 +216,12 @@ module Engine
         [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }]
       end
 
-      def add_free_train(corporation)
+      def add_free_train_and_close_company(corporation, company)
         @free_train.buyable = true
         corporation.buy_train(@free_train, :free)
         @free_train.buyable = false
-        @log << "#{corporation.name} receives a bonus non sellable #{@free_train.name} train"
+        company.close!
+        @log << "#{corporation.name} exchanges #{company.name} for a free non sellable #{@free_train.name} train"
       end
 
       def get_location_name(hex_name)

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -21,6 +21,9 @@ module Engine
 
       HOME_TOKEN_TIMING = :operating_round
 
+      EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false # Emergency buy can buy any available trains
+      EBUY_PRES_SWAP = false # Do not allow presidental swap during emergency buy
+
       STATUS_TEXT = Base::STATUS_TEXT.merge(
         'can_buy_companies_operation_round_one' =>
           ['Can Buy Companies OR 1', 'Corporations can buy AGS/BS companies for face value in OR 1'],

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -163,7 +163,7 @@ module Engine
           # Trains that are going to be salvaged at the end of this OR
           # cannot be sold when they have been run
           t.buyable = false
-        end
+        end if @round.round_num == 2
 
         super
       end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -255,14 +255,18 @@ module Engine
         rusted_trains = trains.select { |t| !t.rusted && t.name == train }
         return if rusted_trains.empty?
 
+        owners = Hash.new(0)
         rusted_trains.each do |t|
-          @bank.spend(salvage, t.owner) if t.buyable
+          if t.owner.corporation? && t.owner.full_name != 'Neutral'
+            @bank.spend(salvage, t.owner)
+            owners[t.owner.name] += 1
+          end
           t.rust!
         end
 
-        @log << "-- Event: #{rusted_trains.map(&:name).uniq.join(', ')} trains rust --"
-        exception = train == '2+' ? ' (except any free 2+ train)' : ''
-        @log << "Corporations salvages #{format_currency(salvage)} from each rusted train#{exception}"
+        @log << "-- Event: #{rusted_trains.map(&:name).uniq} trains rust " \
+          "( #{owners.map { |c, t| "#{c} x#{t}" }.join(', ')}) --"
+        @log << "Corporations salvages #{format_currency(salvage)} from each rusted train"
       end
     end
   end

--- a/lib/engine/step/g_18_ms/buy_company.rb
+++ b/lib/engine/step/g_18_ms/buy_company.rb
@@ -23,7 +23,7 @@ module Engine
           return unless company.id == 'MC'
 
           entity = action.entity
-          @game.add_free_train(entity)
+          @game.add_free_train_and_close_company(entity, company)
         end
       end
     end

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -29,11 +29,6 @@ module Engine
             must_buy_train?(entity) &&
             @game.liquidity(player, emergency: true) == player.cash # Nothing more to sell
 
-            name, variant = train.variants.min_by { |_, v| v[:price] }
-            @game.game_error("Must buy cheapest train, and #{name} is cheaper than #{action.variant}") if name &&
-              name != action.variant &&
-              variant[:price] < price
-
             # Prepare to take a loan
             emergency_buy_with_loan = true
             corporation_cash = entity.cash


### PR DESCRIPTION
- Emergency buy corrections (No requirement to buy cheapest train, Do not allow presidency change)
- Train rusted during ORx.2 should be possible to buy/sell during ORx.1
- Improved rusting message (Make similar to common code)
- Correct salvage calculation (fixed bug, free 2 train should give salvage)
- Correct private P4: Mississippi Central Railway (Description text, close during exchange)
- Correct revenue for private P1