### PR TITLE
Option flag to allow town to upgrade to city

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -111,24 +111,24 @@ module Engine
 		"28": 2,
 		"29": 2,
 		"co8": {
-			"count": 1,
+			"count": 5,
 			"color": "green",
-			"code": "town=revenue:20;junction;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0"
+			"code": "town=revenue:20,to_city:1;junction;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0"
 		},
 		"co9": {
-			"count": 1,
+			"count": 5,
 			"color": "green",
-			"code": "town=revenue:20;junction;path=a:0,b:_0;path=a:5,b:_0;path=a:3,b:_0"
+			"code": "town=revenue:20,to_city:1;junction;path=a:0,b:_0;path=a:5,b:_0;path=a:3,b:_0"
 		},
 		"co10": {
-			"count": 1,
+			"count": 2,
 			"color": "green",
-			"code": "town=revenue:20;junction;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0"
+			"code": "town=revenue:20,to_city:1;junction;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0"
 		},
 		"co2": {
 			"count": 1,
 			"color": "green",
-			"code": "city=revenue:50,slots:3;city=revenue:50,hide:1;path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:2,b:_1;path=a:3,b:_1;label=D;"
+			"code": "city=revenue:50,slots:3;city=revenue:50,hide:1;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;label=D;"
 		},
 		"co6": {
 			"count": 1,
@@ -297,25 +297,25 @@ module Engine
 			"40"
 		],
 		[
-			"10b",
+			"10a",
 			"15",
 			"20",
 			"25",
 			"30"
 		],
 		[
-			"10b",
-			"10b",
+			"10a",
+			"10a",
 			"15",
 			"20",
 			"20"
 		],
 		[
-			"10b",
-			"10b",
-			"10b",
-			"15b",
-			"15b"
+			"10a",
+			"10a",
+			"10a",
+			"15a",
+			"15a"
 		]
 	],
 	"companies": [

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -40,6 +40,8 @@ module Engine
 
       # First 3 are Denver, Second 3 are CO Springs
       TILES_FIXED_ROTATION = %w[co1 co2 co3 co5 co6 co7].freeze
+      GREEN_TOWN_TILES = %w[co8 co9 co10].freeze
+      BROWN_CITY_TILES = %w[co4 63].freeze
 
       PAR_FLOAT_GROUPS = {
         20 => %w[X],
@@ -150,12 +152,28 @@ module Engine
         str
       end
 
+      def upgrades_to?(from, to, special = false)
+        # Green towns can't be upgraded to brown cities unless the hex has the upgrade icon
+        if GREEN_TOWN_TILES.include?(from.hex.tile.name)
+          return BROWN_CITY_TILES.include?(to.name) if from.hex.tile.icons.any? { |icon| icon.name == 'upgrade' }
+
+          return false
+        end
+
+        super
+      end
+
       def all_potential_upgrades(tile, tile_manifest: false)
         upgrades = super
 
         return upgrades unless tile_manifest
 
-        # TODO: co8 / co9 / co10 => 63 / co4
+        if GREEN_TOWN_TILES.include?(tile.name)
+          brown_cityco4 = @tiles.find { |t| t.name == 'co4' }
+          brown_city63 = @tiles.find { |t| t.name == '63' }
+          upgrades |= [brown_cityco4] if brown_cityco4
+          upgrades |= [brown_city63] if brown_city63
+        end
 
         upgrades
       end

--- a/lib/engine/part/town.rb
+++ b/lib/engine/part/town.rb
@@ -5,6 +5,20 @@ require_relative 'revenue_center'
 module Engine
   module Part
     class Town < RevenueCenter
+      attr_reader :to_city
+
+      def initialize(revenue, **opts)
+        super
+
+        @to_city = opts[:to_city]
+      end
+
+      def <=(other)
+        return true if to_city && other.city?
+
+        super
+      end
+
       def town?
         true
       end

--- a/lib/engine/step/g_18_co/track.rb
+++ b/lib/engine/step/g_18_co/track.rb
@@ -9,6 +9,12 @@ module Engine
         def process_lay_tile(action)
           lay_tile_action(action)
 
+          # Remove the upgrade icon when the town is converted to a city
+          if action.hex.tile.cities.any? &&
+             action.hex.tile.icons.any? { |icon| icon.name == 'upgrade' }
+            action.hex.tile.icons.reject! { |icon| icon.name == 'upgrade' }
+          end
+
           # TODO: Implement Mine Collection
           @log << 'TODO: implement mine token collection'
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -100,7 +100,8 @@ module Engine
                               visit_cost: params['visit_cost'],
                               route: params['route'],
                               format: params['format'],
-                              loc: params['loc'])
+                              loc: params['loc'],
+                              to_city: params['to_city'])
         cache << town
         town
       when 'halt'


### PR DESCRIPTION
### Background

From https://github.com/tobymao/18xx/issues/1836

Add a new option that allows a town tile to upgrade to a city tile. Used in 18CO, 18NEB, 1825, 1829, 1856, etc ( Section 5.4 http://www.fwtwr.com/18xx/rules_difference_list/single_list.htm#5 )

### Implementation Notes

The non-18CO specific changes are adding the `to_city` option and changing the definition of `<=` for Town. It would be reasonable to debate the name of the attribute `to_city`, its just what was in my head at the time.

In `<=` I choose to make it explicit that the only time we don't use the `super` definition is when both `to_city && other.city?` are true. There could be an argument made to use the shorthand `return to_city if other.city?` but that would change the logic of how `<=` works for a town tile that doesn't use the new feature and I wanted to avoid that.

Game creators still need to define the upgrade path for town->city tiles within upgrades_to? as the automatic upgrade detection will not determine cities are upgrades of towns. I think this is desirable as most games specify the exact tile(s) and not just any city tile for town upgrades.

Within `all_potential_upgrades`, I originally used the pattern set by other games of pre-determining a tile and saving in memory. This ended up presenting issues when that tile was placed on the board. The manifest would show the tile with tokens placed on it. Other games only have one specific tile, so the manifest would be empty once that tile was placed. Below is a screenshot of that in effect before my change.

<img width="328" alt="Screen Shot 2020-10-26 at 3 37 17 PM" src="https://user-images.githubusercontent.com/15675400/97318469-86440180-1831-11eb-9f25-6bc589b9dba6.png">

### Game Usage

Greeley about to be upgraded
<img width="327" alt="Screen Shot 2020-10-26 at 3 43 32 PM" src="https://user-images.githubusercontent.com/15675400/97241546-185af400-17b7-11eb-8171-1f02289b4d35.png">

Greeley upgraded shows the upgrade icon removed
<img width="276" alt="Screen Shot 2020-10-26 at 6 14 42 PM" src="https://user-images.githubusercontent.com/15675400/97241601-37598600-17b7-11eb-91e9-6f1b3fbd0ce0.png">

Tile Manifest
<img width="308" alt="Screen Shot 2020-10-26 at 6 15 01 PM" src="https://user-images.githubusercontent.com/15675400/97241623-43ddde80-17b7-11eb-8e58-f28f674f6e1f.png">

Limon doesn't have the upgrade icon, and selecting the tile properly shows no tiles.
<img width="293" alt="Screen Shot 2020-10-26 at 6 15 58 PM" src="https://user-images.githubusercontent.com/15675400/97241637-51936400-17b7-11eb-9a2c-27c432eca99f.png">

### Additional Notes

This change involved some 18CO tiles that were defined slightly incorrectly, so I fixed those along the way. The config changes didn't seem worth a separate PR.
1.) Denver green tile was rotated one step in the config
2.) The co8, co9 and co10 tile counts did not match the manifest
3.) Acquisition is the applicable section to show on the Stock Market.

