### PR TITLE
Allows routes to carry over properly when upgrading a simple tile to …

### DIFF
--- a/lib/engine/connection.rb
+++ b/lib/engine/connection.rb
@@ -89,16 +89,13 @@ module Engine
       @id ||=
         begin
           sorted = []
-          path_map = {}
-          node_path = nil
+          junction_map = {}
 
+          # skip over paths that have a junction we've already seen
           @paths.each do |path|
-            node_path = path if path.node?
-            path_map[path] = true
-          end
-
-          node_path.walk(on: path_map) do |path|
-            sorted << path
+            sorted << path unless junction_map[path.a] || junction_map[path.b]
+            junction_map[path.a] = true if path.a.junction?
+            junction_map[path.b] = true if path.b.junction?
           end
 
           sorted.map { |path| path.hex.id }

--- a/lib/engine/connection.rb
+++ b/lib/engine/connection.rb
@@ -93,7 +93,7 @@ module Engine
 
           # skip over paths that have a junction we've already seen
           @paths.each do |path|
-            sorted << path unless junction_map[path.a] || junction_map[path.b]
+            sorted << path if !junction_map[path.a] && !junction_map[path.b]
             junction_map[path.a] = true if path.a.junction?
             junction_map[path.b] = true if path.b.junction?
           end


### PR DESCRIPTION
…a Lawson tile

Fixes #1797 

Since I was mucking around with Connection::id, I simplified it to take advantage of the fact that route paths are always in order and start and end at nodes.