### PR TITLE
fix C&OC still being rendered on tile after it is bought in

### DIFF
--- a/assets/app/view/game/part/blocker.rb
+++ b/assets/app/view/game/part/blocker.rb
@@ -80,7 +80,9 @@ module View
         end
 
         def should_render_company_sym?
-          blocker_open? && (!@blocker.owned_by_corporation? || @blocker.abilities(:tile_lay))
+          blocker_open? && (!@blocker.owned_by_corporation? ||
+                            @blocker.abilities(:tile_lay) ||
+                            @blocker.abilities(:teleport))
         end
 
         def should_render_barbell?


### PR DESCRIPTION
[Fixes #2025]

Screenshots taken immediately after a corp buys in the C&OC...

Before:

![Screenshot from 2020-10-25 19-07-50](https://user-images.githubusercontent.com/1045173/97124413-9656c680-16f5-11eb-93aa-b1ee60b41e0b.png)

After:

![Screenshot from 2020-10-25 19-07-33](https://user-images.githubusercontent.com/1045173/97124423-a5d60f80-16f5-11eb-9510-63da79ef906c.png)

