### PR TITLE
1817: Improvements to auction side for liquidation, acquisition and offering

### DIFF
--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -29,6 +29,8 @@ module View
 
           children << render_convert(entity) if actions.include?('convert')
           children << render_loan(entity) if actions.include?('take_loan')
+          children << render_offer(entity, auctioning_corporation) if actions.include?('assign')
+
           children << render_merge(entity, auctioning_corporation) if actions.include?('merge') && @selected_corporation
           merge_entity = auctioning_corporation || entity
 
@@ -62,6 +64,14 @@ module View
             :button,
             { on: { click: -> { process_action(Engine::Action::Convert.new(corporation)) } } },
             'Convert',
+          )
+        end
+
+        def render_offer(entity, corporation)
+          h(
+            :button,
+            { on: { click: -> { process_action(Engine::Action::Assign.new(entity, target: corporation)) } } },
+            'Offer for Sale',
           )
         end
 

--- a/lib/engine/round/g_1817/acquisition.rb
+++ b/lib/engine/round/g_1817/acquisition.rb
@@ -15,8 +15,8 @@ module Engine
           # Things that are offered up for acquisition, sale etc
           @offering =  @game
                       .corporations
-                      .select { |c| c.floated? && c.share_price.normal_movement? }
-                      .sort
+                      .select(&:floated?)
+                      .sort.reverse
           @game.players.select { |p| p.presidencies.any? }
         end
 

--- a/lib/engine/round/g_1817/merger.rb
+++ b/lib/engine/round/g_1817/merger.rb
@@ -13,7 +13,7 @@ module Engine
         def select_entities
           @game
             .corporations
-            .select { |c| c.floated? && c.share_price.normal_movement? }
+            .select { |c| c.floated? && c.share_price.normal_movement? && !c.share_price.acquisition? }
             .sort
         end
 


### PR DESCRIPTION
Corporations in acquisition cannot be merge/converted.

Fixes the order of corporations in acquisition
Players can offer companies up correctly
Correct initial bid prices
Improve the logging

Company -> Corporation