### PR TITLE
Issue 2477 Clarify Passing your action vs Ending your action

### DIFF
--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -30,12 +30,8 @@ module Engine
       def log_pass(entity)
         return @log << "#{entity.name} passes" if @current_actions.empty?
 
-        action = if bought?
-                   'selling'
-                 else
-                   'buying'
-                 end
-        @log << "#{entity.name} passes #{action} shares"
+        action = bought? ? 'to sell' : 'to buy'
+        @log << "#{entity.name} declines #{action} shares"
       end
 
       def log_skip(entity)


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/2477

Using the word decline instead of pass more clearly indicates that an action was still taken that will affect priority deal rather than passing your action.