### PR TITLE
Fix Corporate Shares not paying dividends

### DIFF
--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -117,8 +117,10 @@ module Engine
         per_share = payout_per_share(entity, revenue)
 
         payouts = {}
-        @game.players.each do |player|
-          payout_entity(entity, player, per_share, payouts)
+        [@game.players, @game.corporations].flatten.each do |payee|
+          next if entity == payee
+
+          payout_entity(entity, payee, per_share, payouts)
         end
 
         payout_entity(entity, holder_for_corporation(entity), per_share, payouts, entity)

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -117,7 +117,7 @@ module Engine
         per_share = payout_per_share(entity, revenue)
 
         payouts = {}
-        [@game.players, @game.corporations].flatten.each do |payee|
+        (@game.players + @game.corporations).each do |payee|
           next if entity == payee
 
           payout_entity(entity, payee, per_share, payouts)


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/2609

Seems fairly self-explanatory. Corporate shareholders should be paid dividends. Before this change, the code only looks at players.

Here we see CM was paid $3 after the change.
<img width="443" alt="Screen Shot 2020-12-12 at 8 39 51 AM" src="https://user-images.githubusercontent.com/15675400/101988256-b9154e00-3c55-11eb-8a40-62395925a80c.png">
