### PR TITLE
1828: Implement C&P company

### DIFF
--- a/lib/engine/config/game/g_1828.rb
+++ b/lib/engine/config/game/g_1828.rb
@@ -488,7 +488,7 @@ module Engine
                 {
                     "type": "revenue_change",
                     "revenue": 0,
-                    "when": "sold"
+                    "when": "auction_end"
                 }
             ]
         },

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -779,6 +779,10 @@ module Engine
         routes.reject { |r| r == route }.flat_map(&:paths)
       end
 
+      def find_token_for_entity(entity, stops)
+        stops.find { |stop| stop.tokened_by?(entity) }
+      end
+
       def check_overlap(routes)
         tracks = []
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -779,8 +779,8 @@ module Engine
         routes.reject { |r| r == route }.flat_map(&:paths)
       end
 
-      def find_token_for_entity(entity, stops)
-        stops.find { |stop| stop.tokened_by?(entity) }
+      def city_tokened_by?(city, entity)
+        city.tokened_by?(entity)
       end
 
       def check_overlap(routes)

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -261,6 +261,12 @@ module Engine
         end
       end
 
+      def can_run_route?(entity)
+        return false if entity.id == 'C&P' && !@round.last_tile_lay
+
+        super
+      end
+
       private
 
       def setup_minors

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -278,6 +278,12 @@ module Engine
         super
       end
 
+      def find_token_for_entity(entity, stops)
+        return (@graph.connected_nodes(entity).keys & stops).first if entity.id == 'C&P'
+
+        super
+      end
+
       private
 
       def setup_minors

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -289,7 +289,7 @@ module Engine
       end
 
       def city_tokened_by?(city, entity)
-        return @graph.connected_nodes(entity).keys.include?(city) if entity.id == 'C&P'
+        return @graph.connected_nodes(entity)[city] if entity.id == 'C&P'
 
         super
       end

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -137,6 +137,14 @@ module Engine
 
       def init_round_finished
         @players.rotate!(@round.entity_index)
+
+        @companies.each do |company|
+          next unless company.owner
+
+          company.abilities(:revenue_change, time: 'auction_end') do |ability|
+            company.revenue = ability.revenue
+          end
+        end
       end
 
       def event_green_par!
@@ -259,6 +267,7 @@ module Engine
         @minors.each do |minor|
           train = @depot.upcoming[0]
           train.buyable = false
+          train.rusts_on = nil
           minor.buy_train(train, :free)
           hex = hex_by_id(minor.coordinates)
           hex.tile.cities[0].place_token(minor, minor.next_token, free: true)

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -90,6 +90,7 @@ module Engine
           Step::DiscardTrain,
           Step::G1828::SpecialTrack,
           Step::G1828::BuyCompany,
+          Step::G1828::SpecialToken,
           Step::G1828::BuySpecial,
           Step::G1828::Track,
           Step::G1828::Token,
@@ -110,6 +111,8 @@ module Engine
         @coal_marker_ability =
           Engine::Ability::Description.new(type: 'description', description: 'Coal Marker')
         block_va_coalfields
+
+        @blocking_corporation = Corporation.new(sym: 'B', name: 'Blocking', logo: '1828/blocking', tokens: [0])
       end
 
       def init_stock_market
@@ -180,14 +183,14 @@ module Engine
       def event_close_companies!
         super
 
-        @minors.dup.each { |minor| remove_minor!(minor) }
+        @minors.dup.each { |minor| remove_minor!(minor, block: true) }
       end
 
       def event_remove_corporations!
         @log << "-- Event: #{EVENTS_TEXT['remove_corporations'][1]}. --"
         @corporations.reject(&:ipoed).each do |corporation|
-          place_home_token(corporation)
-          place_second_home_token(corporation) if corporation.name == 'ERIE'
+          place_home_blocking_token(corporation)
+          place_second_home_blocking_token(corporation) if corporation.name == 'ERIE'
           @log << "Removing #{corporation.name}"
           @corporations.delete(corporation)
         end
@@ -197,10 +200,17 @@ module Engine
         @phase.current[:name] == 'Purple'
       end
 
-      def remove_minor!(minor)
-        @round.force_next_entity! if @round.current_entity == minor
+      def remove_minor!(minor, block: false)
         minor.spend(minor.cash, @bank) if minor.cash.positive?
+        minor.tokens.each do |token|
+          city = token&.city
+          token.remove!
+          place_blocking_token(city.hex) if block && city
+        end
+        @graph.clear_graph_for(minor)
         @minors.delete(minor)
+
+        @round.force_next_entity! if @round.current_entity == minor
       end
 
       def upgrades_to?(from, to, special = false)
@@ -278,8 +288,8 @@ module Engine
         super
       end
 
-      def find_token_for_entity(entity, stops)
-        return (@graph.connected_nodes(entity).keys & stops).first if entity.id == 'C&P'
+      def city_tokened_by?(city, entity)
+        return @graph.connected_nodes(entity).keys.include?(city) if entity.id == 'C&P'
 
         super
       end
@@ -316,11 +326,20 @@ module Engine
         @log << "Removing #{to_remove.name} train"
       end
 
-      def place_second_home_token(corporation)
-        token = corporation.find_token_by_type
+      def place_blocking_token(hex, city_index: 0)
+        @log << "Placing a blocking token on #{hex.name} (#{hex.location_name})"
+        token = Token.new(@blocking_corporation)
+        hex.tile.cities[city_index].place_token(@blocking_corporation, token, check_tokenable: false)
+      end
+
+      def place_home_blocking_token(corporation, city_index: 0)
         hex = hex_by_id(corporation.coordinates)
-        @log << "#{corporation.name} places a second token on #{hex.name}"
-        hex.tile.cities[1].place_token(corporation, token, check_tokenable: false)
+        hex.tile.cities[city_index].remove_reservation!(corporation)
+        place_blocking_token(hex, city_index: city_index)
+      end
+
+      def place_second_home_blocking_token(corporation)
+        place_home_blocking_token(corporation, city_index: 1)
       end
     end
   end

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -205,7 +205,9 @@ module Engine
 
       visited = visited_stops
       @game.game_error('Route must have at least 2 stops') if @connections.any? && visited.size < 2
-      @game.game_error('Route must contain token') unless (token = find_token(visited))
+      unless (token = visited.find { |stop| @game.city_tokened_by?(stop, corporation) })
+        @game.game_error('Route must contain token')
+      end
 
       check_distance!(visited)
       check_cycles!
@@ -219,10 +221,6 @@ module Engine
       end
 
       @game.revenue_for(self, stops)
-    end
-
-    def find_token(stops)
-      @game.find_token_for_entity(corporation, stops)
     end
 
     def subsidy
@@ -266,7 +264,7 @@ module Engine
 
       if possibilities.one?
         connection = possibilities[0].find do |conn|
-          find_token(conn.nodes) && # .any? { |node| node.tokened_by?(corporation) } &&
+          conn.nodes.any? { |node| @game.city_tokened_by?(node, corporation) } &&
             (conn.paths & other_paths).empty?
         end
         left, right = connection&.nodes

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -205,9 +205,7 @@ module Engine
 
       visited = visited_stops
       @game.game_error('Route must have at least 2 stops') if @connections.any? && visited.size < 2
-      unless (token = visited.find { |stop| stop.tokened_by?(corporation) })
-        @game.game_error('Route must contain token')
-      end
+      @game.game_error('Route must contain token') unless (token = find_token(visited))
 
       check_distance!(visited)
       check_cycles!
@@ -221,6 +219,10 @@ module Engine
       end
 
       @game.revenue_for(self, stops)
+    end
+
+    def find_token(stops)
+      @game.find_token_for_entity(corporation, stops)
     end
 
     def subsidy
@@ -264,7 +266,7 @@ module Engine
 
       if possibilities.one?
         connection = possibilities[0].find do |conn|
-          conn.nodes.any? { |node| node.tokened_by?(corporation) } &&
+          find_token(conn.nodes) && # .any? { |node| node.tokened_by?(corporation) } &&
             (conn.paths & other_paths).empty?
         end
         left, right = connection&.nodes

--- a/lib/engine/step/g_1828/buy_company.rb
+++ b/lib/engine/step/g_1828/buy_company.rb
@@ -15,12 +15,17 @@ module Engine
           return unless (minor = @game.minor_by_id(company.id))
 
           cash = minor.cash
+          @log << "#{entity.name} receives #{@game.format_currency(cash)} from #{minor.name}'s treasury"
           minor.spend(cash, entity) if cash.positive?
-          minor.tokens[0].swap!(Engine::Token.new(entity))
-          @log << "#{entity.name} receives #{@game.format_currency(cash)} "\
-            "and may place a token on #{minor.coordinates} for free"
-          @game.graph.clear_graph_for(minor)
-          @game.remove_minor(minor)
+
+          company.add_ability(Engine::Ability::Token.new(type: 'token',
+                                                         hexes: [minor.coordinates],
+                                                         price: 0,
+                                                         teleport_price: 0,
+                                                         from_owner: true,
+                                                         when: 'sold'))
+
+          @game.remove_minor!(minor)
         end
       end
     end

--- a/lib/engine/step/g_1828/route.rb
+++ b/lib/engine/step/g_1828/route.rb
@@ -9,13 +9,33 @@ module Engine
         def process_run_routes(action)
           if route_includes_coalfields?(action.routes) && !@game.coal_marker?(action.entity)
             @game.game_error('Cannot run to Virginia Coalfields without a Coal Marker')
-          else
-            super
           end
+
+          if action.entity.id == 'C&P' && !route_uses_tile_lay(action.routes)
+            @game.game_error("#{action.entity.name} must use laid tile in route")
+          end
+
+          super
         end
 
         def route_includes_coalfields?(routes)
           routes.flat_map(&:connection_hexes).flatten.include?(Engine::Game::G1828::VA_COALFIELDS_HEX)
+        end
+
+        def route_uses_tile_lay(routes)
+          tile_used = false
+          stops = routes.first.visited_stops
+          tile = @round.last_tile_lay
+
+          if tile.nodes.any?
+            tile_used = (stops & tile.nodes).any?
+          else
+            tile.paths.each do |path|
+              path.walk { |p| tile_used ||= (stops & p.nodes).any? }
+            end
+          end
+
+          tile_used
         end
       end
     end

--- a/lib/engine/step/g_1828/special_token.rb
+++ b/lib/engine/step/g_1828/special_token.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative '../special_token'
+require_relative 'token_tracker'
+
+module Engine
+  module Step
+    module G1828
+      class SpecialToken < SpecialToken
+        include TokenTracker
+
+        ACTIONS = %w[place_token pass].freeze
+
+        def actions(entity)
+          blocking_for_sold_company? ? ACTIONS : super
+        end
+
+        def description
+          "Place token for #{@company.owner.name}"
+        end
+
+        def blocking?
+          blocking_for_sold_company? || super
+        end
+
+        def pass_description
+          'Pass (Token)'
+        end
+
+        def active_entities
+          @company ? [@company] : super
+        end
+
+        def process_place_token(entity)
+          @company = nil
+          super
+        end
+
+        def process_pass(action)
+          entity = action.entity
+          ability = @company.abilities(:token, time: 'sold')
+          @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+
+          hex = @game.hex_by_id(ability.hexes.first)
+          @log << "#{entity.owner.name} passes placing a token on #{hex.name} (#{hex.location_name})"
+
+          @game.place_blocking_token(@game.hex_by_id(ability.hexes.first))
+          @company.remove_ability(ability)
+          @company = nil
+
+          pass!
+        end
+
+        def blocking_for_sold_company?
+          return false unless (company = @round.just_sold_company)
+
+#          company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
+
+          if (ability = company.abilities(:token, time: 'sold'))
+            if available_tokens(company.owner) && !already_tokened_this_round?(company.owner)
+              @company = company
+              return true
+            else
+              @log << "#{company.owner.name} does not have the option to replace #{company.name}'s token"
+              @game.place_blocking_token(@game.hex_by_id(ability.hexes.first))
+              company.remove_ability(ability)
+              return false
+            end
+          end
+
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1828/special_token.rb
+++ b/lib/engine/step/g_1828/special_token.rb
@@ -54,7 +54,7 @@ module Engine
         def blocking_for_sold_company?
           return false unless (company = @round.just_sold_company)
 
-#          company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
+          #          company = @round.respond_to?(:just_sold_company) && @round.just_sold_company
 
           if (ability = company.abilities(:token, time: 'sold'))
             if available_tokens(company.owner) && !already_tokened_this_round?(company.owner)

--- a/lib/engine/step/g_1828/token.rb
+++ b/lib/engine/step/g_1828/token.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require_relative '../token'
+require_relative 'token_tracker'
 
 module Engine
   module Step
     module G1828
       class Token < Token
+        include TokenTracker
+
         def place_token(entity, city, token, teleport: false)
           if city.hex.name == Engine::Game::G1828::VA_COALFIELDS_HEX
             @game.game_error("#{city.hex.location_name} may not be tokened")

--- a/lib/engine/step/g_1828/token_tracker.rb
+++ b/lib/engine/step/g_1828/token_tracker.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Engine
+  module Step
+    module G1828
+      module TokenTracker
+        def process_place_token(action)
+          super
+          @round.tokens_placed << corporation_for(action.entity)
+        end
+
+        def already_tokened_this_round?(entity)
+          @round.tokens_placed.include?(corporation_for(entity))
+        end
+
+        def round_state
+          round_state = super || {}
+          round_state[:tokens_placed] = []
+          round_state
+        end
+
+        def corporation_for(entity)
+          entity.company? ? entity.owner : entity
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1828/track.rb
+++ b/lib/engine/step/g_1828/track.rb
@@ -17,12 +17,23 @@ module Engine
           @no_upgrades = false
         end
 
+        def round_state
+          state = super || {}
+          state[:last_tile_lay] = nil
+          state
+        end
+
         def get_tile_lay(entity)
           action = super
           return unless action
 
           action[:upgrade] = false if @no_upgrades
           action
+        end
+
+        def process_lay_tile(action)
+          @round.last_tile_lay = action.tile
+          super
         end
       end
     end

--- a/public/logos/1828/blocking.svg
+++ b/public/logos/1828/blocking.svg
@@ -5,19 +5,19 @@
 	.st3{font-size:22px;}</style>
  <g>
   <title>background</title>
-  <rect fill="none" id="canvas_background" height="602" width="802" y="-1" x="-1"/>
+  <rect x="-1" y="-1" width="39.2" height="39.2" id="canvas_background" fill="none"/>
  </g>
  <g>
   <title>Layer 1</title>
   <g id="svg_1">
    <defs>
-    <circle r="18.6" cy="18.6" cx="18.6" id="SVGID_1_"/>
+    <circle id="SVGID_1_" cx="18.6" cy="18.6" r="18.6"/>
    </defs>
    <clipPath id="SVGID_2_">
-    <use id="svg_2" xlink:href="#SVGID_1_"/>
+    <use xlink:href="#SVGID_1_" id="svg_2"/>
    </clipPath>
-   <path id="svg_3" d="m42.6,18.6c0,-13.3 -10.7,-24 -24,-24c-13.3,0 -24,10.7 -24,24c0,13.3 10.7,24 24,24c13.3,0 24,-10.7 24,-24" class="st0"/>
+   <path class="st0" d="m42.6,18.6c0,-13.3 -10.7,-24 -24,-24c-13.3,0 -24,10.7 -24,24c0,13.3 10.7,24 24,24c13.3,0 24,-10.7 24,-24" id="svg_3"/>
   </g>
-  <text x="10.82845" y="1.56891" id="svg_4" class="st1 st2 st3" transform="matrix(1,0,0,1,1.2301,23.5382) ">B</text>
+  <text class="st1 st2 st3" id="svg_4" y="26.0986" x="11.25657">B</text>
  </g>
 </svg>

--- a/public/logos/1828/blocking.svg
+++ b/public/logos/1828/blocking.svg
@@ -1,0 +1,23 @@
+<svg width="37.2" height="37.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <style type="text/css">.st0{clip-path:url(#SVGID_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#010101;}
+	.st1{fill:#FFFFFF;}
+	.st2{font-family:'Times-Bold';}
+	.st3{font-size:22px;}</style>
+ <g>
+  <title>background</title>
+  <rect fill="none" id="canvas_background" height="602" width="802" y="-1" x="-1"/>
+ </g>
+ <g>
+  <title>Layer 1</title>
+  <g id="svg_1">
+   <defs>
+    <circle r="18.6" cy="18.6" cx="18.6" id="SVGID_1_"/>
+   </defs>
+   <clipPath id="SVGID_2_">
+    <use id="svg_2" xlink:href="#SVGID_1_"/>
+   </clipPath>
+   <path id="svg_3" d="m42.6,18.6c0,-13.3 -10.7,-24 -24,-24c-13.3,0 -24,10.7 -24,24c0,13.3 10.7,24 24,24c13.3,0 24,-10.7 24,-24" class="st0"/>
+  </g>
+  <text x="10.82845" y="1.56891" id="svg_4" class="st1 st2 st3" transform="matrix(1,0,0,1,1.2301,23.5382) ">B</text>
+ </g>
+</svg>

--- a/spec/lib/engine/games/g_1828_spec.rb
+++ b/spec/lib/engine/games/g_1828_spec.rb
@@ -55,8 +55,8 @@ module Engine
         phase.buying_train!(corporation, game.trains.find { |t| t.name == 'D' })
         expect(game.corporations.size).to be(1)
         expect(game.corporations.first).to eq(corporation)
-        expect(erie_home_tile.cities[0].tokened_by?(erie)).to be_truthy
-        expect(erie_home_tile.cities[1].tokened_by?(erie)).to be_truthy
+        expect(erie_home_tile.cities[0].available_slots).to eq(0)
+        expect(erie_home_tile.cities[1].available_slots).to eq(0)
       end
 
       it 'should trigger end game at purple phase' do


### PR DESCRIPTION
Implemented the following abilities for C&P:

- Pays $15 in revenue until the end of the auction
- Train doesn't rust
- Must run the tile it laid
- Run does not need to include its station
- Does not run if no tile laid
- Buying company has the option to replace C&P home token with one of its tokens for free, provided it has a token and has not laid a token this round.
- If the buying company cannot or does not replace the C&P token, a blocking token is placed instead

Cleaned-up the blocking token logic.