### PR TITLE
Fix crossover rendering

### DIFF
--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -368,7 +368,7 @@ module Engine
     end
 
     def compute_crossover
-      return unless @paths.size > 1
+      return false unless @paths.size > 1
 
       edge_paths = Hash.new { |h, k| h[k] = [] }
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -368,12 +368,16 @@ module Engine
     end
 
     def compute_crossover
+      return unless @paths.size > 1
+
       edge_paths = Hash.new { |h, k| h[k] = [] }
 
       paths.each do |p|
         edge_paths[p.a.num] << p if p.a.edge?
         edge_paths[p.b.num] << p if p.b.edge?
+      end
 
+      paths.each do |p|
         next if p.nodes.size > 1
 
         ct_edge = preferred_city_town_edges[p.nodes.first] if p.nodes.one?


### PR DESCRIPTION
Current code in compute_crossover is fragile. It is dependent on the order of the paths in the tile definition. For instance, if the tile definition for tile 19 is changed from:
`path=a:0,b:3;path=a:2,b:4`
to
`path=a:2,b:4;path=a:0,b:3`
we get:
![19_before](https://user-images.githubusercontent.com/8494213/94499604-5f56c900-01ba-11eb-9e5a-ed4b7a708b77.png)

With this change, this becomes:
![19_after](https://user-images.githubusercontent.com/8494213/94499631-6a115e00-01ba-11eb-9089-fffbd9dd340b.png)

I realize this was changed for performance reasons, so I added an early bail-out for tiles with less than two paths, which can never have a crossover.