### PR TITLE
Los Mochos and Puebla tile fixes

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -16,6 +16,7 @@ module Engine
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
       STANDARD_GREEN_CITY_TILES = %w[14 15 619].freeze
+      CURVED_YELLOW_CITY = %w[5 6].freeze
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(
         'minors_closed' => ['Minors closed', 'Minors closed, NdM available'],
@@ -49,6 +50,7 @@ module Engine
 
         @brown_g_tile ||= @tiles.find { |t| t.name == '480' }
         @gray_tile ||= @tiles.find { |t| t.name == '455' }
+        @green_l_tile ||= @tiles.find { |t| t.name == '475' }
       end
 
       def operating_round(round_num)
@@ -101,6 +103,7 @@ module Engine
         # Guadalajara (O8) can only be upgraded to #480 in brown, and #455 in gray
         return to.name == '480' if from.color == :green && from.hex.name == 'O8'
         return to.name == '455' if from.color == :brown && from.hex.name == 'O8'
+        return to.name == '475' if from.color == :yellow && from.hex.name == 'I4'
 
         super
       end
@@ -116,8 +119,11 @@ module Engine
         # Tile manifest for standard green cities should show G tile as an option
         upgrades |= [@brown_g_tile] if @brown_g_tile && STANDARD_GREEN_CITY_TILES.include?(tile.name)
 
-        # Tile manifest for Guadalajara brown (the G tile) should gray tile as an option
+        # Tile manifest for Guadalajara brown (the G tile) should show gray tile as an option
         upgrades |= [@gray_tile] if @gray_tile && tile.name == '480'
+
+        # Tile manifest for standard yellow cities with curve should show Los Mochos green tile as an option
+        upgrades |= [@green_l_tile] if @green_l_tile && CURVED_YELLOW_CITY.include?(tile.name)
 
         upgrades
       end

--- a/lib/engine/step/g_18_mex/track.rb
+++ b/lib/engine/step/g_18_mex/track.rb
@@ -7,6 +7,8 @@ module Engine
     module G18MEX
       class Track < Track
         ACTIONS = %w[lay_tile pass].freeze
+        MEXICO_CITY_MAIN_HEX = 'O10'
+        PUEBLA_HEX = 'P11'
 
         def actions(entity)
           return [] if entity.company? || !remaining_tile_lay?(entity)
@@ -16,7 +18,11 @@ module Engine
 
         def process_lay_tile(action)
           @game.game_error('Cannot do normal tile lay') unless can_lay_tile?(action.entity)
+          if action.hex.name == PUEBLA_HEX
+            @game.game_error("Can only be upgraded via Mexico City (#{MEXICO_CITY_MAIN_HEX})")
+          end
           lay_tile_action(action)
+          lay_in_pueble(action) if action.hex.id == MEXICO_CITY_MAIN_HEX
           pass! unless remaining_tile_lay?(action.entity)
         end
 
@@ -25,6 +31,15 @@ module Engine
         def remaining_tile_lay?(entity)
           can_lay_tile?(entity) ||
           (@game.p2_company.owner == entity && @game.p2_company.abilities(:tile_lay)&.count&.positive?)
+        end
+
+        def lay_in_pueble(action)
+          hex = @game.hexes.find { |h| h.name == PUEBLA_HEX }
+          puebla_tile_name = action.tile.name.sub('MC', 'P')
+          tile = @game.tiles.find { |t| t.name == puebla_tile_name }
+
+          puebla_action = Engine::Action::LayTile.new(action.entity, hex: hex, tile: tile, rotation: 0)
+          lay_tile(puebla_action)
         end
       end
     end


### PR DESCRIPTION
Los Mochos need special handling to upgrade to green.

Mexico City is in the game a two hex tile. So this is implemented in a way that when the Mexico City hex is upgraded, the Puebla hex is automatically upgraded with the corresponding tile.