### PR TITLE
18TN: Use non-routed trains for Civil War resolution (fixes #1683)

### DIFF
--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -80,10 +80,13 @@ module Engine
       def routes_revenue(routes)
         total_revenue = super
 
-        abilities = routes.first&.corporation&.abilities(:civil_war)
+        corporation = routes.first&.corporation
 
-        return total_revenue if !abilities || abilities.empty?
+        abilities = corporation&.abilities(:civil_war)
 
+        return total_revenue if !abilities || abilities.empty? || routes.size < corporation&.trains&.size
+
+        # The train with the lowest revenue loses the income due to the war effort
         total_revenue - routes.map(&:revenue).min
       end
 

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -84,7 +84,7 @@ module Engine
 
         abilities = corporation&.abilities(:civil_war)
 
-        return total_revenue if !abilities || abilities.empty? || routes.size < corporation&.trains&.size
+        return total_revenue if !abilities || abilities.empty? || routes.size < corporation.trains.size
 
         # The train with the lowest revenue loses the income due to the war effort
         total_revenue - routes.map(&:revenue).min


### PR DESCRIPTION
If not all trains in a corporation is routed, the non-active trains
are used as the Civil War candidate trains.