### PR TITLE
1817: Mine discount and add lakes

### DIFF
--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -72,6 +72,7 @@ module View
               water: water(delta_x: delta_x, delta_y: delta_y),
               swamp: svg(delta_x: delta_x, delta_y: delta_y, icon: 'swamp'),
               desert: svg(delta_x: delta_x, delta_y: delta_y, icon: 'cactus'),
+              lake: svg(delta_x: delta_x, delta_y: delta_y, icon: 'lake'),
             }[t]
           end
 

--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -258,7 +258,7 @@ module Engine
           "tiles": [
             "7","8", "9"
           ],
-          "free": true,
+          "free": false,
           "when": "track",
           "owner_type": "corporation",
           "count": 1
@@ -291,7 +291,7 @@ module Engine
           "tiles": [
             "7","8", "9"
           ],
-          "free": true,
+          "free": false,
           "when": "track",
           "owner_type": "corporation",
           "count": 2
@@ -324,7 +324,7 @@ module Engine
           "tiles": [
             "7","8", "9"
           ],
-          "free": true,
+          "free": false,
           "when": "track",
           "owner_type": "corporation",
           "count": 3
@@ -734,7 +734,7 @@ module Engine
         "F19",
         "I16"
       ],
-      "city=revenue:0;upgrade=cost:20": [
+      "city=revenue:0;upgrade=cost:20,terrain:lake": [
         "D7"
       ],
       "city=revenue:0;upgrade=cost:15,terrain:mountain": [
@@ -769,7 +769,7 @@ module Engine
         "G10",
         "H7"
       ],
-      "upgrade=cost:20": [
+      "upgrade=cost:20,terrain:lake": [
         "B9",
         "B27",
         "D25",
@@ -835,13 +835,13 @@ module Engine
       ]
     },
     "yellow": {
-      "city=revenue:30;path=a:4,b:_0;path=a:0,b:_0;label=B;upgrade=cost:20,terrain:water": [
+      "city=revenue:30;path=a:4,b:_0;path=a:0,b:_0;label=B;upgrade=cost:20,terrain:lake": [
         "C8"
       ],
       "city=revenue:30;path=a:3,b:_0;path=a:5,b:_0;label=B": [
         "C26"
       ],
-      "city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:3,b:_1;label=NY;upgrade=cost:20,terrain:water": [
+      "city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:3,b:_1;label=NY;upgrade=cost:20,terrain:lake": [
         "E22"
       ],
       "city=revenue:30;path=a:4,b:_0;path=a:0,b:_0;label=B": [

--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -17,7 +17,8 @@ module Engine
             tile_lay = step.get_tile_lay(owner)
             tile = action.tile
             @game.game_error('Cannot lay an yellow now') if tile.color == :yellow && !tile_lay[:lay]
-            lay_tile(action, extra_cost: tile_lay[:cost], entity: owner, spender: owner)
+            # Subtract 15 from the cost cancelling the terrain cost
+            lay_tile(action, extra_cost: tile_lay[:cost] - 15, entity: owner, spender: owner)
             tile.hex.assign!('mine')
             @game.log << "#{owner.name} adds mine to #{tile.hex.name}"
             ability(action.entity).use!

--- a/public/icons/lake.svg
+++ b/public/icons/lake.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="-12.5 -12.5 25 25">
+    <path class="color-stroke-black" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M-10.75 3c0 3 6 3 6 0 0 3 6 3 6 0 0 3 6 3 6 0m-15-8c0 3 6 3 6 0 0 3 6 3 6 0 0 3 6 3 6 0"/>
+    <path class="color-stroke-main color-stroke-water" fill="none" stroke="#67a7c4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M-10.75 3c0 3 6 3 6 0 0 3 6 3 6 0 0 3 6 3 6 0m-15-8c0 3 6 3 6 0 0 3 6 3 6 0 0 3 6 3 6 0"/>
+</svg>


### PR DESCRIPTION
Players owning mines were getting a free discount on 'mineable' tiles irrespective of using the special (fixes #2066)
Add 'lake' terrain type and update non-discounted $20 tiles to use the lake terrain (fixes #2069)