### PR TITLE
Add ZigZag market for 1860

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -20,6 +20,7 @@ module View
         yellow: '#ffff99',
         black: '#000000',
         gray: '#888888',
+        green: '#aaffaa',
       }.freeze
 
       # All markets
@@ -43,6 +44,29 @@ module View
       RIGHT_TOKEN_POS = RIGHT_MARGIN - TOKEN_SIZE # left edge of rightmost token
       MID_TOKEN_POS = (LEFT_TOKEN_POS + RIGHT_TOKEN_POS) / 2
 
+      TOKEN_STYLE_1D = {
+        textAlign: 'center',
+        lineHeight: '0',
+      }.freeze
+
+      PRICE_STYLE_1D = {
+        fontSize: '100%',
+        textAlign: 'center',
+      }.freeze
+
+      def box_style_1d
+        {
+          position: 'relative',
+          display: 'inline-block',
+          padding: "#{PAD}px",
+          margin: '0',
+          verticalAlign: 'top',
+          width: "#{WIDTH_TOTAL - 2 * PAD - 2 * BORDER}px",
+          border: "solid #{BORDER}px rgba(0,0,0,0.2)",
+          color: color_for(:font2),
+        }
+      end
+
       def cell_style(box_style, price)
         style = box_style.merge(backgroundColor: price.color ? COLOR_MAP[price.color] : color_for(:bg2))
         if price.color == :black
@@ -53,26 +77,7 @@ module View
       end
 
       def grid_1d
-        box_style = {
-          position: 'relative',
-          display: 'inline-block',
-          padding: "#{PAD}px",
-          margin: '0',
-          verticalAlign: 'top',
-          width: "#{WIDTH_TOTAL - 2 * PAD - 2 * BORDER}px",
-          border: "solid #{BORDER}px rgba(0,0,0,0.2)",
-          color: color_for(:font2),
-        }
-
-        tokens_style = {
-          textAlign: 'center',
-          lineHeight: '0',
-        }
-
-        price_style = {
-          fontSize: '100%',
-          textAlign: 'center',
-        }
+        box_style = box_style_1d
 
         max_num_corps = @game.stock_market.market.first.map { |p| p.corporations.size }.push(MIN_NUM_TOKENS).max
         box_height = max_num_corps * (TOKEN_SIZE + VERTICAL_TOKEN_PAD) + VERTICAL_TOKEN_PAD + PRICE_HEIGHT + 2 * PAD
@@ -88,12 +93,52 @@ module View
           end
 
           h(:div, { style: cell_style(box_style, price) }, [
-            h(:div, { style: price_style }, price.price),
-            h(:div, { style: tokens_style }, tokens),
+            h(:div, { style: PRICE_STYLE_1D }, price.price),
+            h(:div, { style: TOKEN_STYLE_1D }, tokens),
           ])
         end
 
         [h(:div, { style: { width: 'max-content' } }, row)]
+      end
+
+      def grid_zigzag
+        box_style = box_style_1d
+
+        half_box_style = box_style_1d
+        half_box_style[:width] = "#{WIDTH_TOTAL / 2 - 2 * PAD - 2 * BORDER}px"
+
+        max_num_corps = @game.stock_market.market.first.map { |p| p.corporations.size }.push(MIN_NUM_TOKENS).max
+        box_height = max_num_corps * (TOKEN_SIZE + VERTICAL_TOKEN_PAD) + VERTICAL_TOKEN_PAD + PRICE_HEIGHT + 2 * PAD
+        box_style[:height] = "#{box_height - 2 * PAD - 2 * BORDER}px"
+        half_box_style[:height] = "#{box_height - 2 * PAD - 2 * BORDER}px"
+
+        row0 = []
+        row1 = [h(:div, style: cell_style(half_box_style, @game.stock_market.market.first.first))]
+
+        @game.stock_market.market.first.each_with_index do |price, idx|
+          tokens = price.corporations.map do |corporation|
+            props = {
+              attrs: { src: corporation.logo, width: "#{TOKEN_SIZE}px" },
+              style: { marginTop: "#{VERTICAL_TOKEN_PAD}px" },
+            }
+            h(:img, props)
+          end
+
+          element = h(:div, { style: cell_style(box_style, price) }, [
+                      h(:div, { style: PRICE_STYLE_1D }, price.price),
+                      h(:div, { style: TOKEN_STYLE_1D }, tokens),
+                    ])
+          if idx.even?
+            row0 << element
+          else
+            row1 << element
+          end
+        end
+
+        row1 << h(:div, style: cell_style(half_box_style, @game.stock_market.market.first.last))
+
+        [h(:div, { style: { width: 'max-content' } }, row0),
+         h(:div, { style: { width: 'max-content' } }, row1)]
       end
 
       def grid_2d
@@ -148,7 +193,15 @@ module View
           color: color_for(:font2),
         )
 
-        grid = @game.stock_market.one_d? ? grid_1d : grid_2d
+        grid = if @game.stock_market.one_d?
+                 if @game.stock_market.zigzag?
+                   grid_zigzag
+                 else
+                   grid_1d
+                 end
+               else
+                 grid_2d
+               end
 
         children = []
         children << h(Bank, game: @game) if @game.game_end_check_values.include?(:bank)
@@ -164,6 +217,8 @@ module View
             [:endgame, 'End game trigger'],
             [:liquidation, 'Liquidation'],
             [:acquisition, 'Acquisition'],
+            [:repar, 'Par value after bankruptcy'],
+            [:ignore_one_sale, 'Ignore first share sold when moving price'],
           ]
 
           types_in_market = @game.stock_market.market.flatten.compact.map { |p| [p.type, p.color] }.to_h

--- a/lib/engine/config/game/g_1860.rb
+++ b/lib/engine/config/game/g_1860.rb
@@ -333,31 +333,31 @@ module Engine
   "market": [
     [
       "0c",
-      "7",
-      "14",
-      "20",
-      "26",
-      "31",
-      "36",
-      "40",
-      "44",
-      "47",
-      "50",
-      "52",
+      "7i",
+      "14i",
+      "20i",
+      "26i",
+      "31i",
+      "36i",
+      "40r",
+      "44r",
+      "47r",
+      "50r",
+      "52r",
       "54p",
-      "56",
+      "56r",
       "58p",
-      "60",
+      "60r",
       "62p",
-      "65",
+      "65r",
       "68p",
-      "71",
+      "71r",
       "74p",
-      "78",
+      "78r",
       "82p",
-      "86",
+      "86r",
       "90p",
-      "95",
+      "95r",
       "100p",
       "105",
       "110",
@@ -367,25 +367,25 @@ module Engine
       "134",
       "142",
       "150",
-      "158",
-      "166",
-      "174",
-      "182",
-      "191",
-      "200",
-      "210",
-      "220",
-      "230",
-      "240",
-      "250",
-      "260",
-      "270",
-      "280",
-      "290",
-      "300",
-      "310",
-      "320",
-      "330",
+      "158i",
+      "166i",
+      "174i",
+      "182i",
+      "191i",
+      "200i",
+      "210i",
+      "220i",
+      "230i",
+      "240i",
+      "250i",
+      "260i",
+      "270i",
+      "280i",
+      "290i",
+      "300i",
+      "310i",
+      "320i",
+      "330i",
       "340e"
     ]
   ],
@@ -469,6 +469,14 @@ module Engine
         100,
         100
       ],
+      "par_range": [
+        74,
+        100
+      ],
+      "repar_range": [
+        40,
+        100
+      ],
       "coordinates": "F2",
       "color": "lightBlue",
       "text_color": "black"
@@ -483,6 +491,14 @@ module Engine
         100,
         100
       ],
+      "par_range": [
+        74,
+        100
+      ],
+      "repar_range": [
+        40,
+        100
+      ],
       "coordinates": "I3",
       "color": "red"
     },
@@ -494,6 +510,14 @@ module Engine
         0,
         40,
         100
+      ],
+      "par_range": [
+        62,
+        82
+      ],
+      "repar_range": [
+        40,
+        82
       ],
       "coordinates": "G7",
       "color": "black"
@@ -507,6 +531,14 @@ module Engine
         40,
         100
       ],
+      "par_range": [
+        62,
+        82
+      ],
+      "repar_range": [
+        40,
+        82
+      ],
       "coordinates": "B4",
       "color": "green"
     },
@@ -517,6 +549,14 @@ module Engine
       "tokens": [
         0,
         40
+      ],
+      "par_range": [
+        58,
+        68
+      ],
+      "repar_range": [
+        40,
+        68
       ],
       "coordinates": "G9",
       "color": "yellow",
@@ -530,6 +570,14 @@ module Engine
         0,
         40
       ],
+      "par_range": [
+        58,
+        68
+      ],
+      "repar_range": [
+        40,
+        68
+      ],
       "coordinates": "L6",
       "color": "pink"
     },
@@ -541,6 +589,14 @@ module Engine
         0,
         40
       ],
+      "par_range": [
+        54,
+        62
+      ],
+      "repar_range": [
+        40,
+        62
+      ],
       "coordinates": "F12",
       "color": "violet"
     },
@@ -551,6 +607,14 @@ module Engine
       "tokens": [
         0,
         40
+      ],
+      "par_range": [
+        54,
+        62
+      ],
+      "repar_range": [
+        40,
+        62
       ],
       "coordinates": "E9",
       "color": "brightGreen"

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -31,14 +31,16 @@ module Engine
           Step::Bankrupt,
           Step::Exchange,
           Step::DiscardTrain,
-          Step::BuyCompany,
           Step::Track,
           Step::Token,
           Step::Route,
           Step::Dividend,
           Step::BuyTrain,
-          [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
+      end
+
+      def init_stock_market
+        StockMarket.new(self.class::MARKET, [], zigzag: true)
       end
 
       def active_players

--- a/lib/engine/share_price.rb
+++ b/lib/engine/share_price.rb
@@ -27,6 +27,10 @@ module Engine
           %i[red liquidation]
         when /a/
           %i[gray acquisition]
+        when /r/
+          %i[gray repar]
+        when /i/
+          %i[green ignore_one_sale]
         end
 
       SharePrice.new([row, column],

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -6,8 +6,9 @@ module Engine
   class StockMarket
     attr_reader :market, :par_prices
 
-    def initialize(market, unlimited_colors, multiple_buy_colors: [])
+    def initialize(market, unlimited_colors, multiple_buy_colors: [], zigzag: nil)
       @par_prices = []
+      @zigzag = zigzag
       @market = market.map.with_index do |row, r_index|
         row.map.with_index do |code, c_index|
           price = SharePrice.from_code(code,
@@ -27,6 +28,10 @@ module Engine
 
     def one_d?
       @one_d ||= @market.one?
+    end
+
+    def zigzag?
+      !!@zigzag
     end
 
     def set_par(corporation, share_price)


### PR DESCRIPTION
Adding support for a new market type: Zig-zag. It's basically a variation of a 1D market:

![1860_stock_market](https://user-images.githubusercontent.com/8494213/96353712-e4cbeb80-108b-11eb-9296-f723fe024ccf.png)

I also added two new share-price types: "repar" and "ignore_one_sale". I added it to the base SharePrice as opposed to a game-specific class because I needed a corresponding change in the UI StockMarket view.  I suspect all of this (price types) should be eventually refactored to be completely game defined and make the UI as generic as possible.