### PR TITLE
fix starting tile definitions for 1867's Toronto and Montreal hexes

### DIFF
--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -718,10 +718,10 @@ module Engine
       ]
     },
     "yellow": {
-      "city=revenue:40;city=revenue:40;city=revenue:40;path=a:1,b:_0;path=a:3,b:_0;label=M;upgrade=cost:20,terrain:water": [
+      "city=revenue:40;city=revenue:40;city=revenue:40;path=a:1,b:_0;path=a:3,b:_1;label=M;upgrade=cost:20,terrain:water": [
         "L12"
       ],
-      "city=revenue:30;city=revenue:30;path=a:1,b:_0;path=a:4,b:_0;label=T": [
+      "city=revenue:30;city=revenue:30;path=a:1,b:_0;path=a:4,b:_1;label=T": [
         "F16"
       ]
     },


### PR DESCRIPTION
The third Montreal city gets placed in the center, will take some more effort to get that placed next to edge 5, but the track is connecting the correct cities at least.

I haven't read the 1867 rules, is it green on the board because it cannot be tokened before a green phase? Nobody can get connected to it until a green M tile is placed, so I was wondering if we could just leave that city off for now, but if there's some teleport-style token ability that would enable a token placement there that option is a no-go.

/cc @jenf 

## AAG board

![Screenshot from 2020-12-05 14-56-25](https://user-images.githubusercontent.com/1045173/101266233-30088f00-370a-11eb-8dc7-183fb97b7b40.png)
![Screenshot from 2020-12-05 14-56-29](https://user-images.githubusercontent.com/1045173/101266237-31d25280-370a-11eb-9c40-dd28bc15a065.png)

## [Before](https://18xx.games/tiles/1867/F16+L12)

![Screenshot from 2020-12-05 14-57-58](https://user-images.githubusercontent.com/1045173/101266250-50384e00-370a-11eb-8784-436da057db51.png)

## After

![Screenshot from 2020-12-05 14-58-24](https://user-images.githubusercontent.com/1045173/101266254-5b8b7980-370a-11eb-9365-fd91e2759543.png)
