### PR TITLE
1817: Remove corporations that have no benefit

### DIFF
--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -36,6 +36,7 @@ module Engine
       GAME_DESIGNER = 'Craig Bartell, Tim Flowers'
       GAME_PUBLISHER = :all_aboard_games
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817'
+      TRAIN_STATION_PRIVATE_NAME = 'TS'
       PITTSBURGH_PRIVATE_NAME = 'PSM'
       PITTSBURGH_PRIVATE_HEX = 'F13'
 

--- a/lib/engine/round/g_1817/stock.rb
+++ b/lib/engine/round/g_1817/stock.rb
@@ -14,6 +14,10 @@ module Engine
               @game.liquidate!(corp)
             end
           end
+
+          # This is done here, as the tokens need to be checked before closing the train station
+          train_station = @game.company_by_id(@game.class::TRAIN_STATION_PRIVATE_NAME)
+          train_station.close! if train_station.owner&.corporation?
         end
 
         def tokens_needed?(corporation)

--- a/lib/engine/round/g_1867/operating.rb
+++ b/lib/engine/round/g_1867/operating.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../operating'
+
+module Engine
+  module Round
+    module G1867
+      class Operating < Operating
+        def select_entities
+          minors, majors = @game.corporations.select(&:floated?).sort.partition(&:type)
+          minors + majors
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -287,13 +287,14 @@ module Engine
           # Pay the player for the company
           corporation.spend(company.value, entity)
 
+          @log << "#{company.name} used for forming #{corporation.name} "\
+            "contributing #{@game.format_currency(company.value)} value"
+
           company.abilities(:additional_token) do |ability|
             corporation.tokens << Engine::Token.new(corporation)
             ability.use!
           end
 
-          @log << "#{company.name} used for forming #{corporation.name} "\
-            "contributing #{@game.format_currency(company.value)} value"
           par_corporation if available_subsidiaries(entity).empty?
         end
 

--- a/lib/engine/step/g_1817/cash_crisis.rb
+++ b/lib/engine/step/g_1817/cash_crisis.rb
@@ -33,8 +33,8 @@ module Engine
           return [] unless @round.cash_crisis_player
 
           # Rotate players to order starting with the current player
-          @game.players.rotate(@game.players.index(@round.cash_crisis_player))
-          .select { |p| p.cash.negative? }
+          [@game.players.rotate(@game.players.index(@round.cash_crisis_player))
+          .find { |p| p.cash.negative? }].compact
         end
 
         def needed_cash(entity)

--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -12,6 +12,7 @@ module Engine
 
           if action.entity.id == @game.class::PITTSBURGH_PRIVATE_NAME
             super
+            action.entity.close!
           else # Mine
             owner = action.entity.owner
             tile_lay = step.get_tile_lay(owner)
@@ -21,7 +22,9 @@ module Engine
             lay_tile(action, extra_cost: tile_lay[:cost] - 15, entity: owner, spender: owner)
             tile.hex.assign!('mine')
             @game.log << "#{owner.name} adds mine to #{tile.hex.name}"
-            tile_lay_abilities(action.entity).use!
+            ability = tile_lay_abilities(action.entity)
+            ability.use!
+            action.entity.close! if ability.count.zero?
           end
           step.laid_track = step.laid_track + 1
         end

--- a/lib/engine/step/g_1817/track.rb
+++ b/lib/engine/step/g_1817/track.rb
@@ -28,6 +28,8 @@ module Engine
           return unless (ability = psm.abilities(:tile_lay))
 
           psm.remove_ability(ability)
+          @game.log << "#{psm.name} closes as it can no longer be used"
+          psm.close!
         end
 
         def upgradeable_tiles(_entity, hex)


### PR DESCRIPTION
1817: Remove corporations that have no benefit (fixes #2459)
1817: Only make the first cash crisis player the active player (fixes #2388)

(Also add 1867 operating that i forgot to add)