### PR TITLE
Fix for upgrading Lawson tiles to Lawson tiles.

### DIFF
--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -239,10 +239,16 @@ module Engine
     end
 
     def paths_are_subset_of?(other_paths)
-      ALL_EDGES.any? do |ticks|
-        @paths.all? do |path|
-          path = path.rotate(ticks)
-          other_paths.any? { |other| path <= other }
+      if @junction
+        # Upgrading from a Lawson tile is a special case
+        other_exits = other_paths.flat_map(&:exits).uniq
+        ALL_EDGES.any? { |ticks| (exits - other_exits.map { |e| (e + ticks) % 6 }).empty? }
+      else
+        ALL_EDGES.any? do |ticks|
+          @paths.all? do |path|
+            path = path.rotate(ticks)
+            other_paths.any? { |other| path <= other }
+          end
         end
       end
     end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -239,8 +239,8 @@ module Engine
     end
 
     def paths_are_subset_of?(other_paths)
-      if @junction
-        # Upgrading from a Lawson tile is a special case
+      if @junction && other_paths.any?(&:junction)
+        # Upgrading from a Lawson tile to a Lawson tile is a special case
         other_exits = other_paths.flat_map(&:exits).uniq
         ALL_EDGES.any? { |ticks| (exits - other_exits.map { |e| (e + ticks) % 6 }).empty? }
       else


### PR DESCRIPTION
Special case for Tile::paths_are_subset_of? => if a Lawson tile to a Lawson tile, just look at exits.

If we ever have a tile with a junction that has anything other than exits on it, this will break (but probably so will a lot of other code).

Fixes #2016 