### PR TITLE
1856 companies may close

### DIFF
--- a/lib/engine/config/game/g_1856.rb
+++ b/lib/engine/config/game/g_1856.rb
@@ -523,7 +523,7 @@ module Engine
       "num": 2,
       "events":[
       {
-         "type":"Nationalization"
+         "type":"nationalization"
       }
       ]
     },
@@ -586,7 +586,7 @@ module Engine
         "F15",
         "M4"
       ],
-      "city=revenue:30;city=revenue:30;path=a:1,b:_0;path=a:4,b:_1": [
+      "city=revenue:30;city=revenue:30;label=T;path=a:1,b:_0;path=a:4,b:_1": [
         "N11"
       ],
       "city=revenue:0;city=revenue:0;label=OO": [

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -124,37 +124,37 @@ module Engine
     "X1": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_0;path=a:_0,b:4;path=a:2,b:_0;path=a:_0,b:5;label=M"
+      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:4;path=a:2,b:_2;path=a:_2,b:5;label=M"
     },
     "X2": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:2,b:_0;path=a:_0,b:4;path=a:1,b:_0;path=a:_0,b:5;label=M"
+      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:5;path=a:2,b:_2;path=a:_2,b:4;label=M"
     },
     "X3": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:1;path=a:3,b:_0;path=a:_0,b:5;path=a:2,b:_0;path=a:_0,b:4;label=M"
+      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:4;path=a:1,b:_1;path=a:_1,b:2;path=a:3,b:_2;path=a:_2,b:5;label=M"
     },
     "X4": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:1,b:_0;path=a:_0,b:2;path=a:0,b:_0;path=a:_0,b:3;path=a:4,b:_0;path=a:_0,b:5;label=M"
+      "code": "city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:2;path=a:4,b:_2;path=a:_2,b:5;label=M"
     },
     "X5": {
       "count": 1,
       "color": "brown",
-      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:5,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=M"
+      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:3,b:_1;path=a:_0,b:_1;label=M"
     },
     "X6": {
       "count": 1,
       "color": "brown",
-      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:_0,b:5;label=M"
+      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;label=M"
     },
     "X7": {
       "count": 1,
       "color": "brown",
-      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:_0,b:4;path=a:3,b:_0;path=a:5,b:_0;label=M"
+      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:2,b:_1;path=a:4,b:_1;label=M"
     },
     "X8": {
       "count": 1,

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -34,6 +34,7 @@ module Engine
 
       # These plain city hexes upgrade to L tiles in brown
       LAKE_HEXES = %w[B19 C14 F17 O18 P9 N3 L13].freeze
+      BROWN_OO_TILES = %w[64 65 66 67 68].freeze
 
       # These cities upgrade to the common BarrieLondon green tile,
       #  but upgrade to specialized brown tiles
@@ -48,6 +49,10 @@ module Engine
 
       HOME_TOKEN_TIMING = :operating_round
 
+      def gray_phase?
+        @phase.tiles.include?('gray')
+      end
+
       def setup
         @straight_city ||= @tiles.find { |t| t.name == '57' }
         @sharp_city ||= @tiles.find { |t| t.name == '5' }
@@ -58,11 +63,12 @@ module Engine
         @gentle_track ||= @tiles.find { |t| t.name == '8' }
 
         @x_city ||= @tiles.find { |t| t.name == '14' }
-        @k_city ||= @tiles.find { |t| (t.name == '15') }
-      end
+        @k_city ||= @tiles.find { |t| t.name == '15' }
 
-      def gray_phase?
-        @phase.tiles.include?('gray')
+        @brown_london ||= @tiles.find { |t| t.name == '126' }
+        @brown_barrie ||= @tiles.find { |t| t.name == '127' }
+
+        @gray_hamilton ||= @tiles.find { |t| t.name == '123' }
       end
 
       def event_nationalization!
@@ -84,18 +90,18 @@ module Engine
       def upgrades_to?(from, to, special = false)
         return false if from.name == '470'
         # double dits upgrade to Green cities in gray
-        return @phase.tiles.include? 'gray' if to.name == '14' && %w[55 1].include?(from.name)
-        return @phase.tiles.include? 'gray' if to.name == '15' && %w[56 2].include?(from.name)
+        return gray_phase? if to.name == '14' && %w[55 1].include?(from.name)
+        return gray_phase? if to.name == '15' && %w[56 2].include?(from.name)
 
         # yellow dits upgrade to yellow cities in gray
-        return @phase.tiles.include? 'gray' if to.name == '5' && from.name == '3'
-        return @phase.tiles.include? 'gray' if to.name == '57' && from.name == '4'
-        return @phase.tiles.include? 'gray' if to.name == '6' && from.name == '58'
+        return gray_phase? if to.name == '5' && from.name == '3'
+        return gray_phase? if to.name == '57' && from.name == '4'
+        return gray_phase? if to.name == '6' && from.name == '58'
 
         # yellow dits upgrade to plain track in gray
-        return @phase.tiles.include? 'gray' if to.name == '7' && from.name == '3'
-        return @phase.tiles.include? 'gray' if to.name == '9' && from.name == '4'
-        return @phase.tiles.include? 'gray' if to.name == '8' && from.name == '58'
+        return gray_phase? if to.name == '7' && from.name == '3'
+        return gray_phase? if to.name == '9' && from.name == '4'
+        return gray_phase? if to.name == '8' && from.name == '58'
 
         # Certain green cities upgrade to other labels
         return to.name == '127' if from.color == :green && from.hex.name == BARRIE_HEX
@@ -123,7 +129,8 @@ module Engine
         return upgrades unless tile_manifest
 
         # In phase 6+ single dits may be turned into plain yellow track or yellow cities
-        if @phase.tiles.include?('gray')
+        if gray_phase?
+          puts 'gray'
           upgrades |= [@straight_city, @straight_track] if tile.name == '4'
           upgrades |= [@gentle_city, @gentle_track] if tile.name == '58'
           upgrades |= [@sharp_city, @sharp_track] if tile.name == '3'
@@ -133,8 +140,10 @@ module Engine
           upgrades |= [@k_city] if tile.name == '56'
           upgrades |= [@k_city] if tile.name == '2'
         end
-        upgrades |= @tiles.find { |t| t.name == '127' } if tile.name == '125'
-        upgrades |= @tiles.find { |t| t.name == '126' } if tile.name == '125'
+        puts 'other'
+        upgrades |= [@brown_london] if tile.name == '121'
+        upgrades |= [@brown_barrie] if tile.name == '121'
+        upgrades |= [@gray_hamilton] if BROWN_OO_TILES.include?(tile.name)
         upgrades
       end
 

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -82,6 +82,32 @@ module Engine
         # trade all shares
       end
 
+      def post_nationalization()
+        # TODO: Update this with something more correct once nationalization is implemented
+        return true
+      end
+
+      def num_corporations()
+        # TODO: Update this with something more correct once nationalization is implemented
+        return @corporations.size - 1
+      end
+
+      def cert_limit()
+        return {3 => 20, 4 => 16, 5 => 13, 6 => 11 }[@players.size] unless post_nationalization
+        {
+          11 => {3 => 28, 4 => 22, 5 => 18, 6 => 15},
+          10 => {3 => 25, 4 => 20, 5 => 16, 6 => 14},
+          9 => {3 => 22, 4 => 18, 5 => 15, 6 => 12},
+          8 => {3 => 20, 4 => 16, 5 => 13, 6 => 11},
+          7 => {3 => 18, 4 => 14, 5 => 11, 6 => 10},
+          6 => {3 => 15, 4 => 12, 5 => 10, 6 => 8},
+          5 => {3 => 13, 4 => 10, 5 => 8, 6 => 7},
+          4 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
+          3 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
+          2 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
+          1 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
+        }[num_corporations()][@players.size]
+      end
       #
       # Get the currently possible upgrades for a tile
       # from: Tile - Tile to upgrade from

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -82,32 +82,34 @@ module Engine
         # trade all shares
       end
 
-      def post_nationalization()
+      def post_nationalization
         # TODO: Update this with something more correct once nationalization is implemented
-        return true
+        true
       end
 
-      def num_corporations()
+      def num_corporations
         # TODO: Update this with something more correct once nationalization is implemented
-        return @corporations.size - 1
+        @corporations.size - 1
       end
 
-      def cert_limit()
-        return {3 => 20, 4 => 16, 5 => 13, 6 => 11 }[@players.size] unless post_nationalization
+      def cert_limit
+        return { 3 => 20, 4 => 16, 5 => 13, 6 => 11 }[@players.size] unless post_nationalization
+
         {
-          11 => {3 => 28, 4 => 22, 5 => 18, 6 => 15},
-          10 => {3 => 25, 4 => 20, 5 => 16, 6 => 14},
-          9 => {3 => 22, 4 => 18, 5 => 15, 6 => 12},
-          8 => {3 => 20, 4 => 16, 5 => 13, 6 => 11},
-          7 => {3 => 18, 4 => 14, 5 => 11, 6 => 10},
-          6 => {3 => 15, 4 => 12, 5 => 10, 6 => 8},
-          5 => {3 => 13, 4 => 10, 5 => 8, 6 => 7},
-          4 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
-          3 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
-          2 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
-          1 => {3 => 10, 4 => 8, 5 => 7, 6 => 6},
-        }[num_corporations()][@players.size]
+          11 => { 3 => 28, 4 => 22, 5 => 18, 6 => 15 },
+          10 => { 3 => 25, 4 => 20, 5 => 16, 6 => 14 },
+          9 => { 3 => 22, 4 => 18, 5 => 15, 6 => 12 },
+          8 => { 3 => 20, 4 => 16, 5 => 13, 6 => 11 },
+          7 => { 3 => 18, 4 => 14, 5 => 11, 6 => 10 },
+          6 => { 3 => 15, 4 => 12, 5 => 10, 6 => 8 },
+          5 => { 3 => 13, 4 => 10, 5 => 8, 6 => 7 },
+          4 => { 3 => 10, 4 => 8, 5 => 7, 6 => 6 },
+          3 => { 3 => 10, 4 => 8, 5 => 7, 6 => 6 },
+          2 => { 3 => 10, 4 => 8, 5 => 7, 6 => 6 },
+          1 => { 3 => 10, 4 => 8, 5 => 7, 6 => 6 },
+        }[num_corporations][@players.size]
       end
+
       #
       # Get the currently possible upgrades for a tile
       # from: Tile - Tile to upgrade from

--- a/lib/engine/step/g_1856/track.rb
+++ b/lib/engine/step/g_1856/track.rb
@@ -1,38 +1,14 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative '../track'
 require_relative 'tracker'
 
 module Engine
   module Step
     module G1856
-      class Track < Base
+      class Track < Track
         include Tracker
-        ACTIONS = %w[lay_tile pass].freeze
-
-        def actions(entity)
-          return [] unless entity == current_entity
-          return [] if entity.company? || !can_lay_tile?(entity)
-
-          ACTIONS
-        end
-
-        def description
-          'Lay Track'
-        end
-
-        def pass_description
-          @acted ? 'Done (Track)' : 'Skip (Track)'
-        end
-
-        def process_lay_tile(action)
-          lay_tile_action(action)
-          pass! unless can_lay_tile?(action.entity)
-        end
-
-        def available_hex(entity, hex)
-          @game.graph.connected_hexes(entity)[hex]
-        end
       end
     end
   end

--- a/lib/engine/step/g_1856/track.rb
+++ b/lib/engine/step/g_1856/track.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative 'tracker'
+
+module Engine
+  module Step
+    module G1856
+      class Track < Base
+        include Tracker
+        ACTIONS = %w[lay_tile pass].freeze
+
+        def actions(entity)
+          return [] unless entity == current_entity
+          return [] if entity.company? || !can_lay_tile?(entity)
+
+          ACTIONS
+        end
+
+        def description
+          'Lay Track'
+        end
+
+        def pass_description
+          @acted ? 'Done (Track)' : 'Skip (Track)'
+        end
+
+        def process_lay_tile(action)
+          lay_tile_action(action)
+          pass! unless can_lay_tile?(action.entity)
+        end
+
+        def available_hex(entity, hex)
+          @game.graph.connected_hexes(entity)[hex]
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1856/tracker.rb
+++ b/lib/engine/step/g_1856/tracker.rb
@@ -8,7 +8,7 @@ module Engine
       module Tracker
         include Step::Tracker
         def available_hex(entity, hex)
-          graph.connected_hexes(entity)[hex]
+          @game.graph.connected_hexes(entity)[hex]
         end
 
         def legal_tile_rotation?(entity, hex, tile)
@@ -48,7 +48,7 @@ module Engine
         end
 
         def path_has_town(path)
-          path.ends.any? { |en| en.class == Engine::Part::Town }
+          path.ends.any?(&:town?)
         end
       end
     end

--- a/lib/engine/step/g_1856/tracker.rb
+++ b/lib/engine/step/g_1856/tracker.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative '../tracker'
+
+module Engine
+  module Step
+    module G1856
+      module Tracker
+        include Step::Tracker
+        def available_hex(entity, hex)
+          graph.connected_hexes(entity)[hex]
+        end
+
+        def legal_tile_rotation?(entity, hex, tile)
+          old_paths = hex.tile.paths
+          old_ctedges = hex.tile.city_town_edges
+
+          new_paths = tile.paths
+          new_exits = tile.exits
+          new_ctedges = tile.city_town_edges
+          extra_cities = [0, new_ctedges.size - old_ctedges.size].max
+
+          new_exits.all? { |edge| hex.neighbors[edge] } &&
+          (new_exits & available_hex(entity, hex)).any? &&
+          old_paths_are_preserved(old_paths, new_paths) &&
+          # Count how many cities on the new tile that aren't included by any of the old tile.
+          # Make sure this isn't more than the number of new cities added.
+          # 1836jr30 D6 -> 54 adds more cities
+          extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } }
+        end
+
+        def old_paths_are_preserved(old_paths, new_paths)
+          # if gray phase, towns can be upgraded or downgraded
+          # and there are no tiles mixed with towns and other things
+          # so if it is gray phase, and the tile has towns, then we only need
+          # to test that exits are preserved
+
+          return old_paths.all? do |path|
+            path.exits.all? do |exit|
+              new_paths.any? do |new_path|
+                new_path.exits.any? do |new_exit|
+                  new_exit == exit
+                end
+              end
+            end
+          end if @game.gray_phase? && old_paths.any? { |old_path| path_has_town(old_path) }
+          old_paths.all? { |path| new_paths.any? { |p| path <= p } }
+        end
+
+        def path_has_town(path)
+          path.ends.any? { |en| en.class == Engine::Part::Town }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based off of [1856 tile upgrades](https://github.com/tobymao/18xx/pull/2439)

I saw some behavior when testing tile upgrades that corporations didn't close but I was able to get corporations to close in a new game by selling shares and by withholding. 

This implements the dynamic certificate limit, with stubs related to nationalization which still needs to be implemented
