### PR TITLE
Fix for #1706 - don't look at paths in current route when selecting n…

### DIFF
--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -44,7 +44,7 @@ module Engine
     end
 
     def select(node, other)
-      other_paths = @routes.flat_map(&:paths)
+      other_paths = @routes.reject { |r| r == self }.flat_map(&:paths)
       nodes = [node, other]
 
       node.hex.all_connections.select do |c|


### PR DESCRIPTION
…odes

Fixes #1706 

Undo culling duplicate paths when selecting connections in a route via the UI.
Note that duplicate paths are still filtered out in restore_connections. This bug doesn't apply there, only when "cycling" nodes via the UI.