### PR TITLE
No grey tiles exist in 18GA

### DIFF
--- a/lib/engine/config/game/g_18_ga.rb
+++ b/lib/engine/config/game/g_18_ga.rb
@@ -655,8 +655,7 @@ module Engine
          "tiles":[
             "yellow",
             "green",
-            "brown",
-            "gray"
+            "brown"
          ],
          "operating_rounds":3
       }


### PR DESCRIPTION
Closes #1895 

I checked the Info page locally and this fixed the issue, but I'm not sure if there are any other implications of this change. 