### PR TITLE
1817: Implement 5 share merges and finish 1817 implementation

### DIFF
--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -52,5 +52,14 @@ module Engine
     def inspect
       "<Share: #{@corporation.id} #{@percent}%>"
     end
+
+    def transfer(new_entity)
+      owner.shares_by_corporation[corporation].delete(self)
+      corporation.share_holders[owner] -= percent
+
+      @owner = new_entity
+      corporation.share_holders[new_entity] += percent
+      new_entity.shares_by_corporation[corporation] << self
+    end
   end
 end

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -146,16 +146,22 @@ module Engine
       # if the owner only sold half of their president's share, take one away
       swap_to = previous_president.percent_of(corporation) >= presidents_share.percent ? previous_president : self
 
-      num_shares = presidents_share.percent / corporation.share_percent
-
-      possible_reorder(president.shares_of(corporation)).take(num_shares).each { |s| move_share(s, swap_to) }
-      move_share(presidents_share, president)
+      change_president(presidents_share, swap_to, president)
 
       return unless bundle.partial?
 
       difference = bundle.shares.sum(&:percent) - bundle.percent
       num_shares = difference / corporation.share_percent
       num_shares.times { move_share(shares_of(corporation).first, owner) }
+    end
+
+    def change_president(presidents_share, swap_to, president)
+      corporation = presidents_share.corporation
+
+      num_shares = presidents_share.percent / corporation.share_percent
+
+      possible_reorder(president.shares_of(corporation)).take(num_shares).each { |s| move_share(s, swap_to) }
+      move_share(presidents_share, president)
     end
 
     def possible_reorder(shares)

--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -290,7 +290,6 @@ module Engine
         def settle_shareholders(acquired_corp)
           # Step 9
           if @shareholder_cash.positive?
-            # @todo: how are shorts done?
             per_share = (@shareholder_cash / acquired_corp.total_shares).to_i
             payouts = {}
             @game.players.each do |player|
@@ -298,7 +297,7 @@ module Engine
               next if amount.zero?
 
               payouts[player] = amount
-              @game.bank.spend(amount, player)
+              @game.bank.spend(amount, player, check_positive: false)
             end
 
             if payouts.any?

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -98,7 +98,7 @@ module Engine
         def can_short?(entity, corporation)
           # check total shorts
           corporation.total_shares > 2 &&
-            @game.shorts(corporation).length < @game.class::MAX_SHORTS &&
+            @game.shorts(corporation).length < corporation.total_shares &&
             corporation.operated? &&
             entity.num_shares_of(corporation) <= 0 &&
             !corporation.share_price.acquisition? &&
@@ -185,7 +185,7 @@ module Engine
 
             super
 
-            @game.unshort(entity, bundle) if unshort
+            @game.unshort(entity, bundle.shares[0]) if unshort
           else
             buy_shares(entity, bundle)
             @corporate_action = action

--- a/lib/engine/step/g_1817/post_conversion.rb
+++ b/lib/engine/step/g_1817/post_conversion.rb
@@ -21,7 +21,10 @@ module Engine
 
         def process_buy_shares(action)
           player = action.entity
+          unshort = player.percent_of(corporation).negative?
           buy_shares(player, action.bundle)
+          @game.unshort(player, action.bundle.shares[0]) if unshort
+
           player.pass! if !corporation.president?(player.owner) || !can_buy_any?(player)
         end
 
@@ -43,7 +46,7 @@ module Engine
           return unless bundle
 
           corporation == bundle.corporation &&
-            bundle.owner != @game.bank &&
+            bundle.owner != @game.share_pool &&
             entity.cash >= bundle.price &&
             can_gain?(entity, bundle)
         end


### PR DESCRIPTION
5 share merger resulted in incorrect results (fixes #1878)
Avoid cross-short president-less merges (fixes #1969)
Shorts are limited to corp size (fixes #1970)
Shorts should cancel when bought in post-conversion (finishes #686)
Short dividend should be payable in acquisitions
Correct share percentage calculations