### PR TITLE
18MEX: Implement support for optional rule 8a and 8d

### DIFF
--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -7,7 +7,7 @@ module Engine
   class Train
     include Ownable
 
-    attr_accessor :obsolete, :operated, :events,  :obsolete_on, :rusts_on
+    attr_accessor :obsolete, :operated, :events, :obsolete_on, :rusts_on
     attr_reader :available_on, :name, :distance, :discount, :multiplier, :rusted, :sym,
                 :variant, :variants
     attr_writer :buyable

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -7,9 +7,9 @@ module Engine
   class Train
     include Ownable
 
-    attr_accessor :obsolete, :operated, :events
-    attr_reader :available_on, :name, :distance, :discount, :multiplier, :obsolete_on,
-                :rusts_on, :rusted, :sym, :variant, :variants
+    attr_accessor :obsolete, :operated, :events,  :obsolete_on, :rusts_on
+    attr_reader :available_on, :name, :distance, :discount, :multiplier, :rusted, :sym,
+                :variant, :variants
     attr_writer :buyable
 
     def initialize(name:, distance:, price:, index: 0, **opts)


### PR DESCRIPTION
8a: Allow corporations (not minors) to lay a 3rd yellow tile (or 1
upgrade) during its first OR. For its second OR and later it is 2
yellow or 1 upgrade.

8d: Use normal (hard rust) 4 trains

Optional rule 8b and 8c are not yet implemented.