### PR TITLE
1817 Bug Fixes

### DIFF
--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -654,6 +654,7 @@ module Engine
       "name": "2+",
       "distance": 2,
       "price": 100,
+      "obsolete_on": "4",
       "num": 4
     },
     {

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -22,7 +22,7 @@ module Engine
     include ShareHolder
     include Spender
 
-    attr_accessor :ipoed, :share_price, :par_via_exchange
+    attr_accessor :ipoed, :share_price, :par_via_exchange, :max_ownership_percent
     attr_reader :capitalization, :companies, :min_price, :name, :full_name, :fraction_shares
     attr_writer :par_price
 

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -124,6 +124,8 @@ module Engine
           shares = 8.times.map { |i| Share.new(corporation, percent: 10, index: i + 1) }
         end
 
+        corporation.max_ownership_percent = 60 unless size == 2
+
         shares.each do |share|
           corporation.shares_by_corporation[corporation] << share
           @_shares[share.id] = share
@@ -155,6 +157,7 @@ module Engine
           game_error('Cannot convert 10 share corporation')
         end
 
+        corporation.max_ownership_percent = 60
         shares.each { |share| corporation.share_holders[share.owner] += share.percent }
 
         new_shares.each do |share|

--- a/lib/engine/round/g_1817/merger.rb
+++ b/lib/engine/round/g_1817/merger.rb
@@ -17,18 +17,30 @@ module Engine
             .sort
         end
 
+        def setup
+          super
+          skip_steps
+          next_entity! if finished?
+        end
+
         def after_process(action)
           return if action.free?
           return if active_step
 
           @converted = nil
           @game.players.each(&:unpass!)
-          next_entity_index!
+          next_entity!
+        end
 
+        def next_entity!
+          next_entity_index! if @entities.any?
           return if @entity_index.zero?
 
           @steps.each(&:unpass!)
           @steps.each(&:setup)
+
+          skip_steps
+          next_entity! if finished?
         end
 
         def entities

--- a/lib/engine/round/g_1817/operating.rb
+++ b/lib/engine/round/g_1817/operating.rb
@@ -12,6 +12,7 @@ module Engine
 
         def setup
           @paid_loans = {}
+          @game.payout_companies
           after_setup
         end
 

--- a/lib/engine/step/g_1817/conversion.rb
+++ b/lib/engine/step/g_1817/conversion.rb
@@ -127,7 +127,12 @@ module Engine
           end
 
           @game.reset_corporation(target)
+
           @round.entities.delete(target)
+
+          # Deleting the entity changes turn order, restore it.
+          @round.goto_entity!(corporation) unless @round.entities.empty?
+
           @round.converted = corporation
         end
 

--- a/lib/engine/step/g_1817/post_conversion.rb
+++ b/lib/engine/step/g_1817/post_conversion.rb
@@ -36,14 +36,14 @@ module Engine
         end
 
         def can_buy_any?(entity)
-          can_buy?(entity, corporation.shares[0]) ||
-            can_buy?(entity, @game.share_pool.shares_by_corporation[corporation][0])
+          can_buy?(entity, corporation.shares[0])
         end
 
         def can_buy?(entity, bundle)
           return unless bundle
 
           corporation == bundle.corporation &&
+            bundle.owner != @game.bank &&
             entity.cash >= bundle.price &&
             can_gain?(entity, bundle)
         end


### PR DESCRIPTION
Turn order in merger (fixes #1884)
2+ train should obsolete (fixes #1871)
Only treasury shares can be bought in merger (fixes #1857)
Mail contracts should payout (fixes #1881)
Merger round skipped if first entity cannot be merged (fixes #1876)