### PR TITLE
1817 Mines restrictions

### DIFF
--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -29,7 +29,8 @@ module Engine
         def available_hex(entity, hex)
           return super if entity.company? && entity.id == 'PSM'
 
-          return if ability(entity)&.hexes&.any? && !ability(entity)&.hexes&.include?(hex.id)
+          hexes = ability(entity)&.hexes
+          return if hexes&.any? && !hexes&.include?(hex.id)
 
           # When actually laying track entity will be the corp.
           owner = entity.corporation? ? entity : entity.owner

--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -25,6 +25,42 @@ module Engine
           end
           step.laid_track = step.laid_track + 1
         end
+
+        def available_hex(entity, hex)
+          return super if entity.company? && entity.id == 'PSM'
+
+          return if ability(entity)&.hexes&.any? && !ability(entity)&.hexes&.include?(hex.id)
+
+          # When actually laying track entity will be the corp.
+          owner = entity.corporation? ? entity : entity.owner
+
+          @game.graph.connected_hexes(owner)[hex]
+        end
+
+        def potential_future_tiles(_entity, hex)
+          @game.tiles
+            .uniq(&:name)
+            .select { |t| @game.upgrades_to?(hex.tile, t) }
+        end
+
+        def legal_tile_rotation?(entity, hex, tile)
+          return super if entity.company? && entity.id == 'PSM'
+
+          super &&
+          tile.exits.any? do |exit|
+            neighbor = hex.neighbors[exit]
+            ntile = neighbor&.tile
+            next false unless ntile
+
+            # The neighbouring tile must have a city or offboard
+            # That neighbouring tile must either connect to an edge on the tile or
+            # potentially be updated in future.
+            (ntile.cities&.any? ||
+             ntile.offboards&.any?) &&
+            (ntile.edges.any? { |e| e.num == Hex.invert(exit) } ||
+             potential_future_tiles(entity, neighbor).any?)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Mines can only be placed next to existing track
Mines must be connected to a revenue location
or could potentially be upgraded to be connected

fixes #2082