### PR TITLE
Add company indicators to 18TN ( Issue 1879 )

### DIFF
--- a/lib/engine/config/game/g_18_tn.rb
+++ b/lib/engine/config/game/g_18_tn.rb
@@ -490,7 +490,6 @@ module Engine
             "H7"
          ],
          "upgrade=cost:60,terrain:mountain":[
-            "E16",
             "B15",
             "C14",
             "C18",
@@ -504,14 +503,21 @@ module Engine
             "I16",
             "J13"
          ],
+         "upgrade=cost:60,terrain:mountain;icon=image:18_tn/owr":[
+            "E16"
+         ],
          "upgrade=cost:120,terrain:mountain":[
-            "F19",
-            "H17",
             "F21",
             "G18",
             "G20"
          ],
-         "city=revenue:0;upgrade=cost:60,terrain:water":[
+         "upgrade=cost:120,terrain:mountain;icon=image:18_tn/etwcr":[
+            "F19"
+         ],
+         "upgrade=cost:120,terrain:mountain;icon=image:18_tn/tcc":[
+            "H17"
+         ],
+         "city=revenue:0;upgrade=cost:60,terrain:water;icon=image:18_tn/mcr":[
             "H3"
          ],
          "town=revenue:0;upgrade=cost:40,terrain:water":[

--- a/public/icons/18_tn/etwcr.svg
+++ b/public/icons/18_tn/etwcr.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 115 78" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <rect x="1.15" y="1.15" width="112.62" height="75" style="fill:white;stroke:rgb(35,31,32);stroke-width:2.31px;"/>
+    <g id="t" transform="matrix(0.696522,0,0,1.16432,2.68708,-9.11232)">
+        <text x="6.601px" y="57.199px" style="font-family:'Athelas-Bold', 'Athelas';font-weight:700;font-size:49.71px;">ETW<tspan x="116.211px " y="57.199px ">C</tspan></text>
+    </g>
+</svg>

--- a/public/icons/18_tn/mcr.svg
+++ b/public/icons/18_tn/mcr.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 115 78" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <rect x="1.15" y="1.15" width="112.62" height="75" style="fill:white;stroke:rgb(35,31,32);stroke-width:2.31px;"/>
+    <g transform="matrix(0.922768,0,0,1.16432,0.743833,-9.11232)">
+        <text x="6.601px" y="57.199px" style="font-family:'Athelas-Bold', 'Athelas';font-weight:700;font-size:49.71px;">M<tspan x="51.34px 84.148px " y="57.199px 57.199px ">CR</tspan></text>
+    </g>
+</svg>

--- a/public/icons/18_tn/owr.svg
+++ b/public/icons/18_tn/owr.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 115 78" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <rect x="1.15" y="1.15" width="112.62" height="75" style="fill:white;stroke:rgb(35,31,32);stroke-width:2.31px;"/>
+    <g id="t" transform="matrix(0.843854,0,0,1.16432,1.47291,-9.11232)">
+        <text x="6.601px" y="57.199px" style="font-family:'Athelas-Bold', 'Athelas';font-weight:700;font-size:49.71px;">O<tspan x="41.249px 90.312px " y="57.199px 57.199px ">WR</tspan></text>
+    </g>
+</svg>

--- a/public/icons/18_tn/tcc.svg
+++ b/public/icons/18_tn/tcc.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 115 78" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <rect x="1.15" y="1.15" width="112.62" height="75" style="fill:white;stroke:rgb(35,31,32);stroke-width:2.31px;"/>
+    <g id="t" transform="matrix(1.04584,0,0,1.16432,-0.313203,-9.11232)">
+        <text x="6.601px" y="57.199px" style="font-family:'Athelas-Bold', 'Athelas';font-weight:700;font-size:49.71px;">T<tspan x="38.465px 70.528px " y="57.199px 57.199px ">CC</tspan></text>
+    </g>
+</svg>


### PR DESCRIPTION
Resolves #1879 

Handle bars are typically used for blocked hexes. This implementation mirrors how 1846 handles denoting tile lay placements for private company hexes that are not blocked.

<img width="182" alt="Screen Shot 2020-10-16 at 3 09 36 PM" src="https://user-images.githubusercontent.com/15675400/96309012-ac5fdb00-0fc1-11eb-847e-8dd344cf6ee7.png">

<img width="398" alt="Screen Shot 2020-10-16 at 3 09 45 PM" src="https://user-images.githubusercontent.com/15675400/96309014-ad910800-0fc1-11eb-8c30-de4e48a9e4bb.png">
