### PR TITLE
Sort corporations in stock rounds.

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -57,7 +57,7 @@ module View
             },
           }
 
-          @game.corporations.map do |corporation|
+          @game.sorted_corporations.map do |corporation|
             next if @auctioning_corporation && @auctioning_corporation != corporation
 
             children = []

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -485,6 +485,12 @@ module Engine
         self
       end
 
+      def sorted_corporations
+        # Corporations sorted by some potential game rules
+        ipoed, others = corporations.partition(&:ipoed)
+        ipoed.sort + others
+      end
+
       def current_action_id
         @actions.size + 1
       end


### PR DESCRIPTION
For 1817 the amount of corporations gets confusing

Sort those that have been IPOed by their running order
Then others leave in symbol order

Done in base class to game so that other games (18CO and 1849 etc) can override.

This does have the slight impact to the UI that the position can change dynamically,
but this makes it clearer the change in stock price.

fixes #1838