### PR TITLE
Fix 5% share presentation in charter, logs and sell button

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -300,14 +300,6 @@ module View
           ]),
         ]
 
-        if @corporation.reserved_shares.any?
-          pool_rows <<
-            h('tr.ipo_reserved', [
-              h('td.left', @game.class::IPO_RESERVED_NAME),
-              h('td.right', shares_props, share_number_str(@corporation.num_ipo_reserved_shares)),
-            ])
-        end
-
         market_tr_props = {
           style: {
             borderBottom: player_rows.any? ? '1px solid currentColor' : '0',

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -23,7 +23,7 @@ module View
 
           num_shares = bundle.num_shares
 
-          text = "Sell #{num_shares} (#{@game.format_currency(bundle.price)})"
+          text = num_shares == 1 && bundle.percent != 10 ? "a #{bundle.percent}%" : num_shares.to_s
 
           props = {
             style: {
@@ -32,7 +32,7 @@ module View
             },
             on: { click: sell },
           }
-          h('button.sell_share', props, text)
+          h('button.sell_share', props, "Sell #{text} (#{@game.format_currency(bundle.price)})")
         end
 
         h(:div, buttons.compact)

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -81,11 +81,10 @@ module Engine
 
     def sell_shares(bundle)
       entity = bundle.owner
-      num_shares = bundle.num_shares
 
       verb = entity.corporation? ? 'issues' : 'sells'
 
-      @log << "#{entity.name} #{verb} #{num_shares} share#{num_shares > 1 ? 's' : ''} " \
+      @log << "#{entity.name} #{verb} #{num_presentation(bundle)} " \
         "#{bundle.corporation.name} and receives #{@game.format_currency(bundle.price)}"
 
       transfer_shares(bundle, self, spender: @bank, receiver: entity)
@@ -184,6 +183,13 @@ module Engine
       share.owner.shares_by_corporation[corporation].delete(share)
       to_entity.shares_by_corporation[corporation] << share
       share.owner = to_entity
+    end
+
+    def num_presentation(bundle)
+      num_shares = bundle.num_shares
+      return "a #{bundle.percent}% share of" if num_shares == 1
+
+      "#{num_shares} share#{num_shares > 1 ? 's' : ''}"
     end
   end
 end


### PR DESCRIPTION
Here is how the charter looks like with the Trade-in line removed. As well as how the sell button looks like for 5% shares.
![image](https://user-images.githubusercontent.com/2631151/98461389-fe081980-21ab-11eb-8f14-0808c3c6039d.png)

And here is how the log looks like after the change:
![image](https://user-images.githubusercontent.com/2631151/98461451-7a026180-21ac-11eb-964c-52d38f87a0d4.png)
