### PR TITLE
18MS: Fix OR history description (fixes #2141)

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -58,7 +58,7 @@ module View
       end
 
       def render_history_titles(corporations)
-        or_history(corporations).map { |turn, round| h(:th, "#{turn}.#{round}") }
+        or_history(corporations).map { |turn, round| h(:th, @game.or_description_short(turn, round)) }
       end
 
       def render_history(corporation)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1438,6 +1438,10 @@ module Engine
 
         description.strip
       end
+
+      def or_description_short(turn, round)
+        "#{turn}.#{round}"
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -178,6 +178,10 @@ module Engine
         end
       end
 
+      def or_description_short(turn, round)
+        ((turn - 1) * 2 + round).to_s
+      end
+
       # Game will end directly after the end of OR 10
       def end_now?(_after)
         @or == 10


### PR DESCRIPTION
Create a general method for printing turn and OR in spreedsheet. Override this for 18MS.