### PR TITLE
1867: Phase 3 events

### DIFF
--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -222,28 +222,64 @@ module Engine
       "sym": "NFB",
       "value": 45,
       "revenue": 15,
-      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Buffalo"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Buffalo",
+      "abilities": [
+        {
+        "type": "hex_bonus",
+        "owner_type": "corporation",
+        "hexes": [
+          "F18"
+        ],
+        "amount": 10
+      }]
     },
     {
       "name": "Montreal Bridge",
       "sym": "MB",
       "value": 60,
       "revenue": 20,
-      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Montreal"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Montreal",
+      "abilities": [
+        {
+        "type": "hex_bonus",
+        "owner_type": "corporation",
+        "hexes": [
+          "L12"
+        ],
+        "amount": 10
+      }]
     },
     {
       "name": "Quebec Bridge",
       "sym": "QB",
       "value": 75,
       "revenue": 25,
-      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Quebec"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Quebec",
+      "abilities": [
+        {
+        "type": "hex_bonus",
+        "owner_type": "corporation",
+        "hexes": [
+          "O7"
+        ],
+        "amount": 10
+      }]
     },
     {
       "name": "St. Clair Tunnel",
       "sym": "SCT",
       "value": 90,
       "revenue": 30,
-      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Detroit"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Detroit",
+      "abilities": [
+        {
+        "type": "hex_bonus",
+        "owner_type": "corporation",
+        "hexes": [
+          "A19"
+        ],
+        "amount": 10
+      }]
     }
   ],
   "corporations": [

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -222,28 +222,28 @@ module Engine
       "sym": "NFB",
       "value": 45,
       "revenue": 15,
-      "desc": "+10 Buffalo"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Buffalo"
     },
     {
       "name": "Montreal Bridge",
       "sym": "MB",
       "value": 60,
       "revenue": 20,
-      "desc": "+10 Montreal"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Montreal"
     },
     {
       "name": "Quebec Bridge",
       "sym": "QB",
       "value": 75,
       "revenue": 25,
-      "desc": "+10 Quebec"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Quebec"
     },
     {
       "name": "St. Clair Tunnel",
       "sym": "SCT",
       "value": 90,
       "revenue": 30,
-      "desc": "+10 Detroit"
+      "desc": "When owned by a corporation, they gain $10 extra revenue for each of their routes that include Detroit"
     }
   ],
   "corporations": [

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -196,6 +196,21 @@ module Engine
   ],
   "companies": [
     {
+      "name": "Hidden corporation to lock the 3 spots",
+      "sym": "3",
+      "value": 3,
+      "revenue": 0,
+      "desc": "Hidden corporation",
+      "abilities": [
+        {
+        "type": "blocks_hexes",
+        "owner_type": "player",
+        "hexes": [
+          "M13"
+        ]
+      }]
+    },
+    {
       "name": "Champlain & St. Lawrence",
       "sym": "C&SL",
       "value": 30,
@@ -526,6 +541,15 @@ module Engine
       "max_ownership_percent": 100,
       "type": "minor",
       "color": "green"
+    },
+    {
+      "sym": "CN",
+      "name": "Canadian National",
+      "logo": "1867/CN",
+      "tokens": [
+        0
+      ],
+      "color": "white"
     }
   ],
   "trains": [

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -208,7 +208,19 @@ module Engine
 
         game_error('Route visits same hex twice') if route.hexes.size != route.hexes.uniq.size
 
-        # @todo: route bonuses
+        route.corporation.companies.each do |company|
+          company.abilities(:hex_bonus) do |ability|
+            revenue += stops.map { |s| s.hex.id }.uniq.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
+          end
+        end
+
+        # Quebec, Montreal and Toronto
+        capitals = stops.find { |stop| %w[F16 L12 O7].include?(stop.hex.name) }
+        # Timmins
+        timmins = stops.find { |stop| stop.hex.name == 'D2' }
+
+        revenue += 40 if capitals && timmins
+
         revenue
       end
 

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -54,6 +54,9 @@ module Engine
 
       GAME_END_CHECK = { bank: :current_or, custom: :one_more_full_or_set }.freeze
 
+      HEX_WITH_O_LABEL = %w[J12].freeze
+      HEX_UPGRADES_FOR_O = %w[201 202 203 207 208 622 623 801 X8].freeze
+
       CERT_LIMIT_CHANGE_ON_BANKRUPTCY = true
 
       # Two lays with one being an upgrade, second tile costs 20
@@ -401,6 +404,15 @@ module Engine
         @final_operating_rounds = 3
 
         @log << "First 8 train bought/exported, ending game at the end of #{@turn + 1}.#{@final_operating_rounds}"
+      end
+
+      def upgrades_to?(from, to, special = false)
+        # O labelled tile upgrades to Ys until Grey
+        return super unless HEX_WITH_O_LABEL.include?(from.hex.name)
+
+        return false unless HEX_UPGRADES_FOR_O.include?(to.name)
+
+        super(from, to, true)
       end
     end
   end

--- a/lib/engine/step/g_1867/single_item_auction.rb
+++ b/lib/engine/step/g_1867/single_item_auction.rb
@@ -64,7 +64,7 @@ module Engine
 
         def setup
           setup_auction
-          @companies = @game.companies.sort_by(&:value)
+          @companies = @game.companies.reject { |c| c.id == '3' }.sort_by(&:value)
 
           auction_entity_log(@companies.first)
         end

--- a/lib/engine/step/g_1867/track.rb
+++ b/lib/engine/step/g_1867/track.rb
@@ -19,6 +19,28 @@ module Engine
           super
           @hex = action.hex
         end
+
+        def connects_to?(hex, tile, to)
+          dir = hex.neighbor_direction(to)
+          tile.exits.include?(dir)
+        end
+
+        def legal_tile_rotation?(entity, hex, tile)
+          legal = super
+          return legal unless legal
+          return legal if tile.color != :yellow
+
+          # G15, K13, M11 have to be connected to specific neighbors
+
+          case hex.id
+          when 'G15'
+            connects_to?(hex, tile, @game.hex_by_id('F16'))
+          when 'K13', 'M11'
+            connects_to?(hex, tile, @game.hex_by_id('L12'))
+          else
+            legal
+          end
+        end
       end
     end
   end

--- a/public/logos/1867/CN.svg
+++ b/public/logos/1867/CN.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="0 0 13.62 13.62"
+   data-name="Layer 1"
+   id="Layer_1"
+   sodipodi:docname="CN.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3696"
+     inkscape:window-height="2032"
+     id="namedview3765"
+     showgrid="false"
+     inkscape:zoom="23.115954"
+     inkscape:cx="17.595477"
+     inkscape:cy="-0.76461825"
+     inkscape:window-x="144"
+     inkscape:window-y="54"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#fff;}.cls-2{fill:#231f20;}</style>
+  </defs>
+  <circle
+     style="fill:#e6e6e6"
+     id="circle6"
+     r="6.81"
+     cy="6.81"
+     cx="6.81"
+     class="cls-1" />
+  <path
+     d="M 6.8098124,1.7829667 5.9968298,3.2992753 C 5.9045813,3.4640725 5.7392993,3.4487871 5.57401,3.3567149 L 4.9854309,3.05194 5.424109,5.3809669 C 5.5163575,5.8064677 5.2203822,5.8064677 5.0743153,5.6224848 L 4.0471316,4.47257 3.8803733,5.0565289 C 3.8611288,5.1332129 3.7765855,5.2137532 3.6497337,5.1945748 L 2.350858,4.9214799 2.6920136,6.1618069 c 0.073011,0.275989 0.1300029,0.3902584 -0.073731,0.4630495 l -0.4629613,0.2175872 2.235941,1.8161985 c 0.088502,0.06868 0.1332128,0.192247 0.1017091,0.304144 l -0.1956911,0.642199 c 0.7698663,-0.08874 1.4596771,-0.222251 2.22994,-0.304481 0.068017,-0.0073 0.1818307,0.104956 0.181368,0.183755 L 6.6065778,11.837033 H 6.9808897 L 6.9219807,9.4893051 c -4.701e-4,-0.0788 0.1028036,-0.196058 0.1707982,-0.188801 0.7702629,0.08223 1.4600744,0.215736 2.2299404,0.304481 l -0.195691,-0.642199 c -0.03151,-0.111897 0.01322,-0.235473 0.101709,-0.304144 L 11.464679,6.8424436 11.001718,6.6248564 C 10.797984,6.5520653 10.854953,6.4377959 10.927986,6.1618069 L 11.269149,4.9214799 9.9702586,5.1945748 C 9.8434146,5.2137458 9.7588566,5.1332423 9.7396266,5.0565289 L 9.5728673,4.47257 8.5456843,5.6224848 C 8.3996173,5.8064677 8.103642,5.8064677 8.1958905,5.3809669 L 8.6345613,3.05194 8.0459894,3.3567149 C 7.8807001,3.4487577 7.7154182,3.4640431 7.6231697,3.2992753"
+     id="path3894"
+     inkscape:connector-curvature="0"
+     style="fill:#ff0000;stroke-width:0.02383193" />
+</svg>

--- a/public/logos/1867/neutral.svg
+++ b/public/logos/1867/neutral.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="0 0 13.62 13.62"
+   data-name="Layer 1"
+   id="Layer_1"
+   sodipodi:docname="neutral.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3696"
+     inkscape:window-height="2032"
+     id="namedview3765"
+     showgrid="false"
+     inkscape:zoom="130.76358"
+     inkscape:cx="6.8099999"
+     inkscape:cy="6.8099999"
+     inkscape:window-x="144"
+     inkscape:window-y="54"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#fff;}.cls-2{fill:#231f20;}</style>
+  </defs>
+  <circle
+     style="fill:#44aa00"
+     id="circle6"
+     r="6.81"
+     cy="6.81"
+     cx="6.81"
+     class="cls-1" />
+  <path
+     id="path8"
+     transform="translate(0 0)"
+     d="M9.3,2.61v.08a1.36,1.36,0,0,0-.19.65V11H8.62L6,5.9v4.38a1.07,1.07,0,0,0,.22.63V11H4.32v-.1a1.36,1.36,0,0,0,.22-.63V3.34a1.06,1.06,0,0,0,0-.31,2,2,0,0,0-.16-.34V2.61H5.88L7.67,6.26V3.34a1.06,1.06,0,0,0-.22-.65V2.61Z"
+     class="cls-2"
+     style="fill:#ffffff" />
+</svg>


### PR DESCRIPTION
Lock tiles with green neutral tokens until phase 3
Lock tile with a fake '3' company
Add the canadian token at the start of the game

(The Canada logo is just until we get the final logos)

O upgrades via Y until grey
G15, K13, L10 must connect to the major city on it's first upgrade
Improve text for privates

Route bonuses for privates and for Timmins