### PR TITLE
Improve log message Fix/18 mex/merge candidates log

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -282,14 +282,14 @@ module Engine
           return merge_major
         end
 
-        @mergable_candidates = mergable_corporations
-        @log << "Merge candidates: #{present_mergable_candidates(@mergable_candidates)}" if @mergable_candidates.any?
+        @mergeable_candidates = mergeable_corporations
+        @log << "Merge candidates: #{present_mergeable_candidates(@mergeable_candidates)}" if @mergeable_candidates.any?
         possible_auto_merge
       end
 
       def decline_merge(major)
         @log << "#{major.name} declines"
-        @mergable_candidates.delete(major)
+        @mergeable_candidates.delete(major)
         possible_auto_merge
       end
 
@@ -297,7 +297,7 @@ module Engine
       # that there is noone that can or want to merge, which is handled here
       # as well.
       def merge_major(major = nil)
-        @mergable_candidates = []
+        @mergeable_candidates = []
 
         # Make reserved share available
         ndm_merge_share.buyable = true
@@ -410,12 +410,12 @@ module Engine
       end
 
       def merge_decider
-        candidate = @mergable_candidates.first
+        candidate = @mergeable_candidates.first
         candidate.floated? ? candidate : ndm
       end
 
-      def mergable_candidates
-        @mergable_candidates ||= []
+      def mergeable_candidates
+        @mergeable_candidates ||= []
       end
 
       def merged_cities_to_select
@@ -524,7 +524,7 @@ module Engine
         minor.close!
       end
 
-      def mergable_corporations
+      def mergeable_corporations
         corporations = @corporations
           .reject { |c| c.player == ndm.player }
           .reject { |c| %w[PAC TM].include? c.name }
@@ -546,11 +546,11 @@ module Engine
 
       def possible_auto_merge
         # Decline merge if no candidates left
-        return merge_major if @mergable_candidates.empty?
+        return merge_major if @mergeable_candidates.empty?
 
         # Auto merge single if it is non-floated
-        candidate = @mergable_candidates.first
-        merge_major(candidate) if @mergable_candidates.one? && !candidate.floated?
+        candidate = @mergeable_candidates.first
+        merge_major(candidate) if @mergeable_candidates.one? && !candidate.floated?
       end
 
       def replace_token(major, major_token, exchange_tokens)
@@ -580,9 +580,9 @@ module Engine
         end
       end
 
-      def present_mergable_candidates(mergable_candidates)
-        last = mergable_candidates.last
-        mergable_candidates.map do |c|
+      def present_mergeable_candidates(mergeable_candidates)
+        last = mergeable_candidates.last
+        mergeable_candidates.map do |c|
           controller_name = if c.floated?
                               # Floated means president gets to merge/decline
                               c.player.name

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -283,7 +283,7 @@ module Engine
         end
 
         @mergable_candidates = mergable_corporations
-        @log << "Merge candidates: #{@mergable_candidates.map(&:name)}" if @mergable_candidates.any?
+        @log << "Merge candidates: #{present_mergable_candidates(@mergable_candidates)}" if @mergable_candidates.any?
         possible_auto_merge
       end
 
@@ -578,6 +578,23 @@ module Engine
         corporation.abilities(ability_name) do |ability|
           corporation.remove_ability(ability)
         end
+      end
+
+      def present_mergable_candidates(mergable_candidates)
+        last = mergable_candidates.last
+        mergable_candidates.map do |c|
+          controller_name = if c.floated?
+                              # Floated means president gets to merge/decline
+                              c.player.name
+                            elsif c == last
+                              # Non-floated and last will be automatically chosen
+                              'automatic'
+                            else
+                              # If several non-floated candidates NdM gets to choose
+                              ndm.player.name
+                            end
+          "#{c.name} (#{controller_name})"
+        end.join(', ')
       end
     end
   end

--- a/lib/engine/step/g_18_mex/merge.rb
+++ b/lib/engine/step/g_18_mex/merge.rb
@@ -26,7 +26,7 @@ module Engine
         def mergeable(_corporation)
           return [] unless merge_ongoing?
 
-          [@game.mergable_candidates.first]
+          [@game.mergeable_candidates.first]
         end
 
         def active?
@@ -50,13 +50,13 @@ module Engine
         end
 
         def process_pass(_action)
-          @game.decline_merge(@game.mergable_candidates.first)
+          @game.decline_merge(@game.mergeable_candidates.first)
         end
 
         private
 
         def merge_ongoing?
-          @game.mergable_candidates.any?
+          @game.mergeable_candidates.any?
         end
       end
     end


### PR DESCRIPTION
Does improve the log message for showing merge candidates.
This addresses issue #2171 although it does not solve it.

This is a slight improvement that address part of issue #2171 

Here is how it looks in the logs after this change:
![image](https://user-images.githubusercontent.com/2631151/98467213-679c1e00-21d4-11eb-99cf-4279aad4ccbf.png)

Note: If a player controls several corporations these will not be grouped.
So it is
  CHI (Player A), MEX (Player A), SPM (Player B)

'automatic' is shown on the last corporation, if it is non-floated. This is as this will be automatically merged, if all corporations before that decline.

The president of NdM appear on the non-floated corporations, except the last one. This is because the NdM president does choose if there are multiple non-floated corporations that are merge candidates. (In case there are non-IPOed corporations, any IPOed but non-floated cannot be merge candidates.)