### PR TITLE
allow "empty" hexes in game conf definition, fix axes for 18MS column 14

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -33,6 +33,8 @@ module View
       needs :unavailable, default: nil
 
       def render
+        return nil if @hex.empty_placeholder?
+
         @selected = @hex == @tile_selector&.hex || @selected_route&.last_node&.hex == @hex
         @tile =
           if @selected && @actions.include?('lay_tile') && @tile_selector&.tile

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -132,7 +132,7 @@ module View
           [(@cols.size * 1.5 + 0.5) * EDGE_LENGTH + 2 * GAP,
            (@rows.size / 2 + 0.5) * SIDE_TO_SIDE + 2 * GAP]
         else
-          [(@cols.size / 2 + 0.5) * SIDE_TO_SIDE + 2 * GAP,
+          [((@cols.size / 2 + 0.5) * SIDE_TO_SIDE + 2 * GAP) + 1,
            (@rows.size * 1.5 + 0.5) * EDGE_LENGTH + 2 * GAP]
         end
       end

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -429,6 +429,9 @@ module Engine
       }
    ],
    "hexes":{
+      "empty": {
+        "": ["B14"]
+      },
       "white":{
          "":[
             "B4",

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -908,6 +908,8 @@ module Engine
         self.class::HEXES.map do |color, hexes|
           hexes.map do |coords, tile_string|
             coords.map.with_index do |coord, index|
+              next Hex.new(coord, layout: layout, axes: axes, empty_placeholder: true) if color == :empty
+
               tile =
                 begin
                   Tile.for(tile_string, preprinted: true, index: index)

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -64,7 +64,8 @@ module Engine
     # Coordinates are of the form A1..Z99
     # x and y map to the double coordinate system
     # layout is :pointy or :flat
-    def initialize(coordinates, layout: nil, axes: nil, tile: Tile.for('blank'), location_name: nil)
+    def initialize(coordinates, layout: nil, axes: nil, tile: Tile.for('blank'),
+                   location_name: nil, empty_placeholder: false)
       @coordinates = coordinates
       @layout = layout
       @x, @y = self.class.init_x_y(@coordinates, axes)
@@ -75,6 +76,7 @@ module Engine
       @original_tile = @tile = tile
       @tile.hex = self
       @activations = []
+      @empty_placeholder = empty_placeholder
     end
 
     def id
@@ -217,6 +219,10 @@ module Engine
 
     def inspect
       "<#{self.class.name}: #{name}, tile: #{@tile.name}>"
+    end
+
+    def empty_placeholder?
+      @empty_placeholder
     end
   end
 end


### PR DESCRIPTION
18MS has no hexes in column 14, now we can add an "empty" hex like B14 to fix axes rendering. Seemed like this would be simpler than trying to identify and fill gaps in letters or numbers.

Before:

![Screenshot from 2020-09-27 11-47-34](https://user-images.githubusercontent.com/1045173/94371928-529d7c80-00b7-11eb-8f1a-45e60bc6ed53.png)

After:

![Screenshot from 2020-09-27 11-46-15](https://user-images.githubusercontent.com/1045173/94371932-56c99a00-00b7-11eb-825b-ebf8607bef45.png)
