### PR TITLE
Fix problems with Buy and Sell button changes

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -30,15 +30,17 @@ module View
           end
 
           # Put up one buy button for each buyable percentage share type in market.
-          # In case there are more than one type of percentages in market or if shares are not 10%
-          # (e.g. 18MEX), show percentage type on button.
-          pool_shares
+          # In case there are more than one type of percentages in market or if shares are not the
+          # standard percent (e.g. 5% in 18MEX), show percentage type on button.
+          # Do skip president's share in case there are other shares available.
+          buyables = pool_shares
             .select { |share| step.can_buy?(current_entity, share) }
-            .each do |share|
-              text = pool_shares.size > 1 || share.percent != 10 ? "#{share.percent}% " : ''
-              children << h(:button, { on: { click: -> { buy_share(current_entity, share) } } },
-                            "Buy #{text}Market Share")
-            end
+            .reject { |share| share.president && pool_shares.size > 1 }
+          buyables.each do |share|
+            text = buyables.size > 1 || share.percent != @corporation.share_percent ? "#{share.percent}% " : ''
+            children << h(:button, { on: { click: -> { buy_share(current_entity, share) } } },
+                          "Buy #{text}Market Share")
+          end
         end
 
         if step.current_actions.include?('short') && step.can_short?(current_entity, @corporation)

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -21,10 +21,6 @@ module View
             ))
           end
 
-          num_shares = bundle.num_shares
-
-          text = num_shares == 1 && bundle.percent != 10 ? "a #{bundle.percent}%" : num_shares.to_s
-
           props = {
             style: {
               padding: '0.2rem 0',
@@ -32,10 +28,17 @@ module View
             },
             on: { click: sell },
           }
-          h('button.sell_share', props, "Sell #{text} (#{@game.format_currency(bundle.price)})")
+          h('button.sell_share', props, "Sell #{share_presentation(bundle)} (#{@game.format_currency(bundle.price)})")
         end
 
         h(:div, buttons.compact)
+      end
+
+      private
+
+      def share_presentation(bundle)
+        num_shares = bundle.num_shares
+        num_shares == 1 && bundle.percent != @corporation.share_percent ? "a #{bundle.percent}%" : num_shares.to_s
       end
     end
   end


### PR DESCRIPTION
Previous commit introduced possibility to show non-standard
percentage in 18MEX, but it introduced problems in other
titles. So this commit improves the solution and solves
a couple of issues.

Disregard president shares for pool shares if there are other
shares that can be bought. This means it will not be possible
to buy president's share directly from the market unless it
is the last one. (And the title need to handle that case.)

Do not let Treasury or Short share presence affect GUI
presentation. Before this fix, the "Buy a 10% Market share"
appeared when Treasury share was present, instead of just
"Buy Market Share".

Also, do not use 10% as the standard share size. Instead use
the share_percent of the corporation in question. This solves
the problem of 20% appearing for 5 share corporations in 1817.

Similar fixes for Sell view. Problem reported in issue #2325.

Fixes #2316 and #2325