### PR TITLE
Revert "Hide bankrupt players from spreadsheet"

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -21,8 +21,6 @@ module View
         @spreadsheet_sort_by = Lib::Storage['spreadsheet_sort_by']
         @spreadsheet_sort_order = Lib::Storage['spreadsheet_sort_order']
 
-        @players = @game.players.reject(&:bankrupt)
-
         children = []
         children << h(Bank, game: @game)
         children << render_table
@@ -152,7 +150,7 @@ module View
         [
           h(:tr, [
             h(:th, ''),
-            h(:th, th_props[@players.size], 'Players'),
+            h(:th, th_props[@game.players.size], 'Players'),
             h(:th, th_props[2, true], 'Bank'),
             h(:th, th_props[2], 'Prices'),
             h(:th, th_props[5 + extra.size, true, false], 'Corporation'),
@@ -161,7 +159,7 @@ module View
           ]),
           h(:tr, [
             h(:th, { style: { paddingBottom: '0.3rem' } }, render_sort_link('SYM', :id)),
-            *@players.map do |p|
+            *@game.players.map do |p|
               h('th.name.nowrap.right', p == @game.priority_deal_player ? pd_props : '', render_sort_link(p.name, p.id))
             end,
             h(:th, @game.ipo_name),
@@ -283,7 +281,7 @@ module View
 
         h(:tr, tr_props, [
           h(:th, name_props, corporation.name),
-          *@players.map do |p|
+          *@game.players.map do |p|
             sold_props = { style: {} }
             if @game.round.active_step&.did_sell?(corporation, p)
               sold_props[:style][:backgroundColor] = '#9e0000'
@@ -317,35 +315,35 @@ module View
       def render_player_companies
         h(:tr, zebra_props, [
           h(:th, 'Companies'),
-          *@players.map { |p| render_companies(p) },
+          *@game.players.map { |p| render_companies(p) },
         ])
       end
 
       def render_player_cash
         h(:tr, zebra_props, [
           h('th.left', 'Cash'),
-          *@players.map { |p| h('td.padded_number', @game.format_currency(p.cash)) },
+          *@game.players.map { |p| h('td.padded_number', @game.format_currency(p.cash)) },
         ])
       end
 
       def render_player_value
         h(:tr, zebra_props(true), [
           h('th.left', 'Value'),
-          *@players.map { |p| h('td.padded_number', @game.format_currency(p.value)) },
+          *@game.players.map { |p| h('td.padded_number', @game.format_currency(p.value)) },
         ])
       end
 
       def render_player_liquidity
         h(:tr, zebra_props, [
           h('th.left', 'Liquidity'),
-          *@players.map { |p| h('td.padded_number', @game.format_currency(@game.liquidity(p))) },
+          *@game.players.map { |p| h('td.padded_number', @game.format_currency(@game.liquidity(p))) },
         ])
       end
 
       def render_player_shares
         h(:tr, zebra_props(true), [
           h('th.left', 'Shares'),
-          *@players.map do |p|
+          *@game.players.map do |p|
             h('td.padded_number', @game.all_corporations.sum { |c| c.minor? ? 0 : num_shares_of(p, c) })
           end,
         ])
@@ -356,7 +354,7 @@ module View
         props = { style: { color: 'red' } }
         h(:tr, zebra_props(true), [
           h('th.left', "Certs/#{cert_limit}"),
-          *@players.map { |player| render_player_cert_count(player, cert_limit, props) },
+          *@game.players.map { |player| render_player_cert_count(player, cert_limit, props) },
         ])
       end
 

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -72,7 +72,7 @@ module View
         zebra_row = true
         last_values = nil
         @game.players.first.history.map do |h|
-          values = @players.map do |p|
+          values = @game.players.map do |p|
             p.history.find { |h2| h2.round == h.round }.value
           end
           next if values == last_values


### PR DESCRIPTION
This reverts commit f995a3df989439483f3fb43389f821af6a5105e8.

This was a bad idea. It is annoying during a game of 1817 to have an unnecessary column full of zeroes, but in games that end in bankruptcy it makes no sense to hide this column.

Since 883dddc407af50689a88f2ce5666daf5bf8b19bf, this column always contains information. Even in games that don't end with a bankruptcy. So I don't think this makes sense anymore in either type of game.