### PR TITLE
Enhancement, 1882: fish icon and "Regina"

### DIFF
--- a/lib/engine/config/game/g_1882.rb
+++ b/lib/engine/config/game/g_1882.rb
@@ -683,7 +683,7 @@ module Engine
       ]
     },
     "blue": {
-      "offboard=revenue:yellow_20|brown_30,visit_cost:0,route:optional;path=a:0,b:_0;path=a:1,b:_0": [
+      "offboard=revenue:yellow_20|brown_30,visit_cost:0,route:optional;path=a:0,b:_0;path=a:1,b:_0;icon=image:1882/fish": [
         "B6"
       ]
     }

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -191,7 +191,12 @@ module Engine
         revenue
       end
 
-      def action_processed(_action)
+      def action_processed(action)
+        if action.is_a?(Action::LayTile) && action.tile.name == 'R2'
+          action.tile.location_name = 'Regina'
+          return
+        end
+
         return unless @sc_company
         return if !@sc_company.closed? && !@sc_company&.owner&.corporation?
 

--- a/public/icons/1882/fish.svg
+++ b/public/icons/1882/fish.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="-16 -16 32 32">
+  <g>
+    <circle fill="#fff" stroke="#000" stroke-width="1" cx="0" cy="0" r="15"></circle>
+    <path fill="#0189d1" stroke="#000" d="M-10-4L4 6A6 6 0 004-6L-10 4z"></path>
+  </g>
+</svg>


### PR DESCRIPTION
* Rename "Pile o' Bones & Lumsden" to "Regina" in brown; AAG's R tiles don't
  have city names, but this matches prototype copies of the game that kept city
  names on the tiles - https://boardgamegeek.com/image/5069960/1882-assiniboia
* Add fish icon from 18xx-maker for the fishing exit on B6

![Screenshot from 2020-12-06 14-21-46](https://user-images.githubusercontent.com/1045173/101292756-b2f31d80-37ce-11eb-9663-934fb08403a0.png)
![Screenshot from 2020-12-06 14-22-38](https://user-images.githubusercontent.com/1045173/101292745-abcc0f80-37ce-11eb-87b5-98868470ceb0.png)
![Screenshot from 2020-12-06 14-22-18](https://user-images.githubusercontent.com/1045173/101292753-b090c380-37ce-11eb-9953-e61be7769b7a.png)