### PR TITLE
1867: More changes for corporation types

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -105,11 +105,14 @@ module View
           extra = []
           extra << h(:td, phase[:corporation_sizes].join(', ')) if corporation_sizes
 
+          train_limit = phase[:train_limit]
+          train_limit = train_limit.map { |type, limit| "#{type} => #{limit}" }.join(',') if train_limit.is_a?(Hash)
+
           h(:tr, [
             h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
             h(:td, phase[:on]),
             h(:td, phase[:operating_rounds]),
-            h(:td, phase[:train_limit]),
+            h(:td, train_limit),
             h(:td, phase_props, phase_color.capitalize),
             *extra,
             h(:td, row_events.map(&:first).join(', ')),

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -98,11 +98,15 @@ module View
         end
 
         def render_pre_ipo
-          if @step.ipo_via_par?(@selected_corporation) && @current_actions.include?('par')
-            return h(Par, corporation: @selected_corporation)
+          type = @step.ipo_type(@selected_corporation)
+          case type
+          when :par
+            return h(Par, corporation: @selected_corporation) if @current_actions.include?('par')
+          when :bid
+            return h(Bid, entity: @current_entity, corporation: @selected_corporation)
+          when String
+            return h(:div, type)
           end
-          return h(Bid, entity: @current_entity, corporation: @selected_corporation) if @current_actions.include?('bid')
-
           nil
         end
 

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -241,6 +241,7 @@ module Engine
         0,
         0
       ],
+      "type": "major",
       "color": "green"
     },
     {
@@ -252,6 +253,7 @@ module Engine
         0,
         0
       ],
+      "type": "major",
       "color": "red"
     },
     {
@@ -263,6 +265,7 @@ module Engine
         0,
         0
       ],
+      "type": "major",
       "color": "cyan"
     },
     {
@@ -274,6 +277,7 @@ module Engine
         0,
         0
       ],
+      "type": "major",
       "color": "orange"
     },
     {
@@ -285,6 +289,7 @@ module Engine
         0,
         0
       ],
+      "type": "major",
       "color": "brown"
     },
     {
@@ -296,6 +301,7 @@ module Engine
         0,
         0
       ],
+      "type": "major",
       "color": "yellow"
     },
     {
@@ -318,6 +324,7 @@ module Engine
         0,
         0
       ],
+      "type": "major",
       "color": "black"
     },
     {
@@ -327,6 +334,7 @@ module Engine
       "tokens": [
         0
       ],
+      "type": "minor",
       "shares": [100],
       "max_ownership_percent": 100,
       "color": "yellow"
@@ -340,6 +348,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -351,6 +360,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -362,6 +372,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -373,6 +384,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -384,6 +396,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -395,6 +408,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -406,6 +420,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -417,6 +432,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -428,6 +444,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "yellow"
     },
     {
@@ -439,6 +456,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "green"
     },
     {
@@ -450,6 +468,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "green"
     },
     {
@@ -461,6 +480,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "green"
     },
     {
@@ -472,6 +492,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "green"
     },
     {
@@ -483,6 +504,7 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "green"
     },
     {
@@ -494,23 +516,8 @@ module Engine
       ],
       "shares": [100],
       "max_ownership_percent": 100,
+      "type": "minor",
       "color": "green"
-    },
-    {
-      "sym": "CN",
-      "name": "Canadian National",
-      "logo": "1867/CN",
-      "tokens": [
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0
-      ],
-      "color": "white"
     }
   ],
   "trains": [
@@ -526,20 +533,30 @@ module Engine
       "distance": 3,
       "price": 225,
       "rusts_on": "6",
-      "num": 7
+      "num": 7,
+      "events":[
+        {"type": "green_minors_available"}
+      ]
     },
     {
       "name": "4",
       "distance": 4,
       "price": 350,
       "rusts_on": "8",
-      "num": 4
+      "num": 4,
+      "events":[
+        {"type": "majors_can_ipo"}
+      ]
     },
     {
       "name": "5",
       "distance": 5,
       "price": 550,
-      "num": 4
+      "num": 4,
+      "events":[
+        {"type": "minors_cannot_start"}
+      ]
+
     },
     {
       "name": "6",
@@ -562,7 +579,9 @@ module Engine
       "price": 1000,
       "num": 6,
       "events": [
-        {"type": "signal_end_game"}
+        {"type": "signal_end_game"},
+        {"type": "minors_nationalized"}
+
       ]
     },
     {
@@ -733,36 +752,52 @@ module Engine
   "phases": [
     {
       "name": "2",
-      "train_limit": 2,
+      "train_limit": {
+        "minor": 2
+      },
       "tiles": [
         "yellow"
-      ]
+      ],
+      "operating_rounds": 2
     },
     {
       "name": "3",
-      "train_limit": 4,
+      "train_limit": {
+        "minor": 2,
+        "major": 4
+      },
       "tiles": [
         "yellow",
         "green"
       ],
       "status":[
         "can_buy_companies"
-      ]
+      ],
+      "on": "3",
+      "operating_rounds": 2
     },
     {
       "name": "4",
-      "train_limit": 3,
+      "train_limit": {
+        "minor": 1,
+        "major": 3
+      },
       "tiles": [
         "yellow",
         "green"
       ],
       "status":[
         "can_buy_companies"
-      ]
+      ],
+      "on": "4",
+      "operating_rounds": 2
     },
     {
       "name": "5",
-      "train_limit": 3,
+      "train_limit": {
+        "minor": 1,
+        "major": 3
+      },
       "tiles": [
         "yellow",
         "green",
@@ -770,36 +805,52 @@ module Engine
       ],
       "status":[
         "can_buy_companies"
-      ]
+      ],
+      "on": "5",
+      "operating_rounds": 2
     },
     {
       "name": "6",
-      "train_limit": 2,
+      "train_limit": {
+        "minor": 1,
+        "major": 2
+      },
       "tiles": [
         "yellow",
         "green",
         "brown"
-      ]
+      ],
+      "on": "6",
+      "operating_rounds": 2
     },
     {
       "name": "7",
-      "train_limit": 2,
+      "train_limit": {
+        "minor": 1,
+        "major": 2
+      },
       "tiles": [
         "yellow",
         "green",
         "brown",
         "gray"
-      ]
+      ],
+      "on": "7",
+      "operating_rounds": 2
     },
     {
       "name": "8",
-      "train_limit": 2,
+      "train_limit":  {
+        "major": 2
+      },
       "tiles": [
         "yellow",
         "green",
         "brown",
         "gray"
-      ]
+      ],
+      "on": "8",
+      "operating_rounds": 2
     }
   ]
 }

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -23,7 +23,7 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent
-    attr_reader :capitalization, :companies, :min_price, :name, :full_name, :fraction_shares
+    attr_reader :capitalization, :companies, :min_price, :name, :full_name, :fraction_shares, :type
     attr_writer :par_price, :share_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze
@@ -57,6 +57,7 @@ module Engine
       @always_market_price = opts[:always_market_price] || false
       @needs_token_to_par = opts[:needs_token_to_par] || false
       @par_via_exchange = nil
+      @type = opts[:type]
 
       init_abilities(opts[:abilities])
       init_operator(opts)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -275,6 +275,7 @@ module Engine
           phase.transform_keys!(&:to_sym)
           phase[:tiles]&.map!(&:to_sym)
           phase[:events]&.transform_keys!(&:to_sym)
+          phase[:train_limit].transform_keys!(&:to_sym) if phase[:train_limit].is_a?(Hash)
           phase
         end
 

--- a/lib/engine/game/interest_on_loans.rb
+++ b/lib/engine/game/interest_on_loans.rb
@@ -18,8 +18,10 @@ module InterestOnLoans
     owed_fmt = format_currency(owed)
 
     if owed <= entity.cash
-      @log << "#{entity.name} pays #{owed_fmt} interest for #{entity.loans.size} loans"
-      entity.spend(owed, bank)
+      if owed.positive?
+        @log << "#{entity.name} pays #{owed_fmt} interest for #{entity.loans.size} loans"
+        entity.spend(owed, bank)
+      end
       return
     end
     owed

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -32,7 +32,13 @@ module Engine
     end
 
     def train_limit(entity)
-      @train_limit + train_limit_increase(entity)
+      limit =
+        if @train_limit.is_a?(Hash)
+          @train_limit[entity.type] || 0
+        else
+          @train_limit
+        end
+      limit + train_limit_increase(entity)
     end
 
     def available?(phase_name)

--- a/lib/engine/round/g_1867/stock.rb
+++ b/lib/engine/round/g_1867/stock.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../stock'
+
+module Engine
+  module Round
+    module G1867
+      class Stock < Stock
+        def sold_out?(corporation)
+          corporation.type == :major && super
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -202,8 +202,8 @@ module Engine
         !bought? && @game.corporations.any? { |c| c.can_par?(entity) && can_buy?(entity, c.shares.first&.to_bundle) }
       end
 
-      def ipo_via_par?(_entity)
-        true
+      def ipo_type(_entity)
+        :par
       end
 
       def purchasable_companies(entity)

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -397,6 +397,10 @@ module Engine
           false
         end
 
+        def ipo_type(_entity)
+          :bid
+        end
+
         def setup
           setup_auction
           super

--- a/lib/engine/step/g_1867/dividend.rb
+++ b/lib/engine/step/g_1867/dividend.rb
@@ -12,13 +12,13 @@ module Engine
         include HalfPay
 
         def actions(entity)
-          return [] if entity.total_shares == 2
+          return [] unless entity.type == :major
 
           super
         end
 
         def skip!
-          return super unless current_entity.total_shares == 2
+          return super if current_entity.type == :major
 
           revenue = @game.routes_revenue(routes)
           process_dividend(Action::Dividend.new(
@@ -28,21 +28,21 @@ module Engine
         end
 
         def payout(entity, revenue)
-          return super unless entity.total_shares == 2
+          return super if entity.type == :major
 
           amount = revenue / 2
           { corporation: amount, per_share: amount }
         end
 
         def payout_shares(entity, revenue)
-          return super unless entity.total_shares == 2
+          return super if entity.type == :major
 
           @log << "#{entity.owner.name} receives #{@game.format_currency(revenue)}"
-          @game.bank.spend(revenue, entity.owner)
+          @game.bank.spend(revenue, entity.owner) if revenue.positive?
         end
 
         def share_price_change(entity, revenue = 0)
-          if entity.total_shares == 2
+          if entity.type == :minor
             super
           else
 


### PR DESCRIPTION
Allow 1867 corps to have different limits
Add events relating to corporations
Allow majors to be floated in the major only region
Limit when majors can be started
Implement 1867 stock price movement and OR order
Skip merger rounds before phase 3