### PR TITLE
18MEX: Improve presentation of fractional/reserved shares (fixes #1848)

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -23,7 +23,7 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :share_price, :par_via_exchange
-    attr_reader :capitalization, :companies, :min_price, :name, :full_name
+    attr_reader :capitalization, :companies, :min_price, :name, :full_name, :fraction_shares
     attr_writer :par_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze
@@ -37,6 +37,7 @@ module Engine
       end
 
       shares.each { |share| shares_by_corporation[self] << share }
+      @fraction_shares = shares.find { |s| (s.percent % 10).positive? }
       @presidents_share = shares.first
       @second_share = shares[1]
 
@@ -97,6 +98,10 @@ module Engine
 
     def reserved_shares
       shares_by_corporation[self].reject(&:buyable)
+    end
+
+    def num_ipo_reserved_shares
+      reserved_shares.sum(&:percent) / share_percent
     end
 
     def num_player_shares

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -16,7 +16,7 @@ module Engine
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18MEX'
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
-      IPO_RESERVED_NAME = 'Trade-in shares'
+      IPO_RESERVED_NAME = 'Trade-in'
 
       STANDARD_GREEN_CITY_TILES = %w[14 15 619].freeze
       CURVED_YELLOW_CITY = %w[5 6].freeze


### PR DESCRIPTION
If there are reserved shares, do deduct them from IPO nunber shown
and show them on a line of their own (without price).

In case the corporation uses fractional shares (e.g. NdM uses
5% shares that appear as 0.5) then show one digit fraction even
if the share number to show has fraction .0. This will make for
better reading of the share number.