### PR TITLE
1817: Acquire bugs

### DIFF
--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -269,16 +269,25 @@ module Engine
           # Step 8
           if acquired_corp.share_price.liquidation?
             president = acquired_corp.owner
-            debt = [0, (@liquidation_loans.size * @game.loan_value) - @liquidation_cash].max
+
+            loan_value = @liquidation_loans.size * @game.loan_value
+            debt = [0, loan_value - @liquidation_cash].max
+            @game.loans.concat(@liquidation_loans)
+            @liquidation_loans = []
 
             if debt.positive?
               unless president == @game.share_pool
                 @game.log << "#{president.name} settles #{acquired_corp.name} debts for #{@game.format_currency(debt)}"
                 president.spend(debt, @game.bank, check_cash: false)
               end
-              @game.loans.concat(@liquidation_loans)
-              @liquidation_loans = []
+
               @shareholder_cash = 0
+            elsif loan_value.positive?
+              unless president == @game.share_pool
+                @game.log << "#{@buyer.name} settles #{acquired_corp.name} loans for "\
+                "#{@game.format_currency(loan_value)}"
+              end
+              @shareholder_cash = @liquidation_cash - loan_value
             else
               @shareholder_cash = @liquidation_cash
             end
@@ -433,7 +442,9 @@ module Engine
           @liquidation_cash = 0
           @liquidation_loans = []
 
-          if corporation.share_price.type != @game.stock_prices_start_merger[corporation].type
+          if %i[acquisition liquidation].include?(corporation.share_price.type) &&
+            corporation.share_price.type != @game.stock_prices_start_merger[corporation].type
+
             type = corporation.share_price.liquidation? ? 'liquidation' : 'acquisition'
             @game.log << "#{corporation.name} moved into #{type} during M&A and so is skipped"
 

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -71,7 +71,7 @@ module Engine
           if entity.corporation?
             entity.cash >= bundle.price && redeemable_shares(entity).include?(bundle)
           else
-            super && !bundle.corporation.share_price.acquisition?
+            super
           end
         end
 

--- a/lib/engine/step/g_1817/conversion.rb
+++ b/lib/engine/step/g_1817/conversion.rb
@@ -121,6 +121,7 @@ module Engine
           @round.goto_entity!(corporation) unless @round.entities.empty?
 
           @round.converted = corporation
+          @round.converted_price = corporation.share_price
           @round.converts << corporation
         end
 
@@ -160,6 +161,7 @@ module Engine
         def round_state
           {
             converted: nil,
+            converted_price: nil,
             tokens_needed: nil,
             converts: [],
           }

--- a/lib/engine/step/g_1817/post_conversion.rb
+++ b/lib/engine/step/g_1817/post_conversion.rb
@@ -72,6 +72,8 @@ module Engine
 
         def active_entities
           return [] unless corporation
+          # Ensure players can't buy after taking loans
+          return [] unless corporation.share_price == @round.converted_price
 
           [@game.players.rotate(@game.players.index(corporation.owner))
           .select { |p| p.active? && can_buy_any?(p) }.first].compact

--- a/lib/engine/step/g_1817/share_buying_with_shorts.rb
+++ b/lib/engine/step/g_1817/share_buying_with_shorts.rb
@@ -15,7 +15,8 @@ module Engine
 
           @game.entity_shorts(entity, corporation).any? ||
           corporation.holding_ok?(entity, bundle.percent) &&
-            (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit)
+            (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit) &&
+           !bundle.corporation.share_price.acquisition?
         end
       end
     end

--- a/migrate_game.rb
+++ b/migrate_game.rb
@@ -36,6 +36,10 @@ def repair(game, original_actions, actions, broken_action)
     # Move token is now place token.
     broken_action['type'] = 'place_token'
     return [broken_action]
+  elsif game.active_step.is_a?(Engine::Step::G1817::Acquire)
+    pass = Engine::Action::Pass.new(game.active_step.current_entity).to_h
+    actions.insert(action_idx, pass)
+    return
   elsif game.active_step.is_a?(Engine::Step::G1889::SpecialTrack)
     # laying track for Ehime Railway didn't always block, now it needs an
     # explicit pass

--- a/spec/fixtures/1817/13707.json
+++ b/spec/fixtures/1817/13707.json
@@ -1,0 +1,2591 @@
+{
+  "id": 13707,
+  "description": "test",
+  "user": {
+    "id": 1605,
+    "name": "sandholm"
+  },
+  "players": [
+    {
+      "id": 5117,
+      "name": "tdh_test"
+    },
+    {
+      "id": 1605,
+      "name": "sandholm"
+    },
+    {
+      "id": 1606,
+      "name": "tdh"
+    }
+  ],
+  "max_players": 3,
+  "title": "1817",
+  "settings": {
+    "seed": 1.3782734540566508e+38
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 3,
+  "round": "Operating Round",
+  "acting": [
+    1605
+  ],
+  "result": {
+    "tdh": 989,
+    "sandholm": 1458,
+    "tdh_test": 420
+  },
+  "actions": [
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 1
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 2,
+      "company": "PSM",
+      "price": 10
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 3,
+      "company": "PSM",
+      "price": 15
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 4
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 5,
+      "company": "PSM",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 6,
+      "company": "PSM",
+      "price": 25
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 7,
+      "company": "PSM",
+      "price": 30
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 8
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 9,
+      "company": "ME",
+      "price": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 10
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 11,
+      "company": "ME",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 12,
+      "company": "ME",
+      "price": 25
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 13,
+      "company": "ME",
+      "price": 30
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 14
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 15
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 16,
+      "company": "MINM",
+      "price": 45
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 17,
+      "company": "MINM",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 18
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 19
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 20
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 21
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 22
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 23,
+      "corporation": "ME",
+      "price": 100
+    },
+    {
+      "type": "place_token",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 24,
+      "user": "tdh",
+      "city": "I16-7-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 25
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 26
+    },
+    {
+      "type": "assign",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 27,
+      "target": "MINM",
+      "target_type": "company"
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 28
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 29,
+      "corporation": "A&S",
+      "price": 105
+    },
+    {
+      "type": "place_token",
+      "entity": "A&S",
+      "entity_type": "corporation",
+      "id": 30,
+      "user": "sandholm",
+      "city": "E22-0-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 31
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 32
+    },
+    {
+      "type": "assign",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 33,
+      "target": "PSM",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 34,
+      "target": "ME",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 35,
+      "corporation": "UR",
+      "price": 100
+    },
+    {
+      "type": "place_token",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 36,
+      "user": "tdh",
+      "city": "G18-0-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 37
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 38
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 39
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 40,
+      "corporation": "GT",
+      "price": 150
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 41,
+      "user": "sandholm",
+      "city": "C26-0-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 42
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 43
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 44
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 45
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 46
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 47,
+      "hex": "B27",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 48
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 49,
+      "train": "2-0",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 50
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 51
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 52,
+      "hex": "I16",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "id": 53,
+      "hex": "H17",
+      "tile": "9-1",
+      "type": "lay_tile",
+      "entity": "ME",
+      "rotation": 0,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 54,
+      "type": "undo",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 55
+    },
+    {
+      "type": "take_loan",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 56,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 57,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "take_loan",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 58,
+      "loan": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 59,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 60
+    },
+    {
+      "type": "lay_tile",
+      "entity": "A&S",
+      "entity_type": "corporation",
+      "id": 61,
+      "hex": "F21",
+      "tile": "8-0",
+      "rotation": 1
+    },
+    {
+      "id": 62,
+      "type": "pass",
+      "entity": "A&S",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 63,
+      "type": "undo",
+      "entity": "A&S",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSM",
+      "entity_type": "company",
+      "id": 64,
+      "hex": "F13",
+      "tile": "X00-0",
+      "rotation": 1
+    },
+    {
+      "type": "take_loan",
+      "entity": "A&S",
+      "entity_type": "corporation",
+      "id": 65,
+      "loan": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "A&S",
+      "entity_type": "corporation",
+      "id": 66,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "A&S",
+      "entity_type": "corporation",
+      "id": 67
+    },
+    {
+      "type": "pass",
+      "entity": "A&S",
+      "entity_type": "corporation",
+      "id": 68
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 69
+    },
+    {
+      "type": "buy_train",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 70,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 71
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 72
+    },
+    {
+      "id": 73,
+      "type": "convert",
+      "entity": "GT",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 74,
+      "type": "undo",
+      "entity": "sandholm",
+      "entity_type": "player"
+    },
+    {
+      "type": "convert",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 75
+    },
+    {
+      "type": "buy_shares",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 76,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 77,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 78
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 79
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 80
+    },
+    {
+      "type": "pass",
+      "entity": "A&S",
+      "entity_type": "corporation",
+      "id": 81
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 82,
+      "corporation": "ME",
+      "price": 10
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 83,
+      "corporation": "ME",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 84,
+      "corporation": "ME",
+      "price": 30
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 85
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 86,
+      "loan": 0
+    },
+    {
+      "type": "assign",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 87,
+      "target": "A&S",
+      "target_type": "corporation"
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 88,
+      "corporation": "A&S",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 89
+    },
+    {
+      "id": 90,
+      "hex": "D27",
+      "tile": "7-0",
+      "type": "lay_tile",
+      "entity": "GT",
+      "rotation": 1,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 91,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 92,
+      "hex": "H17",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 93
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 94,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "I16",
+              "J15"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "I16",
+              "H17",
+              "G18"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C26",
+              "B27",
+              "A28"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 95,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 96
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 97
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 98,
+      "hex": "F19",
+      "tile": "6-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 99
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 100,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "F19",
+              "F21",
+              "E22"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "I16",
+              "H17",
+              "G18"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 101,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 102
+    },
+    {
+      "id": 103,
+      "type": "convert",
+      "entity": "GT",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 104,
+      "type": "undo",
+      "entity": "sandholm",
+      "entity_type": "player"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 105
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 106
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 107
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 108,
+      "corporation": "ME",
+      "price": 210
+    },
+    {
+      "type": "place_token",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 109,
+      "user": "tdh",
+      "city": "H3-1-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 110
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 111
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 112
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 113,
+      "corporation": "PLE",
+      "price": 250
+    },
+    {
+      "type": "place_token",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 114,
+      "user": "sandholm",
+      "city": "X00-0-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 115
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 116,
+      "corporation": "R",
+      "price": 120
+    },
+    {
+      "type": "place_token",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 117,
+      "user": "tdh",
+      "city": "G6-0-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 118
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 119
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 120
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 121
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 122,
+      "hex": "E12",
+      "tile": "8-1",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 123,
+      "hex": "E10",
+      "tile": "8-2",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 124,
+      "train": "2+-1",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 125
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 126
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 127,
+      "hex": "H3",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 128
+    },
+    {
+      "type": "buy_train",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 129,
+      "train": "2+-2",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 130,
+      "train": "2+-3",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 131
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 132
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 133
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 134,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "I16",
+              "J15"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "I16",
+              "H17",
+              "G18"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C26",
+              "B27",
+              "A28"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 135,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 136
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 137
+    },
+    {
+      "type": "lay_tile",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 138,
+      "hex": "G6",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "id": 139,
+      "hex": "F7",
+      "tile": "9-2",
+      "type": "lay_tile",
+      "entity": "R",
+      "rotation": 0,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 140,
+      "type": "undo",
+      "entity": "R",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 141,
+      "hex": "F7",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 142,
+      "loan": 4
+    },
+    {
+      "type": "take_loan",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 143,
+      "loan": 5
+    },
+    {
+      "type": "buy_train",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 144,
+      "train": "3-0",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 145
+    },
+    {
+      "id": 146,
+      "hex": "F19",
+      "tile": "15-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 3,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 147,
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 148,
+      "hex": "F19",
+      "tile": "15-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 149
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 150,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "F19",
+              "F21",
+              "E22"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "I16",
+              "H17",
+              "G18"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 151,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 152
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 153
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 154
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 155
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 156
+    },
+    {
+      "type": "pass",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 157
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 158
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 159
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 160
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 161
+    },
+    {
+      "id": 162,
+      "hex": "E8",
+      "tile": "7-0",
+      "type": "lay_tile",
+      "entity": "PLE",
+      "rotation": 2,
+      "entity_type": "corporation"
+    },
+    {
+      "id": 163,
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 164,
+      "hex": "F15",
+      "tile": "9-3",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 165
+    },
+    {
+      "type": "run_routes",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 166,
+      "routes": [
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "D9",
+              "E10",
+              "E12",
+              "F13"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 167,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 168,
+      "loan": 6
+    },
+    {
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 169,
+      "loan": 7
+    },
+    {
+      "type": "buy_train",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 170,
+      "train": "3-2",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 171
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 172,
+      "hex": "H5",
+      "tile": "8-3",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 173
+    },
+    {
+      "type": "run_routes",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 174,
+      "routes": [
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "H3",
+              "H1"
+            ]
+          ]
+        },
+        {
+          "train": "2+-3",
+          "connections": [
+            [
+              "H3",
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 175,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 176
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 177
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 178,
+      "hex": "G18",
+      "tile": "592-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 179,
+      "hex": "F17",
+      "tile": "8-4",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 180,
+      "city": "592-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 181,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "G18",
+              "F17",
+              "F15",
+              "F13"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G18",
+              "H17",
+              "I16"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C26",
+              "B27",
+              "A28"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 182,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 183
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 184
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 185,
+      "hex": "F17",
+      "tile": "82-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 186
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 187,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "F19",
+              "F21",
+              "E22"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "G18",
+              "F17",
+              "F19"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 188,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 189
+    },
+    {
+      "type": "lay_tile",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 190,
+      "hex": "E8",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 191,
+      "hex": "G6",
+      "tile": "619-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 192,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D9",
+              "E10",
+              "E12",
+              "F13"
+            ],
+            [
+              "G6",
+              "F7",
+              "E8",
+              "D9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 193,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 194
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 195
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 196
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 197
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 198
+    },
+    {
+      "type": "pass",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 199
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 200
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 201
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 202
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 203
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 204
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 205
+    },
+    {
+      "id": 206,
+      "type": "sell_shares",
+      "entity": "tdh",
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 20,
+      "entity_type": "player"
+    },
+    {
+      "id": 207,
+      "type": "short",
+      "entity": "tdh",
+      "corporation": "GT",
+      "entity_type": "player"
+    },
+    {
+      "id": 208,
+      "type": "undo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 209,
+      "type": "undo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 210,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 211,
+      "corporation": "GT"
+    },
+    {
+      "id": 212,
+      "type": "undo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 213,
+      "type": "undo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 214,
+      "type": "redo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 215,
+      "type": "redo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 216,
+      "type": "undo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 217,
+      "type": "redo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 218,
+      "type": "undo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 219,
+      "type": "undo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 220,
+      "type": "redo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 221,
+      "type": "redo",
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 222,
+      "corporation": "Bess",
+      "price": 400
+    },
+    {
+      "type": "place_token",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 223,
+      "user": "tdh",
+      "city": "15-0-0",
+      "slot": 0
+    },
+    {
+      "id": 224,
+      "type": "choose",
+      "choice": 5,
+      "entity": "tdh",
+      "entity_type": "player"
+    },
+    {
+      "id": 225,
+      "type": "undo",
+      "user": "tdh",
+      "entity": "tdh_test",
+      "entity_type": "player"
+    },
+    {
+      "type": "choose",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 226,
+      "choice": 5
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 227
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 228
+    },
+    {
+      "type": "buy_shares",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 229,
+      "shares": [
+        "Bess_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_tokens",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 230
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 231
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 232
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 233
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 234,
+      "hex": "E22",
+      "tile": "54-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 235
+    },
+    {
+      "type": "buy_train",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 236,
+      "train": "3-4",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 237,
+      "train": "3-5",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 238
+    },
+    {
+      "type": "pass",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 239
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 240,
+      "hex": "H3",
+      "tile": "15-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 241
+    },
+    {
+      "type": "run_routes",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 242,
+      "routes": [
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "H3",
+              "H1"
+            ]
+          ]
+        },
+        {
+          "train": "2+-3",
+          "connections": [
+            [
+              "H3",
+              "H5",
+              "G6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 243,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 244
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 245
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 246
+    },
+    {
+      "type": "run_routes",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 247,
+      "routes": [
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "D9",
+              "E10",
+              "E12",
+              "F13"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E22",
+              "F21",
+              "F19"
+            ],
+            [
+              "F13",
+              "F15",
+              "F17",
+              "F19"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 248,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 249
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 250,
+      "hex": "F13",
+      "tile": "592-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 251
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 252,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "F13",
+              "F15",
+              "F17",
+              "G18"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G18",
+              "H17",
+              "I16"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C26",
+              "B27",
+              "A28"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 253,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 254,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 255,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 256
+    },
+    {
+      "id": 257,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 258,
+      "type": "redo",
+      "entity": "GT",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 259,
+      "loan": 1
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 260
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 261,
+      "hex": "E20",
+      "tile": "8-5",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 262,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E22",
+              "F21",
+              "F19"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "F13",
+              "F15",
+              "F17",
+              "G18"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 263,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 264
+    },
+    {
+      "type": "lay_tile",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 265,
+      "hex": "F5",
+      "tile": "8-4",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 266,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F13",
+              "E12",
+              "E10",
+              "D9"
+            ],
+            [
+              "G6",
+              "F7",
+              "E8",
+              "D9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 267,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "Bess",
+      "entity_type": "corporation",
+      "id": 268
+    },
+    {
+      "type": "merge",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 269,
+      "corporation": "Bess"
+    },
+    {
+      "type": "discard_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 270,
+      "train": "2-0"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 271,
+      "shares": [
+        "GT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 272,
+      "shares": [
+        "GT_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 273,
+      "shares": [
+        "GT_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 274
+    },
+    {
+      "type": "merge",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 275,
+      "corporation": "PLE"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 276,
+      "shares": [
+        "ME_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": "tdh_test",
+      "entity_type": "player",
+      "id": 277
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 278
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 279,
+      "corporation": "R",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 280,
+      "corporation": "R",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 281,
+      "corporation": "R",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 282
+    },
+    {
+      "type": "discard_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 283,
+      "train": "2-1"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 284
+    },
+    {
+      "type": "sell_shares",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 285,
+      "shares": [
+        "ME_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 286
+    },
+    {
+      "type": "bid",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 287,
+      "corporation": "UR",
+      "price": 10
+    },
+    {
+      "type": "discard_train",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 288,
+      "train": "2-3"
+    },
+    {
+      "type": "discard_train",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 289,
+      "train": "2-4"
+    },
+    {
+      "id": 290,
+      "loan": 8,
+      "type": "take_loan",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 291,
+      "type": "undo",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 292
+    },
+    {
+      "type": "sell_shares",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 293,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "tdh",
+      "entity_type": "player",
+      "id": 294
+    },
+    {
+      "id": 295,
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 296,
+      "type": "undo",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 297,
+      "hex": "F3",
+      "tile": "57-3",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 298
+    },
+    {
+      "type": "run_routes",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 299,
+      "routes": [
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "H3",
+              "H1"
+            ]
+          ]
+        },
+        {
+          "train": "2+-3",
+          "connections": [
+            [
+              "H3",
+              "H5",
+              "G6"
+            ]
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "F13",
+              "E12",
+              "E10",
+              "D9"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "F13",
+              "F15",
+              "F17",
+              "G18"
+            ],
+            [
+              "G18",
+              "H17",
+              "I16"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 300,
+      "kind": "payout"
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 301,
+      "loan": 6
+    },
+    {
+      "id": 302,
+      "loan": 7,
+      "type": "payoff_loan",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 303,
+      "loan": 8,
+      "type": "take_loan",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 304,
+      "type": "undo",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 305,
+      "type": "undo",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 306,
+      "loan": 8,
+      "type": "take_loan",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "id": 307,
+      "type": "undo",
+      "entity": "ME",
+      "entity_type": "corporation"
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 308,
+      "loan": 7
+    },
+    {
+      "type": "pass",
+      "entity": "ME",
+      "entity_type": "corporation",
+      "id": 309
+    },
+    {
+      "type": "end_game",
+      "entity": "sandholm",
+      "entity_type": "player",
+      "id": 310
+    }
+  ],
+  "loaded": true,
+  "created_at": 1603565216,
+  "updated_at": 1603572181
+}

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -168,6 +168,14 @@ module Engine
         'MontyBrewster71' => 4354,
       },
     },
+    GAMES_BY_TITLE['1817'] => {
+      # Temporary until a fuller game is finished
+      13_707 => {
+        'sandholm' => 1458,
+        'tdh' => 989,
+        'tdh_test' => 420,
+      },
+    },
   }.freeze
 
   TEST_CASES.each do |game, results|


### PR DESCRIPTION
Bid should pay off loans before being distributed to shareholders (fixes #2228)
Disallow buying shares after loans are taken if players can now afford them (fixes #2227)
Disallow buying of shares in acquisition from MA (fixes #2226)
Don't skip corps incorrectly in Acquisitions (fixes #2225)
Restore spec