### PR TITLE
when skipping Step::Dividend, also pass Step::IssueShares

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -801,7 +801,7 @@ module Engine
       end
 
       def buying_power(entity)
-        entity.cash + (issuable_shares(entity).map(&:share_price).max || 0)
+        entity.cash + (issuable_shares(entity).map(&:price).max || 0)
       end
 
       private

--- a/lib/engine/step/g_1846/dividend.rb
+++ b/lib/engine/step/g_1846/dividend.rb
@@ -32,10 +32,10 @@ module Engine
         def skip!
           super
 
+          @round.steps.find { |s| s.class == Step::G1846::IssueShares }.pass!
+
           return unless current_entity.receivership?
-
           return if current_entity.trains.any?
-
           return if current_entity.share_price.price.zero?
 
           @log << "#{current_entity.name} is in receivership and does not own a train."

--- a/spec/fixtures/1846/3099.json
+++ b/spec/fixtures/1846/3099.json
@@ -1779,7 +1779,7 @@
       "type": "run_routes",
       "entity": "GT",
       "entity_type": "corporation",
-      "id": 206,
+      "id": 205,
       "routes": [
         {
           "train": "4-0",
@@ -1812,8 +1812,14 @@
       "type": "dividend",
       "entity": "GT",
       "entity_type": "corporation",
-      "id": 207,
+      "id": 206,
       "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 207
     },
     {
       "type": "pass",
@@ -1822,16 +1828,10 @@
       "id": 208
     },
     {
-      "type": "pass",
-      "entity": "GT",
-      "entity_type": "corporation",
-      "id": 209
-    },
-    {
       "type": "lay_tile",
       "entity": "IC",
       "entity_type": "corporation",
-      "id": 210,
+      "id": 209,
       "hex": "F6",
       "tile": "8-4",
       "rotation": 0
@@ -1840,10 +1840,16 @@
       "type": "lay_tile",
       "entity": "IC",
       "entity_type": "corporation",
-      "id": 211,
+      "id": 210,
       "hex": "E5",
       "tile": "8-5",
       "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 211
     },
     {
       "type": "run_routes",
@@ -8556,7 +8562,7 @@
       "kind": "payout"
     }
   ],
-  "id": "hs_tjflxkfu_3099",
+  "id": "3099",
   "players": [
     {
       "name": "mfmise",


### PR DESCRIPTION
also fix a buying_power bug, it should include the total price of the whole
issuable bundle