### PR TITLE
Only show the "private game" string if the game is new #2067

### DIFF
--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -211,8 +211,8 @@ module View
       end
 
       children = [h(:div, id_line)]
-      children << h(:div, [h(:i, 'Private game')]) if @gdata.dig('settings', 'unlisted')
-      children << h(:div, [h(:strong, 'Description: '), @gdata['description']])
+      children << h(:div, [h(:i, 'Private game')]) if @gdata['status'] == 'new' && @gdata.dig('settings', 'unlisted')
+      children << h(:div, [h(:strong, 'Description: '), @gdata['description']]) unless @gdata['description'].empty?
 
       optional = render_optional_rules
       children << optional if optional


### PR DESCRIPTION
Only show the "private game" string if the game is new, as requested by Toby

Don't show the Description if it's empty