### PR TITLE
[18CO] Specific Mine Implementation

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -326,7 +326,11 @@ module Engine
 			"revenue": 5,
 			"desc": "Money gained from mine tokens is doubled for the owning Corporation. If owned by a Corporation, closes on purchase of “6” train, otherwise closes on purchase of “5” train.",
 			"abilities": [
-
+				{
+					"type": "close",
+					"owner_type": "corporation",
+					"when": "6"
+				}
 			]
 		},
 		{

--- a/lib/engine/step/g_18_co/dividend.rb
+++ b/lib/engine/step/g_18_co/dividend.rb
@@ -13,6 +13,19 @@ module Engine
 
           { share_direction: %i[right up], share_times: [1, 1] }
         end
+
+        def change_share_price(entity, payout)
+          tfm = @game.mines_total(entity)
+
+          # Only pay mines if a train produce revenue regardless of withhold or pay
+          if tfm.positive? && (payout[:corporation].positive? || payout[:per_share].positive?)
+            @game.bank.spend(tfm, entity)
+
+            @log << "#{entity.name} collects #{@game.format_currency(tfm)} from mines"
+          end
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/step/g_18_co/dividend.rb
+++ b/lib/engine/step/g_18_co/dividend.rb
@@ -14,17 +14,15 @@ module Engine
           { share_direction: %i[right up], share_times: [1, 1] }
         end
 
-        def change_share_price(entity, payout)
-          tfm = @game.mines_total(entity)
-
-          # Only pay mines if a train produce revenue regardless of withhold or pay
-          if tfm.positive? && (payout[:corporation].positive? || payout[:per_share].positive?)
-            @game.bank.spend(tfm, entity)
-
-            @log << "#{entity.name} collects #{@game.format_currency(tfm)} from mines"
-          end
-
+        def process_dividend(action)
           super
+
+          entity = action.entity
+          return unless (mine_revenue = @game.mines_total(entity)).positive?
+          return unless entity.operating_history[[@game.turn, @round.round_num]].revenue.positive?
+
+          @game.bank.spend(mine_revenue, entity)
+          @log << "#{entity.name} collects #{@game.format_currency(mine_revenue)} from mines"
         end
       end
     end

--- a/lib/engine/step/g_18_co/track.rb
+++ b/lib/engine/step/g_18_co/track.rb
@@ -15,8 +15,18 @@ module Engine
             action.hex.tile.icons.reject! { |icon| icon.name == 'upgrade' }
           end
 
-          # TODO: Implement Mine Collection
-          @log << 'TODO: implement mine token collection'
+          # Mine Token Collection
+          if action.hex.tile.icons.map(&:name).include?('mine')
+            # Remove mine symbol from hex
+            action.hex.tile.icons.reject! { |icon| icon.name == 'mine' }
+
+            # Add mine to corporation data
+            @game.mine_add(action.entity)
+
+            @log << "#{action.entity.name} collects a mine token from
+              #{action.hex.name} for a total of
+              #{@game.format_currency(@game.mines_total(action.entity))} from mines"
+          end
 
           pass! unless can_lay_tile?(action.entity)
         end

--- a/lib/engine/step/g_18_co/track.rb
+++ b/lib/engine/step/g_18_co/track.rb
@@ -23,9 +23,7 @@ module Engine
             # Add mine to corporation data
             @game.mine_add(action.entity)
 
-            @log << "#{action.entity.name} collects a mine token from
-              #{action.hex.name} for a total of
-              #{@game.format_currency(@game.mines_total(action.entity))} from mines"
+            @log << "#{action.entity.name} collects a mine token from #{action.hex.name}"
           end
 
           pass! unless can_lay_tile?(action.entity)


### PR DESCRIPTION
_This change only impacts 18CO files._

### Background

From https://github.com/tobymao/18xx/issues/1836

- Placing a tile on a location with a mine places the mine token onto the corporation's charter.
- Mines award $10 per mine directly to the treasury after the dividend step as long as a train was run
- Idarado Mining Company: Money gained from mines is doubled for the owning Corporation. Closes phase 5 if owned by a player. Closes phase 6 if owned by a corporation.
- Mines are removed from the board in phase 6

### Results

Mines show up as a corporation ability
<img width="341" alt="Screen Shot 2020-10-25 at 10 13 18 AM" src="https://user-images.githubusercontent.com/15675400/97115618-40662c80-16bd-11eb-9067-37778b7f35b6.png">

Log is written to when a corporation picks up a mine as well as when mine money is awarded
<img width="506" alt="Screen Shot 2020-10-25 at 10 18 04 AM" src="https://user-images.githubusercontent.com/15675400/97115628-4fe57580-16bd-11eb-88ca-65146ca88b8f.png">

### Implementation Notes

Rather than define new Ability classes I am working with the Base class. I don't know any other games that use tokens like this. One downside is the need to build a New object when adding a mine as the attributes are read only.

Piggybacking on **change_share_price** isn't the most ideal place to do this, but the timing is right and the data needed to determine if mines should pay is available.