### PR TITLE
Fix abilities with multiple track lays that need to be laid at the same time

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -166,6 +166,8 @@ normal tile lay actions.
 - `reachable`: If true, when tile layed, a check is done if one of the
   controlling corporation's station tokens are reachable; if not a game
   error is triggered. Default false.
+- `must_lay_together`: If true, all the tile lays must happen at the same
+  time. Default false.
 
 ## train_buy
 

--- a/lib/engine/ability/tile_lay.rb
+++ b/lib/engine/ability/tile_lay.rb
@@ -5,10 +5,10 @@ require_relative 'base'
 module Engine
   module Ability
     class TileLay < Base
-      attr_reader :hexes, :tiles, :free, :discount, :special, :connect, :blocks, :reachable, :cost
+      attr_reader :hexes, :tiles, :free, :discount, :special, :connect, :blocks, :reachable, :must_lay_together, :cost
 
       def setup(tiles:, hexes: nil, free: false, discount: nil, special: nil,
-                connect: nil, blocks: nil, reachable: nil, cost: 0)
+                connect: nil, blocks: nil, reachable: nil, must_lay_together: false, cost: 0)
         @hexes = hexes
         @tiles = tiles
         @free = free
@@ -17,6 +17,7 @@ module Engine
         @connect = connect.nil? ? true : connect
         @blocks = blocks.nil? ? true : blocks
         @reachable = !!reachable
+        @must_lay_together = must_lay_together
         @cost = cost
       end
     end

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -356,6 +356,7 @@ module Engine
            "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
+           "must_lay_together": true,
            "hexes":[
               "B10",
               "B12"
@@ -390,6 +391,7 @@ module Engine
            "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
+           "must_lay_together": true,
            "hexes":[
               "F14",
               "F16"

--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -273,6 +273,7 @@ module Engine
         {
           "type": "tile_lay",
           "owner_type": "corporation",
+          "must_lay_together": true,
           "hexes": [
             "H2",
             "I3"
@@ -304,6 +305,7 @@ module Engine
         {
           "type": "tile_lay",
           "owner_type": "corporation",
+          "must_lay_together": true,
           "hexes": [
             "F4",
             "G5"

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -195,6 +195,7 @@ module Engine
              "free": true,
              "special": false,
              "reachable": true,
+             "must_lay_together": true,
              "hexes": [
              ],
              "tiles": [

--- a/lib/engine/spender.rb
+++ b/lib/engine/spender.rb
@@ -7,7 +7,6 @@ module Engine
     attr_accessor :cash
 
     def check_cash(amount)
-      amount.bad_func if (@cash - amount).negative?
       raise GameError, "#{name} has #{@cash} and cannot spend #{amount}" if (@cash - amount).negative?
     end
 

--- a/lib/engine/spender.rb
+++ b/lib/engine/spender.rb
@@ -7,6 +7,7 @@ module Engine
     attr_accessor :cash
 
     def check_cash(amount)
+      amount.bad_func if (@cash - amount).negative?
       raise GameError, "#{name} has #{@cash} and cannot spend #{amount}" if (@cash - amount).negative?
     end
 

--- a/lib/engine/step/track_lay_when_company_sold.rb
+++ b/lib/engine/step/track_lay_when_company_sold.rb
@@ -14,14 +14,6 @@ module Engine
         @company.abilities(:tile_lay, time: 'sold').blocks ? ACTIONS : ACTIONS_WITH_PASS
       end
 
-      def description
-        "Lay Track for #{@company.name}"
-      end
-
-      def active_entities
-        @company ? [@company] : super
-      end
-
       def blocking?
         blocking_for_sold_company? || super
       end

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -232,6 +232,8 @@ describe 'Assets' do
       ['1817', 16_281, 1183, 'buy_sell_post_conversion',
        ['Merger Round 4.2 (of 2) - Buy/Sell Shares Post Conversion',
         'New York, Susquehanna and Western Railway']],
+      ['18_chesapeake', 1905, 166, 'blocking_special_track',
+       ['Lay Track for Columbia - Philadelphia Railroad']],
     ].freeze
 
     def render_game(jsonfile, no_actions, string)

--- a/spec/fixtures/1846/12666.json
+++ b/spec/fixtures/1846/12666.json
@@ -1201,8 +1201,8 @@
     },
     {
       "type": "lay_tile",
-      "entity": "GT",
-      "entity_type": "corporation",
+      "entity": "MC",
+      "entity_type": "company",
       "id": 115,
       "hex": "B10",
       "tile": "9-8",


### PR DESCRIPTION
New lay_tile param called "must_lay_together". The special_track step will block, after the first tile lay, if must_lay_together is true.

*** May need current games to be pinned. Recommend testing against the production db to verify ***