### PR TITLE
Stock Market View Page

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -67,7 +67,7 @@ class Api < Roda
   use Rack::Deflater unless PRODUCTION
 
   STANDARD_ROUTES = %w[
-    / about hotseat login map new_game profile signup tiles tutorial forgot reset
+    / about hotseat login map market new_game profile signup tiles tutorial forgot reset
   ].freeze
 
   Dir['./routes/*'].sort.each { |file| require file }

--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -12,6 +12,7 @@ require 'view/home'
 require 'view/flash'
 require 'view/game_page'
 require 'view/map_page'
+require 'view/market_page'
 require 'view/navigation'
 require 'view/tiles_page'
 require 'view/user'
@@ -73,6 +74,8 @@ class App < Snabberb::Component
         h(View::TilesPage, route: @app_route)
       when /map/
         h(View::MapPage, route: @app_route)
+      when /market/
+        h(View::MarketPage, route: @app_route)
       else
         h(View::Home, user: @user)
       end

--- a/assets/app/view/market_page.rb
+++ b/assets/app/view/market_page.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'view/game/stock_market'
+
+module View
+  class MarketPage < Snabberb::Component
+    needs :route
+
+    ROUTE_FORMAT = %r{/market/([^/?]*)/?}.freeze
+
+    def render
+      game_title = @route.match(ROUTE_FORMAT)[1].gsub('%20', ' ')
+      game = Engine::GAMES_BY_TITLE[game_title]
+
+      return h(:p, "Bad game title: #{game_title}") unless game
+
+      players = Engine.player_range(game).max.times.map { |n| "Player #{n + 1}" }
+      h(Game::StockMarket, game: game.new(players), explain_colors: true)
+    end
+  end
+end


### PR DESCRIPTION
I found it useful to have a view directly into the stock market while building 18CO. This allows a user to view the market for a specific game without bring in the game. (eg: /market/18AL )

http://0.0.0.0:9292/market/1846

<img width="1294" alt="Screen Shot 2020-12-01 at 7 17 56 AM" src="https://user-images.githubusercontent.com/15675400/100752149-76c25600-33a5-11eb-9c7c-8a4da6ec1de0.png">

http://0.0.0.0:9292/market/18CO

<img width="574" alt="Screen Shot 2020-12-01 at 7 18 10 AM" src="https://user-images.githubusercontent.com/15675400/100752157-7aee7380-33a5-11eb-98f6-f5e80a1ce20d.png">

