### PR TITLE
In case different percentages is in market, separate buy buttons

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -16,7 +16,6 @@ module View
         current_entity = step.current_entity
 
         ipo_share = @corporation.shares[0]
-        pool_share = @game.share_pool.shares_by_corporation[@corporation][0]
 
         children = []
 
@@ -29,13 +28,15 @@ module View
             )
           end
 
-          if step.can_buy?(current_entity, pool_share)
-            children << h(
-              :button,
-              { on: { click: -> { buy_share(current_entity, pool_share) } } },
-              'Buy Market Share',
-            )
-          end
+          # Put up one buy button for each buyable percentage share type in market.
+          # In case there are more than one type of percentages in market (e.g. 18MEX), show percentage type on button.
+          pool_shares = @game.share_pool.shares_by_corporation[@corporation].group_by(&:percent).values.collect(&:first)
+          pool_shares
+            .select { |share| step.can_buy?(current_entity, share) }
+            .each do |share|
+              text = pool_shares.size > 1 ? "Buy #{share.percent}% Market Share" : 'Buy Market Share'
+              children << h(:button, { on: { click: -> { buy_share(current_entity, share) } } }, text)
+            end
         end
 
         if step.current_actions.include?('short') && step.can_short?(current_entity, @corporation)


### PR DESCRIPTION
This is currently only for 18MEX but it is general code that will
be used as soon as there are different percentage shares in the
share pool.

In case there is just one type of shares the behavior will not be changed.

In case there are more the one type of percentage in the share pool
the percentage of the market share will be shown on the Buy button.
This is also presented even if only one of the types are buyable.

So, using 18MEX as an example:

* If 5% and 10% are in market pool, and player can buy both
  Show: "Buy 5% Market Share" "Buy 10% Market Share"

* If 5% and 10% are in market pool, but player can only buy 5%
  Show: "Buy 5% Market Share"

* If just 5% or 10% shares are in market pool
  Show "Buy Market Share"

* And this means - if not 18MEX
  Show "Buy Market Share"

This fixes #2097