### PR TITLE
Correct abilities of 18GA 

### DIFF
--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -30,6 +30,14 @@ module Engine
         @p2_company ||= company_by_id('MRC')
       end
 
+      def p3_company
+        @p3_company ||= company_by_id('W&SR')
+      end
+
+      def waycross_hex
+        @waycross_hex ||= @hexes.find { |h| h.name == 'I9' }
+      end
+
       include CompanyPrice50To150Percent
 
       def setup

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -70,6 +70,13 @@ module Engine
         neutral.buy_train(@free_2_train, :free)
       end
 
+      # Only buy and sell par shares is possible action during SR
+      def stock_round
+        Round::Stock.new(self, [
+          Step::BuySellParShares,
+        ])
+      end
+
       def operating_round(round_num)
         Round::Operating.new(self, [
           Step::Bankrupt,

--- a/lib/engine/step/g_18_ga/only_one_token_per_round.rb
+++ b/lib/engine/step/g_18_ga/only_one_token_per_round.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Engine
+  module Step
+    module G18GA
+      module OnlyOneTokenPerRound
+        def process_place_token(action)
+          super
+          @round.tokens_placed << entity_corporation(action.entity)
+        end
+
+        def entity_corporation(entity)
+          return entity.owner if entity.company?
+
+          entity
+        end
+
+        def already_tokened_this_round?(entity)
+          @round.tokens_placed.include?(entity_corporation(entity))
+        end
+
+        def remaining_token_ability?(entity)
+          corporation = entity_corporation(entity)
+          return false if @game.p3_company.owner != corporation || !@game.p3_company.abilities(:token)&.count&.positive?
+
+          @game.waycross_hex.tile.cities.each do |c|
+            return true if c.tokenable?(corporation, free: true)
+          end
+          false
+        end
+
+        def round_state
+          { tokens_placed: [] }
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_ga/special_token.rb
+++ b/lib/engine/step/g_18_ga/special_token.rb
@@ -1,18 +1,35 @@
 # frozen_string_literal: true
 
 require_relative '../special_token'
+require_relative 'only_one_token_per_round'
 
 module Engine
   module Step
     module G18GA
       class SpecialToken < SpecialToken
+        def actions(entity)
+          return [] if already_tokened_this_round?(entity)
+          return ACTIONS if ability(entity) &&
+            remaining_token_ability?(entity) &&
+            @game.round.active_step.respond_to?(:process_place_token)
+
+          []
+        end
+
         def ability(entity)
           ability = super
 
-          ability if ability &&
-            entity.owner == @game.round.current_entity &&
-            @game.round.active_step.respond_to?(:process_place_token)
+          ability if ability && entity_corporation(entity) == @game.round.current_entity
         end
+
+        def process_place_token(action)
+          target = action.city.hex.name
+          allowed = ability(action.entity).hexes
+          @game.game_error("#{target} not allowed for token. Only allowed: #{allowed}.") unless allowed.include?(target)
+          super
+        end
+
+        include OnlyOneTokenPerRound
       end
     end
   end

--- a/lib/engine/step/g_18_ga/token.rb
+++ b/lib/engine/step/g_18_ga/token.rb
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
 
 require_relative '../token'
+require_relative 'only_one_token_per_round'
 
 module Engine
   module Step
     module G18GA
       class Token < Token
+        PASS_ONLY = %w[pass].freeze
+
+        def actions(entity)
+          return [] if already_tokened_this_round?(entity) || entity.company?
+          return ACTIONS if can_place_token?(entity)
+          return PASS_ONLY if remaining_token_ability?(entity)
+
+          []
+        end
+
         def adjust_token_price_ability!(entity, token, hex)
           return [token, nil] if @game.active_step.current_entity.corporation?
 
           super
         end
+
+        include OnlyOneTokenPerRound
       end
     end
   end

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -45,7 +45,7 @@ module Engine
       end
 
       def ability(entity)
-        return unless entity.company?
+        return unless entity&.company?
 
         entity.abilities(:token)
       end


### PR DESCRIPTION
There were several problems with W&S RR special ability tokening. Now the special tokening and normal tokening act better together and this should be OK. Might break some games where special tokening is not used, as an extra Pass is now required in case it were not possible to token before. Also ensure tokening can only be done in the tokening phase of the OR.

Finally, track laying ability did appear in SR. By removing all other steps (besides buy and sell shares) it should now not appear at all in the SR.