### PR TITLE
18MEX: Do not show exchange tokens in NdM charter

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -423,9 +423,7 @@ module Engine
             0,
             40,
             60,
-            80,
-            0,
-            0
+            80
          ],
          "abilities": [
             {


### PR DESCRIPTION
If need be, NdM tokens will be added as part of the NdM merge in phase 5.