### PR TITLE
Allow the "owner" of the game to act even if they are not in the game

### DIFF
--- a/routes/game.rb
+++ b/routes/game.rb
@@ -32,7 +32,7 @@ class Api
             game.to_h
           end
 
-          not_authorized! unless users.any? { |u| u.id == user.id }
+          not_authorized! unless users.any? { |u| u.id == user.id || game.user_id == user.id }
 
           r.is 'leave' do
             halt(400, 'Cannot leave because game has started') unless game.status == 'new'


### PR DESCRIPTION
I want to automatically create all the games for the 1846 tournament and send the links to the players.

Using the API directly I can create all of them and then leave. But after I leave I cannot start the game (nor could any of the players).