### PR TITLE
Make check_track_restrictions! more robust

### DIFF
--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -176,7 +176,7 @@ module Engine
           used_new_track = true unless op
           old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
           new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
-          changed_city = old_revenues != new_revenues
+          changed_city = true unless old_revenues == new_revenues
         end
 
         case @game.class::TRACK_RESTRICTION


### PR DESCRIPTION
Quick edit to check_track_restrictions!

By inspection, I saw that properly detecting a revenue increase is dependent on the order the paths on the new tile are inspected. I made changed_city parallel how used_new_track works.