### PR TITLE
Use city as centre for TokenSelector, instead of the centre of the tile

### DIFF
--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -288,6 +288,7 @@ module View
                             radius: SLOT_RADIUS,
                             reservation: @city.reservations[slot_index],
                             tile: @tile,
+                            city_render_location: render_location,
                             region_use: @region_use),
               ]),
             ])

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -111,8 +111,8 @@ module View
               process_action(action)
             else
               coords = Hex.coordinates(@tile.hex)
-              coords[0] += @city_render_location[:x]
-              coords[1] += @city_render_location[:y]
+              coords[0] += @city_render_location[:x] if @city_render_location
+              coords[1] += @city_render_location[:y] if @city_render_location
 
               store(:tile_selector,
                     Lib::TokenSelector.new(@tile.hex, coords, @city, @slot_index))

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -22,6 +22,7 @@ module View
         needs :tile_selector, default: nil, store: true
         needs :reservation, default: nil
         needs :game, default: nil, store: true
+        needs :city_render_location, default: nil
 
         RESERVATION_FONT_SIZE = {
           1 => 22,
@@ -109,8 +110,12 @@ module View
               store(:selected_company, nil, skip: true)
               process_action(action)
             else
+              coords = Hex.coordinates(@tile.hex)
+              coords[0] += @city_render_location[:x]
+              coords[1] += @city_render_location[:y]
+
               store(:tile_selector,
-                    Lib::TokenSelector.new(@tile.hex, Hex.coordinates(@tile.hex), @city, @slot_index))
+                    Lib::TokenSelector.new(@tile.hex, coords, @city, @slot_index))
             end
           end
         end


### PR DESCRIPTION
I think this only affects Pile o' Bones in 1882, but looks nicer