### PR TITLE
Add a train_buy ability to allow for restricting train buys

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -191,13 +191,7 @@ module View
                 width: '3rem',
                 padding: '0 0 0 0.2rem',
               },
-              attrs: {
-                type: 'number',
-                min: 1,
-                max: @corporation.cash,
-                value: 1,
-                size: @corporation.cash.to_s.size,
-              },
+              attrs: price_range(group[0]),
             )
 
             buy_train = lambda do
@@ -241,6 +235,27 @@ module View
                              'Hide trains from other players')
         end
         trains_to_buy
+      end
+
+      def price_range(train)
+        step = @game.round.active_step
+        if step.face_value?(train.owner) || step.face_value?(@corporation)
+          {
+            type: 'number',
+            min: train.price,
+            max: train.price,
+            value: train.price,
+            size: 1,
+          }
+        else
+          {
+            type: 'number',
+            min: 1,
+            max: @corporation.cash,
+            value: 1,
+            size: @corporation.cash.to_s.size,
+          }
+        end
       end
 
       def remaining_trains

--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -160,6 +160,13 @@ normal tile lay actions.
   controlling corporation's station tokens are reachable; if not a game
   error is triggered. Default false.
 
+## train_buy
+
+Modify train buy in some way.
+
+- `face_value`: If true, any inter corporation train buy must be at
+  face value. Default false.
+
 ## train_limit
 
 Modify train limit in some way.

--- a/lib/engine/ability/train_buy.rb
+++ b/lib/engine/ability/train_buy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Ability
+    class TrainBuy < Base
+      attr_reader :face_value
+      def setup(face_value: nil)
+        @face_value = !!face_value
+      end
+    end
+  end
+end

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -429,6 +429,11 @@ module Engine
          ],
          "abilities": [
             {
+               "type": "train_buy",
+               "description": "Inter train buy/sell at face value",
+               "face_value": true
+            },
+            {
                "type": "train_limit",
                "description": "+1 train limit",
                "increase": 1

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -37,6 +37,7 @@ module Engine
 
         # Check if the train is actually buyable in the current situation
         @game.game_error('Not a buyable train') unless buyable_train_variants(train, entity).include?(train.variant)
+        @game.game_error('Must pay face value') if must_pay_face_value?(train, entity, price)
 
         remaining = price - entity.cash
         if remaining.positive? && must_buy_train?(entity)
@@ -145,6 +146,17 @@ module Engine
         return false unless corporation.cash < @game.depot.min_depot_price
 
         !must_issue_before_ebuy?(corporation)
+      end
+
+      def must_pay_face_value?(train, entity, price)
+        return if train.from_depot? || (!face_value?(entity) && !face_value?(train.owner))
+
+        train.price != price
+      end
+
+      def face_value?(entity)
+        entity.abilities(:train_buy) { |ability| return ability.face_value }
+        false
       end
     end
   end


### PR DESCRIPTION
Supported attribute is face_value. If true, inter corporation
buy of trains must be at exactly face value.