### PR TITLE
1817 Bug fixes

### DIFF
--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -13,7 +13,7 @@ module Engine
       def self.from_h(h, game)
         entity = game.get(h['entity_type'], h['entity'])
         obj = new(entity, **h_to_args(h, game))
-        obj.user = h['user'] unless h['user'] == entity.player&.name
+        obj.user = h['user'] if entity.player && h['user'] != entity.player&.name
         obj
       end
 

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -348,6 +348,8 @@ module Engine
 
         revenue += 10 * stops.count { |stop| stop.hex.assigned?('bridge') }
 
+        game_error('Route visits same hex twice') if route.hexes.size != route.hexes.uniq.size
+
         mine = 'mine'
         if route.hexes.first.assigned?(mine) || route.hexes.last.assigned?(mine)
           game_error('Route cannot start or end with a mine')

--- a/lib/engine/round/g_1817/operating.rb
+++ b/lib/engine/round/g_1817/operating.rb
@@ -54,13 +54,15 @@ module Engine
 
           bank = @game.bank
           owed = @game.interest_owed(entity)
-          owed_fmt = @game.format_currency(owed)
 
           while owed > entity.cash &&
               (loan = @game.loans[0]) &&
               entity.loans.size < @game.maximum_loans(entity)
             @game.take_loan(entity, loan)
+            owed = @game.interest_owed(entity)
           end
+
+          owed_fmt = @game.format_currency(owed)
 
           if owed <= entity.cash
             @log << "#{entity.name} pays #{owed_fmt} interest for #{entity.loans.size} loans"

--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -350,7 +350,8 @@ module Engine
           elsif corporation.share_price.acquisition?
             10
           else
-            corporation.total_shares * corporation.share_price.price
+            # Needs rounding to 10
+            ((corporation.total_shares * corporation.share_price.price).to_f / 10).round * 10
           end
         end
 
@@ -394,6 +395,7 @@ module Engine
           price = action.price
 
           add_bid(action)
+          @game.game_error("Bid #{price} is not a multple of 10") unless (price % 10).zero?
           @log << "#{entity.name} bids #{@game.format_currency(price)} for #{corporation.name}"
           resolve_bids
         end

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -19,6 +19,7 @@ module Engine
           return [] unless entity.player?
 
           if @corporate_action
+            return [] unless entity.owner == current_entity
             return ['pass'] if any_corporate_actions?(entity)
 
             return []
@@ -34,6 +35,7 @@ module Engine
             end
           end
 
+          return [] unless entity == current_entity
           return %w[bid pass] if @auctioning
 
           actions = super


### PR DESCRIPTION
M&A bids need to be multples of 10 - fixes #2165
Interest needs to be paid on loans taken out to pay interest - fixes #2150
Disallow routes that hit the same tile twice (NYC) - fixes #2146
Catch incorrect entity passing in SR - fixes #2136
Don't log master mode when the entity is unowned - fixes #1985