### PR TITLE
18MS: Add line to P1/P2 description about OR 1 buy-in.

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -252,7 +252,7 @@ module Engine
          "name":"Kansas City, Mexico, & Orient Railroad",
          "value":40,
          "revenue":10,
-         "desc":"Owning company may place the non-upgradable Copper Canyan tile in E6 for $60 (instead of the normal $120) unless that hex is already built. The tile lay does not have to be connected to an existing station token of the owning corporation. The lay does not count toward the normal lay limit but must be done during tile lay.",
+         "desc":"Owning corporation may place the non-upgradable Copper Canyan tile in E6 for $60 (instead of the normal $120) unless that hex is already built. The tile lay does not have to be connected to an existing station token of the owning corporation. The lay does not count toward the normal lay limit but must be done during tile lay.",
          "abilities": [
             {
               "type": "tile_lay",
@@ -274,7 +274,7 @@ module Engine
          "name":"Interoceanic Railroad",
          "value":50,
          "revenue":0,
-         "desc":"Owner takes control of minor company A. Begins in Tampico (M12). This private cannot be sold. When Phase 3½ begins, the minor company closes, but its owner receives a 5% share in NdM.",
+         "desc":"Owner takes control of minor corporation A. Begins in Tampico (M12). This private cannot be sold. When Phase 3½ begins, the minor corporation closes, but its owner receives a 5% share in NdM.",
          "abilities": [
             {
               "type": "no_buy",
@@ -292,7 +292,7 @@ module Engine
          "name":"Sonora-Baja California Railway",
          "value":50,
          "revenue":0,
-         "desc":"Owner takes control of minor company B. Begins in Mazatlán (K6). This private cannot be sold. When Phase 3½ begins, the minor company closes, but its owner receives a 5% share in NdM.",
+         "desc":"Owner takes control of minor corporation B. Begins in Mazatlán (K6). This private cannot be sold. When Phase 3½ begins, the minor corporation closes, but its owner receives a 5% share in NdM.",
          "abilities": [
             {
               "type": "no_buy",
@@ -310,7 +310,7 @@ module Engine
          "name":"Southeastern Railway",
          "value":50,
          "revenue":0,
-         "desc":"Owner takes control of minor company C. Begins in Oaxaca (S12). This private cannot be sold. When Phase 3½ begins, the minor company closes, but its owner receives a 10% share in UdY.",
+         "desc":"Owner takes control of minor corporation C. Begins in Oaxaca (S12). This private cannot be sold. When Phase 3½ begins, the minor corporation closes, but its owner receives a 10% share in UdY.",
          "abilities": [
             {
               "type": "no_buy",
@@ -349,7 +349,7 @@ module Engine
          "name":"Mexican National Railroad",
          "value":140,
          "revenue":20,
-         "desc":"Comes with President's Certificate of NdM. Owner must immediately set NdM's par price. Closes when NdM buys a train. May not be sold to a company.",
+         "desc":"Comes with President's Certificate of NdM. Owner must immediately set NdM's par price. Closes when NdM buys a train. May not be sold to a corporation.",
          "abilities":[
             {
                "type":"shares",

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -163,7 +163,7 @@ module Engine
          "name":"Alabama Great Southern Railroad",
          "value":30,
          "revenue":15,
-         "desc":"The owning Major Company may lay an extra yellow tile for free. This extra tile must extend existing track and could be used to extend from a yellow or green tile played as a company’s  normal tile lay. This ability can only be used once, and using it does not close the company.",
+         "desc":"The owning Major Company may lay an extra yellow tile for free. This extra tile must extend existing track and could be used to extend from a yellow or green tile played as a company’s  normal tile lay. This ability can only be used once, and using it does not close the company. Alabama Great Southern Railroad can be bought for exactly face value during OR 1 by an operating Major Company that is controlled by the owner of the private.",
          "sym":"AGS",
          "abilities": [
            {
@@ -185,7 +185,7 @@ module Engine
          "name":"Birmingham Southern Railroad",
          "value":40,
          "revenue":10,
-         "desc":"The owning Major Company may lay one or two extra yellow tiles for free. This extra tile lay must extend existing track and could be used to extend from a yellow or green tile played as a company’s normal tile lay. This ability can only be used once during a single operating round, and using it does not close the company.",
+         "desc":"The owning Major Company may lay one or two extra yellow tiles for free. This extra tile lay must extend existing track and could be used to extend from a yellow or green tile played as a company’s normal tile lay. This ability can only be used once during a single operating round, and using it does not close the company. Birmingham Southern Railroad can be bought for exactly face value during OR 1 by an operating Major Company that is controlled by the owner of the private.",
          "sym":"BS",
          "abilities": [
            {

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -163,7 +163,7 @@ module Engine
          "name":"Alabama Great Southern Railroad",
          "value":30,
          "revenue":15,
-         "desc":"The owning Major Company may lay an extra yellow tile for free. This extra tile must extend existing track and could be used to extend from a yellow or green tile played as a company’s  normal tile lay. This ability can only be used once, and using it does not close the company. Alabama Great Southern Railroad can be bought for exactly face value during OR 1 by an operating Major Company that is controlled by the owner of the private.",
+         "desc":"The owning Major Corporation may lay an extra yellow tile for free. This extra tile must extend existing track and could be used to extend from a yellow or green tile played as a Major Corporation’s  normal tile lay. This ability can only be used once, and using it does not close the Private Company. Alabama Great Southern Railroad can be bought for exactly face value during OR 1 by an operating Major Corporation if the president owns the Private Company.",
          "sym":"AGS",
          "abilities": [
            {
@@ -185,7 +185,7 @@ module Engine
          "name":"Birmingham Southern Railroad",
          "value":40,
          "revenue":10,
-         "desc":"The owning Major Company may lay one or two extra yellow tiles for free. This extra tile lay must extend existing track and could be used to extend from a yellow or green tile played as a company’s normal tile lay. This ability can only be used once during a single operating round, and using it does not close the company. Birmingham Southern Railroad can be bought for exactly face value during OR 1 by an operating Major Company that is controlled by the owner of the private.",
+         "desc":"The owning Major Corporation may lay one or two extra yellow tiles for free. This extra tile lay must extend existing track and could be used to extend from a yellow or green tile played as a corporation’s normal tile lay. This ability can only be used once during a single operating round, and using it does not close the Private Company. Birmingham Southern Railroad can be bought for exactly face value during OR 1 by an operating Major Corporation if the president owns the Private Company.",
          "sym":"BS",
          "abilities": [
            {
@@ -207,7 +207,7 @@ module Engine
          "name":"Meridian and Memphis Railway",
          "value":50,
          "revenue":15,
-         "desc":"The owning Major Company may lay their cheapest available token for half price. This is not an extra token placement. This ability can only be used once, and using it does not close the private company.",
+         "desc":"The owning Major Corporation may lay their cheapest available token for half price. This is not an extra token placement. This ability can only be used once, and using it does not close the Private Company.",
          "sym":"M&M",
          "abilities": [
             {
@@ -224,14 +224,14 @@ module Engine
          "name":"Mississippi Central Railway",
          "value":60,
          "revenue":5,
-         "desc":"The owning Major Company exchanges this private for a special 2+ train when purchased. (This 2+ train may not be sold.) This exchange occurs immediately when purchased. If this exchange would place the Major Company over the train limit of 3, the purchase is not allowed. If this Private Company is not purchased by the end of OR 4, it may not be sold to a Major Company and counts against the owner's certificate limit until it closed upon the start of Phase 6.",
+         "desc":"The owning Major Corporation exchanges this private for a special 2+ train when purchased. (This 2+ train may not be sold.) This exchange occurs immediately when purchased. If this exchange would place the Major Corporation over the train limit of 3, the purchase is not allowed. If this Private Company is not purchased by the end of OR 4, it may not be sold to a Major Corporation and counts against the owner's certificate limit until it closes upon the start of Phase 6.",
          "sym":"MC"
       },
       {
          "name":"Mobile & Ohio Railway",
          "value":70,
          "revenue":5,
-         "desc":"The owning Major Company may purchase an available 3+ Train or 4+ Train from the bank for a discount of $100, which closes this Private Company. This purchase is subject to the normal rules governing train purchases - only during the train-buying step and train limits.",
+         "desc":"The owning Major Corporation may purchase an available 3+ Train or 4+ Train from the bank for a discount of $100. Using this discount closes this Private Company. The discounted purchase is subject to the normal rules governing train purchases - only during the train-buying step and train limits apply.",
          "sym":"M&O",
          "abilities": [
             {


### PR DESCRIPTION
It seems some players do forget to use this feature so adding it
should hopefully work as a reminder.