### PR TITLE
Fix assignment placement for pointy map tiles

### DIFF
--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -13,17 +13,14 @@ module View
         DELTA_X = (ICON_RADIUS * 2) + 2
 
         def preferred_render_locations
-          if layout == :pointy
-            delta_y = -35
-            delta_x = -60.25
-            [{
-               region_weights: { LEFT_CORNER => 1 },
-               x: delta_x + (DELTA_X / 2) * (@assignments.size - 1),
-               y: delta_y,
-             }]
-
-          elsif layout == :flat
+          if layout == :pointy && @assignments.one?
+            POINTY_SMALL_ITEM_LOCATIONS
+          elsif layout == :pointy
+            POINTY_WIDE_ITEM_LOCATIONS
+          elsif layout == :flat && @assignments.one?
             SMALL_ITEM_LOCATIONS
+          else
+            WIDE_ITEM_LOCATIONS
           end
         end
 

--- a/assets/app/view/game/part/icons.rb
+++ b/assets/app/view/game/part/icons.rb
@@ -9,36 +9,6 @@ module View
       class Icons < Base
         include SmallItem
 
-        P_WIDE_TOP_CORNER = {
-          region_weights: [0, 1, 2, 3, 4],
-          x: 0,
-          y: -65,
-        }.freeze
-
-        P_WIDE_BOTTOM_CORNER = {
-          region_weights: [19, 20, 21, 22, 23],
-          x: 0,
-          y: 65,
-        }.freeze
-
-        PP_WIDE_TOP_CORNER = {
-          region_weights: [0, 1, 2, 3, 5, 6],
-          x: 0,
-          y: -65,
-        }.freeze
-
-        PP_WIDE_BOTTOM_CORNER = {
-          region_weights: [17, 18, 20, 21, 22, 23],
-          x: 0,
-          y: 65,
-        }.freeze
-
-        WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
-                               PP_WIDE_BOTTOM_CORNER].freeze
-
-        POINTY_WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
-                                      PP_WIDE_BOTTOM_CORNER].freeze
-
         ICON_RADIUS = 16
         DELTA_X = (ICON_RADIUS * 2) + 2
 

--- a/assets/app/view/game/part/small_item.rb
+++ b/assets/app/view/game/part/small_item.rb
@@ -84,6 +84,30 @@ module View
           y: 0,
         }.freeze
 
+        P_WIDE_TOP_CORNER = {
+          region_weights: [0, 1, 2, 3, 4],
+          x: 0,
+          y: -65,
+        }.freeze
+
+        P_WIDE_BOTTOM_CORNER = {
+          region_weights: [19, 20, 21, 22, 23],
+          x: 0,
+          y: 65,
+        }.freeze
+
+        PP_WIDE_TOP_CORNER = {
+          region_weights: [0, 1, 2, 3, 5, 6],
+          x: 0,
+          y: -65,
+        }.freeze
+
+        PP_WIDE_BOTTOM_CORNER = {
+          region_weights: [17, 18, 20, 21, 22, 23],
+          x: 0,
+          y: 65,
+        }.freeze
+
         SMALL_ITEM_LOCATIONS = [P_RIGHT_CORNER,
                                 P_LEFT_CORNER,
                                 P_BOTTOM_RIGHT_CORNER,
@@ -98,6 +122,12 @@ module View
                                        PP_BOTTOM_LEFT_CORNER,
                                        PP_UPPER_RIGHT_CORNER,
                                        PP_BOTTOM_RIGHT_CORNER].freeze
+
+        WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
+                               PP_WIDE_BOTTOM_CORNER].freeze
+
+        POINTY_WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
+                                      PP_WIDE_BOTTOM_CORNER].freeze
       end
     end
   end


### PR DESCRIPTION
Allow assignments to be flexibly placed for pointy maps. Essentially repeating code changes already made for icons.

Fixes #1699 

Examples with fix:
![1846_Chicago_Assignment](https://user-images.githubusercontent.com/8494213/94216983-1511d700-fe9e-11ea-8ce9-4aa0d902a28d.png)
![1846_StLouis_Assignment](https://user-images.githubusercontent.com/8494213/94216987-16db9a80-fe9e-11ea-813e-c7d2e3195d74.png)
