### PR TITLE
18 Los Angeles - better handling of passenger/freight route overlap

### DIFF
--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -32,7 +32,7 @@ module View
           path_indexes = paths_and_stubs.map { |p| [p, indexes_for(p)] }.to_h
 
           sorted = paths_and_stubs
-            .map { |path| path_indexes[path].map { |i| [path, i] } }.flatten(1)
+            .flat_map { |path| path_indexes[path].map { |i| [path, i] } }
             .sort_by { |_, index| index || -1 }
 
           sorted.map do |path, index|
@@ -75,7 +75,7 @@ module View
               [1, 3 * path_indexes[path].reverse.index(index)].max
             end
 
-          value_for_index(index, :width) * multiplier
+          value_for_index(index, :width).to_f * multiplier.to_i
         end
       end
     end

--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -28,14 +28,17 @@ module View
           # Array<Array<Path>>
           @routes_paths = @routes.map { |route| route.paths_for(@tile.paths) }
 
-          sorted = (@tile.paths + @tile.stubs)
-            .map { |path| [path, index_for(path)] }
+          paths_and_stubs = @tile.paths + @tile.stubs
+          path_indexes = paths_and_stubs.map { |p| [p, indexes_for(p)] }.to_h
+
+          sorted = paths_and_stubs
+            .map { |path| path_indexes[path].map { |i| [path, i] } }.flatten(1)
             .sort_by { |_, index| index || -1 }
 
           sorted.map do |path, index|
             props = {
               color: value_for_index(index, :color),
-              width: value_for_index(index, :width),
+              width: width_for_index(path, index, path_indexes),
               dash: value_for_index(index, :dash),
             }
 
@@ -51,14 +54,28 @@ module View
 
         private
 
-        def index_for(path)
-          @routes_paths.index do |route_paths|
-            route_paths.any? { |p| path == p }
-          end
+        def indexes_for(path)
+          indexes = @routes_paths
+            .map.with_index
+            .select { |route_paths, _index| route_paths.any? { |p| path == p } }
+            .flat_map { |_, index| index }
+
+          indexes.empty? ? [nil] : indexes
         end
 
         def value_for_index(index, prop)
           index ? route_prop(index, prop) : TRACK[prop]
+        end
+
+        def width_for_index(path, index, path_indexes)
+          multiplier =
+            if !index || path_indexes[path].one?
+              1
+            else
+              [1, 3 * path_indexes[path].reverse.index(index)].max
+            end
+
+          value_for_index(index, :width) * multiplier
         end
       end
     end

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -4,6 +4,7 @@ require_relative 'g_1846'
 require_relative '../config/game/g_1846'
 require_relative '../config/game/g_18_los_angeles'
 require_relative '../step/g_18_los_angeles/draft_distribution'
+require_relative '../step/g_18_los_angeles/route'
 
 module Engine
   module Game
@@ -112,6 +113,23 @@ module Engine
           @log << "#{company.name} is removed" unless company.value >= 100
         end
         @draft_finished = true
+      end
+
+      def operating_round(round_num)
+        Round::G1846::Operating.new(self, [
+          Step::G1846::Bankrupt,
+          Step::DiscardTrain,
+          Step::G1846::Assign,
+          Step::SpecialToken,
+          Step::SpecialTrack,
+          Step::G1846::BuyCompany,
+          Step::G1846::IssueShares,
+          Step::G1846::TrackAndToken,
+          Step::G18LosAngeles::Route,
+          Step::G1846::Dividend,
+          Step::G1846::BuyTrain,
+          [Step::G1846::BuyCompany, blocks: true],
+        ], round_num: round_num)
       end
 
       def num_pass_companies(_players)

--- a/lib/engine/step/g_18_los_angeles/route.rb
+++ b/lib/engine/step/g_18_los_angeles/route.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../route'
+
+module Engine
+  module Step
+    module G18LosAngeles
+      class Route < Route
+        def help
+          text = Array(super)
+
+          trains = current_entity.runnable_trains.group_by { |t| @game.train_type(t) }
+          if trains.keys.size > 1
+            passenger_trains = trains[:passenger].map(&:name).uniq
+            freight_trains = trains[:freight].map(&:name).uniq
+            text << 'Reminder: the routes of Passenger trains '\
+                    "(#{passenger_trains.join(', ')}) may overlap with the "\
+                    "routes of Freight trains (#{freight_trains.join(', ')})"
+          end
+
+          text
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- add help text in route step to tell user the routes can overlap
- render both routes, making the bottom one much thicker so it is visible

## Before

![Screenshot from 2020-10-24 12-49-54](https://user-images.githubusercontent.com/1045173/97091227-98d2f680-15f7-11eb-8a82-5f92a7ee2e16.png)

## After

![Screenshot from 2020-10-24 12-50-26](https://user-images.githubusercontent.com/1045173/97091229-9d97aa80-15f7-11eb-8c11-fdf372fd4995.png)
