### PR TITLE
Change lane attributes to be per exit rather than per path

### DIFF
--- a/assets/app/view/game/part/track_node_path.rb
+++ b/assets/app/view/game/part/track_node_path.rb
@@ -255,7 +255,7 @@ module View
             @end_edge = @path.edges.last.num
             @end_x = edge_x_pos(@end_edge, 87)
             @end_y = edge_y_pos(@end_edge, 87)
-            lanes = @path.ab_lanes
+            lanes = @path.lanes
           elsif @num_exits == 1
             @begin_edge = @path.exits[0]
             @begin_x = edge_x_pos(@begin_edge, 87)
@@ -279,11 +279,8 @@ module View
                                  ]
                                end
             end
-            lanes = if @path.a.edge?
-                      @path.ab_lanes
-                    else
-                      [@path.ab_lanes.last, @path.ab_lanes.first]
-                    end
+            lanes = @path.lanes
+            lanes.reverse! if @path.b.edge?
           else
             # city/town - city/town
             @ct_edge0 = @tile.preferred_city_town_edges[@stop0] if @stop0
@@ -308,11 +305,8 @@ module View
                                    calculate_stop_y(@ct_edge1, @tile),
                                  ]
                                end
-              lanes = if @path.a == @stop0
-                        @path.ab_lanes
-                      else
-                        [@path.ab_lanes.last, @path.ab_lanes.first]
-                      end
+              lanes = @path.lanes
+              lanes.reverse! if @path.b == @stop0
             else
               @begin_edge = @ct_edge1
               @begin_x, @begin_y = if @stop1.rect?
@@ -332,11 +326,8 @@ module View
                                    calculate_stop_y(@ct_edge0, @tile),
                                  ]
                                end
-              lanes = if @path.a == @stop1
-                        @path.ab_lanes
-                      else
-                        [@path.ab_lanes.last, @path.ab_lanes.first]
-                      end
+              lanes = @path.lanes
+              lanes.reverse! if @path.b == @stop1
             end
           end
 
@@ -356,9 +347,11 @@ module View
           begin_shift_edge = @begin_edge || @end_edge
           end_shift_edge = @end_edge || @begin_edge
 
-          if lanes.first[0] > 1
-            begin_shift = (lanes.first[1] * 2 - lanes.first[0] + 1) *
-                          (@width + PARALLEL_SPACING[lanes.first[0] - 2]) / 2.0
+          begin_lane, end_lane = lanes
+
+          if begin_lane[0] > 1
+            begin_shift = (begin_lane[1] * 2 - begin_lane[0] + 1) *
+                          (@width + PARALLEL_SPACING[begin_lane[0] - 2]) / 2.0
             begin_delta_x = (begin_shift * Math.cos(begin_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
             begin_delta_y = (begin_shift * Math.sin(begin_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
 
@@ -366,10 +359,10 @@ module View
             @begin_y += begin_delta_y
           end
 
-          return unless lanes.last[0] > 1
+          return unless end_lane[0] > 1
 
-          end_shift = (lanes.last[1] * 2 - lanes.last[0] + 1) *
-                      (@width + PARALLEL_SPACING[lanes.last[0] - 2]) / 2.0
+          end_shift = (end_lane[1] * 2 - end_lane[0] + 1) *
+                      (@width + PARALLEL_SPACING[end_lane[0] - 2]) / 2.0
           end_delta_x = (end_shift * Math.cos(end_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
           end_delta_y = (end_shift * Math.sin(end_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
 

--- a/assets/app/view/game/part/track_node_path.rb
+++ b/assets/app/view/game/part/track_node_path.rb
@@ -255,6 +255,7 @@ module View
             @end_edge = @path.edges.last.num
             @end_x = edge_x_pos(@end_edge, 87)
             @end_y = edge_y_pos(@end_edge, 87)
+            lanes = @path.ab_lanes
           elsif @num_exits == 1
             @begin_edge = @path.exits[0]
             @begin_x = edge_x_pos(@begin_edge, 87)
@@ -278,6 +279,11 @@ module View
                                  ]
                                end
             end
+            lanes = if @path.a.edge?
+                      @path.ab_lanes
+                    else
+                      [@path.ab_lanes.last, @path.ab_lanes.first]
+                    end
           else
             # city/town - city/town
             @ct_edge0 = @tile.preferred_city_town_edges[@stop0] if @stop0
@@ -302,6 +308,11 @@ module View
                                    calculate_stop_y(@ct_edge1, @tile),
                                  ]
                                end
+              lanes = if @path.a == @stop0
+                        @path.ab_lanes
+                      else
+                        [@path.ab_lanes.last, @path.ab_lanes.first]
+                      end
             else
               @begin_edge = @ct_edge1
               @begin_x, @begin_y = if @stop1.rect?
@@ -321,6 +332,11 @@ module View
                                    calculate_stop_y(@ct_edge0, @tile),
                                  ]
                                end
+              lanes = if @path.a == @stop1
+                        @path.ab_lanes
+                      else
+                        [@path.ab_lanes.last, @path.ab_lanes.first]
+                      end
             end
           end
 
@@ -335,16 +351,30 @@ module View
             @end_y
           ) if @need_arc
 
-          return if !@path.parallel? || !@begin_edge
+          return if @path.single? || !@begin_edge && !@end_edge
 
-          shift = (@path.lane_index * 2 - @path.lanes + 1) * (@width + PARALLEL_SPACING[@path.lanes - 2]) / 2.0
-          delta_x = (shift * Math.cos(@begin_edge * 60.0 * Math::PI / 180.0)).round(2)
-          delta_y = (shift * Math.sin(@begin_edge * 60.0 * Math::PI / 180.0)).round(2)
+          begin_shift_edge = @begin_edge || @end_edge
+          end_shift_edge = @end_edge || @begin_edge
 
-          @begin_x += delta_x
-          @begin_y += delta_y
-          @end_x += delta_x
-          @end_y += delta_y
+          if lanes.first[0] > 1
+            begin_shift = (lanes.first[1] * 2 - lanes.first[0] + 1) *
+                          (@width + PARALLEL_SPACING[lanes.first[0] - 2]) / 2.0
+            begin_delta_x = (begin_shift * Math.cos(begin_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
+            begin_delta_y = (begin_shift * Math.sin(begin_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
+
+            @begin_x += begin_delta_x
+            @begin_y += begin_delta_y
+          end
+
+          return unless lanes.last[0] > 1
+
+          end_shift = (lanes.last[1] * 2 - lanes.last[0] + 1) *
+                      (@width + PARALLEL_SPACING[lanes.last[0] - 2]) / 2.0
+          end_delta_x = (end_shift * Math.cos(end_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
+          end_delta_y = (end_shift * Math.sin(end_shift_edge * 60.0 * Math::PI / 180.0)).round(2)
+
+          @end_x += end_delta_x
+          @end_y += end_delta_y
         end
 
         def preferred_render_locations

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -131,7 +131,7 @@ module Engine
       "485P":{
          "count":1,
          "color":"brown",
-         "code":"town=revenue:10;path=a:2,b:_0;path=a:5,b:_0;path=a:2,b:4;label=P"
+         "code":"town=revenue:10;path=a:2,b:_0,a_lane:2.1;path=a:5,b:_0;path=a:2,b:4,a_lane:2.0;label=P"
       },
       "486MC":{
          "count":1,
@@ -141,7 +141,7 @@ module Engine
       "486P":{
          "count":1,
          "color":"brown",
-         "code":"town=revenue:10;path=a:2,b:_0;path=a:5,b:_0;path=a:2,b:4;label=P"
+         "code":"town=revenue:10;path=a:2,b:_0,a_lane:2.1;path=a:5,b:_0;path=a:2,b:4,a_lane:2.0;label=P"
       },
       "619":1
    },

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -5,8 +5,8 @@ require_relative 'base'
 module Engine
   module Part
     class Path < Base
-      attr_reader :a, :ab_lanes, :b, :branches, :city, :edges, :exit_lanes, :junction,
-                  :nodes, :offboard, :stops, :terminal, :town
+      attr_reader :a, :b, :branches, :city, :edges, :exit_lanes, :junction,
+                  :lanes, :nodes, :offboard, :stops, :terminal, :town
 
       def self.decode_lane_spec(x_lane)
         if x_lane
@@ -32,11 +32,11 @@ module Engine
         end
       end
 
-      def initialize(a, b, terminal = nil, ab_lanes = [[1, 0], [1, 0]])
+      def initialize(a, b, terminal = nil, lanes = [[1, 0], [1, 0]])
         @a = a
         @b = b
         @terminal = terminal
-        @ab_lanes = ab_lanes
+        @lanes = lanes
         @edges = []
         @branches = []
         @stops = []
@@ -106,15 +106,7 @@ module Engine
       end
 
       def single?
-        @_single ||= @ab_lanes.first[0] == 1 && @ab_lanes.last[0] == 1
-      end
-
-      def lanes
-        @ab_lanes.first[0]
-      end
-
-      def lane_index
-        @ab_lanes.first[1]
+        @_single ||= @lanes.first[0] == 1 && @lanes.last[0] == 1
       end
 
       def exits
@@ -122,7 +114,7 @@ module Engine
       end
 
       def rotate(ticks)
-        path = Path.new(@a.rotate(ticks), @b.rotate(ticks), @terminal, @ab_lanes)
+        path = Path.new(@a.rotate(ticks), @b.rotate(ticks), @terminal, @lanes)
         path.index = index
         path.tile = @tile
         path
@@ -133,7 +125,7 @@ module Engine
         if single?
           "<#{name}: hex: #{hex&.name}, exit: #{exits}>"
         else
-          "<#{name}: hex: #{hex&.name}, exit: #{exits}, lane_index: #{lane_index}>"
+          "<#{name}: hex: #{hex&.name}, exit: #{exits}, lanes: #{@lanes.first} #{@lanes.last}>"
         end
       end
 
@@ -144,7 +136,7 @@ module Engine
           case
           when part.edge?
             @edges << part
-            @exit_lanes[part.num] = @ab_lanes[part == @a ? 0 : 1]
+            @exit_lanes[part.num] = @lanes[part == @a ? 0 : 1]
           when part.offboard?
             @offboard = part
             @stops << part

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -65,7 +65,7 @@ module Engine
       when 'path'
         params = params.map do |k, v|
           case k
-          when 'terminal'
+          when 'terminal', 'a_lane', 'b_lane'
             [k, v]
           when 'lanes'
             [k, v.to_i]
@@ -79,10 +79,9 @@ module Engine
           end
         end.to_h
 
-        (params['lanes'] || 1).times.map do |index|
-          Part::Path.new(params['a'], params['b'], terminal: params['terminal'],
-                                                   lanes: params['lanes'], lane_index: index)
-        end
+        Part::Path.make_lanes(params['a'], params['b'], terminal: params['terminal'],
+                                                        lanes: params['lanes'], a_lane: params['a_lane'],
+                                                        b_lane: params['b_lane'])
       when 'city'
         city = Part::City.new(params['revenue'],
                               slots: params['slots'],


### PR DESCRIPTION
Update 18MEX tileset.
Refactored code in Path and track_node_path to use per exit (actually "endpoint" - a or b) lane width and index attributes.
Updated Path#walk to only follow paths across tiles if they have compatible lane attributes.

New MC/P tiles for 18MEX:
![18MEX_MC_P_Split_Track](https://user-images.githubusercontent.com/8494213/93653083-a384e500-f9d4-11ea-923a-69cb1a081845.png)
