### PR TITLE
Fix city assignment on upgrade and set 18CO Token Cities

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -525,6 +525,7 @@ module Engine
 				0,
 				40
 			],
+			"city": 2,
 			"coordinates": "E15",
 			"color": "purple"
 		},
@@ -539,6 +540,7 @@ module Engine
 				0,
 				40
 			],
+			"city": 1,
 			"coordinates": "E15",
 			"color": "green"
 		},
@@ -557,6 +559,7 @@ module Engine
 				100,
 				100
 			],
+			"city": 0,
 			"coordinates": "E15",
 			"color": "yellow",
 			"text_color": "black"

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -112,11 +112,13 @@ module Engine
           @tile.cities.map.with_index do |old_city, index|
             new_city = tile.cities.find do |city|
               # we want old_edges to be subset of new_edges
-              (old_city.exits - city.exits).empty?
+              # without the any? check, first city will always match
+              old_city.exits.any? && (old_city.exits - city.exits).empty?
             end
 
             # When downgrading from yellow to no-exit tiles, assume it's the same index
-            new_city ||= tile.cities[index]
+            # Also, when upgrading a no-exit city, assume it's the same index if possible
+            new_city ||= (tile.cities[index] || tile.cities[0])
             [old_city, new_city]
           end.to_h
         end


### PR DESCRIPTION
Without the _any?_ check, the first city will always match regardless of which city index is specified in the config. We should instead assume the city has the same index. In the case where that city's index is no longer available on the tile, use index 0, which is the same as the original code would have returned.

Ref: https://github.com/tobymao/18xx/issues/1836
DSL, DRG, DPAC and CM have fixed home token locations on tiles that have multiple stations.

---

DSL is assigned the top left position correctly.
<img width="129" alt="Screen Shot 2020-10-31 at 4 06 31 PM" src="https://user-images.githubusercontent.com/15675400/97790973-4bc0c880-1b93-11eb-8cb2-5e5f8701cf00.png">

**Before the fix**, the token would jump to the bottom right because no exits is a subset of exits 0+5, even though the city index is set to 1 in the config file.
<img width="141" alt="Screen Shot 2020-10-31 at 4 06 40 PM" src="https://user-images.githubusercontent.com/15675400/97790983-5a0ee480-1b93-11eb-872b-2a5ae84a9b5b.png">

**After the fix**, the token is in the correct position.
<img width="133" alt="Screen Shot 2020-10-31 at 4 07 05 PM" src="https://user-images.githubusercontent.com/15675400/97790995-6eeb7800-1b93-11eb-930f-892fcdf25b1d.png">

Green Tile upgrade is also grouped correctly ( Different game shown here, so different tokens in play )
<img width="124" alt="Screen Shot 2020-10-31 at 5 07 04 PM" src="https://user-images.githubusercontent.com/15675400/97791763-8af31780-1b9b-11eb-819d-37186d87501c.png">

Brown Tile also merges correctly
<img width="151" alt="Screen Shot 2020-10-31 at 5 08 36 PM" src="https://user-images.githubusercontent.com/15675400/97791788-c392f100-1b9b-11eb-9062-76091cda7152.png">