### PR TITLE
18MEX: Remove train from closing minor (fixes #1926)

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -448,6 +448,11 @@ module Engine
           end
         end
 
+        # Delete train so it wont appear in rust message
+        train = minor.trains.first
+        minor.remove_train(train)
+        trains.delete(train)
+
         @minors.delete(minor)
       end
 


### PR DESCRIPTION
By deleting the train when minor close it will not appear in
the rusting message.