### PR TITLE
18CO Moving Bid Auction

### DIFF
--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -13,7 +13,7 @@ module View
       ABILITIES = %i[tile_lay teleport assign_hexes assign_corporation token exchange].freeze
 
       def render
-        companies = @game.companies.select { |company| !company.closed? && actions_for(company).any? }
+        companies = @game.companies.select { |company| !company.closed? && actions_for(company).any? && company.owner }
         return h(:div) if companies.empty? || @game.round.current_entity.company?
 
         current, others = companies.partition { |company| @game.current_entity.player == company.player }

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -187,25 +187,25 @@ module View
           moveable_bids = @step.moveable_bids(@current_entity, company)
           return [] if moveable_bids.empty?
 
-          moveable_bids.map do |old_company, old_bids|
-            old_bids.map do |old_bid|
+          moveable_bids.flat_map do |from_company, from_bids|
+            from_bids.map do |from_bid|
               move_bid = lambda do
                 hide!
                 price = input.JS['elm'].JS['value'].to_i
                 process_action(Engine::Action::MoveBid.new(
                   @current_entity,
                   company: company,
-                  old_company: old_company,
+                  from_company: from_company,
                   price: price,
-                  old_price: old_bid.price,
+                  from_price: from_bid.price,
                 ))
                 store(:selected_company, nil, skip: true)
               end
 
               h(:button, { on: { click: move_bid } },
-                "Move #{old_company.sym} #{@game.format_currency(old_bid.price)} Bid")
+                "Move #{from_company.sym} #{@game.format_currency(from_bid.price)} Bid")
             end
-          end.flatten
+          end
         end
 
         def render_turn_bid

--- a/lib/engine/action/move_bid.rb
+++ b/lib/engine/action/move_bid.rb
@@ -5,24 +5,24 @@ require_relative 'base'
 module Engine
   module Action
     class MoveBid < Base
-      attr_reader :company, :corporation, :price, :old_company, :old_price
+      attr_reader :company, :corporation, :price, :from_company, :from_price
 
-      def initialize(entity, price:, company: nil, corporation: nil, old_company:, old_price:)
+      def initialize(entity, price:, company: nil, corporation: nil, from_company:, from_price:)
         @entity = entity
         @company = company
         @corporation = corporation
         @price = price
-        @old_company = old_company
-        @old_price = old_price
+        @from_company = from_company
+        @from_price = from_price
       end
 
       def self.h_to_args(h, game)
         {
           company: game.company_by_id(h['company']),
           corporation: game.corporation_by_id(h['corporation']),
-          old_company: game.company_by_id(h['old_company']),
+          from_company: game.company_by_id(h['from_company']),
           price: h['price'],
-          old_price: h['old_price'],
+          from_price: h['from_price'],
         }
       end
 
@@ -31,8 +31,8 @@ module Engine
           'company' => @company&.id,
           'corporation' => @corporation&.id,
           'price' => @price,
-          'old_company' => @old_company&.id,
-          'old_price' => @old_price,
+          'from_company' => @from_company&.id,
+          'from_price' => @from_price,
         }
       end
     end

--- a/lib/engine/action/move_bid.rb
+++ b/lib/engine/action/move_bid.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class MoveBid < Base
+      attr_reader :company, :corporation, :price, :old_company, :old_price
+
+      def initialize(entity, price:, company: nil, corporation: nil, old_company:, old_price:)
+        @entity = entity
+        @company = company
+        @corporation = corporation
+        @price = price
+        @old_company = old_company
+        @old_price = old_price
+      end
+
+      def self.h_to_args(h, game)
+        {
+          company: game.company_by_id(h['company']),
+          corporation: game.corporation_by_id(h['corporation']),
+          old_company: game.company_by_id(h['old_company']),
+          price: h['price'],
+          old_price: h['old_price'],
+        }
+      end
+
+      def args_to_h
+        {
+          'company' => @company&.id,
+          'corporation' => @corporation&.id,
+          'price' => @price,
+          'old_company' => @old_company&.id,
+          'old_price' => @old_price,
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -31,6 +31,8 @@ module Engine
 
       SELL_BUY_ORDER = :sell_buy
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = true
+      MUST_BID_INCREMENT_MULTIPLE = true
+      ONLY_HIGHEST_BID_COMMITTED = false
 
       CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY = true
       CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
@@ -188,7 +190,7 @@ module Engine
       def new_auction_round
         Round::Auction.new(self, [
           Step::G18CO::CompanyPendingPar,
-          Step::WaterfallAuction,
+          Step::G18CO::MovingBidAuction,
         ])
       end
 

--- a/lib/engine/step/g_18_co/moving_bid_auction.rb
+++ b/lib/engine/step/g_18_co/moving_bid_auction.rb
@@ -66,7 +66,8 @@ module Engine
           return unless company
 
           high_bid = highest_bid(company)
-          (high_bid ? high_bid.price + min_increment : company.min_bid)
+
+          high_bid ? high_bid.price + min_increment : company.min_bid
         end
 
         # can never purchase directly
@@ -81,8 +82,14 @@ module Engine
           bids.sum(&:price)
         end
 
+        def highest_player_bid(player, company)
+          return unless (company_bids = @bids[company])
+
+          company_bids&.select { |b| b.entity == player }&.max(&:price)
+        end
+
         def current_bid_amount(player, company)
-          @bids[company]&.select { |b| b.entity == player }&.sort(&:price)&.last&.price || 0
+          highest_player_bid(player, company)&.price || 0
         end
 
         def max_bid(player, company)
@@ -167,8 +174,8 @@ module Engine
           end
 
           bids = @bids[company]
-          highest_player_bid = bids.sort(&:price).reverse.find { |b| b.entity == entity }
-          bids.delete(highest_player_bid) if highest_player_bid
+          player_bid = highest_player_bid(entity, company)
+          bids.delete(player_bid) if player_bid
           bids << bid
 
           @log << "#{entity.name} bids #{@game.format_currency(price)} for #{bid.company.name}"
@@ -177,9 +184,9 @@ module Engine
         def move_bid(bid)
           entity = bid.entity
           company = bid.company
-          old_company = bid.old_company
+          from_company = bid.from_company
           price = bid.price
-          old_price = bid.old_price
+          from_price = bid.from_price
           min = min_bid(company)
 
           @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{company.name}") if price < min
@@ -190,24 +197,24 @@ module Engine
             @game.game_error("Cannot afford bid. Maximum possible bid is
               #{@game.format_currency(max_bid(entity, company))}")
           end
-          if price < (old_price + min_increment)
+          if price < from_price + min_increment
             @game.game_error("Bid movement must increase original bid by a multiple of
               #{@game.format_currency(min_increment)}")
           end
 
-          @bids[old_company].reject! { |b| b.entity == entity && b.price == old_price }
+          @bids[from_company].reject! { |b| b.entity == entity && b.price == from_price }
 
           bids = @bids[company]
           bids << bid
 
-          @log << "#{entity.name} moves #{@game.format_currency(old_price)} bid from
-            #{old_company.name} to bid #{@game.format_currency(price)} for #{bid.company.name}"
+          @log << "#{entity.name} moves #{@game.format_currency(from_price)} bid from
+            #{from_company.name} to bid #{@game.format_currency(price)} for #{bid.company.name}"
         end
 
         def bids_for_player(player)
-          @bids.values.map do |bids|
-            bids.select { |bid| bid.entity == player }
-          end.flatten.compact
+          @bids.values.flat_map do |company_bids|
+            company_bids.select { |bid| bid.entity == player }
+          end
         end
       end
     end

--- a/lib/engine/step/g_18_co/moving_bid_auction.rb
+++ b/lib/engine/step/g_18_co/moving_bid_auction.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../auctioner'
+
+module Engine
+  module Step
+    module G18CO
+      class MovingBidAuction < Base
+        include Auctioner
+        ACTIONS = %w[bid move_bid pass].freeze
+
+        attr_reader :companies
+
+        def description
+          'Moving Bid Auction for Companies'
+        end
+
+        def available
+          @companies
+        end
+
+        def process_pass(action)
+          entity = action.entity
+          @log << "#{entity.name} passes bidding"
+          entity.pass!
+          all_passed! if entities.all?(&:passed?)
+          @round.next_entity_index!
+        end
+
+        def process_bid(action)
+          add_bid(action)
+          action.entity.unpass!
+          @round.next_entity_index!
+        end
+
+        def process_move_bid(action)
+          move_bid(action)
+          action.entity.unpass!
+          @round.next_entity_index!
+        end
+
+        def actions(_entity)
+          return [] if entities.all?(&:passed?)
+
+          ACTIONS
+        end
+
+        def setup
+          setup_auction
+          @companies = @game.companies.sort_by(&:value)
+        end
+
+        def round_state
+          {
+            companies_pending_par: [],
+          }
+        end
+
+        def auctioning
+          nil
+        end
+
+        # min bid is face value or $5 higher than previous bid
+        def min_bid(company)
+          return unless company
+
+          high_bid = highest_bid(company)
+          (high_bid ? high_bid.price + min_increment : company.min_bid)
+        end
+
+        # can never purchase directly
+        def may_purchase?(_company)
+          false
+        end
+
+        def committed_cash(player, _show_hidden = false)
+          bids = bids_for_player(player)
+          return 0 if bids.empty?
+
+          bids.sum(&:price)
+        end
+
+        def current_bid_amount(player, company)
+          @bids[company]&.select { |b| b.entity == player }&.sort(&:price)&.last&.price || 0
+        end
+
+        def max_bid(player, company)
+          player.cash - committed_cash(player) + current_bid_amount(player, company)
+        end
+
+        def moveable_bids(player, company)
+          @bids.map do |cmp, company_bids|
+            next if cmp == company
+
+            player_bids = company_bids.select { |bid| bid.entity == player }
+            next if player_bids.empty?
+
+            [cmp, player_bids]
+          end.compact.to_h
+        end
+
+        protected
+
+        # every company is always up for auction
+        def can_auction?(_company)
+          true
+        end
+
+        def all_passed!
+          @bids.each do |company, bids|
+            resolve_bids_for_company(company, bids)
+          end
+        end
+
+        def resolve_bids_for_company(company, bids)
+          return if bids.empty?
+
+          # Companies without bids can be bought be corporations later
+          # Unsure how that will be accomplished at this time
+          high_bid = highest_bid(company)
+          buy_company(high_bid.entity, company, high_bid.price)
+        end
+
+        def buy_company(player, company, price)
+          company.owner = player
+          player.companies << company
+          player.spend(price, @game.bank) if price.positive?
+          @companies.delete(company)
+
+          @log << "#{player.name} wins the auction for #{company.name} "\
+                  "with #{@bids[company].size > 1 ? 'a' : 'the only'} "\
+                  "bid of #{@game.format_currency(price)}"
+
+          company.abilities(:shares) do |ability|
+            ability.shares.each do |share|
+              if share.president
+                @round.companies_pending_par << company
+              else
+                @game.share_pool.buy_shares(player, share, exchange: :free)
+              end
+            end
+          end
+        end
+
+        def accept_bid(bid)
+          price = bid.price
+          company = bid.company
+          player = bid.entity
+          @bids.delete(company)
+          buy_company(player, company, price)
+        end
+
+        def add_bid(bid)
+          company = bid.company || bid.corporation
+          entity = bid.entity
+          price = bid.price
+          min = min_bid(company)
+
+          @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{company.name}") if price < min
+          if @game.class::MUST_BID_INCREMENT_MULTIPLE && ((price - min) % min_increment).nonzero?
+            @game.game_error("Must increase bid by a multiple of #{@game.format_currency(min_increment)}")
+          end
+          if price > max_bid(entity, company)
+            @game.game_error("Cannot afford bid. Maximum possible bid is
+              #{@game.format_currency(max_bid(entity, company))}")
+          end
+
+          bids = @bids[company]
+          highest_player_bid = bids.sort(&:price).reverse.find { |b| b.entity == entity }
+          bids.delete(highest_player_bid) if highest_player_bid
+          bids << bid
+
+          @log << "#{entity.name} bids #{@game.format_currency(price)} for #{bid.company.name}"
+        end
+
+        def move_bid(bid)
+          entity = bid.entity
+          company = bid.company
+          old_company = bid.old_company
+          price = bid.price
+          old_price = bid.old_price
+          min = min_bid(company)
+
+          @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{company.name}") if price < min
+          if @game.class::MUST_BID_INCREMENT_MULTIPLE && ((price - min) % min_increment).nonzero?
+            @game.game_error("Must increase bid by a multiple of #{@game.format_currency(min_increment)}")
+          end
+          if price > max_bid(entity, company)
+            @game.game_error("Cannot afford bid. Maximum possible bid is
+              #{@game.format_currency(max_bid(entity, company))}")
+          end
+          if price < (old_price + min_increment)
+            @game.game_error("Bid movement must increase original bid by a multiple of
+              #{@game.format_currency(min_increment)}")
+          end
+
+          @bids[old_company].reject! { |b| b.entity == entity && b.price == old_price }
+
+          bids = @bids[company]
+          bids << bid
+
+          @log << "#{entity.name} moves #{@game.format_currency(old_price)} bid from
+            #{old_company.name} to bid #{@game.format_currency(price)} for #{bid.company.name}"
+        end
+
+        def bids_for_player(player)
+          @bids.values.map do |bids|
+            bids.select { |bid| bid.entity == player }
+          end.flatten.compact
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Background

From https://github.com/tobymao/18xx/issues/1836

18CO does not use a waterfall style auction. All privates are available for bids starting at face value.

A bid on a Private Company may be moved to a different Private Company as long as the bid value is increased by 5, in increments of 5. A player may have multiple bids on the same Private Company (via moving a bid between privates), but when "Place Bid" happens on a company with multiple bids already, it always adds to the player's highest bid. All bids are considered committed cash.

The auction ends when all players pass consecutively.

### Implementation Notes

The `&& company.owner` addition fixes the problem of private abilities showing during the SR and will probably fix https://github.com/tobymao/18xx/issues/2122 as you shouldn't be able to activate an ability that's not owned by anyone.

In the view, the new code won't run unless the actions include "move_bid", which no other games implement, and thus the view cannot be broken for current games.

The handling for companies that are not purchased during the auction is done in a follow up PR.

### Impacts

When the first company is selected, Place Bid is shown instead of Purchase. This is NOT a generic change and is done through the already existing "Purchasable Companies" functionality.
<img width="383" alt="Screen Shot 2020-12-05 at 10 19 21 AM" src="https://user-images.githubusercontent.com/15675400/101259209-bf9b4700-36e4-11eb-8c18-3cbb174270e4.png">

Once a player has a bid on a company, selecting a different company to place a bid on will give the option of moving that bid. The bid will be updated to the amount in the text box.
<img width="410" alt="Screen Shot 2020-12-05 at 10 19 42 AM" src="https://user-images.githubusercontent.com/15675400/101259476-0c335200-36e6-11eb-9586-4bee48775925.png">

Showing multiple bids on one company from the same player
<img width="340" alt="Screen Shot 2020-12-05 at 10 54 21 AM" src="https://user-images.githubusercontent.com/15675400/101259815-6af9cb00-36e8-11eb-8b1c-3fd5272dd429.png">

In this case, the user tried to move a higher bid from DNP ($50) to a $45 bid on GJGR, which is not allowed. To move a bid you must increase it by at least $5.
<img width="921" alt="Screen Shot 2020-12-05 at 10 21 17 AM" src="https://user-images.githubusercontent.com/15675400/101259502-39800000-36e6-11eb-850a-87d114779bf0.png">

Log samples from moving bids
<img width="859" alt="Screen Shot 2020-12-05 at 10 42 12 AM" src="https://user-images.githubusercontent.com/15675400/101259556-a85d5900-36e6-11eb-91da-bc12c8276287.png">

Once all players pass consecutively, all the auctions are immediately resolved with the companies going to the highest bidders.
<img width="779" alt="Screen Shot 2020-12-05 at 10 42 48 AM" src="https://user-images.githubusercontent.com/15675400/101259568-bad79280-36e6-11eb-9df5-c672cc5dab8a.png">
