### PR TITLE
Refactor BuySellShares view and add [18CO] DSNG Share Distribution

### DIFF
--- a/assets/app/view/game/button/buy_share.rb
+++ b/assets/app/view/game/button/buy_share.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+
+module View
+  module Game
+    module Button
+      class BuyShare < Snabberb::Component
+        include Actionable
+
+        needs :share
+        needs :entity
+        needs :swap_share, default: nil
+        needs :percentages_available, default: 1
+        needs :prefix, default: 'Buy'
+        needs :source, default: 'Market'
+        needs :action, default: Engine::Action::BuyShares
+
+        def render
+          show_percentage = @percentages_available > 1 || @share.percent != @share.corporation.share_percent
+          reduced_price = @game.format_currency(@share.price - @swap_share.price) if @swap_share
+
+          text = @prefix.to_s
+          text += " #{@share.percent}%" if show_percentage
+          text += " #{@source} Share"
+          text += " (#{reduced_price} + #{@swap_share.percent}% Share)" if @swap_share
+
+          h(:button, { on: { click: -> { buy_share(@entity, @share, swap: @swap_share) } } }, text)
+        end
+
+        def buy_share(entity, share, swap: nil)
+          process_action(@action.new(entity, shares: share, swap: swap))
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -82,11 +82,9 @@ module View
 
         return [] unless price_protection
 
-        protect = lambda do
-          process_action(Engine::Action::BuyShares.new(@current_entity, shares: price_protection.shares))
-        end
+        protect = -> { process_action(Engine::Action::BuyShares.new(@current_entity, shares: price_protection.shares)) }
 
-        [h(:button, { on: { click: -> { protect } } }, 'Protect Shares')]
+        [h(:button, { on: { click: protect } }, 'Protect Shares')]
       end
 
       def render_reduced_price_shares(shares, source: 'Market')
@@ -106,9 +104,7 @@ module View
         return [] unless @step.current_actions.include?('short')
         return [] unless @step.can_short?(@current_entity, @corporation)
 
-        short = lambda do
-          process_action(Engine::Action::Short.new(@current_entity, corporation: @corporation))
-        end
+        short = -> { process_action(Engine::Action::Short.new(@current_entity, corporation: @corporation)) }
 
         [h(:button, { on: { click: short } }, 'Short Share')]
       end

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -3,6 +3,7 @@
 require 'view/game/actionable'
 require 'view/game/corporation'
 require 'view/game/sell_shares'
+require 'view/game/button/buy_share'
 
 module View
   module Game
@@ -12,114 +13,138 @@ module View
       needs :corporation
 
       def render
-        step = @game.round.active_step
-        current_entity = step.current_entity
+        @step = @game.round.active_step
+        @current_entity = @step.current_entity
 
-        ipo_share = @corporation.shares[0]
-        pool_shares = @game.share_pool.shares_by_corporation[@corporation].group_by(&:percent).values.map(&:first)
+        @ipo_shares = @corporation.shares.group_by(&:percent).values
+          .map(&:first).sort { |a, b| b.percent <=> a.percent }
+
+        @pool_shares = @game.share_pool.shares_by_corporation[@corporation].group_by(&:percent).values
+          .map(&:first).sort { |a, b| b.percent <=> a.percent }
 
         children = []
 
-        if step.current_actions.include?('buy_shares')
-          price_protection = step.price_protection if step.respond_to?(:price_protection)
+        children.concat(render_buy_shares)
+        children.concat(render_short)
+        children.concat(render_exchanges)
 
-          if ipo_share && step.can_buy?(current_entity, ipo_share)
-            children << h(
-              :button,
-              { on: { click: -> { buy_share(current_entity, ipo_share) } } },
-              "Buy #{@game.class::IPO_NAME} Share",
-            )
-          end
+        children << h(SellShares, player: @current_entity, corporation: @corporation)
 
-          # Put up one buy button for each buyable percentage share type in market.
-          # In case there are more than one type of percentages in market or if shares are not the
-          # standard percent (e.g. 5% in 18MEX), show percentage type on button.
-          # Do skip president's share in case there are other shares available.
-          buyables = pool_shares
-            .select { |share| step.can_buy?(current_entity, share) }
-            .reject { |share| share.president && pool_shares.size > 1 }
-          buyables.each do |share|
-            text = buyables.size > 1 || share.percent != @corporation.share_percent ? "#{share.percent}% " : ''
-            children << h(:button,
-                          { on: { click: -> { buy_share(current_entity, share) } } },
-                          "Buy #{text}Market Share")
-          end
-
-          if price_protection
-            children << h(
-              :button,
-              { on: { click: -> { buy_share(current_entity, price_protection.shares) } } },
-              'Protect Shares',
-            )
-          end
-
-          if ipo_share && (swap_share = step.swap_buy(current_entity, @corporation, ipo_share))
-            puts("ipo_share = #{ipo_share.class} with price #{ipo_share.price}")
-            reduced_price = @game.format_currency(ipo_share.price - swap_share.price)
-            children << h(
-              :button,
-              { on: { click: -> { buy_share(current_entity, ipo_share, swap: swap_share) } } },
-              "Buy #{@game.class::IPO_NAME} Share (#{reduced_price} + #{swap_share.percent}% Share)",
-            )
-          end
-
-          pool_shares.each do |pool_share|
-            next unless (swap_share = step.swap_buy(current_entity, @corporation, pool_share))
-
-            puts("pool_share = #{pool_share.class} with price #{pool_share.price}")
-            reduced_price = @game.format_currency(pool_share.price - swap_share.price)
-            children << h(
-              :button,
-              { on: { click: -> { buy_share(current_entity, pool_share, swap: swap_share) } } },
-              "Buy #{pool_share.percent}% Market Share (#{reduced_price} + #{swap_share.percent}% Share)",
-            )
-          end
-        end
-
-        if step.current_actions.include?('short') && step.can_short?(current_entity, @corporation)
-          short = lambda do
-            process_action(Engine::Action::Short.new(current_entity, corporation: @corporation))
-          end
-
-          children << h(
-            :button,
-            { on: { click: short } },
-            'Short Share',
-          )
-        end
-
-        # Allow privates to be exchanged for shares
-        @game.companies.each do |company|
-          company.abilities(:exchange) do |ability|
-            next unless ability.corporation == @corporation.name
-            next unless company.owner == current_entity
-
-            prefix = "Exchange #{company.sym} for "
-
-            if ability.from.include?(:ipo) && step.can_gain?(company.owner, ipo_share, exchange: true)
-              children << h(:button, { on: { click: -> { buy_share(company, ipo_share) } } },
-                            "#{prefix} an #{@game.class::IPO_NAME} share")
-            end
-
-            next unless ability.from.include?(:market)
-
-            # Put up one exchange button for each exchangable percentage share type in market.
-            pool_shares
-              .select { |share| step.can_gain?(company.owner, share, exchange: true) }
-              .each do |share|
-              text = pool_shares.size > 1 ? "#{prefix} a #{share.percent}% Market Share" : "#{prefix} a Market Share"
-              children << h(:button, { on: { click: -> { buy_share(company, share) } } }, text)
-            end
-          end
-        end
-
-        children << h(SellShares, player: current_entity, corporation: @corporation)
-
-        h(:div, children)
+        h(:div, children.compact)
       end
 
-      def buy_share(entity, share, swap: nil)
-        process_action(Engine::Action::BuyShares.new(entity, shares: share, swap: swap))
+      def render_buy_shares
+        return [] unless @step.current_actions.include?('buy_shares')
+
+        children = []
+
+        children.concat(render_ipo_shares)
+        children.concat(render_market_shares)
+        children.concat(render_price_protection)
+        children.concat(render_reduced_price_shares(@ipo_shares, source: @game.class::IPO_NAME))
+        children.concat(render_reduced_price_shares(@pool_shares))
+
+        children.compact
+      end
+
+      # Put up one buy button for each buyable percentage share type in market.
+      # In case there are more than one type of percentages in market or if shares are not the
+      # standard percent (e.g. 5% in 18MEX), show percentage type on button.
+      # Do skip president's share in case there are other shares available.
+      def render_market_shares
+        @pool_shares.map do |share|
+          next unless @step.can_buy?(@current_entity, share)
+          next if share.president && @pool_shares.size > 1
+
+          h(Button::BuyShare,
+            share: share,
+            entity: @current_entity,
+            percentages_available: @pool_shares.size)
+        end.compact
+      end
+
+      def render_ipo_shares
+        @ipo_shares.map do |share|
+          next unless @step.can_buy?(@current_entity, share)
+
+          h(Button::BuyShare,
+            share: share,
+            entity: @current_entity,
+            percentages_available: @ipo_shares.size,
+            source: @game.class::IPO_NAME)
+        end.compact
+      end
+
+      def render_price_protection
+        return [] unless @step.respond_to?(:price_protection)
+
+        price_protection = @step.price_protection
+
+        return [] unless price_protection
+
+        protect = lambda do
+          process_action(Engine::Action::BuyShares.new(@current_entity, shares: price_protection.shares))
+        end
+
+        [h(:button, { on: { click: -> { protect } } }, 'Protect Shares')]
+      end
+
+      def render_reduced_price_shares(shares, source: 'Market')
+        shares.map do |share|
+          next unless (swap_share = @step.swap_buy(@current_entity, @corporation, share))
+
+          h(Button::BuyShare,
+            share: share,
+            swap_share: swap_share,
+            entity: @current_entity,
+            percentages_available: shares.size,
+            source: source)
+        end
+      end
+
+      def render_short
+        return [] unless @step.current_actions.include?('short')
+        return [] unless @step.can_short?(@current_entity, @corporation)
+
+        short = lambda do
+          process_action(Engine::Action::Short.new(@current_entity, corporation: @corporation))
+        end
+
+        [h(:button, { on: { click: short } }, 'Short Share')]
+      end
+
+      # Allow privates to be exchanged for shares
+      def render_exchanges
+        children = []
+
+        @game.companies.each do |company|
+          company.abilities(:exchange) do |ability|
+            next if ability.corporation != @corporation.name && ability.corporation != 'any'
+            next unless company.owner == @current_entity
+
+            if ability.from.include?(:ipo)
+              children.concat(render_share_exchange(@ipo_shares, company, source: @game.class::IPO_NAME))
+            end
+
+            children.concat(render_share_exchange(@pool_shares, company)) if ability.from.include?(:market)
+          end
+        end
+
+        children
+      end
+
+      # Put up one exchange button for each exchangable percentage share type in market.
+      def render_share_exchange(shares, company, source: 'Market')
+        shares.map do |share|
+          next unless @step.can_gain?(company.owner, share, exchange: true)
+
+          h(Button::BuyShare,
+            share: share,
+            entity: company,
+            percentages_available: shares.size,
+            prefix: "Exchange #{company.sym} for ",
+            source: source)
+        end.compact
       end
     end
   end

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -17,10 +17,10 @@ module View
         @current_entity = @step.current_entity
 
         @ipo_shares = @corporation.shares.group_by(&:percent).values
-          .map(&:first).sort { |a, b| b.percent <=> a.percent }
+          .map(&:first).sort.reverse
 
         @pool_shares = @game.share_pool.shares_by_corporation[@corporation].group_by(&:percent).values
-          .map(&:first).sort { |a, b| b.percent <=> a.percent }
+          .map(&:first).sort.reverse
 
         children = []
 
@@ -44,7 +44,7 @@ module View
         children.concat(render_reduced_price_shares(@ipo_shares, source: @game.class::IPO_NAME))
         children.concat(render_reduced_price_shares(@pool_shares))
 
-        children.compact
+        children
       end
 
       # Put up one buy button for each buyable percentage share type in market.
@@ -60,7 +60,7 @@ module View
             share: share,
             entity: @current_entity,
             percentages_available: @pool_shares.size)
-        end.compact
+        end
       end
 
       def render_ipo_shares
@@ -72,7 +72,7 @@ module View
             entity: @current_entity,
             percentages_available: @ipo_shares.size,
             source: @game.class::IPO_NAME)
-        end.compact
+        end
       end
 
       def render_price_protection
@@ -144,7 +144,7 @@ module View
             percentages_available: shares.size,
             prefix: "Exchange #{company.sym} for ",
             source: source)
-        end.compact
+        end
       end
     end
   end

--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -650,6 +650,7 @@ module Engine
 			"float_percent": 20,
 			"always_market_price": true,
 			"logo": "18_co/DSNG",
+			"shares":[20, 10, 20, 20, 10, 10, 10],
 			"tokens": [
 				0,
 				40


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/1836

### Background

This started as a simple task to add the unusual "shares" distribution for DSNG. That was a one liner, but in the process I discovered that the view file did not respect different sizes of shares in the treasury, only the market. I found doing so following the current pattern would create a lot of duplicated code for creating the buttons as well determining percentages and text. This also gave me the chance to write a lot of the code using fail first methodology as well as map functions.

The changes will also reduce the complexity needed for creating the buy buttons in https://github.com/tobymao/18xx/pull/2431 as the same Button view file can be reused, passing a different action.

### Implementation

A change I've made is to always show shares in descending percentage. Currently, they were always showing in the order defined in the JSON. This meant a 10% might be first, then a 20%. Once the 10% was purchased, the 20% would show first. Now, they are always in the same order.

Additionally, I've standardized the calculations of share percentage between buy and exchange. They no longer use similar but different code, which I believe was an oversight. All buttons will show the percentage if there are multiple types available or if the share has a different percentage than the "normal" percentage for the corporation, as defined by the second share (not new) in the configuration.

### Status

I have verified the normal use cases of Buy from IPO/Treasury and Market. I still need to verify things don't explode on:

- [x] Price Protection
- [x] Share Exchange
- [x] Reduce Price Shares
- [x] Shorts

<img width="280" alt="Screen Shot 2020-11-25 at 2 13 46 PM" src="https://user-images.githubusercontent.com/15675400/100282226-76026d80-2f28-11eb-8df8-71d4d6d9fa78.png">
