### PR TITLE
18MEX: Minors pays revenue when pre-pass during ISR (fixes #2331)

### DIFF
--- a/lib/engine/step/g_18_mex/waterfall_auction.rb
+++ b/lib/engine/step/g_18_mex/waterfall_auction.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../waterfall_auction'
+
+module Engine
+  module Step
+    module G18Mex
+      class WaterfallAuction < WaterfallAuction
+        protected
+
+        def buy_company(player, company, price)
+          super
+
+          return unless (minor = @game.minor_by_id(company.sym))
+
+          @game.log << "Minor #{minor.name} floats"
+          minor.owner = player
+          minor.float!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
According to the rules any bought minors should run during the OR
(as all privates should give revenue in this situation) but it
would require quite an effort to do this.

So instead a compromise has been reached that almost give the same
effect - any bought/floated will give a $30 (50-50) payout, which
would have been the same as it would have payed out during its
first two ORs, probably.

Although not perfect, it will have more or less the same effect
as according to the rules, and will get players to avoid passing...

Also improved handling of minor floating, which is now connected
to the actual buy of connected company in ISR.

Wiki page will be updated as well.