### PR TITLE
[18CO] Corporate Buy Shares

### DIFF
--- a/assets/app/view/game/corporate_buy_shares.rb
+++ b/assets/app/view/game/corporate_buy_shares.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+
+module View
+  module Game
+    class CorporateBuyShares < Snabberb::Component
+      include Actionable
+
+      needs :game, store: true
+
+      def render
+        @step = @game.round.active_step
+        @current_actions = @step.current_actions
+        @entity ||= @game.current_entity
+        children = []
+
+        children.concat(render_sources) if @step.current_actions.include?('corporate_buy_shares')
+
+        h('div.margined', children.compact)
+      end
+
+      def render_sources
+        props = {
+          style: {
+            display: 'inline-block',
+            verticalAlign: 'top',
+          },
+        }
+
+        @step.source_list(@entity).map do |source|
+          children = []
+          if source.player?
+            children << h(Player, player: source, game: @game)
+            children << render_player_input(source)
+          elsif source.corporation? && @game.corporation_available?(source)
+            children << h(Corporation, corporation: source)
+            children << render_corporation_input(source)
+          end
+          h(:div, props, children)
+        end.compact
+      end
+
+      def render_player_input(player)
+        return unless @step.current_actions.include?('corporate_buy_shares')
+
+        input = []
+        player.shares.group_by(&:corporation).values.each do |corp_shares|
+          input << render_player_buttons(corp_shares.group_by(&:percent).values.map(&:first))
+        end
+
+        h('div.margined_bottom', { style: { width: '20rem' } }, input.compact)
+      end
+
+      def render_player_buttons(shares)
+        children = []
+
+        shares
+          .select { |share| @step.can_buy?(@entity, share.to_bundle) }
+          .each do |share|
+            corp = share.corporation.name
+            text = shares.size > 1 ? "Buy #{share.percent}% #{corp} Share" : "Buy #{corp} Share"
+            children << h(:button, { on: { click: -> { buy_share(@entity, share) } } }, text)
+          end
+
+        h(:div, children) if children.any?
+      end
+
+      def render_corporation_input(corporation)
+        return unless @step.current_actions.include?('corporate_buy_shares')
+
+        pool_shares = @game.share_pool.shares_by_corporation[corporation].group_by(&:percent).values.map(&:first)
+        input = [render_corporation_buttons(pool_shares)]
+
+        h('div.margined_bottom', { style: { width: '20rem' } }, input.compact)
+      end
+
+      def render_corporation_buttons(shares)
+        children = []
+
+        shares
+          .select { |share| @step.can_buy?(@entity, share.to_bundle) }
+          .each do |share|
+            text = shares.size > 1 ? "Buy #{share.percent}% Market Share" : 'Buy Market Share'
+            children << h(:button, { on: { click: -> { buy_share(@entity, share) } } }, text)
+          end
+
+        h(:div, children) if children.any?
+      end
+
+      def buy_share(entity, share)
+        process_action(Engine::Action::CorporateBuyShares.new(entity, shares: share))
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -8,6 +8,7 @@ require 'view/game/corporation'
 require 'view/game/player'
 require 'view/game/dividend'
 require 'view/game/issue_shares'
+require 'view/game/corporate_buy_shares'
 require 'view/game/map'
 require 'view/game/route_selector'
 require 'view/game/cash_crisis'
@@ -38,6 +39,8 @@ module View
             left << h(CashCrisis)
           elsif @current_actions.include?('buy_shares') || @current_actions.include?('sell_shares')
             left << h(IssueShares)
+          elsif @current_actions.include?('corporate_buy_shares')
+            left << h(CorporateBuyShares)
           end
           left << h(Loans, corporation: entity) if (%w[take_loan payoff_loan] & @current_actions).any?
 

--- a/lib/engine/action/corporate_buy_shares.rb
+++ b/lib/engine/action/corporate_buy_shares.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'buy_shares'
+
+module Engine
+  module Action
+    class CorporateBuyShares < BuyShares
+    end
+  end
+end

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -123,6 +123,10 @@ module Engine
       player_share_holders.values.sum / share_percent
     end
 
+    def num_corporate_shares
+      corporate_share_holders.values.sum / share_percent
+    end
+
     def num_market_shares
       share_holders.select { |s_h, _| s_h.share_pool? }.values.sum / share_percent
     end
@@ -133,6 +137,14 @@ module Engine
 
     def player_share_holders
       share_holders.select { |s_h, _| s_h.player? }
+    end
+
+    def corporate_share_holders
+      share_holders.select { |s_h, _| s_h.corporation? && s_h != self }
+    end
+
+    def corporate_shares
+      shares.reject { |share| share.corporation == self }
     end
 
     def id

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -201,6 +201,9 @@ module Engine
       ALL_COMPANIES_ASSIGNABLE = false
       OBSOLETE_TRAINS_COUNT_FOR_LIMIT = false
 
+      CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY = false
+      CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = false
+
       CACHABLE = [
         %i[players player],
         %i[corporations corporation],

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -32,6 +32,9 @@ module Engine
       SELL_BUY_ORDER = :sell_buy
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = true
 
+      CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY = true
+      CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
+
       # Two tiles can be laid, only one upgrade
       # TODO: This changes in phase E to a single tile lay
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: false }].freeze
@@ -164,6 +167,7 @@ module Engine
         Step::HomeToken,
         Step::BuyCompany,
         Step::G18CO::RedeemShares,
+        Step::CorporateBuyShares,
         Step::G18CO::Track,
         Step::Token,
         Step::Route,

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -30,7 +30,10 @@ module Engine
 
     def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil)
       bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
-      @game.game_error('Cannot buy share from player') if shares.owner.player?
+
+      if !@game.class::CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT && shares.owner.player?
+        @game.game_error('Cannot buy share from player')
+      end
 
       corporation = bundle.corporation
       ipoed = corporation.ipoed
@@ -48,7 +51,13 @@ module Engine
       share_str = "a #{bundle.percent}% share of #{corporation.name}"
       incremental = corporation.capitalization == :incremental
 
-      from = bundle.owner.corporation? ? "the #{@game.ipo_name(corporation)}" : 'the market'
+      from = 'the market'
+      if bundle.owner.corporation?
+        from = "the #{@game.ipo_name(corporation)}"
+      elsif bundle.owner.player?
+        from = bundle.owner.name
+      end
+
       if exchange
         price = exchange_price || 0
         case exchange

--- a/lib/engine/step/corporate_buy_shares.rb
+++ b/lib/engine/step/corporate_buy_shares.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'share_buying'
+require_relative '../action/corporate_buy_shares'
+
+module Engine
+  module Step
+    class CorporateBuyShares < Base
+      include ShareBuying
+
+      PURCHASE_ACTIONS = [Action::CorporateBuyShares].freeze
+
+      def description
+        'Corporate Share Buying'
+      end
+
+      def setup
+        @bought = []
+      end
+
+      def actions(entity)
+        return [] unless entity == current_entity
+
+        actions = []
+        actions << 'corporate_buy_shares' if can_buy_any?(entity)
+
+        actions << 'pass' if actions.any?
+
+        actions
+      end
+
+      def log_pass(entity)
+        @log << "#{entity.name} passes buying shares"
+      end
+
+      def log_skip(entity)
+        @log << "#{entity.name} skips corporate share buy"
+      end
+
+      def can_buy_any?(entity)
+        can_buy_any_from_market?(entity) || can_buy_any_from_president?(entity)
+      end
+
+      def can_buy_any_from_market?(entity)
+        @game.share_pool.shares.any? { |s| can_buy?(entity, s.to_bundle) }
+      end
+
+      def can_buy_any_from_president?(entity)
+        return unless @game.class::CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT
+
+        entity.owner.shares.any? { |s| can_buy?(entity, s.to_bundle) }
+      end
+
+      def can_buy?(entity, bundle)
+        return unless bundle
+        return unless bundle.buyable
+        return if bundle.presidents_share
+        return if entity == bundle.corporation
+
+        if @game.class::CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY && bought?
+          return unless bundle.corporation == @bought.last
+        end
+
+        entity.cash >= bundle.price
+      end
+
+      def process_corporate_buy_shares(action)
+        buy_shares(action.entity, action.bundle)
+        @bought << action.bundle.corporation
+        pass! unless can_buy_any?(action.entity)
+      end
+
+      def source_list(entity)
+        if @game.class::CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY && bought?
+          source = @game.sorted_corporations
+            .select { |corp| (corp == @bought.last && !corp.num_market_shares.zero?) }
+        else
+          source = @game.sorted_corporations
+            .select { |corp| corp != entity && corp.floated? && !corp.closed? && !corp.num_market_shares.zero? }
+        end
+
+        if @game.class::CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT && can_buy_any_from_president?(entity)
+          source << entity.owner
+        end
+
+        source
+      end
+
+      def bought?
+        @bought.any?
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/1836

### Background

18CO allows corporations to buy shares from two possible places:
- The market
- The corporation's president

Once a purchase of a corporation is made, only purchases of that specific corporation can be made in that round, though from either source.

### Implementation

I chose to implement this as a generic ( non-18CO ) specific class as I believe there will be other games that allow cross-corp share purchasing.

A new action had to be created to allow the correct actions / display to work, though it implements no specific code of its own.

The displays have a decent amount of repeated code which I am not a fan of, but the code was also just different enough to seem difficult to refactor.

Flag: **CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY** - Without this flag, a corporation can purchase shares of multiple other corporations during the CBS step.
Flag: **CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT** - Without this flag, a corporation can only purchase shares from the market.

**_There currently is nothing to handle what happens when one corporation should become president of another corporation. This triggers a takeover in 18CO, but I want to handle that in a separate PR. Right now the player remains President._**

### Display

Corporation's holdings of other corporation shares show up in a list similar to the player's shares, with the corporation logo indicating it is a share in a different corporation. Here, CM owns 30% of DSNG and 10% of CS.

<img width="268" alt="Screen Shot 2020-11-24 at 10 08 13 AM" src="https://user-images.githubusercontent.com/15675400/100128085-10858280-2e3d-11eb-81d3-88ffa4eae33f.png">

Buttons are available only for the specific shares that can be bought beneath potential sources.

<img width="468" alt="Screen Shot 2020-11-24 at 9 20 40 AM" src="https://user-images.githubusercontent.com/15675400/100122548-bbdf0900-2e36-11eb-96ef-810951c93122.png">

This shows the changes to the share pool, allowing the Corporation to buy from the President and the corresponding log working as expected.

<img width="419" alt="Screen Shot 2020-11-24 at 9 21 29 AM" src="https://user-images.githubusercontent.com/15675400/100122551-bd103600-2e36-11eb-8329-822bb6d09da8.png">

**Styling suggestions appreciated. 😃** 