### PR TITLE
Correct round description in log (fixes #1711)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1157,7 +1157,7 @@ module Engine
       end
 
       def new_operating_round(round_num = 1)
-        @log << "-- #{round_description('Operating')} --"
+        @log << "-- #{round_description('Operating', round_num)} --"
         operating_round(round_num)
       end
 
@@ -1220,9 +1220,10 @@ module Engine
         [0, 0]
       end
 
-      def round_description(name)
+      def round_description(name, round_number = nil)
+        round_number ||= @round.round_num
         description = "#{name} Round #{@turn}"
-        description += ".#{@round.round_num} (of #{total_rounds(name)})" if total_rounds(name)
+        description += ".#{round_number} (of #{total_rounds(name)})" if total_rounds(name)
         description
       end
     end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -116,7 +116,7 @@ module Engine
         super
       end
 
-      def round_description(name)
+      def round_description(name, _round_num = nil)
         case name
         when 'Stock'
           super


### PR DESCRIPTION
@round.round_num is not updated for new round before description
uses it in the log. Now the new round number is passed for this
case which solves the issue.

The game page is correct, as the round is created, and round
number incremented before it is shown.