### PR TITLE
[18CO] Issue and Redeem Shares

### DIFF
--- a/lib/engine/step/g_18_co/issues_shares.rb
+++ b/lib/engine/step/g_18_co/issues_shares.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G18CO
+      class IssueShares < Base
+        def actions(entity)
+          available_actions = []
+          return available_actions unless entity.corporation?
+          return available_actions if entity != current_entity
+
+          available_actions << 'sell_shares' unless issuable_shares(entity).empty?
+          available_actions << 'pass' if blocks? && !available_actions.empty?
+
+          available_actions
+        end
+
+        def description
+          'Issue Shares'
+        end
+
+        def pass_description
+          'Skip Issue Shares'
+        end
+
+        def process_sell_shares(action)
+          @game.sell_shares_and_change_price(action.bundle)
+        end
+
+        def issuable_shares(entity)
+          # Done via Sell Shares
+          @game.issuable_shares(entity)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/redeem_shares.rb
+++ b/lib/engine/step/g_18_co/redeem_shares.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G18CO
+      class RedeemShares < Base
+        def actions(entity)
+          available_actions = []
+          return available_actions unless entity.corporation?
+          return available_actions if entity != current_entity
+
+          available_actions << 'buy_shares' unless redeemable_shares(entity).empty?
+          available_actions << 'pass' if blocks? && !available_actions.empty?
+
+          available_actions
+        end
+
+        def description
+          'Redeem Shares'
+        end
+
+        def pass_description
+          'Skip Redeem'
+        end
+
+        def process_buy_shares(action)
+          @game.share_pool.buy_shares(action.entity, action.bundle)
+          pass!
+        end
+
+        def redeemable_shares(entity)
+          # Done via Buy Shares
+          @game.redeemable_shares(entity)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: https://github.com/tobymao/18xx/issues/1836

Issue and Redeem occur during completely different parts of the OR in 18CO, therefore the existing Step could not be reused.
- The​ ​active​ ​Corporation​ ​may​ ​purchase (redeem) its own​ ​stock​ ​certificates​ ​from​ ​the​ ​Market.
- Shares are issued one at a time. For each share issued, the share price drops.