### PR TITLE
18MEX: Fix info when using optional rule (fixes #2508)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -579,6 +579,11 @@ module Engine
         @depot.trains
       end
 
+      # Before rusting, check if this train individual should rust.
+      def rust?(_train)
+        true
+      end
+
       def shares
         @corporations.flat_map(&:shares)
       end

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -139,7 +139,6 @@ module Engine
         @minors.each do |minor|
           train = @depot.upcoming[0]
           train.buyable = false
-          update_end_of_life(train, nil, nil) if @optional_rules&.include?(:delay_minor_close)
           minor.buy_train(train, :free)
           hex = hex_by_id(minor.coordinates)
           hex.tile.cities[0].place_token(minor, minor.next_token)
@@ -466,6 +465,13 @@ module Engine
         end
 
         major.close!
+      end
+
+      def rust?(train)
+        return super unless @optional_rules&.include?(:delay_minor_close)
+
+        # Do not rust minor's 2 trains
+        !(train.name == '2' && train.owner.minor?)
       end
 
       def buy_first_5_train(player)

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -113,6 +113,7 @@ module Engine
 
         should_rust = t.rusts_on == train.sym || (t.obsolete_on == train.sym && @depot.discarded.include?(t))
         next unless should_rust
+        next unless @game.rust?(t)
 
         rusted_trains << t.name
         owners[t.owner.name] += 1


### PR DESCRIPTION
Have added a rust? method in base class that 18MEX overrides
and use it to skip rusting of minor's two train in case the
optional rule is used.