### PR TITLE
18TN: Fix "company buy during OR1" bug (fixes #1887)

### DIFF
--- a/lib/engine/config/game/g_18_tn.rb
+++ b/lib/engine/config/game/g_18_tn.rb
@@ -582,6 +582,7 @@ module Engine
             "yellow"
          ],
          "status":[
+            "can_buy_companies_from_other_players",
             "can_buy_companies_operation_round_one",
             "limited_train_buy"
          ],
@@ -596,6 +597,7 @@ module Engine
             "green"
          ],
          "status":[
+            "can_buy_companies_from_other_players",
             "can_buy_companies",
             "limited_train_buy"
          ],
@@ -610,6 +612,7 @@ module Engine
             "green"
          ],
          "status":[
+            "can_buy_companies_from_other_players",
             "can_buy_companies",
             "limited_train_buy"
          ],
@@ -624,6 +627,7 @@ module Engine
             "green"
          ],
          "status":[
+            "can_buy_companies_from_other_players",
             "can_buy_companies"
          ],
          "operating_rounds": 2

--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -48,7 +48,7 @@ module Engine
       def active_players
         return super if @finished
 
-        current_entity == company_by_id('ER') ? [@round.company_seller] : super
+        current_entity == company_by_id('ER') ? [@round.company_sellers.first] : super
       end
     end
   end

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -74,7 +74,7 @@ module Engine
         company.remove_ability_when(:sold)
 
         @round.just_sold_company = company
-        @round.company_seller = owner
+        @round.company_sellers << owner
 
         entity.companies << company
         entity.spend(price, owner)
@@ -87,7 +87,7 @@ module Engine
       end
 
       def round_state
-        { just_sold_company: nil, company_seller: nil }
+        { just_sold_company: nil, company_sellers: [] }
       end
 
       def setup

--- a/lib/engine/step/g_1889/special_track.rb
+++ b/lib/engine/step/g_1889/special_track.rb
@@ -19,7 +19,7 @@ module Engine
         def process_lay_tile(action)
           return super unless action.entity == @company
 
-          lay_tile(action, spender: @round.company_seller)
+          lay_tile(action, spender: @round.company_sellers.first)
           tile_lay_abilities(action.entity).use!
         end
 

--- a/lib/engine/step/g_18_tn/buy_company.rb
+++ b/lib/engine/step/g_18_tn/buy_company.rb
@@ -7,18 +7,11 @@ module Engine
     module G18TN
       class BuyCompany < BuyCompany
         def can_buy_company?(entity)
-          return false if @game.turn == 1 && @round.just_sold_company
-
           return true if super
+          return false if entity != current_entity || !@game.allowed_to_buy_during_operation_round_one?
 
           companies = @game.purchasable_companies
-
-          # In OR 1 a corporation can buy a company
-          entity == current_entity &&
-            @game.turn == 1 &&
-            @game.phase.status.include?('can_buy_companies_operation_round_one') &&
-            companies.any? &&
-            companies.map(&:value).min <= entity.cash
+          companies.any? && companies.map(&:value).min <= entity.cash
         end
       end
     end

--- a/lib/engine/step/g_18_tn/track.rb
+++ b/lib/engine/step/g_18_tn/track.rb
@@ -9,6 +9,7 @@ module Engine
         ACTIONS = %w[lay_tile pass].freeze
 
         def actions(entity)
+          return [] unless entity == current_entity
           return [] if entity.company? || !remaining_tile_lay?(entity)
 
           entity == current_entity ? ACTIONS : []

--- a/spec/fixtures/18_tn/7818.json
+++ b/spec/fixtures/18_tn/7818.json
@@ -1,46 +1,5 @@
 {
-  "id": 7818,
-  "description": "Open. Live. Let's dynamite some mountains",
-  "user": {
-    "id": 797,
-    "name": "nigelsandwich"
-  },
-  "players": [
-    {
-      "id": 797,
-      "name": "nigelsandwich"
-    },
-    {
-      "id": 648,
-      "name": "starchitect"
-    },
-    {
-      "id": 523,
-      "name": "MontyBrewster71"
-    },
-    {
-      "id": 3759,
-      "name": "wynad"
-    }
-  ],
-  "max_players": 5,
-  "title": "18TN",
-  "settings": {
-    "seed": 2.6685427666960467e+37
-  },
-  "user_settings": null,
   "status": "finished",
-  "turn": 8,
-  "round": "Operating Round",
-  "acting": [
-
-  ],
-  "result": {
-    "wynad": 4355,
-    "starchitect": 5615,
-    "nigelsandwich": 5368,
-    "MontyBrewster71": 4354
-  },
   "actions": [
     {
       "type": "message",
@@ -286,6 +245,12 @@
       ]
     },
     {
+      "type": "pass",
+      "entity": 523,
+      "entity_type": "player",
+      "id": 31.2
+    },
+    {
       "type": "buy_shares",
       "entity": 3759,
       "entity_type": "player",
@@ -293,6 +258,12 @@
       "shares": [
         "GMO_2"
       ]
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 32.2
     },
     {
       "type": "buy_shares",
@@ -304,6 +275,12 @@
       ]
     },
     {
+      "type": "pass",
+      "entity": 523,
+      "entity_type": "player",
+      "id": 33.2
+    },
+    {
       "type": "buy_shares",
       "entity": 3759,
       "entity_type": "player",
@@ -313,6 +290,12 @@
       ]
     },
     {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 34.2
+    },
+    {
       "type": "buy_shares",
       "entity": 648,
       "entity_type": "player",
@@ -320,6 +303,24 @@
       "shares": [
         "SR_4"
       ]
+    },
+    {
+      "type": "pass",
+      "entity": 523,
+      "entity_type": "player",
+      "id": 35.2
+    },
+    {
+      "type": "pass",
+      "entity": 3759,
+      "entity_type": "player",
+      "id": 35.4
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 35.6
     },
     {
       "type": "lay_tile",
@@ -6902,7 +6903,47 @@
       "message": "see, I am just beinga good teacher, you have learned what to expect!"
     }
   ],
+  "id": "7818",
+  "players": [
+    {
+      "id": 797,
+      "name": "nigelsandwich"
+    },
+    {
+      "id": 648,
+      "name": "starchitect"
+    },
+    {
+      "id": 523,
+      "name": "MontyBrewster71"
+    },
+    {
+      "id": 3759,
+      "name": "wynad"
+    }
+  ],
+  "title": "18TN",
+  "description": "Open. Live. Let's dynamite some mountains",
+  "max_players": 5,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 2.6685427666960467e+37
+  },
+  "user_settings": null,
+  "turn": 8,
+  "round": "Operating Round",
+  "acting": [],
+  "result": {
+    "wynad": 4355,
+    "starchitect": 5615,
+    "nigelsandwich": 5368,
+    "MontyBrewster71": 4354
+  },
   "loaded": true,
   "created_at": 1598498326,
   "updated_at": 1598507133
 }
+


### PR DESCRIPTION
Buy remembering all buys during a round, it is possible to do
a correct check for private buys during OR 1.

Reuse the company_seller round attribute, but change it to a
list instead of a nil/player attribute. This ment refactoring
its use in 1889 a bit. Renamed it to company_sellers to reflect
its changed use.
I do believe it can just contain one value in 1889 so the effect
should be the same.