### PR TITLE
18MEX: Remove CC label when placing Copper Canyon tile

### DIFF
--- a/lib/engine/step/g_18_mex/special_track.rb
+++ b/lib/engine/step/g_18_mex/special_track.rb
@@ -6,12 +6,19 @@ module Engine
   module Step
     module G18MEX
       class SpecialTrack < SpecialTrack
+        COPPER_CANYON = '470'
+
         def ability(entity)
           ability = super
 
           ability if ability &&
             entity.owner == @game.round.current_entity &&
             @game.round.active_step.respond_to?(:process_lay_tile)
+        end
+
+        def process_lay_tile(action)
+          super
+          action.tile.label = nil if action.hex.tile.name == COPPER_CANYON
         end
       end
     end


### PR DESCRIPTION
The label sometimes did cover the revenue circle. So removing
this solves that. And the tile cannot be upgraded so it should
not be a problem.