### PR TITLE
Don't imply shares can be over limit in par step

### DIFF
--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -33,7 +33,8 @@ module View
             },
             on: { click: par },
           }
-          purchasable_shares = [(entity.cash / share_price.price).to_i, @corporation.max_ownership_percent / @corporation.total_shares].min
+          purchasable_shares = [(entity.cash / share_price.price).to_i,
+                                @corporation.max_ownership_percent / @corporation.total_shares].min
           at_limit = purchasable_shares * @corporation.total_shares >= @corporation.max_ownership_percent
           flags = at_limit ? ' L' : ''
           text = "#{@game.format_currency(share_price.price)} (#{purchasable_shares}#{flags})"

--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -33,8 +33,10 @@ module View
             },
             on: { click: par },
           }
-          purchasable_shares = (entity.cash / share_price.price).to_i
-          text = "#{@game.format_currency(share_price.price)} (#{purchasable_shares})"
+          purchasable_shares = [(entity.cash / share_price.price).to_i, @corporation.max_ownership_percent / 10].min
+          at_limit = purchasable_shares * 10 >= @corporation.max_ownership_percent
+          flags = at_limit ? ' L' : ''
+          text = "#{@game.format_currency(share_price.price)} (#{purchasable_shares}#{flags})"
           h('button.small.par_price', props, text)
         end
 

--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -33,8 +33,8 @@ module View
             },
             on: { click: par },
           }
-          purchasable_shares = [(entity.cash / share_price.price).to_i, @corporation.max_ownership_percent / 10].min
-          at_limit = purchasable_shares * 10 >= @corporation.max_ownership_percent
+          purchasable_shares = [(entity.cash / share_price.price).to_i, @corporation.max_ownership_percent / @corporation.total_shares].min
+          at_limit = purchasable_shares * @corporation.total_shares >= @corporation.max_ownership_percent
           flags = at_limit ? ' L' : ''
           text = "#{@game.format_currency(share_price.price)} (#{purchasable_shares}#{flags})"
           h('button.small.par_price', props, text)


### PR DESCRIPTION
Enhances the par share count button helper text by limiting the amount of shares shown to be purchasable to the corporation ownership limit. Appends an "L" flag in this case.

![Screenshot_20201105_011651](https://user-images.githubusercontent.com/105335/98204773-a98f4080-1f04-11eb-8dfc-6ee60f06ee63.png)
