### PR TITLE
Only start operating if the assigning entity is the player-owned steamboat

### DIFF
--- a/lib/engine/step/g_1846/assign.rb
+++ b/lib/engine/step/g_1846/assign.rb
@@ -81,7 +81,10 @@ module Engine
 
         def process_assign(action)
           super
-          @round.start_operating unless blocking_for_steamboat?
+
+          @round.start_operating if (action.entity == @game.steamboat) &&
+                                    @game.steamboat.owned_by_player? &&
+                                    !blocking_for_steamboat?
         end
 
         def process_pass(action)


### PR DESCRIPTION
This is a bug from my steamboat work. When the player-owned steamboat is done
assigning, then the first corporation should `start_operating`. The effect here
was that when the Meat Packing Company was done assigning, `start_operating` was
called again, setting all of its trains to having not operated.

[Fixes #1682]

Unfortunately this will break games wherever a corporation bought in the Big 4, then bought in and assigned the Steamboat or Meat Packing Company, then ran its routes.