### PR TITLE
[18CO] Fix missing market text and color definitions

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -43,6 +43,16 @@ module Engine
       GREEN_TOWN_TILES = %w[co8 co9 co10].freeze
       BROWN_CITY_TILES = %w[co4 63].freeze
 
+      STOCKMARKET_COLORS = {
+        par: :yellow,
+        acquisition: :red,
+      }.freeze
+
+      MARKET_TEXT = {
+        par: 'Par: C [40, 50, 60, 75] - 40%, B/C [80, 90, 100, 110] - 50%, A/B/C: [120, 135, 145, 160] - 60%',
+        acquisition: 'Acquisition: Corporation assets will be auctioned if entering Stock Round',
+      }.freeze
+
       PAR_FLOAT_GROUPS = {
         20 => %w[X],
         40 => %w[C B A],


### PR DESCRIPTION
**_This change only affects 18CO_**

Recent changes removing Acquisition from the base game definition caused it to be missing from the Market. Additionally, the colors were backwards.

Additionally, add some helpful text to the market zone definitions, as implementing separate par zones as currently not supported.

<img width="671" alt="Screen Shot 2020-11-24 at 10 55 51 AM" src="https://user-images.githubusercontent.com/15675400/100136649-893e0c00-2e48-11eb-996c-ff1d1a95ddb2.png">
