### PR TITLE
Don't show loans in spreadsheet view for games without loan mechanics

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -113,7 +113,7 @@ module View
         }
 
         extra = []
-        extra << h(:th, 'Loans') if @game.total_loans
+        extra << h(:th, 'Loans') if @game.total_loans&.nonzero?
         [
           h(:tr, [
             h(:th, ''),
@@ -244,7 +244,7 @@ module View
         end
 
         extra = []
-        extra << h(:td, "#{corporation.loans.size}/#{@game.maximum_loans(corporation)}") if @game.total_loans
+        extra << h(:td, "#{corporation.loans.size}/#{@game.maximum_loans(corporation)}") if @game.total_loans&.nonzero?
 
         h(:tr, tr_props, [
           h(:th, name_props, corporation.name),


### PR DESCRIPTION
Fixes a logic issue (Ruby apparently treats numeric zero as "True")

This caused a "Loans" column to show up, even if games didn't have a loan mechanic

Tested locally, seems to work as expected for '46 and '17