### PR TITLE
Bug fix, 1846: add potential cash from minor to entity's buying power

### DIFF
--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -568,6 +568,24 @@ module Engine
 
         help
       end
+
+      def potential_minor_cash(entity, allowed_trains: (0..3))
+        if entity.corporation? && entity.cash.positive? && allowed_trains.include?(entity.trains.size)
+          @minors.reduce(0) do |memo, minor|
+            minor.owned_by_player? && minor.cash.positive? ? memo + minor.cash - 1 : memo
+          end
+        else
+          0
+        end
+      end
+
+      def track_buying_power(entity)
+        buying_power(entity) + potential_minor_cash(entity)
+      end
+
+      def train_buying_power(entity)
+        buying_power(entity) + potential_minor_cash(entity, allowed_trains: (1..2))
+      end
     end
   end
 end

--- a/lib/engine/step/g_1846/buy_train.rb
+++ b/lib/engine/step/g_1846/buy_train.rb
@@ -115,6 +115,10 @@ module Engine
 
           variants
         end
+
+        def buying_power(entity)
+          @game.train_buying_power(entity)
+        end
       end
     end
   end

--- a/lib/engine/step/g_1846/track_and_token.rb
+++ b/lib/engine/step/g_1846/track_and_token.rb
@@ -8,6 +8,10 @@ module Engine
     module G1846
       class TrackAndToken < TrackAndToken
         include ReceivershipSkip
+
+        def buying_power(entity)
+          @game.track_buying_power(entity)
+        end
       end
     end
   end


### PR DESCRIPTION
This prevents auto-skipping track/train steps when the corporation doesn't currently have enough cash for the action, but could have enough cash if they buy in one of the minors.

* because the minors come with a train, the entity's current trains must be
  taken into account
* when considering train buying power for an entity, if they have 0
  trains (i.e., if they must buy a train), the minor's potential cash should
  *not* be considered, as this prevents the president from contributing cash for
  EMR

[Fixes #2566]

-----

The migration is very straightforward, just inserting pass actions when necessary. I ran it locally for all "active" games and then all "finished" games; active took around 4 minutes while finished took around 40, so when released I'll do the same.