### PR TITLE
1856 look and feel tweaks

### DIFF
--- a/lib/engine/config/game/g_1856.rb
+++ b/lib/engine/config/game/g_1856.rb
@@ -313,7 +313,8 @@ module Engine
         100
       ],
       "coordinates": "J15",
-      "color": "pink"
+      "color": "bbgPink",
+      "text_color": "black"
     },
     {
       "sym": "CA",
@@ -325,7 +326,7 @@ module Engine
         100
       ],
       "coordinates": "D17",
-      "color": "red"
+      "color": "caRed"
     },
     {
       "sym": "CPR",
@@ -351,7 +352,7 @@ module Engine
       ],
       "coordinates": "N11",
       "city": 0,
-      "color": "purple"
+      "color": "cvPurple"
     },
     {
       "sym": "GT",
@@ -388,7 +389,8 @@ module Engine
         40
       ],
       "coordinates": "C14",
-      "color": "lpsBlue"
+      "color": "lpsBlue",
+      "text_color": "black"
     },
     {
       "sym": "TGB",
@@ -410,7 +412,8 @@ module Engine
         40
       ],
       "coordinates": "L15",
-      "color": "thbYellow"
+      "color": "thbYellow",
+      "text_color": "black"
     },
     {
       "sym": "WR",
@@ -450,7 +453,7 @@ module Engine
         100,
         100
       ],
-      "color": "black"
+      "color": "cgrBlack"
     }
   ],
   "trains": [
@@ -592,6 +595,11 @@ module Engine
       ],
       "city=revenue:0;city=revenue:0;label=OO;upgrade=cost:40,terrain:mountain": [
         "L15"
+      ]
+    },
+    "blue": {
+      "": [
+        "N5"
       ]
     },
     "white": {

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -9,14 +9,22 @@ module Engine
       register_colors(black: '#37383a',
                       orange: '#f48221',
                       brightGreen: '#76a042',
-                      tgbOrange: '#fa460f',
-                      gtGreen: '#78c292',
+
+
+                      bbgPink: '#ffd9eb',
+                      caRed: '#f72d2d',
+                      cprPink: '#c474bc',
+                      cvPurple: '#2d0047',
+                      cgrBlack: '#000',
                       lpsBlue: '#c3deeb',
-                      wgbBlue: '#21234a',
-                      cprPink: '#91498b',
-                      thbYellow: '#979e5d',
+                      gtGreen: '#78c292',
                       gwGray: '#6e6966',
+                      tgbOrange: '#c94d00',
+                      thbYellow: '#ebff45',
+                      wgbBlue: '#494d99',
                       wrBrown: '#664c3a',
+
+                      
                       red: '#d81e3e',
                       turquoise: '#00a993',
                       blue: '#0189d1',

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -10,7 +10,6 @@ module Engine
                       orange: '#f48221',
                       brightGreen: '#76a042',
 
-
                       bbgPink: '#ffd9eb',
                       caRed: '#f72d2d',
                       cprPink: '#c474bc',
@@ -24,7 +23,6 @@ module Engine
                       wgbBlue: '#494d99',
                       wrBrown: '#664c3a',
 
-                      
                       red: '#d81e3e',
                       turquoise: '#00a993',
                       blue: '#0189d1',
@@ -34,12 +32,11 @@ module Engine
 
       DEV_STAGE = :prealpha
 
+      # These plain city hexes upgrade to L tiles in brown
+      LAKE_HEXES = %w[B19 C14 F17 O18 P9 N3 L13].freeze
 
-      #These plain city hexes upgrade to L tiles in brown
-      LAKE_HEXES = ['B19', 'C14', 'F17', 'O18', 'P9', 'N3', 'L13']
-
-      #These cities upgrade to the common BarrieLondon green tile, 
-      # but upgrade to specialized brown tiles
+      # These cities upgrade to the common BarrieLondon green tile,
+      #  but upgrade to specialized brown tiles
       BARRIE_HEX = 'M4'
       LONDON_HEX = 'F15'
 

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -34,6 +34,15 @@ module Engine
 
       DEV_STAGE = :prealpha
 
+
+      #These plain city hexes upgrade to L tiles in brown
+      LAKE_HEXES = ['B19', 'C14', 'F17', 'O18', 'P9', 'N3', 'L13']
+
+      #These cities upgrade to the common BarrieLondon green tile, 
+      # but upgrade to specialized brown tiles
+      BARRIE_HEX = 'M4'
+      LONDON_HEX = 'F15'
+
       GAME_LOCATION = 'Ontario, Canada'
       GAME_RULES_URL = 'http://google.com'
       GAME_DESIGNER = 'Bill Dixon'


### PR DESCRIPTION
Change the colors of companies in 1856 so that they are both more distinct than before and more closely match the colors on the charters in the physical copy
![image](https://user-images.githubusercontent.com/2993555/99486258-f544df80-2931-11eb-99b2-ea0797a4e086.png)
