### PR TITLE
1817: Fix M&A in OR 2, add end game after the 8 train is bought/exported

### DIFF
--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -692,7 +692,10 @@ module Engine
       "name": "8",
       "distance": 8,
       "price": 1100,
-      "num": 16
+      "num": 16,
+      "events": [
+        {"type": "signal_end_game"}
+      ]
     }
   ],
   "hexes": {

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1077,12 +1077,17 @@ module Engine
         self.class::GAME_END_CHECK
       end
 
+      def custom_end_game_reached?
+        false
+      end
+
       def game_end_check
         triggers = {
           bankrupt: bankruptcy_limit_reached?,
           bank: @bank.broken?,
           stock_market: @stock_market.max_reached?,
           final_train: @depot.empty?,
+          custom: custom_end_game_reached?,
         }.select { |_, t| t }
 
         %i[immediate current_round current_or full_or one_more_full_or_set].each do |after|
@@ -1101,7 +1106,7 @@ module Engine
         return false unless after
         return true if after == :immediate
         return true if after == :current_round
-        return false unless @round.is_a?(Round::Operating)
+        return false unless @round.is_a?(round_end)
         return true if after == :current_or
 
         final_or_in_set = @round.round_num == @operating_rounds
@@ -1109,6 +1114,14 @@ module Engine
         return (@turn == @final_turn) if final_or_in_set && (after == :one_more_full_or_set)
 
         final_or_in_set
+      end
+
+      def round_end
+        Round::Operating
+      end
+
+      def final_operating_rounds
+        operating_rounds
       end
 
       def game_ending_description
@@ -1130,9 +1143,10 @@ module Engine
                        when :current_or
                          " : Game Ends at conclusion of this OR (#{turn}.#{@round.round_num})"
                        when :full_or
-                         " : Game Ends at conclusion of OR #{turn}.#{operating_rounds}"
+                         " : Game Ends at conclusion of #{round_end.short_name} #{turn}.#{operating_rounds}"
                        when :one_more_full_or_set
-                         " : Game Ends at conclusion of OR #{@final_turn}.#{operating_rounds}"
+                         " : Game Ends at conclusion of #{round_end.short_name}"\
+                         " #{@final_turn}.#{final_operating_rounds}"
                        end
         end
 

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -40,7 +40,7 @@ module Engine
       SEED_MONEY = 200
       MUST_BUY_TRAIN = :never
       EBUY_PRES_SWAP = false # allow presidential swaps of other corps when ebuying
-      POOL_SHARE_DROP = :one
+      POOL_SHARE_DROP = :each
       SELL_MOVEMENT = :none
       ALL_COMPANIES_ASSIGNABLE = true
 
@@ -168,7 +168,7 @@ module Engine
 
       def stock_round
         @interest_fixed = nil
-        Round::Stock.new(self, [
+        Round::G1817::Stock.new(self, [
           Step::DiscardTrain,
           Step::HomeToken,
           Step::G1817::BuySellParShares,

--- a/lib/engine/round/g_1817/acquisition.rb
+++ b/lib/engine/round/g_1817/acquisition.rb
@@ -9,6 +9,10 @@ module Engine
         attr_accessor :offering
         attr_accessor :cash_crisis_player
 
+        def self.short_name
+          'AR'
+        end
+
         def name
           'Acquisition Round'
         end

--- a/lib/engine/round/g_1817/stock.rb
+++ b/lib/engine/round/g_1817/stock.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../stock'
+
+module Engine
+  module Round
+    module G1817
+      class Stock < Stock
+        def sold_out?(corporation)
+          corporation.total_shares > 2 && corporation.player_share_holders.values.sum >= 100
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -5,6 +5,10 @@ require_relative 'base'
 module Engine
   module Round
     class Operating < Base
+      def self.short_name
+        'OR'
+      end
+
       def name
         'Operating Round'
       end


### PR DESCRIPTION
M&A didn't happen in the second OR.
Add end game due to train export