### PR TITLE
1817 corp card fixes

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -61,7 +61,9 @@ module View
 
         extras = []
         extras.concat(render_loans) if @corporation.loans.any?
-        extras << render_buying_power if @game.total_loans.positive?
+        if @corporation.corporation? && @corporation.floated? && @game.total_loans.positive?
+          extras << render_buying_power
+        end
         if extras.any?
           props = { style: { borderCollapse: 'collapse' } }
           children << h('table.center', props, [h(:tbody, extras)])
@@ -153,7 +155,7 @@ module View
           elsif @corporation.cash.positive?
             h(:div, holdings_props, [render_to_float, render_cash])
           else
-            h(:div, holdings_props, "#{@corporation.percent_to_float}% to float")
+            h(:div, holdings_props, @game.float_str(@corporation))
           end
 
         h('div.corp__holdings', holdings_row_props, [

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -725,6 +725,10 @@ module Engine
         route.hexes.map(&:name).join('-')
       end
 
+      def float_str(entity)
+        "#{entity.percent_to_float}% to float"
+      end
+
       def routes_revenue(routes)
         routes.sum(&:revenue)
       end

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -374,6 +374,10 @@ module Engine
           @loans.any?
       end
 
+      def float_str(_entity)
+        '2 shares to start'
+      end
+
       def buying_power(entity)
         return entity.cash unless entity.corporation?
 


### PR DESCRIPTION
Don't show buying power on unfloated corps (fixes #2255)
Show "2 shares to start" rather than %age (fixes #1834)