### PR TITLE
"cheater" tokens for 18LA DC&H, 1846 2p Variant setup

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -82,7 +82,8 @@ module View
           entity = @selected_company || step.current_entity
           actions = step.actions(entity)
           return if (%w[remove_token place_token] & actions).empty?
-          return if @token && !step.can_replace_token?(entity, @token)
+          return if @token && !step.can_replace_token?(entity, @token) &&
+                    !(cheater = entity.abilities(:token)&.cheater)
 
           event.JS.stopPropagation
 
@@ -102,7 +103,7 @@ module View
               action = Engine::Action::PlaceToken.new(
                 @selected_company || @game.current_entity,
                 city: @city,
-                slot: @slot_index,
+                slot: cheater || @slot_index,
                 token_type: next_tokens[0].type
               )
               store(:selected_company, nil, skip: true)

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -15,9 +15,9 @@ module View
 
     def render_notification
       message = <<~MESSAGE
+        <p>18 Los Angeles is now in beta!</p>
         <p>1817 is now more stable and in alpha! Feel free to play multiplayer games.</p>
         <p>18MEX is now in alpha!</p>
-        <p>18 Los Angeles by Tony Fryer is now in alpha! It is based on 1846, and plays 2-5 players. Learn more on the <a href='https://traxx-denver.com/games/'>TraXX</a> website.</p>
         <p>Please file <a href='https://github.com/tobymao/18xx/issues'>issues and ideas</a> on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>.<br>
         If you have any questions, check out the <a href="https://github.com/tobymao/18xx/wiki/FAQ">FAQ</a> and other

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -15,7 +15,6 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p>18 Los Angeles is now in beta!</p>
         <p>1817 is now more stable and in alpha! Feel free to play multiplayer games.</p>
         <p>18MEX is now in alpha!</p>
         <p>Please file <a href='https://github.com/tobymao/18xx/issues'>issues and ideas</a> on

--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -6,10 +6,11 @@ module Engine
   module Ability
     class Token < Base
       attr_reader :hexes, :teleport_price, :extra, :from_owner, :discount, :city,
-                  :neutral
+                  :neutral, :cheater
 
       def setup(hexes:, price: nil, teleport_price: nil, extra: nil,
-                from_owner: nil, discount: nil, city: nil, neutral: nil)
+                from_owner: nil, discount: nil, city: nil, neutral: nil,
+                cheater: nil)
         @hexes = hexes
         @price = price
         @teleport_price = teleport_price
@@ -18,6 +19,7 @@ module Engine
         @discount = discount
         @city = city
         @neutral = neutral || false
+        @cheater = cheater || false
       end
 
       def price(token = nil)

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -324,6 +324,29 @@ module Engine
       ]
     },
     {
+      "name": "Dewey, Cheatham, and Howe",
+      "value": 40,
+      "revenue": 10,
+      "desc": "The owning corporation may place a token (from their charter, paying the normal cost) in a city they are connected to that does not have any open token slots. If a later tile placement adds a new slot, this token fills that slot. This ability may not be used in Long Beach (E8).",
+      "sym": "DC&H",
+      "min_players": 3,
+      "abilities": [
+        {
+          "type": "token",
+          "owner_type":"corporation",
+          "count": 1,
+          "from_owner": true,
+          "cheater": 0,
+          "discount": 0,
+          "hexes": [
+            "A2", "A4", "A6", "A8", "B5", "B7", "B9", "B11", "B13", "C2", "C4",
+            "C6", "C8", "C12", "D5", "D7", "D9", "D11", "D13", "E4", "E6",
+            "E10", "E12", "F7", "F9", "F11", "F13"
+          ]
+        }
+      ]
+    },
+    {
       "name": "Los Angeles Title",
       "value": 40,
       "revenue": 10,
@@ -524,7 +547,6 @@ module Engine
         },
         {
           "type": "reservation",
-          "slot": 1,
           "hex": "C6",
           "remove": "IV"
         }

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -53,12 +53,13 @@ module Engine
       SOUTH_GROUP = %w[B&O C&O IC].freeze
 
       REMOVED_CORP_SECOND_TOKEN = {
-        'D14' => ['GT'],
-        'D20' => ['ERIE'],
-        'E11' => ['PRR'],
-        'E17' => ['NYC'],
-        'G7' => ['IC'],
-        'H12' => ['B&O', 'C&O'],
+        'B&O' => 'H12',
+        'C&O' => 'H12',
+        'ERIE' => 'D20',
+        'GT' => 'D14',
+        'IC' => 'G7',
+        'NYC' => 'E17',
+        'PRR' => 'E11',
       }.freeze
 
       LSL_HEXES = %w[D14 E17].freeze
@@ -156,10 +157,10 @@ module Engine
         corporation_removal_groups.each do |group|
           remove_from_group!(group, @corporations) do |corporation|
             place_home_token(corporation)
-            place_second_token(corporation)
             corporation.abilities(:reservation) do |ability|
               corporation.remove_ability(ability)
             end
+            place_second_token(corporation)
           end
         end
 
@@ -209,17 +210,13 @@ module Engine
         two_player? ? [NORTH_GROUP, SOUTH_GROUP] : [GREEN_GROUP]
       end
 
-      def place_second_token(corporation)
-        return unless two_player?
+      def place_second_token(corporation, two_player_only: true, cheater: 1)
+        return if two_player_only && !two_player?
 
-        if corporation.id == 'ERIE'
-          token = corporation.find_token_by_type
-          hex_by_id('D20').tile.cities.first.place_token(corporation, token, check_tokenable: false)
-          @log << 'ERIE places a token on D20'
-        else
-          hex = self.class::REMOVED_CORP_SECOND_TOKEN.find { |_h, corps| corps.include?(corporation.name) }.first
-          @log << "#{corporation.name} will place a second token on #{hex} when a green tile is laid there"
-        end
+        hex_id = self.class::REMOVED_CORP_SECOND_TOKEN[corporation.id]
+        token = corporation.find_token_by_type
+        hex_by_id(hex_id).tile.cities.first.place_token(corporation, token, check_tokenable: false, cheater: cheater)
+        @log << "#{corporation.id} places a token on #{hex_id}"
       end
 
       def num_trains(train)
@@ -338,8 +335,6 @@ module Engine
             @bank.spend(bonus, illinois_central)
             @log << "#{illinois_central.name} receives a #{format_currency(bonus)} subsidy"
           end
-        when Action::LayTile
-          check_removed_corp_second_token(action.hex, action.tile) if two_player?
         end
 
         check_special_tile_lay(action)
@@ -562,17 +557,6 @@ module Engine
         return [biggest_bundle] if biggest_bundle
 
         []
-      end
-
-      def check_removed_corp_second_token(hex, tile)
-        return unless tile.color.to_sym == :green
-        return unless (corp_ids = self.class::REMOVED_CORP_SECOND_TOKEN[hex.id])
-        return unless (corp = @removals.find { |c| corp_ids.include?(c.id) })
-        return if corp.id == 'ERIE' # their second token is placed during setup
-
-        token = corp.find_token_by_type
-        @log << "#{corp.name} places a token on #{hex.name}"
-        tile.cities.first.place_token(corp, token, check_tokenable: false)
       end
 
       def next_round!

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -12,7 +12,7 @@ module Engine
     class G18LosAngeles < G1846
       load_from_json(Config::Game::G18LosAngeles::JSON, Config::Game::G1846::JSON)
 
-      DEV_STAGE = :beta
+      DEV_STAGE = :alpha
 
       GAME_LOCATION = nil
       GAME_RULES_URL = {

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -136,8 +136,9 @@ module Engine
       # when upgrading, preserve tokens on previous tile (must be handled after
       # reservations are completely done due to OO weirdness)
       city_map.each do |old_city, new_city|
-        old_city.tokens.each do |token|
-          new_city.exchange_token(token) if token
+        old_city.tokens.each.with_index do |token, index|
+          cheater = (index >= old_city.normal_slots) && index
+          new_city.exchange_token(token, cheater: cheater) if token
         end
         old_city.remove_tokens!
       end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -7,13 +7,21 @@ module Engine
   module Part
     class City < RevenueCenter
       attr_accessor :reservations
-      attr_reader :slots, :tokens
+      attr_reader :tokens
 
       def initialize(revenue, **opts)
         super
         @slots = (opts[:slots] || 1).to_i
         @tokens = Array.new(@slots)
         @reservations = []
+      end
+
+      def slots
+        @tokens.size
+      end
+
+      def normal_slots
+        @slots
       end
 
       def remove_tokens!
@@ -57,12 +65,12 @@ module Engine
         true
       end
 
-      def tokenable?(corporation, free: false, tokens: corporation.tokens_by_type)
+      def tokenable?(corporation, free: false, tokens: corporation.tokens_by_type, cheater: false)
         tokens = Array(tokens)
         return false if tokens.empty?
 
         tokens.any? do |t|
-          next false unless get_slot(t.corporation)
+          next false unless get_slot(t.corporation, cheater: cheater)
           next false if !free && t.price > corporation.cash
           next false if @tile.cities.any? { |c| c.tokened_by?(t.corporation) }
           next true if reserved_by?(corporation)
@@ -76,25 +84,28 @@ module Engine
         @tokens.each_with_index.count { |t, i| t.nil? && @reservations[i].nil? }
       end
 
-      def get_slot(corporation)
+      def get_slot(corporation, cheater: false)
         reservation = find_reservation(corporation)
-        reservation || @tokens.find_index.with_index do |t, i|
+        open_slot = @tokens.find_index.with_index do |t, i|
           t.nil? && @reservations[i].nil?
         end
+        return [open_slot || @slots, cheater].max if cheater
+
+        reservation || open_slot
       end
 
-      def place_token(corporation, token, free: false, check_tokenable: true)
-        if check_tokenable && !tokenable?(corporation, free: free, tokens: token)
+      def place_token(corporation, token, free: false, check_tokenable: true, cheater: false)
+        if check_tokenable && !tokenable?(corporation, free: free, tokens: token, cheater: cheater)
           raise GameError, "#{corporation.name} cannot lay token on #{id}"
         end
 
-        exchange_token(token)
+        exchange_token(token, cheater: cheater)
         tile.reservations.delete(corporation)
       end
 
-      def exchange_token(token)
+      def exchange_token(token, cheater: false)
         token.place(self)
-        @tokens[get_slot(token.corporation)] = token
+        @tokens[get_slot(token.corporation, cheater: cheater)] = token
       end
     end
   end

--- a/lib/engine/step/g_18_los_angeles/special_token.rb
+++ b/lib/engine/step/g_18_los_angeles/special_token.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../special_token'
+
+module Engine
+  module Step
+    module G18LosAngeles
+      class SpecialToken < SpecialToken
+        def process_place_token(action)
+          if (action.entity == @game.dch) && action.city.tokenable?(action.entity.owner)
+            @game.game_error('Dewey, Cheatham, and Howe can only place a token in '\
+                             'a city (other than Long Beach) with no open slots.')
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -39,7 +39,7 @@ module Engine
         token, ability = adjust_token_price_ability!(entity, token, hex, city)
         entity.remove_ability(ability) if ability
         free = !token.price.positive?
-        city.place_token(entity, token, free: free)
+        city.place_token(entity, token, free: free, cheater: special_ability&.cheater)
         unless free
           entity.spend(token.price, @game.bank)
           price_log = " for #{@game.format_currency(token.price)}"


### PR DESCRIPTION
- 18 Los Angeles's private company "Dewey, Cheatham, and Howe": place a token in
  city with no available slots (and provide the name for this token argument)
- 1846 2p Variant setup: removed corporations place a second token in slot 1
  instead of slot 0; this is functionally equivalent to current behavior (token
  is placed when green tile is laid, has no real effect before then) but way
  more obvious what is happening, and takes advantage of the digital platform

[Closes #1806]

## 1846 2p Before

![1846 2p before log](https://user-images.githubusercontent.com/1045173/97115347-eca71380-16bb-11eb-80bc-8cd580fe9673.png) 
![1846 2p before map](https://user-images.githubusercontent.com/1045173/97115349-ef096d80-16bb-11eb-8036-2216fd3e63f1.png)

## 1846 2p After

![1846 2p cheaters log](https://user-images.githubusercontent.com/1045173/97115359-fcbef300-16bb-11eb-9b26-2f19e1d8e098.png)
![1846 2p cheaters](https://user-images.githubusercontent.com/1045173/97115360-ff214d00-16bb-11eb-8028-8e2aaf3bcde3.png)
![Screenshot from 2020-10-25 12-18-38](https://user-images.githubusercontent.com/1045173/97115436-57f0e580-16bc-11eb-88ea-32f81b9df5c3.png)
![Screenshot from 2020-10-25 12-18-49](https://user-images.githubusercontent.com/1045173/97115439-5b846c80-16bc-11eb-8c9d-dfe56dd63493.png)
![Screenshot from 2020-10-25 12-18-58](https://user-images.githubusercontent.com/1045173/97115442-5de6c680-16bc-11eb-86d5-0a898d088243.png)



## 18 Los Angeles - DC&H

![DCH before](https://user-images.githubusercontent.com/1045173/97115488-a0a89e80-16bc-11eb-8d2e-5bd5d27300fb.png)
![DCH after](https://user-images.githubusercontent.com/1045173/97115502-a56d5280-16bc-11eb-88c6-4484d293909d.png)
