### PR TITLE
Various publisher improvements

### DIFF
--- a/assets/app/lib/publisher.rb
+++ b/assets/app/lib/publisher.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_tree 'engine'
+
+module Lib
+  module Publisher
+    def self.link_list(component: nil, publishers: [])
+      # show publishers for all playable games on the welcome page
+      publishers = Engine::VISIBLE_GAMES.flat_map { |g| g::GAME_PUBLISHER }.compact.uniq.sort if publishers.empty?
+
+      publishers.map! do |p|
+        publisher = Engine::Publisher::INFO[p]
+
+        if component
+          component.h(:a, { attrs: { href: publisher[:url] } }, publisher[:name])
+        else
+          "<a href='#{publisher[:url]}'>#{publisher[:name]}</a>"
+        end
+      end
+
+      if publishers.size > 1
+        if publishers.size > 2
+          commas = (publishers.size - 1).times.map { ', ' }
+          publishers = publishers.zip(commas).flatten.compact
+        end
+        publishers.insert(-2, ' and ')
+      end
+
+      publishers
+    end
+  end
+end

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -2,6 +2,7 @@
 
 require 'lib/color'
 require 'lib/settings'
+require 'lib/publisher'
 require 'lib/text'
 
 module View
@@ -50,7 +51,7 @@ module View
         if (publisher = @game.class::GAME_PUBLISHER)
           children << h(:p, [
               'Published by ',
-              h(:a, { attrs: { href: publisher[:url] } }, publisher[:name]),
+              *Lib::Publisher.link_list(component: self, publishers: Array(publisher)),
             ])
         end
         children << h(:p, "Designed by #{@game.class::GAME_DESIGNER}") if @game.class::GAME_DESIGNER

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lib/publisher'
+
 module View
   class Welcome < Snabberb::Component
     needs :app_route, default: nil, store: true
@@ -26,12 +28,7 @@ module View
         resources in our <a href='https://github.com/tobymao/18xx/wiki'>Wiki!</a>
         </p>
 
-        Support our publishers: <a href='https://all-aboardgames.com'>All-Aboard Games</a>,
-        <a href='https://www.grandtrunkgames.com'>Grand Trunk Games</a>,
-        <a href='https://goldenspikegames.com'>Golden Spike Games</a>,
-        <a href='https://www.gmtgames.com/'>GMT Games</a>,
-        and <a href='https://traxx-denver.com/games/'>TraXX</a>.
-        </p>
+        <p>Support our publishers: #{Lib::Publisher.link_list.join}.</p>
 
         <p>You can support this project on <a href='https://www.patreon.com/18xxgames'>Patreon</a>.
         </p>

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -33,7 +33,7 @@ module Engine
       GAME_LOCATION = 'NYSE, USA'
       GAME_RULES_URL = 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view'
       GAME_DESIGNER = 'Craig Bartell, Tim Flowers'
-      GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_PUBLISHER = :all_aboard_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817'
 
       MUST_BID_INCREMENT_MULTIPLE = true

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -23,7 +23,7 @@ module Engine
       GAME_LOCATION = 'Midwest, USA'
       GAME_RULES_URL = 'https://s3-us-west-2.amazonaws.com/gmtwebsiteassets/1846/1846-RULES-GMT.pdf'
       GAME_DESIGNER = 'Thomas Lehmann'
-      GAME_PUBLISHER = Publisher::INFO[:gmt_games]
+      GAME_PUBLISHER = %i[gmt_games golden_spike].freeze
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1846'
 
       POOL_SHARE_DROP = :one

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -19,7 +19,7 @@ module Engine
       GAME_LOCATION = 'Isle of Wight'
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/79633/second-edition-rules'
       GAME_DESIGNER = 'Mike Hutton'
-      GAME_PUBLISHER = Publisher::INFO[:zman_games]
+      GAME_PUBLISHER = :zman_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1860'
 
       EBUY_PRES_SWAP = false # allow presidential swaps of other corps when ebuying

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -23,7 +23,7 @@ module Engine
       GAME_LOCATION = 'Assiniboia, Canada'
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/206629/1882-rules'
       GAME_DESIGNER = 'Marc Voyer'
-      GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_PUBLISHER = :all_aboard_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1882'
 
       MUST_BID_INCREMENT_MULTIPLE = true

--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -22,7 +22,7 @@ module Engine
       GAME_LOCATION = 'Shikoku, Japan'
       GAME_RULES_URL = 'http://dl.deepthoughtgames.com/1889-Rules.pdf'
       GAME_DESIGNER = 'Yasutaka Ikeda (池田 康隆)'
-      GAME_PUBLISHER = Publisher::INFO[:grand_trunk_games]
+      GAME_PUBLISHER = :grand_trunk_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1889'
 
       EBUY_PRES_SWAP = false # allow presidential swaps of other corps when ebuying

--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -23,7 +23,7 @@ module Engine
       GAME_LOCATION = nil
       GAME_RULES_URL = 'https://www.dropbox.com/s/x0dsehrxqr1tl6w/18Chesapeake_Rules.pdf'
       GAME_DESIGNER = 'Scott Petersen'
-      GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_PUBLISHER = :all_aboard_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
 
       MUST_BID_INCREMENT_MULTIPLE = true

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -20,7 +20,7 @@ module Engine
         '1846 Rules' => 'https://s3-us-west-2.amazonaws.com/gmtwebsiteassets/1846/1846-RULES-GMT.pdf',
       }.freeze
       GAME_DESIGNER = 'Anthony Fryer'
-      GAME_PUBLISHER = Publisher::INFO[:traxx]
+      GAME_PUBLISHER = %i[traxx sea_horse].freeze
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18LosAngeles'
 
       OPTIONAL_RULES = [

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -15,6 +15,7 @@ module Engine
       GAME_LOCATION = 'Mexico'
       GAME_RULES_URL = 'https://secure.deepthoughtgames.com/games/18MEX/rules.pdf'
       GAME_DESIGNER = 'Mark Derrick'
+      GAME_PUBLISHER = :all_aboard_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18MEX'
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -16,7 +16,7 @@ module Engine
       GAME_LOCATION = 'Mississippi, USA'
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/209791'
       GAME_DESIGNER = 'Mark Derrick'
-      GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_PUBLISHER = :all_aboard_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18MS'
 
       # Game will end after 10 ORs - checked in end_now? below

--- a/lib/engine/game/g_18_new_england.rb
+++ b/lib/engine/game/g_18_new_england.rb
@@ -11,7 +11,7 @@ module Engine
       GAME_LOCATION = 'Southern New England, USA'
       GAME_RULES_URL = 'https://docs.google.com/document/d/1hgh1_-RMgEnQI1XlodT_6UpPU5ZnEZtMT6Yg5TOuXOw'
       GAME_DESIGNER = 'Scott Petersen'
-      GAME_PUBLISHER = Publisher::INFO[:all_aboard_games]
+      GAME_PUBLISHER = :all_aboard_games
 
       SELL_BUY_ORDER = :sell_buy
 

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -15,6 +15,7 @@ module Engine
       GAME_LOCATION = 'Tennessee, USA'
       GAME_RULES_URL = 'http://dl.deepthoughtgames.com/18TN-Rules.pdf'
       GAME_DESIGNER = 'Mark Derrick'
+      GAME_PUBLISHER = :golden_spike
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18TN'
 

--- a/lib/engine/publisher.rb
+++ b/lib/engine/publisher.rb
@@ -3,17 +3,25 @@
 module Engine
   module Publisher
     INFO = {
-      grand_trunk_games: {
-        name: 'Grand Trunk Games',
-        url: 'https://www.grandtrunkgames.com/',
-      },
       all_aboard_games: {
-        name: 'All Aboard Games',
+        name: 'All-Aboard Games',
         url: 'https://all-aboardgames.com/',
       },
       gmt_games: {
         name: 'GMT Games',
         url: 'https://www.gmtgames.com/',
+      },
+      golden_spike: {
+        name: 'Golden Spike Games',
+        url: 'https://goldenspikegames.com/',
+      },
+      grand_trunk_games: {
+        name: 'Grand Trunk Games',
+        url: 'https://www.grandtrunkgames.com/',
+      },
+      sea_horse: {
+        name: 'Sea Horse Laser & Design',
+        url: 'https://www.etsy.com/shop/SeahorseLaserDesign?section_id=24360565',
       },
       traxx: {
         name: 'TraXX',


### PR DESCRIPTION
* a game's `GAME_PUBLISHER` is now just the symbol (or array of symbols)
* on the welcome page, automatically display the publishers of all alpha-and-up
  games, sorted alphabetically--no more manually updating this list when a new
  publisher is added
* fix `<p>` tag for publishers section on welcome page
* support for displaying multiple publishers on game info pages
* add Golden Spike Games as a second publisher of 1846
* add Sea Horse Laser & Design as a second publisher of 18 Los Angeles
* add missing publisher info for some games:
    * 18MEX (All-Aboard Games)
    * 18TN (Golden Spike Games)
* fix spelling ("All Aboard" -> "All-Aboard")
* alphabetize publishers in `lib/engine/publisher.rb`
* add Golden Spike Games to `lib/engine/publisher.rb`