### PR TITLE
Use upcoming trains in Info (fixes #2508)

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -163,7 +163,7 @@ module View
       def upcoming_trains
         rust_schedule = {}
         obsolete_schedule = {}
-        @depot.trains.group_by(&:name).each do |name, trains|
+        @depot.upcoming.group_by(&:name).each do |name, trains|
           first = trains.first
           rust_schedule[first.rusts_on] = Array(rust_schedule[first.rusts_on]).append(name)
           obsolete_schedule[first.obsolete_on] = Array(obsolete_schedule[first.obsolete_on]).append(name)


### PR DESCRIPTION
When having a specific optional rule in 18MEX the minors' trains
become (sort-of) non-rustable. For some reason this affects the
two train info for rusting.

By using @depot.upcoming instead the problem does not appear.