### PR TITLE
Add master mode to log ( Issue 509 )

### DIFF
--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -34,15 +34,12 @@ module View
         if !hotseat &&
             !action.free? &&
             participant &&
-            !@game.active_players.map(&:name).include?(@user['name']) &&
-            !Lib::Storage[@game.id]&.dig('master_mode')
-          return store(:flash_opts, 'Not your turn. Turn on master mode in the tools tab to act for others.')
-        end
-
-        if !hotseat &&
-          Lib::Storage[@game.id]&.dig('master_mode') &&
-          !@game.active_players.map(&:name).include?(@user['name'])
-          action.master_user = @user['name']
+            !@game.active_players.map(&:name).include?(@user['name'])
+            if !Lib::Storage[@game.id]&.dig('master_mode')
+              return store(:flash_opts, 'Not your turn. Turn on master mode in the tools tab to act for others.')
+            else
+              action.master_user = @user['name']
+            end
         end
 
         game = @game.process_action(action)

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -39,6 +39,12 @@ module View
           return store(:flash_opts, 'Not your turn. Turn on master mode in the tools tab to act for others.')
         end
 
+        if !hotseat &&
+          Lib::Storage[@game.id]&.dig('master_mode') &&
+          !@game.active_players.map(&:name).include?(@user['name'])
+          action.master_user = @user['name']
+        end
+
         game = @game.process_action(action)
         @game_data[:actions] << action.to_h
         store(:game_data, @game_data, skip: true)

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -40,7 +40,7 @@ module View
             return store(:flash_opts, 'Not your turn. Turn on master mode in the tools tab to act for others.')
           end
 
-          action.master_user = @user['name']
+          action.user = @user['name']
         end
 
         game = @game.process_action(action)

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -32,14 +32,15 @@ module View
         end
 
         if !hotseat &&
-            !action.free? &&
-            participant &&
-            !@game.active_players.map(&:name).include?(@user['name'])
-            if !Lib::Storage[@game.id]&.dig('master_mode')
-              return store(:flash_opts, 'Not your turn. Turn on master mode in the tools tab to act for others.')
-            else
-              action.master_user = @user['name']
-            end
+          !action.free? &&
+          participant &&
+          !@game.active_players.map(&:name).include?(@user['name'])
+
+          unless Lib::Storage[@game.id]&.dig('master_mode')
+            return store(:flash_opts, 'Not your turn. Turn on master mode in the tools tab to act for others.')
+          end
+
+          action.master_user = @user['name']
         end
 
         game = @game.process_action(action)

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -13,7 +13,7 @@ module Engine
       def self.from_h(h, game)
         entity = game.get(h['entity_type'], h['entity'])
         obj = new(entity, **h_to_args(h, game))
-        obj.user = h['user'] unless h['user'] == entity.owner.name
+        obj.user = h['user'] unless h['user'] == entity.player
         obj
       end
 

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -12,7 +12,9 @@ module Engine
 
       def self.from_h(h, game)
         entity = game.get(h['entity_type'], h['entity'])
-        new(entity, **h_to_args(h, game))
+        obj = new(entity, **h_to_args(h, game))
+        obj.master_user = h['master_user'] if !h['master_user'].nil?
+        obj
       end
 
       def self.h_to_args(_h, _game)
@@ -37,7 +39,7 @@ module Engine
           'entity' => entity.id,
           'entity_type' => type_s(entity),
           'id' => @id,
-          'master_user' => master_user,
+          'master_user' => @master_user,
           **args_to_h,
         }.reject { |_, v| v.nil? }
       end

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -8,12 +8,12 @@ module Engine
       include Helper::Type
 
       attr_reader :entity
-      attr_accessor :id, :master_user
+      attr_accessor :id, :user
 
       def self.from_h(h, game)
         entity = game.get(h['entity_type'], h['entity'])
         obj = new(entity, **h_to_args(h, game))
-        obj.master_user = h['master_user'] unless h['master_user'].nil?
+        obj.user = h['user'] unless h['user'] == entity.owner.name
         obj
       end
 
@@ -39,7 +39,7 @@ module Engine
           'entity' => entity.id,
           'entity_type' => type_s(entity),
           'id' => @id,
-          'master_user' => @master_user,
+          'user' => @user,
           **args_to_h,
         }.reject { |_, v| v.nil? }
       end

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -8,7 +8,7 @@ module Engine
       include Helper::Type
 
       attr_reader :entity
-      attr_accessor :id
+      attr_accessor :id, :master_user
 
       def self.from_h(h, game)
         entity = game.get(h['entity_type'], h['entity'])
@@ -37,6 +37,7 @@ module Engine
           'entity' => entity.id,
           'entity_type' => type_s(entity),
           'id' => @id,
+          'master_user' => master_user,
           **args_to_h,
         }.reject { |_, v| v.nil? }
       end

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -13,7 +13,7 @@ module Engine
       def self.from_h(h, game)
         entity = game.get(h['entity_type'], h['entity'])
         obj = new(entity, **h_to_args(h, game))
-        obj.master_user = h['master_user'] if !h['master_user'].nil?
+        obj.master_user = h['master_user'] unless h['master_user'].nil?
         obj
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -443,13 +443,14 @@ module Engine
 
       def process_action(action)
         action = action_from_h(action) if action.is_a?(Hash)
+
         action.id = current_action_id
         if action.is_a?(Action::Undo) || action.is_a?(Action::Redo)
           @actions << action
           return clone(@actions)
         end
 
-        @log << "- Action via Master Mode by #{action.master_user} -" if !action.master_user.nil?
+        @log << "- Action(#{action.type}) via Master Mode by #{action.master_user} -" if !action.master_user.nil?
 
         @round.process_action(action)
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -449,7 +449,7 @@ module Engine
           return clone(@actions)
         end
 
-        @log << "• Action(#{action.type}) via Master Mode by #{action.master_user}:" unless action.master_user.nil?
+        @log << "• Action(#{action.type}) via Master Mode by #{action.user}:" if action.user
 
         @round.process_action(action)
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -443,14 +443,13 @@ module Engine
 
       def process_action(action)
         action = action_from_h(action) if action.is_a?(Hash)
-
         action.id = current_action_id
         if action.is_a?(Action::Undo) || action.is_a?(Action::Redo)
           @actions << action
           return clone(@actions)
         end
 
-        @log << "• Action(#{action.type}) via Master Mode by #{action.master_user}:" if !action.master_user.nil?
+        @log << "• Action(#{action.type}) via Master Mode by #{action.master_user}:" unless action.master_user.nil?
 
         @round.process_action(action)
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -449,6 +449,8 @@ module Engine
           return clone(@actions)
         end
 
+        @log << "- Action via Master Mode by #{action.master_user} -" if !action.master_user.nil?
+
         @round.process_action(action)
 
         unless action.is_a?(Action::Message)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -450,7 +450,7 @@ module Engine
           return clone(@actions)
         end
 
-        @log << "- Action(#{action.type}) via Master Mode by #{action.master_user} -" if !action.master_user.nil?
+        @log << "• Action(#{action.type}) via Master Mode by #{action.master_user}:" if !action.master_user.nil?
 
         @round.process_action(action)
 

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -89,6 +89,8 @@ class Api
                 action_id = r.params['id']
                 halt(400, 'Game out of sync') unless engine.actions.size + 1 == action_id
 
+                r.params['user'] = user.name
+
                 engine = engine.process_action(r.params)
                 action = engine.actions.last.to_h
 


### PR DESCRIPTION
Resolves #509 

This is a normal action
```
{
  "type": "bid",
  "entity": "Vanish",
  "entity_type": "player",
  "id": 2,
  "company": "O&I",
  "price": 40
},
```

This an action when taken with master mode and it isn't your turn
```
{
  "type": "bid",
  "entity": "Garramon",
  "entity_type": "player",
  "id": 3,
  "master_user": "Vanish",
  "company": "C&WI",
  "price": 60
},
```
_Note: Currently, the value of master_user is the user['name'] following the pattern set by entity. It could be the user['id'], with the name fetched at display time. That might be a better implementation for the future. Thoughts?_

Sample of log output
<img width="461" alt="Screen Shot 2020-10-16 at 1 05 38 PM" src="https://user-images.githubusercontent.com/15675400/96304328-22ac0f80-0fb9-11eb-86bb-cb6e704d12fd.png">

**lib/engine/action/base.rb** - I don't love the code here. I feel like there is probably a cleaner way to implement within the other methods of the action class. However, subclasses directly implement _self.h_to_args_  without using super and thus any changes to those functions would require refactoring many classes. Maybe that refactor is still the way to go?