### PR TITLE
Fix 18Mex doubling of mail contract

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -400,7 +400,7 @@ module Engine
 
       def handle_mail(entity)
         hex = hex_by_id(entity.coordinates)
-        income = hex.tile.city_towns.first.route_revenue(@phase, entity.trains.first)
+        income = hex.tile.city_towns.first.route_base_revenue(@phase, entity.trains.first)
         @bank.spend(income, entity)
         @log << "#{entity.name} receives #{format_currency(income)} in mail"
       end


### PR DESCRIPTION
Resolves https://github.com/tobymao/18xx/issues/1948

Mail contract needs to use the base revenue for the location, not the train multiplier modified value.