### PR TITLE
[1846, 18 Los Angeles] fix C&WI (and PMC) giving free token in connected other city

### DIFF
--- a/lib/engine/step/g_18_ga/token.rb
+++ b/lib/engine/step/g_18_ga/token.rb
@@ -17,7 +17,7 @@ module Engine
           []
         end
 
-        def adjust_token_price_ability!(entity, token, hex)
+        def adjust_token_price_ability!(entity, token, hex, city)
           return [token, nil] if @game.active_step.current_entity.corporation?
 
           super

--- a/lib/engine/step/g_18_ms/token.rb
+++ b/lib/engine/step/g_18_ms/token.rb
@@ -36,7 +36,7 @@ module Engine
           entity.cash += one_time_bonus
         end
 
-        def adjust_token_price_ability!(entity, token, hex)
+        def adjust_token_price_ability!(entity, token, hex, city)
           return [token, nil] if @game.active_step.current_entity.corporation?
 
           super

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -36,7 +36,7 @@ module Engine
 
         @game.game_error('Token is already used') if token.used
 
-        token, ability = adjust_token_price_ability!(entity, token, hex)
+        token, ability = adjust_token_price_ability!(entity, token, hex, city)
         entity.remove_ability(ability) if ability
         free = !token.price.positive?
         city.place_token(entity, token, free: free)
@@ -71,7 +71,7 @@ module Engine
         prices.compact.min
       end
 
-      def adjust_token_price_ability!(entity, token, hex)
+      def adjust_token_price_ability!(entity, token, hex, city)
         if (teleport = @round.teleported?(entity))
           token.price = 0
           return [token, teleport]
@@ -79,6 +79,7 @@ module Engine
 
         entity.abilities(:token) do |ability, _|
           next if ability.hexes.any? && !ability.hexes.include?(hex.id)
+          next if ability.city && ability.city != city.index
 
           # check if this is correct or should be a corporation
           token = Engine::Token.new(entity) if ability.extra


### PR DESCRIPTION
Should only be able to give the free token in the originally reserved city, not another city even if the owning corporation is connected.

Reported as an 18 Los Angeles problem, but unsurprisingly also applies to 1846

[Fixes #1897]