### PR TITLE
1817: Players can take loans to be able to buy trains, tokens and track

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -789,6 +789,10 @@ module Engine
           liquidity(player, emergency: true)
       end
 
+      def buying_power(entity)
+        entity.cash
+      end
+
       private
 
       def init_bank

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -116,6 +116,12 @@ module Engine
           @loans.any?
       end
 
+      def buying_power(entity)
+        return entity.cash unless entity.corporation?
+
+        entity.cash + ((maximum_loans(entity) - entity.loans.size) * @loan_value)
+      end
+
       def liquidate!(corporation)
         @stock_market.move(corporation, 0, 0, force: true)
       end

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -9,7 +9,7 @@ module Engine
       def can_place_token?(entity)
         current_entity == entity &&
           (tokens = available_tokens(entity)).any? &&
-          min_token_price(tokens) <= entity.cash &&
+          min_token_price(tokens) <= @game.buying_power(entity) &&
           @game.graph.can_token?(entity)
       end
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -14,7 +14,7 @@ module Engine
         action = get_tile_lay(entity)
         return false unless action
 
-        entity.tokens.any? && (entity.cash >= action[:cost]) && (action[:lay] || action[:upgrade])
+        entity.tokens.any? && (@game.buying_power(entity) >= action[:cost]) && (action[:lay] || action[:upgrade])
       end
 
       def get_tile_lay(entity)

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -10,11 +10,11 @@ module Engine
       def can_buy_train?(entity = nil)
         entity ||= current_entity
         can_buy_normal = room?(entity) &&
-          entity.cash >= @depot.min_price(entity)
+          @game.buying_power(entity) >= @depot.min_price(entity)
 
         can_buy_normal || @depot
           .discountable_trains_for(entity)
-          .any? { |_, _, price| entity.cash >= price }
+          .any? { |_, _, price| @game.buying_power(entity) >= price }
       end
 
       def room?(entity)


### PR DESCRIPTION
Stops skipping ahead and allows users to buy track/trains or tokens