### PR TITLE
Add a shadow to cheater tokens to make them distinguishable from normal tokens

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -44,13 +44,30 @@ module View
 
         def render_part
           children = []
-          children << h(:circle, attrs: { r: @radius, fill: 'white' })
+          circle_attrs = { r: @radius, fill: 'white' }
+
+          props = { on: { click: ->(event) { on_click(event) } },
+                    attrs: { transform: '' } }
+
+          props[:attrs][:transform] = rotation_for_layout if @edge
+
+          if @city && @slot_index >= @city.normal_slots
+            children << h(:defs, [
+              h(:filter, { attrs: { id: 'shadow', x: '-50%', y: '-50%', width: '200%', height: '200%' } }, [
+                h(:feOffset, attrs: { result: 'offOut', in: 'SourceAlpha', dx: 2, dy: 2 }),
+                h(:feGaussianBlur, attrs: { result: 'blurOut', in: 'offOut', stdDeviation: '5' }),
+                h(:feBlend, attrs: { in: 'SourceGraphic', in2: 'blurOut', mode: 'normal' }),
+              ]),
+            ])
+            circle_attrs[:filter] = 'url(#shadow)'
+
+            # The shadow makes the token look larger, this offsets the effect a little
+            props[:attrs][:transform] += ' scale(0.95)'
+          end
+
+          children << h(:circle, attrs: circle_attrs)
           children << reservation if @reservation && !@token
           children << h(Token, token: @token, radius: @radius) if @token
-
-          props = { on: { click: ->(event) { on_click(event) } } }
-
-          props[:attrs] = { transform: rotation_for_layout } if @edge
 
           h(:g, props, children)
         end


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3337865/101267820-17719680-3755-11eb-9765-564d3f2f2b18.png)

After:

![image](https://user-images.githubusercontent.com/3337865/101267812-03c63000-3755-11eb-8aca-4c2745e47bf2.png)
