### PR TITLE
Enhancement: "Nil" border rendering

### DIFF
--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -12,6 +12,15 @@ module Lib
 
     POINTS = "#{X_R},#{Y_M} #{X_M_R},#{Y_B} #{X_M_L},#{Y_B} #{X_L},#{Y_M} #{X_M_L},#{Y_T} #{X_M_R},#{Y_T}"
 
+    EDGE_PATHS = [
+      "M #{X_M_R},#{Y_B} H #{X_M_L}",
+      "M #{X_M_L},#{Y_B} L #{X_L}, #{Y_M}",
+      "M #{X_L},#{Y_M} #{X_M_L},#{Y_T}",
+      "M #{X_M_L},#{Y_T} H #{X_M_R}",
+      "M #{X_M_R},#{Y_T} L #{X_R},#{Y_M}",
+      "M #{X_R},#{Y_M} L #{X_M_R}, #{Y_B}",
+    ].freeze
+
     COLOR = {
       white: '#EAE0C8',
       yellow: '#fde900',

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -45,7 +45,7 @@ module View
           else
             @hex.tile
           end
-        children = [h(:polygon, attrs: { points: Lib::Hex::POINTS })]
+        children = hex_outline
         if @tile
           children << h(
             Tile,
@@ -73,6 +73,24 @@ module View
         props[:on] = { click: ->(e) { on_hex_click(e) } }
         props[:attrs]['stroke-width'] = 5 if @selected
         h(:g, props, children)
+      end
+
+      def hex_outline
+        polygon_props = { attrs: { points: Lib::Hex::POINTS } }
+
+        invisible_edges = @tile.borders.select { |b| b.type.nil? }.map(&:edge) if @tile
+        if invisible_edges&.any?
+          polygon_props[:attrs][:stroke] = 'none'
+          shapes = [h(:polygon, polygon_props)]
+
+          (Engine::Tile::ALL_EDGES - invisible_edges).each do |edge|
+            shapes << h(:path, attrs: { d: Lib::Hex::EDGE_PATHS[edge] })
+          end
+
+          shapes
+        else
+          [h(:polygon, polygon_props)]
+        end
       end
 
       def translation

--- a/assets/app/view/game/part/borders.rb
+++ b/assets/app/view/game/part/borders.rb
@@ -58,8 +58,6 @@ module View
         def color(border)
           color =
             case border.type
-            when nil
-              @tile.color
             when :mountain
               :brown
             when :water
@@ -106,6 +104,8 @@ module View
           children = []
 
           @tile.borders.each do |border|
+            next unless border.type
+
             children << h(:line, attrs: {
               **EDGES[border.edge],
               stroke: color(border),

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -55,7 +55,7 @@ module View
         children << render_tile_part(Part::Cities, show_revenue: !render_revenue) if @tile.cities.any?
         children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
 
-        borders = render_tile_part(Part::Borders) if @tile.borders.any?
+        borders = render_tile_part(Part::Borders) if @tile.borders.any?(&:type)
         # OO tiles have different rules...
         rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && @tile.cities.size > 1
 

--- a/lib/engine/config/game/g_1817_na.rb
+++ b/lib/engine/config/game/g_1817_na.rb
@@ -686,11 +686,15 @@ module Engine
       "offboard=revenue:yellow_0,visit_cost:99;path=a:3,b:_0": [
         "I17",
         "C1",
-        "F8",
-        "I9",
+        "F8"
+      ],
+      "offboard=revenue:yellow_0,visit_cost:99;path=a:3,b:_0;border=edge:4": [
+        "I9"
+      ],
+      "offboard=revenue:yellow_0,visit_cost:99;path=a:3,b:_0;border=edge:2": [
         "J12"
       ],
-      "offboard=revenue:yellow_0,visit_cost:99;path=a:2,b:_0;offboard=revenue:yellow_0,visit_cost:99;path=a:4,b:_0": [
+      "offboard=revenue:yellow_0,visit_cost:99;path=a:2,b:_0;offboard=revenue:yellow_0,visit_cost:99;path=a:4,b:_0;border=edge:1;border=edge:5": [
         "I11"
       ],
       "offboard=revenue:yellow_0,visit_cost:99;path=a:5,b:_0": [

--- a/lib/engine/config/game/g_1828.rb
+++ b/lib/engine/config/game/g_1828.rb
@@ -1309,10 +1309,10 @@ module Engine
             "offboard=revenue:60;path=a:4,b:_0": [
                 "A3"
             ],
-            "offboard=revenue:yellow_30|brown_50,groups:Canada;path=a:4,b:5": [
+            "offboard=revenue:yellow_30|brown_50,groups:Canada;path=a:4,b:5;border=edge:4": [
                 "A13"
             ],
-            "city=revenue:yellow_30|brown_50,groups:Canada;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;path=a:5,b:_0,terminal:1": [
+            "city=revenue:yellow_30|brown_50,groups:Canada;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;path=a:5,b:_0,terminal:1;border=edge:1": [
                 "A15"
             ],
             "offboard=revenue:yellow_20|brown_30;path=a:0,b:_0;path=a:1,b:_0": [

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -701,13 +701,13 @@ module Engine
       ]
     },
     "gray": {
-      "city=revenue:40;path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_0;path=a:5,b:_0": [
+      "city=revenue:40;path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_0;path=a:5,b:_0;border=edge:1;border=edge:4": [
         "D2"
       ],
-      "path=a:0,b:4": [
+      "path=a:0,b:4;border=edge:4": [
         "C3"
       ],
-      "path=a:1,b:5": [
+      "path=a:1,b:5;border=edge:1": [
         "E1"
       ],
       "path=a:0,b:5": [

--- a/lib/engine/config/game/g_1882.rb
+++ b/lib/engine/config/game/g_1882.rb
@@ -643,16 +643,16 @@ module Engine
       "city=revenue:30;path=a:2,b:_0;path=a:_0,b:4": [
         "N6"
       ],
-      "path=a:0,b:1": [
+      "path=a:0,b:1;border=edge:5": [
         "C7"
       ],
-      "city=revenue:30;path=a:0,b:_0;path=a:1,b:_0;border=edge:0,type:water,cost:40": [
+      "city=revenue:30;path=a:0,b:_0;path=a:1,b:_0;border=edge:0,type:water,cost:40;border=edge:2;border=edge:4": [
         "D8"
       ],
       "path=a:3,b:4": [
         "N8"
       ],
-      "town=revenue:10;path=a:0,b:_0;path=a:_0,b:4;border=edge:0,type:water,cost:20": [
+      "town=revenue:10;path=a:0,b:_0;path=a:_0,b:4;border=edge:0,type:water,cost:20;border=edge:1": [
         "C9"
       ],
       "path=a:2,b:4": [

--- a/lib/engine/config/game/g_18_mex.rb
+++ b/lib/engine/config/game/g_18_mex.rb
@@ -112,12 +112,12 @@ module Engine
       "479MC":{
          "count":1,
          "color":"green",
-         "code":"city=revenue:40,slots:2,loc:center;town=revenue:0,loc:2.5;path=a:3,b:_0;path=a:5,b:_0;label=MC"
+         "code":"city=revenue:40,slots:2,loc:center;town=revenue:0,loc:2.5;path=a:3,b:_0;path=a:5,b:_0;label=MC;border=edge:5"
       },
       "479P":{
          "count":1,
          "color":"green",
-         "code":"town=revenue:10;path=a:2,b:_0;path=a:_0,b:5;upgrade=cost:40,terrain:mountain;label=P"
+         "code":"town=revenue:10;path=a:2,b:_0;path=a:_0,b:5;upgrade=cost:40,terrain:mountain;label=P;border=edge:2"
       },
       "480":1,
       "481":1,
@@ -137,12 +137,12 @@ module Engine
       "486MC":{
          "count":1,
          "color":"brown",
-         "code":"city=revenue:50,slots:4,loc:center;town=revenue:10,loc:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:2,b:_1;path=a:5,b:_0,lanes:2;path=a:_1,b:_0;label=MC"
+         "code":"city=revenue:50,slots:4,loc:center;town=revenue:10,loc:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:2,b:_1;path=a:5,b:_0,lanes:2;path=a:_1,b:_0;label=MC;border=edge:5"
       },
       "486P":{
          "count":1,
          "color":"brown",
-         "code":"town=revenue:10;path=a:2,b:_0,a_lane:2.1;path=a:5,b:_0;path=a:2,b:4,a_lane:2.0;label=P"
+         "code":"town=revenue:10;path=a:2,b:_0,a_lane:2.1;path=a:5,b:_0;path=a:2,b:4,a_lane:2.0;label=P;border=edge:2"
       },
       "619":2
    },
@@ -854,10 +854,10 @@ module Engine
          "city=revenue:20;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0":[
             "E6"
          ],
-         "city=revenue:20,loc:center;town=revenue:0,loc:2;path=a:3,b:_0;path=a:5,b:_0;border=edge:4,type:impassable;label=MC":[
+         "city=revenue:20,loc:center;town=revenue:0,loc:2;path=a:3,b:_0;path=a:5,b:_0;border=edge:4,type:impassable;label=MC;border=edge:5":[
             "O10"
          ],
-         "town=revenue:10;path=a:2,b:_0;path=a:_0,b:5;upgrade=cost:60,terrain:mountain;border=edge:0,type:impassable;border=edge:1,type:impassable;border=edge:3,type:impassable;label=P":[
+         "town=revenue:10;path=a:2,b:_0;path=a:_0,b:5;upgrade=cost:60,terrain:mountain;border=edge:0,type:impassable;border=edge:1,type:impassable;border=edge:3,type:impassable;label=P;border=edge:2":[
             "P11"
          ],
          "path=a:1,b:4;upgrade=cost:60,terrain:mountain":[

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -494,25 +494,25 @@ module Engine
          "offboard=revenue:yellow_30|brown_50;path=a:1,b:_0":[
             "H10"
          ],
-         "city=revenue:yellow_40|brown_50;path=a:5,b:_0;path=a:4,b:_0":[
+         "city=revenue:yellow_40|brown_50;path=a:5,b:_0;path=a:4,b:_0;border=edge:4":[
             "A1"
          ],
          "city=revenue:yellow_50|brown_80,loc:center;town=revenue:10,loc:5.5;path=a:3,b:_0;path=a:_1,b:_0;icon=image:18_ms/coins":[
             "I1"
          ],
-         "path=a:1,b:5":[
+         "path=a:1,b:5;border=edge:1":[
             "A3"
          ],
-         "path=a:0,b:5":[
+         "path=a:0,b:5;border=edge:5":[
             "D12"
          ],
-         "path=a:0,b:4;path=a:1,b:4;path=a:2,b:4":[
+         "path=a:0,b:4;path=a:1,b:4;path=a:2,b:4;border=edge:0;border=edge:2;border=edge:4":[
             "E13"
          ],
-         "path=a:2,b:3":[
+         "path=a:2,b:3;border=edge:3":[
             "F12"
          ],
-         "offboard=revenue:yellow_40|brown_50;path=a:1,b:_0":[
+         "offboard=revenue:yellow_40|brown_50;path=a:1,b:_0;border=edge:1":[
             "E15"
          ]
       },


### PR DESCRIPTION
When a hex/tile has a border with no defined type, don't render a border element on top of it; instead, remove the "stroke" from the hex `<polygon>` and draw a partial outline with `<path>` elements. Drastically improves rendering of 18MEX's Mexico City double-tile, and somewhat improves rendering of paired offboards when opacity is low.

It's not perfect, there seems to still be either a slight seam or overlap that is visible, depending on the orientation of the two tiles being rendered. For instance, see the two different offboard pairs in the 1846 "after" screenshot; the lower one has a visible line that isn't present on the higher one

## Before

![MC yellow before](https://user-images.githubusercontent.com/1045173/101233369-c63ea580-3675-11eb-9699-fdedb0b8b0c1.png)
![MC green before](https://user-images.githubusercontent.com/1045173/101233371-c9399600-3675-11eb-9383-aa090cd7418b.png)
![MC brown before](https://user-images.githubusercontent.com/1045173/101233372-cb035980-3675-11eb-9d31-4f6c57e30f56.png)
![1846 low opacity before](https://user-images.githubusercontent.com/1045173/101233377-d0f93a80-3675-11eb-82e7-52da0c4c925c.png)

## After

![MC yellow after](https://user-images.githubusercontent.com/1045173/101233400-f7b77100-3675-11eb-9b4d-b4abed8d0d69.png)
![MC green after](https://user-images.githubusercontent.com/1045173/101233405-fab26180-3675-11eb-89d2-345439208b4f.png)
![MC brown after](https://user-images.githubusercontent.com/1045173/101233407-fd14bb80-3675-11eb-84e0-966bd92d31c0.png)
![1846 low opacity after](https://user-images.githubusercontent.com/1045173/101233408-02720600-3676-11eb-8a31-cb3d3e43fc01.png)



