### PR TITLE
fix rendering when bankruptcy caused by acquisition cash crisis in 1817

### DIFF
--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -24,6 +24,10 @@ module Engine
       nil
     end
 
+    def owner
+      nil
+    end
+
     def buy_shares(entity, shares, exchange: nil, exchange_price: nil)
       bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
       @game.game_error('Cannot buy share from player') if shares.owner.player?


### PR DESCRIPTION
Fixes #2276; I can't say whether everything about the bankruptcy or acquisition of the current corporation is handled correctly, but this at least keeps the game from crashing at that point.