### PR TITLE
Generalize private company prices that are up to face value

### DIFF
--- a/lib/engine/game/company_price_up_to_face.rb
+++ b/lib/engine/game/company_price_up_to_face.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#
+# This module can be called from setup method
+# in the Engine::Game class for the game to
+# modify the allowed price for purchasing companies
+# to between 1 to face value
+
+module CompanyPriceUpToFace
+  def setup_company_price_up_to_face
+    @companies.each do |company|
+      company.min_price = 1
+      company.max_price = company.value
+    end
+  end
+end

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../config/game/g_1846'
+require_relative 'company_price_up_to_face'
 require_relative 'base'
 
 module Engine
@@ -106,6 +107,8 @@ module Engine
         two_player? ? 0 : players.size
       end
 
+      include CompanyPriceUpToFace
+
       def setup
         @turn = setup_turn
 
@@ -138,10 +141,8 @@ module Engine
 
         @cert_limit = init_cert_limit
 
-        @companies.each do |company|
-          company.min_price = 1
-          company.max_price = company.value
-        end
+        setup_company_price_up_to_face
+
         @draft_finished = false
 
         @minors.each do |minor|


### PR DESCRIPTION
Similar to the [module to set private prices to between 0.5 face to 1.5x face](https://github.com/benjaminxscott/18xx/blob/master/lib/engine/game/company_price_50_to_150_percent.rb), also generalize a module that allows games to set legal private prices to between 1 to face value (such as 1848)

Updated the 1846 game engine, which also covers 18LA