### PR TITLE
optional rule fixes, plus 18 Los Angeles beta

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -168,8 +168,8 @@ module View
       else
         game_data = {
           settings: {
-            optional_rules_selected: game_params[:optional_rules_selected] || []
-          }
+            optional_rules_selected: game_params[:optional_rules_selected] || [],
+          },
         }
       end
 

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -159,19 +159,19 @@ module View
 
       return store(:flash_opts, 'Cannot have duplicate player names') if players.uniq.size != players.size
 
-      game_data = game_params['game_data']
-
       if @mode == :json
         begin
-          game_data = JSON.parse(game_data)
+          game_data = JSON.parse(game_params['game_data'])
         rescue JSON::ParserError => e
           return store(:flash_opts, e.message)
         end
       else
-        game_data = {}
+        game_data = {
+          settings: {
+            optional_rules_selected: game_params[:optional_rules_selected] || []
+          }
+        }
       end
-      game_data[:settings] ||= {}
-      game_data[:settings][:optional_rules_selected] = game_params[:optional_rules_selected] || []
 
       create_hotseat(
         id: Time.now.to_i,
@@ -212,7 +212,10 @@ module View
       range.value = (min..max).include?(val) ? val : max
       store(:num_players, range.value.to_i)
 
-      store(:optional_rules, selected_game::OPTIONAL_RULES)
+      visible_rules = selected_game::OPTIONAL_RULES.reject do |rule|
+        rule[:players] && !rule[:players].include?(@num_players)
+      end
+      store(:optional_rules, visible_rules)
     end
   end
 end

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -15,6 +15,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
+        <p>18 Los Angeles is now in beta!</p>
         <p>You can now create private games. After you create the game, use the "copy invite link" button to<br>
         get a URL to send to your opponents.</p>
         <p>1817 is now more stable and in alpha! Feel free to play multiplayer games.</p>

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -209,7 +209,7 @@ module Engine
       def setup; end
 
       def init_optional_rules(optional_rules)
-        optional_rules ||= []
+        optional_rules = (optional_rules || []).map(&:to_sym)
         self.class::OPTIONAL_RULES.each do |rule|
           optional_rules.delete(rule[:sym]) if rule[:players] && !rule[:players].include?(@players.size)
         end

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -28,7 +28,7 @@ module Engine
           sym: :dch,
           short_name: 'Dewey, Cheatham, and Howe',
           desc: 'add a private company which allows the owning corporation to '\
-                'place a token in a city that has no open slots (3+ players only)',
+                'place a token in a city that has no open slots; 3+ players only',
           players: [3, 4, 5],
         },
         {

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -12,7 +12,7 @@ module Engine
     class G18LosAngeles < G1846
       load_from_json(Config::Game::G18LosAngeles::JSON, Config::Game::G1846::JSON)
 
-      DEV_STAGE = :alpha
+      DEV_STAGE = :beta
 
       GAME_LOCATION = nil
       GAME_RULES_URL = {

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -84,6 +84,7 @@ class Api
                   users.map(&:name),
                   id: game.id,
                   actions: actions_h(game),
+                  optional_rules: game.settings['optional_rules_selected']&.map(&:to_sym),
                 )
 
                 action_id = r.params['id']
@@ -145,7 +146,11 @@ class Api
 
           # POST '/api/game/<game_id>/start
           r.is 'start' do
-            engine = Engine::GAMES_BY_TITLE[game.title].new(users.map(&:name), id: game.id)
+            engine = Engine::GAMES_BY_TITLE[game.title].new(
+              users.map(&:name),
+              id: game.id,
+              optional_rules: game.settings['optional_rules_selected']&.map(&:to_sym),
+            )
             unless game.players.size.between?(*Engine.player_range(engine.class))
               halt(400, 'Player count not supported')
             end


### PR DESCRIPTION
- fix including optional rules when importing games with JSON [Fixes #2053]
- fix server side creation of games to include the optional rules [Fixes #2062]
- don't show optional rules that aren't valid for the given player count