### PR TITLE
18MEX: Remove Toluca from Mexico City location name

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -47,7 +47,7 @@ module Engine
       "M10":"Querétaro",
       "M12":"Tampico",
       "O8":"Guadalajara",
-      "O10":"Mexico City & Toluca",
+      "O10":"Mexico City",
       "P7":"Puerto Vallarta",
       "P11":"Puebla",
       "P13":"Veracruz",


### PR DESCRIPTION
That hex is a very crowded one.