### PR TITLE
18MEX tile update to use double track

### DIFF
--- a/TILES.md
+++ b/TILES.md
@@ -60,8 +60,8 @@ game config/code:
       integer to refer by index to a city/town/offboard/junction defined earlier
       on the tile
     - **terminal** - `1` - indicates that path is part of a non-passthru path, typically for off-board cities. Tapered track will be drawn.
-    - **track** - broad/narrow/dual/line/dashed; this option is not yet
-      implemented, so track is always broad
+    - **lanes** - integer - number of parallel paths. Effectively creates multiple copies of this path, each uniquely identified.
+    - **track** - `broad/narrow/line/dashed`; this option is not yet implemented, so track is always broad
 - **label** - large letter(s) on tile (e.g., "Chi", "OO", or "Z")
 - **upgrade**
     - **cost** - *required* - integer

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -111,12 +111,12 @@ module Engine
       "479MC":{
          "count":1,
          "color":"green",
-         "code":"city=revenue:40,slots:2,loc:center;town=revenue:0,loc:2.5;path=a:0,b:_0;path=a:4,b:_0;label=MC"
+         "code":"city=revenue:40,slots:2,loc:center;town=revenue:0,loc:2.5;path=a:3,b:_0;path=a:5,b:_0;label=MC"
       },
       "479P":{
          "count":1,
          "color":"green",
-         "code":"town=revenue:10;path=a:3,b:_0;path=a:_0,b:0;upgrade=cost:40,terrain:mountain;label=P"
+         "code":"town=revenue:10;path=a:2,b:_0;path=a:_0,b:5;upgrade=cost:40,terrain:mountain;label=P"
       },
       "480":1,
       "481":1,
@@ -126,22 +126,22 @@ module Engine
       "485MC":{
          "count":1,
          "color":"brown",
-         "code":"city=revenue:60,slots:3,loc:center;town=revenue:10,loc:4;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_1;path=a:5,b:_0;path=a:_1,b:_0;label=MC"
+         "code":"city=revenue:60,slots:3,loc:center;town=revenue:10,loc:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:2,b:_1;path=a:5,b:_0,lanes:2;path=a:_1,b:_0;label=MC"
       },
       "485P":{
          "count":1,
          "color":"brown",
-         "code":"town=revenue:10,loc:0;path=a:0,b:_0;path=a:3,b:_0;path=a:5,b:3;label=P"
+         "code":"town=revenue:10;path=a:2,b:_0;path=a:5,b:_0;path=a:2,b:4;label=P"
       },
       "486MC":{
          "count":1,
          "color":"brown",
-         "code":"city=revenue:50,slots:4,loc:center;town=revenue:10,loc:4;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_1;path=a:5,b:_0;path=a:_1,b:_0;label=MC"
+         "code":"city=revenue:50,slots:4,loc:center;town=revenue:10,loc:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:2,b:_1;path=a:5,b:_0,lanes:2;path=a:_1,b:_0;label=MC"
       },
       "486P":{
          "count":1,
          "color":"brown",
-         "code":"town=revenue:10,loc:0;path=a:0,b:_0;path=a:3,b:_0;path=a:5,b:3;label=P"
+         "code":"town=revenue:10;path=a:2,b:_0;path=a:5,b:_0;path=a:2,b:4;label=P"
       },
       "619":1
    },

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -304,7 +304,7 @@ module Engine
         return ct_edges
       end
       # if a tile has no cities and exactly one town that doesn't have two exits, place in center
-      if @cities.empty? && @towns.one? && (exits.size != 2) && !compute_loc(@towns.first.loc)
+      if @cities.empty? && @towns.one? && (@towns[0].exits.size != 2) && !compute_loc(@towns.first.loc)
         ct_edges[@towns.first] = nil
         return ct_edges
       end


### PR DESCRIPTION
1. Change Mexico City upgrade tiles to use double track
2. Minor change to allow town_rect rendering on Puebla tile without specifying a location for the town
![18MEX_Tiles_new](https://user-images.githubusercontent.com/8494213/93267404-dfb40d80-f768-11ea-9f11-26f11fb9a228.png)
