### PR TITLE
1817: Corps entering acquisition in merger round should skip acqusition round.

### DIFF
--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -67,7 +67,7 @@ module Engine
       MARKET_TEXT = Base::MARKET_TEXT.merge(safe_par: 'Minimum Price for a 2($55), 5($70) and 10($120) share'\
       ' corporation taking maximum loans to ensure it avoids acquisition').freeze
       MARKET_SHARE_LIMIT = 1000 # notionally unlimited shares in market
-      attr_reader :loan_value, :owner_when_liquidated
+      attr_reader :loan_value, :owner_when_liquidated, :stock_prices_start_merger
 
       def bankruptcy_limit_reached?
         @players.reject(&:bankrupt).one?
@@ -419,6 +419,8 @@ module Engine
             new_operating_round
           when Round::Operating
             or_round_finished
+            # Store the share price of each corp to determine if they can be acted upon in the AR
+            @stock_prices_start_merger = @corporations.map { |corp| [corp, corp.share_price] }.to_h
             @log << "-- Merger and Conversion Round #{@turn}.#{@round.round_num} (of #{@operating_rounds}) --"
             Round::G1817::Merger.new(self, [
               Step::G1817::ReduceTokens,

--- a/lib/engine/round/g_1817/acquisition.rb
+++ b/lib/engine/round/g_1817/acquisition.rb
@@ -21,7 +21,9 @@ module Engine
           # Things that are offered up for acquisition, sale etc
           @offering =  @game
                       .corporations
-                      .select(&:floated?)
+                      .select do |corp|
+                        corp.floated? && !corp.share_price.acquisition? || @game.stock_prices_start_merger[corp].acquisition?
+                      end
                       .sort.reverse
                       .select do |corp|
                         !corp.share_price.acquisition? || @game.stock_prices_start_merger[corp].acquisition?

--- a/lib/engine/round/g_1817/acquisition.rb
+++ b/lib/engine/round/g_1817/acquisition.rb
@@ -23,6 +23,9 @@ module Engine
                       .corporations
                       .select(&:floated?)
                       .sort.reverse
+                      .select do |corp|
+                        !corp.share_price.acquisition? || @game.stock_prices_start_merger[corp].acquisition?
+                      end
           @game.players.select { |p| p.presidencies.any? }
         end
 

--- a/lib/engine/round/g_1817/acquisition.rb
+++ b/lib/engine/round/g_1817/acquisition.rb
@@ -19,15 +19,14 @@ module Engine
 
         def select_entities
           # Things that are offered up for acquisition, sale etc
-          @offering =  @game
-                      .corporations
-                      .select do |corp|
-                        corp.floated? && !corp.share_price.acquisition? || @game.stock_prices_start_merger[corp].acquisition?
-                      end
-                      .sort.reverse
-                      .select do |corp|
-                        !corp.share_price.acquisition? || @game.stock_prices_start_merger[corp].acquisition?
-                      end
+          @offering = @game
+                        .corporations
+                        .select do |corp|
+                          corp.floated? &&
+                            (!corp.share_price.acquisition? ||
+                             @game.stock_prices_start_merger[corp].acquisition?)
+                        end
+                        .sort.reverse
           @game.players.select { |p| p.presidencies.any? }
         end
 


### PR DESCRIPTION
Keep a track of corps share price before the merger round and filter out those
which just entered acquisition (fixes #2061)