### PR TITLE
acting entity for EndGame is the player corresponding to logged in user

### DIFF
--- a/assets/app/view/game/tools.rb
+++ b/assets/app/view/game/tools.rb
@@ -42,7 +42,8 @@ module View
         end_game = if @confirm_endgame
                      confirm = lambda do
                        store(:confirm_endgame, false)
-                       process_action(Engine::Action::EndGame.new(@game.current_entity))
+                       player = @game.players.find { |p| p.name == @user&.dig('name') }
+                       process_action(Engine::Action::EndGame.new(player || @game.current_entity))
                        # Go to main page
                        store(:app_route, @app_route.split('#').first)
                      end

--- a/lib/engine/step/end_game.rb
+++ b/lib/engine/step/end_game.rb
@@ -13,8 +13,8 @@ module Engine
         ACTIONS
       end
 
-      def process_end_game(_action)
-        @log << 'Game ended manually by a user'
+      def process_end_game(action)
+        @log << "Game ended manually by #{action.entity.name}"
         @game.end_game!
       end
 


### PR DESCRIPTION
still use `current_entity` in hotseat mode

[Fixes #1614]

This probably will need to be changed on #1330