### PR TITLE
18MEX: Fix bug with delayed minor close (fixes #2457)

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -325,6 +325,7 @@ module Engine
           @minor_close = true
           return
         end
+        @minor_close = false
         merge_and_close_minor(a_company, minor_a, ndm, minor_a_reserved_share)
         merge_and_close_minor(b_company, minor_b, ndm, minor_b_reserved_share)
         merge_and_close_minor(c_company, minor_c, udy, minor_c_reserved_share)


### PR DESCRIPTION
If the game uses the optional rule of delayed close of minors
the minor close in the Stock Round following the OR set where
the 5th 3 train was bought.

But the bug was that it was attempted to do the delayed minor
close in the Stock Round after that. So the delayed minor close
just had to be reset.