### PR TITLE
1860 Corporate Bankruptcy

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -87,19 +87,22 @@ module View
           children << h(:div, props, subchildren)
         end
 
-        if @game.status_str(@corporation)
-          props = {
-            style: {
-              grid: '1fr / repeat(2, max-content)',
-              gap: '2rem',
-              justifyContent: 'center',
-              backgroundColor: color_for(:bg2),
-              color: color_for(:font2),
-            },
-          }
+        status_props = {
+          style: {
+            grid: '1fr / repeat(2, max-content)',
+            gap: '2rem',
+            justifyContent: 'center',
+            backgroundColor: color_for(:bg2),
+            color: color_for(:font2),
+          },
+        }
 
-          children << h(:div, props, render_status)
+        if @corporation.trains.any? && !@corporation.floated?
+          if @corporation.trains.any? && !@corporation.floated?
+            children << h(:div, status_props, @game.float_str(@corporation))
+          end
         end
+        children << h(:div, status_props, render_status) if @game.status_str(@corporation)
 
         h('div.corp.card', { style: card_style, on: { click: select_corporation } }, children)
       end
@@ -166,7 +169,7 @@ module View
         }
 
         holdings =
-          if !@corporation.corporation? || @corporation.floated?
+          if !@corporation.corporation? || @corporation.floated? || @corporation.trains.any?
             h(:div, holdings_props, [render_trains, render_cash])
           elsif @corporation.cash.positive?
             h(:div, holdings_props, [render_to_float, render_cash])
@@ -203,12 +206,17 @@ module View
             grid: '25px auto / 1fr',
           },
         }
+
         value_props = {
           style: {
             maxWidth: '7.5rem',
             fontWeight: 'bold',
           },
         }
+
+        value_props[:style].merge!(fontSize: 'small') if value.size > 6
+        value_props[:style].merge!(fontSize: 'x-small') if value.size > 10
+
         key_props = {
           style: {
             alignSelf: 'end',

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -98,9 +98,7 @@ module View
         }
 
         if @corporation.trains.any? && !@corporation.floated?
-          if @corporation.trains.any? && !@corporation.floated?
-            children << h(:div, status_props, @game.float_str(@corporation))
-          end
+          children << h(:div, status_props, @game.float_str(@corporation))
         end
         children << h(:div, status_props, render_status) if @game.status_str(@corporation)
 

--- a/assets/app/view/game/token.rb
+++ b/assets/app/view/game/token.rb
@@ -7,6 +7,16 @@ module View
       needs :radius
 
       def render
+        if @token.status != :flipped
+          render_token
+        else
+          children = [render_token]
+          children.concat(render_stroke)
+          h(:g, children)
+        end
+      end
+
+      def render_token
         h(
           :image, attrs: {
             href: @token.logo,
@@ -16,6 +26,39 @@ module View
             width: (2 * @radius),
           },
         )
+      end
+
+      def render_stroke
+        redw = 7
+        whitew = 2
+        s = (@radius / Math.sqrt(2)).round(2)
+        d = ((redw + whitew) / 2.0 / Math.sqrt(2)).round(2)
+        [
+          h(
+            :path, attrs: {
+              d: "M #{s} #{-s} L #{-s} #{s}",
+              stroke: 'red',
+              'stroke-width': redw,
+              'stroke-opacity': '0.6',
+            },
+          ),
+          h(
+            :path, attrs: {
+              d: "M #{s - d} #{-s - d} L #{-s - d} #{s - d}",
+              stroke: 'white',
+              'stroke-width': whitew,
+              'stroke-opacity': '1.0',
+            },
+          ),
+          h(
+            :path, attrs: {
+              d: "M #{s + d} #{-s + d} L #{-s + d} #{s + d}",
+              stroke: 'white',
+              'stroke-width': whitew,
+              'stroke-opacity': '1.0',
+            },
+          ),
+        ]
       end
     end
   end

--- a/assets/app/view/game/token.rb
+++ b/assets/app/view/game/token.rb
@@ -6,6 +6,9 @@ module View
       needs :token
       needs :radius
 
+      RED_WIDTH = 7
+      WHITE_WIDTH = 2
+
       def render
         if @token.status != :flipped
           render_token
@@ -29,16 +32,14 @@ module View
       end
 
       def render_stroke
-        redw = 7
-        whitew = 2
         s = (@radius / Math.sqrt(2)).round(2)
-        d = ((redw + whitew) / 2.0 / Math.sqrt(2)).round(2)
+        d = ((RED_WIDTH + WHITE_WIDTH) / 2.0 / Math.sqrt(2)).round(2)
         [
           h(
             :path, attrs: {
               d: "M #{s} #{-s} L #{-s} #{s}",
               stroke: 'red',
-              'stroke-width': redw,
+              'stroke-width': RED_WIDTH,
               'stroke-opacity': '0.6',
             },
           ),
@@ -46,7 +47,7 @@ module View
             :path, attrs: {
               d: "M #{s - d} #{-s - d} L #{-s - d} #{s - d}",
               stroke: 'white',
-              'stroke-width': whitew,
+              'stroke-width': WHITE_WIDTH,
               'stroke-opacity': '1.0',
             },
           ),
@@ -54,7 +55,7 @@ module View
             :path, attrs: {
               d: "M #{s + d} #{-s + d} L #{-s + d} #{s + d}",
               stroke: 'white',
-              'stroke-width': whitew,
+              'stroke-width': WHITE_WIDTH,
               'stroke-opacity': '1.0',
             },
           ),

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -165,6 +165,10 @@ module Engine
       @floated ? 0 : percent_of(self) - (100 - @float_percent)
     end
 
+    def unfloat!
+      @floated = false
+    end
+
     def corporation?
       true
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -141,6 +141,9 @@ module Engine
       # none, one, each
       POOL_SHARE_DROP = :none
 
+      # do sold out shares increase the price?
+      SOLD_OUT_INCREASE = true
+
       # :after_last_to_act -- player after the last to act goes first. Order remains the same.
       # :first_to_pass -- players ordered by when they first started passing.
       NEXT_SR_PLAYER_ORDER = :after_last_to_act

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -124,6 +124,10 @@ module Engine
         reserve_share('IOW')
       end
 
+      def share_prices
+        repar_prices
+      end
+
       def reserve_share(name)
         @corporations.find { |c| c.name == name }.shares.last.buyable = false
       end

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -33,6 +33,8 @@ module Engine
       TRAIN_PRICE_MIN = 10
       TRAIN_PRICE_MULTIPLE = 10
 
+      SOLD_OUT_INCREASE = false
+
       STOCKMARKET_COLORS = {
         par: :yellow,
         endgame: :orange,
@@ -46,6 +48,16 @@ module Engine
         acquisition: :yellow,
         safe_par: :white,
       }.freeze
+
+      MARKET_TEXT = { par: 'Par values (varies by corporation)',
+                      no_cert_limit: 'UNUSED',
+                      unlimited: 'UNUSED',
+                      multiple_buy: 'UNUSED',
+                      close: 'Corporation bankrupts',
+                      endgame: 'End game trigger',
+                      liquidation: 'UNUSED',
+                      repar: 'Par values after bankruptcy (varies by corporation)',
+                      ignore_one_sale: 'Ignore first share sold when moving price' }.freeze
 
       HALT_SUBSIDY = 10
 
@@ -198,11 +210,63 @@ module Engine
         @bankrupt_corps.include?(corp)
       end
 
-      def make_bankrupt(corp)
-        @bankrupt_corps << corp unless bankrupt(corp)
+      def make_bankrupt!(corp)
+        return if bankrupt?(corp)
+
+        @bankrupt_corps << corp
+        @log << "#{corp.name} enters Bankruptcy"
+
+        # un-IPO the corporation
+        corp.share_price.corporations.delete(corp)
+        corp.share_price = nil
+        corp.par_price = nil
+        corp.ipoed = false
+        corp.unfloat!
+
+        # return shares to IPO
+        corp.share_holders.keys.each do |share_holder|
+          next if share_holder == corp
+
+          shares = share_holder.shares_by_corporation[corp].compact
+          corp.share_holders.delete(share_holder)
+          shares.each do |share|
+            share_holder.shares_by_corporation[corp].delete(share)
+            share.owner = corp
+            corp.shares_by_corporation[corp] << share
+          end
+        end
+        corp.shares_by_corporation[corp].sort_by!(&:index)
+        corp.share_holders[corp] = 100
+        corp.owner = nil
+
+        # "flip" any tokens for corporation placed on map
+        corp.tokens.each do |token|
+          token.status = :flipped if token.used
+        end
+
+        # find new priority deal: player with lowest total share count
+        @players.rotate!(@players.index(priority_deal_player))
+        player = @players.min_by { |p| p.shares.sum(&:percent) }
+        @players.rotate!(@players.index(player))
+        @log << "#{@players.first.name} has priority deal"
+
+        # restart stock round if in middle of one
+        return unless @round.class == Round::Stock
+
+        @log << 'Restarting Stock Round'
+        @round.entities.each(&:unpass!)
+        @round = stock_round
       end
 
-      def clear_bankrupt(corp)
+      def clear_bankrupt!(corp)
+        return unless bankrupt?(corp)
+
+        # Designer says that bankrupt corps keep insolvency flag
+
+        # "unflip" any tokens for corporation placed on map
+        corp.tokens.each do |token|
+          token.status = nil if token.used
+        end
         @bankrupt_corps.delete(corp)
       end
 
@@ -252,9 +316,14 @@ module Engine
       end
 
       def float_corporation(corporation)
-        # Designer says that bankrupt corps keep insolvency flag
-        clear_bankrupt(corporation)
+        clear_bankrupt!(corporation)
         super
+      end
+
+      def action_processed(_action)
+        @corporations.each do |corporation|
+          make_bankrupt!(corporation) if corporation.share_price&.type == :close
+        end
       end
 
       def sorted_corporations
@@ -289,6 +358,11 @@ module Engine
         bundles
       end
 
+      def selling_movement?(corporation)
+        # FIXME: no price movement on selling after 8 train
+        corporation.operated?
+      end
+
       def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
         corporation = bundle.corporation
         price = corporation.share_price.price
@@ -296,7 +370,7 @@ module Engine
         @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
         num_shares = bundle.num_shares
         num_shares -= 1 if corporation.share_price.type == :ignore_one_sale
-        num_shares.times { @stock_market.move_left(corporation) }
+        num_shares.times { @stock_market.move_left(corporation) } if selling_movement?(corporation)
         log_share_price(corporation, price)
       end
 
@@ -450,6 +524,56 @@ module Engine
         @hex_distances[corporation] = h_distances
       end
 
+      # needed for custom_node_walk
+      def custom_node_select(node, paths, corporation: nil)
+        on = paths.map { |p| [p, 0] }.to_h
+
+        custom_node_walk(node, on: on, corporation: corporation) do |path|
+          on[path] = 1 if on[path]
+        end
+
+        val = on.keys.select { |p| on[p] == 1 }
+        val
+      end
+
+      # needed for custom_blocks?
+      def custom_node_walk(node, visited: nil, on: nil, corporation: nil, visited_paths: {})
+        return if visited&.[](node)
+
+        visited = visited&.dup || {}
+        visited[node] = true
+
+        node.paths.each do |node_path|
+          node_path.walk(visited: visited_paths, on: on) do |path, vp|
+            yield path
+            path.nodes.each do |next_node|
+              next if next_node == node
+              next if corporation && custom_blocks?(next_node, corporation)
+              next if path.terminal?
+
+              custom_node_walk(
+                next_node,
+                visited: visited,
+                on: on,
+                corporation: corporation,
+                visited_paths: visited_paths.merge(vp),
+              ) { |p| yield p }
+            end
+          end
+        end
+      end
+
+      # needed for :flipped check
+      def custom_blocks?(node, corporation)
+        return false unless node.city?
+        return false unless corporation
+        return false if node.tokened_by?(corporation)
+        return false if node.tokens.include?(nil)
+        return false if node.tokens.any? { |t| t&.type == :neutral || t&.status == :flipped }
+
+        true
+      end
+
       def legal_tile_rotation?(_entity, _hex, tile)
         return true unless NO_ROTATION_TILES.include?(tile.name)
 
@@ -509,7 +633,7 @@ module Engine
         if visits.size > 2
           corporation = route.corporation
           visits[1..-2].each do |node|
-            if node.city? && node.blocks?(corporation)
+            if node.city? && custom_blocks?(node, corporation)
               game_error('Route can only bypass one tokened-out city') if blocked
               blocked = node
             end
@@ -518,7 +642,9 @@ module Engine
 
         paths_ = route.paths.uniq
         token = blocked if blocked
-        game_error('Route is not connected') if token.select(paths_, corporation: route.corporation).size != paths_.size
+        if custom_node_select(token, paths_, corporation: route.corporation).size != paths_.size
+          game_error('Route is not connected')
+        end
 
         return unless blocked && route.routes.any? { |r| r != route && tokened_out?(r) }
 

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -536,8 +536,7 @@ module Engine
           on[path] = 1 if on[path]
         end
 
-        val = on.keys.select { |p| on[p] == 1 }
-        val
+        on.keys.select { |p| on[p] == 1 }
       end
 
       # needed for custom_blocks?

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -62,7 +62,7 @@ module Engine
         @game.corporations.select(&:floated?).sort.each do |corp|
           prev = corp.share_price.price
 
-          @game.stock_market.move_up(corp) if sold_out?(corp)
+          @game.stock_market.move_up(corp) if sold_out?(corp) && @game.class::SOLD_OUT_INCREASE
           pool_share_drop = @game.class::POOL_SHARE_DROP
           price_drops =
             if (pool_share_drop == :none) || (shares_in_pool = corp.num_market_shares).zero?

--- a/lib/engine/step/g_1860/buy_train.rb
+++ b/lib/engine/step/g_1860/buy_train.rb
@@ -56,7 +56,8 @@ module Engine
         end
 
         def illegal_train_buy?(entity, train)
-          entity.receivership? ||
+          @game.bankrupt?(train.owner) ||
+            entity.receivership? ||
             train.owner.receivership? ||
             entity.trains.any? && train.owner.trains.size < 2
         end

--- a/lib/engine/step/g_1860/route.rb
+++ b/lib/engine/step/g_1860/route.rb
@@ -26,8 +26,8 @@ module Engine
 
           text = ''
           if current_entity.receivership?
-            text += "#{current_entity.name} is in receivership (it has no president)."\
-              'Most of its actions are automated, but it must have a player manually run'\
+            text += "#{current_entity.name} is in receivership (it has no president). "\
+              'Most of its actions are automated, but it must have a player manually run '\
               "its trains. Please enter the best route you see for #{current_entity.name}."
           end
           text += ' In addition, ' if current_entity.receivership? && @game.insolvent?(current_entity)

--- a/lib/engine/token.rb
+++ b/lib/engine/token.rb
@@ -3,7 +3,7 @@
 module Engine
   class Token
     attr_reader :corporation, :logo
-    attr_accessor :city, :price, :type, :used
+    attr_accessor :city, :price, :type, :used, :status
 
     def initialize(corporation, price: 0, logo: nil, type: :normal)
       @corporation = corporation
@@ -12,6 +12,7 @@ module Engine
       @used = false
       @type = type
       @city = nil
+      @status = nil
     end
 
     def destroy!


### PR DESCRIPTION
Last of the big corporate status implementations: Corporate Bankruptcy

Unlike closing a corporation, a bankrupt corporation keeps it's assets and can be re-parred with a wider range of prices than before it was bankrupt. Any outstanding stock shares are moved from players/pool back to IPO. A new priority deal is assigned and if the bankruptcy occurs in the middle of a stock round, the stock round is restarted. It also implements the concept of "flipped" tokens for bankrupted corps that block track laying and tokening, but not running trains:

![Flipped_token](https://user-images.githubusercontent.com/8494213/101699757-fcdf3c00-3a38-11eb-82a2-b51727b40a04.png)

Common file changes:

- UI: Corporation: handle showing assets for bankrupt corps, shrink font for really long train strings (1860 is bad in this regard)
- UI: Token: render flipped tokens
- Engine::Token: new status instance var
- Engine::Corporation: new unfloat! method
- Round::Stock: game configuration to prevent share price change when stock is sold out
- Game::Base: add config variable for above

![bankrupte corp card](https://user-images.githubusercontent.com/8494213/101700618-99560e00-3a3a-11eb-99cc-0d145f761182.png)
