### PR TITLE
Attempts to optimize connections

### DIFF
--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -104,13 +104,6 @@ module Engine
       # values: city on tile (AKA new_city)
       #
       # map old cities to new based on edges they are connected to
-      #isolated = false
-      isolated = isolated_lay?(tile) && !downgrade
-      #if id == 'E20'
-        
-      #  puts isolated, $actionid
-      #  puts "before", @connections
-      #end
 
       city_map =
         # if @tile is blank, map cities by index
@@ -188,11 +181,7 @@ module Engine
       @tile = tile
 
       @paths = nil
-      if isolated
-        Connection.migration_connections(self, old_tile)
-      else
-        connect!
-      end
+      Connection.connect!(self, old_tile)
       #puts "after", @connections if id == 'D7'
     end
 
@@ -216,29 +205,6 @@ module Engine
 
     def connect!
       Connection.connect!(self)
-    end
-
-    def isolated_lay?(tile)
-      # Does laying this tile add no new connections?
-      #wanted_hex = 'D6'
-      #if id == wanted_hex
-      #  puts "old", @tile.paths 
-      #  puts "new", tile.paths
-      #  puts tile.paths.map(&:exits)
-      #  puts tile.paths.map(&:exits).uniq
-      #end
-
-      # The migration code cannot handle Chicago like upgrades
-      return false if tile.paths.map(&:exits) != tile.paths.map(&:exits).uniq
-
-      old_active=@tile.paths.count do |path|
-        path.exits.any? { |e| @neighbors[e].targeting?(self) }
-      end
-      new_active=tile.paths.count do |path|
-        path.exits.any? { |e| @neighbors[e].targeting?(self) }
-      end
-      #puts old_active,new_active
-      return old_active == new_active
     end
 
     def paths


### PR DESCRIPTION
Skip reconnection walking if all new paths do not connect to anything,
simplify it to just migrate the references to the new hex