### PR TITLE
Fix the seed money log in 1817 so 1817NA and other subclasses may ove…

### DIFF
--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -476,7 +476,7 @@ module Engine
       private
 
       def new_auction_round
-        log << "Seed Money for initial auction is #{format_currency(SEED_MONEY)}" unless @round
+        log << "Seed Money for initial auction is #{format_currency(self.class::SEED_MONEY)}" unless @round
         Round::Auction.new(self, [
           Step::G1817::SelectionAuction,
         ])


### PR DESCRIPTION
…rride the SEED_MONEY constant

To reproduce the issue, simply start a hotseat (or live) game of 1817NA. In the log it will say (erroneously) that the seed money is $200
![image](https://user-images.githubusercontent.com/2993555/101126056-b0bf7200-35c8-11eb-9062-df3bd5eb40fa.png)


The fix fixes this

![image](https://user-images.githubusercontent.com/2993555/101126080-bd43ca80-35c8-11eb-838d-27fd5715f97b.png)
