### PR TITLE
1817 Bug Fixes:

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -38,7 +38,7 @@ module View
           end
         end
 
-        if step.current_actions.include?('short')
+        if step.current_actions.include?('short') && step.can_short?(current_entity, @corporation)
           short = lambda do
             process_action(Engine::Action::Short.new(current_entity, corporation: @corporation))
           end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -166,7 +166,7 @@ module Engine
 
       IPO_NAME = 'IPO'
       IPO_RESERVED_NAME = 'IPO Reserved'
-
+      MARKET_SHARE_LIMIT = 50 # percent
       ALL_COMPANIES_ASSIGNABLE = false
 
       CACHABLE = [

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -66,6 +66,7 @@ module Engine
                                                                   'Game Ends 3 ORs after purchase/export'\
                                                                   ' of first 8 train']).freeze
 
+      MARKET_SHARE_LIMIT = 1000 # notionally unlimited shares in market
       attr_reader :loan_value, :owner_when_liquidated
 
       def bankruptcy_limit_reached?
@@ -181,7 +182,7 @@ module Engine
         shares = @_shares.values.select { |share| share.corporation == corporation }
 
         # Highest share (9 is all the potential 'normal' share certificates)
-        highest_share = [shares.max(&:index).index, 9].max
+        highest_share = [shares.map(&:index).max, 9].max
 
         share = Share.new(corporation, owner: @share_pool, percent: percent, index: highest_share + 1)
         short = Share.new(corporation, percent: -percent, index: highest_share + 2)

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -96,11 +96,11 @@ module Engine
     end
 
     def fit_in_bank?(bundle)
-      (bundle.percent + percent_of(bundle.corporation)) <= 50
+      (bundle.percent + percent_of(bundle.corporation)) <= @game.class::MARKET_SHARE_LIMIT
     end
 
     def bank_at_limit?(corporation)
-      percent_of(corporation) >= 50
+      percent_of(corporation) >= @game.class::MARKET_SHARE_LIMIT
     end
 
     def transfer_shares(bundle, to_entity, spender: nil, receiver: nil, price: nil)


### PR DESCRIPTION
Remove button to short when unable to short a corp (fixes #1964)
Remove market limit on shares for 1817
Fix error in use of max (fixes #1963)