### PR TITLE
18MEX: Fix sorting problem with minors in spreadsheet

### DIFF
--- a/lib/engine/minor.rb
+++ b/lib/engine/minor.rb
@@ -67,6 +67,14 @@ module Engine
 
     def par_price; end
 
+    def num_shares_of(_corporation, _ceil = true)
+      0
+    end
+
+    def share_percent
+      100
+    end
+
     def president?(player)
       return false unless player
 


### PR DESCRIPTION
If trying to sort the player columns, the minors throw an exception.
So I have added dummy implementations of num_shares_of and share_percent
for minors so that they can be sorted as well. They will end up at
top or bottom when sorted on shares for a player.

Fixes #2368 and #2370