### PR TITLE
More robust handling of crossovers with cities/towns

### DIFF
--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -117,12 +117,24 @@ module Engine
         @exits ||= @edges.map(&:num)
       end
 
+      def node_edge
+        return nil unless @nodes.one?
+
+        @node_edge ||= @tile.preferred_city_town_edges[@nodes.first]
+      end
+
+      # like a.num except it works when a is a town/city next to an edge
+      def a_num
+        @a_num ||= @a.edge? ? @a.num : node_edge
+      end
+
+      # like b.num except it works when b is a town/city next to an edge
+      def b_num
+        @b_num ||= @b.edge? ? @b.num : node_edge
+      end
+
       def straight?
         return @_straight if defined?(@_straight)
-
-        ct_edge = @tile.preferred_city_town_edges[@nodes.first] if @nodes.one?
-        a_num = @a.edge? ? @a.num : ct_edge
-        b_num = @b.edge? ? @b.num : ct_edge
 
         @_straight = a_num && b_num && (a_num - b_num).abs == 3
       end
@@ -130,9 +142,6 @@ module Engine
       def gentle_curve?
         return @_gentle_curve if defined?(@_gentle_curve)
 
-        ct_edge = @tile.preferred_city_town_edges[@nodes.first] if @nodes.one?
-        a_num = @a.edge? ? @a.num : ct_edge
-        b_num = @b.edge? ? @b.num : ct_edge
         @_gentle_curve = a_num && b_num && (((d = (a_num - b_num).abs) == 2) || d == 4 || d == 2.5 || d == 3.5)
       end
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -373,16 +373,18 @@ module Engine
       edge_paths = Hash.new { |h, k| h[k] = [] }
 
       paths.each do |p|
-        edge_paths[p.a.num] << p if p.a.edge?
-        edge_paths[p.b.num] << p if p.b.edge?
+        next if p.nodes.size > 1
+        next if p.a_num == p.b_num
+
+        edge_paths[p.a_num] << p
+        edge_paths[p.b_num] << p
       end
 
       paths.each do |p|
         next if p.nodes.size > 1
 
-        ct_edge = preferred_city_town_edges[p.nodes.first] if p.nodes.one?
-        a_num = p.a.edge? ? p.a.num : ct_edge
-        b_num = p.b.edge? ? p.b.num : ct_edge
+        a_num = p.a_num
+        b_num = p.b_num
 
         if p.straight?
           return true if edge_paths[(a_num + 1) % 6].any?(&:straight?)


### PR DESCRIPTION
Refactored crossover methods to allow a node rendered next to an edge (i.e. not in center) to act like the path connected to it from a different edge is connected to that edge (only for the purposes of crossover detection).

Fixes #1753 

This gets us here:

![452a_after](https://user-images.githubusercontent.com/8494213/94598980-05531380-024d-11eb-8eda-b01b857bc3a1.png)
