### PR TITLE
Add possibility to restrict tile discount to specific hexes

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -139,6 +139,8 @@ Discount the cost for laying tiles in the specified terrain type
 
 - `discount`: Discount amount
 - `terrain`: Type of terrain for which discount is provided
+- `hexes`: If not specified, all applicable hexes qualifies for
+  the discount. If specified, only specified hexes qualify
 
 ## tile_income
 

--- a/lib/engine/ability/tile_discount.rb
+++ b/lib/engine/ability/tile_discount.rb
@@ -5,10 +5,11 @@ require_relative 'base'
 module Engine
   module Ability
     class TileDiscount < Base
-      attr_reader :terrain, :discount
-      def setup(terrain:, discount:)
+      attr_reader :terrain, :discount, :hexes
+      def setup(terrain:, discount:, hexes: nil)
         @terrain = terrain.to_sym
         @discount = discount
+        @hexes = hexes
       end
     end
   end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -981,8 +981,11 @@ module Engine
         city.place_token(corporation, token)
       end
 
-      def tile_cost(tile, entity)
-        ability = entity.all_abilities.find { |a| a.type == :tile_discount }
+      def tile_cost(tile, hex, entity)
+        ability = entity.all_abilities.find do |a|
+          a.type == :tile_discount &&
+          (!a.hexes || a.hexes.include?(hex.name))
+        end
 
         tile.upgrades.sum do |upgrade|
           discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -381,7 +381,7 @@ module Engine
         ], round_num: round_num)
       end
 
-      def tile_cost(tile, entity)
+      def tile_cost(tile, hex, entity)
         [TILE_COST, super].max
       end
 

--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -110,7 +110,7 @@ module Engine
             else
               border, border_types = border_cost(tile, entity)
               terrain += border_types if border.positive?
-              @game.tile_cost(old_tile, entity) + border + extra_cost - discount
+              @game.tile_cost(old_tile, hex, entity) + border + extra_cost - discount
             end
 
           spender.spend(cost, @game.bank) if cost.positive?

--- a/lib/engine/step/g_18_mex/track.rb
+++ b/lib/engine/step/g_18_mex/track.rb
@@ -35,7 +35,7 @@ module Engine
           return super unless entity.minor?
 
           home_hex = @game.hex_by_id(entity.coordinates)
-          return @game.tile_cost(home_hex.tile, entity) <= entity.cash if home_hex.tile.color == :white
+          return @game.tile_cost(home_hex.tile, home_hex, entity) <= entity.cash if home_hex.tile.color == :white
 
           super
         end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -115,7 +115,7 @@ module Engine
           else
             border, border_types = border_cost(tile, entity)
             terrain += border_types if border.positive?
-            @game.tile_cost(old_tile, entity) + border + extra_cost - discount
+            @game.tile_cost(old_tile, hex, entity) + border + extra_cost - discount
           end
 
         try_take_loan(spender, cost)
@@ -169,7 +169,9 @@ module Engine
           neighbor.tile.borders.map! { |nb| nb.edge == hex.invert(edge) ? nil : nb }.compact!
 
           ability = entity.all_abilities.find do |a|
-            (a.type == :tile_discount) && (border.type == a.terrain)
+            (a.type == :tile_discount) &&
+             (border.type == a.terrain) &&
+             (!a.hexes || a.hexes.include?(hex.name))
           end
           discount = ability&.discount || 0
 


### PR DESCRIPTION
If hexes field is specified for tile_discount ability, only
the specified hexes will give the discount.