### PR TITLE
18MEX: Support optional rule 8b and 8c (fixes #2038)

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -280,11 +280,6 @@ module Engine
             {
               "type": "no_buy",
               "owner_type": "player"
-            },
-            {
-               "type": "close",
-               "when": "3½",
-               "owner_type": "player"
             }
          ]
       },
@@ -298,11 +293,6 @@ module Engine
             {
               "type": "no_buy",
               "owner_type": "player"
-            },
-            {
-               "type": "close",
-               "when": "3½",
-               "owner_type": "player"
             }
          ]
       },
@@ -316,11 +306,6 @@ module Engine
             {
               "type": "no_buy",
               "owner_type": "player"
-            },
-            {
-               "type": "close",
-               "when": "3½",
-               "owner_type": "player"
             }
          ]
       },
@@ -581,7 +566,10 @@ module Engine
          ],
          "price":180,
          "num":4,
-         "rusts_on":"6"
+         "rusts_on":"6",
+         "events":[
+            {"type": "companies_buyable"}
+         ]
       },
       {
          "name":"3'",

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1436,11 +1436,10 @@ module Engine
         description.strip
       end
 
-
       def or_description_short(turn, round)
         "#{turn}.#{round}"
       end
-      
+
       # Override this, and add elements (paragraphs of text) here to display it on Info page.
       def timeline
         []

--- a/lib/engine/step/g_18_mex/buy_company.rb
+++ b/lib/engine/step/g_18_mex/buy_company.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../buy_company'
+
+module Engine
+  module Step
+    module G18Mex
+      class BuyCompany < BuyCompany
+        def can_buy_company?(entity)
+          return false if entity.company?
+          return super if @game.phase.current[:name] != '2' || !@game.optional_rules&.include?(:early_buy_of_kcmo)
+
+          companies = @game.purchasable_companies
+
+          entity == @game.current_entity &&
+            companies.any? &&
+            companies.map(&:min_price).min <= entity.cash
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Optional rule 8b is to make it allowed to by KCM&O private
from any player, for up to face value.

Optional rule 8c is to delay close of minors until next SR.