### PR TITLE
refactor: drop "selected" from `optional_rules_selected`

### DIFF
--- a/assets/app/mail/turn.rb
+++ b/assets/app/mail/turn.rb
@@ -14,7 +14,7 @@ class Turn < Snabberb::Component
       @game_data['players'].map { |p| p['name'] },
       id: @game_data['id'],
       actions: @game_data['actions'],
-      optional_rules: @game_data.dig('settings', 'optional_rules_selected') || [],
+      optional_rules: @game_data.dig('settings', 'optional_rules') || [],
     )
 
     store(:game, @game, skip: true)

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -147,7 +147,7 @@ module View
     end
 
     def render_optional_rules
-      selected_rules = @gdata.dig('settings', 'optional_rules_selected') || []
+      selected_rules = @gdata.dig('settings', 'optional_rules') || []
       return if selected_rules.empty?
 
       rendered_rules = Engine::GAMES_BY_TITLE[@gdata['title']]::OPTIONAL_RULES

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -57,7 +57,7 @@ module View
         id: game_id,
         actions: cursor ? actions.take(cursor) : actions,
         pin: @pin,
-        optional_rules: @game_data.dig('settings', 'optional_rules_selected') || [],
+        optional_rules: @game_data.dig('settings', 'optional_rules') || [],
       )
       store(:game, @game, skip: true)
     end

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -84,7 +84,7 @@ class Api
                   users.map(&:name),
                   id: game.id,
                   actions: actions_h(game),
-                  optional_rules: game.settings['optional_rules_selected']&.map(&:to_sym),
+                  optional_rules: game.settings['optional_rules']&.map(&:to_sym),
                 )
 
                 action_id = r.params['id']
@@ -149,7 +149,7 @@ class Api
             engine = Engine::GAMES_BY_TITLE[game.title].new(
               users.map(&:name),
               id: game.id,
-              optional_rules: game.settings['optional_rules_selected']&.map(&:to_sym),
+              optional_rules: game.settings['optional_rules']&.map(&:to_sym),
             )
             unless game.players.size.between?(*Engine.player_range(engine.class))
               halt(400, 'Player count not supported')
@@ -186,7 +186,7 @@ class Api
             settings: {
               seed: Random.new_seed % 2**31,
               unlisted: r['unlisted'],
-              optional_rules_selected: r['optional_rules_selected'],
+              optional_rules: r['optional_rules'],
             },
             title: title,
             round: Engine::GAMES_BY_TITLE[title].new([]).round&.name,

--- a/spec/fixtures/18_ms/14375.json
+++ b/spec/fixtures/18_ms/14375.json
@@ -24,7 +24,7 @@
   "settings": {
     "seed": 1002827552,
     "unlisted": true,
-    "optional_rules_selected": []
+    "optional_rules": []
   },
   "user_settings": null,
   "status": "finished",

--- a/validate.rb
+++ b/validate.rb
@@ -19,7 +19,7 @@ def run_game(game, actions = nil)
   begin
     $total += 1
     time = Time.now
-    engine = Engine::GAMES_BY_TITLE[game.title].new(game.ordered_players.map(&:name), id: game.id, actions: actions, optional_rules: game.settings['optional_rules_selected'] || [])
+    engine = Engine::GAMES_BY_TITLE[game.title].new(game.ordered_players.map(&:name), id: game.id, actions: actions, optional_rules: game.settings['optional_rules'] || [])
     time = Time.now - time
     $total_time += time
     data['finished']=true
@@ -106,7 +106,7 @@ def validate_json(filename)
   data = JSON.parse(File.read(filename))
   players = data['players'].map { |p| p['name'] }
   engine = Engine::GAMES_BY_TITLE[data['title']]
-  engine.new(players, id: data['id'], actions: data['actions'], optional_rules: data.dig('settings', 'optional_rules_selected') || [])
+  engine.new(players, id: data['id'], actions: data['actions'], optional_rules: data.dig('settings', 'optional_rules') || [])
 end
 
 def pin_games(pin_version, game_ids)


### PR DESCRIPTION
Migration script I used locally to fix game settings for this change:

```
require_relative 'validate'

where_args = {
  Sequel.pg_jsonb_op(:settings).has_key?('optional_rules_selected') => true,
}

Game.where(**where_args).each do |game|

  game.settings['optional_rules'] =
    if game.settings.has_key?('pin')
      # keep the old key on pinned games so they work correctly, but still add
      # the new key so their info is displayed on game cards on the home page
      # correctly as well
      game.settings['optional_rules_selected'] || []
    else
      game.settings.delete('optional_rules_selected') || []
    end

  game.save
end
```