### PR TITLE
Added invite link to games

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -105,7 +105,6 @@ class Api < Roda
 
     r.on 'game', Integer do |id|
       halt(404, 'Game not found') unless (game = Game[id])
-      halt(400, 'Game has not started yet') if game.status == 'new'
 
       pin = game.settings['pin']
       render(pin: pin, game_data: pin ? game.to_h(include_actions: true) : game.to_h)

--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -7,6 +7,7 @@ require 'lib/connection'
 require 'lib/storage'
 require 'view/about'
 require 'view/create_game'
+require 'view/invite_game'
 require 'view/home'
 require 'view/flash'
 require 'view/game_page'
@@ -90,6 +91,8 @@ class App < Snabberb::Component
       else
         enter_game(id: match[2], mode: match[1] == 'game' ? :muti : :hotseat, pin: @pin)
       end
+    elsif @game_data['status'] == "new"
+      return h(View::InviteGame, user: @user, game: @game_data)
     elsif !@game_data['loaded'] && !@game_data['loading']
       enter_game(id: match[2], mode: match[1] == 'game' ? :muti : :hotseat, pin: @pin)
       enter_game(@game_data)

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -157,5 +157,6 @@ module GameManager
     @games.reject! { |g| g['id'] == game['id'] } if game['deleted']
     @games.map! { |g| g['id'] == game['id'] ? game : g }
     store(:games, @games.sort_by { |g| g['id'] }.reverse)
+    store(:game, game, skip: true) if @game && @game['id'] == game['id']
   end
 end

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require 'lib/color'

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require 'lib/color'
@@ -16,6 +17,7 @@ module View
     needs :gdata # can't conflict with game_data
     needs :confirm_delete, store: true, default: false
     needs :confirm_kick, store: true, default: nil
+    needs :flash_opts, default: {}, store: true
 
     def render
       h('div.game.card', [
@@ -183,8 +185,15 @@ module View
         elm
       end
 
+
+      if owner?
+        msg = 'You can copy this link to invite other players'
+        flash = -> { store(:flash_opts, { message: msg, color: 'lightgreen' }, skip: false) }
+        invite_button = render_link(url(@gdata), flash, 'Invite')
+      end
+
       children = [
-        h(:div, [h(:strong, 'Id: '), @gdata['id'].to_s]),
+        h(:div, [h(:strong, 'Id: '), @gdata['id'].to_s, invite_button]),
         h(:div, [h(:strong, 'Description: '), @gdata['description']]),
       ]
       children << h(:div, [h(:strong, 'Players: '), *p_elm]) if @gdata['status'] != 'finished'

--- a/assets/app/view/invite_game.rb
+++ b/assets/app/view/invite_game.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'game_manager'
+require 'view/game_row'
+
+module View
+  class InviteGame < Snabberb::Component
+    include GameManager
+
+    needs :user
+    needs :refreshing, default: nil, store: true
+
+    def render
+      children = [h(:h2, {}, "Ths game has not started yet")]
+      if !@user
+        children << h(:h3, {}, "You need to login before joining a game:")
+        children << h(View::User, type: :login)
+      else
+        children << h(:div, {}, [h(GameCard, gdata: @game, user: @user)])
+      end
+
+      children << h(:a, { attrs: { href: '/' } }, 'Return home')
+
+      h('div#invitepage', {}, children)
+    end
+  end
+end


### PR DESCRIPTION
When the url of a new game, instead of showing an error message now we see the game card allowing the user to join the game. Furthermore now the owner sees an "Invite" button on their new games.

Up next: unlisted games

