### PR TITLE
1817: Show two entity bars during acquisitions (corps and players)

### DIFF
--- a/assets/app/view/game/entity_list.rb
+++ b/assets/app/view/game/entity_list.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'lib/truncate'
+require 'lib/settings'
+
+module View
+  module Game
+    class EntityList < Snabberb::Component
+      needs :round
+      needs :entities
+      needs :acting_entity, default: nil
+
+      include Lib::Settings
+
+      def render
+        items = @entities.map.with_index do |entity, index|
+          entity_props = {
+            key: "entity_#{index}",
+            style: {
+              float: 'left',
+              listStyle: 'none',
+              paddingRight: '1rem',
+            },
+          }
+
+          if @acting_entity == entity
+            scroll_to = lambda do |vnode|
+              elm = Native(vnode)['elm']
+              elm['parentElement']['parentElement'].scrollLeft = elm['offsetLeft'] - 10
+            end
+
+            entity_props[:hook] = {
+              insert: scroll_to,
+              update: ->(_, vnode) { scroll_to.call(vnode) },
+            }
+          end
+
+          style = entity_props[:style]
+
+          if @acting_entity == entity || @round.can_act?(entity)
+            style[:textDecoration] = 'underline'
+            style[:fontSize] = '1.1rem'
+            style[:fontWeight] = 'bold'
+          end
+
+          if index.positive?
+            style[:borderLeft] = "#{setting_for(:font)} solid thin"
+            style[:paddingLeft] = '1rem'
+          end
+
+          children = []
+          if entity.corporation?
+            logo_props = {
+              attrs: { src: entity.logo },
+              style: {
+                padding: '0 0.4rem 0 0',
+                height: '1.2rem',
+              },
+            }
+            children << h(:img, logo_props)
+          end
+
+          owner = " (#{entity.owner.name.truncate})" if !entity.player? && entity.owner
+          owner = ' (CLOSED)' if entity.closed?
+          children << h(:span, "#{entity.name}#{owner}")
+
+          h(:li, entity_props, children)
+        end
+
+        div_props = {
+          key: 'entity_order',
+          attrs: { title: 'Order' },
+          style: {
+            margin: '1rem 0',
+            overflow: 'auto',
+          },
+        }
+
+        ul_props = {
+          key: 'entity_order_container',
+          style: {
+            width: 'max-content',
+            margin: '0',
+            padding: '0',
+          },
+        }
+
+        h(:div, div_props, [
+          h(:ul, ul_props, items),
+        ])
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -24,7 +24,9 @@ module View
 
           if @step.respond_to?(:mergeable)
             mergeable_entities = @step.mergeable(merge_entity)
-            player_corps = mergeable_entities.select { |target| target.owner == merge_entity.owner }
+            player_corps = mergeable_entities.select do |target|
+              target.owner == merge_entity.owner || @step.show_other_players
+            end
             @selected_corporation = player_corps.first if player_corps.one?
           end
 
@@ -80,7 +82,7 @@ module View
             hidden_corps = false
             mergeable_entities.each do |target|
               corp = @selected_corporation if corps_actionable
-              if @show_other_players || target.owner == merge_entity.owner
+              if @step.show_other_players || @show_other_players || target.owner == merge_entity.owner
                 children << h(Corporation, corporation: target, selected_corporation: corp)
               else
                 hidden_corps = true

--- a/lib/engine/round/g_1817/acquisition.rb
+++ b/lib/engine/round/g_1817/acquisition.rb
@@ -17,6 +17,14 @@ module Engine
           'Acquisition Round'
         end
 
+        def context_entities
+          @offering
+        end
+
+        def active_context_entity
+          @offering.first
+        end
+
         def select_entities
           # Things that are offered up for acquisition, sale etc
           @offering = @game

--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -90,6 +90,10 @@ module Engine
           acquire_post_loan unless can_take_loan?(corporation)
         end
 
+        def show_other_players
+          false
+        end
+
         def process_payoff_loan(action)
           entity = action.entity
           loan = action.loan

--- a/lib/engine/step/g_1817/conversion.rb
+++ b/lib/engine/step/g_1817/conversion.rb
@@ -134,6 +134,10 @@ module Engine
           "Corporations that can merge with #{corporation.name}"
         end
 
+        def show_other_players
+          false
+        end
+
         def mergeable(corporation)
           return [] if !corporation.floated? || !corporation.share_price.normal_movement?
 

--- a/lib/engine/step/g_18_mex/merge.rb
+++ b/lib/engine/step/g_18_mex/merge.rb
@@ -33,6 +33,14 @@ module Engine
           [@game.mergeable_candidates.first]
         end
 
+        def override_entities
+          @game.mergeable_candidates
+        end
+
+        def show_other_players
+          true
+        end
+
         def active?
           merge_ongoing?
         end


### PR DESCRIPTION
fixes #2147
Both are valid information to display

18MEX: Override entity order during merger (fixes #2171)
18MEX: Don't hide other player corps