### PR TITLE
Check for terminal path in middle of route

### DIFF
--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -166,9 +166,19 @@ module Engine
     end
 
     def check_terminals!
-      if paths.size > 2
-        @game.game_error('Route cannot pass through terminal') if path[1..-2].any? { |p| p.terminal? }
+      return unless paths.size > 2
+
+      ordered_paths = []
+      @connections.each do |c|
+        cpaths = c[:connection].paths
+        if cpaths.first.nodes.any?(c[:left])
+          ordered_paths.concat(cpaths)
+        else
+          ordered_paths.concat(cpaths.reverse)
+        end
       end
+
+      @game.game_error('Route cannot pass through terminal') if ordered_paths[1..-2].any?(&:terminal?)
     end
 
     def distance

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -166,16 +166,11 @@ module Engine
     end
 
     def check_terminals!
-      return unless paths.size > 2
+      return if paths.size < 3
 
-      ordered_paths = []
-      @connections.each do |c|
+      ordered_paths = @connections.flat_map do |c|
         cpaths = c[:connection].paths
-        if cpaths.first.nodes.any?(c[:left])
-          ordered_paths.concat(cpaths)
-        else
-          ordered_paths.concat(cpaths.reverse)
-        end
+        cpaths[0].nodes.any?(c[:left]) ? cpaths : cpaths.reverse
       end
 
       @game.game_error('Route cannot pass through terminal') if ordered_paths[1..-2].any?(&:terminal?)

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -165,6 +165,12 @@ module Engine
       # rubocop:enable Style/GuardClause, Style/IfUnlessModifier
     end
 
+    def check_terminals!
+      if paths.size > 2
+        @game.game_error('Route cannot pass through terminal') if path[1..-2].any? { |p| p.terminal? }
+      end
+    end
+
     def distance
       visited_stops.sum(&:visit_cost)
     end
@@ -221,6 +227,7 @@ module Engine
       check_distance!(visited)
       check_cycles!
       check_overlap!
+      check_terminals!
       check_connected!(token)
 
       visited.flat_map(&:groups).flatten.group_by(&:itself).each do |key, group|


### PR DESCRIPTION
Current code doesn't check to see if a route passes through a city that has "terminal" paths.
This fixes that by checking to see if a route has a terminal flag on any path that is not at the very beginning or end of the route.
Only games known to be impacted: 18AL and 18MEX.

Fixes #1967 