### PR TITLE
18CO Return Token Ability

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -66,7 +66,7 @@ company is bought in by a corporation.
 Describe when the company closes, using the `when` attribute.
 
 - `corporation'`: If `when` is set to `"train"`, this value is the name
-of the corporation whose train purchase closes this company.
+  of the corporation whose train purchase closes this company.
 
 ## description
 
@@ -101,6 +101,14 @@ Reserve a token slot
 - `slot`: A specific token slot to designate
 - `city`: Which city to reserve, if multiple cities are on one hex
 
+## return_token
+
+Take a station token off the board and place back on the charter
+in the most expensive open location
+
+- `reimburse`: If true, the corporation is reimbursed the token cost
+  of the location where the token is placed
+
 ## revenue_change
 
 The revenue for this company changes when the conditions set by `when`
@@ -119,8 +127,7 @@ This company comes with a share of a corporation when acquired.
   president's certificate randomly selected at game setup. Gives one
   ordinary share of one the corporations listed in `corporations`,
   randomly selected at game setup.
-- `corporations`: A list of corporations to be used with `"share":
-  "random_share"`
+- `corporations`: A list of corporations to be used with `"share": "random_share"`
 
 ## teleport
 

--- a/lib/engine/ability/return_token.rb
+++ b/lib/engine/ability/return_token.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Ability
+    class ReturnToken < Base
+      attr_reader :reimburse
+
+      def setup(reimburse: false)
+        @reimburse = reimburse
+      end
+    end
+  end
+end

--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -398,7 +398,12 @@ module Engine
 			"revenue": 10,
 			"desc": "An owning Corporation may return a station token to its charter to gain the token cost. Corporation must always have at least one token on the board. Action closes the company or closes on purchase of “5” train.",
 			"abilities": [
-
+				{
+					"type": "return_token",
+					"owner_type": "corporation",
+					"count": 1,
+					"reimburse": true
+				}
 			]
 		},
 		{

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -171,6 +171,7 @@ module Engine
         Step::Bankrupt,
         Step::DiscardTrain,
         Step::HomeToken,
+        Step::ReturnToken,
         Step::BuyCompany,
         Step::G18CO::RedeemShares,
         Step::CorporateBuyShares,

--- a/lib/engine/step/return_token.rb
+++ b/lib/engine/step/return_token.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Step
+    class ReturnToken < Base
+      ACTIONS = %w[remove_token].freeze
+
+      def actions(entity)
+        return [] unless ability(entity)
+
+        ACTIONS
+      end
+
+      def blocks?
+        false
+      end
+
+      def process_remove_token(action)
+        company = action.entity
+        corporation = action.entity.owner
+
+        @game.game_error("#{company.name} must be owned by a corporation") unless corporation.corporation?
+
+        last_used_token = available_tokens(corporation).first
+
+        @game.game_error("#{corporation.name} cannot return its only placed token") unless last_used_token
+
+        selected_city = action.city
+        hex = selected_city.hex
+
+        city_string = hex.tile.cities.size > 1 ? " city #{selected_city.index}" : ''
+        unless available_city(corporation, selected_city)
+          @game.game_error("Cannot return token from #{hex.name}#{city_string} to #{corporation.name}")
+        end
+
+        last_city = last_used_token.city
+        return_ability = ability(company)
+        selected_token = selected_city.tokens[action.slot]
+
+        selected_token.remove!
+        selected_city&.remove_reservation!(corporation)
+        if selected_token != last_used_token
+          last_used_token.remove!
+          last_city.place_token(corporation, selected_token)
+        end
+
+        @game.bank.spend(last_used_token.price, corporation) if return_ability.reimburse
+
+        return_ability.use!
+
+        @log <<
+          "#{corporation.name} returns the token from #{hex.name}#{city_string} using #{company.name}"\
+          "#{(return_ability.reimburse ? " and is reimbursed #{@game.format_currency(last_used_token.price)}" : '')}"
+      end
+
+      def can_replace_token?(company, token)
+        corporation = company.owner
+        return unless corporation.corporation?
+
+        available_tokens(corporation).any? && corporation.tokens.find { |t| t.city == token.city }
+      end
+
+      def available_hex(company, hex)
+        corporation = company.owner
+        return unless corporation.corporation?
+
+        corporation.tokens.map { |t| t.city&.hex }.include?(hex)
+      end
+
+      def available_city(corporation, city)
+        return unless corporation.corporation?
+
+        corporation.tokens.map(&:city).include?(city)
+      end
+
+      def available_tokens(corporation)
+        return [] unless corporation.corporation?
+
+        used_tokens = corporation.tokens.select(&:used)
+
+        # You cannot return your last token
+        return [] unless used_tokens.size > 1
+
+        [used_tokens.last]
+      end
+
+      def ability(entity)
+        return unless entity&.company?
+
+        entity.abilities(:return_token)
+      end
+    end
+  end
+end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836

Denver,​ ​Northwestern and​ ​Pacific​ ​Railroad
New Ability: An owning Corporation may return a station token to its charter to regain the token cost. The token is always placed on the most expensive open token slot and reimburses that cost. Corporation must always have at least one token on the board.

DPAC used DNPR to remove the token in Denver. The token was returned, $40 reimbursed and the reservation in Denver removed.
<img width="1072" alt="Screen Shot 2020-12-10 at 4 50 30 PM" src="https://user-images.githubusercontent.com/15675400/101843616-d63c0680-3b07-11eb-9d13-1a98711990ad.png">
