### PR TITLE
1817: UI fixes and improvements

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -151,7 +151,11 @@ module View
 
         @hidden_divs[company.sym] = h('div#hidden', hidden_props, company.desc)
 
-        [h('div.nowrap', name_props, company.name),
+        extra = []
+        if (uses = company.ability_uses)
+          extra << " (#{uses[0]}/#{uses[1]})"
+        end
+        [h('div.nowrap', name_props, company.name + extra.join(',')),
          @company.owner.player? ? h('div.right', @game.format_currency(company.value)) : '',
          h('div.padded_number', @game.format_currency(company.revenue)),
          @hidden_divs[company.sym]]

--- a/lib/engine/abilities.rb
+++ b/lib/engine/abilities.rb
@@ -74,5 +74,12 @@ module Engine
     def reset_ability_count_this_or!
       @abilities.each { |a| a.count_this_or = 0 }
     end
+
+    def ability_uses
+      # This assumes that only one ability per company has multiple uses
+      @abilities.map do |a|
+        [a.count, a.start_count] if a.start_count
+      end.compact.first
+    end
   end
 end

--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -22,6 +22,9 @@ These attributes may be set for all ability types
 - `count_per_or`: The number of times the ability may be used in each OR; the
   property `count_this_or` is reset to 0 at the start of each OR and increments
   each time the ability is used
+- `show_count`: If the count used/count started should be shown to the user; this
+  this assumes that the ability can be partially used and also that the entity only has
+  one ability with show_count = true
 
 ## additional_token
 

--- a/lib/engine/ability/base.rb
+++ b/lib/engine/ability/base.rb
@@ -10,9 +10,10 @@ module Engine
       include Ownable
 
       attr_accessor :count_this_or, :description
-      attr_reader :type, :owner_type, :remove, :when, :count, :count_per_or
+      attr_reader :type, :owner_type, :remove, :when, :count, :count_per_or, :start_count
 
-      def initialize(type:, description: nil, owner_type: nil, count: nil, remove: nil, count_per_or: nil, **opts)
+      def initialize(type:, description: nil, owner_type: nil, count: nil, remove: nil,
+                     count_per_or: nil, show_count: false, **opts)
         @type = type&.to_sym
         @description = description&.to_s
         @owner_type = owner_type&.to_sym
@@ -22,6 +23,7 @@ module Engine
         @count_this_or = 0
         @used = false
         @remove = remove&.to_s
+        @start_count = @count if show_count
 
         setup(**opts)
       end

--- a/lib/engine/config/game/g_1817.rb
+++ b/lib/engine/config/game/g_1817.rb
@@ -189,7 +189,8 @@ module Engine
             "G6",
             "H9"
           ],
-          "owner_type": "corporation"
+          "owner_type": "corporation",
+          "show_count": true
         }
       ]
     },
@@ -214,6 +215,7 @@ module Engine
             "H9"
           ],
           "count": 2,
+          "show_count": true,
           "owner_type": "corporation"
         }
       ]
@@ -261,7 +263,8 @@ module Engine
           "free": false,
           "when": "track",
           "owner_type": "corporation",
-          "count": 1
+          "count": 1,
+          "show_count": true
         }
       ]
     },
@@ -294,7 +297,8 @@ module Engine
           "free": false,
           "when": "track",
           "owner_type": "corporation",
-          "count": 2
+          "count": 2,
+          "show_count": true
         }
       ]
     },
@@ -327,7 +331,8 @@ module Engine
           "free": false,
           "when": "track",
           "owner_type": "corporation",
-          "count": 3
+          "count": 3,
+          "show_count": true
         }
       ]
     },

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -95,7 +95,7 @@ module Engine
       def interest_change
         rate = future_interest_rate
         summary = []
-        summary << ["Interest if #{((loans_taken + 4) % 5)} more loans repaid", rate - 5] unless rate == 5
+        summary << ["Interest if #{(loans_taken % 5)} more loans repaid", rate - 5] unless rate == 5
         summary << ["Interest if #{5 - ((loans_taken + 4) % 5)} more loans taken", rate + 5] unless rate == 70
         summary
       end

--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -403,9 +403,9 @@ module Engine
           corporation = action.corporation
           price = action.price
 
-          add_bid(action)
           @game.game_error("Bid #{price} is not a multple of 10") unless (price % 10).zero?
           @log << "#{entity.name} bids #{@game.format_currency(price)} for #{corporation.name}"
+          add_bid(action)
           resolve_bids
         end
 


### PR DESCRIPTION
Repay loan is off by one (fixes #2263)
Add count of coal mine and bridges (fixes #2204)
Correct order of bid msg if players autopass (fixes #2189)