### PR TITLE
Improved chat style

### DIFF
--- a/assets/app/view/chat.rb
+++ b/assets/app/view/chat.rb
@@ -74,10 +74,7 @@ module View
     end
 
     def add_line(data)
-      name = data[:user][:name]
-      ts = Time.at(data[:created_at]).strftime('%Y-%m-%d %H:%M:%S')
-      message = data[:message]
-      store(:log, @log << "#{ts} #{name}: #{message}")
+      store(:log, @log << data)
     end
   end
 end

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -56,6 +56,17 @@ module View
             line_props[:style][:marginTop] = '0.5em' if index.positive?
           end
           h(:div, line_props, line)
+
+        elsif line.is_a?(Hash) # Homepage chat
+          timestamp = Time.at(line[:created_at])
+          time = timestamp.strftime(timestamp + 86_400 < Time.now ? '%F %T' : '%T')
+
+          h('div.chatline', line_props, [
+            h('span.username', line[:user][:name]),
+            h('span.timestamp', time),
+            h('span.message', line[:message]),
+          ])
+
         elsif line.is_a?(Engine::Action::Message)
           h(:div, { style: { fontWeight: 'bold' } }, "#{line.entity.name}: #{line.message}")
         end

--- a/assets/app/view/log.rb
+++ b/assets/app/view/log.rb
@@ -48,25 +48,30 @@ module View
         props[:style][:boxSizing] = 'border-box'
       end
 
+      timestamp_props = { style: { margin: '0 0.2rem',
+                                   fontSize: 'smaller' } }
+      username_props = { style: { margin: '0 0.2rem',
+                                  fontWeight: 'bold' } }
+      message_props = { style: { margin: '0 0.2rem' } }
+
       lines = @log.each_with_index.map do |line, index|
-        line_props = { style: {} }
+        line_props = { style: { marginBottom: '0.2rem',
+                                paddingLeft: '0.5rem',
+                                textIndent: '-0.5rem' } }
         if line.is_a?(String)
           if line.start_with?('--')
             line_props[:style][:fontWeight] = 'bold'
             line_props[:style][:marginTop] = '0.5em' if index.positive?
           end
           h(:div, line_props, line)
-
         elsif line.is_a?(Hash) # Homepage chat
-          timestamp = Time.at(line[:created_at])
-          time = timestamp.strftime(timestamp + 86_400 < Time.now ? '%F %T' : '%T')
-
+          time = Time.at(line[:created_at])
+          timestamp = time.strftime(time + 86_400 < Time.now ? '%F %T' : '%T')
           h('div.chatline', line_props, [
-            h('span.username', line[:user][:name]),
-            h('span.timestamp', time),
-            h('span.message', line[:message]),
+            h('span.timestamp', timestamp_props, timestamp),
+            h('span.username', username_props, line[:user][:name]),
+            h('span.message', message_props, line[:message]),
           ])
-
         elsif line.is_a?(Engine::Action::Message)
           h(:div, { style: { fontWeight: 'bold' } }, "#{line.entity.name}: #{line.message}")
         end

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -347,6 +347,24 @@ table.center {
   }
 }
 
+#chatlog > div {
+  margin-bottom: 0.2rem;
+  padding-left: 0.5rem;
+  text-indent: -0.5rem;
+}
+
+#homepage #chatlog .chatline span {
+  margin: 0 0.2rem;
+}
+
+#homepage #chatlog .chatline .username {
+  font-weight: bold;
+}
+
+#homepage #chatlog .chatline .timestamp {
+  font-size: smaller;
+}
+
 div.game.card em {
   font-style: normal;
   text-decoration: underline;

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -347,24 +347,6 @@ table.center {
   }
 }
 
-#chatlog > div {
-  margin-bottom: 0.2rem;
-  padding-left: 0.5rem;
-  text-indent: -0.5rem;
-}
-
-#homepage #chatlog .chatline span {
-  margin: 0 0.2rem;
-}
-
-#homepage #chatlog .chatline .username {
-  font-weight: bold;
-}
-
-#homepage #chatlog .chatline .timestamp {
-  font-size: smaller;
-}
-
 div.game.card em {
   font-style: normal;
   text-decoration: underline;


### PR DESCRIPTION
Improves the styling of the homepage chat.

- Bolded username
- Smaller timestamp
- Timestamp only shows date for messages older than one day
- Slight indentation of word wrapped messages (also applied to the in-game log)
- Slightly increased spacing between messages

![Screenshot_20201028_224216](https://user-images.githubusercontent.com/105335/97519429-a2e65380-196f-11eb-8f4d-2b8e919f7cce.png)
