### PR TITLE
18MEX: Show minors in spreadsheet (fixes #2286)

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -67,7 +67,7 @@ module View
           # This is a company that hasn't floated yet
           []
         else
-          or_history(@game.corporations).map do |x|
+          or_history(@game.all_corporations).map do |x|
             if hist[x]
               props = {
                 style: {
@@ -103,7 +103,7 @@ module View
           props
         end
 
-        or_history_titles = render_history_titles(@game.corporations)
+        or_history_titles = render_history_titles(@game.all_corporations)
 
         pd_props = {
           style: {
@@ -188,7 +188,7 @@ module View
       def sorted_corporations
         floated_corporations = @game.round.entities
 
-        result = @game.corporations.map do |c|
+        result = @game.all_corporations.map do |c|
           operating_order = (floated_corporations.find_index(c) || -1) + 1
           [operating_order, c]
         end
@@ -254,7 +254,9 @@ module View
               sold_props[:style][:backgroundColor] = '#9e0000'
               sold_props[:style][:color] = 'white'
             end
-            h('td.padded_number', sold_props, "#{corporation.president?(p) ? '*' : ''}#{num_shares_of(p, corporation)}")
+            share_holding = corporation.president?(p) ? '*' : ''
+            share_holding += num_shares_of(p, corporation).to_s unless corporation.minor?
+            h('td.padded_number', sold_props, share_holding)
           end,
           h('td.padded_number', { style: { borderLeft: border_style } }, num_shares_of(corporation, corporation).to_s),
           h('td.padded_number', { style: { borderRight: border_style } },
@@ -308,7 +310,9 @@ module View
       def render_player_shares
         h(:tr, zebra_props(true), [
           h('th.left', 'Shares'),
-          *@game.players.map { |p| h('td.padded_number', @game.corporations.sum { |c| num_shares_of(p, c) }) },
+          *@game.players.map do |p|
+            h('td.padded_number', @game.all_corporations.sum { |c| c.minor? ? 0 : num_shares_of(p, c) })
+          end,
         ])
       end
 
@@ -339,6 +343,8 @@ module View
       private
 
       def num_shares_of(entity, corporation)
+        return corporation.president?(entity) ? 1 : 0 if corporation.minor?
+
         entity.num_shares_of(corporation, ceil: false)
       end
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -537,6 +537,10 @@ module Engine
         self
       end
 
+      def all_corporations
+        corporations
+      end
+
       def sorted_corporations
         # Corporations sorted by some potential game rules
         ipoed, others = corporations.partition(&:ipoed)

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -266,6 +266,10 @@ module Engine
         entity.trains.empty? ? handle_no_mail(entity) : handle_mail(entity)
       end
 
+      def all_corporations
+        @minors + @corporations
+      end
+
       def event_companies_buyable!
         setup_company_price_50_to_150_percent
       end
@@ -540,7 +544,6 @@ module Engine
         minor.remove_train(train)
         trains.delete(train)
 
-        @minors.delete(minor)
         minor.close!
         company.close!
       end

--- a/lib/engine/minor.rb
+++ b/lib/engine/minor.rb
@@ -63,6 +63,16 @@ module Engine
       @closed
     end
 
+    def share_price; end
+
+    def par_price; end
+
+    def president?(player)
+      return false unless player
+
+      owner == player
+    end
+
     def close!
       @closed = true
       @floated = false


### PR DESCRIPTION
General code but only affects 18MEX at the moment.

To enable code in other titles, override all_corporations
from game base class to include minors.

For example how the result looks, see #2286.