### PR TITLE
18MEX: Disable revenue/new-track check for Puebla triggered lay (fixe…

### DIFF
--- a/lib/engine/step/g_18_mex/track.rb
+++ b/lib/engine/step/g_18_mex/track.rb
@@ -17,6 +17,7 @@ module Engine
         end
 
         def process_lay_tile(action)
+          @puebla_lay = false
           @game.game_error('Cannot do normal tile lay') unless can_lay_tile?(action.entity)
           if action.hex.name == PUEBLA_HEX
             @game.game_error("Can only be upgraded via Mexico City (#{MEXICO_CITY_MAIN_HEX})")
@@ -24,6 +25,12 @@ module Engine
           lay_tile_action(action)
           lay_in_pueble(action) if action.hex.id == MEXICO_CITY_MAIN_HEX
           pass! unless remaining_tile_lay?(action.entity)
+        end
+
+        def check_track_restrictions!(entity, old_tile, new_tile)
+          return if @puebla_lay
+
+          super
         end
 
         private
@@ -34,6 +41,7 @@ module Engine
         end
 
         def lay_in_pueble(action)
+          @puebla_lay = true
           hex = @game.hexes.find { |h| h.name == PUEBLA_HEX }
           puebla_tile_name = action.tile.name.sub('MC', 'P')
           tile = @game.tiles.find { |t| t.name == puebla_tile_name }


### PR DESCRIPTION
…s #1788)

When Mexico City is upgraded correctly Pueble hex is upgraded
automatically, and that does not have to comply with restrictivness
of tile upgrades.