### PR TITLE
Add support for Lawson tiles: upgrades and routes

### DIFF
--- a/lib/engine/connection.rb
+++ b/lib/engine/connection.rb
@@ -114,25 +114,20 @@ module Engine
     #    see paths for ealier connections
     # 2. @paths are in order (i.e. the head of one connects to the tail of the next)
     def branch!(path)
-      ends = Hash.new(0)
-      @paths.each do |p|
-        ends[p.a_id] += 1 if p.a.junction? || p.a.edge?
-        ends[p.b_id] += 1 if p.b.junction? || p.b.edge?
-      end
-
-      return self unless ends[path.a_id] > 1 || ends[path.b_id] > 1 ||
-                         (ends[path.a_id].positive? && path.a.edge?) ||
-                         (ends[path.b_id].positive? && path.b.edge?)
-
-      # only keep paths leading to edge/junction
       branched_paths = []
       @paths.each do |p|
+        # we've seen this edge before
         break if path.a.edge? && (path.a_id == p.a_id || path.a_id == p.b_id)
         break if path.b.edge? && (path.b_id == p.a_id || path.b_id == p.b_id)
 
         branched_paths << p
-        break if ([path.a_id, path.b_id] & [p.a_id, p.b_id]).any?
+
+        # we've seen this junction before
+        break if path.a.junction? && (path.a == p.a || path.a == p.b)
+        break if path.b.junction? && (path.b == p.a || path.b == p.b)
       end
+
+      return self if branched_paths.size == @paths.size
 
       branch = self.class.new(branched_paths)
 

--- a/lib/engine/connection.rb
+++ b/lib/engine/connection.rb
@@ -117,8 +117,8 @@ module Engine
       branched_paths = []
       @paths.each do |p|
         # we've seen this edge before
-        break if path.a.edge? && (path.a_id == p.a_id || path.a_id == p.b_id)
-        break if path.b.edge? && (path.b_id == p.a_id || path.b_id == p.b_id)
+        break if path.a.edge? && (path.a.id == p.a.id || path.a.id == p.b.id)
+        break if path.b.edge? && (path.b.id == p.a.id || path.b.id == p.b.id)
 
         branched_paths << p
 

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -7,7 +7,7 @@ module Engine
     class Base
       include Helper::Type
 
-      attr_accessor :index, :tile
+      attr_accessor :index, :tile, :lanes
 
       def id
         "#{tile.id}-#{index}"

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -7,7 +7,7 @@ module Engine
     class Base
       include Helper::Type
 
-      attr_accessor :index, :tile, :lanes
+      attr_accessor :index, :tile
 
       def id
         "#{tile.id}-#{index}"

--- a/lib/engine/part/edge.rb
+++ b/lib/engine/part/edge.rb
@@ -5,10 +5,10 @@ require_relative 'base'
 module Engine
   module Part
     class Edge < Base
-      attr_accessor :num
+      attr_accessor :lanes, :num
 
       def id
-        @id ||= "#{hex.id}-#{@num}-#{@lanes[1]}"
+        @_id ||= "#{hex.id}-#{@num}-#{@lanes[1]}"
       end
 
       def initialize(num)

--- a/lib/engine/part/edge.rb
+++ b/lib/engine/part/edge.rb
@@ -7,6 +7,10 @@ module Engine
     class Edge < Base
       attr_accessor :num
 
+      def id
+        @id ||= "#{hex.id}-#{@num}-#{@lanes[1]}"
+      end
+
       def initialize(num)
         @num = num.to_i
       end
@@ -23,6 +27,7 @@ module Engine
         edge = Edge.new((@num + ticks) % 6)
         edge.index = index
         edge.tile = @tile
+        edge.lanes = @lanes
         edge
       end
     end

--- a/lib/engine/part/junction.rb
+++ b/lib/engine/part/junction.rb
@@ -4,9 +4,22 @@ require_relative 'node'
 
 module Engine
   module Part
-    class Junction < Node
+    class Junction < Base
       def junction?
         true
+      end
+
+      def clear!
+        @paths = nil
+        @exits = nil
+      end
+
+      def paths
+        @paths ||= @tile.paths.select { |p| p.junction == self }
+      end
+
+      def exits
+        @exits ||= paths.flat_map(&:exits)
       end
     end
   end

--- a/lib/engine/part/junction.rb
+++ b/lib/engine/part/junction.rb
@@ -5,6 +5,8 @@ require_relative 'node'
 module Engine
   module Part
     class Junction < Base
+      attr_accessor :lanes
+
       def junction?
         true
       end

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -3,6 +3,8 @@
 module Engine
   module Part
     class Node < Base
+      attr_accessor :lanes
+
       def clear!
         @paths = nil
         @exits = nil

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -188,6 +188,22 @@ module Engine
         path
       end
 
+      def a_id
+        @a_id ||= if a.edge?
+                    hex.id + '-' + a.num.to_s + '-' + @lanes.first[1].to_s
+                  else
+                    a
+                  end
+      end
+
+      def b_id
+        @b_id ||= if b.edge?
+                    hex.id + '-' + b.num.to_s + '-' + @lanes.last[1].to_s
+                  else
+                    b
+                  end
+      end
+
       def inspect
         name = self.class.name.split('::').last
         if single?

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -50,32 +50,34 @@ module Engine
       end
 
       def <=(other)
-        other_list = []
-        other.jwalk { |t| other_list << t }
-        this_list = []
-        jwalk { |t| this_list << t }
-        this_list.all? { |tt| other_list.any? { |ot| tt <= ot } }
+        other_ends = other.ends
+        ends.all? { |t| other_ends.any? { |o| t <= o } }
       end
 
       def match?(other)
         (@a <= other.a && @b <= other.b) ||
-        (@a <= other.b && @b <= other.a)
+          (@a <= other.b && @b <= other.a)
       end
 
-      # yields all edges and non-junction nodes connected to this path on this tile, following junctions
-      # assumes only one junction per tile
-      def jwalk(jskip: nil)
-        yield @a unless @a.junction?
-        yield @b unless @b.junction?
+      def ends
+        @ends ||= calculate_ends
+      end
 
+      def calculate_ends
+        e = []
+        e << @a unless @a.junction?
+        e << @b unless @b.junction?
         [@a, @b].each do |j|
           next unless j.junction?
-          next if j == jskip
 
           j.paths.each do |jp|
-            jp.jwalk(jskip: j) { |p| yield p }
+            next if jp == self
+
+            e << jp.a unless jp.a.junction?
+            e << jp.b unless jp.b.junction?
           end
         end
+        e
       end
 
       def select(paths)

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -55,16 +55,14 @@ module Engine
       end
 
       def ends
-        @ends ||= calculate_ends
+        @ends ||= calculate_ends.flatten
       end
 
       def calculate_ends
-        [@a, @b].flat_map do |j|
-          next [j] unless j.junction?
+        [@a, @b].map do |j|
+          next j unless j.junction?
 
-          j.paths.map do |p|
-            next if p == self
-
+          j.paths.reject { |p| p == self }.map do |p|
             [p.a, p.b].reject(&:junction?)
           end
         end

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -54,11 +54,6 @@ module Engine
         ends.all? { |t| other_ends.any? { |o| t <= o } }
       end
 
-      def match?(other)
-        (@a <= other.a && @b <= other.b) ||
-          (@a <= other.b && @b <= other.a)
-      end
-
       def ends
         @ends ||= calculate_ends
       end
@@ -70,7 +65,7 @@ module Engine
           j.paths.map do |p|
             next if p == self
 
-            [p.a, p.b].select(&:junction?)
+            [p.a, p.b].reject(&:junction?)
           end
         end
       end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -172,7 +172,7 @@ module Engine
         new_tile.paths.each do |np|
           next unless @game.graph.connected_paths(entity)[np]
 
-          op = old_paths.find { |path| path <= np }
+          op = old_paths.find { |path| path.match?(np) }
           used_new_track = true unless op
           old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
           new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -172,7 +172,7 @@ module Engine
         new_tile.paths.each do |np|
           next unless @game.graph.connected_paths(entity)[np]
 
-          op = old_paths.find { |path| path.match?(np) }
+          op = old_paths.find { |path| np <= path }
           used_new_track = true unless op
           old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
           new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -469,6 +469,8 @@ module Engine
       @nodes = @paths.flat_map(&:nodes).uniq
       @stops = @paths.flat_map(&:stops).uniq
       @edges = @paths.flat_map(&:edges).uniq
+
+      @edges.each { |e| e.tile = self }
     end
   end
 end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -153,7 +153,6 @@ module Engine
       @offboards = []
       @original_borders = []
       @borders = []
-      @branches = nil
       @nodes = nil
       @stops = nil
       @edges = nil
@@ -186,6 +185,7 @@ module Engine
         @rotation
       @rotation = new_rotation
       @nodes.each(&:clear!)
+      @junction&.clear!
       @_paths = nil
       @_exits = nil
       @preferred_city_town_edges = nil
@@ -467,7 +467,6 @@ module Engine
       end
 
       @nodes = @paths.flat_map(&:nodes).uniq
-      @branches = @paths.flat_map(&:branches).uniq
       @stops = @paths.flat_map(&:stops).uniq
       @edges = @paths.flat_map(&:edges).uniq
     end


### PR DESCRIPTION
Fixes #1756 

1. Recoded Path "<=" method to comprehend junctions (via new jwalk method). This was needed to allow upgrades to Lawson tiles.
2. Junction class no longer is a subclass of Node, but of Base directly
3. Modified Path "walk" method to comprehend junctions
4. Added Path "match?" method that is identical to old "<=" method
5. Modified Connection "branch!" method to deal with junctions
6. Removed branches array from Path and Tile