### PR TITLE
18CO Takeovers

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -76,15 +76,23 @@ module View
           h(:text, { attrs: attrs }, text)
         end
 
+        def cheater_token(entity)
+          token_abilities = entity.abilities(:token)
+          return nil if token_abilities.empty?
+
+          token_abilities&.cheater
+        end
+
         def on_click(event)
           return if @tile_selector&.is_a?(Lib::TileSelector)
 
           step = @game.round.active_step(@selected_company)
           entity = @selected_company || step.current_entity
           actions = step.actions(entity)
+
           return if (%w[remove_token place_token] & actions).empty?
-          return if @token && !step.can_replace_token?(entity, @token) &&
-                    !(cheater = entity.abilities(:token)&.cheater)
+
+          return if @token && !step.can_replace_token?(entity, @token) && !(cheater = cheater_token(entity))
 
           event.JS.stopPropagation
 

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -76,23 +76,15 @@ module View
           h(:text, { attrs: attrs }, text)
         end
 
-        def cheater_token(entity)
-          token_abilities = entity.abilities(:token)
-          return nil if token_abilities.empty?
-
-          token_abilities&.cheater
-        end
-
         def on_click(event)
           return if @tile_selector&.is_a?(Lib::TileSelector)
 
           step = @game.round.active_step(@selected_company)
           entity = @selected_company || step.current_entity
           actions = step.actions(entity)
-
           return if (%w[remove_token place_token] & actions).empty?
-
-          return if @token && !step.can_replace_token?(entity, @token) && !(cheater = cheater_token(entity))
+          return if @token && !step.can_replace_token?(entity, @token) &&
+                    !(cheater = entity.abilities(:token)&.cheater)
 
           event.JS.stopPropagation
 

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -143,8 +143,12 @@ module Engine
         end
       end
 
+      def mines_add(entity, count)
+        mine_create(entity, mines_count(entity) + count)
+      end
+
       def mine_add(entity)
-        mine_create(entity, mines_count(entity) + 1)
+        mines_add(entity, 1)
       end
 
       def mine_update_text(entity)
@@ -169,6 +173,7 @@ module Engine
       def operating_round(round_num)
         Round::Operating.new(self, [
         Step::Bankrupt,
+        Step::G18CO::Takeover,
         Step::DiscardTrain,
         Step::HomeToken,
         Step::ReturnToken,
@@ -188,6 +193,7 @@ module Engine
 
       def stock_round
         Round::Stock.new(self, [
+        Step::G18CO::Takeover,
         Step::DiscardTrain,
         Step::G18CO::BuySellParShares,
         ])

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -62,5 +62,13 @@ module Engine
     def tokens_by_type
       @tokens.reject(&:used).uniq(&:type)
     end
+
+    def unplaced_tokens
+      @tokens.reject(&:city)
+    end
+
+    def placed_tokens
+      @tokens.select(&:city)
+    end
   end
 end

--- a/lib/engine/step/g_18_co/takeover.rb
+++ b/lib/engine/step/g_18_co/takeover.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../tokener'
+
+module Engine
+  module Step
+    module G18CO
+      class Takeover < Base
+        include Tokener
+        ACTIONS = %w[place_token pass].freeze
+
+        def actions(entity)
+          return [] unless entity == current_entity
+
+          ACTIONS
+        end
+
+        def round_state
+          {
+            pending_takeover: nil,
+          }
+        end
+
+        def active?
+          takeover_in_progress?
+        end
+
+        def current_entity
+          pending_takeover[:destination_corp]
+        end
+
+        def taken_entity
+          pending_takeover[:source_corp]
+        end
+
+        def place_count
+          pending_takeover[:place_count]
+        end
+
+        def pending_takeover
+          @round.pending_takeover || {}
+        end
+
+        def description
+          "Replace up to #{place_count} Tokens"
+        end
+
+        def available_cities
+          taken_entity.tokens.map(&:city).compact
+        end
+
+        def available_city(_entity, city)
+          available_cities.include?(city)
+        end
+
+        def available_hex(_entity, hex)
+          available_cities.map(&:hex).include?(hex)
+        end
+
+        def pass_description
+          'Discard Remaining Tokens'
+        end
+
+        def process_pass(_action)
+          @game.log << "#{current_entity.name} passes replacing remaining #{taken_entity.name} tokens"
+
+          close_corporation(taken_entity)
+        end
+
+        def process_place_token(action)
+          entity = action.entity
+
+          unless available_hex(entity, action.city.hex)
+            @game.game_error("Cannot place a token on #{action.city.hex.name}")
+          end
+
+          old_token = taken_entity.tokens.find { |t| t.city == action.city }
+          new_token = entity.unplaced_tokens.last
+          old_token.swap!(new_token)
+          pending_takeover[:place_count] -= 1
+
+          @game.log << "#{current_entity.name} replaces #{taken_entity.name} token on #{action.city.hex.name}"
+
+          return if place_count.positive? &&
+            taken_entity.placed_tokens.any? &&
+            current_entity.unplaced_tokens.empty?
+
+          close_corporation(taken_entity)
+        end
+
+        def takeover_in_progress?
+          return true unless current_entity.nil?
+
+          @game.corporations.find do |source|
+            next if source.nil?
+            next unless source.floated?
+
+            takeover_corporation?(source)
+          end
+        end
+
+        def takeover_corporation?(source)
+          president_share_count = source.owner.num_shares_of(source)
+          source.corporate_share_holders.find do |c_s_h|
+            corporation, corporate_share_percent = c_s_h
+            next unless president_share_count < (corporate_share_percent / source.share_percent)
+
+            execute(source, corporation)
+          end
+        end
+
+        def execute(source, destination)
+          @game.log << "#{source.name} to be taken over by #{destination.name}"
+
+          @round.pending_takeover = {
+            destination_corp: destination,
+            source_corp: source,
+            place_count: 0,
+          }
+
+          return_corporate_shares_to_market(source)
+          distribute_treasury(source, destination)
+          remove_redundant_tokens(source, destination)
+          increase_train_limit(source, destination)
+          transfer_companies(source, destination)
+          transfer_mines(source, destination)
+          transfer_trains(source, destination)
+          replace_tokens(source, destination)
+          close_corporation(source) unless place_count.positive?
+
+          current_entity
+        end
+
+        def return_corporate_shares_to_market(source)
+          return unless source.corporate_shares.any?
+
+          returned_certs = source.corporate_shares.group_by(&:corporation)
+            .map { |key, vals| [key, vals.size] }
+
+          cash = {}
+          # must use while as shares array is modified by transfer
+          while (share = source.corporate_shares.first)
+            @game.bank.spend(share.price, source)
+            cash[share.corporation] =
+              cash[share.corporation].nil? ? share.price : cash[share.corporation] + share.price
+            share.transfer(@game.share_pool)
+          end
+
+          total_count = 0
+          share_string = returned_certs.map do |corp, count|
+            total_count += count
+            "#{count} #{corp.name} (#{@game.format_currency(cash[corp])})"
+          end.join(', ')
+
+          @game.log << "#{source.name} returns #{share_string} to the market"
+        end
+
+        def remove_redundant_tokens(source, destination)
+          return if source.placed_tokens.empty?
+          return if destination.unplaced_tokens.empty?
+
+          destination_cities = destination.tokens.map(&:city).compact
+
+          source.tokens.each do |token|
+            next unless token.used
+
+            token.city&.remove_reservation!(source)
+            token.remove! if destination_cities.include?(token.city)
+          end
+        end
+
+        def transfer_companies(source, destination)
+          return unless source.companies.any?
+
+          transferred = source.transfer(:companies, destination)
+
+          @game.log << "#{destination.name} takes #{transferred.map(&:name).join(', ')} from #{source.name}"
+        end
+
+        def transfer_trains(source, destination)
+          return unless source.trains.any?
+
+          transferred = source.transfer(:trains, destination)
+
+          @game.log << "#{destination.name} takes #{transferred.map(&:name).join(', ')}"\
+                       " train#{transferred.one? ? '' : 's'} from #{source.name}"
+        end
+
+        def transfer_mines(source, destination)
+          mine_count = @game.mines_count(source)
+          return unless mine_count.positive?
+
+          @game.log << "#{destination.name} takes #{mine_count} mines from #{source.name}"
+          @game.mines_add(destination, mine_count)
+          @game.mines_remove(source)
+        end
+
+        # The owned Corporation's Treasury, rounded down to the nearest $10
+        # is paid out to the owned Corporation's shareholders as if it were a dividend.
+        # Treasury money paid to shares in the Market is returned to the Bank.
+        # Any leftover treasury cash is transferred to the owning Corporation's treasury.
+        def distribute_treasury(source, destination)
+          payout = (source.cash.to_f / 10).floor.to_i
+
+          payout_shareholders(source, payout)
+
+          remaining_cash = source.cash
+
+          return unless remaining_cash.positive?
+
+          source.spend(remaining_cash, destination)
+          @game.log << "#{destination.name} takes #{@game.format_currency(remaining_cash)}"\
+                       " from #{source.name} remaining cash"
+        end
+
+        def payout_shareholders(source, payout)
+          share_percent = source.share_percent
+
+          payout_string = source.share_holders.map do |s_h|
+            entity, percent = s_h
+            next if source == entity
+
+            total_payout = payout * percent / share_percent
+            next unless total_payout.positive?
+
+            entity = @game.bank if entity.name == 'Market'
+
+            source.spend(total_payout, entity)
+            "#{@game.format_currency(total_payout)} to #{entity.name}"
+          end.compact.join(', ')
+
+          @game.log << "#{source.name} distributes #{payout_string}"
+        end
+
+        def increase_train_limit(source, destination)
+          destination.add_ability(
+            Engine::Ability::TrainLimit.new(
+              type: 'train_limit',
+              description: "+1 train limit from #{source.name} takeover",
+              increase: 1
+            )
+          )
+
+          @game.log << "#{destination.name} has +1 train limit from #{source.name} takeover"
+        end
+
+        def replace_tokens(source, destination)
+          return if source.placed_tokens.empty?
+          return if destination.unplaced_tokens.empty?
+
+          @round.pending_takeover[:place_count] = 2
+        end
+
+        def close_corporation(entity)
+          @game.close_corporation(entity)
+          entity.close!
+          @round.pending_takeover = nil
+        end
+
+        def can_replace_token?(entity, token)
+          available_city(entity, token.city)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836

If,​ ​at​ ​any​ ​time,​ ​a​ ​Corporation​ ​owns​ ​the​ ​President’s​ ​Certificate​ ​of​ ​another​ ​Corporation,​ ​the​ ​owning​ ​Corporation​ ​must​ ​take​ ​over​ ​the owned​ ​Corporation​ ​as​ ​follows:

- [x] Third-party shares on the owned Corporation charter are sold to the Market with no impact to share price. This money is placed in the owned Corporation Treasury.
- [x] Remove​ ​any​ ​owned​ ​Station​ ​Tokens​ ​in​ ​hexes​ ​containing​ ​the​ ​owning​ ​Corporation’s​ ​Station​ ​tokens.
- [x] Up​ ​to​ ​two​ ​owned​ ​Station​ ​Tokens​ ​on​ ​the​ ​board​ ​may​ ​be​ ​replaced​ ​with​ ​the​ ​owning​ ​Corporation’s​ ​Station​ ​Tokens​ ​at​ ​no​ ​cost. Use​ ​tokens​ ​from​ ​the​ ​right​ ​side​ ​of​ ​the​ ​Corporation​ ​Charter​ ​for​ ​this​ ​purpose.
- [x] The​ ​owning​ ​Corporation​ ​receives​ ​the​ ​Trains,​ ​Mine​ ​Tokens​ ​and​ ​Private​ ​Companies.
- [x] The​ ​owned​ ​Corporation’s​ ​Treasury,​ ​rounded​ ​down​ ​to​ ​the​ ​nearest​ ​$10,​ ​is​ ​paid​ ​out​ ​to​ ​the​ ​owned​ ​Corporation’s​ ​shareholders as​ ​if​ ​it​ ​were​ ​a​ ​dividend.​ ​Treasury​ ​money​ ​paid​ ​to​ ​shares​ ​in​ ​the​ ​Market​ ​is​ ​returned​ ​to​ ​the​ ​Bank.​ ​Any​ ​leftover​ ​treasury​ ​cash​ ​is transferred​ ​to​ ​the​ ​owning​ ​Corporation’s​ ​treasury.
- [x] The​ ​owning​ ​Corporation’s​ ​Train​ ​limit​ ​is​ ​increased​ ​by​ ​one.
- [x] Any​ ​excess​ ​trains​ ​are​ ​discarded​ ​to​ ​the​ ​Market​ ​down​ ​to​ ​the​ ​new​ ​limit.
- [x]  The​ ​owned​ ​Corporation​ ​is​ ​closed.​ ​Remove​ ​its​ ​Shares,​ ​Stock​ ​Token,​ ​any​ ​remaining​ ​Station​ ​Tokens​ ​and​ ​any​ ​previously​ ​taken​ ​over Charters​ ​underneath​ ​the​ ​owned​ ​Corporation’s​ ​charter​ ​from​ ​the​ ​game.

### Implementation Notes

TBD

### In Action

Most of the Takeover is automated. The only player choice is which of up to 2 tokens to swap to the new corporation.
<img width="604" alt="Screen Shot 2020-12-06 at 3 18 07 PM" src="https://user-images.githubusercontent.com/15675400/101294682-4419c280-37d6-11eb-913e-663cd82846af.png">

Showing the DPAC Denver redundant token was removed, and the remaining DPAC token hex is highlighted.
<img width="312" alt="Screen Shot 2020-12-06 at 3 18 33 PM" src="https://user-images.githubusercontent.com/15675400/101294686-53007500-37d6-11eb-8487-e7ba10777408.png">

The DPAC token was replaced with a DSNG token. Since no further DPAC tokens remained on the board, the Takeover step ended.
<img width="259" alt="Screen Shot 2020-12-06 at 3 19 45 PM" src="https://user-images.githubusercontent.com/15675400/101294701-7f1bf600-37d6-11eb-997e-cee774880630.png">

DSNG has 5 trains, legal with the +1 ability from the takeover. The ability is also shown on the card.
<img width="331" alt="Screen Shot 2020-12-06 at 3 16 41 PM" src="https://user-images.githubusercontent.com/15675400/101294670-32d0b600-37d6-11eb-8121-38e45d542ebd.png">
