### PR TITLE
18MEX: Corrections of Close handling of corporation during merge

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -230,7 +230,6 @@ module Engine
     def close!
       share_price&.corporations&.delete(self)
       @closed = true
-      @floated = false
       @ipoed = false
       @owner = nil
     end

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -263,6 +263,10 @@ module Engine
             end
             s.transfer(major)
           end
+          # Transfer bank pool shares to IPO
+          @share_pool.shares_of(major).dup.each do |s|
+            s.transfer(major)
+          end
           if refund_count.positive?
             @log << "#{p.name} receives #{format_currency(refund * refund_count)} in share compensation"
           end


### PR DESCRIPTION
Added move of shares in bank pool to IPO. Failure to do this
caused games with 50% in bank pool of shares from merged corporation
to fail as it was still regarded as floated.