### PR TITLE
Add Show/Hide buttons for location names, hex coordinates, and "starting" map

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -31,6 +31,8 @@ module View
       needs :actions, default: []
       needs :entity, default: nil
       needs :unavailable, default: nil
+      needs :show_coords, default: true
+      needs :show_location_names, default: true
 
       def render
         return nil if @hex.empty
@@ -43,7 +45,14 @@ module View
             @hex.tile
           end
         children = [h(:polygon, attrs: { points: Lib::Hex::POINTS })]
-        children << h(Tile, tile: @tile) if @tile
+        if @tile
+          children << h(
+            Tile,
+            tile: @tile,
+            show_coords: @show_coords,
+            show_location_names: @show_location_names,
+          )
+        end
         children << h(TriangularGrid) if Lib::Params['grid']
         children << h(TileUnavailable, unavailable: @unavailable, layout: @hex.layout) if @unavailable
 

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require '../lib/storage'
 require 'view/game/axis'
 require 'view/game/hex'
 require 'view/game/tile_confirmation'
@@ -14,6 +15,9 @@ module View
       needs :selected_route, default: nil, store: true
       needs :selected_company, default: nil, store: true
       needs :opacity, default: nil
+      needs :show_coords, default: Lib::Storage['show_coords'], store: true
+      needs :show_location_names, default: (s = Lib::Storage['show_location_names']).nil? ? true : s, store: true
+      needs :show_starting_map, default: false, store: true
 
       EDGE_LENGTH = 50
       SIDE_TO_SIDE = 87
@@ -22,7 +26,7 @@ module View
       SCALE = 0.5 # Scale for the map
 
       def render
-        @hexes = @game.hexes.dup
+        @hexes = @show_starting_map ? @game.init_hexes(@game.companies, @game.corporations) : @game.hexes.dup
         @cols = @hexes.reject(&:ignore_for_axes).map(&:x).uniq.sort.map(&:next)
         @rows = @hexes.reject(&:ignore_for_axes).map(&:y).uniq.sort.map(&:next)
         @layout = @game.layout
@@ -35,20 +39,22 @@ module View
         @hexes << @hexes.delete(selected_hex) if @hexes.include?(selected_hex)
 
         @hexes.map! do |hex|
-          clickable = step&.available_hex(current_entity, hex)
+          clickable = @show_starting_map ? false : step&.available_hex(current_entity, hex)
           opacity = clickable ? 1.0 : 0.5
           h(
             Hex,
             hex: hex,
-            opacity: @opacity || opacity,
+            opacity: @show_starting_map ? 1.0 : (@opacity || opacity),
             entity: current_entity,
             clickable: clickable,
             actions: actions,
+            show_coords: @show_coords,
+            show_location_names: @show_location_names,
           )
         end
         @hexes.compact!
 
-        children = [render_map]
+        children = [render_map, render_controls]
 
         if current_entity && @tile_selector
           left = (@tile_selector.x + map_x) * SCALE
@@ -136,6 +142,10 @@ module View
           [((@cols.size / 2 + 0.5) * SIDE_TO_SIDE + 2 * GAP) + 1,
            (@rows.size * 1.5 + 0.5) * EDGE_LENGTH + 2 * GAP]
         end
+      end
+
+      def render_controls
+        h(MapControls, show_location_names: @show_location_names, show_coords: @show_coords)
       end
 
       def render_map

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require '../lib/storage'
+
+module View
+  module Game
+    class MapControls < Snabberb::Component
+      needs :show_coords, default: true, store: true
+      needs :show_location_names, default: true, store: true
+      needs :show_starting_map, default: false, store: true
+
+      def render
+        children = [
+          location_names_controls,
+          hex_coord_controls,
+          starting_map_controls,
+        ]
+
+        h(:div, children)
+      end
+
+      def location_names_controls
+        show_hide = @show_location_names ? 'Hide' : 'Show'
+        text = "#{show_hide} Location Names"
+
+        on_click = lambda do
+          new_value = !@show_location_names
+          Lib::Storage['show_location_names'] = new_value
+          store(:show_location_names, new_value)
+        end
+
+        render_button(text, on_click)
+      end
+
+      def hex_coord_controls
+        show_hide = @show_coords ? 'Hide' : 'Show'
+        text = "#{show_hide} Hex Coordinates"
+
+        on_click = lambda do
+          new_value = !@show_coords
+          Lib::Storage['show_coords'] = new_value
+          store(:show_coords, new_value)
+        end
+
+        render_button(text, on_click)
+      end
+
+      def starting_map_controls
+        text = @show_starting_map ? 'Show Current Map' : 'Show Starting Map'
+
+        on_click = lambda do
+          store(:show_starting_map, !@show_starting_map)
+        end
+
+        render_button(text, on_click)
+      end
+
+      def render_button(text, action)
+        props = {
+          style: {
+            top: '1rem',
+            # float: 'right',
+            borderRadius: '5px',
+            margin: '0 0.3rem',
+            padding: '0.2rem 0.5rem',
+          },
+          on: {
+            click: action,
+          },
+        }
+
+        h(:button, props, text)
+      end
+    end
+  end
+end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -15,6 +15,8 @@ module View
     class Tile < Snabberb::Component
       needs :tile
       needs :routes, default: [], store: true
+      needs :show_coords, default: true
+      needs :show_location_names, default: true
 
       # helper method to pass @tile and @region_use to every part
       def render_tile_part(part_class, **kwargs)
@@ -69,11 +71,38 @@ module View
         # borders should always be the top layer
         children << borders if borders
 
-        children << rendered_loc_name if rendered_loc_name
+        children << rendered_loc_name if rendered_loc_name && @show_location_names
+        children << render_coords if @show_coords
 
         children.flatten!
 
         h('g.tile', children)
+      end
+
+      def rotation
+        @rotation ||=
+          if @tile.hex.layout == :pointy
+            'rotate(-30) translate(62 40.5)'
+          else
+            'rotate(0) translate(32 70.02)'
+          end
+      end
+
+      def render_coords
+        props = {
+          attrs: {
+            'dominant-baseline': 'central',
+            fill: 'black',
+            transform: rotation,
+          },
+          style: {
+            fontSize: '24px',
+          },
+        }
+
+        h(:g, [
+          h(:text, props, @tile.hex.coordinates),
+          ])
       end
     end
   end


### PR DESCRIPTION
* use localStorage to persist the last show/hide click
* workaround location names overlapping with important info by making it easy to
  hide (partially addresses #2113)
* default location names to the localStorage value iff there is a value there;
  this preserves the current behavior for users (showing the names) until they
  click on something to hide them, and keeps the tests passing which expect city
  names to be there
* show the "starting" map by re-using `init_hexes`; it's not exactly the
  starting map depending on how some starting tokens/ability icons are handled,
  but should be close enough for those that want it (I don't see a GitHub issue
  for this, but it's a request that's come up a few times in chat)

[Fixes #322]