### PR TITLE
18MEX: Skip minor track lay if it cannot afford to lay in home hex

### DIFF
--- a/lib/engine/step/g_18_mex/track.rb
+++ b/lib/engine/step/g_18_mex/track.rb
@@ -33,6 +33,15 @@ module Engine
           super
         end
 
+        def can_lay_tile?(entity)
+          return super unless entity.minor?
+
+          home_hex = @game.hex_by_id(entity.coordinates)
+          return @game.tile_cost(home_hex.tile, entity) <= entity.cash if home_hex.tile.color == :white
+
+          super
+        end
+
         private
 
         def remaining_tile_lay?(entity)


### PR DESCRIPTION
If minor corporation does not have enough cash to lay a yellow in
its home hex, the track lay is skipped.

In case home hex has a yellow/green tile then normal track laying
check is done. This might mean that minor gets to manually pass
as there are no allowed track lays it can afford.

But that last is an exceptional case.

Fixes #1944 