### PR TITLE
18MEX: Fix nil problem in corporation order sort

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -62,8 +62,9 @@ module Engine
 
     def <=>(other)
       # corporation with higher share price, farthest on the right, and first position on the share price goes first
-      sp = share_price
-      ops = other.share_price
+      return 1 unless (sp = share_price)
+      return -1 unless (ops = other.share_price)
+
       [ops.price, ops.coordinates.last, -ops.coordinates.first, -ops.corporations.find_index(other)] <=>
       [sp.price, sp.coordinates.last, -sp.coordinates.first, -sp.corporations.find_index(self)]
     end


### PR DESCRIPTION
In case a corporation is merged, it loses its share prace (it
becomes nil) but then the merged corporation can move to last place
in the list as it will not do anything during the operation round.
(And the next OR/SR it will not appear.)