### PR TITLE
18MEX: Temporarily remove it from new games creation

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -21,7 +21,7 @@ module View
         <p>You can now create private games. After you create the game, use the "copy invite link" button to
         get a URL to send to your opponents.</p>
         <p>1817 is now more stable and in alpha! Feel free to play multiplayer games.</p>
-        <p>18MEX is now in alpha!</p>
+        <p>18MEX is temporarily removed from new games creation due to game-breaking changes to be done.</p>
         <p>Please file <a href='https://github.com/tobymao/18xx/issues'>issues and ideas</a> on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>.<br>
         If you have any questions, check out the <a href="https://github.com/tobymao/18xx/wiki/FAQ">FAQ</a> and other

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -10,8 +10,6 @@ module Engine
       load_from_json(Config::Game::G18Mex::JSON)
       AXES = { x: :number, y: :letter }.freeze
 
-      DEV_STAGE = :alpha
-
       GAME_LOCATION = 'Mexico'
       GAME_RULES_URL = 'https://secure.deepthoughtgames.com/games/18MEX/rules.pdf'
       GAME_DESIGNER = 'Mark Derrick'


### PR DESCRIPTION
To avoid some frustration stop new games of 18MEX to be created.
That is because I plan to implement a couple of game breaking
things, and then it is good if as few ongoing games as possible
have to be deleted.

The alpha testing will resume as soon as those game-breaking changes
have been deployed.