### PR TITLE
18CO Corporations can buy Un-auctioned Companies

### DIFF
--- a/assets/app/view/game/buy_company_from_other_player.rb
+++ b/assets/app/view/game/buy_company_from_other_player.rb
@@ -42,7 +42,8 @@ module View
             price: price,
           ))
         end
-        h(:button, { on: { click: buy_company } }, "Buy #{company.id} from #{company.owner.name}")
+        owner_name = company.owner.nil? ? 'the market' : company.owner.name
+        h(:button, { on: { click: buy_company } }, "Buy #{company.id} from #{owner_name}")
       end
     end
   end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -354,6 +354,14 @@ module Engine
         bundles_for_corporation(share_pool, entity)
           .reject { |bundle| entity.cash < bundle.price }
       end
+
+      def purchasable_companies(entity = nil)
+        @companies.select do |company|
+          (company.owner&.player? || company.owner.nil?) &&
+            (entity.nil? || entity != company.owner) &&
+            !company.abilities(:no_buy)
+        end
+      end
     end
   end
 end

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -58,7 +58,7 @@ module Engine
 
         log_later = []
         company.owner = entity
-        owner.companies.delete(company)
+        owner&.companies&.delete(company)
 
         company.abilities(:assign_corporation) do |ability|
           Assignable.remove_from_all!(assignable_corporations, company.id) do |unassigned|
@@ -82,8 +82,10 @@ module Engine
         @round.company_sellers << owner
 
         entity.companies << company
-        entity.spend(price, owner)
-        @log << "#{entity.name} buys #{company.name} from #{owner.name} for #{@game.format_currency(price)}"
+        entity.spend(price, owner.nil? ? @game.bank : owner)
+        @log << "#{entity.name} buys #{company.name} from"\
+                "#{owner.nil? ? 'the market' : owner.name} for"\
+                "#{@game.format_currency(price)}"
         log_later.each { |l| @log << l }
       end
 

--- a/lib/engine/step/g_18_co/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_co/buy_sell_par_shares.rb
@@ -15,6 +15,12 @@ module Engine
 
           @game.par_change_float_percent(action.corporation)
         end
+
+        def purchasable_companies(entity = nil)
+          companies = super
+
+          companies.select(&:owner)
+        end
       end
     end
   end

--- a/lib/engine/step/g_18_co/moving_bid_auction.rb
+++ b/lib/engine/step/g_18_co/moving_bid_auction.rb
@@ -115,16 +115,21 @@ module Engine
         end
 
         def all_passed!
+          # company is deleted from @companies when they are won, so we can't loop
+          # through @companies instead of @bids.
           @bids.each do |company, bids|
             resolve_bids_for_company(company, bids)
+          end
+
+          # discount the price of remaining companies
+          @companies.each do |company|
+            company.max_price = company.min_price
           end
         end
 
         def resolve_bids_for_company(company, bids)
           return if bids.empty?
 
-          # Companies without bids can be bought be corporations later
-          # Unsure how that will be accomplished at this time
           high_bid = highest_bid(company)
           buy_company(high_bid.entity, company, high_bid.price)
         end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836

A​ ​Private​ ​Company​ ​in​ ​the​ ​Market​ ​is​ ​purchased​ ​at​ ​50%​ ​of​ ​the​ ​Private​ ​Company’s​ ​face​ ​value.

Private companies wind up in the market if they are not purchased during auction. They can only be bought by corporations, not players.

### Implementation Notes

Changes to the generic **buy_company.rb**
- Don't run the companies.delete call if the owner is nil, because it will throw an error
- Pay to bank if owner is nil ( the market )
- Add text to show "the market" if owner is nil

Changes to the generic **buy_company.rb** were not strictly necessary for 18CO as a player cannot buy from market but rather done for consistency and to prevent errors if a game allowed it in the future.
- Add text to show "the market" if owner is nil

Corporations can buy from market
<img width="1042" alt="Screen Shot 2020-12-06 at 10 27 26 AM" src="https://user-images.githubusercontent.com/15675400/101287519-ecfff780-37ad-11eb-947b-190adab2bfdd.png">

Players correctly cannot buy from market
<img width="712" alt="Screen Shot 2020-12-06 at 9 42 34 AM" src="https://user-images.githubusercontent.com/15675400/101287524-f2f5d880-37ad-11eb-8585-4509b4b324b3.png">
