### PR TITLE
[18 Los Angeles] fix terrain border not disappearing when completed by a company

### DIFF
--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -92,6 +92,9 @@ module Engine
         terrain = old_tile.terrain
         cost =
           if free
+            # call for the side effect of deleting a completed border cost
+            border_cost(tile, entity)
+
             extra_cost
           else
             border, border_types = border_cost(tile, entity)


### PR DESCRIPTION
in 18 Los Angeles, Beverly Hills Company can lay track pointing towards
Hollywood and completing the bridge; even though it doesn't have to pay for
this cost, the border needs to be removed

[Fixes #1906]