### PR TITLE
Add desktop notification toggle

### DIFF
--- a/assets/app/lib/notification.rb
+++ b/assets/app/lib/notification.rb
@@ -13,19 +13,31 @@ module Lib
       }
     end
 
-    def self.notify(message)
+    def self.notify(message, send_focused)
       %x{
-        if ("Notification" in window) {
-          if (Notification.permission === "granted") {
-            new Notification(#{message});
+        let is_hidden = document.hidden;
+        let in_focus = document.hasFocus();
+
+        let send_notification = (msg) => {
+          if ("Notification" in window) {
+            if (Notification.permission === "granted") {
+              new Notification(msg);
+            }
+            else if (Notification.permission !== "denied") {
+              Notification.requestPermission().then(function (permission) {
+                if (permission === "granted") {
+                  new Notification(msg);
+                }
+              });
+            }
           }
-          else if (Notification.permission !== "denied") {
-            Notification.requestPermission().then(function (permission) {
-              if (permission === "granted") {
-                new Notification(#{message});
-              }
-            });
-          }
+        }
+        // Dont send the notification unless the window is active and 
+        // user has the notification setting on
+        if (!#{send_focused} && !is_hidden && !in_focus) {
+
+        } else {
+          send_notification(#{message})
         }
       }
     end

--- a/assets/app/lib/notification.rb
+++ b/assets/app/lib/notification.rb
@@ -12,5 +12,22 @@ module Lib
         }
       }
     end
+
+    def self.notify(message)
+      %x{
+        if ("Notification" in window) {
+          if (Notification.permission === "granted") {
+            new Notification(#{message});
+          }
+          else if (Notification.permission !== "denied") {
+            Notification.requestPermission().then(function (permission) {
+              if (permission === "granted") {
+                new Notification(#{message});
+              }
+            });
+          }
+        }
+      }
+    end
   end
 end

--- a/assets/app/lib/notification.rb
+++ b/assets/app/lib/notification.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Lib
+  module Notification
+    def self.ask_permission
+      %x{
+        if ("Notification" in window) {
+          if (Notification.permission === "default") {
+            Notification.requestPermission().then(function(permission) {
+            })
+          }
+        }
+      }
+    end
+  end
+end

--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -20,6 +20,7 @@ module Lib
 
     SETTINGS = {
       notifications: true,
+      desktop_notifications: false,
       red_logo: false,
       bg: DARK ? '#000000' : '#ffffff',
       bg2: DARK ? '#dcdcdc' : '#d3d3d3',

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -110,6 +110,14 @@ module View
           game_data['actions'] << data
           store(:game_data, game_data, skip: true)
           store(:game, game.process_action(data))
+
+          begin
+            if @game_data["acting"].include? @user['id']
+              Lib::Notification.notify("18xx - Game #{@game.id.to_s} Your turn", setting_for(:desktop_notifications))
+          end
+          rescue => e
+            puts e
+          end
         elsif n_id > o_id
           store['connection'].get(game_path) do |new_data|
             store(:game_data, new_data, skip: true)

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -2,6 +2,7 @@
 
 require 'game_manager'
 require 'lib/settings'
+require 'lib/notification'
 require 'lib/storage'
 require 'view/chat'
 require 'view/game_row'
@@ -58,6 +59,13 @@ module View
       `document.title = #{(acting ? '* ' : '') + '18xx.Games'}`
       change_favicon(acting)
       change_tab_color(acting)
+
+      @connection.subscribe('/games') do |data|
+        update_game(data)
+        if data['acting']&.include?(@user['id'])
+          Lib::Notification.notify('18xx - Game ' + data['id'].to_s + ' - Your turn')
+        end
+      end
 
       destroy = lambda do
         `clearTimeout(#{@refreshing})`

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -3,6 +3,7 @@
 require 'game_manager'
 require 'user_manager'
 require 'lib/settings'
+require 'lib/notification'
 require 'view/game_row'
 require 'view/logo'
 require 'view/form'
@@ -39,6 +40,7 @@ module View
         when :profile
           ['Profile Settings', [
             render_notifications(setting_for(:notifications)),
+            render_desktop_notifications(setting_for(:desktop_notifications)),
             h('div#settings__colors', [
               render_logo_color(setting_for(:red_logo)),
               h(:div, [
@@ -119,6 +121,18 @@ module View
           id: :notifications,
           type: :checkbox,
           attrs: { checked: checked },
+        ),
+      ])
+    end
+
+    def render_desktop_notifications(checked = false)
+      h('div#settings__desktop_notifications', [
+        render_input(
+          'Allow Desktop Turn and Message Notifications while in game',
+          id: :desktop_notifications,
+          type: :checkbox,
+          attrs: { checked: checked },
+          on: { change: -> { Lib::Notification.ask_permission } },
         ),
       ])
     end

--- a/models/user.rb
+++ b/models/user.rb
@@ -15,7 +15,7 @@ class User < Base
       "r#{index}_#{prop}"
     end
   end + %w[
-    consent notifications red_logo bg font bg2 font2 your_turn white yellow green
+    consent desktop_notifications notifications red_logo bg font bg2 font2 your_turn white yellow green
     brown gray red blue
   ]).freeze
 


### PR DESCRIPTION
Adds a setting to toggle whether desktop notifications should be triggered while the game is in focus.

If this is ok, I can finish this up with the notification sending code and focus checking as discussed in #386 .