### PR TITLE
18MEX: Introduce swap functionality (fixes #1921)

### DIFF
--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -20,7 +20,6 @@ module View
               percent: bundle.percent,
             ))
           end
-
           props = {
             style: {
               padding: '0.2rem 0',
@@ -31,6 +30,16 @@ module View
           h('button.sell_share', props, "Sell #{share_presentation(bundle)} (#{@game.format_currency(bundle.price)})")
         end
 
+        step = @game.round.active_step
+        @game.bundles_for_corporation(@player, @corporation).map do |bundle|
+          pool_shares = @game.share_pool.shares_by_corporation[@corporation].group_by(&:percent).values.map(&:first)
+          pool_shares.each do |pool_share|
+            next unless (swap_sell = step.swap_sell(@player, @corporation, bundle, pool_share))
+
+            buttons << sell_with_swap(@player, bundle, swap_sell)
+          end
+        end
+
         h(:div, buttons.compact)
       end
 
@@ -39,6 +48,39 @@ module View
       def share_presentation(bundle)
         num_shares = bundle.num_shares
         num_shares == 1 && bundle.percent != @corporation.share_percent ? "a #{bundle.percent}%" : num_shares.to_s
+      end
+
+      def sell_with_swap(player, bundle, swap_sell)
+        reduced_price = @game.format_currency(bundle.price - swap_sell.price)
+        swap = lambda do
+          process_action(Engine::Action::SellShares.new(
+            player,
+            shares: bundle.shares,
+            share_price: bundle.share_price,
+            percent: bundle.percent,
+            swap: swap_sell,
+          ))
+        end
+        props = {
+          style: {
+            padding: '0.2rem 0',
+            width: '6rem',
+          },
+          on: { click: swap },
+        }
+        h('button.swap_share',
+          props,
+          "Sell #{share_presentation(bundle)} (#{reduced_price} + #{swap_sell.percent}% Share)")
+      end
+
+      def sell_bundle(player, bundle, swap: nil)
+        process_action(Engine::Action::SellShares.new(
+          player,
+          shares: bundle.shares,
+          share_price: bundle.share_price,
+          percent: bundle.percent,
+          swap: swap,
+        ))
       end
     end
   end

--- a/lib/engine/action/buy_shares.rb
+++ b/lib/engine/action/buy_shares.rb
@@ -5,12 +5,13 @@ require_relative 'base'
 module Engine
   module Action
     class BuyShares < Base
-      attr_reader :entity, :bundle
+      attr_reader :entity, :bundle, :swap
 
-      def initialize(entity, shares:, share_price: nil, percent: nil)
+      def initialize(entity, shares:, share_price: nil, percent: nil, swap: nil)
         @entity = entity
         @bundle = ShareBundle.new(Array(shares), percent)
         @bundle.share_price = share_price
+        @swap = swap
       end
 
       def self.h_to_args(h, game)
@@ -18,6 +19,7 @@ module Engine
           shares: h['shares'].map { |id| game.share_by_id(id) },
           share_price: h['share_price'],
           percent: h['percent'],
+          swap: game.share_by_id(h['swap']),
         }
       end
 
@@ -26,6 +28,7 @@ module Engine
           'shares' => @bundle.shares.map(&:id),
           'percent' => @bundle.percent,
           'share_price' => @bundle.share_price,
+          'swap' => @swap&.id,
         }
       end
     end

--- a/lib/engine/action/sell_shares.rb
+++ b/lib/engine/action/sell_shares.rb
@@ -6,12 +6,13 @@ require_relative '../share_bundle'
 module Engine
   module Action
     class SellShares < Base
-      attr_reader :entity, :bundle
+      attr_reader :entity, :bundle, :swap
 
-      def initialize(entity, shares:, share_price: nil, percent: nil)
+      def initialize(entity, shares:, share_price: nil, percent: nil, swap: nil)
         @entity = entity
         @bundle = ShareBundle.new(shares, percent)
         @bundle.share_price = share_price
+        @swap = swap
       end
 
       def self.h_to_args(h, game)
@@ -19,6 +20,7 @@ module Engine
           shares: h['shares'].map { |id| game.share_by_id(id) },
           share_price: h['share_price'],
           percent: h['percent'],
+          swap: game.share_by_id(h['swap']),
         }
       end
 
@@ -27,6 +29,7 @@ module Engine
           'shares' => @bundle.shares.map(&:id),
           'percent' => @bundle.percent,
           'share_price' => @bundle.share_price,
+          'swap' => @swap&.id,
         }
       end
     end

--- a/lib/engine/g_18_chesapeake/share_pool.rb
+++ b/lib/engine/g_18_chesapeake/share_pool.rb
@@ -6,7 +6,7 @@ require_relative '../share_pool'
 module Engine
   module G18Chesapeake
     class SharePool < SharePool
-      def buy_shares(entity, shares, exchange: nil, exchange_price: nil)
+      def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil)
         return super unless shares
         return super unless @game.two_player?
 

--- a/lib/engine/g_18_tn/share_pool.rb
+++ b/lib/engine/g_18_tn/share_pool.rb
@@ -5,7 +5,7 @@ require_relative '../share_pool'
 module Engine
   module G18TN
     class SharePool < SharePool
-      def buy_shares(entity, shares, exchange: nil, exchange_price: nil)
+      def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil)
         super
 
         return if shares.corporation.id != 'L&N' || !@game.lnr.owner

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -699,16 +699,18 @@ module Engine
         self.class::SELL_AFTER == :first ? @turn > 1 : true
       end
 
-      def sell_shares_and_change_price(bundle, allow_president_change: true)
+      def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
         corporation = bundle.corporation
         price = corporation.share_price.price
         was_president = corporation.president?(bundle.owner)
-        @share_pool.sell_shares(bundle, allow_president_change: allow_president_change)
+        @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
         case self.class::SELL_MOVEMENT
         when :down_share
           bundle.num_shares.times { @stock_market.move_down(corporation) }
         when :down_per_10
-          (bundle.percent / 10).to_i.times { @stock_market.move_down(corporation) }
+          percent = bundle.percent
+          percent -= swap.percent if swap
+          (percent / 10).to_i.times { @stock_market.move_down(corporation) }
         when :left_block_pres
           stock_market.move_left(corporation) if was_president
         when :none

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -21,9 +21,9 @@ module Engine
 
       IPO_RESERVED_NAME = 'Trade-in'
 
-      # Sell of one 5% wont affect stock price.
-      # Actually neither will 2 but they will be
-      # sold one at a time to accomplish that.
+      # Sell of one 5% NdM share wont affect stock price.
+      # Actually neither should sell of 2 5% but they will
+      # always be sold just one at a time.
       SELL_MOVEMENT = :down_per_10
 
       TRACK_RESTRICTION = :city_permissive
@@ -239,9 +239,10 @@ module Engine
         super
       end
 
-      # 5% NdM is not counted for cert limit
-      def countable_shares(shares)
-        shares.select { |s| s.percent > 5 }
+      def num_certs(entity)
+        entity.companies.size + entity.shares.count do |s|
+          s.corporation.counts_for_limit && s.counts_for_limit && (s.corporation != ndm || s.percent > 5)
+        end
       end
 
       # In case of selling NdM, split 5% share in separate bundle and regular

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -136,13 +136,13 @@ module Engine
       end
 
       def process_buy_shares(action)
-        buy_shares(action.entity, action.bundle)
+        buy_shares(action.entity, action.bundle, swap: action.swap)
         @round.last_to_act = action.entity
         @current_actions << action
       end
 
       def process_sell_shares(action)
-        sell_shares(action.entity, action.bundle)
+        sell_shares(action.entity, action.bundle, swap: action.swap)
         @round.last_to_act = action.entity
         @current_actions << action
       end
@@ -217,11 +217,11 @@ module Engine
           .select { |p| p.price * 2 <= entity.cash }
       end
 
-      def sell_shares(entity, shares)
-        @game.game_error("Cannot sell shares of #{shares.corporation.name}") unless can_sell?(entity, shares)
+      def sell_shares(entity, shares, swap: nil)
+        @game.game_error("Cannot sell shares of #{shares.corporation.name}") if !can_sell?(entity, shares) && !swap
 
         @round.players_sold[shares.owner][shares.corporation] = :now
-        @game.sell_shares_and_change_price(shares)
+        @game.sell_shares_and_change_price(shares, swap: swap)
       end
 
       def bought?
@@ -244,6 +244,10 @@ module Engine
         @current_actions << action
         @log << "-- #{entity.name} buys #{company.name} from #{owner.name} for #{@game.format_currency(price)}"
       end
+
+      def swap_buy(_player, _corporation, _ipo_or_pool_share); end
+
+      def swap_sell(_player, _corporation, _bundle, _pool_share); end
     end
   end
 end

--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -53,6 +53,8 @@ module Engine
         buy_train_action(action)
         pass! unless can_buy_train?(action.entity)
       end
+
+      def swap_sell(_player, _corporation, _bundle, _pool_share); end
     end
   end
 end

--- a/lib/engine/step/g_18_mex/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_mex/buy_sell_par_shares.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../buy_sell_par_shares'
+require_relative 'swap_buy_sell'
 
 module Engine
   module Step
@@ -15,16 +16,15 @@ module Engine
         end
 
         def can_gain?(entity, bundle)
-          return super if bundle.corporation != @game.ndm || bundle&.percent != 5
-
-          # NdM 5% shares does not affect cert limit
-          bundle.corporation.holding_ok?(entity, bundle.percent)
+          super && !attempt_ndm_action_on_unavailable?(bundle)
         end
+
+        include SwapBuySell
 
         private
 
         def attempt_ndm_action_on_unavailable?(bundle)
-          bundle.corporation.name == 'NdM' && @game.phase.status.include?('ndm_unavailable')
+          bundle.corporation == @game.ndm && @game.phase.status.include?('ndm_unavailable')
         end
       end
     end

--- a/lib/engine/step/g_18_mex/single_depot_train_buy.rb
+++ b/lib/engine/step/g_18_mex/single_depot_train_buy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../single_depot_train_buy'
+require_relative 'swap_buy_sell'
 
 module Engine
   module Step
@@ -11,6 +12,8 @@ module Engine
 
           super
         end
+
+        include SwapBuySell
       end
     end
   end

--- a/lib/engine/step/g_18_mex/swap_buy_sell.rb
+++ b/lib/engine/step/g_18_mex/swap_buy_sell.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# This module is used in classes that need to support
+# swapping of shares.
+module SwapBuySell
+  # Check if it is possible to buy an NdM IPO or Pool share of 10%
+  # when player swaps in a 5% share.
+  def swap_buy(player, corporation, ipo_or_pool_share)
+    return if @game.ndm != corporation || ipo_or_pool_share.percent != 10
+
+    swap_share = player.shares_of(corporation).find { |s| s.percent == 5 }
+    return unless swap_share
+
+    # If we were allowed to buy another 5% then swap is OK.
+    # We test that a reduced buy of 5% would be allowed.
+    can_buy?(player, bundle_reduced_five_percent([ipo_or_pool_share])) ? swap_share : nil
+  end
+
+  # Check if it is possible to sell an NdM bundle if player swap 5% share from pool
+  def swap_sell(player, corporation, bundle, pool_share)
+    return if @game.ndm != corporation || pool_share.percent != 5 || bundle.percent == 5
+
+    # If we were allowed to buy another 5% then swap is OK. Test this by
+    # creating a new bundle where one of the shares has its percentage reduced
+    # by 5. This way we can test if the swap will not exceed market limit of 50%.
+    can_sell?(player, bundle_reduced_five_percent(bundle.shares)) ? pool_share : nil
+  end
+
+  # Private method used by other methods in this module
+  def bundle_reduced_five_percent(shares)
+    # Dup is needed to avoid affecting the actual percentage in the original bundle
+    updated_bundle = Engine::ShareBundle.new(shares.map(&:dup))
+    updated_bundle.shares.first.percent -= 5
+    updated_bundle
+  end
+end

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -5,10 +5,10 @@ require_relative 'base'
 module Engine
   module Step
     module ShareBuying
-      def buy_shares(entity, shares, exchange: nil)
-        @game.game_error("Cannot buy a share of #{shares&.corporation&.name}") unless can_buy?(entity, shares)
+      def buy_shares(entity, shares, exchange: nil, swap: nil)
+        @game.game_error("Cannot buy a share of #{shares&.corporation&.name}") if !can_buy?(entity, shares) && !swap
 
-        @game.share_pool.buy_shares(entity, shares, exchange: exchange)
+        @game.share_pool.buy_shares(entity, shares, exchange: exchange, swap: swap)
         corporation = shares.corporation
         @game.place_home_token(corporation) if @game.class::HOME_TOKEN_TIMING == :float && corporation.floated?
       end


### PR DESCRIPTION
In 18MEX it is possible to swap a 5% share as part of a sell/buy.

If selling shares and there is a 5% share in the market, player
can choose to get the 5% as part of the deal, reducing the money
received for the sell. Note: Selling 30%, with a 5% swap, just
decreases stock market price as if 20% had been sold.

If buying shares and the player owns one 5% share, the player
can choose to use the 5% as a partial payment, reducing the
money needed by the value of the 5% share. This is counted
as a buy for all purposes.

Have introduced swap_sell and swap_share methods, which if
implemented will enable the swap buttons to appear in the GUI.
So far only 18MEX has these implemented.

Note! Swap button is Sell/Buy buttons, which do show info
about 5% share as part of deal.

A bunch of smaller bug fixes for 18MEX 5% share handling.
 - Now handles the 60% roof correctly for NdM.
   Note! If holding 55%, buying 10% is allowed if you swap
   your 5%. Similar if 25% in market, you can sell 30% if
   you swap in 5%.
 - Use SELL_MOVEMENT :down_by_10 instead of override of
   sell_shares_and_change_price
 - Override num_certs to handle the special case for NdM 5%.
   Have rewritten can_gain? to use similar guard as
   can_buy? and can_sell? (stop NdM actions before phase
   minors have merged)

[Fixes #1921]