### PR TITLE
18MS: Improve display of OR description, and add special info

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -27,7 +27,21 @@ module View
       def render_body
         children = upcoming_trains
         children.concat(discarded_trains) if @depot.discarded.any?
-        children.concat(phases, game_info)
+        children.concat(phases)
+        children.concat(timeline) if timeline
+        children.concat(game_info)
+      end
+
+      def timeline
+        return nil if @game.class::TIMELINE.empty?
+
+        children = [h(:h3, 'Timeline')]
+
+        @game.class::TIMELINE.each do |line|
+          children << h(:p, line)
+        end
+
+        children
       end
 
       def game_info

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -226,9 +226,9 @@ module View
     end
 
     def render_round
+      description = "#{@game.class.title}: "
       name = @round.class.name.split(':').last
-      description = "#{@game.class.title}: #{name} Round #{@game.turn}"
-      description += ".#{@round.round_num} (of #{@game.total_rounds})" if @game.total_rounds
+      description += @game.round_description(name)
       description += @game.finished ? ' - Game Over' : " - #{@round.description}"
       game_end = @game.game_ending_description
       description += " - #{game_end}" if game_end

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -204,7 +204,7 @@ describe 'Assets' do
       ['18_al', 4714, nil, 'endgame', '18AL: Operating Round 7.2 (of 3) - Game Over - Company hit max stock value'],
       ['18_ga', 8643, nil, 'endgame', '18GA: Operating Round 8.1 (of 3) - Game Over - Bank Broken'],
       ['18_tn', 7818, nil, 'endgame', '18TN: Operating Round 8.2 (of 3) - Game Over - Bank Broken'],
-      ['18_ms', 9882, nil, 'endgame', '18MS: Operating Round 5.2 (of 2) - Game Over - Last OR in game'],
+      ['18_ms', 9882, nil, 'endgame', '18MS: Operating Round 10 (of 10) - Game end after OR 10 - Game Over'],
     ].freeze
 
     def render_game(jsonfile, no_actions, string)


### PR DESCRIPTION
The game now shows OR 1 (of 10) etc instead of OR 1.1 (of 2).
The OR numbering is local to 18MS, so the change of OR presentation
is only done in 18MS, but it is possible to override the
round_name method in game base class if a title want to
modify this.

18MS also add information in the log, and game page, about the next
upcoming time based event. So e.g.
In the log:
  -- Operating Round 6 (of 10) - 3+ trains rust after OR 6 --
In the game page:
  18MS: Operating Round 6 (of 10) - 3+ trains rust after OR 6 - Lay Track
Or
  18MS: Operating Round 1 (of 10) - Change to Phase 3 after OR 1 -
  2+ trains rust after OR 4 - Buy Trains
This is done by extracting the description to the round_description
method in game base class, and overriding it in 18MS.

Stock round description has not been changed.

Draft round now says the following in the game page for 18MS:
  18MS: Draft - Draft One Company Each
It was "Draft round 1" but as there is only one round this was
confusing.

The description for all other titles should be unchanged.

Have added a "Timeline Info" to the Info tab that only display if the
list TIMELINE_INFO contains anything. If it do the Info page will just
append the elements in the list as paragraph with text, one paragraph
per element. This has only been added to 18MS in this commit but it
can easily be added other titles as needed, e.g. 18Chesapeake could add
a paragraph on how a non-parament train is exported at end of each
OR set.

Internally the game end check for specific OR has been removed. This
was only used in 18MS and it is better to implement it just in that
title, as the OR numbering is local to 18MS. It is also a game
end that is very few titles, only 18CZ as far as I know.

This commit is an attempt to handle the tickets #1675 and #1685.