### PR TITLE
1817 Bug Sweep:

### DIFF
--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -175,7 +175,7 @@ module Engine
         @stock_market
           .market[0]
           .reverse
-          .find { |sp| sp.price < price }
+          .find { |sp| sp.price <= price }
       end
 
       def revenue_for(route, stops)

--- a/lib/engine/step/g_1817/selection_auction.rb
+++ b/lib/engine/step/g_1817/selection_auction.rb
@@ -20,6 +20,17 @@ module Engine
           @companies
         end
 
+        def active_entities
+          if @auctioning
+            winning_bid = highest_bid(@auctioning)
+            if winning_bid
+              return [@active_bidders[(@active_bidders.index(winning_bid.entity) + 1) % @active_bidders.size]]
+            end
+          end
+
+          super
+        end
+
         def process_pass(action)
           entity = action.entity
 
@@ -30,9 +41,9 @@ module Engine
             @log << "#{entity.name} passes bidding"
             entity.pass!
             return all_passed! if entities.all?(&:passed?)
-          end
 
-          next_entity!
+            next_entity!
+          end
         end
 
         def entity_in_auction!(entity)
@@ -49,11 +60,7 @@ module Engine
         def next_entity!
           @round.next_entity_index!
           entity = entities[entity_index]
-          if auctioning
-            next_entity! unless entity_in_auction!(entity)
-          elsif entity&.passed?
-            next_entity!
-          end
+          next_entity! if entity&.passed?
         end
 
         def process_bid(action)
@@ -63,8 +70,8 @@ module Engine
             add_bid(action)
           else
             selection_bid(action)
+            next_entity!
           end
-          next_entity!
         end
 
         def actions(entity)
@@ -155,6 +162,7 @@ module Engine
           super
           entities.each(&:unpass!)
           @round.goto_entity!(@auction_triggerer)
+          next_entity!
         end
       end
     end


### PR DESCRIPTION
Fix initial auction player order on >3 players
Correct PAR value
Allow players to PAR when cash doesn't cover all of the money
Don't show bid if players cannot afford it
Allow subsidiries to cover exactly the price of a corporation (fixes #1833)