### PR TITLE
18 Los Angeles - allow Freight and Passenger trains to use the same track

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -661,6 +661,28 @@ module Engine
         routes.sum(&:revenue)
       end
 
+      def compute_other_paths(routes, route)
+        routes.reject { |r| r == route }.flat_map(&:paths)
+      end
+
+      def check_overlap(routes)
+        tracks = []
+
+        routes.each do |route|
+          route.paths.each do |path|
+            a = path.a
+            b = path.b
+
+            tracks << [path.hex, a.num, path.lanes[0][1]] if a.edge?
+            tracks << [path.hex, b.num, path.lanes[1][1]] if b.edge?
+          end
+        end
+
+        tracks.group_by(&:itself).each do |k, v|
+          @game.game_error("Route cannot reuse track on #{k[0].id}") if v.size > 1
+        end
+      end
+
       def get(type, id)
         send("#{type}_by_id", id)
       end

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -136,6 +136,38 @@ module Engine
 
         bonus
       end
+
+      def compute_other_paths(routes, route)
+        routes
+          .reject { |r| r == route }
+          .select { |r| train_type(route.train) == train_type(r.train) }
+          .flat_map(&:paths)
+      end
+
+      def train_type(train)
+        train.name.include?('/') ? :freight : :passenger
+      end
+
+      def check_overlap(routes)
+        tracks_by_type = Hash.new { |h, k| h[k] = [] }
+
+        routes.each do |route|
+          route.paths.each do |path|
+            a = path.a
+            b = path.b
+
+            tracks = tracks_by_type[train_type(route.train)]
+            tracks << [path.hex, a.num, path.lanes[0][1]] if a.edge?
+            tracks << [path.hex, b.num, path.lanes[1][1]] if b.edge?
+          end
+        end
+
+        tracks_by_type.each do |_type, tracks|
+          tracks.group_by(&:itself).each do |k, v|
+            @game.game_error("Route cannot reuse track on #{k[0].id}") if v.size > 1
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
only trains in the same overlap group are not allowed to reuse track; this
allows for 18 Los Angeles's Freight and Passenger trains to work correctly