### PR TITLE
1817 bug fixes

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -89,6 +89,8 @@ module Engine
       }.freeze
 
       CERT_LIMIT_TYPES = %i[multiple_buy unlimited no_cert_limit].freeze
+      # Does the cert limit decrease when a player becomes bankrupt?
+      CERT_LIMIT_CHANGE_ON_BANKRUPTCY = false
 
       MULTIPLE_BUY_TYPES = %i[multiple_buy].freeze
 
@@ -855,6 +857,11 @@ module Engine
         end
 
         player.bankrupt = true
+        return unless self.class::CERT_LIMIT_CHANGE_ON_BANKRUPTCY
+
+        remaining_players = @players.reject(&:bankrupt).length
+        # Assume that games without cert limits at lower player counts retain previous counts (1817 and 2 players)
+        @cert_limit = self.class::CERT_LIMIT[remaining_players] || @cert_limit
       end
 
       def tile_lays(_entity)

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -17,7 +17,7 @@ module Engine
     end
 
     def name
-      'Sharepool'
+      'Market'
     end
 
     def player
@@ -70,7 +70,7 @@ module Engine
         transfer_shares(
           bundle,
           entity,
-          spender: entity,
+          spender: entity == self ? @bank : entity,
           receiver: incremental && bundle.owner.corporation? ? bundle.owner : @bank,
           price: price
         )

--- a/lib/engine/step/g_1817/bankrupt.rb
+++ b/lib/engine/step/g_1817/bankrupt.rb
@@ -30,7 +30,6 @@ module Engine
 
             @game.sell_shares_and_change_price(bundle)
           end
-          # @todo: shorts
 
           # finally, the president sells all their shares, regardless of 50% and
           # presidency restrictions
@@ -60,6 +59,7 @@ module Engine
           @game.bank.spend(-player.cash, player) if player.cash.negative?
 
           @game.declare_bankrupt(player)
+          @game.close_market_shorts
         end
       end
     end

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -3,12 +3,14 @@
 require_relative '../buy_sell_par_shares'
 require_relative '../../action/take_loan'
 require_relative 'passable_auction'
+require_relative 'share_buying_with_shorts'
 
 module Engine
   module Step
     module G1817
       class BuySellParShares < BuySellParShares
         include PassableAuction
+        include ShareBuyingWithShorts
         TOKEN_COST = 50
         MIN_BID = 100
         MAX_BID = 400

--- a/lib/engine/step/g_1817/post_conversion.rb
+++ b/lib/engine/step/g_1817/post_conversion.rb
@@ -2,12 +2,14 @@
 
 require_relative '../base'
 require_relative '../share_buying'
+require_relative 'share_buying_with_shorts'
 
 module Engine
   module Step
     module G1817
       class PostConversion < Base
         include ShareBuying
+        include ShareBuyingWithShorts
 
         def actions(entity)
           return [] if !entity.player? || !@round.converted

--- a/lib/engine/step/g_1817/share_buying_with_shorts.rb
+++ b/lib/engine/step/g_1817/share_buying_with_shorts.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Engine
+  module Step
+    module G1817
+      module ShareBuyingWithShorts
+        # Returns if a share can be gained by an entity respecting the cert limit
+        # This works irrespective of if that player has sold this round
+        # such as in 1889 for exchanging Dougo
+        #
+        def can_gain?(entity, bundle, exchange: false)
+          return if !bundle || !entity
+
+          corporation = bundle.corporation
+
+          @game.entity_shorts(entity, corporation).any? ||
+          corporation.holding_ok?(entity, bundle.percent) &&
+            (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1817 Increase cert limit after bankruptcy (fixes #2174)
1817 Allow buying certs when shorted at cert limit (fixes #2178)
1817 Remove shorts in the market if market has share
1817 Bank buys treasury stock in order to remove short (fixes #2176)