### PR TITLE
18TN: Civil War should affect triggering company (fixes #1873)

### DIFF
--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -103,15 +103,26 @@ module Engine
 
       def event_civil_war!
         @log << '-- Event: Civil War! --'
-        @corporations.each do |c|
-          # No effect if corporation has no trains
-          next if c.trains.empty?
+        @corporations.sort_by(&:name).each do |c|
+          unless c.floated?
+            @log << "#{c.name} does not revceive any Civil War token as it has not floated yet"
+            next
+          end
+
+          if c.trains.empty? && current_entity != c
+            # No effect if corporation has no trains, current entity does not yet have
+            # any trains as it is in the middle of a train purchase (which triggered the event)
+            # but as it will have a train after the buy is completed it gets the token anyway.
+            @log << "#{c.name} does not revceive any Civil War token as it owns no trains" if c.floated?
+            next
+          end
 
           c.add_ability(Engine::Ability::Base.new(
             type: :civil_war,
             description: 'Civil War! (One time effect)',
             count: 1,
           ))
+          @log << "#{c.name} receives a Civil War token which affects its next OR"
         end
       end
 

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -105,7 +105,7 @@ module Engine
         @log << '-- Event: Civil War! --'
         @corporations.sort_by(&:name).each do |c|
           unless c.floated?
-            @log << "#{c.name} does not revceive any Civil War token as it has not floated yet"
+            @log << "#{c.name} does not receive any Civil War token as it has not floated yet"
             next
           end
 
@@ -113,7 +113,7 @@ module Engine
             # No effect if corporation has no trains, current entity does not yet have
             # any trains as it is in the middle of a train purchase (which triggered the event)
             # but as it will have a train after the buy is completed it gets the token anyway.
-            @log << "#{c.name} does not revceive any Civil War token as it owns no trains" if c.floated?
+            @log << "#{c.name} does not receive any Civil War token as it owns no trains" if c.floated?
             next
           end
 


### PR DESCRIPTION
There was a bug if the triggering company's only train was the
one triggering the Civil War. In which case trains was still
empty when checking for Civil War token.

Have now included the trigger in the event even if it has no
other trains.

Also added a log line per corporation describing if it gets
Civil War token or not, to make it more visible.