### PR TITLE
Generic support for Multi-directional Dividend Movement ( 18CO rule )

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -38,9 +38,7 @@ module View
           button = h('td.no_padding', [h(:button, { style: { margin: '0.2rem 0' }, on: { click: click } }, text)])
           direction =
             if option[:share_direction]
-              Array(option[:share_direction]).map.with_index {
-                |dir, i| "#{option[:share_times][i]} #{dir}"
-              }.join(', ')
+              Array(option[:share_direction]).map.with_index { |dir, i| "#{option[:share_times][i]} #{dir}" }.join(', ')
             else
               'None'
             end

--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -36,14 +36,14 @@ module View
             cleanup
           end
           button = h('td.no_padding', [h(:button, { style: { margin: '0.2rem 0' }, on: { click: click } }, text)])
-          direction = ''
-          if option[:share_direction]
-            Array(option[:share_direction]).each_with_index do |dir, i|
-              direction += "#{option[:share_times][i]} #{dir} "
+          direction =
+            if option[:share_direction]
+              Array(option[:share_direction]).map.with_index {
+                |dir, i| "#{option[:share_times][i]} #{dir}"
+              }.join(', ')
+            else
+              'None'
             end
-          else
-            direction = 'None'
-          end
 
           props = { style: { paddingRight: '1rem' } }
           h(:tr, [

--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -36,12 +36,14 @@ module View
             cleanup
           end
           button = h('td.no_padding', [h(:button, { style: { margin: '0.2rem 0' }, on: { click: click } }, text)])
-          direction =
-            if option[:share_direction]
-              "#{option[:share_times]} #{option[:share_direction]}"
-            else
-              'None'
+          direction = ''
+          if option[:share_direction]
+            Array(option[:share_direction]).each_with_index do |dir, i|
+              direction += "#{option[:share_times][i]} #{dir} "
             end
+          else
+            direction = 'None'
+          end
 
           props = { style: { paddingRight: '1rem' } }
           h(:tr, [

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -66,7 +66,7 @@ module Engine
         Step::G18CO::Track,
         Step::Token,
         Step::Route,
-        Step::Dividend,
+        Step::G18CO::Dividend,
         Step::BuyTrain,
         [Step::BuyCompany, blocks: true],
         ], round_num: round_num)

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -143,10 +143,8 @@ module Engine
 
         prev = entity.share_price.price
 
-        Array(payout[:share_times]).each_with_index do |share_times, share_times_index|
+        Array(payout[:share_times]).zip(Array(payout[:share_direction])).each do |share_times, direction|
           share_times.times do
-            direction = Array(payout[:share_direction])[share_times_index]
-
             case direction
             when :left
               @game.stock_market.move_left(entity)

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -142,12 +142,23 @@ module Engine
         return unless payout[:share_direction]
 
         prev = entity.share_price.price
-        payout[:share_times].times do
-          case payout[:share_direction]
-          when :left
-            @game.stock_market.move_left(entity)
-          when :right
-            @game.stock_market.move_right(entity)
+
+        share_times = Array(payout[:share_times])
+
+        share_times.each_with_index do |share_time, share_time_index|
+          share_time.times do
+            direction = Array(payout[:share_direction])[share_time_index]
+
+            case direction
+            when :left
+              @game.stock_market.move_left(entity)
+            when :right
+              @game.stock_market.move_right(entity)
+            when :up
+              @game.stock_market.move_up(entity)
+            when :down
+              @game.stock_market.move_down(entity)
+            end
           end
         end
         @game.log_share_price(entity, prev)

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -143,11 +143,9 @@ module Engine
 
         prev = entity.share_price.price
 
-        share_times = Array(payout[:share_times])
-
-        share_times.each_with_index do |share_time, share_time_index|
-          share_time.times do
-            direction = Array(payout[:share_direction])[share_time_index]
+        Array(payout[:share_times]).each_with_index do |share_times, share_times_index|
+          share_times.times do
+            direction = Array(payout[:share_direction])[share_times_index]
 
             case direction
             when :left

--- a/lib/engine/step/g_18_co/dividend.rb
+++ b/lib/engine/step/g_18_co/dividend.rb
@@ -7,8 +7,11 @@ module Engine
     module G18CO
       class Dividend < Dividend
         def share_price_change(entity, revenue = 0)
-          @log << 'TODO: implement multi-jump'
-          super
+          return { share_direction: :left, share_times: 1 } unless revenue.positive?
+
+          return { share_direction: :right, share_times: 1 } unless revenue >= entity.share_price.price * 2
+
+          { share_direction: %i[right up], share_times: [1, 1] }
         end
       end
     end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836

### Running Trains
**Dividends**: Adjust​ ​the​ ​Stock​ ​Token​ ​one​ ​space​ ​right.​ ​If​ ​the​ ​revenue​ ​was​ ​at​ ​least​ ​twice​ ​the​ ​original​ ​Stock​ ​Market​ ​Value​ ​this round,​​ ​move​ ​the​ ​token​ ​one​ ​space​ ​up.

-----

The current code only allows for one direction of movement, as well as only right and left.

My solution is to allow an array to be specified for both share_direction and share_times. This is supported by the changes to **lib/engine/step/dividend.rb** . I have chosen to make this change to the base dividend.rb (rather than 18CO specific) so any future game could take advantage of the capability. I chose to add support for _down_ for completeness. Current integer format still works the same way. Here is a working example of the newly supported format:

`{ share_direction: %i[right up], share_times: [1, 1] }`

The changes to **assets/app/view/game/dividend.rb** allow for displaying the array based information, as seen in this example from my testing:

<img width="315" alt="Screen Shot 2020-10-15 at 3 09 48 PM" src="https://user-images.githubusercontent.com/15675400/96189962-ace36d80-0efe-11eb-80ee-8a78c0ba7e8c.png">
