### PR TITLE
Correct price for 5% shares (on the server side)

### DIFF
--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -29,7 +29,11 @@ module Engine
     end
 
     def num_shares
-      @percent / corporation.share_percent
+      num_shares_float.ceil
+    end
+
+    def num_shares_float
+      1.0 * @percent / corporation.share_percent
     end
 
     def price_per_share
@@ -38,7 +42,7 @@ module Engine
     end
 
     def price
-      price_per_share * num_shares
+      (price_per_share * num_shares_float).ceil
     end
 
     def to_s

--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -28,12 +28,9 @@ module Engine
       "#{@corporation.id}_#{@index}"
     end
 
-    def num_shares
-      num_shares_float.ceil
-    end
-
-    def num_shares_float
-      1.0 * @percent / corporation.share_percent
+    def num_shares(ceil: true)
+      num = @percent.to_f / corporation.share_percent
+      ceil ? num.ceil : num
     end
 
     def price_per_share
@@ -42,7 +39,7 @@ module Engine
     end
 
     def price
-      (price_per_share * num_shares_float).ceil
+      (price_per_share * num_shares(ceil: false)).ceil
     end
 
     def to_s

--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -44,7 +44,7 @@ module Engine
     end
 
     def price
-      (price_per_share.to_f * num_shares(ceil: false)).ceil
+      (price_per_share * num_shares(ceil: false)).ceil
     end
 
     def can_dump?(entity)

--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -15,7 +15,11 @@ module Engine
     end
 
     def num_shares
-      @percent / corporation.share_percent
+      num_shares_float.ceil
+    end
+
+    def num_shares_float
+      1.0 * @percent / corporation.share_percent
     end
 
     def partial?
@@ -43,7 +47,7 @@ module Engine
     end
 
     def price
-      price_per_share * num_shares
+      (price_per_share * num_shares_float).ceil
     end
 
     def can_dump?(entity)

--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -14,12 +14,9 @@ module Engine
       @share_price = nil
     end
 
-    def num_shares
-      num_shares_float.ceil
-    end
-
-    def num_shares_float
-      1.0 * @percent / corporation.share_percent
+    def num_shares(ceil: true)
+      num = @percent.to_f / corporation.share_percent
+      ceil ? num.ceil : num
     end
 
     def partial?
@@ -47,7 +44,7 @@ module Engine
     end
 
     def price
-      (price_per_share * num_shares_float).ceil
+      (price_per_share.to_f * num_shares(ceil: false)).ceil
     end
 
     def can_dump?(entity)

--- a/lib/engine/share_holder.rb
+++ b/lib/engine/share_holder.rb
@@ -27,7 +27,11 @@ module Engine
     end
 
     def num_shares_of(corporation)
-      percent_of(corporation) / corporation.share_percent
+      num_shares_of_float(corporation).ceil
+    end
+
+    def num_shares_of_float(corporation)
+      1.0 * percent_of(corporation) / corporation.share_percent
     end
   end
 end

--- a/lib/engine/share_holder.rb
+++ b/lib/engine/share_holder.rb
@@ -26,12 +26,9 @@ module Engine
       @shares_by_corporation.select { |_c, shares| shares.any?(&:president) }.keys
     end
 
-    def num_shares_of(corporation)
-      num_shares_of_float(corporation).ceil
-    end
-
-    def num_shares_of_float(corporation)
-      1.0 * percent_of(corporation) / corporation.share_percent
+    def num_shares_of(corporation, ceil: true)
+      num = percent_of(corporation).to_f / corporation.share_percent
+      ceil ? num.ceil : num
     end
   end
 end

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -96,7 +96,7 @@ module Engine
 
       def dividends_for_entity(entity, holder, per_share)
         # 1817 2 share half pay uses floats, for 18MEX num_shares can be a float for NdM
-        (holder.num_shares_of_float(entity) * per_share).ceil
+        (holder.num_shares_of(entity, ceil: false) * per_share).ceil
       end
 
       def corporation_dividends(entity, per_share)

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -95,8 +95,8 @@ module Engine
       end
 
       def dividends_for_entity(entity, holder, per_share)
-        # 1817 2 share half pay uses floats
-        (holder.num_shares_of(entity) * per_share).to_i
+        # 1817 2 share half pay uses floats, for 18MEX num_shares can be a float for NdM
+        (holder.num_shares_of_float(entity) * per_share).ceil
       end
 
       def corporation_dividends(entity, per_share)


### PR DESCRIPTION
share.rb and share_bundle.rb gave 0 as price for share counts
not evenly divisable by 10. This caused the 5% of NdM in 18MEX
to be excluded from the value (on the server side).

When paying out revenue, use float for num_shares to handle
the NdM case.

In both cases ceil is used to round up.

This might fix several problems that has been reported, although it is hard to verify.
But I think the following might be solved:

- Fixes #1978 
- Fixes #1939 
- Fixes #1955 
- Fixes #2006 

If this PR is approved I intend to close the issues.