### PR TITLE
Still render IssueShares when sell_shares action available

### DIFF
--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -34,8 +34,9 @@ module View
             left << h(BuyTrains)
           elsif @current_actions.include?('sell_shares') && entity.player?
             left << h(CashCrisis)
+          elsif @current_actions.include?('buy_shares') || @current_actions.include?('sell_shares')
+            left << h(IssueShares)
           end
-          left << h(IssueShares) if @current_actions.include?('buy_shares')
           left << h(Loans, corporation: entity) if (%w[take_loan payoff_loan] & @current_actions).any?
 
           if entity.player?

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -170,6 +170,9 @@ describe 'Assets' do
        ['1846: Operating Round 1.1 (of 2) - Place a Token or Lay Track',
         # Minor charter stuff
         'Michigan Southern', 'Trains', '2', 'Cash', 'C15', '$60']],
+      ['1846', 3099, 96, 'issue_shares',
+       ['1846: Operating Round 1.1 (of 2) - Place a Token or Lay Track',
+        'Issue', '1 ($50)', '2 ($100)', '3 ($150)', '4 ($200)']],
       ['1846', 3099, 186, 'assign',
        ['1846: Operating Round 2.1 (of 2) - Assign Steamboat Company',
         'Blondie may assign Steamboat Company to a new hex and/or corporation or minor.',


### PR DESCRIPTION
Fixes bug where IssueShares was only being rendered if there were shares to redeem. IssueShares should be rendered if there are shares to issue or redeem. h/t michealjb for issue shares view test.