### PR TITLE
[18CO] Towns on route ends are counted against city limit.

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -185,6 +185,23 @@ module Engine
         end
       end
 
+      def check_distance(route, visits)
+        super
+
+        distance = route.train.distance
+
+        return if distance.is_a?(Numeric)
+
+        cities_allowed = distance.find { |d| d['nodes'].include?('city') }['pay']
+        cities_visited = visits.count { |v| v.city? || v.offboard? }
+        start_at_town = visits.first.town? ? 1 : 0
+        end_at_town = visits.last.town? ? 1 : 0
+
+        return unless cities_allowed < (cities_visited + start_at_town + end_at_town)
+
+        game_error('Towns on route ends are counted against city limit.')
+      end
+
       def revenue_for(route, stops)
         revenue = super
 


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/1836

In 18CO, unlimited towns are paid but towns on route ends are counted against city limit. It is legal for a 2 train to run "C t t t t" for example, but not "t C t t t". Similarly, a 4 train can run "t C C t" or "C t C C t" but not "t C C C t".

<img width="1276" alt="Screen Shot 2020-11-24 at 7 12 58 PM" src="https://user-images.githubusercontent.com/15675400/100174381-8ca5b780-2e89-11eb-8b2c-9dce2314c676.png">
