### PR TITLE
Make it possible to introduce a different train limit for a corporation

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -160,6 +160,13 @@ normal tile lay actions.
   controlling corporation's station tokens are reachable; if not a game
   error is triggered. Default false.
 
+## train_limit
+
+Modify train limit in some way.
+
+- `increase`: If positive, this will increase the train limit with this
+  amount in all faces. Default 0.
+
 ## token
 
 Modified station token placement

--- a/lib/engine/ability/train_limit.rb
+++ b/lib/engine/ability/train_limit.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Ability
+    class TrainLimit < Base
+      attr_reader :increase
+      def setup(increase: nil)
+        @increase = increase
+      end
+    end
+  end
+end

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -426,6 +426,13 @@ module Engine
             0,
             0
          ],
+         "abilities": [
+            {
+               "type": "train_limit",
+               "description": "+1 train limit",
+               "increase": 1
+            }
+         ],
          "coordinates":"O10",
          "color":"green"
       },

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -190,7 +190,7 @@ module Engine
         # Only companies owned by the president may be bought
         # Allow MC to be bought only before OR 3.1 and there is room for a 2+ train
         companies = super.select { |c| c.owned_by?(entity.player) }
-        companies.reject! { |c| c.id == 'MC' && (@turn >= 3 || entity.trains.size == @phase.train_limit) }
+        companies.reject! { |c| c.id == 'MC' && (@turn >= 3 || entity.trains.size == @phase.train_limit(entity)) }
 
         return companies unless @phase.status.include?('can_buy_companies_operation_round_one')
 

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -126,8 +126,8 @@ module Engine
     private
 
     def train_limit_increase(entity)
-      ability = entity.abilities(:train_limit)
-      ability.any? ? ability.first.increase : 0
+      entity.abilities(:train_limit) { |ability| return ability.increase }
+      0
     end
   end
 end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -4,7 +4,7 @@ require_relative 'action/buy_train'
 
 module Engine
   class Phase
-    attr_reader :name, :operating_rounds, :train_limit, :tiles, :phases, :status
+    attr_reader :name, :operating_rounds, :tiles, :phases, :status
 
     def initialize(phases, game)
       @index = 0
@@ -29,6 +29,10 @@ module Engine
 
     def current
       @phases[@index]
+    end
+
+    def train_limit(entity)
+      @train_limit + train_limit_increase(entity)
     end
 
     def available?(phase_name)
@@ -117,6 +121,13 @@ module Engine
     def next!
       @index += 1
       setup_phase!
+    end
+
+    private
+
+    def train_limit_increase(entity)
+      ability = entity.abilities(:train_limit)
+      ability.any? ? ability.first.increase : 0
     end
   end
 end

--- a/lib/engine/step/discard_train.rb
+++ b/lib/engine/step/discard_train.rb
@@ -34,7 +34,7 @@ module Engine
 
       def crowded_corps
         @game.corporations.select do |c|
-          c.trains.reject(&:obsolete).size > @game.phase.train_limit
+          c.trains.reject(&:obsolete).size > @game.phase.train_limit(c)
         end
       end
     end

--- a/lib/engine/step/g_1846/buy_company.rb
+++ b/lib/engine/step/g_1846/buy_company.rb
@@ -15,7 +15,7 @@ module Engine
         end
 
         def room?(entity)
-          entity.trains.reject(&:obsolete).size < @game.phase.train_limit
+          entity.trains.reject(&:obsolete).size < @game.phase.train_limit(entity)
         end
 
         def process_buy_company(action)

--- a/lib/engine/step/g_18_ga/buy_company.rb
+++ b/lib/engine/step/g_18_ga/buy_company.rb
@@ -12,7 +12,7 @@ module Engine
           return unless action.company.sym == 'OSR'
 
           owner = action.company.owner
-          return if owner.player? || owner.trains.size == @game.phase.train_limit || @game.phase.available?('4')
+          return if owner.player? || owner.trains.size == @game.phase.train_limit(owner) || @game.phase.available?('4')
 
           @game.add_free_two_train(owner)
         end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -18,7 +18,7 @@ module Engine
       end
 
       def room?(entity)
-        entity.trains.reject(&:obsolete).size < @game.phase.train_limit
+        entity.trains.reject(&:obsolete).size < @game.phase.train_limit(entity)
       end
 
       def must_buy_train?(entity)


### PR DESCRIPTION
Add a train_limit ability, with attribute increase, that can be added
to a corporation to set a permanent increase in the train limit.