### PR TITLE
18MEX: NdM trains should not be buyable unless enough cash (fixes #2044)

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -239,7 +239,7 @@ module View
 
       def price_range(train)
         step = @game.round.active_step
-        if step.face_value?(train.owner) || step.face_value?(@corporation)
+        if step.must_buy_at_face_value?(train, @corporation)
           {
             type: 'number',
             min: train.price,

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -111,6 +111,8 @@ module Engine
           end
         end
 
+        other_trains.reject! { |t| entity.cash < t.price && must_buy_at_face_value?(t, entity) }
+
         depot_trains + other_trains
       end
 
@@ -149,12 +151,18 @@ module Engine
       end
 
       def must_pay_face_value?(train, entity, price)
-        return if train.from_depot? || (!face_value?(entity) && !face_value?(train.owner))
+        return if train.from_depot? || !must_buy_at_face_value?(train, entity)
 
         train.price != price
       end
 
-      def face_value?(entity)
+      def must_buy_at_face_value?(train, entity)
+        face_value_ability?(entity) || face_value_ability?(train.owner)
+      end
+
+      private
+
+      def face_value_ability?(entity)
         entity.abilities(:train_buy) { |ability| return ability.face_value }
         false
       end


### PR DESCRIPTION
In case buying trains from/to a corporation that has the train_buy
ability (that restricts to only sell/buy trains at face value) those
trains should not appear as buyable in case they cost more than the
buying corporation has in cash.