### PR TITLE
18MEX: Fix 4 errors reported

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -143,6 +143,8 @@ module View
         holdings =
           if !@corporation.corporation? || @corporation.floated?
             h(:div, holdings_props, [render_trains, render_cash])
+          elsif @corporation.cash.positive?
+            h(:div, holdings_props, [render_to_float, render_cash])
           else
             h(:div, holdings_props, "#{@corporation.percent_to_float}% to float")
           end
@@ -156,6 +158,10 @@ module View
 
       def render_cash
         render_header_segment(@game.format_currency(@corporation.cash), 'Cash')
+      end
+
+      def render_to_float
+        render_header_segment("#{@corporation.percent_to_float}%", 'to float')
       end
 
       def render_trains

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -252,7 +252,7 @@ module Engine
          "name":"Kansas City, Mexico, & Orient Railroad",
          "value":40,
          "revenue":10,
-         "desc":"Owning corporation may place the non-upgradable Copper Canyan tile in F5 for $60 (instead of the normal $120) unless that hex is already built. The tile lay does not have to be connected to an existing station token of the owning corporation. The lay does not count toward the normal lay limit but must be done during tile lay.",
+         "desc":"Owning corporation may place the non-upgradable Copper Canyon tile in F5 for $60 (instead of the normal $120) unless that hex is already built. The tile lay does not have to be connected to an existing station token of the owning corporation. The lay does not count toward the normal lay limit but must be done during tile lay.",
          "abilities": [
             {
               "type": "tile_lay",

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -260,11 +260,11 @@ module Engine
           p.shares_of(major).dup.each do |s|
             next unless s
 
-            share_pool.move_share(s, @neutral)
+            remove_share(major, s)
             if s.president
               # Rule 5d: Give owner of presidency share (if any) the reserved share
               # Might trigger presidency change in NdM
-              share_pool.buy_shares(major.shares[0].player, ndm_merge_share, exchange: :free, exchange_price: 0)
+              @share_pool.buy_shares(major.shares[0].player, ndm_merge_share, exchange: :free, exchange_price: 0)
             else
               bank.spend(refund, p) if refund.positive?
               refund_count += 1
@@ -417,7 +417,7 @@ module Engine
         @log << "-- Minor #{minor.name} merges into #{major.name} who receives the treasury of #{treasury} --"
 
         share.buyable = true
-        share_pool.buy_shares(minor.player, share, exchange: :free, exchange_price: 0)
+        @share_pool.buy_shares(minor.player, share, exchange: :free, exchange_price: 0)
 
         hexes.each do |hex|
           hex.tile.cities.each do |city|
@@ -467,6 +467,12 @@ module Engine
         # Auto merge single if it is non-floated
         candidate = @mergable_candidates.first
         merge_major(candidate) if @mergable_candidates.one? && !candidate.floated?
+      end
+
+      def remove_share(major, share)
+        share.owner.shares_by_corporation[major].delete(share)
+        @neutral.shares_by_corporation[major] << share
+        share.owner = @neutral
       end
     end
   end


### PR DESCRIPTION
Fixed spelling error for Copper Canyon private.

Fix three reported bugs:
- #1916 Show treasury for unfloated corporation if it is non-zero
- #1917 Fix invalid method call during NdM merge
- #1918 Place NdM in home city for merged even if merged haven't operated yet
- #1919 Fix invalid exchange token swap during NdM merge

