### PR TITLE
1828: Implement E&K private

### DIFF
--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -284,7 +284,8 @@ module Engine
           ],
           "when": "sold",
           "owner_type": "corporation",
-          "count": 1
+          "count": 1,
+          "blocks": false
         }
       ]
     },

--- a/lib/engine/step/g_1828/special_track.rb
+++ b/lib/engine/step/g_1828/special_track.rb
@@ -10,6 +10,16 @@ module Engine
       class SpecialTrack < SpecialTrack
         include AcquireVaTunnelCoalMarker
         include TrackLayWhenCompanySold
+
+        def process_lay_tile(action)
+          if action.entity.id == 'E&K' && !@company
+            track_step = @round.steps.find { |step| step.is_a?(Track) }
+            @game.game_error("Cannot use #{action.entity.name} after a tile upgrade") if track_step.upgraded
+            track_step.no_upgrades = true
+          end
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/step/g_1828/special_track.rb
+++ b/lib/engine/step/g_1828/special_track.rb
@@ -2,12 +2,14 @@
 
 require_relative '../special_track'
 require_relative 'acquire_va_tunnel_coal_marker'
+require_relative '../tile_lay_when_company_sold'
 
 module Engine
   module Step
     module G1828
       class SpecialTrack < SpecialTrack
         include AcquireVaTunnelCoalMarker
+        include TileLayWhenCompanySold
       end
     end
   end

--- a/lib/engine/step/g_1828/special_track.rb
+++ b/lib/engine/step/g_1828/special_track.rb
@@ -2,14 +2,14 @@
 
 require_relative '../special_track'
 require_relative 'acquire_va_tunnel_coal_marker'
-require_relative '../tile_lay_when_company_sold'
+require_relative '../track_lay_when_company_sold'
 
 module Engine
   module Step
     module G1828
       class SpecialTrack < SpecialTrack
         include AcquireVaTunnelCoalMarker
-        include TileLayWhenCompanySold
+        include TrackLayWhenCompanySold
       end
     end
   end

--- a/lib/engine/step/g_1828/track.rb
+++ b/lib/engine/step/g_1828/track.rb
@@ -8,6 +8,22 @@ module Engine
     module G1828
       class Track < Track
         include AcquireVaTunnelCoalMarker
+
+        attr_accessor :no_upgrades
+        attr_reader :upgraded
+
+        def setup
+          super
+          @no_upgrades = false
+        end
+
+        def get_tile_lay(entity)
+          action = super
+          return unless action
+
+          action[:upgrade] = false if @no_upgrades
+          action
+        end
       end
     end
   end

--- a/lib/engine/step/g_1889/special_track.rb
+++ b/lib/engine/step/g_1889/special_track.rb
@@ -1,55 +1,24 @@
 # frozen_string_literal: true
 
 require_relative '../special_track'
+require_relative '../tile_lay_when_company_sold'
 
 module Engine
   module Step
     module G1889
       class SpecialTrack < SpecialTrack
-        ACTIONS = %w[lay_tile pass].freeze
-
-        def actions(entity)
-          blocking_for_sold_company? ? ACTIONS : super
-        end
-
-        def description
-          "Lay Track for #{@company.name}"
-        end
-
-        def active_entities
-          @company ? [@company] : super
-        end
-
-        def blocking?
-          blocking_for_sold_company? || super
-        end
+        include TileLayWhenCompanySold
 
         def process_lay_tile(action)
           return super unless action.entity == @company
 
-          lay_tile(action, spender: @round.company_sellers.first)
-          tile_lay_abilities(action.entity).use!
-        end
-
-        def process_pass(action)
-          @game.game_error("Not #{action.entity.name}'s turn: #{action.to_h}") unless action.entity == @company
-
+          entity = action.entity
           ability = @company.abilities(:tile_lay, time: 'sold')
-          @company.remove_ability(ability)
-          @log << "#{action.entity.name} passes lay track"
-          pass!
-        end
+          @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
 
-        def blocking_for_sold_company?
-          @company = nil
-          just_sold_company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
-
-          if just_sold_company&.abilities(:tile_lay, time: 'sold')
-            @company = just_sold_company
-            return true
-          end
-
-          false
+          lay_tile(action, spender: @round.company_sellers.first)
+          check_connect(action, ability)
+          ability.use!
         end
       end
     end

--- a/lib/engine/step/g_1889/special_track.rb
+++ b/lib/engine/step/g_1889/special_track.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require_relative '../special_track'
-require_relative '../tile_lay_when_company_sold'
+require_relative '../track_lay_when_company_sold'
 
 module Engine
   module Step
     module G1889
       class SpecialTrack < SpecialTrack
-        include TileLayWhenCompanySold
+        include TrackLayWhenCompanySold
 
         def process_lay_tile(action)
           return super unless action.entity == @company

--- a/lib/engine/step/tile_lay_when_company_sold.rb
+++ b/lib/engine/step/tile_lay_when_company_sold.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative 'special_track'
+
+module Engine
+  module Step
+    module TileLayWhenCompanySold
+      ACTIONS = %w[lay_tile].freeze
+      ACTIONS_WITH_PASS = %w[lay_tile pass].freeze
+
+      def actions(entity)
+        return super unless blocking_for_sold_company?
+
+        @company.abilities(:tile_lay, time: 'sold').blocks ? ACTIONS : ACTIONS_WITH_PASS
+      end
+
+      def description
+        "Lay Track for #{@company.name}"
+      end
+
+      def active_entities
+        @company ? [@company] : super
+      end
+
+      def blocking?
+        blocking_for_sold_company? || super
+      end
+
+      def process_lay_tile(action)
+        return super unless action.entity == @company
+
+        entity = action.entity
+        ability = @company.abilities(:tile_lay, time: 'sold')
+        @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+
+        lay_tile(action, spender: entity.owner)
+        check_connect(action, ability)
+        ability.use!
+      end
+
+      def process_pass(action)
+        entity = action.entity
+        ability = @company.abilities(:tile_lay, time: 'sold')
+        @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+
+        @company.remove_ability(ability)
+        @log << "#{entity.name} passes lay track"
+        pass!
+      end
+
+      def blocking_for_sold_company?
+        @company = nil
+        just_sold_company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
+
+        if just_sold_company&.abilities(:tile_lay, time: 'sold')
+          @company = just_sold_company
+          return true
+        end
+
+        false
+      end
+    end
+  end
+end

--- a/lib/engine/step/track_lay_when_company_sold.rb
+++ b/lib/engine/step/track_lay_when_company_sold.rb
@@ -4,7 +4,7 @@ require_relative 'special_track'
 
 module Engine
   module Step
-    module TileLayWhenCompanySold
+    module TrackLayWhenCompanySold
       ACTIONS = %w[lay_tile].freeze
       ACTIONS_WITH_PASS = %w[lay_tile pass].freeze
 


### PR DESCRIPTION
- E&K has a mandatory track lay when sold
- E&K has another track lay ability that can be used to place an additional yellow tile (e.g. no upgrades)