### PR TITLE
Fix waterfall auction over-committing (again)

### DIFF
--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -135,7 +135,7 @@ module View
           end
 
           company_actions =
-            if @step.respond_to?(:available_cash) && @step.available_cash(@current_entity) < @step.min_bid(company)
+            if @step.auctioneer? && @step.max_bid(@current_entity, company) < @step.min_bid(company)
               []
             elsif @step.may_purchase?(company)
               [h(:button, { on: { click: buy } }, 'Buy')]

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -135,7 +135,9 @@ module View
           end
 
           company_actions =
-            if @step.may_purchase?(company)
+            if @step.respond_to?(:available_cash) && @step.available_cash(@current_entity) < @step.min_bid(company)
+              []
+            elsif @step.may_purchase?(company)
               [h(:button, { on: { click: buy } }, 'Buy')]
             elsif @step.may_choose?(company)
               [h(:button, { on: { click: choose } }, 'Choose')]

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -109,8 +109,8 @@ module Engine
       }.freeze
 
       MIN_BID_INCREMENT = 5
-
       MUST_BID_INCREMENT_MULTIPLE = false
+      ONLY_HIGHEST_BID_COMMITTED = false
 
       CAPITALIZATION = :full
 

--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -27,6 +27,7 @@ module Engine
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
 
       MUST_BID_INCREMENT_MULTIPLE = true
+      ONLY_HIGHEST_BID_COMMITTED = true
       SELL_BUY_ORDER = :sell_buy
 
       def init_share_pool

--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -93,9 +93,14 @@ module Engine
         bids << bid
       end
 
-      def bids_for_player(player)
+      def committed_bids_for_player(player)
         @bids.values.map do |bids|
-          bids.find { |bid| bid.entity == player }
+          if @game.class::ONLY_HIGHEST_BID_COMMITTED
+            highest_bid = bids.max_by(&:price)
+            highest_bid if highest_bid&.entity == player
+          else
+            bids.find { |bid| bid.entity == player }
+          end
         end.compact
       end
     end

--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -15,6 +15,10 @@ module Engine
 
       attr_reader :bids
 
+      def auctioneer?
+        true
+      end
+
       def pass_description
         if auctioning
           "Pass (on #{auctioning.id})"
@@ -93,7 +97,7 @@ module Engine
         bids << bid
       end
 
-      def committed_bids_for_player(player)
+      def bids_for_player(player)
         @bids.values.map do |bids|
           if @game.class::ONLY_HIGHEST_BID_COMMITTED
             highest_bid = bids.max_by(&:price)

--- a/lib/engine/step/base.rb
+++ b/lib/engine/step/base.rb
@@ -92,6 +92,10 @@ module Engine
         ''
       end
 
+      def auctioneer?
+        false
+      end
+
       private
 
       def entities

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -91,7 +91,7 @@ module Engine
       end
 
       def committed_cash(player, _show_hidden = false)
-        committed_bids_for_player(player).sum(&:price)
+        bids_for_player(player).sum(&:price)
       end
 
       def max_bid(player, company)
@@ -166,7 +166,7 @@ module Engine
       end
 
       def buy_company(player, company, price)
-        if (available = available_cash(player)) < price
+        if (available = max_bid(player, company)) < price
           @game.game_error("#{player.name} has #{@game.format_currency(available)} "\
                            'available and cannot spend '\
                            "#{@game.format_currency(price)}")
@@ -197,10 +197,6 @@ module Engine
             end
           end
         end
-      end
-
-      def available_cash(player)
-        player.cash - committed_cash(player)
       end
 
       private

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -91,7 +91,7 @@ module Engine
       end
 
       def committed_cash(player, _show_hidden = false)
-        bids_for_player(player).sum(&:price)
+        committed_bids_for_player(player).sum(&:price)
       end
 
       def max_bid(player, company)
@@ -166,6 +166,12 @@ module Engine
       end
 
       def buy_company(player, company, price)
+        if (available = available_cash(player)) < price
+          @game.game_error("#{player.name} has #{@game.format_currency(available)} "\
+                           'available and cannot spend '\
+                           "#{@game.format_currency(price)}")
+        end
+
         company.owner = player
         player.companies << company
         player.spend(price, @game.bank) if price.positive?
@@ -193,14 +199,18 @@ module Engine
         end
       end
 
+      def available_cash(player)
+        player.cash - committed_cash(player)
+      end
+
       private
 
       def accept_bid(bid)
         price = bid.price
         company = bid.company
         player = bid.entity
-        buy_company(player, company, price)
         @bids.delete(company)
+        buy_company(player, company, price)
       end
 
       def add_bid(bid)


### PR DESCRIPTION
use the existing `max_bid` method instead of trying to write a new
`available_cash` method

[Fixes #2302]
