### PR TITLE
The treasury should receive money for shares from abilities in incremental cap games

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -905,6 +905,19 @@ module Engine
         extra_cities.each { |c| @_cities[c.id] = c }
       end
 
+      def after_par(corporation)
+        return unless corporation.capitalization == :incremental
+
+        all_companies_with_ability(:shares) do |company, ability|
+          next unless corporation.name == ability.shares.first.corporation.name
+
+          amount = ability.shares.sum { |share| corporation.par_price.price * share.num_shares }
+          @bank.spend(amount, corporation)
+          @log << "#{corporation.name} receives #{format_currency(amount)}
+                   from #{company.name}"
+        end
+      end
+
       private
 
       def init_bank

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -152,6 +152,7 @@ module Engine
         @game.stock_market.set_par(corporation, share_price)
         share = corporation.shares.first
         buy_shares(entity, share.to_bundle)
+        @game.after_par(corporation)
         @round.last_to_act = entity
         @current_actions << action
       end

--- a/lib/engine/step/company_pending_par.rb
+++ b/lib/engine/step/company_pending_par.rb
@@ -30,6 +30,7 @@ module Engine
         corporation = action.corporation
         @game.stock_market.set_par(corporation, share_price)
         @game.share_pool.buy_shares(action.entity, corporation.shares.first, exchange: :free)
+        @game.after_par(corporation)
         @round.companies_pending_par.shift
       end
 


### PR DESCRIPTION
From the discussion originally started here: https://18xxgames.slack.com/archives/C012K0CNY5C/p1603228267463700

**Background**

18CO is incremental capitalization. It has two privates built with the Shares ability. As the ability is currently written, the corporation does not receive treasury cash for those shares when the par is set. https://github.com/tobymao/18xx/issues/1836

I wanted opinions on whether I should:
1.) Implement this at the 18CO game level
2.) Add a new optional attribute to the Shares Ability ( par_cash: boolean ? )
3.) Make this the default for Shares abilities with incremental cap

Further discussion suggested option 3 as the appropriate path:

Chris Rericha  4:15 PM
Option 3 makes sense to me. To my knowledge, **that is the standard for how incremental cap games work** when a director share is awarded. It would help other games, looking at you 1849, if implemented generically imo. 

**Implementation**

I chose to add a new function to **game/base.rb** so that both typically used steps for parring a company can reference a shared implementation.

**Current Game Impacts**

This change should not impact any existing games on the platform, only those in development ( 18CO and 1849 for certain ). The implemented incremental games, as far as I know and as far as grep revealed, are 1817, 1846, and 18 Los Angeles, none of which utilize the Share Ability.

**Examples of log in a test game of 18CO**

<img width="736" alt="Screen Shot 2020-10-22 at 12 03 13 PM" src="https://user-images.githubusercontent.com/15675400/96912790-2085fd00-1460-11eb-82e6-d1cd809c791c.png">
