### PR TITLE
Detect illegal routes to towns not in center of tile

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -743,11 +743,20 @@ module Engine
 
             tracks << [path.hex, a.num, path.lanes[0][1]] if a.edge?
             tracks << [path.hex, b.num, path.lanes[1][1]] if b.edge?
+
+            # check track between edges and towns not in center
+            # (essentially, that town needs to act like an edge for this purpose)
+            if b.edge? && a.town? && (nedge = a.tile.preferred_city_town_edges[a]) && nedge != b.num
+              tracks << [path.hex, a, path.lanes[0][1]]
+            end
+            if a.edge? && b.town? && (nedge = b.tile.preferred_city_town_edges[b]) && nedge != a.num
+              tracks << [path.hex, b, path.lanes[1][1]]
+            end
           end
         end
 
         tracks.group_by(&:itself).each do |k, v|
-          @game.game_error("Route cannot reuse track on #{k[0].id}") if v.size > 1
+          game_error("Route cannot reuse track on #{k[0].id}") if v.size > 1
         end
       end
 


### PR DESCRIPTION
Treat towns rendered near edge of tile like an edge for the purposes of detecting track re-use.

Specifically, this will detect the following illegal route using the Copper Canyon tile in 18MEX:
![CC_bug](https://user-images.githubusercontent.com/8494213/98482277-99ee5100-21bd-11eb-8fb8-11fe769af0a5.png)

Fixes #2149 

This also fixes a latent bug in the check_overlap method in game/base where game_error was not being called correctly.