### PR TITLE
1860 tile placement and upgrades

### DIFF
--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -257,7 +257,7 @@ module Engine
       end
 
       def biggest_train(corporation)
-        corporation.trains.max_by(&:distance) || 0
+        corporation.trains.map(&:distance).max || 0
       end
 
       def get_token_cities(corporation)

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -59,6 +59,14 @@ module Engine
         'VYSC' => 4,
       }.freeze
 
+      NO_ROTATION_TILES = %w[
+        758
+        761
+        763
+        773
+        775
+      ].freeze
+
       def setup
         @bankrupt_corps = []
         @receivership_corps = []
@@ -359,6 +367,12 @@ module Engine
         @node_distances[corporation] = n_distances
         @path_distances[corporation] = p_distances
         @hex_distances[corporation] = h_distances
+      end
+
+      def legal_tile_rotation?(_entity, _hex, tile)
+        return true unless NO_ROTATION_TILES.include?(tile.name)
+
+        tile.rotation.zero?
       end
     end
   end

--- a/lib/engine/part/halt.rb
+++ b/lib/engine/part/halt.rb
@@ -12,6 +12,12 @@ module Engine
         super('0', **opts)
       end
 
+      def <=(other)
+        return true if other.town?
+
+        super
+      end
+
       def halt?
         true
       end

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -70,7 +70,7 @@ module Engine
           super
 
           corporation = action.bundle.corporation
-          @game.place_home_track(corporation) if corporation.floated?
+          place_home_track(corporation) if corporation.floated?
           @game.check_new_layer
         end
 
@@ -132,6 +132,23 @@ module Engine
           @game.bank.spend(price, player) if price.positive?
           @log << "#{player.name} sells #{company.name} to bank for #{@game.format_currency(price)}"
           @players_sold[player][company] = :now
+        end
+
+        def place_home_track(corporation)
+          hex = @game.hex_by_id(corporation.coordinates)
+          tile = hex.tile
+
+          # skip if a tile is already in home location
+          return unless tile.color == :white
+
+          @log << "#{corporation.name} must choose tile for home location"
+
+          @round.pending_tracks << {
+            entity: corporation,
+            hexes: [hex],
+          }
+
+          @round.clear_cache!
         end
       end
     end

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -69,6 +69,8 @@ module Engine
         def process_buy_shares(action)
           super
 
+          corporation = action.bundle.corporation
+          @game.place_home_track(corporation) if corporation.floated?
           @game.check_new_layer
         end
 

--- a/lib/engine/step/g_1860/home_track.rb
+++ b/lib/engine/step/g_1860/home_track.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative 'tracker'
+
+module Engine
+  module Step
+    module G1860
+      class HomeTrack < Base
+        include Tracker
+        ACTIONS = %w[lay_tile].freeze
+
+        def actions(entity)
+          return [] unless entity == pending_entity
+
+          ACTIONS
+        end
+
+        def round_state
+          {
+            pending_tracks: [],
+          }
+        end
+
+        def active?
+          pending_entity
+        end
+
+        def current_entity
+          pending_entity
+        end
+
+        def pending_entity
+          pending_track[:entity]
+        end
+
+        def pending_track
+          @round.pending_tracks&.first || {}
+        end
+
+        def description
+          "Lay home track for #{pending_entity.name}"
+        end
+
+        def process_lay_tile(action)
+          lay_tile_action(action)
+          @round.pending_tracks.shift
+        end
+
+        def available_hex(_entity, hex)
+          pending_track[:hexes].include?(hex)
+        end
+
+        def hex_neighbors(entity, hex)
+          @game.graph.connected_hexes(entity)[hex]
+        end
+
+
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1860/home_track.rb
+++ b/lib/engine/step/g_1860/home_track.rb
@@ -47,6 +47,14 @@ module Engine
           @round.pending_tracks.shift
         end
 
+        def reachable_node?(_entity, _node)
+          true
+        end
+
+        def reachable_hex?(_entity, _hex)
+          true
+        end
+
         def available_hex(_entity, hex)
           pending_track[:hexes].include?(hex)
         end
@@ -54,8 +62,6 @@ module Engine
         def hex_neighbors(entity, hex)
           @game.graph.connected_hexes(entity)[hex]
         end
-
-
       end
     end
   end

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -29,16 +29,14 @@ module Engine
           pass! unless can_lay_tile?(action.entity)
         end
 
-        def reachable_path?(entity, path)
-          max_distance = @game.biggest_train(entity)
+        def reachable_path?(entity, path, max_distance)
           return false if max_distance.zero?
 
           path_distances = @game.path_distances(entity)
           path_distances[path] <= max_distance
         end
 
-        def reachable_node?(entity, node)
-          max_distance = @game.biggest_train(entity)
+        def reachable_node?(entity, node, max_distance)
           return false if max_distance.zero?
 
           node_distances = @game.node_distances(entity)
@@ -51,10 +49,7 @@ module Engine
           end
         end
 
-        def reachable_hex?(entity, hex)
-          max_distance = @game.biggest_train(entity)
-          return false if max_distance.zero?
-
+        def reachable_hex?(entity, hex, max_distance)
           node_distances = @game.node_distances(entity)
           path_distances = @game.path_distances(entity)
           return false unless hex.tile.paths.any? { |p| path_distances[p] }
@@ -88,11 +83,11 @@ module Engine
           # laying yellow always OK
           return true if hex.tile.color == :white
 
-          return true if reachable_hex?(entity, hex)
-
           # upgrades subject to train size
           max_distance = @game.biggest_train(entity)
           return false if max_distance.zero?
+
+          return true if reachable_hex?(entity, hex, max_distance)
 
           path_distances = @game.path_distances(entity)
           return false if hex.tile.paths.any? { |p| path_distances[p] }

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -29,6 +29,14 @@ module Engine
           pass! unless can_lay_tile?(action.entity)
         end
 
+        def reachable_path?(entity, path)
+          max_distance = @game.biggest_train(entity).distance
+          return false if max_distance.zero?
+
+          path_distances = @game.path_distances(entity)
+          path_distances[path] <= max_distance
+        end
+
         def reachable_node?(entity, node)
           max_distance = @game.biggest_train(entity).distance
           return false if max_distance.zero?

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -29,8 +29,81 @@ module Engine
           pass! unless can_lay_tile?(action.entity)
         end
 
+        def reachable_node?(entity, node)
+          max_distance = @game.biggest_train(entity).distance
+          return false if max_distance.zero?
+
+          node_distances = @game.node_distances(entity)
+          return false unless node_distances[node]
+
+          if node.city?
+            node_distances[node] < max_distance
+          else
+            node_distances[node] <= max_distance
+          end
+        end
+
+        def reachable_hex?(entity, hex)
+          max_distance = @game.biggest_train(entity).distance
+          return false if max_distance.zero?
+
+          node_distances = @game.node_distances(entity)
+          path_distances = @game.path_distances(entity)
+          return false unless hex.tile.paths.any? { |p| path_distances[p] }
+
+          # tile currently on network
+          if hex.tile.nodes.any?
+            # tile has a city/town/halt
+            hex.tile.nodes.each do |tile_node|
+              nd = node_distances[tile_node] if node_distances[tile_node]
+              if tile_node.city? || tile_node.offboard?
+                return true if nd && nd < max_distance
+              elsif nd && nd <= max_distance
+                return true
+              end
+            end
+          else
+            # tile is just track
+            # Assumption: 1860 has no tiles that have track that doesn't connect to a node on the same tile
+            hex.tile.paths.each do |tile_path|
+              pd = path_distances[tile_path] if path_distances[tile_path]
+              return true if pd && pd <= max_distance
+            end
+          end
+
+          false
+        end
+
         def available_hex(entity, hex)
-          hex_neighbors(entity, hex)
+          return false unless (neighbors = @game.graph.connected_hexes(entity)[hex])
+
+          # laying yellow always OK
+          return true if hex.tile.color == :white
+
+          return true if reachable_hex?(entity, hex)
+
+          # upgrades subject to train size
+          max_distance = @game.biggest_train(entity).distance
+          return false if max_distance.zero?
+
+          path_distances = @game.path_distances(entity)
+          return false if hex.tile.paths.any? { |p| path_distances[p] }
+
+          # tile is currently not on network (it should be a neighbor to one that is)
+          # We err on the side of caution, final determination needs to be based on actual tile placed
+          neighbors.each do |edge|
+            nhex = hex.neighbors[edge]
+            nedge = hex.invert(edge)
+
+            # find path on network that connects to that edge (1860 can only have one)
+            npath = nhex.tile.paths.find { |p| path_distances[p] && p.exits.include?(nedge) }
+            next unless npath
+
+            return true if hex.tile.cities.any? && path_distances[npath] < max_distance
+            return true if hex.tile.cities.empty? && path_distances[npath] <= max_distance
+          end
+
+          false
         end
 
         def hex_neighbors(entity, hex)

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -30,7 +30,7 @@ module Engine
         end
 
         def reachable_path?(entity, path)
-          max_distance = @game.biggest_train(entity).distance
+          max_distance = @game.biggest_train(entity)
           return false if max_distance.zero?
 
           path_distances = @game.path_distances(entity)
@@ -38,7 +38,7 @@ module Engine
         end
 
         def reachable_node?(entity, node)
-          max_distance = @game.biggest_train(entity).distance
+          max_distance = @game.biggest_train(entity)
           return false if max_distance.zero?
 
           node_distances = @game.node_distances(entity)
@@ -52,7 +52,7 @@ module Engine
         end
 
         def reachable_hex?(entity, hex)
-          max_distance = @game.biggest_train(entity).distance
+          max_distance = @game.biggest_train(entity)
           return false if max_distance.zero?
 
           node_distances = @game.node_distances(entity)
@@ -91,7 +91,7 @@ module Engine
           return true if reachable_hex?(entity, hex)
 
           # upgrades subject to train size
-          max_distance = @game.biggest_train(entity).distance
+          max_distance = @game.biggest_train(entity)
           return false if max_distance.zero?
 
           path_distances = @game.path_distances(entity)

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative 'tracker'
+
+module Engine
+  module Step
+    module G1860
+      class Track < Base
+        include Tracker
+        ACTIONS = %w[lay_tile pass].freeze
+
+        def actions(entity)
+          return [] if entity.company? || !can_lay_tile?(entity)
+
+          entity == current_entity ? ACTIONS : []
+        end
+
+        def description
+          'Lay Track'
+        end
+
+        def pass_description
+          @acted ? 'Done (Track)' : 'Skip (Track)'
+        end
+
+        def process_lay_tile(action)
+          lay_tile_action(action)
+          pass! unless can_lay_tile?(action.entity)
+        end
+
+        def available_hex(entity, hex)
+          hex_neighbors(entity, hex)
+        end
+
+        def hex_neighbors(entity, hex)
+          @game.graph.connected_hexes(entity)[hex]
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G1860
+      module Tracker
+        def setup
+          @upgraded = false
+          @laid_track = 0
+          @laid_city = false
+        end
+
+        def can_lay_tile?(entity)
+          action = get_tile_lay(entity)
+          return false unless action
+
+          entity.tokens.any? && (@game.buying_power(entity) >= action[:cost]) && (action[:lay] || action[:upgrade])
+        end
+
+        def get_tile_lay(entity)
+          action = @game.tile_lays(entity)[@laid_track]&.clone
+          return unless action
+
+          action[:lay] = !@upgraded && !@laid_city if action[:lay] == :not_if_upgraded_or_city
+          action[:upgrade] = !@upgraded if action[:upgrade] == :not_if_upgraded
+          action[:cost] = action[:cost] || 0
+          action
+        end
+
+        def lay_tile_action(action)
+          tile = action.tile
+          tile_lay = get_tile_lay(action.entity)
+          @game.game_error('Cannot lay an upgrade now') if tile.color != :yellow && !tile_lay[:upgrade]
+          @game.game_error('Cannot lay an yellow now') if tile.color == :yellow && !tile_lay[:lay]
+          @game.game_error('Cannot lay a city tile now') if tile.cities.any? && @laid_track.positive?
+
+          lay_tile(action, extra_cost: tile_lay[:cost])
+          @upgraded = true if action.tile.color != :yellow
+          @laid_city = true if action.tile.cities.any?
+          @laid_track += 1
+        end
+
+        def tile_lay_abilities(entity, &block)
+          entity.abilities(:tile_lay, &block)
+        end
+
+        def lay_tile(action, extra_cost: 0, entity: nil, spender: nil)
+          entity ||= action.entity
+          spender ||= entity
+          tile = action.tile
+          hex = action.hex
+          rotation = action.rotation
+          old_tile = hex.tile
+
+          @game.companies.each do |company|
+            next if company.closed?
+            next unless (ability = company.abilities(:blocks_hexes))
+
+            @game.game_error("#{hex.id} is blocked by #{company.name}") if ability.hexes.include?(hex.id)
+          end
+
+          tile.rotate!(rotation)
+
+          unless @game.upgrades_to?(old_tile, tile, entity.company?)
+            @game.game_error("#{old_tile.name} is not upgradeable to #{tile.name}")
+          end
+
+          if !@game.loading && !legal_tile_rotation?(entity, hex, tile)
+            @game.game_error("#{old_tile.name} is not legally rotated for #{tile.name}")
+          end
+
+          @game.add_extra_tile(tile) if tile.unlimited
+
+          @game.tiles.delete(tile)
+          @game.tiles << old_tile unless old_tile.preprinted
+
+          hex.lay(tile)
+
+          @game.graph.clear
+          check_track_restrictions!(entity, old_tile, tile)
+          free = false
+          discount = 0
+
+          tile_lay_abilities(entity) do |ability|
+            next if ability.hexes.any? && (!ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name))
+
+            @game.game_error("Track laid must be connected to one of #{spender.id}'s stations") if ability.reachable &&
+              hex.name != spender.coordinates &&
+              !@game.loading &&
+              !@game.graph.reachable_hexes(spender)[hex]
+
+            free = ability.free
+            discount = ability.discount
+            extra_cost += ability.cost
+          end
+
+          entity.abilities(:teleport) do |ability, _|
+            ability.use! if ability.hexes.include?(hex.id) && ability.tiles.include?(tile.name)
+          end
+
+          terrain = old_tile.terrain
+          cost =
+            if free
+              # call for the side effect of deleting a completed border cost
+              border_cost(tile, entity)
+
+              extra_cost
+            else
+              border, border_types = border_cost(tile, entity)
+              terrain += border_types if border.positive?
+              @game.tile_cost(old_tile, entity) + border + extra_cost - discount
+            end
+
+          spender.spend(cost, @game.bank) if cost.positive?
+
+          cities = tile.cities
+          if old_tile.paths.empty? &&
+              tile.paths.any? &&
+              cities.size > 1 &&
+              cities.flat_map(&:tokens).any?
+            token = cities.flat_map(&:tokens).find(&:itself)
+            @round.pending_tokens << {
+              entity: entity,
+              hexes: [action.hex],
+              token: token,
+            }
+
+            token.remove!
+          end
+          @log << "#{spender.name}"\
+            "#{cost.zero? ? '' : " spends #{@game.format_currency(cost)} and"}"\
+            " lays tile ##{tile.name}"\
+            " with rotation #{rotation} on #{hex.name}"
+
+          return unless terrain.any?
+
+          @game.all_companies_with_ability(:tile_income) do |company, ability|
+            if terrain.include?(ability.terrain) && (!ability.owner_only || company.owner == entity)
+              # If multiple borders are connected bonus counts each individually
+              income = ability.income * terrain.find_all { |t| t == ability.terrain }.size
+              @game.bank.spend(income, company.owner)
+              @log << "#{company.owner.name} earns #{@game.format_currency(income)}"\
+                " for the #{ability.terrain} tile built by #{company.name}"
+            end
+          end
+        end
+
+        def border_cost(tile, entity)
+          hex = tile.hex
+          types = []
+
+          total_cost = tile.borders.dup.sum do |border|
+            next 0 unless (cost = border.cost)
+
+            edge = border.edge
+            neighbor = hex.neighbors[edge]
+            next 0 if !hex.targeting?(neighbor) || !neighbor.targeting?(hex)
+
+            types << border.type
+            tile.borders.delete(border)
+            neighbor.tile.borders.map! { |nb| nb.edge == hex.invert(edge) ? nil : nb }.compact!
+
+            ability = entity.all_abilities.find do |a|
+              (a.type == :tile_discount) && (border.type == a.terrain)
+            end
+            discount = ability&.discount || 0
+
+            if discount.positive?
+              @log << "#{entity.name} receives a discount of "\
+                "#{@game.format_currency(discount)} from "\
+                "#{ability.owner.name}"
+            end
+
+            cost - discount
+          end
+          [total_cost, types]
+        end
+
+        def check_track_restrictions!(entity, old_tile, new_tile)
+          return if @game.loading || !entity.operator?
+
+          old_paths = old_tile.paths
+          changed_city = false
+          used_new_track = old_paths.empty?
+
+          new_tile.paths.each do |np|
+            next unless @game.graph.connected_paths(entity)[np]
+
+            op = old_paths.find { |path| np <= path }
+            used_new_track = true unless op
+            old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
+            new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
+            changed_city = true unless old_revenues == new_revenues
+          end
+
+          case @game.class::TRACK_RESTRICTION
+          when :permissive
+            true
+          when :city_permissive
+            @game.game_error('Must be city tile or use new track') if new_tile.cities.none? && !used_new_track
+          when :restrictive
+            @game.game_error('Must use new track') unless used_new_track
+          when :semi_restrictive
+            @game.game_error('Must use new track or change city value') if !used_new_track && !changed_city
+          else
+            raise
+          end
+        end
+
+        def potential_tiles(_entity, hex)
+          colors = @game.phase.tiles
+          @game.tiles
+            .select { |tile| colors.include?(tile.color) }
+            .uniq(&:name)
+            .select { |t| @game.upgrades_to?(hex.tile, t) }
+            .reject(&:blocks_lay)
+        end
+
+        def upgradeable_tiles(entity, hex)
+          potential_tiles(entity, hex).map do |tile|
+            tile.rotate!(0) # reset tile to no rotation since calculations are absolute
+            tile.legal_rotations = legal_tile_rotations(entity, hex, tile)
+            next if tile.legal_rotations.empty?
+
+            tile.rotate! # rotate it to the first legal rotation
+            tile
+          end.compact
+        end
+
+        def legal_tile_rotation?(entity, hex, tile)
+          return false unless @game.legal_tile_rotation?(entity, hex, tile)
+
+          old_paths = hex.tile.paths
+          old_ctedges = hex.tile.city_town_edges
+
+          new_paths = tile.paths
+          new_exits = tile.exits
+          new_ctedges = tile.city_town_edges
+          extra_cities = [0, new_ctedges.size - old_ctedges.size].max
+
+          new_exits.all? { |edge| hex.neighbors[edge] } &&
+            (new_exits & hex_neighbors(entity, hex)).any? &&
+            old_paths.all? { |path| new_paths.any? { |p| path <= p } } &&
+            # Count how many cities on the new tile that aren't included by any of the old tile.
+            # Make sure this isn't more than the number of new cities added.
+            # 1836jr30 D6 -> 54 adds more cities
+            extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } }
+        end
+
+        def legal_tile_rotations(entity, hex, tile)
+          Engine::Tile::ALL_EDGES.select do |rotation|
+            tile.rotate!(rotation)
+            legal_tile_rotation?(entity, hex, tile)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Home track tile lay when corp is floated if no tile on home hex
- Yellow tile placement rules (2x, unless one is a city)
- Upgrade rules (must be able to reach with a single train corporation owns)
- Constrained rotation for (some) N, M and R tiles
- Fixed Halt to allow upgrade to Town.