### PR TITLE
Fix Revenue Nil for positive?

### DIFF
--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -327,6 +327,8 @@ module Engine
           [stops, @game.revenue_for(self, stops)]
         end.compact.max_by(&:last)
 
+        revenue ||= 0
+
         # We assume that no stop collection with m < n stops could be
         # better than a stop collection with n stops, so if we found
         # anything usable with this number of stops we return it


### PR DESCRIPTION
When a train ignores a revenue center type, such as the 4Ds in 18CO visiting but not paying towns, the block above is never run and thus revenue is never defined. This results in an error being thrown on return stops if revenue.positive?

Fix is to ensure revenue is defined with a default of 0

<img width="584" alt="Screen Shot 2020-10-25 at 11 29 02 AM" src="https://user-images.githubusercontent.com/15675400/97114660-743e5380-16b7-11eb-9ffa-9c16093c9a14.png">
