### PR TITLE
18CO Corporate Share Sales

### DIFF
--- a/assets/app/view/game/corporate_sell_shares.rb
+++ b/assets/app/view/game/corporate_sell_shares.rb
@@ -10,16 +10,15 @@ module View
 
       def render
         @step = @game.round.active_step
-        current_actions = @step.current_actions
-        @entity ||= @game.current_entity
-        children = []
+        @current_actions = @step.current_actions
+        @entity = @game.current_entity
 
-        children.concat(render_sources) if current_actions.include?('corporate_sell_shares')
-
-        h('div.margined', children.compact)
+        h('div.margined', render_sources)
       end
 
       def render_sources
+        return [] unless @current_actions.include?('corporate_sell_shares')
+
         @step.source_list(@entity).flat_map do |source|
           [
             h(Corporation, corporation: source),

--- a/assets/app/view/game/corporate_sell_shares.rb
+++ b/assets/app/view/game/corporate_sell_shares.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+require 'view/game/sell_shares'
+
+module View
+  module Game
+    class CorporateSellShares < Snabberb::Component
+      include Actionable
+
+      def render
+        @step = @game.round.active_step
+        current_actions = @step.current_actions
+        @entity ||= @game.current_entity
+        children = []
+
+        children.concat(render_sources) if current_actions.include?('corporate_sell_shares')
+
+        h('div.margined', children.compact)
+      end
+
+      def render_sources
+        @step.source_list(@entity).flat_map do |source|
+          [
+            h(Corporation, corporation: source),
+            h(SellShares,
+              player: @entity,
+              corporation: source,
+              action: Engine::Action::CorporateSellShares),
+          ]
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -41,6 +41,8 @@ module View
             left << h(IssueShares)
           elsif @current_actions.include?('corporate_buy_shares')
             left << h(CorporateBuyShares)
+          elsif @current_actions.include?('corporate_sell_shares')
+            left << h(CorporateSellShares)
           end
           left << h(Loans, corporation: entity) if (%w[take_loan payoff_loan] & @current_actions).any?
 

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -9,11 +9,12 @@ module View
 
       needs :player
       needs :corporation
+      needs :action, default: Engine::Action::SellShares
 
       def render
         buttons = @game.sellable_bundles(@player, @corporation).map do |bundle|
           sell = lambda do
-            process_action(Engine::Action::SellShares.new(
+            process_action(@action.new(
               @player,
               shares: bundle.shares,
               share_price: bundle.share_price,
@@ -27,7 +28,11 @@ module View
             },
             on: { click: sell },
           }
-          h('button.sell_share', props, "Sell #{share_presentation(bundle)} (#{@game.format_currency(bundle.price)})")
+          h(
+            'button.sell_share',
+            props,
+            "Sell #{share_presentation(bundle)} (#{@game.format_currency(bundle.price)})"
+          )
         end
 
         step = @game.round.active_step
@@ -53,7 +58,7 @@ module View
       def sell_with_swap(player, bundle, swap_sell)
         reduced_price = @game.format_currency(bundle.price - swap_sell.price)
         swap = lambda do
-          process_action(Engine::Action::SellShares.new(
+          process_action(@action.new(
             player,
             shares: bundle.shares,
             share_price: bundle.share_price,
@@ -74,7 +79,7 @@ module View
       end
 
       def sell_bundle(player, bundle, swap: nil)
-        process_action(Engine::Action::SellShares.new(
+        process_action(@action.new(
           player,
           shares: bundle.shares,
           share_price: bundle.share_price,

--- a/lib/engine/action/corporate_sell_shares.rb
+++ b/lib/engine/action/corporate_sell_shares.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'sell_shares'
+
+module Engine
+  module Action
+    class CorporateSellShares < SellShares
+    end
+  end
+end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -180,6 +180,7 @@ module Engine
         Step::Route,
         Step::G18CO::Dividend,
         Step::BuyTrain,
+        Step::CorporateSellShares,
         Step::G18CO::IssueShares,
         [Step::BuyCompany, blocks: true],
         ], round_num: round_num)

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -99,7 +99,7 @@ module Engine
     def sell_shares(bundle, allow_president_change: true, swap: nil)
       entity = bundle.owner
 
-      verb = entity.corporation? ? 'issues' : 'sells'
+      verb = entity.corporation? && entity == bundle.corporation ? 'issues' : 'sells'
 
       price = bundle.price
       price -= swap.price if swap

--- a/lib/engine/step/corporate_sell_shares.rb
+++ b/lib/engine/step/corporate_sell_shares.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'share_buying'
+require_relative '../action/corporate_sell_shares'
+
+module Engine
+  module Step
+    class CorporateSellShares < Base
+      include ShareBuying
+
+      def description
+        'Corporate Share Sales'
+      end
+
+      def actions(entity)
+        return [] unless entity == current_entity
+
+        actions = []
+        actions << 'corporate_sell_shares' if can_sell_any?(entity)
+
+        actions << 'pass' if actions.any?
+
+        actions
+      end
+
+      def log_pass(entity)
+        @log << "#{entity.name} passes selling shares"
+      end
+
+      def log_skip(entity)
+        @log << "#{entity.name} skips corporate share sales"
+      end
+
+      def can_sell_any?(entity)
+        entity.corporate_shares.select { |share| can_sell?(entity, share.to_bundle) }.any?
+      end
+
+      def can_sell?(entity, bundle)
+        return unless bundle
+
+        entity != bundle.corporation && !bought?(entity, bundle.corporation)
+      end
+
+      def process_corporate_sell_shares(action)
+        sell_shares(action.entity, action.bundle, swap: action.swap)
+        pass! unless can_sell_any?(action.entity)
+      end
+
+      def sell_shares(entity, shares, swap: nil)
+        @game.game_error("Cannot sell shares of #{shares.corporation.name}") if !can_sell?(entity, shares) && !swap
+
+        @game.sell_shares_and_change_price(shares, swap: swap)
+      end
+
+      def source_list(entity)
+        entity.corporate_shares.map do |share|
+          next if bought?(entity, share.corporation)
+
+          share.corporation
+        end.compact
+      end
+
+      def bought?(entity, corporation)
+        @round.corporations_bought[entity].include?(corporation)
+      end
+    end
+  end
+end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836

Shares (of other corporations)​ ​owned​ ​by​ ​a​ ​Corporation​ ​can​ ​be​ ​sold​ ​if​ ​the​ ​operating​ ​Corporation​ ​did​ ​not​ ​purchase​ ​any​ ​shares​ ​in​ ​the​ ​target Corporation​ ​earlier in​ ​the​ ​same​ ​operating round.

### Implementation Notes

Changes to _operating.rb_ were required to add the new view
Changes to _sell_shares.rb_ allow for the corporate sell action which is necessary to allow for the corporate view.
Changes to _share_pool.rb_ correct the assumption that if a corporation is selling shares, its an issue. That's only true if the corporation is the same as the bundle.
Changes to _corporate_buy_shares.rb_ allow for distinguishing between which corporation bought which other corporations

### Impacts

Here we see DPAC owns both CM and KPAC. DPAC can sell CM. DPAC cannot sell KPAC because, as the log shows, they just bought KPAC this round.

<img width="593" alt="Screen Shot 2020-12-11 at 10 03 10 AM" src="https://user-images.githubusercontent.com/15675400/101934154-6a56ae00-3b9a-11eb-9de6-8ed3e1cffcb9.png">
