### PR TITLE
18MEX: Close KCMO private when its ability is used

### DIFF
--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -253,7 +253,7 @@ module Engine
          "name":"Kansas City, Mexico, & Orient Railroad",
          "value":40,
          "revenue":10,
-         "desc":"Owning corporation may place the non-upgradable Copper Canyon tile in F5 for $60 (instead of the normal $120) unless that hex is already built. The tile lay does not have to be connected to an existing station token of the owning corporation. The lay does not count toward the normal lay limit but must be done during tile lay.",
+         "desc":"Owning corporation may place the non-upgradable Copper Canyon tile in F5 for $60 (instead of the normal $120) unless that hex is already built. The tile lay does not have to be connected to an existing station token of the owning corporation. The lay does not count toward the normal lay limit but must be done during tile lay. Using this tile laying ability closes the private company.",
          "abilities": [
             {
               "type": "tile_lay",

--- a/lib/engine/step/g_18_mex/special_track.rb
+++ b/lib/engine/step/g_18_mex/special_track.rb
@@ -19,7 +19,11 @@ module Engine
 
         def process_lay_tile(action)
           super
-          action.tile.label = nil if action.hex.tile.name == COPPER_CANYON
+          return unless action.tile.name == COPPER_CANYON
+
+          action.tile.label = nil
+          @game.log << "#{@game.p2_company.name} closes"
+          @game.p2_company.close!
         end
 
         private

--- a/spec/fixtures/18_mex/13315.json
+++ b/spec/fixtures/18_mex/13315.json
@@ -44,11 +44,11 @@
     1395
   ],
   "result": {
-    "LenaC": 3440,
-    "Cogust": 3872,
-    "shingoi": 3388,
-    "Jen Freeman": 4156,
-    "Swedish-Per (GMT+2)": 3499
+    "LenaC": 3499,
+    "Cogust": 3862,
+    "shingoi": 3362,
+    "Jen Freeman": 4146,
+    "Swedish-Per (GMT+2)": 3255
   },
   "actions": [
     {
@@ -3667,17 +3667,6 @@
       "original_id": 405
     },
     {
-      "id": 339,
-      "type": "buy_shares",
-      "entity": 1048,
-      "shares": [
-        "TM_4"
-      ],
-      "percent": 10,
-      "entity_type": "player",
-      "original_id": 406
-    },
-    {
       "id": 340,
       "type": "pass",
       "entity": 1048,
@@ -5899,82 +5888,6 @@
       "original_id": 643
     },
     {
-      "id": 493,
-      "type": "pass",
-      "entity": "TM",
-      "entity_type": "corporation",
-      "original_id": 644
-    },
-    {
-      "id": 494,
-      "type": "run_routes",
-      "entity": "TM",
-      "routes": [
-        {
-          "train": "4D-3",
-          "connections": [
-            [
-              "I4",
-              "G4",
-              "F5"
-            ],
-            [
-              "J5",
-              "I4"
-            ],
-            [
-              "J5",
-              "K6"
-            ],
-            [
-              "K6",
-              "J7"
-            ],
-            [
-              "J7",
-              "K8"
-            ],
-            [
-              "L9",
-              "K8"
-            ],
-            [
-              "I12",
-              "J11",
-              "K10",
-              "L9"
-            ],
-            [
-              "I12",
-              "H11",
-              "F11",
-              "D11"
-            ]
-          ]
-        }
-      ],
-      "entity_type": "corporation",
-      "original_id": 645
-    },
-    {
-      "id": 495,
-      "kind": "withhold",
-      "type": "dividend",
-      "entity": "TM",
-      "entity_type": "corporation",
-      "original_id": 648
-    },
-    {
-      "id": 496,
-      "type": "buy_train",
-      "price": 700,
-      "train": "4D-5",
-      "entity": "TM",
-      "variant": "4D",
-      "entity_type": "corporation",
-      "original_id": 649
-    },
-    {
       "id": 497,
       "hex": "O8",
       "tile": "480-0",
@@ -6244,6 +6157,82 @@
       "entity": "UdY",
       "entity_type": "corporation",
       "original_id": 663
+    },
+    {
+      "id": 510.1,
+      "type": "pass",
+      "entity": "TM",
+      "entity_type": "corporation",
+      "original_id": 644
+    },
+    {
+      "id": 510.2,
+      "type": "run_routes",
+      "entity": "TM",
+      "routes": [
+        {
+          "train": "4D-3",
+          "connections": [
+            [
+              "I4",
+              "G4",
+              "F5"
+            ],
+            [
+              "J5",
+              "I4"
+            ],
+            [
+              "J5",
+              "K6"
+            ],
+            [
+              "K6",
+              "J7"
+            ],
+            [
+              "J7",
+              "K8"
+            ],
+            [
+              "L9",
+              "K8"
+            ],
+            [
+              "I12",
+              "J11",
+              "K10",
+              "L9"
+            ],
+            [
+              "I12",
+              "H11",
+              "F11",
+              "D11"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "original_id": 645
+    },
+    {
+      "id": 510.3,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "TM",
+      "entity_type": "corporation",
+      "original_id": 648
+    },
+    {
+      "id": 510.4,
+      "type": "buy_train",
+      "price": 700,
+      "train": "4D-5",
+      "entity": "TM",
+      "variant": "4D",
+      "entity_type": "corporation",
+      "original_id": 649
     },
     {
       "id": 511,

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -209,11 +209,11 @@ module Engine
     },
     GAMES_BY_TITLE['18MEX'] => {
       13_315 => {
-        'Jen Freeman' => 4156,
-        'Cogust' => 3872,
-        'Swedish-Per (GMT+2)' => 3499,
+        'Jen Freeman' => 4146,
+        'Cogust' => 3862,
         'LenaC' => 3440,
-        'shingoi' => 3388,
+        'shingoi' => 3362,
+        'Swedish-Per (GMT+2)' => 3255,
       },
     },
   }.freeze


### PR DESCRIPTION
This is an official errata to 18MEX that was published in
May 2020; it has been an error in the rules for MANY years
although the components in some version has the correct
rule.

Have updated the description to KCMO to reflect this.

Also remove CC label to avoid it cluttering up the hex.
(Actually this was as intended in the implementation but
 action.hex.tile.name were not the expected value...)

This removes some income to the owning corporation which might affect
some games. For e.g the fixture that was checked in for 18MEX.
The extra $20 that now disappear means that the forced
train purchase deduct $20 from one of the players which also
meant that TM is not sold out, meaning there is a shift in
operating order... And the final scores are adjusted, affecting
the final ranks...

So, I think game 13315 can be pinned to the previous version.
Have not check if any other 18MEX games are affected by this
change but it is likely. They can be pinned as well - fixing
them is not possible to do in an automated way.