### PR TITLE
1828: Allow the game class's cache to be cleared

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1641,6 +1641,8 @@ module Engine
       end
 
       def clear_cache(type)
+        return unless CACHABLE.any? {|t,_n| t == type }
+
         ivar = "@_#{type}"
         instance_variable_set(ivar, send(type).map { |x| [x.id, x] }.to_h)
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1631,6 +1631,8 @@ module Engine
 
       def cache_objects
         CACHABLE.each do |type, name|
+          next if methods.include?("#{name}_by_id")
+
           ivar = "@_#{type}"
           instance_variable_set(ivar, send(type).map { |x| [x.id, x] }.to_h)
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1640,7 +1640,7 @@ module Engine
         end
       end
 
-      def clear_cache(type)
+      def update_cache(type)
         return unless CACHABLE.any? { |t, _n| t == type }
 
         ivar = "@_#{type}"

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1641,7 +1641,7 @@ module Engine
       end
 
       def clear_cache(type)
-        return unless CACHABLE.any? {|t,_n| t == type }
+        return unless CACHABLE.any? { |t, _n| t == type }
 
         ivar = "@_#{type}"
         instance_variable_set(ivar, send(type).map { |x| [x.id, x] }.to_h)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1631,8 +1631,6 @@ module Engine
 
       def cache_objects
         CACHABLE.each do |type, name|
-          next if methods.include?("#{name}_by_id")
-
           ivar = "@_#{type}"
           instance_variable_set(ivar, send(type).map { |x| [x.id, x] }.to_h)
 
@@ -1640,6 +1638,11 @@ module Engine
             instance_variable_get(ivar)[id]
           end
         end
+      end
+
+      def clear_cache(type)
+        ivar = "@_#{type}"
+        instance_variable_set(ivar, send(type).map { |x| [x.id, x] }.to_h)
       end
 
       def bank_cash

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -131,10 +131,6 @@ module Engine
         super
       end
 
-      def share_price_by_id(id)
-        share_prices.find {|sp| sp.id == id}
-      end
-
       def corporation_opts
         { can_hold_above_max: true }
       end
@@ -147,16 +143,19 @@ module Engine
         @log << "-- Event: #{EVENTS_TEXT['green_par'][1]} --"
         stock_market.enable_par_price(86)
         stock_market.enable_par_price(94)
+        clear_cache('share_prices')
       end
 
       def event_blue_par!
         @log << "-- Event: #{EVENTS_TEXT['blue_par'][1]} --"
         stock_market.enable_par_price(105)
+        clear_cache('share_prices')
       end
 
       def event_brown_par!
         @log << "-- Event: #{EVENTS_TEXT['brown_par'][1]} --"
         stock_market.enable_par_price(120)
+        clear_cache('share_prices')
       end
 
       def event_close_companies!

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -143,19 +143,19 @@ module Engine
         @log << "-- Event: #{EVENTS_TEXT['green_par'][1]} --"
         stock_market.enable_par_price(86)
         stock_market.enable_par_price(94)
-        clear_cache('share_prices')
+        clear_cache(:share_prices)
       end
 
       def event_blue_par!
         @log << "-- Event: #{EVENTS_TEXT['blue_par'][1]} --"
         stock_market.enable_par_price(105)
-        clear_cache('share_prices')
+        clear_cache(:share_prices)
       end
 
       def event_brown_par!
         @log << "-- Event: #{EVENTS_TEXT['brown_par'][1]} --"
         stock_market.enable_par_price(120)
-        clear_cache('share_prices')
+        clear_cache(:share_prices)
       end
 
       def event_close_companies!

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -131,6 +131,10 @@ module Engine
         super
       end
 
+      def share_price_by_id(id)
+        share_prices.find {|sp| sp.id == id}
+      end
+
       def corporation_opts
         { can_hold_above_max: true }
       end

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -143,19 +143,19 @@ module Engine
         @log << "-- Event: #{EVENTS_TEXT['green_par'][1]} --"
         stock_market.enable_par_price(86)
         stock_market.enable_par_price(94)
-        clear_cache(:share_prices)
+        update_cache(:share_prices)
       end
 
       def event_blue_par!
         @log << "-- Event: #{EVENTS_TEXT['blue_par'][1]} --"
         stock_market.enable_par_price(105)
-        clear_cache(:share_prices)
+        update_cache(:share_prices)
       end
 
       def event_brown_par!
         @log << "-- Event: #{EVENTS_TEXT['brown_par'][1]} --"
         stock_market.enable_par_price(120)
-        clear_cache(:share_prices)
+        update_cache(:share_prices)
       end
 
       def event_close_companies!


### PR DESCRIPTION
- Add function to clear cache of the specified type
- Use to clear share_prices cache when new par prices become unlocked.