### PR TITLE
18CO President's Choice Round

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -878,6 +878,11 @@ module Engine
 					"visit": 99
 				}
 			],
+			"events": [
+				{
+					"type": "presidents_choice"
+				}
+			],
 			"available_on": "6",
 			"price": 850,
 			"num": 2
@@ -899,6 +904,11 @@ module Engine
 					],
 					"pay": 99,
 					"visit": 99
+				}
+			],
+			"events": [
+				{
+					"type": "presidents_choice"
 				}
 			],
 			"available_on": "6",

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -147,6 +147,10 @@ module Engine
       shares.reject { |share| share.corporation == self }
     end
 
+    def ipo_shares
+      shares.select { |share| share.corporation == self }
+    end
+
     def id
       @name
     end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -8,6 +8,8 @@ require_relative 'company_price_50_to_150_percent'
 module Engine
   module Game
     class G18CO < Base
+      attr_accessor :presidents_choice
+
       register_colors(green: '#237333',
                       red: '#d81e3e',
                       blue: '#0189d1',
@@ -84,7 +86,11 @@ module Engine
       BASE_MINE_VALUE = 10
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(
-          'remove_mines' => ['Mines Close', 'Mine tokens removed from board and corporations']
+          'remove_mines' => ['Mines Close', 'Mine tokens removed from board and corporations'],
+          'presidents_choice' => [
+            'President\'s Choice Triggered',
+            'President\'s choice round will occur at the beginning of the next Stock Round',
+          ]
         ).freeze
 
       STATUS_TEXT = Base::STATUS_TEXT.merge(
@@ -112,6 +118,7 @@ module Engine
       def setup
         setup_company_price_50_to_150_percent
         setup_corporations
+        @presidents_choice = nil
       end
 
       def setup_corporations
@@ -208,11 +215,48 @@ module Engine
         ])
       end
 
+      def new_presidents_choice_round
+        @log << '-- President\'s Choice --'
+        Round::G18CO::PresidentsChoice.new(self, [
+          Step::G18CO::PresidentsChoice,
+        ])
+      end
+
       def new_auction_round
         Round::Auction.new(self, [
           Step::G18CO::CompanyPendingPar,
           Step::G18CO::MovingBidAuction,
         ])
+      end
+
+      def next_round!
+        @round =
+          case @round
+          when Round::G18CO::PresidentsChoice
+            new_stock_round
+          when Round::Stock
+            @operating_rounds = @phase.operating_rounds
+            reorder_players
+            new_operating_round
+          when Round::Operating
+            if @round.round_num < @operating_rounds
+              or_round_finished
+              new_operating_round(@round.round_num + 1)
+            else
+              @turn += 1
+              or_round_finished
+              or_set_finished
+              if @presidents_choice == :triggered
+                new_presidents_choice_round
+              else
+                new_stock_round
+              end
+            end
+          when init_round.class
+            init_round_finished
+            reorder_players
+            new_stock_round
+          end
       end
 
       def action_processed(action)
@@ -316,6 +360,15 @@ module Engine
         return REDUCED_TILE_LAYS if @phase.status.include?('reduced_tile_lay')
 
         super
+      end
+
+      def event_presidents_choice!
+        return if @presidents_choice
+
+        @log << '-- Event: President\'s Choice --'
+        @log << 'President\'s choice round will occur at the beginning of the next Stock Round'
+
+        @presidents_choice = :triggered
       end
 
       def sell_shares_and_change_price(bundle)

--- a/lib/engine/round/g_18_co/presidents_choice.rb
+++ b/lib/engine/round/g_18_co/presidents_choice.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative '../stock'
+
+module Engine
+  module Round
+    module G18CO
+      class PresidentsChoice < Stock
+        def self.short_name
+          'PCR'
+        end
+
+        def name
+          'President\'s Choice Round'
+        end
+
+        def setup
+          start_entity
+        end
+
+        def select_entities
+          @game.players.dup
+        end
+
+        def after_process(action)
+          return if action.type == :message
+
+          if action.type == :pass
+            @entities.reject! { |e| e == action.entity }
+            return finish_round if finished?
+
+            passed_next_entity_index!
+          else
+            next_entity_index!
+          end
+
+          start_entity
+        end
+
+        def passed_next_entity_index!
+          @entity_index = @entity_index % @entities.size
+        end
+
+        def skip_to_next_entity!
+          @entities.delete_at(@entity_index)
+          return finish_round if finished?
+
+          passed_next_entity_index!
+          start_entity
+        end
+
+        def start_entity
+          @steps.each(&:unpass!)
+          @steps.each(&:setup)
+
+          skip_steps
+          skip_to_next_entity! unless active_step
+        end
+
+        def finished?
+          @game.finished || @entities.empty?
+        end
+
+        private
+
+        def finish_round
+          @game.presidents_choice = :done
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/round/g_18_co/presidents_choice.rb
+++ b/lib/engine/round/g_18_co/presidents_choice.rb
@@ -26,7 +26,7 @@ module Engine
           return if action.type == :message
 
           if action.type == :pass
-            @entities.reject! { |e| e == action.entity }
+            @entities.delete(action.entity)
             return finish_round if finished?
 
             passed_next_entity_index!

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -53,7 +53,7 @@ module Engine
 
       from = 'the market'
       if bundle.owner.corporation?
-        from = "the #{@game.ipo_name(corporation)}"
+        from = bundle.owner == bundle.corporation ? "the #{@game.ipo_name(corporation)}" : bundle.owner.name
       elsif bundle.owner.player?
         from = bundle.owner.name
       end

--- a/lib/engine/step/g_18_co/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_co/buy_sell_par_shares.rb
@@ -21,6 +21,14 @@ module Engine
 
           companies.select(&:owner)
         end
+
+        def can_buy?(entity, bundle)
+          if bundle&.owner&.corporation? && bundle.corporation != bundle.owner && @game.presidents_choice != :done
+            return false unless bundle.owner.president?(entity)
+          end
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/step/g_18_co/presidents_choice.rb
+++ b/lib/engine/step/g_18_co/presidents_choice.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G18CO
+      class PresidentsChoice < Base
+        include ShareBuying
+
+        def actions(entity)
+          return [] unless entity.player?
+          return [] unless entity == current_entity
+
+          available_actions = []
+
+          available_actions << 'buy_shares' if can_buy_any?(entity)
+          available_actions << 'pass' if available_actions.any?
+
+          available_actions
+        end
+
+        def description
+          'Buy Shares'
+        end
+
+        def pass_description
+          'Leave Round'
+        end
+
+        def log_pass(entity)
+          @log << "#{entity.name} leaves President's Choice round"
+        end
+
+        def log_skip(entity)
+          @log << "#{entity.name} cannot buy any shares and leaves President's Choice round"
+        end
+
+        def process_buy_shares(action)
+          buy_shares(action.entity, action.bundle, swap: action.swap)
+          pass!
+        end
+
+        def buyable_shares(entity)
+          @game.corporations.flat_map do |corporation|
+            next unless corporation.president?(entity)
+
+            corporation.corporate_shares.select { |s| can_buy?(entity, s.to_bundle) }
+          end.compact
+        end
+
+        def can_buy_any?(entity)
+          buyable_shares(entity).any?
+        end
+
+        # Returns if a share can be bought via a normal buy actions
+        # If a player has sold shares they cannot buy in many 18xx games
+        # Some 18xx games can only buy one share per turn.
+        def can_buy?(entity, bundle)
+          return unless bundle&.buyable
+          return unless bundle.owner.corporation?
+
+          corporation = bundle.corporation
+          entity.cash >= bundle.price &&
+            can_gain?(entity, bundle) &&
+            bundle.owner.president?(entity) &&
+            corporation != bundle.owner
+        end
+
+        def purchasable_companies
+          []
+        end
+
+        def can_buy_corporate_shares?
+          true
+        end
+
+        def can_buy_normal_shares?
+          false
+        end
+
+        def can_sell?
+          false
+        end
+
+        def can_ipo_any?(_entity)
+          false
+        end
+
+        def ipo_type(_entity) end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/presidents_choice.rb
+++ b/lib/engine/step/g_18_co/presidents_choice.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative '../share_buying'
 
 module Engine
   module Step


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/1836

**President's Choice Round**

This​ ​special​ ​stock​ ​round​ ​will​ ​occur​ ​once​ ​before​ ​the​ ​Stock​ ​Round​ ​following​ ​the​ ​first​ ​purchase​ ​of​ ​a​ ​5D​ ​or​ ​E​ ​train. Starting​ ​with​ ​the​ ​Priority​ ​Deal​ ​and​ ​moving​ ​clockwise,​ ​each​ ​player​ ​may​ ​purchase​ ​one​ ​Certificate​ ​from​ ​the​ ​Treasury​ ​of​ ​a Corporation​ ​for​ ​which​ ​they​ ​are​ ​President. Once​ ​a​ ​player​ ​passes,​ ​they​ ​may​ ​no​ ​longer​ ​purchase​ ​Certificates​ ​during​ ​this​ ​special​ ​stock​ ​round. Once​ ​all​ ​players​ ​pass,​ ​proceed​ ​to​ ​the​ ​normal​ ​Stock​ ​Round.​ ​All​ ​Certificates​ ​in​ ​the​ ​Treasuries​ ​of​ ​Corporations​ ​are​ ​now available​ ​for​ ​all​ ​players​ ​to​ ​purchase​ ​for​ ​the​ ​remainder​ ​of​ ​the​ ​game.

This PR also implements another feature from that list almost incidentally:

For 18CO, A player may purchase a third party corporation share from the treasury of any corporation where they are President.

### Implementation Notes

**buy_sell_shares.rb** - 1.) The change to using ipo_shares instead of shares is actually a bug fix. Corporate shares could be bought once the treasury was empty, but they were displayed as ipo shares on the button. 2.) Displaying the corporate shares will only impact games that utilize them.

**g_18_co/buy_sell_par_shares.rb** - This change actually _prevents_ a player from buying a corporate share unless they are president, as once I fixed the share/ipo_share display bug in _buy_sell_shares.rb_ I found that any players could buy any corporate share at any point in the game.

### In Action

Player 5 bought a share and thus stays in the round.
Player 1 was at cert limit and thus was forced to leave the round. This is automatic when there is no share a player can buy ( ie Skip ).
Player 2 is considering whether to buy that CM share from KPAC ( where he is President ).
<img width="1295" alt="Screen Shot 2020-12-12 at 7 09 18 AM" src="https://user-images.githubusercontent.com/15675400/101986079-fcb58b00-3c48-11eb-92b5-164edbbb9ad9.png">

The PCR has finished and Player 5 resumes normal SR ( Priority does not change due to PCR ). Here we can see DPAC's CS share can now be bought ( _All​ ​Certificates​ ​in​ ​the​ ​Treasuries​ ​of​ ​Corporations​ ​are​ ​now available​ ​for​ ​all​ ​players​ ​to​ ​purchase​ ​for​ ​the​ ​remainder​ ​of​ ​the​ ​game._ )

<img width="775" alt="Screen Shot 2020-12-12 at 7 15 08 AM" src="https://user-images.githubusercontent.com/15675400/101986227-ff64b000-3c49-11eb-91d1-d889a950f5a6.png">