### PR TITLE
1860 Insolvency and train buying rules

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -86,6 +86,20 @@ module View
           children << h(:div, props, subchildren)
         end
 
+        if @game.status_str(@corporation)
+          props = {
+            style: {
+              grid: '1fr / repeat(2, max-content)',
+              gap: '2rem',
+              justifyContent: 'center',
+              backgroundColor: color_for(:bg2),
+              color: color_for(:font2),
+            },
+          }
+
+          children << h(:div, props, render_status)
+        end
+
         h('div.corp.card', { style: card_style, on: { click: select_corporation } }, children)
       end
 
@@ -377,6 +391,12 @@ module View
           'Last Run: ',
           h('span.bold', @game.format_currency(last_run)),
         ])
+      end
+
+      def render_status
+        [h(:div, { style: { display: 'inline' } }, [
+          h('span.bold', @game.status_str(@corporation)),
+        ])]
       end
 
       def render_operating_order

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -23,7 +23,7 @@ module View
       end
 
       def generate_last_routes!
-        trains = @game.round.current_entity.runnable_trains
+        trains = @game.route_trains(@game.round.current_entity)
         operating = @game.round.current_entity.operating_history
         last_run = operating[operating.keys.max]&.routes
         return [] unless last_run
@@ -34,12 +34,12 @@ module View
 
           # A future enhancement to this could be to find trains and move the routes over
           @routes << Engine::Route.new(@game, @game.phase, train, connection_hexes: connections,
-                                                                  routes: @routes, num_halts: halts[train])
+                                                                  routes: @routes, halts: halts[train])
         end.compact
       end
 
       def render
-        trains = @game.round.current_entity.runnable_trains
+        trains = @game.route_trains(@game.round.current_entity)
 
         train_help =
           if (helps = @game.train_help(trains)).any?

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -579,6 +579,14 @@ module Engine
         @depot.trains
       end
 
+      def train_owner(train)
+        train.owner
+      end
+
+      def route_trains(entity)
+        entity.runnable_trains
+      end
+
       def shares
         @corporations.flat_map(&:shares)
       end
@@ -1711,6 +1719,8 @@ module Engine
       def show_corporation_size?(_entity)
         false
       end
+
+      def status_str(_corporation); end
 
       # Override this, and add elements (paragraphs of text) here to display it on Info page.
       def timeline

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -30,6 +30,8 @@ module Engine
       SELL_AFTER = :any_time
       SELL_BUY_ORDER = :sell_buy
       MARKET_SHARE_LIMIT = 100
+      TRAIN_PRICE_MIN = 10
+      TRAIN_PRICE_MULTIPLE = 10
 
       STOCKMARKET_COLORS = {
         par: :yellow,
@@ -97,7 +99,6 @@ module Engine
 
       def setup
         @bankrupt_corps = []
-        @receivership_corps = []
         @insolvent_corps = []
         @closed_corps = []
         @highest_layer = 1
@@ -175,16 +176,49 @@ module Engine
         @log << "#{ffc.name} is now available for purchase from the Bank"
       end
 
-      def corp_bankrupt?(corp)
+      def insolvent?(corp)
+        @insolvent_corps.include?(corp)
+      end
+
+      def make_insolvent(corp)
+        return if insolvent?(corp)
+
+        @insolvent_corps << corp
+        @log << "#{corp.name} is now Insolvent"
+      end
+
+      def clear_insolvent(corp)
+        return unless insolvent?(corp)
+
+        @insolvent_corps.delete(corp)
+        @log << "#{corp.name} is no longer Insolvent"
+      end
+
+      def bankrupt?(corp)
         @bankrupt_corps.include?(corp)
       end
 
+      def make_bankrupt(corp)
+        @bankrupt_corps << corp unless bankrupt(corp)
+      end
+
+      def clear_bankrupt(corp)
+        @bankrupt_corps.delete(corp)
+      end
+
+      def status_str(corp)
+        status = nil
+        status = 'Insolvent' if insolvent?(corp)
+        status = status ? status + ', Bankrupt' : 'Bankrupt' if bankrupt?(corp)
+        status
+      end
+
       def corp_hi_par(corp)
-        (corp_bankrupt?(corp) ? REPAR_RANGE[corp_layer(corp)] : PAR_RANGE[corp_layer(corp)]).last
+        (bankrupt?(corp) ? REPAR_RANGE[corp_layer(corp)] : PAR_RANGE[corp_layer(corp)]).last
       end
 
       def corp_lo_par(corp)
-        (corp_bankrupt?(corp) ? REPAR_RANGE[corp_layer(corp)] : PAR_RANGE[corp_layer(corp)]).first
+        (bankrupt?(corp) ? REPAR_RANGE[corp_layer(corp)] : PAR_RANGE[corp_layer(corp)]).first
       end
 
       def corp_layer(corp)
@@ -192,7 +226,7 @@ module Engine
       end
 
       def par_prices(corp)
-        par_prices = corp_bankrupt?(corp) ? repar_prices : stock_market.par_prices
+        par_prices = bankrupt?(corp) ? repar_prices : stock_market.par_prices
         par_prices.select { |p| p.price <= corp_hi_par(corp) && p.price >= corp_lo_par(corp) }
       end
 
@@ -216,6 +250,12 @@ module Engine
           corp.num_ipo_shares.zero? || corp.operated?
         end.values
         layers.empty? ? 1 : layers.max + 1
+      end
+
+      def float_corporation(corporation)
+        # Designer says that bankrupt corps keep insolvency flag
+        clear_bankrupt(corporation)
+        super
       end
 
       def sorted_corporations
@@ -267,6 +307,33 @@ module Engine
         @corporations.each { |corp| corp.shares.each { |share| share.buyable = true } }
         @companies.reject { |c| c == company }.each(&:close!)
         @log << '-- Event: starting private companies close --'
+      end
+
+      def train_help(trains)
+        help = []
+
+        if trains.select { |t| t.owner == @depot }.any?
+          help << 'Leased trains ignore town/halt allowance.'
+          help << "Revenue = #{format_currency(40)} + number_of_stops * #{format_currency(20)}"
+        end
+
+        help
+      end
+
+      def train_owner(train)
+        train.owner == @depot ? lesee : train.owner
+      end
+
+      def lesee
+        current_entity
+      end
+
+      def route_trains(entity)
+        if insolvent?(entity)
+          [@depot.min_depot_train]
+        else
+          super
+        end
       end
 
       def biggest_train(corporation)
@@ -503,9 +570,13 @@ module Engine
 
         # in 1860, unused city/offboard allowance can be used for towns/halts
         c_allowance = route.train.distance[0]['pay']
-        th_allowance = route.train.distance[-1]['pay'] + c_allowance - stops.size
+        th_allowance = if route.train.owner != @depot
+                         route.train.distance[-1]['pay'] + c_allowance - stops.size
+                       else
+                         c_allowance - stops.size
+                       end
 
-        # add in halts requested
+        # add in halts requested (should be 0 for leased train)
         halts = visits.select(&:halt?)
         num_halts = [halts.size, (route.halts || 0)].min
         if num_halts.positive?
@@ -527,23 +598,33 @@ module Engine
           stops.concat(halts.take(num_halts))
         end
 
-        route.halts = num_halts if halts.any?
+        # update route halts unless this is a loaner train
+        route.halts = num_halts if halts.any? && route.train.owner != @depot
 
         stops
       end
 
       def route_distance(route)
         n_cities = route.stops.select { |n| n.city? || n.offboard? }.size
-        n_towns = route.stops.select { |n| n.town? && !n.halt? }.size
+        # halts are treated like towns for leased trains
+        n_towns = if route.train.owner != @depot
+                    route.stops.select { |n| n.town? && !n.halt? }.size
+                  else
+                    route.stops.select(&:town?).size
+                  end
         "#{n_cities}+#{n_towns}"
       end
 
       def revenue_for(route, stops)
-        stops.sum { |stop| stop.route_base_revenue(route.phase, route.train) }
+        if route.train.owner != @depot
+          stops.sum { |stop| stop.route_base_revenue(route.phase, route.train) }
+        else
+          40 + 20 * stops.size
+        end
       end
 
-      def subsidy_for(_route, stops)
-        stops.select(&:halt?).size * HALT_SUBSIDY
+      def subsidy_for(route, stops)
+        route.train.owner != @depot ? stops.select(&:halt?).size * HALT_SUBSIDY : 0
       end
 
       def routes_revenue(routes)

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -207,7 +207,6 @@ module Engine
       end
 
       def status_str(corp)
-        status = nil
         status = 'Insolvent' if insolvent?(corp)
         status = status ? status + ', Bankrupt' : 'Bankrupt' if bankrupt?(corp)
         status
@@ -321,10 +320,10 @@ module Engine
       end
 
       def train_owner(train)
-        train.owner == @depot ? lesee : train.owner
+        train.owner == @depot ? lessee : train.owner
       end
 
-      def lesee
+      def lessee
         current_entity
       end
 
@@ -623,9 +622,9 @@ module Engine
         n_cities = route.stops.select { |n| n.city? || n.offboard? }.size
         # halts are treated like towns for leased trains
         n_towns = if route.train.owner != @depot
-                    route.stops.select { |n| n.town? && !n.halt? }.size
+                    route.stops.count { |n| n.town? && !n.halt? }
                   else
-                    route.stops.select(&:town?).size
+                    route.stops.count(&:town?)
                   end
         "#{n_cities}+#{n_towns}"
       end
@@ -639,7 +638,7 @@ module Engine
       end
 
       def subsidy_for(route, stops)
-        route.train.owner != @depot ? stops.select(&:halt?).size * HALT_SUBSIDY : 0
+        route.train.owner != @depot ? stops.count(&:halt?) * HALT_SUBSIDY : 0
       end
 
       def routes_revenue(routes)

--- a/lib/engine/round/g_1860/operating.rb
+++ b/lib/engine/round/g_1860/operating.rb
@@ -9,7 +9,7 @@ module Engine
     module G1860
       class Operating < Operating
         def after_process(action)
-          if (entity = @entities[@entity_index]).receivership?
+          if (entity = @entities[@entity_index]).receivership? || @game.insolvent?(entity)
             case action
             when Engine::Action::RunRoutes
               process_action(Engine::Action::Dividend.new(entity, kind: 'withhold'))
@@ -17,6 +17,21 @@ module Engine
           end
 
           super
+        end
+
+        def next_entity!
+          after_operating(@entities[@entity_index])
+          super
+        end
+
+        def after_operating(entity)
+          return unless entity.corporation?
+
+          if entity.trains.empty? && @game.can_run_route?(entity)
+            @game.make_insolvent(entity)
+          elsif !entity.trains.empty?
+            @game.clear_insolvent(entity)
+          end
         end
       end
     end

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -228,7 +228,7 @@ module Engine
     end
 
     def corporation
-      train.owner
+      @game.train_owner(train)
     end
 
     def connection_hexes

--- a/lib/engine/step/g_1860/buy_train.rb
+++ b/lib/engine/step/g_1860/buy_train.rb
@@ -8,8 +8,61 @@ module Engine
       class BuyTrain < BuyTrain
         def actions(entity)
           return [] if entity.receivership? && entity.trains.any?
+          return [] if entity != current_entity || buyable_trains(entity).empty?
+          return %w[buy_train] if must_buy_train?(entity)
 
           super
+        end
+
+        def process_buy_train(action)
+          if action.train.owned_by_corporation?
+            min, max = spend_minmax(action.entity, action.train)
+            unless (min..max).include?(action.price)
+              @game.game_error("#{action.entity.name} may not spend "\
+                               "#{@game.format_currency(action.price)} on "\
+                               "#{action.train.owner.name}'s #{action.train.name} "\
+                               'train; may only spend between '\
+                               "#{@game.format_currency(min)} and "\
+                               "#{@game.format_currency(max)}.")
+            end
+            unless (action.price % @game.class::TRAIN_PRICE_MULTIPLE).zero?
+              @game.game_error('Train purchase price must be a multiple of '\
+                               "#{@game.format_currency(@game.class::TRAIN_PRICE_MULTIPLE)}")
+            end
+          end
+
+          buy_train_action(action)
+          pass! unless can_buy_train?(action.entity)
+        end
+
+        def must_buy_train?(entity)
+          entity.trains.empty? &&
+            @game.depot.min_depot_price.positive? &&
+            entity.cash > @game.depot.min_depot_price &&
+            @game.can_run_route?(entity)
+        end
+
+        def buyable_trains(entity)
+          depot_trains = @depot.depot_trains
+          other_trains = @depot.other_trains(entity)
+
+          depot_trains = [] if entity.cash < @depot.min_depot_price
+
+          other_trains = [] if entity.cash < @game.class::TRAIN_PRICE_MIN
+
+          other_trains.reject! { |t| illegal_train_buy?(entity, t) }
+
+          depot_trains + other_trains
+        end
+
+        def illegal_train_buy?(entity, train)
+          entity.receivership? ||
+            train.owner.receivership? ||
+            entity.trains.any? && train.owner.trains.size < 2
+        end
+
+        def spend_minmax(entity, _train)
+          [@game.class::TRAIN_PRICE_MIN, buying_power(entity)]
         end
       end
     end

--- a/lib/engine/step/g_1860/dividend.rb
+++ b/lib/engine/step/g_1860/dividend.rb
@@ -31,7 +31,7 @@ module Engine
             revenue
           )
 
-          entity.trains.each { |train| train.operated = true }
+          entity.trains.each { |train| train.operated = true } unless @game.insolvent?(entity)
 
           @round.routes = []
 

--- a/lib/engine/step/g_1860/route.rb
+++ b/lib/engine/step/g_1860/route.rb
@@ -9,8 +9,10 @@ module Engine
         ACTIONS = %w[run_routes].freeze
 
         def actions(entity)
-          # FIXME: deal with insolvency
-          return [] if !entity.operator? || entity.runnable_trains.empty? || !@game.can_run_route?(entity)
+          check_insolvency!(entity)
+          return [] if !entity.operator? ||
+                       entity.trains.empty? && !@game.insolvent?(entity) ||
+                       !@game.can_run_route?(entity)
 
           ACTIONS
         end
@@ -20,27 +22,54 @@ module Engine
         end
 
         def help
-          # FIXME: deal with insolvency
-          # FIXME: deal with receivership
-          return super unless current_entity.receivership?
+          return super if !current_entity.receivership? && !@game.insolvent?(current_entity)
 
-          "#{current_entity.name} is in receivership (it has no president). Most of its "\
-            'actions are automated, but it must have a player manually run its trains. '\
-            "Please enter the best route you see for #{current_entity.name}."
+          text = ''
+          if current_entity.receivership?
+            text += "#{current_entity.name} is in receivership (it has no president)."\
+              'Most of its actions are automated, but it must have a player manually run'\
+              "its trains. Please enter the best route you see for #{current_entity.name}."
+          end
+          text += ' In addition, ' if current_entity.receivership? && @game.insolvent?(current_entity)
+          if @game.insolvent?(current_entity)
+            text += "#{current_entity.name} is insolvent. It is running a train leased from "\
+              'the bank'
+          end
+          text
+        end
+
+        def check_insolvency!(entity)
+          return unless entity.corporation?
+
+          if entity.receivership? && entity.trains.empty? &&
+              @game.can_run_route?(entity) && !can_afford_depot_train?(entity)
+            @game.make_insolvent(entity)
+          elsif @game.insolvent?(entity) && can_afford_depot_train?(entity)
+            @game.clear_insolvent(entity)
+          end
+        end
+
+        def can_afford_depot_train?(entity)
+          min_price = @game.depot.min_depot_price
+          min_price.positive? && entity.cash >= min_price
         end
 
         def process_run_routes(action)
           entity = action.entity
           @round.routes = action.routes
+
           # the following two checks must be made here, after all routes have been defined
           if @round.routes.reject { |r| r.connections.empty? }.any?
             @game.check_home_token(entity, @round.routes)
             @game.check_intersection(@round.routes)
           end
           trains = {}
+
           @round.routes.each do |route|
             train = route.train
-            @game.game_error("Cannot run another corporation's train. refresh") if train.owner && train.owner != entity
+            if train.owner && @game.train_owner(train) != entity
+              @game.game_error("Cannot run another corporation's train. refresh")
+            end
             @game.game_error('Cannot run train twice') if trains[train]
             @game.game_error('Cannot run train that operated') if train.operated
 

--- a/lib/engine/step/g_1860/token.rb
+++ b/lib/engine/step/g_1860/token.rb
@@ -7,7 +7,7 @@ module Engine
     module G1860
       class Token < Token
         def actions(entity)
-          return [] if entity.receivership?
+          return [] if entity.receivership? || @game.insolvent?(entity)
 
           super
         end

--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -113,6 +113,10 @@ module Engine
               @game.tile_cost(old_tile, hex, entity) + border + extra_cost - discount
             end
 
+          if @game.insolvent?(spender) && cost.positive?
+            @game.game_error("#{spender.id} cannot pay for a tile when insolvent")
+          end
+
           spender.spend(cost, @game.bank) if cost.positive?
 
           cities = tile.cities


### PR DESCRIPTION
Implements all the insolvency rules
Implements train buy restrictions

Common code changes:
- Added ability for show status line for corporations (Game/Base, UI:Corporation)
- Game-specific train owner (Game/Base, Engine/Route)
- Game-specific trains list (Game/Base, UI:Route_Selector)