### PR TITLE
Make empty space in stock market more robust

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -135,16 +135,15 @@ module View
           position: 'relative',
           display: 'inline-block',
           padding: "#{PAD}px",
-          width: "#{WIDTH_TOTAL - 2 * PAD}px",
-          height: "#{HEIGHT_TOTAL - 2 * PAD}px",
+          width: "#{WIDTH_TOTAL - 2 * PAD - 2 * BORDER}px",
+          height: "#{HEIGHT_TOTAL - 2 * PAD - 2 * BORDER}px",
+          border: "solid #{BORDER}px rgba(0,0,0,0)",
           margin: '0',
           verticalAlign: 'top',
         }
 
         # For cells with prices
         @box_style_2d = @space_style_2d.merge(
-          width: "#{WIDTH_TOTAL - 2 * PAD - 2 * BORDER}px",
-          height: "#{HEIGHT_TOTAL - 2 * PAD - 2 * BORDER}px",
           border: "solid #{BORDER}px rgba(0,0,0,0.2)",
           color: color_for(:font2),
         )


### PR DESCRIPTION
Firefox has an issue where borders are not scaled exactly when a page is not viewed at the 100% zoom level. This means that the calculation designed to make blank areas in the stock market exactly match the size of market cells fails, with the following effect:

<img width="348" alt="Screen Shot 2020-09-19 at 10 02 11 AM" src="https://user-images.githubusercontent.com/1295244/93669132-b98bb780-fa5f-11ea-9121-ad9aae586dec.png">

This code makes blank cells match the size of real cells exactly, by giving them the same width, height, and border sizes, but with a border alpha of 0.