### PR TITLE
Fix base Emergency Buy + Issue Shares, add 18CO Implementation

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -133,7 +133,9 @@ module View
         children << remaining_trains
 
         children << h(:div, "#{@corporation.name} has #{@game.format_currency(@corporation.cash)}.")
-        if (issuable_cash = @game.emergency_issuable_cash(@corporation)).positive?
+
+        if step.issuable_shares(@corporation).any? &&
+           (issuable_cash = @game.emergency_issuable_cash(@corporation)).positive?
           children << h(:div, "#{@corporation.name} can issue shares to raise up to "\
                               "#{@game.format_currency(issuable_cash)} (the corporation "\
                               'must issue shares before the president may contribute).')

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -30,6 +30,7 @@ module Engine
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18CO:-Rock-&-Stock'
 
       SELL_BUY_ORDER = :sell_buy
+      EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = true
       MUST_BID_INCREMENT_MULTIPLE = true
       ONLY_HIGHEST_BID_COMMITTED = false
@@ -189,7 +190,7 @@ module Engine
         Step::Token,
         Step::Route,
         Step::G18CO::Dividend,
-        Step::BuyTrain,
+        Step::G18CO::BuyTrain,
         Step::CorporateSellShares,
         Step::G18CO::IssueShares,
         [Step::BuyCompany, blocks: true],
@@ -350,6 +351,14 @@ module Engine
 
           break
         end
+      end
+
+      def emergency_issuable_cash(corporation)
+        emergency_issuable_bundles(corporation).max_by(&:num_shares)&.price || 0
+      end
+
+      def emergency_issuable_bundles(entity)
+        issuable_shares(entity)
       end
 
       def issuable_shares(entity)

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -60,8 +60,10 @@ module Engine
         remaining < next_highest
       end
 
-      def issuable_shares
-        []
+      def issuable_shares(entity)
+        return [] unless entity.corporation?
+
+        @game.emergency_issuable_bundles(entity)
       end
     end
   end

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -29,25 +29,35 @@ module Engine
       end
 
       def sellable_bundle?(bundle)
-        player = bundle.owner
+        seller = bundle.owner
         # Can't sell president's share
-        return false unless bundle.can_dump?(player)
+        return false unless bundle.can_dump?(seller)
 
         # Can't oversaturate the market
         return false unless @game.share_pool.fit_in_bank?(bundle)
 
-        # Can't swap presidency
         corporation = bundle.corporation
-        if corporation.president?(player) &&
-            (!@game.class::EBUY_PRES_SWAP || corporation == current_entity)
-          share_holders = corporation.player_share_holders
-          remaining = share_holders[player] - bundle.percent
-          next_highest = share_holders.reject { |k, _| k == player }.values.max || 0
-          return false if remaining < next_highest
-        end
+        return true if corporation == seller
+
+        # Can't swap presidency
+        return false if president_swap_disallowed?(corporation, seller) &&
+          causes_president_swap?(corporation, bundle)
 
         # Otherwise we're good
         true
+      end
+
+      def president_swap_disallowed?(corporation, seller)
+        corporation.president?(seller) &&
+          (!@game.class::EBUY_PRES_SWAP || corporation == current_entity)
+      end
+
+      def causes_president_swap?(corporation, bundle)
+        seller = bundle.owner
+        share_holders = corporation.player_share_holders
+        remaining = share_holders[seller] - bundle.percent
+        next_highest = share_holders.reject { |k, _| k == seller }.values.max || 0
+        remaining < next_highest
       end
 
       def issuable_shares

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -19,13 +19,13 @@ module Engine
         return false unless sellable_bundle?(bundle)
 
         # Can only sell as much as you need to afford the train
-        player = bundle.owner
-        unless @game.class::EBUY_SELL_MORE_THAN_NEEDED
-          total_cash = bundle.price + available_cash(player)
-          return false if total_cash >= needed_cash(player) + bundle.price_per_share
-        end
+        selling_minimum_shares?(bundle) unless @game.class::EBUY_SELL_MORE_THAN_NEEDED
+      end
 
-        true
+      def selling_minimum_shares?(bundle)
+        seller = bundle.owner
+        total_cash = bundle.price + available_cash(seller)
+        total_cash < needed_cash(seller) + bundle.price_per_share
       end
 
       def sellable_bundle?(bundle)

--- a/lib/engine/step/g_1846/buy_train.rb
+++ b/lib/engine/step/g_1846/buy_train.rb
@@ -30,12 +30,6 @@ module Engine
           @round.receivership_train_buy(self, :process_buy_train)
         end
 
-        def issuable_shares(entity)
-          return [] unless entity.corporation?
-
-          @game.emergency_issuable_bundles(entity)
-        end
-
         def process_sell_shares(action)
           return process_issue_shares(action) if action.entity.corporation?
 

--- a/lib/engine/step/g_18_co/buy_train.rb
+++ b/lib/engine/step/g_18_co/buy_train.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../buy_train.rb'
+
+module Engine
+  module Step
+    module G18CO
+      class BuyTrain < BuyTrain
+        def issuable_shares
+          # seems likes this should be generic?
+          return [] if room?(current_entity) && available_cash(current_entity) >= @depot.min_depot_price
+
+          @game.emergency_issuable_bundles(current_entity)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/buy_train.rb
+++ b/lib/engine/step/g_18_co/buy_train.rb
@@ -6,11 +6,12 @@ module Engine
   module Step
     module G18CO
       class BuyTrain < BuyTrain
-        def issuable_shares
-          # seems likes this should be generic?
-          return [] if room?(current_entity) && available_cash(current_entity) >= @depot.min_depot_price
+        def issuable_shares(entity)
+          shares = super
 
-          @game.emergency_issuable_bundles(current_entity)
+          return [] if available_cash(entity) >= @depot.min_depot_price
+
+          shares
         end
       end
     end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -144,10 +144,6 @@ module Engine
         @corporations_sold = []
       end
 
-      def issuable_shares
-        []
-      end
-
       def must_issue_before_ebuy?(corporation)
         @game.class::MUST_EMERGENCY_ISSUE_BEFORE_EBUY &&
           !@last_share_issued_price &&

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -80,9 +80,9 @@ module Engine
         pass! unless can_buy_train?(entity)
       end
 
-      def can_sell?(_entity, bundle)
+      def can_sell?(entity, bundle)
         return false if @game.class::MUST_SELL_IN_BLOCKS && @corporations_sold.include?(bundle.corporation)
-        return false if must_issue_before_ebuy?(current_entity)
+        return false if current_entity != entity && must_issue_before_ebuy?(current_entity)
 
         super
       end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -97,8 +97,10 @@ module Engine
         @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST ? @depot.min_depot_price : @depot.max_depot_price
       end
 
-      def available_cash(player)
-        player.cash + current_entity.cash
+      def available_cash(entity)
+        return current_entity.cash if entity == current_entity
+
+        entity.cash + current_entity.cash
       end
 
       def buyable_trains(entity)

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -88,9 +88,9 @@ module Engine
       end
 
       def process_sell_shares(action)
-        @last_share_sold_price = action.bundle.price_per_share
+        @last_share_sold_price = action.bundle.price_per_share unless action.entity == current_entity
         super
-        @corporations_sold << action.bundle.corporation
+        @corporations_sold << action.bundle.corporation unless action.entity == current_entity
       end
 
       def needed_cash(_entity)


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/2609

Each commit is specific to a change.

**Refactor Emergency Selling Minimum Shares**
This is a readability refactor

**EMR Refactor Presidency Swap Check …**
Change player to seller, as if it is a share issue, the bundle owner will be the corporation, not a player. No need to check if Presidency changes since issuing shares to the market cannot trigger a presidency change.

**Fix train available_cash double counting …**
If the corp is issuing shares, this prevents double counting the corporation cash, which would prevent the corporation from ever being able to buy a train if there are issuable shares.

**Fix train can_sell? preventing issuing …**
An issue share is a share sale by the current entity (the corporation) and should not be prevented by the must_issue_before_ebuy

**Fix train_buy issue shares modifying president sales variables …**
last_share_sold_price and corporations_sold are only applicable to what the President has done, not the corporation.

**Refactor EMR issuable_shares …**
The default should be to return the game's emergency_issuable_bundles for the corporation. All games that don't allow EMR issuing aren't going to implement that anyway and thus it will still return []

**18CO EMR Don't show issue options if can already afford a train**
Before this change the Issue Share buttons would show, but not work, since the player did not need to raise money anymore.

**Only show information about issuing if there are shares to issue**

The text "DPAC can issue shares to raise..." was showing regardless of whether there were shares to issue.
<img width="561" alt="Screen Shot 2020-12-13 at 11 05 37 AM" src="https://user-images.githubusercontent.com/15675400/102020283-66ab5e80-3d35-11eb-9fec-d1f3584bbfd6.png">

After the change the paragraph no longer renders since it is irrelevant
<img width="494" alt="Screen Shot 2020-12-13 at 11 05 25 AM" src="https://user-images.githubusercontent.com/15675400/102020320-b722bc00-3d35-11eb-9c69-f0858ca3b75b.png">
