### PR TITLE
Fix 18MS home token timing

### DIFF
--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -24,8 +24,6 @@ module Engine
 
       BANKRUPTCY_ALLOWED = false
 
-      HOME_TOKEN_TIMING = :operating_round
-
       EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false # Emergency buy can buy any available trains
       EBUY_PRES_SWAP = false # Do not allow presidental swap during emergency buy
       EBUY_SELL_MORE_THAN_NEEDED = true # Allow to sell extra to force buy a more expensive train


### PR DESCRIPTION
 [Fixes #2183]

AAG rules, section 11.3:

    A major company can do the following on its turn. ...

    1. If this is the major company’s first operating turn of the game, place a
    station token in its home city or off-board location, as indicated by the
    company logo. (Required)