### PR TITLE
Variants should also be considered for discount (fixes #2492)

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -109,20 +109,21 @@ module View
         if discountable_trains.any?
           children << h(:h3, h3_props, 'Exchange Trains')
 
-          discountable_trains.each do |train, discount_train, price|
+          discountable_trains.each do |train, discount_train, discount_name, price|
             exchange_train = lambda do
               process_action(
                 Engine::Action::BuyTrain.new(
                   @corporation,
                   train: discount_train,
                   price: price,
+                  variant: discount_name,
                   exchange: train,
                 )
               )
             end
 
             children << h(:div, [
-              "#{train.name} -> #{discount_train.name} #{@game.format_currency(price)} ",
+              "#{train.name} -> #{discount_name} #{@game.format_currency(price)} ",
               h('button.no_margin', { on: { click: exchange_train } }, 'Exchange'),
             ])
           end

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -109,21 +109,21 @@ module View
         if discountable_trains.any?
           children << h(:h3, h3_props, 'Exchange Trains')
 
-          discountable_trains.each do |train, discount_train, discount_name, price|
+          discountable_trains.each do |train, discount_train, variant, price|
             exchange_train = lambda do
               process_action(
                 Engine::Action::BuyTrain.new(
                   @corporation,
                   train: discount_train,
                   price: price,
-                  variant: discount_name,
+                  variant: variant,
                   exchange: train,
                 )
               )
             end
 
             children << h(:div, [
-              "#{train.name} -> #{discount_name} #{@game.format_currency(price)} ",
+              "#{train.name} -> #{variant} #{@game.format_currency(price)} ",
               h('button.no_margin', { on: { click: exchange_train } }, 'Exchange'),
             ])
           end

--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -89,9 +89,20 @@ module Engine
           discounted_price = discount_train.price(train)
           next if discount_train.price == discounted_price
 
-          [train, discount_train, discounted_price]
+          name = discount_train.name
+          discount_info = [[train, discount_train, name, discounted_price]]
+
+          # Add variants if any - they have same discount as base version
+          discount_train.variants.each do |_, v|
+            next if v[:name] == name
+
+            price = v[:price] - (discount_train.price - discounted_price)
+            discount_info << [train, discount_train, v[:name], price]
+          end
+
+          discount_info
         end.compact
-      end
+      end.flatten(1)
     end
 
     def available(corporation)

--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -85,7 +85,7 @@ module Engine
       discountable_trains = depot_trains.select(&:discount)
 
       corporation.trains.flat_map do |train|
-        discountable_trains.map do |discount_train|
+        discountable_trains.flat_map do |discount_train|
           discounted_price = discount_train.price(train)
           next if discount_train.price == discounted_price
 
@@ -102,7 +102,7 @@ module Engine
 
           discount_info
         end.compact
-      end.flatten(1)
+      end
     end
 
     def available(corporation)

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -14,7 +14,7 @@ module Engine
 
         can_buy_normal || @depot
           .discountable_trains_for(entity)
-          .any? { |_, _, price| buying_power(entity) >= price }
+          .any? { |_, _, _, price| buying_power(entity) >= price }
       end
 
       def room?(entity)


### PR DESCRIPTION
Now variants is added to discountable trains, if the base version
has a discount for the a train. The discount will be the same for
the variants as for the base version.