### PR TITLE
Issue 1888 Half-pay dividend for 2-share companies.

### DIFF
--- a/lib/engine/step/g_1817/dividend.rb
+++ b/lib/engine/step/g_1817/dividend.rb
@@ -10,6 +10,10 @@ module Engine
         DIVIDEND_TYPES = %i[payout half withhold].freeze
         include HalfPay
 
+        def half_pay_withhold_amount(entity, revenue)
+          entity.total_shares == 2 ? revenue / 2 : super
+        end
+
         def share_price_change(entity, revenue = 0)
           price = entity.share_price.price
           return { share_direction: :left, share_times: 1 } unless revenue.positive?

--- a/lib/engine/step/half_pay.rb
+++ b/lib/engine/step/half_pay.rb
@@ -4,8 +4,12 @@ module Engine
   module Step
     module HalfPay
       def half(entity, revenue)
-        withheld = (revenue / 2 / entity.total_shares).to_i * entity.total_shares
+        withheld = half_pay_withhold_amount(entity, revenue)
         { corporation: withheld, per_share: payout_per_share(entity, revenue - withheld) }
+      end
+
+      def half_pay_withhold_amount(entity, revenue)
+        (revenue / 2 / entity.total_shares).to_i * entity.total_shares
       end
     end
   end


### PR DESCRIPTION
Half-paying as 2-share companies in 1817 is off as reported in [issue 1888](https://github.com/tobymao/18xx/issues/1888). This PR updates dividend logic to support this case.

I can think of 2 sensible approaches:
- extend 1817 dividend logic to accommodate half-paying as 2-share companies.
- update half-paying logic to work for 2-share companies in 1817.

While private companies and minor companies are common in 18xx games, I cannot think of another title, 18USA excluded, with 2-share companies. The key questions for choosing between the above options are:
- how likely are we to add another title with variable number of shares?
- when that day comes, are we happier refactoring 1817 logic for the new title (downside of first approach) or branching out 2 different logic for 2 different titles (downside of second approach).

For the time being, this PR implements the second approach. And I will happily revise it to take the first approach if we think the first approach is better.