### PR TITLE
1817: Improve display of loan info, add buying power

### DIFF
--- a/assets/app/view/game/bank.rb
+++ b/assets/app/view/game/bank.rb
@@ -8,22 +8,8 @@ module View
       include Lib::Settings
 
       needs :game
-      needs :layout, default: nil
 
       def render
-        if @layout == :card
-          render_card
-        else
-          props = {
-            style: {
-              marginBottom: '1rem',
-            },
-          }
-          h(:div, props, "Bank Cash: #{@game.format_currency(@game.bank.cash)}")
-        end
-      end
-
-      def render_card
         title_props = {
           style: {
             padding: '0.4rem',
@@ -63,6 +49,14 @@ module View
             h(:td, 'Loans'),
             h('td.right', "#{@game.loans_taken}/#{@game.total_loans}"),
           ])
+          if @game.respond_to?(:interest_change)
+            @game.interest_change.each do |text, price_change|
+              trs << h(:tr, [
+                h(:td, text),
+                h('td.right', @game.format_currency(price_change)),
+              ])
+            end
+          end
           trs << h(:tr, [
             h(:td, 'Loan Value'),
             h('td.right', @game.format_currency(@game.loan_value)),

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -60,8 +60,8 @@ module View
         children << render_abilities(abilities_to_display) if abilities_to_display.any?
 
         extras = []
-        extras += render_loans if @corporation.loans.any?
-        extras += render_buying_power if @game.total_loans.positive?
+        extras << render_loans if @corporation.loans.any?
+        extras << render_buying_power if @game.total_loans.positive?
         if extras.any?
           props = { style: { borderCollapse: 'collapse' } }
           children << h('table.center', props, [h(:tbody, extras)])

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -58,7 +58,14 @@ module View
           ability.owner.corporation? && ability.description
         end
         children << render_abilities(abilities_to_display) if abilities_to_display.any?
-        children << render_loans if @corporation.loans.any?
+
+        extras = []
+        extras += render_loans if @corporation.loans.any?
+        extras += render_buying_power if @game.total_loans.positive?
+        if extras.any?
+          props = { style: { borderCollapse: 'collapse' } }
+          children << h('table.center', props, [h(:tbody, extras)])
+        end
 
         if @corporation.owner
           props = {
@@ -394,22 +401,32 @@ module View
       end
 
       def render_loans
-        props = { style: { borderCollapse: 'collapse' } }
-        h('table.center', props, [
-          h(:thead, [
-            h(:tr, [
-              h(:th, 'Loans'),
-              h(:th, 'Interest Due'),
-            ]),
+        interest_props = { style: {} }
+        if @game.interest_owed(@corporation) > @corporation.cash
+          color = StockMarket::COLOR_MAP[:red]
+          interest_props[:style][:backgroundColor] = color
+          interest_props[:style][:color] = contrast_on(color)
+        end
+
+        [
+          h('tr.ipo', [
+            h('td.right', 'Loans'),
+            h('td.padded_number', "#{@corporation.loans.size}/"\
+            "#{@game.maximum_loans(@corporation)}"),
           ]),
-          h(:tbody, [
-            h('tr.ipo', [
-              h('td.right', "#{@corporation.loans.size}/"\
-              "#{@game.maximum_loans(@corporation)}"),
-              h('td.padded_number', @game.format_currency(@game.interest_owed(@corporation)).to_s),
-            ]),
+
+          h('tr.ipo', interest_props, [
+            h('td.right', 'Interest Due'),
+            h('td.padded_number', @game.format_currency(@game.interest_owed(@corporation)).to_s),
           ]),
-        ])
+        ]
+      end
+
+      def render_buying_power
+        [h('tr.ipo', [
+          h('td.right', 'Buying Power'),
+          h('td.padded_number', @game.format_currency(@game.buying_power(@corporation)).to_s),
+        ])]
       end
 
       def render_abilities(abilities)

--- a/assets/app/view/game/entities.rb
+++ b/assets/app/view/game/entities.rb
@@ -38,7 +38,7 @@ module View
         end
 
         children << h(:div, [
-          h(Bank, game: @game, layout: :card),
+          h(Bank, game: @game),
           *@game.corporations.select(&:receivership?).map { |c| h(Corporation, corporation: c) },
           *bank_owned.map { |c| h(Corporation, corporation: c) },
         ].compact)

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -218,7 +218,14 @@ module View
                end
 
         children = []
-        children << h(Bank, game: @game) if @game.game_end_check_values.include?(:bank)
+
+        props = {
+          style: {
+            marginBottom: '1rem',
+          },
+        }
+
+        children << h(:div, props, [h(Bank, game: @game)])
         children.concat(grid)
 
         if @explain_colors

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -92,6 +92,14 @@ module Engine
         (interest_rate * entity.loans.size * @loan_value) / 100
       end
 
+      def interest_change
+        rate = future_interest_rate
+        summary = []
+        summary << ["Interest if #{((loans_taken + 4) % 5)} more loans repayed", rate - 5] unless rate == 5
+        summary << ["Interest if #{5 - ((loans_taken + 4) % 5)} more loans taken", rate + 5] unless rate == 70
+        summary
+      end
+
       def maximum_loans(entity)
         entity.total_shares
       end

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -127,7 +127,7 @@ describe 'Assets' do
       expect(render(app_route: '/game/1', **needs)).to include('Takamatsu E-Railroad')
       expect(render(app_route: '/game/1#entities', **needs)).to include('Entities', 'Player 1', 'Awa Railroad')
       expect(render(app_route: '/game/1#map', **needs)).to include('Kotohira')
-      expect(render(app_route: '/game/1#market', **needs)).to include('Bank Cash')
+      expect(render(app_route: '/game/1#market', **needs)).to include('The Bank', 'Cash', 'Par value')
       expect(render(app_route: '/game/1#info', **needs)).to include('Upcoming')
       expect(render(app_route: '/game/1#tiles', **needs)).to include('492')
       expect(render(app_route: '/game/1#spreadsheet', **needs)).to include('Value')


### PR DESCRIPTION
Change stock market tab to use the card form (fixes #2192)
Add detail showing how loans go up and down (also #2192)
Add colour for acquisition and liquidation (fixes #2186)
Highlight red when corp cannot pay its loans (also #2186)
Add buying power for games where loans are present (also #2186)