### PR TITLE
Improvements for trains buy

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -132,6 +132,7 @@ module Engine
       EBUY_OTHER_VALUE = true # allow ebuying other corp trains for up to face
       EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = true # if ebuying from depot, must buy cheapest train
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = false # corporation must issue shares before ebuy (if possible)
+      EBUY_SELL_MORE_THAN_NEEDED = false # true if corporation may continue to sell shares even though enough funds
 
       # when is the home token placed? on...
       # operate

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -247,7 +247,7 @@ module Engine
 
           fee = 50
           president_assist = price - corporation.cash
-          return [president_assist, fee] unless corporation.owner.cash < president_assist + fee
+          return [president_assist, fee] unless corporation.player.cash < president_assist + fee
         end
 
         super

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -23,6 +23,7 @@ module Engine
 
       EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false # Emergency buy can buy any available trains
       EBUY_PRES_SWAP = false # Do not allow presidental swap during emergency buy
+      EBUY_SELL_MORE_THAN_NEEDED = true # Allow to sell extra to force buy a more expensive train
 
       STATUS_TEXT = Base::STATUS_TEXT.merge(
         'can_buy_companies_operation_round_one' =>

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -14,18 +14,25 @@ module Engine
       end
 
       def can_sell?(_entity, bundle)
+        return false unless sellable_bundle?(bundle)
+
+        # Can only sell as much as you need to afford the train
+        player = bundle.owner
+        unless @game.class::EBUY_SELL_MORE_THAN_NEEDED
+          total_cash = bundle.price + available_cash(player)
+          return false if total_cash >= needed_cash(player) + bundle.price_per_share
+        end
+
+        true
+      end
+
+      def sellable_bundle?(bundle)
         player = bundle.owner
         # Can't sell president's share
         return false unless bundle.can_dump?(player)
 
         # Can't oversaturate the market
         return false unless @game.share_pool.fit_in_bank?(bundle)
-
-        # Can only sell as much as you need to afford the train
-        unless @game.class::EBUY_SELL_MORE_THAN_NEEDED
-          total_cash = bundle.price + available_cash(player)
-          return false if total_cash >= needed_cash(player) + bundle.price_per_share
-        end
 
         # Can't swap presidency
         corporation = bundle.corporation

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -22,8 +22,10 @@ module Engine
         return false unless @game.share_pool.fit_in_bank?(bundle)
 
         # Can only sell as much as you need to afford the train
-        total_cash = bundle.price + available_cash(player)
-        return false if total_cash >= needed_cash(player) + bundle.price_per_share
+        unless @game.class::EBUY_SELL_MORE_THAN_NEEDED
+          total_cash = bundle.price + available_cash(player)
+          return false if total_cash >= needed_cash(player) + bundle.price_per_share
+        end
 
         # Can't swap presidency
         corporation = bundle.corporation

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -23,12 +23,17 @@ module Engine
           end
 
           emergency_buy_with_loan = false
+          available_funds = entity.cash + player.cash
 
-          if price > entity.cash + player.cash && must_buy_train?(entity)
+          if price > available_funds && must_buy_train?(entity)
 
             if can_sell_anything?(player, entity)
               @game.game_error("#{player.name} may not loan money as long as #{entity.name} has shares to sell")
             end
+
+            cheapest = @game.depot.min_depot_train
+            @game.game_error("#{player.name} may not loan money when affordable trains exist") if
+              cheapest.price <= available_funds
 
             # Prepare to take a loan
             emergency_buy_with_loan = true

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -67,10 +67,8 @@ module Engine
         private
 
         def can_sell_anything?(player)
-          bundles = []
           @game.corporations.each do |c|
-            bundles = player.bundles_for_corporation(c)
-            return true if bundles.select { |bundle| sellable_bundle?(bundle) }.any?
+            return true if player.bundles_for_corporation(c).any? { |bundle| sellable_bundle?(bundle) }
           end
 
           false

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -24,10 +24,11 @@ module Engine
 
           emergency_buy_with_loan = false
 
-          if train == @depot.min_depot_train &&
-            price > entity.cash + player.cash &&
-            must_buy_train?(entity) &&
-            @game.liquidity(player, emergency: true) == player.cash # Nothing more to sell
+          if price > entity.cash + player.cash && must_buy_train?(entity)
+
+            if can_sell_anything?(player, entity)
+              @game.game_error("#{player.name} may not loan money as long as #{entity.name} has shares to sell")
+            end
 
             # Prepare to take a loan
             emergency_buy_with_loan = true
@@ -56,6 +57,18 @@ module Engine
           @log << "#{player.name} has to borrow #{@game.format_currency(debt)} to pay for the train"
           @log << "An extra #{@game.format_currency(interest)} is added to the debt"
           pass!
+        end
+
+        private
+
+        def can_sell_anything?(player)
+          bundles = []
+          @game.corporations.each do |c|
+            bundles = player.bundles_for_corporation(c)
+            return true if bundles.select { |bundle| sellable_bundle?(bundle) }.any?
+          end
+
+          false
         end
       end
     end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -48,6 +48,7 @@ module Engine
 
           @game.game_error('Cannot contribute funds when exchanging') if exchange
           @game.game_error('Cannot buy for more than cost') if price > train.price
+          @game.game_error('Cannot contribute funds when affordable trains exist') if cheapest.price <= entity.cash
 
           player = entity.owner
           player.spend(remaining, entity)

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -41,9 +41,11 @@ module Engine
         remaining = price - entity.cash
         if remaining.positive? && must_buy_train?(entity)
           cheapest = @depot.min_depot_train
-          if train != cheapest && (!@game.class::EBUY_OTHER_VALUE || train.from_depot?)
-            @game.game_error("Cannot purchase #{train.name} train: #{cheapest.name} train available")
-          end
+          @game.game_error("Cannot purchase #{train.name} train: #{cheapest.name} train available") if
+            train != cheapest &&
+            @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST &&
+            (!@game.class::EBUY_OTHER_VALUE || train.from_depot?)
+
           @game.game_error('Cannot contribute funds when exchanging') if exchange
           @game.game_error('Cannot buy for more than cost') if price > train.price
 


### PR DESCRIPTION
Introduce a possibility to sell more shares than needed during emergency buy.
Only title that supports this at the moment are 18MS.

Refactor emergency buy so that check for sellable bundles can be
used by sub classes of train buy.

Bug fix: Do not enforce purchase of cheapest train if game title
(1846, 18MS) allows buy of more expensive train during emergency buy.

Bug fix 18MS: Do not allow player loans to purchase train if there
still are shares to sell. This stops the bugs there game made it possible to
take loans to buy a non-emergency train via president assist.

Sort of bug fix: Avoid doing emergency buy in case there is an affordable cheaper train.