### PR TITLE
18MEX: Minors are only allowed to lay one yellow, and no upgrades.

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -407,7 +407,7 @@ module Engine
       end
 
       def tile_lays(entity)
-        return super if entity.minor?
+        return [{ lay: true, upgrade: false }] if entity.minor?
 
         [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }]
       end


### PR DESCRIPTION
Fixes #1976