### PR TITLE
Switch blocking? call to blocks? call to prevent infinite loop

### DIFF
--- a/lib/engine/step/issue_shares.rb
+++ b/lib/engine/step/issue_shares.rb
@@ -12,7 +12,7 @@ module Engine
 
         available_actions << 'buy_shares' unless redeemable_shares(entity).empty?
         available_actions << 'sell_shares' unless issuable_shares(entity).empty?
-        available_actions << 'pass' if blocking? && !available_actions.empty?
+        available_actions << 'pass' if blocks? && !available_actions.empty?
 
         available_actions
       end


### PR DESCRIPTION
In IssueShares, a call to blocking? results in a call to actions, generating an infinite loop if actions isn't empty and the step is set to block. Not seen in any current games due to 1846 being the only current game using IssueShares and being set to non-blocking.