### PR TITLE
18MEX: Correct bug with hard rust 4 train (fixes #2049)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -225,7 +225,7 @@ module Engine
         self.class::OPTIONAL_RULES.each do |o_r|
           next unless @optional_rules.include?(o_r[:sym])
 
-          @log << " * #{o_r[:short_name]}: (#{o_r[:desc]})"
+          @log << " * #{o_r[:short_name]}: #{o_r[:desc]}"
         end
       end
 

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -520,9 +520,13 @@ module Engine
       def change_4t_to_hardrust
         @depot.trains
           .select { |t| t.name == '4' }
-          .each do |t|
-            t.update_end_of_life(t.obsolete_on, nil)
-          end
+          .each { |t| change_to_hardrust(t) }
+      end
+
+      def change_to_hardrust(t)
+        t.rusts_on = t.obsolete_on
+        t.obsolete_on = nil
+        t.variants.each { |_, v| v.merge!(rusts_on: rusts_on, obsolete_on: obsolete_on) }
       end
     end
   end

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -41,10 +41,10 @@ module Engine
       OPTIONAL_RULES = [
         { sym: :triple_yellow_first_or,
           short_name: 'Extra yellow',
-          desc: '8a: Allow corporation to lay 3 yellows its first OR' },
+          desc: 'Allow corporations to lay 3 yellow tiles their first OR' },
         { sym: :hard_rust_t4,
           short_name: 'Hard rust',
-          desc: '8d: Hard rust for 4 trains' },
+          desc: "4 trains rust when 6' train is bought" },
       ].freeze
 
       def p2_company
@@ -521,8 +521,7 @@ module Engine
         @depot.trains
           .select { |t| t.name == '4' }
           .each do |t|
-            t.rusts_on = t.obsolete_on
-            t.obsolete_on = nil
+            t.update_end_of_life(t.obsolete_on, nil)
           end
       end
     end

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -7,9 +7,9 @@ module Engine
   class Train
     include Ownable
 
-    attr_accessor :obsolete, :operated, :events, :obsolete_on, :rusts_on
+    attr_accessor :obsolete, :operated, :events
     attr_reader :available_on, :name, :distance, :discount, :multiplier, :rusted, :sym,
-                :variant, :variants
+                :variant, :variants, :obsolete_on, :rusts_on
     attr_writer :buyable
 
     def initialize(name:, distance:, price:, index: 0, **opts)
@@ -53,6 +53,14 @@ module Engine
 
       @variant = @variants[new_variant]
       @variant.each { |k, v| instance_variable_set("@#{k}", v) }
+    end
+
+    def update_end_of_life(rusts_on, obsolete_on)
+      @rusts_on = rusts_on
+      @obsolete_on = obsolete_on
+      @variants = @variants.map do |name, variant|
+        [name, variant.merge(rusts_on: rusts_on, obsolete_on: obsolete_on)]
+      end.to_h
     end
 
     def names_to_prices

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -58,9 +58,7 @@ module Engine
     def update_end_of_life(rusts_on, obsolete_on)
       @rusts_on = rusts_on
       @obsolete_on = obsolete_on
-      @variants = @variants.map do |name, variant|
-        [name, variant.merge(rusts_on: rusts_on, obsolete_on: obsolete_on)]
-      end.to_h
+      @variants.each { |_, v| v.merge!(rusts_on: rusts_on, obsolete_on: obsolete_on) }
     end
 
     def names_to_prices

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -7,9 +7,9 @@ module Engine
   class Train
     include Ownable
 
-    attr_accessor :obsolete, :operated, :events
+    attr_accessor :obsolete, :operated, :events, :variants, :obsolete_on, :rusts_on
     attr_reader :available_on, :name, :distance, :discount, :multiplier, :rusted, :sym,
-                :variant, :variants, :obsolete_on, :rusts_on
+                :variant
     attr_writer :buyable
 
     def initialize(name:, distance:, price:, index: 0, **opts)
@@ -53,12 +53,6 @@ module Engine
 
       @variant = @variants[new_variant]
       @variant.each { |k, v| instance_variable_set("@#{k}", v) }
-    end
-
-    def update_end_of_life(rusts_on, obsolete_on)
-      @rusts_on = rusts_on
-      @obsolete_on = obsolete_on
-      @variants.each { |_, v| v.merge!(rusts_on: rusts_on, obsolete_on: obsolete_on) }
     end
 
     def names_to_prices


### PR DESCRIPTION
Need to update variant as well when setting obsolete_on, rusts_on.

Update description text for optional rules.

Also remove unnecessary parantheses in the general presentation
of optional rules.

Before:

-- Phase 2 (Operating Rounds: 1, Train Limit: 3, Available Tiles: Yellow ) --
Optional rules used in this game:
* Hard rust: (8d: Hard rust for 4 trains)

After change:

-- Phase 2 (Operating Rounds: 1, Train Limit: 3, Available Tiles: Yellow ) --
Optional rules used in this game:
* Hard rust: 4 trains rust when 6' train is bought