### PR TITLE
1817 Bug Fixes

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -41,7 +41,7 @@ module View
               moves = Array(option[:share_times]).zip(Array(option[:share_direction]))
 
               moves.map do |times, dir|
-                new_share = @game.stock_market.find_relative_share_price(new_share, dir)
+                times.times { new_share = @game.stock_market.find_relative_share_price(new_share, dir) }
 
                 "#{times} #{dir}"
               end.join(', ')

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -132,12 +132,12 @@ module Engine
         summary
       end
 
-      def can_pay_interest?(entity, extra_cash = 0)
-        # Can they cover it using cash?
-        return true if entity.cash + extra_cash > interest_owed(entity)
+      def format_currency(val)
+        # On dividends per share can be a float
+        # But don't show decimal points on all
+        return format('$%.1<val>f', val: val) if val.is_a?(Float) && (val % 1 != 0)
 
-        # Can they cover it using buying_power minus the full interest
-        (buying_power(entity) + extra_cash) > interest_owed_for_loans(maximum_loans(entity))
+        self.class::CURRENCY_FORMAT_STR % val
       end
 
       def maximum_loans(entity)

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -96,14 +96,6 @@ module Engine
 
       # @todo: unchanged from here
 
-      def can_pay_interest?(entity, extra_cash = 0)
-        # Can they cover it using cash?
-        return true if entity.cash + extra_cash > interest_owed(entity)
-
-        # Can they cover it using buying_power minus the full interest
-        (buying_power(entity, true) + extra_cash) > interest_owed_for_loans(maximum_loans(entity))
-      end
-
       # @todo: unchanged to here
       def maximum_loans(entity)
         entity.type == :major ? 5 : 2

--- a/lib/engine/game/interest_on_loans.rb
+++ b/lib/engine/game/interest_on_loans.rb
@@ -26,4 +26,12 @@ module InterestOnLoans
     end
     owed
   end
+
+  def can_pay_interest?(entity, extra_cash = 0)
+    # Can they cover it using cash?
+    return true if entity.cash + extra_cash >= interest_owed(entity)
+
+    # Can they cover it using buying_power minus the full interest
+    (buying_power(entity) + extra_cash) >= interest_owed_for_loans(maximum_loans(entity))
+  end
 end

--- a/lib/engine/step/g_1817/share_buying_with_shorts.rb
+++ b/lib/engine/step/g_1817/share_buying_with_shorts.rb
@@ -13,10 +13,10 @@ module Engine
 
           corporation = bundle.corporation
 
-          @game.entity_shorts(entity, corporation).any? ||
+          !(bundle.corporation.share_price.acquisition? || bundle.corporation.share_price.liquidation?) &&
+          (@game.entity_shorts(entity, corporation).any? ||
           corporation.holding_ok?(entity, bundle.percent) &&
-            (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit) &&
-           !(bundle.corporation.share_price.acquisition? || bundle.corporation.share_price.liquidation?)
+            (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit))
         end
       end
     end


### PR DESCRIPTION
Use >= rather than > for interest (fixes #2468)
Format floating half pays as floats (fixes #2464)
Calculate liquidity correctly if share price moves multiple times (fixes #2445)
Disallow buying shares in liquidity if you own shorts (fixes #2444)