### PR TITLE
18MEX: Fix problem with KCM&O private (fixes #2480)

### DIFF
--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -316,7 +316,7 @@ module Engine
 
       def purchasable_companies(entity = nil)
         return super if @phase.current[:name] != '2' || !@optional_rules&.include?(:early_buy_of_kcmo)
-        return [] unless p2_company.owner.player?
+        return [] unless p2_company.owner&.player?
 
         [p2_company]
       end


### PR DESCRIPTION
If KCM&O uses its ability, the private is closed, and it loses
its owner attribute. Need to add a nil guard to avoid crash.