### PR TITLE
18MEX: Closed corporation caused exception (fixes #2623)

### DIFF
--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -76,7 +76,7 @@ module Engine
         @entities[index..-1] = @entities[index..-1].sort if index < @entities.size - 1
 
         @entities.pop while @entities.last&.corporation? &&
-          @entities.last.share_price.liquidation? &&
+          @entities.last.share_price&.liquidation? &&
           @entities.size > index
       end
 


### PR DESCRIPTION
Closed corporation has no share price. So need to be ignored during
recalculation of order.