### PR TITLE
1817 minor fixes

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -396,8 +396,8 @@ module View
 
       def render_loans
         interest_props = { style: {} }
-        if @game.interest_owed(@corporation) > @corporation.cash
-          color = StockMarket::COLOR_MAP[:red]
+        unless @game.can_pay_interest?(@corporation)
+          color = StockMarket::COLOR_MAP[:yellow]
           interest_props[:style][:backgroundColor] = color
           interest_props[:style][:color] = contrast_on(color)
         end

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -25,7 +25,7 @@ module View
 
         h('div#spreadsheet', { style: {
           overflow: 'auto',
-        } }, children)
+        } }, children.compact)
       end
 
       def render_table

--- a/lib/engine/abilities.rb
+++ b/lib/engine/abilities.rb
@@ -11,12 +11,16 @@ module Engine
   module Abilities
     def init_abilities(abilities)
       @abilities = []
+      @start_count = nil
 
       (abilities || []).each do |ability|
         klass = Ability::Base.type(ability[:type])
         ability = Object.const_get("Engine::Ability::#{klass}").new(**ability)
         ability.owner = self
         @abilities << ability
+        next unless ability.start_count
+
+        @start_count = ability.start_count
       end
     end
 
@@ -76,10 +80,15 @@ module Engine
     end
 
     def ability_uses
+      return unless @start_count
+
+      count = [0, @start_count]
       # This assumes that only one ability per company has multiple uses
-      @abilities.map do |a|
-        [a.count, a.start_count] if a.start_count
-      end.compact.first
+      # and the ability never separates from the entity
+      @abilities.each do |a|
+        count = [a.count, a.start_count] if a.start_count
+      end
+      count
     end
   end
 end

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -99,8 +99,12 @@ module Engine
         @interest_fixed || future_interest_rate
       end
 
+      def interest_owed_for_loans(loans)
+        (interest_rate * loans * @loan_value) / 100
+      end
+
       def interest_owed(entity)
-        (interest_rate * entity.loans.size * @loan_value) / 100
+        interest_owed_for_loans(entity.loans.size)
       end
 
       def interest_change
@@ -119,6 +123,14 @@ module Engine
           summary << ["Interest if #{loans} more loan#{s} taken", rate + 5]
         end
         summary
+      end
+
+      def can_pay_interest?(entity, extra_cash = 0)
+        # Can they cover it using cash?
+        return true if entity.cash + extra_cash > interest_owed(entity)
+
+        # Can they cover it using buying_power minus the full interest
+        (buying_power(entity) + extra_cash) > interest_owed_for_loans(maximum_loans(entity))
       end
 
       def maximum_loans(entity)

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -107,7 +107,7 @@ module Engine
         rate = future_interest_rate
         summary = []
         unless rate == 5
-          loans = (loans_taken % 5)
+          loans = ((loans_taken - 1) % 5) + 1
           s = loans == 1 ? '' : 's'
           summary << ["Interest if #{loans} more loan#{s} repaid", rate - 5]
         end

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -209,7 +209,12 @@ module Engine
 
           options = available_company_options(entity).map(&:sum)
           if options.none? { |option| price >= option && price <= option + entity.cash }
-            @game.game_error("Invalid bid, valid bids are #{options} + cash #{entity.cash}")
+            valid_options = options
+            .select { |o| o + entity.cash >= min_bid(corporation) }
+            .map { |o| @game.format_currency(o) }
+            .join(', ')
+            @game.game_error("Invalid bid, bids using privates include #{valid_options}"\
+            " and can be supplemented with cash between $0 and #{@game.format_currency(entity.cash)}")
           end
 
           if @auctioning

--- a/lib/engine/step/g_1817/cash_crisis.rb
+++ b/lib/engine/step/g_1817/cash_crisis.rb
@@ -12,6 +12,12 @@ module Engine
         def actions(entity)
           return [] unless entity == current_entity
 
+          if @active_entity.nil?
+            @active_entity = entity
+            @game.log << "#{@active_entity.name} enters Cash Crisis and owes"\
+            " the bank #{@game.format_currency(needed_cash(@active_entity))}"
+          end
+
           ['sell_shares']
         end
 
@@ -27,8 +33,8 @@ module Engine
           return [] unless @round.cash_crisis_player
 
           # Rotate players to order starting with the current player
-          players = @game.players.rotate(@game.players.index(@round.cash_crisis_player))
-          players.select { |p| p.cash.negative? }
+          @game.players.rotate(@game.players.index(@round.cash_crisis_player))
+          .select { |p| p.cash.negative? }
         end
 
         def needed_cash(entity)
@@ -37,6 +43,13 @@ module Engine
 
         def available_cash(_player)
           0
+        end
+
+        def process_sell_shares(action)
+          super
+          return if action.entity.cash.negative?
+
+          @active_entity = nil
         end
       end
     end

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -79,7 +79,11 @@ module Engine
     end
 
     def find_share_price(corporation, directions)
-      r, c = corporation.share_price.coordinates
+      find_relative_share_price(corporation.share_price, directions)
+    end
+
+    def find_relative_share_price(share, directions)
+      r, c = share.coordinates
 
       prices = [share_price(r, c)]
 


### PR DESCRIPTION
1817 Correct rounding so that 5 displays properly on interest (fixes #2300)
1817 Show 0/n when all token actions are used up (fixes #2298)
1817 Improve phrasing on valid bids error (fixes #2223)
1817 Add log message on cash crisis (fixes #2205)
1817 Include buying power in interest highlight (fixes #2254)
1817 Change interest warning to yellow
1817 Show liquidation/acquisition on dividend screen (fixes #2209)
18MS Remove 'undefined' from spreadsheet (fixes #2297)
    

