### PR TITLE
When selecting par value, display number of purchasable shares.

### DIFF
--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -29,11 +29,13 @@ module View
           props = {
             style: {
               width: 'calc(17.5rem/6)',
-              padding: '0.2rem 0',
+              padding: '0.2rem',
             },
             on: { click: par },
           }
-          h('button.small.par_price', props, @game.format_currency(share_price.price))
+          purchasable_shares = entity.cash.div(share_price.price)
+          text = "#{@game.format_currency(share_price.price)} (#{purchasable_shares})"
+          h('button.small.par_price', props, text)
         end
 
         div_class = par_buttons.size < 5 ? '.inline' : ''

--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -33,7 +33,7 @@ module View
             },
             on: { click: par },
           }
-          purchasable_shares = entity.cash.div(share_price.price)
+          purchasable_shares = (entity.cash / share_price.price).to_i
           text = "#{@game.format_currency(share_price.price)} (#{purchasable_shares})"
           h('button.small.par_price', props, text)
         end


### PR DESCRIPTION
Displays the number of shares the player could buy with cash in each par price button. Adjusts the button padding so the number is on its own line.

This is a feature that the old DOS 1830 game has that makes it easy to see at which par prices you can float a company on your own.

This does not take into consideration the per corporation share limit, so games with low par prices (e.g. 1846) will show an unobtainable amount of shares.