### PR TITLE
Filter out illegal paths during run_routes

### DIFF
--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -38,13 +38,15 @@ module Engine
     end
 
     def next_connection(node, connection, other)
-      connections = select(node, other)
+      connections = select(node, other, connection)
       index = connections.find_index(connection) || connections.size
       connections[index + 1]
     end
 
-    def select(node, other)
+    def select(node, other, keep = nil)
       other_paths = @routes.reject { |r| r == self }.flat_map(&:paths)
+      other_paths.concat(@connections.reject { |c| c[:connection] == keep }
+                          .flat_map { |c| c[:connection].paths })
       nodes = [node, other]
 
       node.hex.all_connections.select do |c|

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -50,9 +50,7 @@ module Engine
       nodes = [node, other]
 
       node.hex.all_connections.select do |c|
-        (c.nodes & nodes).size == 2 &&
-          !@connections.include?(c) &&
-          (c.paths & other_paths).empty?
+        (c.nodes & nodes).size == 2 && (c.paths & other_paths).empty?
       end
     end
 


### PR DESCRIPTION
Fixes #1125 

Modify behavior of Route.touch_node to filter out connections that use paths already in the partially completed route being built. Unlike the last time I tried this - I specifically do _not_ filter out the paths in the most recently added connection so that clicking on the last node in the connection list will correctly switch between alternatives (but now, only legal alternatives).

For example, when selecting this route, the existing code initially creates an illegal route:
Before:
![OldRouting](https://user-images.githubusercontent.com/8494213/95692340-4ef31500-0be2-11eb-8570-8f54dc8c0fa7.png)

After:
![NewRouting](https://user-images.githubusercontent.com/8494213/95692341-53b7c900-0be2-11eb-9df0-b3b20efd3512.png)
