### PR TITLE
Minor fixes/refactoring

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -41,7 +41,7 @@ module View
         children.concat(render_ipo_shares)
         children.concat(render_market_shares)
         children.concat(render_price_protection)
-        children.concat(render_reduced_price_shares(@ipo_shares, source: @game.class::IPO_NAME))
+        children.concat(render_reduced_price_shares(@ipo_shares, source: @game.ipo_name(@corporation)))
         children.concat(render_reduced_price_shares(@pool_shares))
 
         children
@@ -71,7 +71,7 @@ module View
             share: share,
             entity: @current_entity,
             percentages_available: @ipo_shares.size,
-            source: @game.class::IPO_NAME)
+            source: @game.ipo_name(@current_entity))
         end
       end
 
@@ -119,7 +119,7 @@ module View
             next unless company.owner == @current_entity
 
             if ability.from.include?(:ipo)
-              children.concat(render_share_exchange(@ipo_shares, company, source: @game.class::IPO_NAME))
+              children.concat(render_share_exchange(@ipo_shares, company, source: @game.ipo_name(@corporation)))
             end
 
             children.concat(render_share_exchange(@pool_shares, company)) if ability.from.include?(:market)

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -304,7 +304,7 @@ module View
         num_ipo_shares = share_number_str(@corporation.num_ipo_shares - @corporation.num_ipo_reserved_shares)
         pool_rows = [
           h('tr.ipo', [
-            h('td.left', @game.class::IPO_NAME),
+            h('td.left', @game.ipo_name(@corporation)),
             h('td.right', shares_props, num_ipo_shares),
             h('td.padded_number', share_price_str(@corporation.par_price)),
           ]),
@@ -364,7 +364,7 @@ module View
         h('table.center', [
           h(:tbody, [
             h('tr.reserved', [
-              h('td.left', bold, "#{@game.class::IPO_RESERVED_NAME} shares:"),
+              h('td.left', bold, "#{@game.ipo_reserved_name} shares:"),
               h('td.right', @corporation.reserved_shares.map { |s| "#{s.percent}%" }.join(', ')),
             ]),
           ]),

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -30,7 +30,7 @@ module View
           ability.corporation == 'any' ? @game.corporations : [@game.corporation_by_id(ability.corporation)]
         corporations.each do |corporation|
           ipo_share = corporation.shares.find { |s| !s.president }
-          children << render_exchange(ipo_share, @game.class::IPO_NAME) if ability.from.include?(:ipo)
+          children << render_exchange(ipo_share, @game.ipo_name(corporation)) if ability.from.include?(:ipo)
 
           pool_share = @game.share_pool.shares_by_corporation[corporation]&.first
           children << render_exchange(pool_share, 'Market') if ability.from.include?(:market)

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -141,9 +141,9 @@ module View
             *@players.map do |p|
               h('th.name.nowrap.right', p == @game.priority_deal_player ? pd_props : '', render_sort_link(p.name, p.id))
             end,
-            h(:th, @game.class::IPO_NAME),
+            h(:th, @game.ipo_name),
             h(:th, 'Market'),
-            h(:th, render_sort_link(@game.class::IPO_NAME, :par_price)),
+            h(:th, render_sort_link(@game.ipo_name, :par_price)),
             h(:th, render_sort_link('Market', :share_price)),
             h(:th, render_sort_link('Cash', :cash)),
             h(:th, render_sort_link('Order', :order)),

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -10,6 +10,7 @@ require_relative 'share'
 require_relative 'share_holder'
 require_relative 'spender'
 require_relative 'token'
+require_relative 'transfer'
 
 module Engine
   class Corporation
@@ -21,9 +22,10 @@ module Engine
     include Passer
     include ShareHolder
     include Spender
+    include Transfer
 
-    attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent
-    attr_reader :capitalization, :companies, :min_price, :name, :full_name, :fraction_shares, :type
+    attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent, :capitalization
+    attr_reader :companies, :min_price, :name, :full_name, :fraction_shares, :type
     attr_writer :par_price, :share_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze
@@ -209,20 +211,6 @@ module Engine
 
     def share_percent
       @second_share&.percent || presidents_percent / 2
-    end
-
-    def transfer(ownable_type, to)
-      ownables = send(ownable_type)
-      to_ownables = to.send(ownable_type)
-
-      ownables.each do |ownable|
-        ownable.owner = to
-        to_ownables << ownable
-      end
-
-      transferred = ownables.dup
-      ownables.clear
-      transferred
     end
 
     def closed?

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -197,8 +197,6 @@ module Engine
                       repar: 'Par value after bankruptcy',
                       ignore_one_sale: 'Ignore first share sold when moving price' }.freeze
 
-      IPO_NAME = 'IPO'
-      IPO_RESERVED_NAME = 'IPO Reserved'
       MARKET_SHARE_LIMIT = 50 # percent
       ALL_COMPANIES_ASSIGNABLE = false
       OBSOLETE_TRAINS_COUNT_FOR_LIMIT = false
@@ -1195,6 +1193,14 @@ module Engine
       def flush_log!
         @queued_log.each { |l| @log << l }
         @queued_log = []
+      end
+
+      def ipo_name(_entity = nil)
+        'IPO'
+      end
+
+      def ipo_reserved_name(_entity = nil)
+        'IPO Reserved'
       end
 
       private

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -62,8 +62,6 @@ module Engine
       # Two lays with one being an upgrade, second tile costs 20
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded, cost: 20 }].freeze
 
-      IPO_NAME = 'Treasury'
-
       LIMIT_TOKENS = 8
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge('signal_end_game' => ['Signal End Game',
@@ -87,6 +85,10 @@ module Engine
         @log << '1817 has not been tested thoroughly with more than seven players.' if @players.size > 7
 
         super
+      end
+
+      def ipo_name(_entity = nil)
+        'Treasury'
       end
 
       def init_stock_market

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -81,7 +81,9 @@ module Engine
       # Two tiles can be laid, only one upgrade
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded }].freeze
 
-      IPO_NAME = 'Treasury'
+      def ipo_name(_entity = nil)
+        'Treasury'
+      end
 
       def corporation_opts
         two_player? ? { max_ownership_percent: 70 } : {}

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -59,8 +59,6 @@ module Engine
       # Two lays with one being an upgrade, second tile costs 20
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded, cost: 20 }].freeze
 
-      IPO_NAME = 'Treasury'
-
       LIMIT_TOKENS = 8
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge('signal_end_game' => ['Signal End Game',
@@ -80,6 +78,10 @@ module Engine
       # Minors are done as corporations with a size of 2
 
       attr_reader :loan_value, :owner_when_liquidated, :stock_prices_start_merger
+
+      def ipo_name(_entity = nil)
+        'Treasury'
+      end
 
       # @todo: unchanged to here
       def interest_rate

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -36,8 +36,6 @@ module Engine
       # TODO: This changes in phase E to a single tile lay
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: false }].freeze
 
-      IPO_NAME = 'Treasury'
-
       # First 3 are Denver, Second 3 are CO Springs
       TILES_FIXED_ROTATION = %w[co1 co2 co3 co5 co6 co7].freeze
       GREEN_TOWN_TILES = %w[co8 co9 co10].freeze
@@ -83,6 +81,10 @@ module Engine
         ).freeze
 
       include CompanyPrice50To150Percent
+
+      def ipo_name(_entity = nil)
+        'Treasury'
+      end
 
       def dsng
         @dsng ||= corporation_by_id('DSNG')

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -19,8 +19,6 @@ module Engine
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18MEX'
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
-      IPO_RESERVED_NAME = 'Trade-in'
-
       # Sell of one 5% NdM share wont affect stock price.
       # Actually neither should sell of 2 5% but they will
       # always be sold just one at a time.
@@ -232,6 +230,10 @@ module Engine
         super
       end
 
+      def ipo_reserved_name(_entity = nil)
+        'Trade-in'
+      end
+
       def float_corporation(corporation)
         @recently_floated << corporation
 
@@ -291,8 +293,8 @@ module Engine
         default_revenue_minor = 15
         revenue = format_currency(default_revenue_minor)
         @minors.select(&:floated?).each do |minor|
-          bank.spend(default_revenue_minor, minor.owner)
-          bank.spend(default_revenue_minor, minor)
+          @bank.spend(default_revenue_minor, minor.owner)
+          @bank.spend(default_revenue_minor, minor)
           @log << "Minor #{minor.name} receives #{revenue}, as does its owner #{minor.owner.name}"
         end
       end
@@ -382,6 +384,7 @@ module Engine
               # Might trigger presidency change in NdM
               @share_pool.buy_shares(major.owner, ndm_merge_share, exchange: :free, exchange_price: 0)
             else
+              # Refund 10% share (as it is never NdM)
               refund_amount += refund
             end
             s.transfer(major)

--- a/lib/engine/minor.rb
+++ b/lib/engine/minor.rb
@@ -7,6 +7,7 @@ require_relative 'operator'
 require_relative 'ownable'
 require_relative 'passer'
 require_relative 'spender'
+require_relative 'transfer'
 
 module Engine
   class Minor
@@ -17,6 +18,7 @@ module Engine
     include Ownable
     include Passer
     include Spender
+    include Transfer
 
     attr_reader :name, :full_name
 

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -48,7 +48,7 @@ module Engine
       share_str = "a #{bundle.percent}% share of #{corporation.name}"
       incremental = corporation.capitalization == :incremental
 
-      from = bundle.owner.corporation? ? "the #{@game.class::IPO_NAME}" : 'the market'
+      from = bundle.owner.corporation? ? "the #{@game.ipo_name(corporation)}" : 'the market'
       if exchange
         price = exchange_price || 0
         case exchange

--- a/lib/engine/step/g_1860/buy_cert.rb
+++ b/lib/engine/step/g_1860/buy_cert.rb
@@ -243,7 +243,7 @@ module Engine
           share_str = "a #{bundle.percent}% share of #{corporation.name}"
 
           @log << "#{entity.name} buys #{share_str} "\
-            "from the #{@game.class::IPO_NAME} "\
+            "from the #{@game.ipo_name(corporation)} "\
             "for #{@game.format_currency(discounted_price)}"
 
           @game.share_pool.transfer_shares(

--- a/lib/engine/transfer.rb
+++ b/lib/engine/transfer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Engine
+  module Transfer
+    def transfer(ownable_type, to)
+      ownables = send(ownable_type)
+      to_ownables = to.send(ownable_type)
+
+      ownables.each do |ownable|
+        ownable.owner = to
+        to_ownables << ownable
+      end
+
+      transferred = ownables.dup
+      ownables.clear
+      transferred
+    end
+  end
+end


### PR DESCRIPTION
18MEX: Correct bank -> @bank in game class

corporation.rb: Make capitilization modifiable. This is for 1856
(and 18SJ) so that they can change capitilization for corporation
due to phase change.

corporation.rb, minor.rb: Extract the transfer part to a module
that can be shared. Today only corporations can transfer things
(because of merge) but there are titles that have minors that
can own things  which can be merged, so this is a preparation for that.