### PR TITLE
Fixes for using abilities out of turn

### DIFF
--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -45,6 +45,15 @@ module Engine
         ], round_num: round_num)
       end
 
+      def stock_round
+        Round::Stock.new(self, [
+          Step::DiscardTrain,
+          Step::Exchange,
+          Step::G1889::SpecialTrack,
+          Step::BuySellParShares,
+        ])
+      end
+
       def active_players
         return super if @finished
 

--- a/lib/engine/step/g_1889/special_track.rb
+++ b/lib/engine/step/g_1889/special_track.rb
@@ -27,8 +27,9 @@ module Engine
 
         def blocking_for_sold_company?
           just_sold_company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
+          return false unless just_sold_company
 
-          if just_sold_company&.abilities(:tile_lay, 'sold')
+          if just_sold_company.abilities(:tile_lay, 'sold')
             @company = just_sold_company
             return true
           end


### PR DESCRIPTION
1889: Correct how Ferry private is used. (Fixes #1725 and #1558) 

General: Make it possible for owner to use ability out-of-turn. And stop non-user for doing this.

The general fix works for both Duogo Railway and Mitsubishi Ferry privates.

The general fix need to be verified versus existing games that it does not break anything, or at least that it works as intended in the cases it do break some game. Have verified that it work as intended in a multi-player 1889.