### PR TITLE
18MEX: Correct tile count (fixes #2118)

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -104,7 +104,7 @@ module Engine
       "471":1,
       "472":1,
       "473":1,
-      "474":1,
+      "474":2,
       "475":1,
       "476":1,
       "477":1,
@@ -144,7 +144,7 @@ module Engine
          "color":"brown",
          "code":"town=revenue:10;path=a:2,b:_0,a_lane:2.1;path=a:5,b:_0;path=a:2,b:4,a_lane:2.0;label=P"
       },
-      "619":1
+      "619":2
    },
    "market":[
       [


### PR DESCRIPTION
Green tiles 474 and 619 should be 2 according to the rules, but was 1.