### PR TITLE
Fix 18CO IMC Ability and Mine Display

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -148,6 +148,8 @@ module Engine
       end
 
       def mine_create(entity, count)
+        return unless count.positive?
+
         mines_remove(entity)
         total = count * mine_value(entity)
         entity.add_ability(Engine::Ability::Base.new(


### PR DESCRIPTION
We recompute to Mine Ability information when the IMC is purchased. However, If a corporation purchased the IMC before it collected any mines, the Mine Ability was added showing a $0 payout. Better to not add the ability until it actually has mines.