### PR TITLE
18 Los Angeles path stubs, fix rendering for offboards and terminal cities

### DIFF
--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -28,7 +28,7 @@ module View
           # Array<Array<Path>>
           @routes_paths = @routes.map { |route| route.paths_for(@tile.paths) }
 
-          sorted = (@tile.paths + @tile.path_stubs)
+          sorted = (@tile.paths + @tile.stubs)
             .map { |path| [path, index_for(path)] }
             .sort_by { |_, index| index || -1 }
 
@@ -39,8 +39,8 @@ module View
               dash: value_for_index(index, :dash),
             }
 
-            if path.path_stub?
-              h(TrackStub, path_stub: path, region_use: @region_use, **props)
+            if path.stub?
+              h(TrackStub, stub: path, region_use: @region_use, **props)
             elsif path.offboard
               h(TrackOffboard, offboard: path.offboard, path: path, region_use: @region_use, **props)
             else

--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -3,6 +3,7 @@
 require 'lib/settings'
 require 'view/game/part/track_node_path'
 require 'view/game/part/track_offboard'
+require 'view/game/part/track_stub'
 
 module View
   module Game
@@ -27,8 +28,7 @@ module View
           # Array<Array<Path>>
           @routes_paths = @routes.map { |route| route.paths_for(@tile.paths) }
 
-          sorted = @tile
-            .paths
+          sorted = (@tile.paths + @tile.path_stubs)
             .map { |path| [path, index_for(path)] }
             .sort_by { |_, index| index || -1 }
 
@@ -39,7 +39,9 @@ module View
               dash: value_for_index(index, :dash),
             }
 
-            if path.offboard
+            if path.path_stub?
+              h(TrackStub, path_stub: path, region_use: @region_use, **props)
+            elsif path.offboard
               h(TrackOffboard, offboard: path.offboard, path: path, region_use: @region_use, **props)
             else
               h(TrackNodePath, tile: @tile, path: path, region_use: @region_use, **props)

--- a/assets/app/view/game/part/track_node_path.rb
+++ b/assets/app/view/game/part/track_node_path.rb
@@ -419,10 +419,12 @@ module View
             "0 0 #{@arc_parameters[:sweep]} #{@end_x} #{@end_y}",
           ) if @need_arc
 
+          d_width = @width.to_i / 2
+
           # terminal tapered track only supported for centered city/town
           props[:attrs].merge!(
             transform: "rotate(#{rotation})",
-            d: 'M6 60 L 6 85 L -6 85 L -6 60 L 0 25 Z',
+            d: "M #{d_width} 60 L #{d_width} 87 L -#{d_width} 87 L -#{d_width} 60 L 0 25 Z",
             fill: @color,
             stroke: 'none',
             'stroke-linecap': 'butt',

--- a/assets/app/view/game/part/track_offboard.rb
+++ b/assets/app/view/game/part/track_offboard.rb
@@ -38,10 +38,12 @@ module View
         def render_part
           rotate = 60 * edge
 
+          d_width = @width.to_i / 2
+
           props = {
             attrs: {
               transform: "rotate(#{rotate})",
-              d: 'M6 75 L 6 85 L -6 85 L -6 75 L 0 48 Z',
+              d: "M #{d_width} 75 L #{d_width} 87 L -#{d_width} 87 L -#{d_width} 75 L 0 48 Z",
               fill: @color,
               stroke: 'none',
               'stroke-linecap': 'butt',

--- a/assets/app/view/game/part/track_stub.rb
+++ b/assets/app/view/game/part/track_stub.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'view/game/part/base'
+
+module View
+  module Game
+    module Part
+      class TrackStub < Base
+        needs :path_stub
+        needs :color, default: 'black'
+        needs :width, default: 8
+        needs :dash, default: '0'
+
+        REGIONS = {
+          0 => [21],
+          1 => [13],
+          2 => [6],
+          3 => [2],
+          4 => [10],
+          5 => [17],
+        }.freeze
+
+        def load_from_tile
+          @edge = @path_stub.edge
+        end
+
+        def preferred_render_locations
+          [
+            {
+              region_weights: REGIONS[@edge],
+              x: 0,
+              y: 0,
+            },
+          ]
+        end
+
+        def render_part
+          rotate = 60 * @edge
+
+          props = {
+            attrs: {
+              transform: "rotate(#{rotate})",
+              d: 'M 0 87 L 0 65',
+              fill: @color,
+              stroke: @color,
+              'stroke-linecap': 'butt',
+              'stroke-linejoin': 'miter',
+              'stroke-width': @width,
+              'stroke-dasharray': @dash,
+            },
+          }
+
+          h(:path, props)
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game/part/track_stub.rb
+++ b/assets/app/view/game/part/track_stub.rb
@@ -6,7 +6,7 @@ module View
   module Game
     module Part
       class TrackStub < Base
-        needs :path_stub
+        needs :stub
         needs :color, default: 'black'
         needs :width, default: 8
         needs :dash, default: '0'
@@ -21,7 +21,7 @@ module View
         }.freeze
 
         def load_from_tile
-          @edge = @path_stub.edge
+          @edge = @stub.edge
         end
 
         def preferred_render_locations

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -48,7 +48,7 @@ module View
         children = []
 
         render_revenue = should_render_revenue?
-        children << render_tile_part(Part::Track, routes: @routes) if (@tile.paths + @tile.path_stubs).any?
+        children << render_tile_part(Part::Track, routes: @routes) if @tile.paths.any? || @tile.stubs.any?
         children << render_tile_part(Part::Cities, show_revenue: !render_revenue) if @tile.cities.any?
         children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -48,7 +48,7 @@ module View
         children = []
 
         render_revenue = should_render_revenue?
-        children << render_tile_part(Part::Track, routes: @routes) if @tile.paths.any?
+        children << render_tile_part(Part::Track, routes: @routes) if (@tile.paths + @tile.path_stubs).any?
         children << render_tile_part(Part::Cities, show_revenue: !render_revenue) if @tile.cities.any?
         children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -518,17 +518,19 @@ module Engine
       "city=revenue:0;upgrade=cost:40,terrain:mountain": [
         "C12"
       ],
-      "city=revenue:0;border=edge:4,type:water,cost:40": [
+      "city=revenue:0;border=edge:4,type:water,cost:40;path_stub=edge:0": [
         "D9"
       ],
       "city=revenue:0;border=edge:1,type:water,cost:40": [
         "D11"
       ],
       "city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1": [
-        "E4",
+        "E4"
+      ],
+      "city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1;path_stub=edge:4": [
         "E6"
       ],
-      "city=revenue:0;border=edge:0,type:water,cost:40": [
+      "city=revenue:0;border=edge:0,type:water,cost:40;path_stub=edge:1": [
         "E10"
       ],
       "city=revenue:0;label=Z": [
@@ -540,8 +542,10 @@ module Engine
       "city=revenue:0": [
         "A6",
         "C4",
-        "D7",
         "F11"
+      ],
+      "city=revenue:0;path_stub=edge:5": [
+        "D7"
       ]
     },
     "gray": {
@@ -606,7 +610,7 @@ module Engine
       "city=revenue:40,slots:2;path=a:0,b:_0;path=a:4,b:_0;label=Z;border=edge:0,type:water,cost:40": [
         "C6"
       ],
-      "city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_2;path=a:4,b:_3;label=LB": [
+      "city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_2;path=a:4,b:_3;path_stub=edge:0;label=LB": [
         "E8"
       ],
       "city=revenue:20,slots:2;path=a:1,b:_0;path=a:3,b:_0": [

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -552,7 +552,7 @@ module Engine
       "city=revenue:0;upgrade=cost:40,terrain:mountain": [
         "C12"
       ],
-      "city=revenue:0;border=edge:4,type:water,cost:40;path_stub=edge:0": [
+      "city=revenue:0;border=edge:4,type:water,cost:40;stub=edge:0": [
         "D9"
       ],
       "city=revenue:0;border=edge:1,type:water,cost:40": [
@@ -561,10 +561,10 @@ module Engine
       "city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1": [
         "E4"
       ],
-      "city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1;path_stub=edge:4": [
+      "city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1;stub=edge:4": [
         "E6"
       ],
-      "city=revenue:0;border=edge:0,type:water,cost:40;path_stub=edge:1": [
+      "city=revenue:0;border=edge:0,type:water,cost:40;stub=edge:1": [
         "E10"
       ],
       "city=revenue:0;label=Z": [
@@ -578,7 +578,7 @@ module Engine
         "C4",
         "F11"
       ],
-      "city=revenue:0;path_stub=edge:5": [
+      "city=revenue:0;stub=edge:5": [
         "D7"
       ]
     },
@@ -644,7 +644,7 @@ module Engine
       "city=revenue:40,slots:2;path=a:0,b:_0;path=a:4,b:_0;label=Z;border=edge:0,type:water,cost:40": [
         "C6"
       ],
-      "city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_2;path=a:4,b:_3;path_stub=edge:0;label=LB": [
+      "city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_2;path=a:4,b:_3;stub=edge:0;label=LB": [
         "E8"
       ],
       "city=revenue:20,slots:2;path=a:1,b:_0;path=a:3,b:_0": [

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -820,6 +820,10 @@ module Engine
         true
       end
 
+      def legal_tile_rotation?(_entity, _hex, _tile)
+        true
+      end
+
       def game_error(msg)
         raise GameError.new(msg, current_action_id)
       end

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -117,6 +117,10 @@ module Engine
       # unlike in 1846, none of the private companies get 2 tile lays
       def check_special_tile_lay(_action); end
 
+      def legal_tile_rotation?(_entity, hex, tile)
+        hex.tile.path_stubs.map(&:edge).all? { |e| tile.exits.include?(e) }
+      end
+
       def east_west_bonus(stops)
         bonus = { revenue: 0 }
 

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -118,7 +118,7 @@ module Engine
       def check_special_tile_lay(_action); end
 
       def legal_tile_rotation?(_entity, hex, tile)
-        hex.tile.path_stubs.map(&:edge).all? { |e| tile.exits.include?(e) }
+        tile.exits.include?(hex.tile.stubs.first)
       end
 
       def east_west_bonus(stops)

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -93,6 +93,10 @@ module Engine
         false
       end
 
+      def path_stub?
+        false
+      end
+
       def visit_cost
         0
       end

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -93,7 +93,7 @@ module Engine
         false
       end
 
-      def path_stub?
+      def stub?
         false
       end
 

--- a/lib/engine/part/path_stub.rb
+++ b/lib/engine/part/path_stub.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Part
+    class PathStub < Base
+      attr_reader :edge
+
+      def initialize(edge)
+        @edge = edge
+      end
+
+      def path_stub?
+        true
+      end
+    end
+  end
+end

--- a/lib/engine/part/stub.rb
+++ b/lib/engine/part/stub.rb
@@ -4,14 +4,14 @@ require_relative 'base'
 
 module Engine
   module Part
-    class PathStub < Base
+    class Stub < Base
       attr_reader :edge
 
       def initialize(edge)
         @edge = edge
       end
 
-      def path_stub?
+      def stub?
         true
       end
     end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -214,6 +214,8 @@ module Engine
       end
 
       def legal_tile_rotation?(entity, hex, tile)
+        return false unless @game.legal_tile_rotation?(entity, hex, tile)
+
         old_paths = hex.tile.paths
         old_ctedges = hex.tile.city_town_edges
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -17,7 +17,7 @@ module Engine
     attr_accessor :hex, :icons, :index, :legal_rotations, :location_name, :name, :reservations
     attr_reader :blocks_lay, :borders, :cities, :color, :edges, :junction, :label, :nodes,
                 :parts, :preprinted, :rotation, :stops, :towns, :upgrades, :offboards, :blockers,
-                :city_towns, :unlimited
+                :city_towns, :unlimited, :path_stubs
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -128,6 +128,8 @@ module Engine
         junction
       when 'icon'
         Part::Icon.new(params['image'], params['name'], params['sticky'], params['blocks_lay'])
+      when 'path_stub'
+        Part::PathStub.new(params['edge'].to_i)
       end
     end
 
@@ -148,6 +150,7 @@ module Engine
       @rotation = rotation
       @cities = []
       @paths = []
+      @path_stubs = []
       @towns = []
       @city_towns = []
       @all_stop = []
@@ -471,6 +474,8 @@ module Engine
           @junction = part
         elsif part.icon?
           @icons << part
+        elsif part.path_stub?
+          @path_stubs << part
         else
           raise "Part #{part} not separated."
         end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -17,7 +17,7 @@ module Engine
     attr_accessor :hex, :icons, :index, :legal_rotations, :location_name, :name, :reservations
     attr_reader :blocks_lay, :borders, :cities, :color, :edges, :junction, :label, :nodes,
                 :parts, :preprinted, :rotation, :stops, :towns, :upgrades, :offboards, :blockers,
-                :city_towns, :unlimited, :path_stubs
+                :city_towns, :unlimited, :stubs
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -128,8 +128,8 @@ module Engine
         junction
       when 'icon'
         Part::Icon.new(params['image'], params['name'], params['sticky'], params['blocks_lay'])
-      when 'path_stub'
-        Part::PathStub.new(params['edge'].to_i)
+      when 'stub'
+        Part::Stub.new(params['edge'].to_i)
       end
     end
 
@@ -150,7 +150,7 @@ module Engine
       @rotation = rotation
       @cities = []
       @paths = []
-      @path_stubs = []
+      @stubs = []
       @towns = []
       @city_towns = []
       @all_stop = []
@@ -474,8 +474,8 @@ module Engine
           @junction = part
         elsif part.icon?
           @icons << part
-        elsif part.path_stub?
-          @path_stubs << part
+        elsif part.stub?
+          @stubs << part
         else
           raise "Part #{part} not separated."
         end


### PR DESCRIPTION
"Stubs" around Long Beach in 18 Los Angeles that count as track which must be respected when laying a tile:

![Screenshot from 2020-10-13 20-30-05](https://user-images.githubusercontent.com/1045173/95936557-19d9f480-0d93-11eb-8f60-54ee4ca17f2e.png)

Offboard/Terminal Cities Before:

![Screenshot from 2020-10-13 20-30-35](https://user-images.githubusercontent.com/1045173/95936555-19415e00-0d93-11eb-9e13-e1d883081f6e.png)

Offboard/Terminal Cities After:

![Screenshot from 2020-10-13 20-30-14](https://user-images.githubusercontent.com/1045173/95936556-19415e00-0d93-11eb-8d62-573a5d22d175.png)