### PR TITLE
[18CO] Game specific stock market to allow for right movement at top

### DIFF
--- a/lib/engine/g_18_co/stock_market.rb
+++ b/lib/engine/g_18_co/stock_market.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../stock_market'
+
+module Engine
+  module G18CO
+    class StockMarket < StockMarket
+      # In 18CO, stock that hit the top move right
+      def move_up(corporation)
+        r, c = corporation.share_price.coordinates
+
+        if r - 1 >= 0 && share_price(r - 1, c)
+          r -= 1
+          move(corporation, r, c)
+        elsif share_price(r, c + 1)
+          move_right(corporation)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../config/game/g_18_co'
+require_relative '../g_18_co/stock_market'
 require_relative 'base'
 require_relative 'company_price_50_to_150_percent'
 require_relative 'revenue_4d'
@@ -55,6 +56,14 @@ module Engine
         train = @depot.upcoming[0]
         train.buyable = false
         dsng.buy_train(train, :free)
+      end
+
+      def init_stock_market
+        Engine::G18CO::StockMarket.new(
+          self.class::MARKET,
+          self.class::CERT_LIMIT_COLORS,
+          multiple_buy_colors: self.class::MULTIPLE_BUY_COLORS
+        )
       end
 
       def operating_round(round_num)


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836
... If​ ​the​ ​token​ ​is​ ​at​ ​the​ ​top​ ​edge​ ​upon​ ​an​ ​upwards​ ​movement,​ ​instead​ ​move​ ​it​ ​one​ ​space​ ​right.

None of this code is mindblowingly new.

The `share_price(r - 1, c)` check is not explicitly necessary considering we know the shape of the 18CO market and there are no blanks possible if the row is greater than or equal to zero, but I would rather not make that assumption.

The elsif prevents an infinite loop of move_right calling move_up and vice versa.