### PR TITLE
[18CO] A single share sold by a non-President does not cause a stock to drop…

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -103,6 +103,19 @@ module Engine
         end
       end
 
+      def sell_shares_and_change_price(bundle)
+        corporation = bundle.corporation
+        price = corporation.share_price.price
+        was_president = corporation.president?(bundle.owner)
+        @share_pool.sell_shares(bundle)
+
+        return if !was_president && bundle.num_shares == 1
+
+        bundle.num_shares.times { @stock_market.move_down(corporation) }
+
+        log_share_price(corporation, price) if self.class::SELL_MOVEMENT != :none
+      end
+
       private
 
       def route_bonus(route, type)


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/1836

18CO specific rule: A single share sold by a non-President does not cause a stock to drop in value. Or to phrase it the other way, when a single share is sold, the share price only drops if it was the president that sold that stock.