### PR TITLE
Render optional rules when creating a game, implement 18 Los Angeles's optional LA Title company

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -72,19 +72,17 @@ module View
         val = range.value.to_i
         range.value = (min..max).include?(val) ? val : max
         store(:num_players, range.value.to_i, skip: true)
-
-        if Native(@inputs[:optional_rules_selected])
-          Native(@inputs[:optional_rules_selected]).elm.value = ''
-          @optional_rules_selected = nil
-        end
-        store(:optional_rules_available, @optional_rules_per_title[title])
+        update_optional_rules_store
       end
 
       enforce_range = lambda do
         elm = Native(@inputs[:max_players]).elm
         if elm.value.to_i.positive?
           elm.value = elm.max.to_i unless (elm.min.to_i..elm.max.to_i).include?(elm.value.to_i)
-          store(:num_players, elm.value.to_i) if @mode == :hotseat
+          if @mode == :hotseat
+            store(:num_players, elm.value.to_i)
+            update_optional_rules_store
+          end
         end
       end
 
@@ -153,6 +151,7 @@ module View
         elm = Native(@inputs[:max_players]).elm
         elm.value = [elm.value.to_i, elm.min.to_i].max
         store(:num_players, elm.value.to_i)
+        update_optional_rules_store
       end
 
       [render_input(
@@ -196,6 +195,15 @@ module View
         max_players: params[:max_players],
         **game_data,
       )
+    end
+
+    def update_optional_rules_store
+      title = Native(@inputs[:title]).elm.value
+      if Native(@inputs[:optional_rules_selected])
+        Native(@inputs[:optional_rules_selected]).elm.value = ''
+        @optional_rules_selected = nil
+      end
+      store(:optional_rules_available, @optional_rules_per_title[title])
     end
   end
 end

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -11,8 +11,7 @@ module View
     needs :num_players, default: 3, store: true
     needs :flash_opts, default: {}, store: true
     needs :user, default: nil, store: true
-    needs :optional_rules_available, default: [], store: true
-    needs :optional_rules_selected, default: nil, store: true
+    needs :optional_rules_available, default: nil, store: true
 
     def render_content
       inputs = [
@@ -20,8 +19,6 @@ module View
         render_button('Create') { submit },
         render_inputs,
       ]
-      inputs << render_optional if @optional_rules_available.any?
-      @chosen_title = nil
 
       if @mode == :hotseat
         @num_players.times do |index|
@@ -57,7 +54,7 @@ module View
 
       games = (Lib::Params['all'] ? Engine::GAMES : Engine::VISIBLE_GAMES).sort.map do |game|
         @min_p[game.title], @max_p[game.title] = Engine.player_range(game)
-        @optional_rules_per_title[game.title] = game::OPTIONAL_RULES
+        @optional_rules_per_title[game.title] = game::OPTIONAL_RULES != [] ? game::OPTIONAL_RULES : nil
 
         title = game.title
         title += " (#{game::GAME_LOCATION})" if game::GAME_LOCATION
@@ -67,16 +64,20 @@ module View
         h(:option, { attrs: attrs }, title)
       end
 
-      limit_range = lambda do
+      title_change = lambda do
         range = Native(@inputs[:max_players]).elm
         title = Native(@inputs[:title]).elm.value
         min = range.min = @min_p[title]
         max = range.max = @max_p[title]
         val = range.value.to_i
         range.value = (min..max).include?(val) ? val : max
-        store(:num_players, range.value.to_i)
-        optional_rules = @optional_rules_per_title[title] || []
-        store(:optional_rules_available, optional_rules)
+        store(:num_players, range.value.to_i, skip: true)
+
+        if Native(@inputs[:optional_rules_selected])
+          Native(@inputs[:optional_rules_selected]).elm.value = ''
+          @optional_rules_selected = nil
+        end
+        store(:optional_rules_available, @optional_rules_per_title[title])
       end
 
       enforce_range = lambda do
@@ -88,7 +89,7 @@ module View
       end
 
       inputs = [
-        render_input('Game Title', id: :title, el: 'select', on: { input: limit_range }, children: games),
+        render_input('Game Title', id: :title, el: 'select', on: { input: title_change }, children: games),
         render_input('Description', placeholder: 'Add a title', id: :description),
         render_input(
           @mode != :hotseat ? 'Max Players' : 'Players',
@@ -104,19 +105,26 @@ module View
           on: { input: enforce_range },
         ),
       ]
+      inputs << render_optional if @optional_rules_available
+
       h(:div, inputs)
     end
 
     def render_optional
-      choice_select = lambda do
-        choice = Native(@inputs[:optional_rules_selected]).elm.value
-        store(:optional_rules_selected, choice)
+      return unless @optional_rules_available
+
+      save_selection = lambda do
+        @optional_rules_selected = Native(@inputs[:optional_rules_selected]).elm.selectedOptions
+        # TODO: get values from HTML-Collection
+        # https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedOptions
       end
 
       optional_rules = []
       @optional_rules_available.each do |o_r|
         optional_rules << h(:option, { attrs: { value: o_r[:sym] } }, o_r[:desc])
       end
+      store(:optional_rules_available, nil, skip: true) # wipe to prevent rendering on next game creation
+
       inputs = [
         render_input(
           'Optional rules',
@@ -125,7 +133,7 @@ module View
           attrs: {
             multiple: true,
           },
-          on: { input: choice_select },
+          on: { input: save_selection },
           children: optional_rules,
         ),
       ]

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -62,6 +62,14 @@ module View
         else
           children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_RULES_URL } }, 'Rules')])
         end
+        begin
+          children << h(:h3, 'Optional Rules Used')
+          @game.class::OPTIONAL_RULES.each do |o_r|
+            next unless o_r[:sym] == @game.optional_rules
+
+            children << h(:p, o_r[:desc].to_s)
+          end
+        end if @game.optional_rules
 
         if @game.class::GAME_INFO_URL
           children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_INFO_URL } }, 'More info')])

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -57,6 +57,7 @@ module View
         id: game_id,
         actions: cursor ? actions.take(cursor) : actions,
         pin: @pin,
+        optional_rules: @game_data.dig('settings', 'optional_rules_selected'),
       )
       store(:game, @game, skip: true)
     end

--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -5,9 +5,11 @@ require_relative 'base'
 module Engine
   module Ability
     class Token < Base
-      attr_reader :hexes, :teleport_price, :extra, :from_owner, :discount, :city
+      attr_reader :hexes, :teleport_price, :extra, :from_owner, :discount, :city,
+                  :neutral
 
-      def setup(hexes:, price: nil, teleport_price: nil, extra: nil, from_owner: nil, discount: nil, city: nil)
+      def setup(hexes:, price: nil, teleport_price: nil, extra: nil,
+                from_owner: nil, discount: nil, city: nil, neutral: nil)
         @hexes = hexes
         @price = price
         @teleport_price = teleport_price
@@ -15,6 +17,7 @@ module Engine
         @from_owner = from_owner || false
         @discount = discount
         @city = city
+        @neutral = neutral || false
       end
 
       def price(token = nil)

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -317,6 +317,29 @@ module Engine
            "count": 1
         }
       ]
+    },
+    {
+      "name": "Los Angeles Title",
+      "value": 40,
+      "revenue": 10,
+      "desc": "The owning corporation may place an Open City token in any unreserved slot except for Long Beach (E8).",
+      "sym": "LAT",
+      "min_players": 3,
+      "abilities": [
+        {
+          "type": "token",
+          "owner_type":"corporation",
+          "price": 0,
+          "teleport_price": 0,
+          "count": 1,
+          "neutral": true,
+          "hexes": [
+            "A4", "A6", "A8", "B5", "B7", "B9", "B11", "B13", "C4", "C6", "C8",
+            "C12", "D5", "D7", "D9", "D11", "D13", "E4", "E6", "E10", "E12",
+            "F7", "F9", "F11", "F13"
+          ]
+        }
+      ]
     }
   ],
   "minors": [

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -33,7 +33,8 @@ module Engine
       attr_reader :actions, :bank, :cert_limit, :cities, :companies, :corporations,
                   :depot, :finished, :graph, :hexes, :id, :loading, :loans, :log, :minors,
                   :phase, :players, :operating_rounds, :round, :share_pool, :stock_market,
-                  :tiles, :turn, :total_loans, :undo_possible, :redo_possible, :round_history, :all_tiles
+                  :tiles, :turn, :total_loans, :undo_possible, :redo_possible, :round_history, :all_tiles,
+                  :optional_rules
 
       DEV_STAGES = %i[production beta alpha prealpha].freeze
       DEV_STAGE = :prealpha
@@ -60,6 +61,8 @@ module Engine
       #  one_more_full_or_set - finish the current OR set, then
       #                         end after the next complete OR set
       GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
+
+      OPTIONAL_RULES = [].freeze
 
       BANKRUPTCY_ALLOWED = true
 
@@ -276,12 +279,13 @@ module Engine
         const_set(:LAYOUT, data['layout'].to_sym)
       end
 
-      def initialize(names, id: 0, actions: [], pin: nil, strict: false)
+      def initialize(names, id: 0, actions: [], pin: nil, strict: false, optional_rules: [])
         @id = id
         @turn = 1
         @final_turn = nil
         @loading = false
         @strict = strict
+        @optional_rules = optional_rules
         @finished = false
         @log = []
         @actions = []
@@ -490,7 +494,7 @@ module Engine
       end
 
       def clone(actions)
-        self.class.new(@names, id: @id, pin: @pin, actions: actions)
+        self.class.new(@names, id: @id, pin: @pin, actions: actions, optional_rules: @optional_rules)
       end
 
       def trains

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -21,6 +21,10 @@ module Engine
       GAME_PUBLISHER = Publisher::INFO[:traxx]
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18LosAngeles'
 
+      OPTIONAL_RULES = [
+        { sym: :la_title, desc: 'LA Title: add a private company which can lay an Open City token (3+ players only)'},
+      ].freeze
+
       ASSIGNMENT_TOKENS = {
         'LAC' => '/icons/18_los_angeles/lac_token.svg',
         'LAS' => '/icons/1846/sc_token.svg',
@@ -47,6 +51,12 @@ module Engine
 
       def self.title
         '18 Los Angeles'
+      end
+
+      def init_companies(_players)
+        companies = super
+        companies.reject! { |c| c.sym == 'LAT' } unless @optional_rules&.include?(:la_title)
+        companies
       end
 
       def init_hexes(_companies, _corporations)

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -81,7 +81,18 @@ module Engine
           next if ability.hexes.any? && !ability.hexes.include?(hex.id)
 
           # check if this is correct or should be a corporation
-          token = Engine::Token.new(entity) if ability.extra
+          if ability.extra
+            token = Engine::Token.new(entity)
+          elsif ability.neutral
+            neutral_corp = Corporation.new(
+              sym: 'N',
+              name: 'Neutral',
+              logo: 'open_city',
+              tokens: [0],
+            )
+            token = Engine::Token.new(neutral_corp, type: :neutral)
+          end
+
           token.price = ability.teleport_price if ability.teleport_price
           token.price = ability.price(token) if @game.graph.reachable_hexes(entity)[hex]
           return [token, ability]

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -75,7 +75,7 @@ input, select, textarea {
   cursor: pointer;
   margin: 0.5rem;
 }
-input:not([type=radio]):not([type=checkbox]), select {
+input:not([type=radio]):not([type=checkbox]), select:not([multiple]) {
   height: 1.5rem;
 }
 input + label, select + label {

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -176,7 +176,7 @@ class Api
             user: user,
             description: r['description'],
             max_players: r['max_players'],
-            settings: { seed: Random.new_seed },
+            settings: { seed: Random.new_seed, optional_rules_selected: r['optional_rules_selected'] },
             title: title,
             round: Engine::GAMES_BY_TITLE[title].new([]).round&.name,
           }


### PR DESCRIPTION
Taken from @perwestling's branch for #1082. I left off the optional 18AL rules added there to keep this branch smaller. I also added a minor fix so that the optional rules render correctly when swapping between multiplayer and hotseat, as well as changing player count in hotseat mode.

Seems to work just fine with LA Title, and there's an added bonus to making it optional right away--I was worried that games created before LA Title was implemented would break since they would be expecting a different number of companies in the draft, but since it's not included by default, those games will be fine.

I guess we could say this Fixes #1082 and use different issues to track specific optional rules that people want added?

![Screenshot from 2020-10-15 23-07-58](https://user-images.githubusercontent.com/1045173/96215659-d4a4f680-0f3b-11eb-901a-4cf1216873e3.png)
