### PR TITLE
Bug fix: make abilities of 18LA optional companies only activate if explicitly chosen

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -197,3 +197,14 @@ Modified station token placement
   token without connectivity, for the given price.
 - `extra`: If true, this ability may be used in addition to the turn's
   normal token placement step. Default false.
+- `cheater`: If an integer is given, this token will be placed into a city at
+  whichever is the lowest unoccupied slot index of the following: a regular slot
+  in the city; the `cheater` value; one slot higher than the city actually has,
+  effectively increasing the city's size by one. (See 18 Los Angeles's optional
+  company "Dewey, Cheatham, and Howe" or the corporations which get removed in
+  1846 2p Variant for examples). Default nil.
+- `special_only`: If true, this ability may only be used by explicitly
+  activating the company to which it belongs (i.e., using the `SpecialTrack`
+  step); if unset or false, `Engine::Step::Tokener#adjust_token_price_ability!`
+  infers that the special ability ought to be used whenever a token is being
+  placed in a location that the ability is allowed to use. Default false.

--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -6,11 +6,11 @@ module Engine
   module Ability
     class Token < Base
       attr_reader :hexes, :teleport_price, :extra, :from_owner, :discount, :city,
-                  :neutral, :cheater
+                  :neutral, :cheater, :special_only
 
       def setup(hexes:, price: nil, teleport_price: nil, extra: nil,
                 from_owner: nil, discount: nil, city: nil, neutral: nil,
-                cheater: nil)
+                cheater: nil, special_only: nil)
         @hexes = hexes
         @price = price
         @teleport_price = teleport_price
@@ -20,6 +20,7 @@ module Engine
         @city = city
         @neutral = neutral || false
         @cheater = cheater || false
+        @special_only = special_only || false
       end
 
       def price(token = nil)

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -341,6 +341,7 @@ module Engine
           "count": 1,
           "from_owner": true,
           "cheater": 0,
+          "special_only": true,
           "discount": 0,
           "hexes": [
             "A2", "A4", "A6", "A8", "B5", "B7", "B9", "B11", "B13", "C2", "C4",
@@ -365,6 +366,7 @@ module Engine
           "price": 0,
           "teleport_price": 0,
           "count": 1,
+          "special_only": true,
           "neutral": true,
           "hexes": [
             "A4", "A6", "A8", "B5", "B7", "B9", "B11", "B13", "C4", "C6", "C8",

--- a/lib/engine/step/g_18_ga/token.rb
+++ b/lib/engine/step/g_18_ga/token.rb
@@ -17,7 +17,7 @@ module Engine
           []
         end
 
-        def adjust_token_price_ability!(entity, token, hex, city)
+        def adjust_token_price_ability!(entity, token, hex, city, special_ability = nil)
           return [token, nil] if @game.active_step.current_entity.corporation?
 
           super

--- a/lib/engine/step/g_18_ms/token.rb
+++ b/lib/engine/step/g_18_ms/token.rb
@@ -36,7 +36,7 @@ module Engine
           entity.cash += one_time_bonus
         end
 
-        def adjust_token_price_ability!(entity, token, hex, city)
+        def adjust_token_price_ability!(entity, token, hex, city, special_ability = nil)
           return [token, nil] if @game.active_step.current_entity.corporation?
 
           super

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -36,7 +36,7 @@ module Engine
 
         @game.game_error('Token is already used') if token.used
 
-        token, ability = adjust_token_price_ability!(entity, token, hex, city)
+        token, ability = adjust_token_price_ability!(entity, token, hex, city, special_ability)
         tokener = entity.name
         if ability
           tokener = "#{entity.name} (#{ability.owner.sym})" if ability.owner != entity
@@ -76,13 +76,14 @@ module Engine
         prices.compact.min
       end
 
-      def adjust_token_price_ability!(entity, token, hex, city)
+      def adjust_token_price_ability!(entity, token, hex, city, special_ability = nil)
         if (teleport = @round.teleported?(entity))
           token.price = 0
           return [token, teleport]
         end
 
         entity.abilities(:token) do |ability, _|
+          next if ability.special_only && ability != special_ability
           next if ability.hexes.any? && !ability.hexes.include?(hex.id)
           next if ability.city && ability.city != city.index
 


### PR DESCRIPTION
Add `special_only` attribute to token abilities; if `true`, prevents Tokener
from using the ability implicitly.

[Fixes #2512]