### PR TITLE
Adding Halts. Other 1860 tile rendering fixes.

### DIFF
--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -112,10 +112,12 @@ module View
           pointy: [nil, 42, 62, 57],
         }.freeze
 
+        ANGLE_RIGHT = -5
         ANGLE_UPPER_RIGHT = -60
         ANGLE_LOWER_RIGHT = 10
         ANGLE_LOWER_LEFT = 170
         ANGLE_UPPER_LEFT = -120
+        ANGLE_LEFT = -175
 
         REVENUE_LOCATIONS_BY_EDGE = {
           0 => [
@@ -125,10 +127,10 @@ module View
             { regions: [16], angle: ANGLE_UPPER_RIGHT },
           ],
           0.5 => [
-            { regions: [12, 13], angle: ANGLE_LOWER_LEFT },
+            { regions: [12, 13], angle: ANGLE_LEFT },
             { regions: [7, 14], angle: ANGLE_UPPER_LEFT },
             { regions: [15, 16], angle: ANGLE_UPPER_RIGHT },
-            { regions: [21, 22], angle: ANGLE_LOWER_RIGHT },
+            { regions: [21, 22], angle: ANGLE_RIGHT },
           ],
           1 => [
             { regions: [5], angle: ANGLE_LOWER_LEFT },
@@ -137,8 +139,8 @@ module View
             { regions: [20], angle: ANGLE_LOWER_RIGHT },
           ],
           1.5 => [
-            { regions: [0, 6], angle: ANGLE_LOWER_LEFT },
-            { regions: [13, 19], angle: ANGLE_LOWER_RIGHT },
+            { regions: [0, 6], angle: ANGLE_LEFT },
+            { regions: [13, 19], angle: ANGLE_RIGHT },
             { regions: [7, 8], angle: ANGLE_UPPER_LEFT },
             { regions: [14, 15], angle: ANGLE_UPPER_RIGHT },
           ],
@@ -149,10 +151,10 @@ module View
             { regions: [1], angle: ANGLE_LOWER_LEFT },
           ],
           2.5 => [
-            { regions: [5, 6], angle: ANGLE_LOWER_RIGHT },
+            { regions: [5, 6], angle: ANGLE_RIGHT },
             { regions: [7, 14], angle: ANGLE_UPPER_RIGHT },
             { regions: [8, 9], angle: ANGLE_UPPER_LEFT },
-            { regions: [2, 3], angle: ANGLE_LOWER_LEFT },
+            { regions: [2, 3], angle: ANGLE_LEFT },
           ],
           3 => [
             { regions: [4], angle: ANGLE_LOWER_LEFT },
@@ -161,10 +163,10 @@ module View
             { regions: [7], angle: ANGLE_UPPER_RIGHT },
           ],
           3.5 => [
-            { regions: [10, 11], angle: ANGLE_LOWER_LEFT },
+            { regions: [10, 11], angle: ANGLE_LEFT },
             { regions: [9, 16], angle: ANGLE_UPPER_LEFT },
             { regions: [7, 8], angle: ANGLE_UPPER_RIGHT },
-            { regions: [1, 2], angle: ANGLE_LOWER_RIGHT },
+            { regions: [1, 2], angle: ANGLE_RIGHT },
           ],
           4 => [
             { regions: [18], angle: ANGLE_LOWER_LEFT },
@@ -173,8 +175,8 @@ module View
             { regions: [3], angle: ANGLE_LOWER_RIGHT },
           ],
           4.5 => [
-            { regions: [4, 10], angle: ANGLE_LOWER_RIGHT },
-            { regions: [17, 23], angle: ANGLE_LOWER_LEFT },
+            { regions: [4, 10], angle: ANGLE_RIGHT },
+            { regions: [17, 23], angle: ANGLE_LEFT },
             { regions: [8, 9], angle: ANGLE_UPPER_RIGHT },
             { regions: [15, 16], angle: ANGLE_UPPER_LEFT },
           ],
@@ -185,10 +187,10 @@ module View
             { regions: [22], angle: ANGLE_LOWER_LEFT },
           ],
           5.5 => [
-            { regions: [17, 18], angle: ANGLE_LOWER_RIGHT },
+            { regions: [17, 18], angle: ANGLE_RIGHT },
             { regions: [14, 15], angle: ANGLE_UPPER_LEFT },
             { regions: [9, 16], angle: ANGLE_UPPER_RIGHT },
-            { regions: [20, 21], angle: ANGLE_LOWER_LEFT },
+            { regions: [20, 21], angle: ANGLE_LEFT },
           ],
         }.freeze
 
@@ -217,6 +219,8 @@ module View
             weights = EDGE_CITY_REGIONS[@edge]
             weights += EXTRA_SLOT_REGIONS[@edge] unless @city.slots == 1
             distance = 50
+            # move in if city is on a "half" edge and has more that one slot
+            distance -= 8 if @edge.to_i != @edge && @city.slots > 1
 
             # If there's a border on this edge, move the city slightly
             # towards the center to ensure track is visible.

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -32,6 +32,15 @@ module View
           6 => 13,
         }.freeze
 
+        RESERVATION_VERT_SCALING = {
+          1 => 1,
+          2 => 1,
+          3 => 1,
+          4 => 1.4,
+          5 => 2.0,
+          6 => 2.0,
+        }.freeze
+
         def render_part
           children = []
           children << h(:circle, attrs: { r: @radius, fill: 'white' })
@@ -54,6 +63,7 @@ module View
           attrs = {
             fill: 'black',
             'font-size': "#{RESERVATION_FONT_SIZE[text.size]}px",
+            transform: "scale(1.0,#{RESERVATION_VERT_SCALING[text.size]})",
             'dominant-baseline': 'central',
           }
 

--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -94,6 +94,12 @@ module View
           P_LEFT_CORNER[:flat],
           P_RIGHT_CORNER[:flat],
           P_BOTTOM_LEFT_CORNER[:flat],
+          # bottom right corner
+          {
+            region_weights: { BOTTOM_RIGHT_CORNER => 1.0, [21] => 0.5 },
+            x: 30,
+            y: 65,
+          },
           # edge 1
           {
             region_weights: { [12, 13] => 1.0, [14] => 0.5 },

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -16,7 +16,7 @@ module View
         needs :width, default: 8
 
         REVENUE_DISPLACEMENT = 42
-        REVENUE_EDGE_DISPLACEMENT = 50
+        REVENUE_EDGE_DISPLACEMENT = 38
         REVENUE_ANGLE = -60
 
         REVENUE_REGIONS = {
@@ -69,32 +69,54 @@ module View
               },
             ]
           else
-            @tile.towns.size > 1 ? OFFSET_TOWNS : CENTER_TOWN
+            # see if any other towns are also in the center
+            @tile.towns.count { |t| !@tile.preferred_city_town_edges[t] } > 1 ? OFFSET_TOWNS : CENTER_TOWN
           end
         end
 
         def render_revenue
-          revenues = @tile.towns.first.revenue.values.uniq
-          return unless revenues.one? && @town.paths.any?
+          revenues = @town.uniq_revenues
+          return if revenues.size > 1
 
           revenue = revenues.first
+          return if !@town.halt? && revenue.zero?
+
+          x = render_location[:x]
+          y = render_location[:y]
 
           angle = layout == :pointy ? -60 : 0
 
           displacement = @edge ? REVENUE_EDGE_DISPLACEMENT : REVENUE_DISPLACEMENT
 
           increment_weight_for_regions(REVENUE_REGIONS[layout])
-          h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
-              h(:g, { attrs: { transform: "translate(#{displacement} 0) rotate(#{-angle})" } }, [
-                  h(Part::SingleRevenue,
-                    revenue: revenue,
-                    transform: rotation_for_layout),
+          if @town.halt?
+            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
+              h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+                h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
+                  h('text.tile__text', { attrs: { transform: "scale(1.5), rotate(#{-angle})" } }, @town.symbol),
                 ]),
+              ]),
             ])
+          else
+            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
+              h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+                h(:g, { attrs: { transform: "translate(#{displacement} 0) rotate(#{-angle})" } }, [
+                  h(Part::SingleRevenue, revenue: revenue, transform: rotation_for_layout),
+                ]),
+              ]),
+            ])
+          end
         end
 
         def render_part
-          children = [h(:circle, attrs: { transform: translate, fill: @color, r: 10 * (0.8 + @width.to_i / 40) })]
+          children = [h(:circle, attrs: {
+            transform: translate.to_s,
+            r: 10 * (0.8 + @width.to_i / 40),
+            fill: (@town.halt? ? 'gray' : @color),
+            stroke: (@town.halt? ? @color : 'none'),
+            'stroke-width': 4,
+          })]
+
           children << render_revenue
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, { key: "#{@town.id}-d" }, children)

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -89,23 +89,20 @@ module View
           displacement = @edge ? REVENUE_EDGE_DISPLACEMENT : REVENUE_DISPLACEMENT
 
           increment_weight_for_regions(REVENUE_REGIONS[layout])
-          if @town.halt?
-            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
-              h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
-                h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
-                  h('text.tile__text', { attrs: { transform: "scale(1.5), rotate(#{-angle})" } }, @town.symbol),
-                ]),
+
+          h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
+            h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+              h(:g, { attrs: { transform: "translate(#{displacement} 0) rotate(#{-angle})" } }, [
+                if @town.halt?
+                  h('text.tile__text',
+                    { attrs: { transform: "scale(1.5), rotate(#{rotation_for_layout})" } },
+                    @town.symbol)
+                else
+                  h(Part::SingleRevenue, revenue: revenue, transform: rotation_for_layout)
+                end,
               ]),
-            ])
-          else
-            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
-              h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
-                h(:g, { attrs: { transform: "translate(#{displacement} 0) rotate(#{-angle})" } }, [
-                  h(Part::SingleRevenue, revenue: revenue, transform: rotation_for_layout),
-                ]),
-              ]),
-            ])
-          end
+            ]),
+          ])
         end
 
         def render_part

--- a/assets/app/view/game/part/town_rect.rb
+++ b/assets/app/view/game/part/town_rect.rb
@@ -65,8 +65,9 @@ module View
             y: -height / 2,
             width: width,
             height: height,
-            fill: @color,
-            stroke: 'none',
+            fill: (@town.halt? ? 'gray' : @color),
+            stroke: (@town.halt? ? @color : 'none'),
+            'stroke-width': 4,
           })]
 
           if (revenue = render_revenue)
@@ -83,7 +84,7 @@ module View
           return if revenues.size > 1
 
           revenue = revenues.first
-          return if revenue.zero?
+          return if !@town.halt? && revenue.zero?
 
           angle = 0
           displacement = 38
@@ -121,15 +122,25 @@ module View
 
           angle += 180 if reverse_side
 
-          h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
-            h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
-              h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
-                h(SingleRevenue,
-                  revenue: revenue,
-                  transform: "rotate(#{-angle})"),
-              ]),
-            ]),
-          ])
+          if @town.halt?
+            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
+             h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+               h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
+                 h('text.tile__text', { attrs: { transform: "scale(1.5), rotate(#{-angle})" } }, @town.symbol),
+               ]),
+             ]),
+            ])
+          else
+            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
+             h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+               h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
+                 h(SingleRevenue,
+                   revenue: revenue,
+                   transform: "rotate(#{-angle})"),
+               ]),
+             ]),
+            ])
+          end
         end
       end
     end

--- a/assets/app/view/game/part/town_rect.rb
+++ b/assets/app/view/game/part/town_rect.rb
@@ -122,25 +122,17 @@ module View
 
           angle += 180 if reverse_side
 
-          if @town.halt?
-            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
-             h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
-               h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
-                 h('text.tile__text', { attrs: { transform: "scale(1.5), rotate(#{-angle})" } }, @town.symbol),
-               ]),
-             ]),
-            ])
-          else
-            h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
-             h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
-               h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
-                 h(SingleRevenue,
-                   revenue: revenue,
-                   transform: "rotate(#{-angle})"),
-               ]),
-             ]),
-            ])
-          end
+          h(:g, { key: "#{@town.id}-r", attrs: { transform: "translate(#{x.round(2)} #{y.round(2)})" } }, [
+            h(:g, { attrs: { transform: "rotate(#{angle})" } }, [
+              h(:g, { attrs: { transform: "translate(#{displacement} 0) #{rotation_for_layout}" } }, [
+              if @town.halt?
+                h('text.tile__text', { attrs: { transform: "scale(1.5), rotate(#{-angle})" } }, @town.symbol)
+              else
+                h(SingleRevenue, revenue: revenue, transform: "rotate(#{-angle})")
+              end,
+              ]),
+            ]),
+          ])
         end
       end
     end

--- a/lib/engine/config/game/g_1860.rb
+++ b/lib/engine/config/game/g_1860.rb
@@ -87,27 +87,27 @@ module Engine
     "741": {
       "count": 5,
       "color": "yellow",
-      "code": "town=revenue:0;path=a:0,b:_0;path=a:1,b:_0;label=£"
+      "code": "halt=symbol:£;path=a:0,b:_0;path=a:1,b:_0"
     },
     "742": {
       "count": 10,
       "color": "yellow",
-      "code": "town=revenue:0;path=a:0,b:_0;path=a:2,b:_0;label=£"
+      "code": "halt=symbol:£;path=a:0,b:_0;path=a:2,b:_0"
     },
     "743": {
       "count": 7,
       "color": "yellow",
-      "code": "town=revenue:0;path=a:0,b:_0;path=a:3,b:_0;label=£"
+      "code": "halt=symbol:£;path=a:0,b:_0;path=a:3,b:_0"
     },
     "744": {
       "count": 2,
       "color": "yellow",
-      "code": "town=revenue:0,loc:0;town=revenue:0,loc:3;path=a:0,b:_0;path=a:3,b:_1;path=a:_0,b:_1;label=£"
+      "code": "halt=symbol:£,loc:0;halt=symbol:£,loc:3;path=a:0,b:_0;path=a:3,b:_1;path=a:_0,b:_1"
     },
     "745": {
       "count": 2,
       "color": "yellow",
-      "code": "town=revenue:0,loc:0;town=revenue:0,loc:2;path=a:0,b:_0;path=a:2,b:_1;path=a:_0,b:_1;label=£"
+      "code": "halt=symbol:£,loc:0;halt=symbol:£,loc:2;path=a:0,b:_0;path=a:2,b:_1;path=a:_0,b:_1"
     },
     "746": {
       "count": 2,
@@ -132,32 +132,32 @@ module Engine
     "750": {
       "count": 3,
       "color": "green",
-      "code": "town=revenue:0;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;label=£"
+      "code": "halt=symbol:£;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0"
     },
     "751": {
       "count": 3,
       "color": "green",
-      "code": "town=revenue:0;path=a:0,b:_0;path=a:5,b:_0;path=a:3,b:_0;label=£"
+      "code": "halt=symbol:£;path=a:0,b:_0;path=a:5,b:_0;path=a:3,b:_0"
     },
     "752": {
       "count": 3,
       "color": "green",
-      "code": "town=revenue:0;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;label=£"
+      "code": "halt=symbol:£;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0"
     },
     "753": {
       "count": 3,
       "color": "green",
-      "code": "town=revenue:0;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=£"
+      "code": "halt=symbol:£;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0"
     },
     "754": {
       "count": 2,
       "color": "green",
-      "code": "town=revenue:0,loc:0;town=revenue:10,loc:center;path=a:0,b:_0;path=a:2,b:_1;path=a:3,b:_1;path=a:_0,b:_1;label=£"
+      "code": "halt=symbol:£,loc:0;town=revenue:10,loc:center;path=a:0,b:_0;path=a:2,b:_1;path=a:3,b:_1;path=a:_0,b:_1"
     },
     "755": {
       "count": 2,
       "color": "green",
-      "code": "town=revenue:0,loc:0;town=revenue:10,loc:center;path=a:0,b:_0;path=a:4,b:_1;path=a:3,b:_1;path=a:_0,b:_1;label=£"
+      "code": "halt=symbol:£,loc:0;town=revenue:10,loc:center;path=a:0,b:_0;path=a:4,b:_1;path=a:3,b:_1;path=a:_0,b:_1"
     },
     "756": {
       "count": 2,
@@ -182,12 +182,12 @@ module Engine
     "760": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:40,loc:center;city=revenue:40,loc:0.5;path=a:1,b:_1;path=a:2,b:_0;label=V"
+      "code": "city=revenue:40,loc:4;city=revenue:40,loc:0.5;path=a:1,b:_1;path=a:2,b:_0;label=V"
     },
     "761": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:20;town=revenue:0;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:3,b:_1;path=a:_0,b:_1;label=M"
+      "code": "city=revenue:20,loc:center;halt=symbol:£,loc:3;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:3,b:_1;path=a:_0,b:_1;label=M"
     },
     "762": {
       "count": 2,
@@ -292,22 +292,22 @@ module Engine
     "782": {
       "count": 1,
       "color": "brown",
-      "code": "town=revenue:20,loc:center;town=revenue:0,loc:0;path=a:0,b:_1;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1;label=£"
+      "code": "town=revenue:20,loc:center;halt=symbol:£,loc:0;path=a:0,b:_1;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1"
     },
     "783": {
       "count": 1,
       "color": "brown",
-      "code": "town=revenue:20,loc:center;town=revenue:0,loc:0;path=a:0,b:_1;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1;label=£"
+      "code": "town=revenue:20,loc:center;halt=symbol:£,loc:0;path=a:0,b:_1;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1"
     },
     "784": {
       "count": 1,
       "color": "brown",
-      "code": "town=revenue:20,loc:center;town=revenue:0,loc:0;path=a:0,b:_1;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1;label=£"
+      "code": "town=revenue:20,loc:center;halt=symbol:£,loc:0;path=a:0,b:_1;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1"
     },
     "785": {
       "count": 1,
       "color": "brown",
-      "code": "town=revenue:20,loc:center;town=revenue:0,loc:0;path=a:0,b:_1;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:_0,b:_1;label=£"
+      "code": "town=revenue:20,loc:center;halt=symbol:£,loc:0;path=a:0,b:_1;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:_0,b:_1"
     },
     "786": {
       "count": 1,
@@ -317,48 +317,48 @@ module Engine
     "787": {
       "count": 1,
       "color": "yellow",
-      "code": "city=revenue:20,loc:3;town=revenue:10,loc:center;town=revenue:0,loc:0;path=a:0,b:_2;path=a:_2,b:_1;path=a:_0,b:_1;label=C"
+      "code": "city=revenue:20,loc:3;town=revenue:10,loc:center;halt=symbol:£,loc:0;path=a:0,b:_2;path=a:_2,b:_1;path=a:_0,b:_1;label=C"
     },
     "788": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:30,loc:3;town=revenue:10,loc:center;town=revenue:0,loc:0;path=a:0,b:_2;path=a:1,b:_2;path=a:_2,b:_1;path=a:_0,b:_1;label=C"
+      "code": "city=revenue:30,loc:3;town=revenue:10,loc:center;halt=symbol:£,loc:0;path=a:0,b:_2;path=a:1,b:_2;path=a:_2,b:_1;path=a:_0,b:_1;label=C"
     },
     "789": {
       "count": 1,
       "color": "brown",
-      "code": "city=revenue:60,loc:3;town=revenue:20,loc:center;town=revenue:0,loc:0;path=a:0,b:_2;path=a:1,b:_2;path=a:_2,b:_1;path=a:_0,b:_1;label=C"
+      "code": "city=revenue:60,loc:3;town=revenue:20,loc:center;halt=symbol:£,loc:0;path=a:0,b:_2;path=a:1,b:_2;path=a:_2,b:_1;path=a:_0,b:_1;label=C"
     }
   },
   "market": [
     [
-      "0",
-      "7b",
-      "14b",
-      "20b",
-      "26b",
-      "31b",
-      "36b",
-      "40o",
-      "44o",
-      "47o",
-      "50o",
-      "52o",
-      "54y",
-      "56o",
-      "58y",
-      "60o",
-      "62y",
-      "65o",
-      "68y",
-      "71o",
-      "74y",
-      "78o",
-      "82y",
-      "86o",
-      "90y",
-      "95o",
-      "100y",
+      "0c",
+      "7",
+      "14",
+      "20",
+      "26",
+      "31",
+      "36",
+      "40",
+      "44",
+      "47",
+      "50",
+      "52",
+      "54p",
+      "56",
+      "58p",
+      "60",
+      "62p",
+      "65",
+      "68p",
+      "71",
+      "74p",
+      "78",
+      "82p",
+      "86",
+      "90p",
+      "95",
+      "100p",
       "105",
       "110",
       "116",
@@ -367,26 +367,26 @@ module Engine
       "134",
       "142",
       "150",
-      "158b",
-      "166b",
-      "174b",
-      "182b",
-      "191b",
-      "200b",
-      "210b",
-      "220b",
-      "230b",
-      "240b",
-      "250b",
-      "260b",
-      "270b",
-      "280b",
-      "290b",
-      "300b",
-      "310b",
-      "320b",
-      "330b",
-      "340"
+      "158",
+      "166",
+      "174",
+      "182",
+      "191",
+      "200",
+      "210",
+      "220",
+      "230",
+      "240",
+      "250",
+      "260",
+      "270",
+      "280",
+      "290",
+      "300",
+      "310",
+      "320",
+      "330",
+      "340e"
     ]
   ],
   "companies": [
@@ -698,7 +698,7 @@ module Engine
       "city=revenue:30;path=a:2,b:_0;path=a:3,b:_0;label=N": [
         "G5"
       ],
-      "city=revenue:10;town=revenue:10;path=a:5,b:_0;label=M": [
+      "city=revenue:10;town=revenue:0;path=a:5,b:_0;label=M": [
         "G7"
       ],
       "city=revenue:30;path=a:2,b:_0;label=V;border=edge:3,type:impassable": [

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -73,6 +73,10 @@ module Engine
         false
       end
 
+      def halt?
+        false
+      end
+
       def upgrade?
         false
       end

--- a/lib/engine/part/halt.rb
+++ b/lib/engine/part/halt.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'town'
+
+module Engine
+  module Part
+    class Halt < Town
+      attr_reader :symbol
+
+      def initialize(symbol, **opts)
+        @revenue = parse_revenue('0', opts[:format])
+        @groups = (opts[:groups] || '').split('|')
+        @hide = opts[:hide]
+        @visit_cost = (opts[:visit_cost] || 1).to_i
+        @loc = opts[:loc]
+
+        @route = (opts[:route] || :mandatory).to_sym
+        @symbol = symbol
+      end
+
+      def halt?
+        true
+      end
+    end
+  end
+end

--- a/lib/engine/part/halt.rb
+++ b/lib/engine/part/halt.rb
@@ -8,14 +8,8 @@ module Engine
       attr_reader :symbol
 
       def initialize(symbol, **opts)
-        @revenue = parse_revenue('0', opts[:format])
-        @groups = (opts[:groups] || '').split('|')
-        @hide = opts[:hide]
-        @visit_cost = (opts[:visit_cost] || 1).to_i
-        @loc = opts[:loc]
-
-        @route = (opts[:route] || :mandatory).to_sym
         @symbol = symbol
+        super('0', **opts)
       end
 
       def halt?

--- a/lib/engine/part/town.rb
+++ b/lib/engine/part/town.rb
@@ -13,7 +13,7 @@ module Engine
       # it has any paths and either it's not in the center or it is in the center
       # and has less than two exits and less than three paths
       def rect?
-        paths.any? && (@tile.preferred_city_town_edges[self] || (exits.size < 2 && paths.size < 3))
+        paths.any? && paths.size < 3
       end
     end
   end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -103,6 +103,16 @@ module Engine
                               loc: params['loc'])
         cache << town
         town
+      when 'halt'
+        halt = Part::Halt.new(params['symbol'],
+                              groups: params['groups'],
+                              hide: params['hide'],
+                              visit_cost: params['visit_cost'],
+                              route: params['route'],
+                              format: params['format'],
+                              loc: params['loc'])
+        cache << halt
+        halt
       when 'offboard'
         offboard = Part::Offboard.new(params['revenue'],
                                       groups: params['groups'],


### PR DESCRIPTION
Created new tile part: Halt, which is a subclass of Town.
Changed 1860 tile definition to use Halts.
Changed rendering to handle Halts.
Also made other rendering tweaks/fixes so 1860 tiles display correctly.

New:
![877_782](https://user-images.githubusercontent.com/8494213/96283569-a524d700-0f99-11eb-82ab-b1936fe3f8a5.png)
