### PR TITLE
Added option to create unlisted/private game

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -19,7 +19,9 @@ module View
         render_inputs,
       ]
 
-      if @mode == :hotseat
+      if @mode == :multi
+        inputs << render_input('Private game', id: "unlisted", type: :checkbox)
+      elsif @mode == :hotseat
         @num_players.times do |index|
           num = index + 1
           inputs << render_input("Player #{num}", id: "player_#{num}", attrs: { value: "Player #{num}" })

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require 'lib/color'
@@ -183,10 +184,9 @@ module View
         elm
       end
 
-      children = [
-        h(:div, [h(:strong, 'Id: '), @gdata['id'].to_s]),
-        h(:div, [h(:strong, 'Description: '), @gdata['description']]),
-      ]
+      children = [h(:div, [h(:strong, 'Id: '), @gdata['id'].to_s])]
+      children << h(:div, [h(:i, 'Private game')]) if @gdata['settings'] && @gdata['settings']['unlisted']
+      children << h(:div, [h(:strong, 'Description: '), @gdata['description']])
       children << h(:div, [h(:strong, 'Players: '), *p_elm]) if @gdata['status'] != 'finished'
 
       if new?

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -29,6 +29,8 @@ module View
 
       grouped = other_games.group_by { |game| game['status'] }
 
+      grouped['new'].reject! { |game| game['settings']['unlisted'] } if grouped['new']
+
       # Ready, then active, then unstarted, then completed
       your_games.sort_by! do |game|
         [

--- a/models/game.rb
+++ b/models/game.rb
@@ -103,7 +103,7 @@ class Game < Base
 
   def to_h(include_actions: false, player: nil)
     actions_h = include_actions ? actions.map(&:to_h) : []
-    settings_h = include_actions ? settings.to_h : {}
+    settings_h = settings.to_h
 
     # Move user settings and hide from other players
     user_settings_h = settings_h.dig('players', player)

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -178,7 +178,7 @@ class Api
             user: user,
             description: r['description'],
             max_players: r['max_players'],
-            settings: { seed: Random.new_seed },
+            settings: { seed: Random.new_seed, unlisted: r['unlisted'] },
             title: title,
             round: Engine::GAMES_BY_TITLE[title].new([]).round&.name,
           }


### PR DESCRIPTION
The unlisted games are only hidden from the new games queue. Should they be also hidden from active games and finished games? Maybe we could have that as a separate option?

The unlisted games are hidden on the client side, after being fetched from the db. This means that each page will have less games. I don't think that's a big problem. It's not trivial to workaround, because the db is "not aware" of this field.
An alternative would be to always show all the cards, but hide the Join (and maybe Enter) buttons. 

Do not pull this before #2010 