### PR TITLE
18 Los Angeles - offboards to nowhere, "negative" lettered axes

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -23,8 +23,8 @@ module View
 
       def render
         @hexes = @game.hexes.dup
-        @cols = @hexes.map(&:x).uniq.sort.map(&:next)
-        @rows = @hexes.map(&:y).uniq.sort.map(&:next)
+        @cols = @hexes.reject(&:ignore_for_axes).map(&:x).uniq.sort.map(&:next)
+        @rows = @hexes.reject(&:ignore_for_axes).map(&:y).uniq.sort.map(&:next)
         @layout = @game.layout
 
         step = @game.round.active_step(@selected_company)

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -559,6 +559,12 @@ module Engine
       ],
       "path=a:2,b:3": [
         "F5"
+      ],
+      "offboard=revenue:0,visit_cost:100;path=a:0,b:_0": [
+        "a9"
+      ],
+      "offboard=revenue:0,visit_cost:100;path=a:2,b:_0": [
+        "G14"
       ]
     },
     "red": {

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -49,6 +49,16 @@ module Engine
         '18 Los Angeles'
       end
 
+      def init_hexes(_companies, _corporations)
+        hexes = super
+
+        hexes.each do |hex|
+          hex.ignore_for_axes = true if %w[a9 G14].include?(hex.id)
+        end
+
+        hexes
+      end
+
       def num_removals(group)
         return 0 if @players.size == 5
         return 1 if @players.size == 4

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -7,7 +7,7 @@ module Engine
   class Hex
     include Assignable
 
-    attr_accessor :x, :y
+    attr_accessor :x, :y, :ignore_for_axes
     attr_reader :connections, :coordinates, :empty, :layout, :neighbors, :tile, :location_name, :original_tile
 
     DIRECTIONS = {
@@ -30,8 +30,9 @@ module Engine
     }.freeze
 
     LETTERS = ('A'..'Z').to_a
+    NEGATIVE_LETTERS = [0] + ('a'..'z').to_a
 
-    COORD_LETTER = /([A-Z]+)/.freeze
+    COORD_LETTER = /([A-Za-z]+)/.freeze
     COORD_NUMBER = /([0-9]+)/.freeze
 
     def self.invert(dir)
@@ -46,14 +47,14 @@ module Engine
 
       x =
         if axes_config[:x] == :letter
-          LETTERS.index(letter)
+          LETTERS.index(letter) || -NEGATIVE_LETTERS.index(letter)
         else
           number - 1
         end
 
       y =
         if axes_config[:y] == :letter
-          LETTERS.index(letter)
+          LETTERS.index(letter) || -NEGATIVE_LETTERS.index(letter)
         else
           number - 1
         end
@@ -77,6 +78,7 @@ module Engine
       @tile.hex = self
       @activations = []
       @empty = empty
+      @ignore_for_axes = false
     end
 
     def id


### PR DESCRIPTION
- a9 and G14 really only exist so that upgrades for A8 and F13 are less
  restricted; on the actual map they aren't drawn as a full hex

- use small letters for "negative" letters, i.e., row a is above row A, row b is
  above row a, and so on; #1849 will use this for an "a12" hex

- add hex attr `ignore_for_axes` to keep the axes rendering from taking a hex
  into account--in the case of 18 Los Angeles, don't render labels for rows "a"
  or "G"

![Screenshot from 2020-10-13 11-58-59](https://user-images.githubusercontent.com/1045173/95897955-8e894080-0d4b-11eb-999e-2f8fca609f0f.png)
