### PR TITLE
18MEX: Special handling of NdM 5% shares

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -65,7 +65,7 @@ module View
       end
 
       def render_info
-        num_certs = @player.num_certs
+        num_certs = @game.num_certs(@player)
         cert_limit = @game.cert_limit
 
         td_cert_props = {

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -34,7 +34,7 @@ module View
 
           children = []
           if @step.respond_to?(:must_sell?) && @step.must_sell?(@current_entity)
-            children << if @current_entity.num_certs > @game.cert_limit
+            children << if @game.num_certs(@current_entity) > @game.cert_limit
                           h('div.margined', 'Must sell stock: above certificate limit')
                         else
                           h('div.margined', 'Must sell stock: above 60% limit in corporation(s)')

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -314,8 +314,13 @@ module View
         props = { style: { color: 'red' } }
         h(:tr, zebra_props(true), [
           h('th.left', "Certs/#{cert_limit}"),
-          *@game.players.map { |p| h('td.padded_number', p.num_certs > cert_limit ? props : '', p.num_certs) },
+          *@game.players.map { |player| render_player_cert_count(player, cert_limit, props) },
         ])
+      end
+
+      def render_player_cert_count(player, cert_limit, props)
+        num_certs = @game.num_certs(player)
+        h('td.padded_number', num_certs > cert_limit ? props : '', num_certs)
       end
 
       def zebra_props(alt_bg = false)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -564,8 +564,16 @@ module Engine
       end
 
       def sellable_bundles(player, corporation)
-        bundles = player.bundles_for_corporation(corporation)
+        bundles = bundles_for_corporation(player, corporation)
         bundles.select { |bundle| @round.active_step.can_sell?(player, bundle) }
+      end
+
+      def bundles_for_corporation(player, corporation)
+        player.bundles_for_corporation(corporation)
+      end
+
+      def num_certs(entity)
+        entity.companies.size + entity.shares.count { |s| s.corporation.counts_for_limit && s.counts_for_limit }
       end
 
       def sellable_turn?

--- a/lib/engine/player.rb
+++ b/lib/engine/player.rb
@@ -15,11 +15,10 @@ module Engine
     attr_accessor :bankrupt
     attr_reader :name, :companies
 
-    def initialize(name, count_companies: true)
+    def initialize(name)
       @name = name
       @cash = 0
       @companies = []
-      @count_companies = count_companies
     end
 
     def value
@@ -44,11 +43,6 @@ module Engine
 
     def player?
       true
-    end
-
-    def num_certs
-      num_companies = @count_companies ? companies.size : 0
-      num_companies + shares.count { |s| s.corporation.counts_for_limit }
     end
 
     def to_s

--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -7,7 +7,7 @@ module Engine
   class Share
     include Ownable
 
-    attr_accessor :percent, :buyable
+    attr_accessor :percent, :buyable, :counts_for_limit
     attr_reader :corporation, :president
 
     def initialize(corporation, owner: nil, president: false, percent: 10, index: 0)
@@ -16,7 +16,12 @@ module Engine
       @percent = percent
       @owner = owner || corporation
       @index = index
+
+      # buyable: set to false if the share is reserved (e.g. trade-in)
       @buyable = true
+
+      # counts_for_limit: set to false if share is disregarded for cert limit
+      @counts_for_limit = true
     end
 
     def id

--- a/lib/engine/share_holder.rb
+++ b/lib/engine/share_holder.rb
@@ -30,10 +30,10 @@ module Engine
       percent_of(corporation) / corporation.share_percent
     end
 
-    def bundles_for_corporation(corporation)
+    def bundles_for_corporation(corporation, shares: shares_of(corporation))
       return [] unless corporation.ipoed
 
-      shares = shares_of(corporation).sort_by(&:price)
+      shares = shares.sort_by(&:price)
 
       bundles = shares.flat_map.with_index do |share, index|
         bundle = shares.take(index + 1)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -87,7 +87,7 @@ module Engine
       end
 
       def must_sell?(entity)
-        entity.num_certs > @game.cert_limit ||
+        @game.num_certs(entity) > @game.cert_limit ||
           !@game.corporations.all? { |corp| corp.holding_ok?(entity) }
       end
 

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -23,7 +23,7 @@ module Engine
         corporation = bundle.corporation
 
         corporation.holding_ok?(entity, bundle.percent) &&
-          (!corporation.counts_for_limit || exchange || entity.num_certs < @game.cert_limit)
+          (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit)
       end
     end
   end

--- a/spec/lib/engine/player_spec.rb
+++ b/spec/lib/engine/player_spec.rb
@@ -14,16 +14,16 @@ module Engine
 
     describe '#num_certs' do
       it 'privates' do
-        expect(player.num_certs).to eq(0)
+        expect(game.num_certs(player)).to eq(0)
         player.companies << company
-        expect(player.num_certs).to eq(1)
+        expect(game.num_certs(player)).to eq(1)
       end
 
       it 'shares' do
         current_price = market.market[0][0]
         market.set_par(corporation, current_price)
         share_pool.buy_shares(player, corporation.shares[0])
-        expect(player.num_certs).to eq(1)
+        expect(game.num_certs(player)).to eq(1)
       end
 
       it 'privates and shares' do
@@ -31,14 +31,14 @@ module Engine
         current_price = market.market[0][0]
         market.set_par(corporation, current_price)
         share_pool.buy_shares(player, corporation.shares[0])
-        expect(player.num_certs).to eq(2)
+        expect(game.num_certs(player)).to eq(2)
       end
 
       it 'non-limit shares' do
         current_price = market.market[-1][0]
         market.set_par(corporation, current_price)
         share_pool.buy_shares(player, corporation.shares[0])
-        expect(player.num_certs).to eq(0)
+        expect(game.num_certs(player)).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Do not count 5% shares for cert limit

5% are sold one at a time, in separate bundles.

When selling a 5% share it does not affect share price.

TODO: What remains to implement is two things:
- If owning 2 5% it looks as if it is 1 share
- The rules have a special case where you can sell 5%
  if you own 10% or more, and there is a 5% in the open market.
  Maybe this should be an exchange action? As we are
  not allowed to sell 10% and then buy 5%.