### PR TITLE
18MEX: Fix crash for optional rule (fixes #2202)

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -270,7 +270,7 @@ module Engine
         setup_company_price_50_to_150_percent
       end
 
-      def purchasable_companies(_entity)
+      def purchasable_companies(entity = nil)
         return super if @phase.current[:name] != '2' || !@optional_rules&.include?(:early_buy_of_kcmo)
         return [] unless p2_company.owner.player?
 


### PR DESCRIPTION
Early buy of KCM&O had a bug.