### PR TITLE
18MEX: Add mining icon in the Copper Canyon hex (fixes #1923)

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -754,7 +754,9 @@ module Engine
             "H5",
             "I6",
             "N9",
-            "P9",
+            "P9"
+         ],
+         "upgrade=cost:120,terrain:mountain;icon=image:18_al/coal":[
             "F5"
          ],
          "upgrade=cost:120,terrain:mountain;border=edge:4,type:impassable":[


### PR DESCRIPTION
Visual update of hex F5 to make it indicate that this hex is special.
This might be improved in the future.