### PR TITLE
Add new TRACK_RESTRICTION type for 18MEX

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -20,6 +20,8 @@ module Engine
 
       IPO_RESERVED_NAME = 'Trade-in'
 
+      TRACK_RESTRICTION = :city_permissive
+
       STANDARD_GREEN_CITY_TILES = %w[14 15 619].freeze
       CURVED_YELLOW_CITY = %w[5 6].freeze
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -187,6 +187,8 @@ module Engine
         case @game.class::TRACK_RESTRICTION
         when :permissive
           true
+        when :city_permissive
+          @game.game_error('Must be city tile or use new track') if new_tile.cities.none? && !used_new_track
         when :restrictive
           @game.game_error('Must use new track') unless used_new_track
         when :semi_restrictive


### PR DESCRIPTION
Adding "city_permissive" - allows any tile with a city to be laid, but restrictive o.w.

Fixes #1945 
Fixes #1947 