### PR TITLE
Revert "Use upcoming trains in Info" (fixes #2513)

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -163,7 +163,7 @@ module View
       def upcoming_trains
         rust_schedule = {}
         obsolete_schedule = {}
-        @depot.upcoming.group_by(&:name).each do |name, trains|
+        @depot.trains.group_by(&:name).each do |name, trains|
           first = trains.first
           rust_schedule[first.rusts_on] = Array(rust_schedule[first.rusts_on]).append(name)
           obsolete_schedule[first.obsolete_on] = Array(obsolete_schedule[first.obsolete_on]).append(name)


### PR DESCRIPTION
This fix caused problems in other titles. So we need to
try another solution.

This reverts commit 27b88f52f7d1d9714815b389934f32ae743c4b1a.