### PR TITLE
Fix: Missing Base May_Reduce

### DIFF
--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -70,6 +70,10 @@ module Engine
         raise NotImplementedError
       end
 
+      def may_reduce?(_company)
+        false
+      end
+
       protected
 
       def auctioning


### PR DESCRIPTION
Dutch Auctions allow for reducing bids. In the view, the Auction is checked for if a bid can be reduced, but this check is missing for other auction types.