### PR TITLE
Enforce minimum spend when emergency buying train from a corporation, enforce EBUY_OTHER_VALUE for cashless corporations

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -248,11 +248,12 @@ module View
             size: 1,
           }
         else
+          min, max = step.spend_minmax(@corporation, train)
           {
             type: 'number',
-            min: 1,
-            max: @corporation.cash,
-            value: 1,
+            min: min,
+            max: max,
+            value: min,
             size: @corporation.cash.to_s.size,
           }
         end

--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -38,6 +38,18 @@ module Engine
       end
 
       def process_buy_train(action)
+        if action.train.owned_by_corporation?
+          min, max = spend_minmax(action.entity, action.train)
+          unless Range.new(min, max).include?(action.price)
+            @game.game_error("#{action.entity.name} may not spend "\
+                             "#{@game.format_currency(action.price)} on "\
+                             "#{action.train.owner.name}'s #{action.train.name} "\
+                             'train; may only spend between '\
+                             "#{@game.format_currency(min)} and "\
+                             "#{@game.format_currency(max)}.")
+          end
+        end
+
         buy_train_action(action)
         pass! unless can_buy_train?(action.entity)
       end

--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -40,7 +40,7 @@ module Engine
       def process_buy_train(action)
         if action.train.owned_by_corporation?
           min, max = spend_minmax(action.entity, action.train)
-          unless Range.new(min, max).include?(action.price)
+          unless (min..max).include?(action.price)
             @game.game_error("#{action.entity.name} may not spend "\
                              "#{@game.format_currency(action.price)} on "\
                              "#{action.train.owner.name}'s #{action.train.name} "\

--- a/validate.rb
+++ b/validate.rb
@@ -35,7 +35,7 @@ def run_game(game, actions = nil)
   data
 end
 
-def validate_all(title = nil)
+def validate_all(*titles)
   $count = 0
   $total = 0
   $total_time = 0
@@ -43,14 +43,13 @@ def validate_all(title = nil)
   data = {}
 
   where_args = {Sequel.pg_jsonb_op(:settings).has_key?('pin') => false, status: %w[active finished]}
-  where_args[:title] = title if title
-
+  where_args[:title] = titles if titles.any?
 
   DB[:games].order(:id).where(**where_args).select(:id).paged_each(rows_per_fetch: 100) do |game|
     page << game
     if page.size >= 100
       where_args2 = {id: page.map { |p| p[:id] }}
-      where_args2[:title] = title if title
+      where_args2[:title] = titles if titles.any?
       games = Game.eager(:user, :players, :actions).where(**where_args2).all
       _ = games.each do |game|
         data[game.id]=run_game(game)
@@ -60,7 +59,7 @@ def validate_all(title = nil)
   end
 
   where_args3 = {id: page.map { |p| p[:id] }}
-  where_args3[:title] = title if title
+  where_args3[:title] = titles if titles.any?
 
   games = Game.eager(:user, :players, :actions).where(**where_args3).all
   _ = games.each do |game|

--- a/validate.rb
+++ b/validate.rb
@@ -19,7 +19,7 @@ def run_game(game, actions = nil)
   begin
     $total += 1
     time = Time.now
-    engine = Engine::GAMES_BY_TITLE[game.title].new(game.ordered_players.map(&:name), id: game.id, actions: actions)
+    engine = Engine::GAMES_BY_TITLE[game.title].new(game.ordered_players.map(&:name), id: game.id, actions: actions, optional_rules: game.settings['optional_rules_selected'] || [])
     time = Time.now - time
     $total_time += time
     data['finished']=true
@@ -106,7 +106,7 @@ def validate_json(filename)
   data = JSON.parse(File.read(filename))
   players = data['players'].map { |p| p['name'] }
   engine = Engine::GAMES_BY_TITLE[data['title']]
-  engine.new(players, id: data['id'], actions: data['actions'])
+  engine.new(players, id: data['id'], actions: data['actions'], optional_rules: data.dig('settings', 'optional_rules_selected') || [])
 end
 
 def pin_games(pin_version, game_ids)


### PR DESCRIPTION
* if shares have been sold to help buy a train, that cash must be used if buying
  from another corporation
* also fix max spend; if the game allows EMR when cross-buying a train, allow
  president to contribute cash even before shares have been sold
* don't allow cashless corporations to ebuy from others when EBUY_OTHER_VALUE is false
* update `validate_all()` in `validate.rb` to take a list of titles

[Fixes #968]
[Fixes #2230]

examples of behavior that this PR fixes: https://www.18xx.games/game/3063?action=442 and https://www.18xx.games/game/13894?action=376