### PR TITLE
18CO Special Tile Lays

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -75,15 +75,27 @@ module Engine
 		"L20": "Fort Worth, TX"
 	},
 	"tiles": {
-		"3": 6,
-		"4": 6,
+		"3a": {
+			"count": 6,
+			"color": "yellow",
+			"code": "town=revenue:10,to_city:1;path=a:0,b:_0;path=a:_0,b:1"
+		},
+		"4a": {
+			"count": 6,
+			"color": "yellow",
+			"code": "town=revenue:10,to_city:1;path=a:0,b:_0;path=a:_0,b:3"
+		},
 		"5": 3,
 		"6": 6,
 		"7": 15,
 		"8": 25,
 		"9": 25,
 		"57": 6,
-		"58": 6,
+		"58a": {
+			"count": 6,
+			"color": "yellow",
+			"code": "town=revenue:10,to_city:1;path=a:0,b:_0;path=a:_0,b:2"
+		},
 		"co1": {
 			"count": 1,
 			"color": "yellow",
@@ -346,6 +358,7 @@ module Engine
 					"owner_type": "corporation",
 					"when": "track",
 					"count": 1,
+					"special": true,
 					"tiles": [
 						"14",
 						"15"
@@ -421,7 +434,17 @@ module Engine
 
 					],
 					"tiles": [
-
+						"co1",
+						"co5",
+						"3a",
+						"4a",
+						"5",
+						"6",
+						"7",
+						"8",
+						"9",
+						"57",
+						"58a"
 					]
 				}
 			]

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -43,6 +43,7 @@ module Engine
       # First 3 are Denver, Second 3 are CO Springs
       TILES_FIXED_ROTATION = %w[co1 co2 co3 co5 co6 co7].freeze
       GREEN_TOWN_TILES = %w[co8 co9 co10].freeze
+      GREEN_CITY_TILES = %w[14 15].freeze
       BROWN_CITY_TILES = %w[co4 63].freeze
 
       STOCKMARKET_COLORS = {
@@ -171,6 +172,7 @@ module Engine
         Step::BuyCompany,
         Step::G18CO::RedeemShares,
         Step::CorporateBuyShares,
+        Step::G18CO::SpecialTrack,
         Step::G18CO::Track,
         Step::Token,
         Step::Route,
@@ -253,6 +255,8 @@ module Engine
       end
 
       def upgrades_to?(from, to, special = false)
+        return true if special && from.hex.tile.color == :yellow && GREEN_CITY_TILES.include?(to.name)
+
         # Green towns can't be upgraded to brown cities unless the hex has the upgrade icon
         if GREEN_TOWN_TILES.include?(from.hex.tile.name)
           return BROWN_CITY_TILES.include?(to.name) if from.hex.tile.icons.any? { |icon| icon.name == 'upgrade' }

--- a/lib/engine/step/g_18_co/special_track.rb
+++ b/lib/engine/step/g_18_co/special_track.rb
@@ -10,7 +10,7 @@ module Engine
         include Tracker
 
         def process_lay_tile(action)
-          super(action)
+          super
 
           clear_upgrade_icon(action.hex.tile)
           collect_mines(action.entity.owner, action.hex)

--- a/lib/engine/step/g_18_co/special_track.rb
+++ b/lib/engine/step/g_18_co/special_track.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../special_track'
+require_relative 'tracker'
+
+module Engine
+  module Step
+    module G18CO
+      class SpecialTrack < SpecialTrack
+        include Tracker
+
+        def process_lay_tile(action)
+          super(action)
+
+          clear_upgrade_icon(action.hex.tile)
+          collect_mines(action.entity.owner, action.hex)
+          action.entity.close! if ability.count.zero?
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/track.rb
+++ b/lib/engine/step/g_18_co/track.rb
@@ -1,30 +1,18 @@
 # frozen_string_literal: true
 
 require_relative '../track'
+require_relative 'tracker'
 
 module Engine
   module Step
     module G18CO
       class Track < Track
+        include Tracker
+
         def process_lay_tile(action)
           lay_tile_action(action)
-
-          # Remove the upgrade icon when the town is converted to a city
-          if action.hex.tile.cities.any? &&
-             action.hex.tile.icons.any? { |icon| icon.name == 'upgrade' }
-            action.hex.tile.icons.reject! { |icon| icon.name == 'upgrade' }
-          end
-
-          # Mine Token Collection
-          if action.hex.tile.icons.map(&:name).include?('mine')
-            # Remove mine symbol from hex
-            action.hex.tile.icons.reject! { |icon| icon.name == 'mine' }
-
-            # Add mine to corporation data
-            @game.mine_add(action.entity)
-
-            @log << "#{action.entity.name} collects a mine token from #{action.hex.name}"
-          end
+          clear_upgrade_icon(action.hex.tile)
+          collect_mines(action)
 
           pass! unless can_lay_tile?(action.entity)
         end

--- a/lib/engine/step/g_18_co/tracker.rb
+++ b/lib/engine/step/g_18_co/tracker.rb
@@ -14,7 +14,7 @@ module Engine
 
         def collect_mines(corporation, hex)
           # Mine Token Collection
-          return unless hex.tile.icons.map(&:name).include?('mine')
+          return unless hex.tile.icons.any? { |icon| icon.name == 'mine' }
 
           # Remove mine symbol from hex
           hex.tile.icons.reject! { |icon| icon.name == 'mine' }

--- a/lib/engine/step/g_18_co/tracker.rb
+++ b/lib/engine/step/g_18_co/tracker.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Engine
+  module Step
+    module G18CO
+      module Tracker
+        # Remove the upgrade icon when the town is converted to a city
+        def clear_upgrade_icon(tile)
+          return if tile.cities.empty?
+          return if tile.icons.empty? { |icon| icon.name == 'upgrade' }
+
+          tile.icons.reject! { |icon| icon.name == 'upgrade' }
+        end
+
+        def collect_mines(corporation, hex)
+          # Mine Token Collection
+          return unless hex.tile.icons.map(&:name).include?('mine')
+
+          # Remove mine symbol from hex
+          hex.tile.icons.reject! { |icon| icon.name == 'mine' }
+
+          # Add mine to corporation data
+          @game.mine_add(corporation)
+
+          @log << "#{corporation.name} collects a mine token from #{hex.name}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Background 

**GJGR**: An owning Corporation may upgrade a yellow town to a green city in additional to its normal tile lay. Action closes the company or closes on purchase of “5” train.

**LNPW**: An owning Corporation may lay an extra tile at no cost in addition to its normal tile lay. Action closes the company or closes on purchase of “5” train.

### Implementation Notes

I moved some shared code between the Normal Track Step and Special Track Step into a shared Tracker module.

I don't love having to modify the tiles in the json. However, I can't see a way to fake it at runtime. The explicit code in upgrades_to? allows it to work, though. No need to detect if the hex has a town since the ability definition restricts the upgrade to town hexes.

### Impacts 

GJGR only activates on towns, and only shows green cities on yellow towns
<img width="602" alt="Screen Shot 2020-12-05 at 8 59 00 PM" src="https://user-images.githubusercontent.com/15675400/101271235-2f89eb80-373e-11eb-8261-7095332473b4.png">

LNPW can lay a yellow tile
<img width="332" alt="Screen Shot 2020-12-05 at 9 02 26 PM" src="https://user-images.githubusercontent.com/15675400/101271238-30bb1880-373e-11eb-8da0-51dcfb7b044e.png">

LNPW doesn't allow upgrades
<img width="275" alt="Screen Shot 2020-12-05 at 9 02 20 PM" src="https://user-images.githubusercontent.com/15675400/101271237-30bb1880-373e-11eb-875b-d64857eb6cfc.png">
