### PR TITLE
18CO Add Discarded Train Discount

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -162,6 +162,7 @@ module View
             price = variant[:price]
             president_assist, _fee = @game.president_assisted_buy(@corporation, train, price)
             price = @ability&.discounted_price(train, price) || price
+            price = @game.apply_discard_discount(train, price)
 
             buy_train = lambda do
               process_action(Engine::Action::BuyTrain.new(

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -162,7 +162,7 @@ module View
             price = variant[:price]
             president_assist, _fee = @game.president_assisted_buy(@corporation, train, price)
             price = @ability&.discounted_price(train, price) || price
-            price = @game.apply_discard_discount(train, price)
+            price = @game.discard_discount(train, price)
 
             buy_train = lambda do
               process_action(Engine::Action::BuyTrain.new(

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -764,11 +764,11 @@ module Engine
            (self.class::MUST_BUY_TRAIN == :route && @graph.route_info(entity)&.dig(:route_train_purchase)))
       end
 
-      def apply_discard_discount(train, price)
-        return price unless DISCARDED_TRAIN_DISCOUNT
+      def discard_discount(train, price)
+        return price unless self.class::DISCARDED_TRAIN_DISCOUNT
         return price unless @depot.discarded.include?(train)
 
-        (price * (100 - DISCARDED_TRAIN_DISCOUNT) / 100).ceil
+        (price * (100.0 - self.class::DISCARDED_TRAIN_DISCOUNT.to_f) / 100.0).ceil.to_i
       end
 
       def end_game!

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -172,6 +172,7 @@ module Engine
       HOME_TOKEN_TIMING = :operate
 
       DISCARDED_TRAINS = :discard # discarded or removed?
+      DISCARDED_TRAIN_DISCOUNT = 0 # percent
       CLOSED_CORP_TRAINS = :removed # discarded or removed?
 
       MUST_BUY_TRAIN = :route # When must the company buy a train if it doesn't have one (route, never, always)
@@ -761,6 +762,13 @@ module Engine
           depot.depot_trains.any? &&
           (self.class::MUST_BUY_TRAIN == :always ||
            (self.class::MUST_BUY_TRAIN == :route && @graph.route_info(entity)&.dig(:route_train_purchase)))
+      end
+
+      def apply_discard_discount(train, price)
+        return price unless DISCARDED_TRAIN_DISCOUNT
+        return price unless @depot.discarded.include?(train)
+
+        (price * (100 - DISCARDED_TRAIN_DISCOUNT) / 100).ceil
       end
 
       def end_game!

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -34,6 +34,7 @@ module Engine
 
       CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY = true
       CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
+      DISCARDED_TRAIN_DISCOUNT = 50
 
       # Two tiles can be laid, only one upgrade
       # TODO: This changes in phase E to a single tile lay


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836

Trains in the Market ( from discards ) are purchased at 50% face value.

Normal price of the 3 was 180. With discount its 90.
<img width="406" alt="Screen Shot 2020-12-05 at 11 47 58 AM" src="https://user-images.githubusercontent.com/15675400/101260822-c4192d00-36ef-11eb-9c57-277c3fbb4ff2.png">

### Implementation Notes

Since the final price is calculated in the view itself, I couldn't figure out a good way to make this 18CO specific. The calculation seemed straightforward enough to roll into the base, though.