### PR TITLE
Make it possible to trigger event last during train buy

### DIFF
--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -18,13 +18,18 @@ module Engine
     def buying_train!(entity, train)
       next! if train.sym == @next_on
 
-      train.events.each do |event|
+      train.events.reject { |e| e['at'] == 'post' }.each do |event|
         @game.send("event_#{event['type']}!")
       end
-      train.events.clear
 
       rust_trains!(train, entity)
       close_companies_on_train!(entity)
+
+      train.events.select { |e| e['at'] == 'post' }.each do |event|
+        @game.send("event_#{event['type']}!")
+      end
+
+      train.events.clear
     end
 
     def current


### PR DESCRIPTION
Some events require the trains to be rusted before they can trigger,
so by setting 'when' to 'post' for the event, the will be done last,
post. If not set, or set to another value, it will be done first,
before the rusting (which is the current behavior).