### PR TITLE
Some 1817 games were confusingly crashing, due to the pass on the sto…

### DIFF
--- a/lib/engine/step/token.rb
+++ b/lib/engine/step/token.rb
@@ -10,6 +10,7 @@ module Engine
       ACTIONS = %w[place_token pass].freeze
 
       def actions(entity)
+        return [] unless entity == current_entity
         return [] unless can_place_token?(entity)
 
         ACTIONS

--- a/lib/engine/step/track.rb
+++ b/lib/engine/step/track.rb
@@ -10,9 +10,10 @@ module Engine
       ACTIONS = %w[lay_tile pass].freeze
 
       def actions(entity)
+        return [] unless entity == current_entity
         return [] if entity.company? || !can_lay_tile?(entity)
 
-        entity == current_entity ? ACTIONS : []
+        ACTIONS
       end
 
       def description


### PR DESCRIPTION
…ck round

no longer being relevant, this adds a check to see
if the current entity is correct on track and token.