### PR TITLE
1817: More bankrupcy fixes

### DIFF
--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -81,6 +81,8 @@ module Engine
             [@buyer]
           elsif @winner
             [@winner.entity]
+          else
+            []
           end
         end
 
@@ -441,7 +443,7 @@ module Engine
         end
 
         def auctioning_corporation
-          @offer || @auctioning || @winner.corporation
+          @offer || @auctioning || @winner&.corporation
         end
 
         def setup

--- a/lib/engine/step/g_1817/bankrupt.rb
+++ b/lib/engine/step/g_1817/bankrupt.rb
@@ -15,7 +15,7 @@ module Engine
 
           # Rotate players to order starting with the current player
           players = @game.players.rotate(@game.players.index(@round.cash_crisis_player))
-          players.select { |p| p.cash.negative? }
+          [players.find { |p| p.cash.negative? }]
         end
 
         def process_bankrupt(action)


### PR DESCRIPTION
Only allow the first player be the active entity in bankrupcy (fixes #2353)
Handle action after bankrupcy being finishing acquisitions (fixes #2367)