### PR TITLE
18AL: Implement optional rules (fixes #2036)

### DIFF
--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -68,6 +68,12 @@ module Engine
       @discarded.delete(train)
     end
 
+    def add_train(train)
+      train.owner = self
+      @trains << train
+      @upcoming << train
+    end
+
     def depot_trains
       [
         @upcoming.first,

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -33,6 +33,21 @@ module Engine
 
       STANDARD_YELLOW_CITY_TILES = %w[5 6 57].freeze
 
+      OPTIONAL_RULES = [
+        { sym: :double_yellow_first_or,
+          short_name: 'Extra yellow',
+          desc: 'Allow corporation to lay 2 yellows its first OR' },
+        { sym: :LN_home_city_moved,
+          short_name: 'Move L&N home',
+          desc: 'Move L&N home city to Decatur - Nashville becomes off board hex' },
+        { sym: :unlimited_4d,
+          short_name: 'Unlimited 4D',
+          desc: 'Unlimited number of 4D' },
+        { sym: :hard_rust_t4,
+          short_name: 'Hard rust',
+          desc: '4 trains rust when 7 train is bought' },
+      ].freeze
+
       ASSIGNMENT_TOKENS = {
         'SNAR' => '/icons/18_al/snar_token.svg',
       }.freeze
@@ -43,7 +58,13 @@ module Engine
       end
 
       def setup
+        @recently_floated = []
+
         setup_company_price_50_to_150_percent
+
+        move_ln_corporation if @optional_rules&.include?(:LN_home_city_moved)
+        add_extra_4d if @optional_rules&.include?(:unlimited_4d)
+        change_4t_to_hardrust if @optional_rules&.include?(:hard_rust_t4)
 
         @corporations.each do |corporation|
           corporation.abilities(:assign_hexes) do |ability|
@@ -74,6 +95,10 @@ module Engine
           Step::SingleDepotTrainBuy,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
+      end
+
+      def or_round_finished
+        @recently_floated = []
       end
 
       def stock_round
@@ -152,6 +177,12 @@ module Engine
         super
       end
 
+      def float_corporation(corporation)
+        @recently_floated << corporation
+
+        super
+      end
+
       def all_potential_upgrades(tile, tile_manifest: false)
         # Lumber terminal cannot be upgraded
         return [] if tile.name == '445'
@@ -166,12 +197,55 @@ module Engine
         upgrades
       end
 
+      def tile_lays(entity)
+        return super if !@optional_rules&.include?(:double_yellow_first_or) ||
+          !@recently_floated&.include?(entity)
+
+        [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }]
+      end
+
       private
 
       def route_bonus(route, type)
         route.corporation.abilities(type).sum do |ability|
           ability.hexes == (ability.hexes & route.hexes.map(&:name)) ? ability.amount : 0
         end
+      end
+
+      def move_ln_corporation
+        ln = corporation_by_id('L&N')
+        previous_hex = hex_by_id('A4')
+        old_tile = previous_hex.tile
+        tile_string = 'offboard=revenue:yellow_40|brown_50;path=a:0,b:_0;path=a:1,b:_0'
+        previous_hex.tile = Tile.from_code(old_tile.name, old_tile.color, tile_string)
+        previous_hex.tile.location_name = 'Nashville'
+
+        new_hex = hex_by_id('C4')
+        new_hex.tile.add_reservation!(ln, 0, 0)
+
+        ln.coordinates = 'C4'
+      end
+
+      def add_extra_4d
+        diesel_trains = @depot.trains.select { |t| t.name == '4D' }
+        diesel = diesel_trains.first
+        (diesel_trains.length + 1).upto(8) do |i|
+          new_4d = diesel.clone
+          new_4d.index = i
+          @depot.add_train(new_4d)
+        end
+      end
+
+      def change_4t_to_hardrust
+        @depot.trains
+          .select { |t| t.name == '4' }
+          .each { |t| change_to_hardrust(t) }
+      end
+
+      def change_to_hardrust(t)
+        t.rusts_on = t.obsolete_on
+        t.obsolete_on = nil
+        t.variants.each { |_, v| v.merge!(rusts_on: t.rusts_on, obsolete_on: t.obsolete_on) }
       end
     end
   end

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -7,8 +7,8 @@ module Engine
   class Hex
     include Assignable
 
-    attr_accessor :x, :y, :ignore_for_axes
-    attr_reader :connections, :coordinates, :empty, :layout, :neighbors, :tile, :location_name, :original_tile
+    attr_accessor :x, :y, :ignore_for_axes, :location_name
+    attr_reader :connections, :coordinates, :empty, :layout, :neighbors, :tile, :original_tile
 
     DIRECTIONS = {
       flat: {
@@ -91,6 +91,11 @@ module Engine
 
     def name
       @coordinates
+    end
+
+    def tile=(new_tile)
+      @original_tile = @tile = new_tile
+      new_tile.hex = self
     end
 
     def lay(tile)

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -6,9 +6,8 @@ module Engine
   module Operator
     include Entity
 
-    attr_accessor :rusted_self
-    attr_reader :color, :coordinates, :city, :loans, :logo,
-                :operating_history, :text_color, :tokens, :trains
+    attr_accessor :rusted_self, :coordinates
+    attr_reader :color, :city, :loans, :logo, :operating_history, :text_color, :tokens, :trains
 
     def init_operator(opts)
       @cash = 0

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -7,7 +7,7 @@ module Engine
   class Train
     include Ownable
 
-    attr_accessor :obsolete, :operated, :events, :variants, :obsolete_on, :rusts_on
+    attr_accessor :obsolete, :operated, :events, :variants, :obsolete_on, :rusts_on, :index
     attr_reader :available_on, :name, :distance, :discount, :multiplier, :rusted, :sym,
                 :variant
     attr_writer :buyable


### PR DESCRIPTION
Optional rule 7a means that the first OR for any corporation, it
may lay 2 yellow tiles instead of 1 yellow or 1 upgrade.

Optional rule 7b means that the home location for L&N corporation
is moved to Decatur. This also means that hex A3 is turned into
an off board hex.

Optional rule 7c means that the number of 4D trains are unlimited.
This will change the number of 4D from 5 to 8. Theoretically
each of the 6 corporations may own 2 trains each, and there are
4 other permanent trains, so 8 4D is the max number of trains
that can be owned by corporations.

Optional rule 7d means that the 4T trains now are rusted by 7T
instead of phased out.