### PR TITLE
1817: Allow more than 10 tiles

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -928,8 +928,8 @@ module Engine
 
         # Find the highest tile that exists of this type in the tile list and duplicate it.
         # The highest one in the list should be the highest index anywhere.
-        tiles = @tiles.select { |t| t.name == tile.name }
-        new_tile = tiles.max { |a, b| a.id <=> b.id }.dup
+        tiles = @_tiles.values.select { |t| t.name == tile.name }
+        new_tile = tiles.max { |a, b| a.index <=> b.index }.dup
         @tiles << new_tile
 
         @_tiles[new_tile.id] = new_tile

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -66,6 +66,7 @@ module Engine
         @game.tiles.delete(tile)
         @game.tiles << old_tile unless old_tile.preprinted
 
+        @game.game_error('Tile is already used') if tile.hex
         hex.lay(tile)
 
         @game.graph.clear


### PR DESCRIPTION
Game 13797 created a tile 8-10, and then created another.
This caused a second 8-10 tile to be created corrupting the game.