### PR TITLE
1817NA: Fix bank text for # of loans to raise interest rate

### DIFF
--- a/lib/engine/game/g_1817_na.rb
+++ b/lib/engine/game/g_1817_na.rb
@@ -46,7 +46,7 @@ module Engine
         if loans_taken.zero?
           summary << ['Interest if 5 more loans taken', 10]
         elsif rate != 70
-          loans = 5 - ((loans_taken + 4) % 4)
+          loans = 4 - ((loans_taken + 3) % 4)
           s = loans == 1 ? '' : 's'
           summary << ["Interest if #{loans} more loan#{s} taken", rate + 5]
         end


### PR DESCRIPTION
Before this fix, the # of loans to raise interest rate was correct except
 for when the # of loans was a multiple of 4, in which case it showed
 5 loans to increase interest, instead of the correct 1