### PR TITLE
1817: Various fixes for stock rounds

### DIFF
--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -45,6 +45,14 @@ module Engine
           actions
         end
 
+        def can_sell_order?
+          !bought? && !shorted?
+        end
+
+        def shorted?
+          @current_actions.any? { |x| x.class == Action::Short }
+        end
+
         def cash_with_subsidiaries(entity)
           entity.cash + @subsidiaries.sum(&:value)
         end
@@ -63,7 +71,7 @@ module Engine
           if entity.corporation?
             entity.cash >= bundle.price && redeemable_shares(entity).include?(bundle)
           else
-            super
+            super && !bundle.corporation.share_price.acquisition?
           end
         end
 
@@ -140,7 +148,13 @@ module Engine
         end
 
         def log_pass(entity)
-          return super unless @auctioning
+          return if @auctioning
+
+          if @corporate_action
+            @log << "#{entity.name} finishes acting for #{@corporate_action.entity.name}"
+          else
+            super
+          end
         end
 
         def pass!


### PR DESCRIPTION
Improve wording of log on player pass when acting for corps (fixes #2111)
Cannot purchase shares of corps in acquisition (fixes #2107)
SR order should be Sell, Short then Buy (fixes #2108)