### PR TITLE
More verbose route descriptions in log (fixes #1063)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -625,6 +625,10 @@ module Engine
         stops.sum { |stop| stop.route_revenue(route.phase, route.train) }
       end
 
+      def revenue_str(route)
+        route.hexes.map(&:name).join('-')
+      end
+
       def routes_revenue(routes)
         routes.sum(&:revenue)
       end

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -210,6 +210,34 @@ module Engine
         revenue
       end
 
+      def revenue_str(route)
+        stops = route.stops
+        stop_hexes = stops.map(&:hex)
+        str = route.hexes.map do |h|
+          stop_hexes.include?(h) ? h&.name : "(#{h&.name})"
+        end.join('-')
+
+        east = stops.find { |stop| stop.groups.include?('E') }
+        west = stops.find { |stop| stop.tile.label&.to_s == 'W' }
+
+        meat = meat_packing.id
+
+        str += ' + Meat-Packing' if route.corporation.assigned?(meat) && stops.any? { |stop| stop.hex.assigned?(meat) }
+
+        steam = steamboat.id
+
+        str += ' + Port' if route.corporation.assigned?(steam) && (stops.map(&:hex).find { |hex| hex.assigned?(steam) })
+
+        str += ' + E/W' if east && west
+
+        if route.train.owner.companies.include?(mail_contract)
+          longest = route.routes.max_by { |r| [r.visited_stops.size, r.train.id] }
+          str += ' + Mail Contract' if route == longest
+        end
+
+        str
+      end
+
       def meat_packing
         @meat_packing ||= company_by_id('MPC')
       end

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -36,9 +36,8 @@ module Engine
           @game.game_error('Cannot run train that operated') if train.operated
 
           trains[train] = true
-          hexes = route.hexes.map(&:name).join(', ')
           @log << "#{entity.name} runs a #{train.name} train for "\
-            "#{@game.format_currency(route.revenue)} (#{hexes})"
+            "#{@game.format_currency(route.revenue)}: #{@game.revenue_str(route)}"
         end
         pass!
       end


### PR DESCRIPTION
It's not awesome that there is now a `revenue_str` method that parallels `revenue_for`. However, refactoring the code so that the logic all happens in one place (building up the descriptive string while calculating the revenue) is not trivial and would also lead to some wasted computation (since `revenue_for` is called many times when the correct stops have to be chosen).