### PR TITLE
Refactor: move abilities() method from Abilities module to Game::Base

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -129,7 +129,7 @@ module View
         children = []
 
         @game.companies.each do |company|
-          company.abilities(:exchange) do |ability|
+          @game.abilities(company, :exchange) do |ability|
             next if ability.corporation != @corporation.name && ability.corporation != 'any'
             next unless company.owner == @current_entity
 

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -65,7 +65,7 @@ module View
         step = @game.round.active_step
         @corporation = step.current_entity
         if @selected_company&.owner == @corporation
-          @ability = @selected_company&.abilities(:train_discount, time: 'train')
+          @ability = @game.abilities(@selected_company, :train_discount, time: 'train')
         end
 
         @depot = @game.depot

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -541,7 +541,7 @@ module View
       end
 
       def can_assign_corporation?
-        @selected_corporation && @selected_company&.abilities(:assign_corporation)
+        @selected_corporation && @game.abilities(@selected_company, :assign_corporation)
       end
     end
   end

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -23,7 +23,7 @@ module View
       end
 
       def render
-        return h(:span) unless (ability = @selected_company&.abilities(:exchange))
+        return h(:span) unless (ability = @game.abilities(@selected_company, :exchange))
 
         children = []
         corporations =

--- a/assets/app/view/game/part/blocker.rb
+++ b/assets/app/view/game/part/blocker.rb
@@ -6,6 +6,8 @@ module View
   module Game
     module Part
       class Blocker < Base
+        needs :game, default: nil, store: true
+
         # prefix these constant names with "P" (for "PART") to avoid conflicts
         # with constants in Part::Base
         P_CENTER = {
@@ -81,8 +83,8 @@ module View
 
         def should_render_company_sym?
           blocker_open? && (!@blocker.owned_by_corporation? ||
-                            @blocker.abilities(:tile_lay) ||
-                            @blocker.abilities(:teleport))
+                            @game.abilities(@blocker, :tile_lay) ||
+                            @game.abilities(@blocker, :teleport))
         end
 
         def should_render_barbell?

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -84,7 +84,7 @@ module View
           actions = step.actions(entity)
           return if (%w[remove_token place_token] & actions).empty?
           return if @token && !step.can_replace_token?(entity, @token) &&
-                    !(cheater = entity.abilities(:token)&.cheater)
+                    !(cheater = @game.abilities(entity, :token)&.cheater)
 
           event.JS.stopPropagation
 

--- a/assets/app/view/game/part/partitions.rb
+++ b/assets/app/view/game/part/partitions.rb
@@ -52,7 +52,9 @@ module View
           children = []
 
           @tile.partitions.each do |partition|
-            next unless partition.blockers.any? { |b| b.abilities(:blocks_partition)&.blocks?(partition.type) }
+            next if partition.blockers.none? do |blocker|
+              blocker.all_abilities.find { |a| a.type == :blocks_partition && a.blocks?(partition.type) }
+            end
 
             a_control = VERTICES[(partition.a + partition.a_sign) % 6]
             vertex_a = convex_combination(VERTICES[partition.a], a_control)

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -61,7 +61,8 @@ module View
         def render_company_pending_par
           children = []
 
-          @step.companies_pending_par.first.abilities(:shares).shares.each do |share|
+          company = @step.companies_pending_par.first
+          @game.abilities(company, :shares).shares.each do |share|
             next unless share.president
 
             children << h(Corporation, corporation: share.corporation)

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -55,7 +55,7 @@ module View
           elsif (company = entity).company?
             left << h(Company, company: company)
 
-            if company.abilities(:assign_corporation)
+            if @game.abilities(company, :assign_corporation)
               props = {
                 style: {
                   display: 'inline-block',

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -68,9 +68,10 @@ module Engine
     end
 
     def find_token_by_type(token_type)
-      raise GameError, "#{name} does not have a token" unless abilities(:token)
+      token_ability = all_abilities.find { |a| a.type == :token }
+      raise GameError, "#{name} does not have a token" unless token_ability
 
-      return @owner.find_token_by_type(token_type) if abilities(:token).from_owner
+      return @owner.find_token_by_type(token_type) if token_ability.from_owner
 
       Token.new(@owner)
     end

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -203,24 +203,6 @@ module Engine
       @companies.each { |company| company.remove_ability(ability) }
     end
 
-    def abilities(type = nil, **opts)
-      abilities = []
-
-      if (ability = super(type, **opts, &nil))
-        abilities << ability
-        yield ability, self if block_given?
-      end
-
-      @companies.each do |company|
-        company.abilities(type, **opts) do |company_ability|
-          abilities << company_ability
-          yield company_ability, company if block_given?
-        end
-      end
-
-      abilities
-    end
-
     def available_share
       shares_by_corporation[self].find { |share| !share.president }
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1261,6 +1261,24 @@ module Engine
         'IPO Reserved'
       end
 
+      def abilities(entity, type = nil, time: nil, owner_type: nil, strict_time: false)
+        return nil unless entity
+
+        active_abilities = entity.all_abilities.select do |ability|
+          ability_right_type?(ability, type) &&
+            ability_right_owner?(ability.owner, ability, owner_type) &&
+            ability_usable_this_or?(ability) &&
+            ability_right_time?(ability, time, strict_time) &&
+            ability_usable?(ability)
+        end
+        active_abilities.each { |a| yield a, a.owner } if block_given?
+
+        return nil if active_abilities.empty?
+        return active_abilities.first if active_abilities.one?
+
+        active_abilities
+      end
+
       private
 
       def init_bank
@@ -1789,6 +1807,63 @@ module Engine
       # Override this, and add elements (paragraphs of text) here to display it on Info page.
       def timeline
         []
+      end
+
+      def ability_right_type?(ability, type)
+        !type || (ability.type == type)
+      end
+
+      def ability_right_owner?(entity, ability, owner_type)
+        correct_owner_type =
+          case ability.owner_type
+          when :player
+            !entity.owner || entity.owner.player?
+          when :corporation
+            entity.owner&.corporation?
+          when nil
+            true
+          end
+        return false unless correct_owner_type
+        return false if owner_type && (ability.owner_type.to_s != owner_type.to_s)
+
+        true
+      end
+
+      def ability_usable_this_or?(ability)
+        !ability.count_per_or || (ability.count_this_or < ability.count_per_or)
+      end
+
+      def ability_right_time?(ability, time, strict_time)
+        return false if strict_time && !ability.when
+        return true unless time
+
+        if ability.when == 'any'
+          !strict_time
+        elsif ability.when == 'owning_corp_or_turn'
+          %w[owning_corp_or_turn track].include?(time)
+        else
+          ability.when == time.to_s
+        end
+      end
+
+      def ability_usable?(ability)
+        case ability
+        when Ability::Token
+          return true if ability.hexes.none?
+
+          corporation =
+            if ability.owner.is_a?(Corporation)
+              ability.owner
+            elsif ability.owner.owner.is_a?(Corporation)
+              ability.owner.owner
+            end
+          return true unless corporation
+
+          tokened_hexes = corporation.tokens.select(&:used).map(&:city).map(&:hex).map(&:id)
+          (ability.hexes - tokened_hexes).any?
+        else
+          true
+        end
       end
     end
   end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -643,7 +643,7 @@ module Engine
 
       def purchasable_companies(entity = nil)
         @companies.select do |company|
-          company.owner&.player? && entity != company.owner && !company.abilities(:no_buy)
+          company.owner&.player? && entity != company.owner && !abilities(company, :no_buy)
         end
       end
 
@@ -960,7 +960,7 @@ module Engine
 
       def all_companies_with_ability(ability)
         @companies.each do |company|
-          if (found_ability = company.abilities(ability))
+          if (found_ability = abilities(company, ability))
             yield company, found_ability
           end
         end
@@ -1366,7 +1366,7 @@ module Engine
       def init_hexes(companies, corporations)
         blockers = {}
         companies.each do |company|
-          company.abilities(:blocks_hexes) do |ability|
+          abilities(company, :blocks_hexes) do |ability|
             ability.hexes.each do |hex|
               blockers[hex] = company
             end
@@ -1375,7 +1375,7 @@ module Engine
 
         partition_blockers = {}
         companies.each do |company|
-          company.abilities(:blocks_partition) do |ability|
+          abilities(company, :blocks_partition) do |ability|
             partition_blockers[ability.partition_type] = company
           end
         end
@@ -1387,7 +1387,7 @@ module Engine
         end
 
         (corporations + companies).each do |c|
-          c.abilities(:reservation) do |ability|
+          abilities(c, :reservation) do |ability|
             reservations[ability.hex] << { entity: c,
                                            city: ability.city.to_i,
                                            slot: ability.slot.to_i,
@@ -1472,7 +1472,7 @@ module Engine
 
       def init_company_abilities
         @companies.each do |company|
-          next unless (ability = company.abilities(:shares))
+          next unless (ability = abilities(company, :shares))
 
           real_shares = []
           ability.shares.each do |share|
@@ -1722,7 +1722,7 @@ module Engine
         @log << '-- Event: Private companies close --'
 
         @companies.each do |company|
-          if (ability = company.abilities(:close))
+          if (ability = abilities(company, :close))
             next if ability.when == 'never' ||
               @phase.phases.any? { |phase| ability.when == phase[:name] }
           end

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -500,7 +500,7 @@ module Engine
         @companies.each do |company|
           next unless company.owner
 
-          company.abilities(:revenue_change, time: 'has_train') do |ability|
+          abilities(company, :revenue_change, time: 'has_train') do |ability|
             company.revenue = company.owner.trains.any? ? ability.revenue : 0
           end
         end

--- a/lib/engine/game/g_1817_wo.rb
+++ b/lib/engine/game/g_1817_wo.rb
@@ -139,7 +139,7 @@ module Engine
         @companies.each do |company|
           next unless company.owner
 
-          company.abilities(:revenue_change, time: 'has_train') do |ability|
+          abilities(company, :revenue_change, time: 'has_train') do |ability|
             company.revenue = company.owner.trains.any? ? ability.revenue : 0
           end
         end

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -156,7 +156,7 @@ module Engine
         @companies.each do |company|
           next unless company.owner
 
-          company.abilities(:revenue_change, time: 'auction_end') do |ability|
+          abilities(company, :revenue_change, time: 'auction_end') do |ability|
             company.revenue = ability.revenue
           end
         end

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -132,7 +132,7 @@ module Engine
         corporation_removal_groups.each do |group|
           remove_from_group!(group, @corporations) do |corporation|
             place_home_token(corporation)
-            corporation.abilities(:reservation) do |ability|
+            abilities(corporation, :reservation) do |ability|
               corporation.remove_ability(ability)
             end
             place_second_token(corporation)
@@ -336,7 +336,7 @@ module Engine
       def check_special_tile_lay(action)
         company = @last_action&.entity
         return unless special_tile_lay?(@last_action)
-        return unless (ability = company.abilities(:tile_lay))
+        return unless (ability = abilities(company, :tile_lay))
         return if action.entity == company
 
         company.remove_ability(ability)

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -221,7 +221,7 @@ module Engine
         game_error('Route visits same hex twice') if route.hexes.size != route.hexes.uniq.size
 
         route.corporation.companies.each do |company|
-          company.abilities(:hex_bonus) do |ability|
+          abilities(company, :hex_bonus) do |ability|
             revenue += stops.map { |s| s.hex.id }.uniq.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
           end
         end

--- a/lib/engine/game/g_1870.rb
+++ b/lib/engine/game/g_1870.rb
@@ -172,7 +172,7 @@ module Engine
       end
 
       def legal_tile_rotation?(_entity, hex, tile)
-        return true unless river_company.abilities(:blocks_partition)
+        return true unless abilities(river_company, :blocks_partition)
 
         (tile.exits & hex.tile.borders.select { |b| b.type == :water }.map(&:edge)).empty? &&
           hex.tile.partitions.all? do |partition|

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -121,13 +121,13 @@ module Engine
         cp.add_ability(Ability::Close.new(
           type: :close,
           when: :train,
-          corporation: cp.abilities(:shares).shares.first.corporation.name,
+          corporation: abilities(cp, :shares).shares.first.corporation.name,
         ))
       end
 
       def init_company_abilities
         @companies.each do |company|
-          next unless (ability = company.abilities(:exchange))
+          next unless (ability = abilities(company, :exchange))
 
           next unless ability.from.include?(:par)
 

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -67,7 +67,7 @@ module Engine
         change_4t_to_hardrust if @optional_rules&.include?(:hard_rust_t4)
 
         @corporations.each do |corporation|
-          corporation.abilities(:assign_hexes) do |ability|
+          abilities(corporation, :assign_hexes) do |ability|
             ability.description = "Historical objective: #{get_location_name(ability.hexes.first)}"
           end
         end
@@ -111,7 +111,7 @@ module Engine
       def revenue_for(route, stops)
         revenue = super
 
-        route.corporation.abilities(:hexes_bonus) do |ability|
+        abilities(route.corporation, :hexes_bonus) do |ability|
           revenue += stops.sum { |stop| ability.hexes.include?(stop.hex.id) ? ability.amount : 0 }
         end
 
@@ -130,7 +130,7 @@ module Engine
 
       def event_remove_tokens!
         @corporations.each do |corporation|
-          corporation.abilities(:hexes_bonus) do |a|
+          abilities(corporation, :hexes_bonus) do |a|
             assigned_hex = @hexes.find { |h| a.hexes.include?(h.name) }
             hex_name = assigned_hex.name
             assigned_hex.remove_assignment!(south_and_north_alabama_railroad.id)
@@ -149,7 +149,7 @@ module Engine
           next unless abilities(corporation, :hexes_bonus)
 
           @companies.each do |company|
-            company.abilities(:assign_hexes) do |ability|
+            abilities(company, :assign_hexes) do |ability|
               remove_mining_icons(ability.hexes)
             end
           end

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -121,8 +121,7 @@ module Engine
       def routes_revenue(routes)
         total_revenue = super
         route_bonuses.each do |type|
-          abilities = routes.first.corporation.abilities(type)
-          return total_revenue if abilities.empty?
+          return total_revenue unless abilities(routes.first.corporation, type)
 
           total_revenue += routes.map { |r| route_bonus(r, type) }.max
         end if routes.any?
@@ -147,7 +146,7 @@ module Engine
 
         # Remove mining icons if Warrior Coal Field has not been assigned
         @corporations.each do |corporation|
-          next if corporation.abilities(:hexes_bonus).empty?
+          next unless abilities(corporation, :hexes_bonus)
 
           @companies.each do |company|
             company.abilities(:assign_hexes) do |ability|
@@ -207,7 +206,7 @@ module Engine
       private
 
       def route_bonus(route, type)
-        route.corporation.abilities(type).sum do |ability|
+        Array(abilities(route.corporation, type)).sum do |ability|
           ability.hexes == (ability.hexes & route.hexes.map(&:name)) ? ability.amount : 0
         end
       end

--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -68,12 +68,12 @@ module Engine
         cornelius.add_ability(Ability::Close.new(
           type: :close,
           when: :train,
-          corporation: cornelius.abilities(:shares).shares.first.corporation.name,
+          corporation: abilities(cornelius, :shares).shares.first.corporation.name,
         ))
 
         return unless two_player?
 
-        cv_corporation = cornelius.abilities(:shares).shares.first.corporation
+        cv_corporation = abilities(cornelius, :shares).shares.first.corporation
 
         @corporations.each do |corporation|
           next if corporation == cv_corporation
@@ -87,7 +87,7 @@ module Engine
       end
 
       def check_special_tile_lay(action, company)
-        company.abilities(:tile_lay) do |ability|
+        abilities(company, :tile_lay) do |ability|
           hexes = ability.hexes
           next unless hexes.include?(action.hex.id)
           next if company.closed? || action.entity == company

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -164,7 +164,7 @@ module Engine
       end
 
       def mines_remove(entity)
-        entity.abilities(:mine_income) do |ability|
+        abilities(entity, :mine_income) do |ability|
           entity.remove_ability(ability)
         end
       end
@@ -515,7 +515,7 @@ module Engine
         @companies.select do |company|
           (company.owner&.player? || company.owner.nil?) &&
             (entity.nil? || entity != company.owner) &&
-            !company.abilities(:no_buy)
+            !abilities(company, :no_buy)
         end
       end
     end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -148,7 +148,7 @@ module Engine
       end
 
       def mines_count(entity)
-        entity.abilities(:mine_income).sum(&:count_per_or)
+        Array(abilities(entity, :mine_income)).sum(&:count_per_or)
       end
 
       def mine_multiplier(entity)

--- a/lib/engine/game/g_18_mex.rb
+++ b/lib/engine/game/g_18_mex.rb
@@ -648,7 +648,7 @@ module Engine
       end
 
       def remove_ability(corporation, ability_name)
-        corporation.abilities(ability_name) do |ability|
+        abilities(corporation, ability_name) do |ability|
           corporation.remove_ability(ability)
         end
       end

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -229,7 +229,7 @@ module Engine
       def revenue_for(route, stops)
         revenue = super
 
-        route.corporation.abilities(:hexes_bonus) do |ability|
+        abilities(route.corporation, :hexes_bonus) do |ability|
           revenue += stops.map { |s| s.hex.id }.uniq.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
         end
 
@@ -250,7 +250,7 @@ module Engine
 
       def event_remove_tokens!
         @corporations.each do |corporation|
-          corporation.abilities(:hexes_bonus) do |a|
+          abilities(corporation, :hexes_bonus) do |a|
             bonus_hex = @hexes.find { |h| a.hexes.include?(h.name) }
             hex_name = bonus_hex.name
             corporation.remove_ability(a)

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -92,9 +92,7 @@ module Engine
 
         corporation = routes.first&.corporation
 
-        abilities = corporation&.abilities(:civil_war)
-
-        return total_revenue if !abilities || abilities.empty? || routes.size < corporation.trains.size
+        return total_revenue if !abilities(corporation, :civil_war) || routes.size < corporation.trains.size
 
         # The train with the lowest revenue loses the income due to the war effort
         total_revenue - routes.map(&:revenue).min

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -105,7 +105,7 @@ module Engine
 
       tokens = nodes.dup
 
-      corporation.abilities(:token) do |ability, c|
+      @game.abilities(corporation, :token) do |ability, c|
         next unless c == corporation # Private company token ability uses round/special.rb.
         next unless ability.teleport_price
 
@@ -117,7 +117,7 @@ module Engine
         end
       end
 
-      corporation.abilities(:teleport) do |ability, _|
+      @game.abilities(corporation, :teleport) do |ability, _|
         ability.hexes.each do |hex_id|
           hex = @game.hex_by_id(hex_id)
           hex.neighbors.each { |e, _| hexes[hex][e] = true }

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -126,7 +126,8 @@ module Engine
       # when upgrading, preserve reservations on previous tile
       city_map.each do |old_city, new_city|
         old_city.reservations.compact.each do |entity|
-          entity.abilities(:reservation) do |ability|
+          entity.all_abilities.each do |ability|
+            next unless ability.type == :reservation
             next unless ability.hex == coordinates
 
             ability.tile = new_city.tile

--- a/lib/engine/minor.rb
+++ b/lib/engine/minor.rb
@@ -31,8 +31,6 @@ module Engine
       init_abilities(opts[:abilities])
     end
 
-    def abilities(_type = nil, **opts); end
-
     def companies
       @companies ||= []
     end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -70,11 +70,11 @@ module Engine
       @game.companies.each do |company|
         next unless company.owner
 
-        company.abilities(:revenue_change, time: @name) do |ability|
+        @game.abilities(company, :revenue_change, time: @name) do |ability|
           company.revenue = ability.revenue
         end
 
-        company.abilities(:close, time: @name) do
+        @game.abilities(company, :close, time: @name) do
           @log << "Company #{company.name} closes"
           company.close!
         end
@@ -87,7 +87,7 @@ module Engine
       @game.companies.each do |company|
         next if company.closed?
 
-        company.abilities(:close, time: :train) do |ability|
+        @game.abilities(company, :close, time: :train) do |ability|
           next if entity&.name != ability.corporation
 
           company.close!
@@ -134,7 +134,7 @@ module Engine
     private
 
     def train_limit_increase(entity)
-      entity.abilities(:train_limit) { |ability| return ability.increase }
+      @game.abilities(entity, :train_limit) { |ability| return ability.increase }
       0
     end
   end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -81,7 +81,7 @@ module Engine
       end
 
       def teleported?(entity)
-        entity.abilities(:teleport)&.find(&:used?)
+        Array(@game.abilities(entity, :teleport)).find(&:used?)
       end
 
       def operating?

--- a/lib/engine/step/assign.rb
+++ b/lib/engine/step/assign.rb
@@ -9,7 +9,8 @@ module Engine
 
       def actions(entity)
         return [] unless entity.company?
-        return ACTIONS if entity.abilities(:assign_hexes) || entity.abilities(:assign_corporation)
+        return ACTIONS if @game.abilities(entity, :assign_hexes) ||
+                          @game.abilities(entity, :assign_corporation)
 
         []
       end
@@ -21,7 +22,7 @@ module Engine
 
         case target
         when Hex
-          if (ability = company.abilities(:assign_hexes))
+          if (ability = @game.abilities(company, :assign_hexes))
             assignable_hexes = ability.hexes.map { |h| @game.hex_by_id(h) }
             Assignable.remove_from_all!(assignable_hexes, company.id) do |unassigned|
               @log << "#{company.name} is unassigned from #{unassigned.name}"
@@ -33,7 +34,8 @@ module Engine
             @game.game_error("Could not assign #{company.name} to #{target.name}; :assign_hexes ability not found")
           end
         when Corporation, Minor
-          if assignable_corporations(company).include?(target) && (ability = company.abilities(:assign_corporation))
+          if assignable_corporations(company).include?(target) &&
+             (ability = @game.abilities(company, :assign_corporation))
             Assignable.remove_from_all!(assignable_corporations, company.id) do |unassigned|
               @log << "#{company.name} is unassigned from #{unassigned.name}"
             end
@@ -54,7 +56,7 @@ module Engine
 
       def available_hex(entity, hex)
         return unless entity.company?
-        return unless entity.abilities(:assign_hexes)&.hexes&.include?(hex.id)
+        return unless @game.abilities(entity, :assign_hexes)&.hexes&.include?(hex.id)
         return if hex.assigned?(entity.id)
 
         @game.hex_by_id(hex.id).neighbors.keys

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -63,7 +63,7 @@ module Engine
         company.owner = entity
         owner&.companies&.delete(company)
 
-        company.abilities(:assign_corporation) do |ability|
+        @game.abilities(company, :assign_corporation) do |ability|
           Assignable.remove_from_all!(assignable_corporations, company.id) do |unassigned|
             log_later << "#{company.name} is unassigned from #{unassigned.name}" if unassigned.name != entity.name
           end
@@ -79,7 +79,7 @@ module Engine
             end
         end
 
-        company.abilities(:revenue_change, time: :sold) { |ability| company.revenue = ability.revenue }
+        @game.abilities(company, :revenue_change, time: :sold) { |ability| company.revenue = ability.revenue }
 
         company.remove_ability_when(:sold)
 

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -16,7 +16,10 @@ module Engine
 
         return PASS if blocks? &&
                        entity.corporation? &&
-                       entity.abilities(time: 'owning_corp_or_turn', owner_type: 'corporation', strict_time: true).any?
+                       @game.abilities(entity,
+                                       time: 'owning_corp_or_turn',
+                                       owner_type: 'corporation',
+                                       strict_time: true)
 
         []
       end

--- a/lib/engine/step/exchange.rb
+++ b/lib/engine/step/exchange.rb
@@ -37,7 +37,7 @@ module Engine
 
       def can_exchange?(entity, bundle = nil)
         return false unless entity.company?
-        return false unless (ability = entity.abilities(:exchange))
+        return false unless (ability = @game.abilities(entity, :exchange))
 
         owner = entity.owner
         return can_gain?(owner, bundle, exchange: true) if bundle

--- a/lib/engine/step/g_1817/assign.rb
+++ b/lib/engine/step/g_1817/assign.rb
@@ -10,7 +10,7 @@ module Engine
           company = action.entity
           target = action.target
 
-          unless (ability = company.abilities(:assign_hexes))
+          unless (ability = @game.abilities(company, :assign_hexes))
             @game.game_error("Could not assign #{company.name} to #{target.name}; :assign_hexes ability not found")
           end
 

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -290,7 +290,7 @@ module Engine
           @log << "#{company.name} used for forming #{corporation.name} "\
             "contributing #{@game.format_currency(company.value)} value"
 
-          company.abilities(:additional_token) do |ability|
+          @game.abilities(company, :additional_token) do |ability|
             corporation.tokens << Engine::Token.new(corporation)
             ability.use!
           end

--- a/lib/engine/step/g_1817/track.rb
+++ b/lib/engine/step/g_1817/track.rb
@@ -25,7 +25,7 @@ module Engine
 
           # PSM loses it's special if something else goes on F13
           psm = @game.company_by_id(@game.class::PITTSBURGH_PRIVATE_NAME)
-          return unless (ability = psm.abilities(:tile_lay))
+          return unless (ability = @game.abilities(psm, :tile_lay))
 
           psm.remove_ability(ability)
           @game.log << "#{psm.name} closes as it can no longer be used"

--- a/lib/engine/step/g_1828/special_token.rb
+++ b/lib/engine/step/g_1828/special_token.rb
@@ -38,7 +38,7 @@ module Engine
 
         def process_pass(action)
           entity = action.entity
-          ability = @company.abilities(:token, time: 'sold')
+          ability = @game.abilities(@company, :token, time: 'sold')
           @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
 
           hex = @game.hex_by_id(ability.hexes.first)
@@ -56,7 +56,7 @@ module Engine
 
           #          company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
 
-          if (ability = company.abilities(:token, time: 'sold'))
+          if (ability = @game.abilities(company, :token, time: 'sold'))
             if available_tokens(company.owner) && !already_tokened_this_round?(company.owner)
               @company = company
               return true

--- a/lib/engine/step/g_1846/assign.rb
+++ b/lib/engine/step/g_1846/assign.rb
@@ -46,13 +46,13 @@ module Engine
         end
 
         def steamboat_assignable_to_corp?
-          return false unless @steamboat.abilities(:assign_corporation)
+          return false unless @game.abilities(@steamboat, :assign_corporation)
 
           assignable_corporations(@steamboat).any?
         end
 
         def steamboat_assignable_to_hex?
-          return false unless @steamboat.abilities(:assign_hexes)
+          return false unless @game.abilities(@steamboat, :assign_hexes)
           return true if steamboat_assigned_corp
 
           steamboat_assignable_to_corp?
@@ -104,7 +104,7 @@ module Engine
         def process_pass(action)
           @game.game_error("Not #{action.entity.name}'s turn: #{action.to_h}") unless action.entity == @steamboat
 
-          if (ability = @steamboat.abilities(:assign_hexes))
+          if (ability = @game.abilities(@steamboat, :assign_hexes))
             ability.use!
             @log <<
               if (hex = steamboat_assigned_hex)
@@ -114,7 +114,7 @@ module Engine
               end
           end
 
-          if (ability = @steamboat.abilities(:assign_corporation))
+          if (ability = @game.abilities(@steamboat, :assign_corporation))
             ability.use!
             @log <<
               if (corp = steamboat_assigned_corp)

--- a/lib/engine/step/g_1848/dutch_auction.rb
+++ b/lib/engine/step/g_1848/dutch_auction.rb
@@ -123,7 +123,7 @@ module Engine
           @companies.delete(company)
           @log << "#{player.name} buys #{company.name} for #{@game.format_currency(price)}"
 
-          company.abilities(:share) do |ability|
+          @game.abilities(company, :share) do |ability|
             share = ability.share
 
             if share.president

--- a/lib/engine/step/g_1860/buy_cert.rb
+++ b/lib/engine/step/g_1860/buy_cert.rb
@@ -15,7 +15,7 @@ module Engine
         MIN_BID_RAISE = 5
 
         def setup
-          @companies = @game.companies.select { |c| c.abilities(:exchange) }.sort +
+          @companies = @game.companies.select { |c| @game.abilities(c, :exchange) }.sort +
             @game.corporations.select { |c| @game.corp_layer(c) == 1 }
           @bids = {}
           setup_auction

--- a/lib/engine/step/g_1860/exchange.rb
+++ b/lib/engine/step/g_1860/exchange.rb
@@ -43,7 +43,7 @@ module Engine
 
         def can_exchange?(entity, bundle = nil)
           return false unless entity.company?
-          return false unless (ability = entity.abilities(:exchange))
+          return false unless (ability = @game.abilities(entity, :exchange))
 
           owner = entity.owner
           return can_gain?(owner, bundle, exchange: true) if bundle

--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -47,7 +47,7 @@ module Engine
 
           @game.companies.each do |company|
             next if company.closed?
-            next unless (ability = company.abilities(:blocks_hexes))
+            next unless (ability = @game.abilities(company, :blocks_hexes))
 
             @game.game_error("#{hex.id} is blocked by #{company.name}") if ability.hexes.include?(hex.id)
           end
@@ -96,7 +96,7 @@ module Engine
             extra_cost += ability.cost
           end
 
-          entity.abilities(:teleport) do |ability, _|
+          @game.abilities(entity, :teleport) do |ability, _|
             ability.use! if ability.hexes.include?(hex.id) && ability.tiles.include?(tile.name)
           end
 

--- a/lib/engine/step/g_1882/special_nwr.rb
+++ b/lib/engine/step/g_1882/special_nwr.rb
@@ -152,11 +152,11 @@ module Engine
 
           case @state
           when nil
-            entity.abilities(:token)
+            @game.abilities(entity, :token)
           when :place_token
-            entity.abilities(:token)
+            @game.abilities(entity, :token)
           when :lay_tile
-            entity.abilities(:tile_lay, time: 'track')
+            @game.abilities(entity, :tile_lay, time: 'track')
           end
         end
       end

--- a/lib/engine/step/g_1889/special_track.rb
+++ b/lib/engine/step/g_1889/special_track.rb
@@ -13,7 +13,7 @@ module Engine
           return super unless action.entity == @company
 
           entity = action.entity
-          ability = @company.abilities(:tile_lay, time: 'sold')
+          ability = @game.abilities(@company, :tile_lay, time: 'sold')
           @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
 
           lay_tile(action, spender: @round.company_sellers[@company])

--- a/lib/engine/step/g_18_al/assign.rb
+++ b/lib/engine/step/g_18_al/assign.rb
@@ -12,7 +12,7 @@ module Engine
           @game.game_error("#{company.owner.name} owns no trains") if company.owner.trains.empty?
 
           target = action.target
-          hexes = company.abilities(:assign_hexes)&.hexes
+          hexes = @game.abilities(company, :assign_hexes)&.hexes
           location = @game.get_location_name(target.id)
           if !@game.loading && @game.graph.reachable_hexes(company.owner).find { |h, _| h.id == target.id }.nil?
             @game.game_error("#{location} is not reachable")

--- a/lib/engine/step/g_18_al/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_al/buy_sell_par_shares.rb
@@ -28,7 +28,7 @@ module Engine
 
         def route_bonus_ability
           @game.corporations.each do |corporation|
-            corporation.abilities(@game.route_bonuses.first) do |ability|
+            @game.abilities(corporation, @game.route_bonuses.first) do |ability|
               return ability
             end
           end
@@ -38,7 +38,7 @@ module Engine
 
         def president_changed(corporation)
           @game.route_bonuses.each do |type|
-            corporation.abilities(type) do |ability|
+            @game.abilities(corporation, type) do |ability|
               corporation.remove_ability(ability)
             end
           end

--- a/lib/engine/step/g_18_al/token.rb
+++ b/lib/engine/step/g_18_al/token.rb
@@ -9,7 +9,7 @@ module Engine
         def place_token(entity, city, token, teleport: false)
           super
 
-          entity.abilities(:assign_hexes) do |ability|
+          @game.abilities(entity, :assign_hexes) do |ability|
             next unless ability.hexes.one?
 
             if city.hex.name == ability.hexes.first

--- a/lib/engine/step/g_18_co/moving_bid_auction.rb
+++ b/lib/engine/step/g_18_co/moving_bid_auction.rb
@@ -151,7 +151,7 @@ module Engine
                   "with #{@bids[company].size > 1 ? 'a' : 'the only'} "\
                   "bid of #{@game.format_currency(price)}"
 
-          company.abilities(:shares) do |ability|
+          @game.abilities(company, :shares) do |ability|
             ability.shares.each do |share|
               if share.president
                 @round.companies_pending_par << company

--- a/lib/engine/step/g_18_ga/only_one_token_per_round.rb
+++ b/lib/engine/step/g_18_ga/only_one_token_per_round.rb
@@ -21,7 +21,8 @@ module Engine
 
         def remaining_token_ability?(entity)
           corporation = entity_corporation(entity)
-          return false if @game.p3_company.owner != corporation || !@game.p3_company.abilities(:token)&.count&.positive?
+          return false if @game.p3_company.owner != corporation ||
+                          !@game.abilities(@game.p3_company, :token)&.count&.positive?
 
           @game.waycross_hex.tile.cities.each do |c|
             return true if c.tokenable?(corporation, free: true)

--- a/lib/engine/step/g_18_ga/track.rb
+++ b/lib/engine/step/g_18_ga/track.rb
@@ -24,7 +24,7 @@ module Engine
 
         def remaining_tile_lay?(entity)
           can_lay_tile?(entity) ||
-          (@game.p2_company.owner == entity && @game.p2_company.abilities(:tile_lay)&.count&.positive?)
+          (@game.p2_company.owner == entity && @game.abilities(@game.p2_company, :tile_lay)&.count&.positive?)
         end
       end
     end

--- a/lib/engine/step/g_18_mex/track.rb
+++ b/lib/engine/step/g_18_mex/track.rb
@@ -44,7 +44,7 @@ module Engine
 
         def remaining_tile_lay?(entity)
           can_lay_tile?(entity) ||
-          (@game.p2_company.owner == entity && @game.p2_company.abilities(:tile_lay)&.count&.positive?)
+          (@game.p2_company.owner == entity && @game.abilities(@game.p2_company, :tile_lay)&.count&.positive?)
         end
 
         def lay_in_other_hex_of_double_hex(action)

--- a/lib/engine/step/g_18_ms/special_track.rb
+++ b/lib/engine/step/g_18_ms/special_track.rb
@@ -13,7 +13,7 @@ module Engine
           super
 
           # If private P2 was used once it cannot be used again
-          tile_lay = @game.p2_company.abilities(:tile_lay)
+          tile_lay = @game.abilities(@game.p2_company, :tile_lay)
           tile_lay.use! if tile_lay&.count == 1
         end
       end

--- a/lib/engine/step/g_18_ms/track.rb
+++ b/lib/engine/step/g_18_ms/track.rb
@@ -33,7 +33,7 @@ module Engine
           [@game.p1_company, @game.p2_company]
             .select { |p| p.owner == entity }
             .each do |p|
-              ability = p.abilities(:tile_lay)
+              ability = @game.abilities(p, :tile_lay)
               use_left += ability.count if ability
             end
 

--- a/lib/engine/step/g_18_tn/dividend.rb
+++ b/lib/engine/step/g_18_tn/dividend.rb
@@ -9,10 +9,8 @@ module Engine
         def process_dividend(action)
           super
 
-          abilities = action.entity.abilities(:civil_war)
-          return if !abilities || abilities.empty?
+          return unless (civil_war = @game.abilities(action.entity, :civil_war))
 
-          civil_war = abilities.first
           @log << "#{action.entity.name} resolves Civil War"
           civil_war.use!
         end
@@ -43,8 +41,8 @@ module Engine
 
         private
 
-        def civil_war_effect_with_single_train?(entity)
-          entity.trains.one? && entity.abilities(:civil_war)&.any?
+        def civil_war_effect_with_single_train?(corporation)
+          corporation.trains.one? && Array(@game.abilities(corporation, :civil_war)).any?
         end
       end
     end

--- a/lib/engine/step/g_18_tn/track.rb
+++ b/lib/engine/step/g_18_tn/track.rb
@@ -25,7 +25,7 @@ module Engine
 
         def remaining_tile_lay?(entity)
           can_lay_tile?(entity) ||
-          @game.companies.find { |c| c.owner == entity && c.abilities(:tile_lay)&.count&.positive? }
+          @game.companies.find { |c| c.owner == entity && @game.abilities(c, :tile_lay)&.count&.positive? }
         end
       end
     end

--- a/lib/engine/step/return_token.rb
+++ b/lib/engine/step/return_token.rb
@@ -89,7 +89,7 @@ module Engine
       def ability(entity)
         return unless entity&.company?
 
-        entity.abilities(:return_token)
+        @game.abilities(entity, :return_token)
       end
     end
   end

--- a/lib/engine/step/special_buy_train.rb
+++ b/lib/engine/step/special_buy_train.rb
@@ -42,7 +42,7 @@ module Engine
       def ability(entity)
         return unless entity.company?
 
-        entity.abilities(:train_discount, time: 'train')
+        @game.abilities(entity, :train_discount, time: 'train')
       end
     end
   end

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -51,7 +51,7 @@ module Engine
       def ability(entity)
         return unless entity&.company?
 
-        entity.abilities(:token)
+        @game.abilities(entity, :token)
       end
     end
   end

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -71,9 +71,9 @@ module Engine
       def tile_lay_abilities(entity, &block)
         return unless entity&.company?
 
-        ability = entity.abilities(:tile_lay, time: 'sold', &block) if @round.respond_to?(:just_sold_company) &&
+        ability = @game.abilities(entity, :tile_lay, time: 'sold', &block) if @round.respond_to?(:just_sold_company) &&
           entity == @round.just_sold_company
-        ability || entity.abilities(:tile_lay, time: 'track', &block)
+        ability || @game.abilities(entity, :tile_lay, time: 'track', &block)
       end
 
       def check_connect(_action, ability)

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -68,7 +68,7 @@ module Engine
 
         prices = tokens.map(&:price)
 
-        token.corporation.abilities(:token) do |ability, _|
+        @game.abilities(token.corporation, :token) do |ability, _|
           prices << ability.price(token)
           prices << ability.teleport_price
         end
@@ -82,7 +82,7 @@ module Engine
           return [token, teleport]
         end
 
-        entity.abilities(:token) do |ability, _|
+        @game.abilities(entity, :token) do |ability, _|
           next if ability.special_only && ability != special_ability
           next if ability.hexes.any? && !ability.hexes.include?(hex.id)
           next if ability.city && ability.city != city.index

--- a/lib/engine/step/track_and_token.rb
+++ b/lib/engine/step/track_and_token.rb
@@ -44,7 +44,7 @@ module Engine
       def can_lay_tile?(entity)
         free = false
 
-        entity.abilities(:tile_lay) do |ability|
+        @game.abilities(entity, :tile_lay) do |ability|
           ability.hexes.each do |hex_id|
             free = true if ability.free && @game.hex_by_id(hex_id).tile.preprinted
           end

--- a/lib/engine/step/track_lay_when_company_sold.rb
+++ b/lib/engine/step/track_lay_when_company_sold.rb
@@ -11,7 +11,7 @@ module Engine
       def actions(entity)
         return super unless blocking_for_sold_company?
 
-        @company.abilities(:tile_lay, time: 'sold').blocks ? ACTIONS : ACTIONS_WITH_PASS
+        @game.abilities(@company, :tile_lay, time: 'sold').blocks ? ACTIONS : ACTIONS_WITH_PASS
       end
 
       def blocking?
@@ -22,7 +22,7 @@ module Engine
         return super unless action.entity == @company
 
         entity = action.entity
-        ability = @company.abilities(:tile_lay, time: 'sold')
+        ability = @game.abilities(@company, :tile_lay, time: 'sold')
         @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
 
         lay_tile(action, spender: entity.owner)
@@ -34,7 +34,7 @@ module Engine
 
       def process_pass(action)
         entity = action.entity
-        ability = @company.abilities(:tile_lay, time: 'sold')
+        ability = @game.abilities(@company, :tile_lay, time: 'sold')
         @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
 
         @company.remove_ability(ability)
@@ -48,7 +48,7 @@ module Engine
         @company = nil
         just_sold_company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
 
-        if just_sold_company&.abilities(:tile_lay, time: 'sold')
+        if @game.abilities(just_sold_company, :tile_lay, time: 'sold')
           @company = just_sold_company
           return true
         end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -39,7 +39,7 @@ module Engine
       end
 
       def tile_lay_abilities(entity, &block)
-        entity.abilities(:tile_lay, &block)
+        @game.abilities(entity, :tile_lay, &block)
       end
 
       def lay_tile(action, extra_cost: 0, entity: nil, spender: nil)
@@ -52,7 +52,7 @@ module Engine
 
         @game.companies.each do |company|
           next if company.closed?
-          next unless (ability = company.abilities(:blocks_hexes))
+          next unless (ability = @game.abilities(company, :blocks_hexes))
 
           @game.game_error("#{hex.id} is blocked by #{company.name}") if ability.hexes.include?(hex.id)
         end
@@ -90,7 +90,7 @@ module Engine
           extra_cost += ability.cost
         end
 
-        entity.abilities(:teleport) do |ability, _|
+        @game.abilities(entity, :teleport) do |ability, _|
           next if !ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name)
 
           teleport = true

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -183,7 +183,7 @@ module Engine
       private
 
       def face_value_ability?(entity)
-        entity.abilities(:train_buy) { |ability| return ability.face_value }
+        @game.abilities(entity, :train_buy) { |ability| return ability.face_value }
         false
       end
     end

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -189,7 +189,7 @@ module Engine
             "with a bid of #{@game.format_currency(price)}"
         end
 
-        company.abilities(:shares) do |ability|
+        @game.abilities(company, :shares) do |ability|
           ability.shares.each do |share|
             if share.president
               @round.companies_pending_par << company

--- a/spec/lib/engine/round/stock_spec.rb
+++ b/spec/lib/engine/round/stock_spec.rb
@@ -147,7 +147,7 @@ module Engine
       let(:game) { Game::G18Chesapeake.new(%w[a b]) }
       it '30% presidency, remove share from share pool, allow dumping' do
         bo = game.corporation_by_id('B&O')
-        cv = game.cornelius.abilities(:shares).shares.first.corporation
+        cv = game.abilities(game.cornelius, :shares).shares.first.corporation
         corp = game.corporations.find { |c| ![bo, cv].include?(c) }
 
         player_0.cash = 10_000


### PR DESCRIPTION
Changes:
* find an entity's abilities via `@game.abilities(entity, ...)` instead of `entity.abilities(...)`
  * on current master, there are only a few instances where the `abilities()` caller does not have access to a `@game`, and in those cases it happens to work fine to use `all_abilities`; d2fa7d2fa6c425da68436034ce1ec5cddd9fb1e0
* `corporation.abilities(...)` always returned an Array of abilities, but the new `@game.abilities(entity, ...)` matches the interface for companies; that is, if there are no abilities, `nil` is returned; if there is exactly one, that one ability is returned; if there are more than one, then the Array is returned (code that expected the Array has been updated in ab6492fcc6b36dac6338fdb4795c130adf6702cf)
* `Corporation` and `Minor` no longer need their own overrides for `abilities()`
* the private methods from the `Abilities` module that `abilities()` called have moved to private methods in `Game::Base`, with `ability_` prepended to their names

Putting `abilities()` in the `Game` class will allow for more precise control of the timing of when private companies can and cannot be used, as the code in `abilities()` will have access to the whole game state. This will be very helpful in addressing issues like the ones I've labeled with [ability timing](https://github.com/tobymao/18xx/issues?q=is%3Aopen+is%3Aissue+label%3A%22ability+timing%22), but I didn't want to pile any of those fixes on top of this change.

The tests are all passing (and a few test failures along the way did help me catch bugs in my refactor), and last night I validated against an entire DB backup and there were no issues.

-----
Probably easier to look at the diff one commit at a time instead of all at once; the earliest commits are the most interesting, the last one touches many files but has only very simple changes in it--basically swapping the order of arguments for `abilities()`.