### PR TITLE
18MEX: Support NdM merge

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -50,6 +50,7 @@ module View
 
         unless @corporation.minor?
           children << render_shares
+          children << render_reserved if @corporation.reserved_shares.any?
           children << h(Companies, owner: @corporation, game: @game) if @corporation.companies.any?
         end
 
@@ -335,6 +336,18 @@ module View
         ])
       end
 
+      def render_reserved
+        bold = { style: { fontWeight: 'bold' } }
+        h('table.center', [
+          h(:tbody, [
+            h('tr.reserved', [
+              h('td.left', bold, "#{@game.class::IPO_RESERVED_NAME}:"),
+              h('td.right', @corporation.reserved_shares.map { |s| "#{s.percent}%" }.join(', ')),
+            ]),
+          ]),
+        ])
+      end
+
       def render_revenue_history
         last_run = @corporation.operating_history[@corporation.operating_history.keys.max].revenue
         h(:div, { style: { display: 'inline' } }, [
@@ -347,8 +360,9 @@ module View
         return [] unless @game.round.current_entity&.operator?
 
         round = @game.round
-        if (n = @game.round.entities.find_index(@corporation))
-          span_class = '.bold' if n >= round.entities.find_index(round.current_entity)
+        if (n = @game.round.entities.index(@corporation))
+          m = round.entities.index(round.current_entity)
+          span_class = '.bold' if n && m && n >= m
           [h(:div, { style: { display: 'inline' } }, [
             'Order: ',
             h("span#{span_class}", n + 1),

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -251,7 +251,7 @@ module View
           h(Game::Round::Stock, game: @game)
         end
       when Engine::Round::Operating
-        if (%w[merge] & current_actions).any?
+        if current_actions.include?('merge')
           h(Game::Round::Merger, game: @game)
         else
           h(Game::Round::Operating, game: @game)

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -251,7 +251,11 @@ module View
           h(Game::Round::Stock, game: @game)
         end
       when Engine::Round::Operating
-        h(Game::Round::Operating, game: @game)
+        if (%w[merge] & current_actions).any?
+          h(Game::Round::Merger, game: @game)
+        else
+          h(Game::Round::Operating, game: @game)
+        end
       when Engine::Round::Draft
         h(Game::Round::Auction, game: @game, user: @user, before_process_pass: @before_process_pass)
       when Engine::Round::Auction

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -95,6 +95,10 @@ module Engine
       num_shares_of(self)
     end
 
+    def reserved_shares
+      shares_by_corporation[self].reject(&:buyable)
+    end
+
     def num_player_shares
       player_share_holders.values.sum / total_shares
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -164,6 +164,7 @@ module Engine
       TIMELINE = [].freeze
 
       IPO_NAME = 'IPO'
+      IPO_RESERVED_NAME = 'IPO Reserved'
 
       ALL_COMPANIES_ASSIGNABLE = false
 

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -49,6 +49,10 @@ module Engine
         end
       end
 
+      def remove_reservation!(entity)
+        @reservations.delete(entity)
+      end
+
       def city?
         true
       end

--- a/lib/engine/step/g_18_mex/assign.rb
+++ b/lib/engine/step/g_18_mex/assign.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative '../assign'
+
+module Engine
+  module Step
+    module G18MEX
+      class Assign < Assign
+        ACTIONS = %w[assign].freeze
+
+        def actions(entity)
+          return ACTIONS if entity == @game.ndm && ndm_merge_assign_ongoing?
+
+          []
+        end
+
+        def active_entities
+          [@game.ndm].compact
+        end
+
+        def active?
+          ndm_merge_assign_ongoing?
+        end
+
+        def description
+          'NdM Select Token to Convert'
+        end
+
+        def process_assign(action)
+          @game.select_ndm_city(action.target)
+        end
+
+        def blocks?
+          ndm_merge_assign_ongoing?
+        end
+
+        def available_hex(entity, hex)
+          return if !ndm_merge_assign_ongoing? || entity != @game.ndm
+
+          @game.merged_cities_to_select.find { |t| t.city.hex == hex }
+        end
+
+        private
+
+        def ndm_merge_assign_ongoing?
+          @game.merged_cities_to_select.any?
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mex/merge.rb
+++ b/lib/engine/step/g_18_mex/merge.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+# require_relative 'tokener'
+
+module Engine
+  module Step
+    module G18MEX
+      class Merge < Base
+        ACTIONS = %w[merge pass].freeze
+
+        def actions(_entity)
+          return [] unless merge_ongoing?
+
+          ACTIONS
+        end
+
+        def active_entities
+          merge_ongoing? ? [@game.merge_decider].compact : []
+        end
+
+        def merge_target
+          @game.ndm
+        end
+
+        def mergeable(_corporation)
+          return [] unless merge_ongoing?
+
+          [@game.mergable_candidates.first]
+        end
+
+        def active?
+          merge_ongoing?
+        end
+
+        def blocking?
+          merge_ongoing?
+        end
+
+        def description
+          'NdM Merge'
+        end
+
+        def pass_description
+          'Decline'
+        end
+
+        def process_merge(action)
+          @game.merge_major(action.corporation)
+        end
+
+        def process_pass(_action)
+          @game.decline_merge(@game.mergable_candidates.first)
+        end
+
+        private
+
+        def merge_ongoing?
+          @game.mergable_candidates.any?
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mex/single_depot_train_buy.rb
+++ b/lib/engine/step/g_18_mex/single_depot_train_buy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../single_depot_train_buy'
+
+module Engine
+  module Step
+    module G18MEX
+      class SingleDepotTrainBuy < SingleDepotTrainBuy
+        def process_buy_train(action)
+          @game.buy_first_5_train(action.entity.player) if action.train.id == '5-0'
+
+          super
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When first 5 train is bought the NdM merge event is triggered
if NdM has floated.

The merge process if that player in order, left of the player
that has bought the 5 train, is asked if their corporation wants
to merge. (Excluding "American" corporations, and corporations
controlled by NdM president.) If there is no floated corporation
that accepts, NdM will merge with any non floated, if there is
any eligible one.
The president of the merged corporation receives a 10% reserved
NdM share in exchange for their presidency. Remaining shares
in merged corporation is force sold for half amrket price.
Treasury and trains are transfered to NdM.
NdM also exchanges up to two tokens, one should at least be
the home token if any.

There are a new step: merge, which is located in module 18MEX.
This is used for the merge question. A connected view has
been added for the merge step.

18MEX also uses an assign step which is used in case NdM need
to choose between several tokens on the map.

---------

Have added a buyable attribute to share. This is set to true by
default, and is set to false if share reserved. In 18MEX this
is done for exchange shares that will be used during minor
closure and NdM merge.