### PR TITLE
1867 Trains:

### DIFF
--- a/assets/app/view/game/choose.rb
+++ b/assets/app/view/game/choose.rb
@@ -8,7 +8,8 @@ module View
       include Actionable
 
       def render
-        choice_buttons = @game.round.active_step.choices.map do |choice|
+        choice_buttons = @game.round.active_step.choices.map do |choice, label|
+          label ||= choice
           click = lambda do
             process_action(Engine::Action::Choose.new(
               @game.current_entity,
@@ -18,12 +19,11 @@ module View
 
           props = {
             style: {
-              width: 'calc(17.5rem/6)',
-              padding: '0.2rem 0',
+              padding: '0.2rem 0.2rem',
             },
             on: { click: click },
           }
-          h('button.small', props, choice)
+          h('button', props, label)
         end
 
         div_class = choice_buttons.size < 5 ? '.inline' : ''

--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -33,6 +33,8 @@ module View
 
           children = []
 
+          children << h(Choose) if actions.include?('choose')
+
           if (%w[buy_shares sell_shares] & actions).any?
             return h(CashCrisis) if @step.respond_to?(:needed_cash)
 

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -43,6 +43,8 @@ module View
             left << h(CorporateBuyShares)
           elsif @current_actions.include?('corporate_sell_shares')
             left << h(CorporateSellShares)
+          elsif @current_actions.include?('choose')
+            left << h(Choose)
           end
           left << h(Loans, corporation: entity) if (%w[take_loan payoff_loan] & @current_actions).any?
 

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -26,7 +26,7 @@ module Engine
     "5": 252,
     "6": 210
   },
-  "capitalization": "full",
+  "capitalization": "incremental",
   "layout": "flat",
   "mustSellInBlocks": false,
   "locationNames": {
@@ -390,6 +390,7 @@ module Engine
       "sym": "BBG",
       "name": "Buffalo, Brantford, and Goderich",
       "logo": "1867/BBG",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -402,6 +403,7 @@ module Engine
       "sym": "BO",
       "name": "Brockville and Ottawa",
       "logo": "1867/BO",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -426,6 +428,7 @@ module Engine
       "sym": "CV",
       "name": "Credit Valley Railway",
       "logo": "1867/CV",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -438,6 +441,7 @@ module Engine
       "sym": "KP",
       "name": "Kingston and Pembroke",
       "logo": "1867/KP",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -450,6 +454,7 @@ module Engine
       "sym": "LPS",
       "name": "London and Port Stanley",
       "logo": "1867/LPS",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -462,6 +467,7 @@ module Engine
       "sym": "OP",
       "name": "Ottawa and Prescott",
       "logo": "1867/OP",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -474,6 +480,7 @@ module Engine
       "sym": "SLA",
       "name": "St. Lawrence and Atlantic",
       "logo": "1867/SLA",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -486,6 +493,7 @@ module Engine
       "sym": "TGB",
       "name": "Toronto, Grey, and Bruce",
       "logo": "1867/TGB",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -498,6 +506,7 @@ module Engine
       "sym": "TN",
       "name": "Toronto and Nipissing",
       "logo": "1867/TN",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -510,6 +519,7 @@ module Engine
       "sym": "TN",
       "name": "Algoma Eastern Railway",
       "logo": "1867/TN",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -522,6 +532,7 @@ module Engine
       "sym": "CA",
       "name": "Canada Atlantic Railway",
       "logo": "1867/CA",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -534,6 +545,7 @@ module Engine
       "sym": "NYO",
       "name": "New York and Ottawa",
       "logo": "1867/NYO",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -546,6 +558,7 @@ module Engine
       "sym": "PM",
       "name": "Pere Marquette Railway",
       "logo": "1867/PM",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -558,6 +571,7 @@ module Engine
       "sym": "QLS",
       "name": "Quebec and Lake St. John",
       "logo": "1867/QLS",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -570,6 +584,7 @@ module Engine
       "sym": "THB",
       "name": "Toronto, Hamilton and Buffalo",
       "logo": "1867/THB",
+      "float_percent": 100,
       "tokens": [
         0
       ],
@@ -591,14 +606,36 @@ module Engine
   "trains": [
     {
       "name": "2",
-      "distance": 2,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 2,
+          "visit": 2
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 100,
       "rusts_on": "4",
       "num": 10
     },
     {
       "name": "3",
-      "distance": 3,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 3,
+          "visit": 3
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 225,
       "rusts_on": "6",
       "num": 7,
@@ -608,17 +645,40 @@ module Engine
     },
     {
       "name": "4",
-      "distance": 4,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 4,
+          "visit": 4
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 350,
       "rusts_on": "8",
       "num": 4,
       "events":[
-        {"type": "majors_can_ipo"}
+        {"type": "majors_can_ipo"},
+        {"type": "trainless_nationalization"}
       ]
     },
     {
       "name": "5",
-      "distance": 5,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 5,
+          "visit": 5
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 550,
       "num": 4,
       "events":[
@@ -628,40 +688,97 @@ module Engine
     },
     {
       "name": "6",
-      "distance": 6,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 6,
+          "visit": 6
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 650,
       "num": 2,
       "events":[
-        {"type": "close_companies"}
+        {"type": "close_companies"},
+        {"type": "trainless_nationalization"}
       ]
     },
     {
       "name": "7",
-      "distance": 7,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 7,
+          "visit": 7
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 800,
       "num": 2
     },
     {
       "name": "8",
-      "distance": 8,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 8,
+          "visit": 8
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 1000,
       "num": 6,
       "events": [
         {"type": "signal_end_game"},
-        {"type": "minors_nationalized"}
-
+        {"type": "minors_nationalized"},
+        {"type": "trainless_nationalization"}
       ]
     },
     {
       "name": "2+2",
-      "distance": 2,
+      "distance": [
+        {
+          "nodes": ["city", "offboard"],
+          "pay": 2,
+          "visit": 2,
+          "multiplier":2
+        },
+        {
+          "nodes": ["town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 600,
       "num": 6,
       "available_on": "8"
     },
     {
       "name": "5+5E",
-      "distance": 5,
+      "distance": [
+        {
+          "nodes": ["offboard"],
+          "pay": 5,
+          "visit": 5
+        },
+        {
+          "nodes": ["city", "town"],
+          "pay": 0,
+          "visit": 99
+        }
+      ],
       "price": 1500,
       "num": 7,
       "available_on": "8"
@@ -847,7 +964,8 @@ module Engine
     {
       "name": "2",
       "train_limit": {
-        "minor": 2
+        "minor": 2,
+        "major": 2
       },
       "tiles": [
         "yellow"

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -59,7 +59,7 @@ module Engine
       @always_market_price = opts[:always_market_price] || false
       @needs_token_to_par = opts[:needs_token_to_par] || false
       @par_via_exchange = nil
-      @type = opts[:type]
+      @type = opts[:type]&.to_sym
 
       init_abilities(opts[:abilities])
       init_operator(opts)

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -492,6 +492,7 @@ module Engine
           end
         end
 
+        @trainless_major = @trainless_major.sort.reverse
         @trainless_nationalization = false
       end
     end

--- a/lib/engine/round/g_1867/operating.rb
+++ b/lib/engine/round/g_1867/operating.rb
@@ -7,7 +7,7 @@ module Engine
     module G1867
       class Operating < Operating
         def select_entities
-          minors, majors = @game.corporations.select(&:floated?).sort.partition(&:type)
+          minors, majors = @game.corporations.select(&:floated?).sort.partition { |c| c.type == :minor }
           minors + majors
         end
       end

--- a/lib/engine/step/g_1867/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1867/buy_sell_par_shares.rb
@@ -11,6 +11,7 @@ module Engine
         TOKEN_COST = 50
         MIN_BID = 100
         MAX_BID = 400
+        MAJOR_PHASE = 4
 
         def actions(entity)
           return [] unless entity == current_entity
@@ -107,7 +108,7 @@ module Engine
         end
 
         def can_ipo_any?(entity)
-          @game.phase.name.to_i >= 4 && !bought? &&
+          @game.phase.name.to_i >= MAJOR_PHASE && !bought? &&
           @game.corporations.any? do |c|
             c.can_par?(entity) && c.type == :major && can_buy?(entity, c.shares.first&.to_bundle)
           end
@@ -142,10 +143,10 @@ module Engine
           # Major's are par, minors are bid
           phase = @game.phase.name.to_i
           if entity.type == :major
-            if phase >= 4
+            if phase >= MAJOR_PHASE
               :par
             else
-              'Cannot start till phase 4'
+              "Cannot start till phase #{MAJOR_PHASE}"
             end
           else
             :bid

--- a/lib/engine/step/g_1867/buy_train.rb
+++ b/lib/engine/step/g_1867/buy_train.rb
@@ -34,6 +34,7 @@ module Engine
         def buy_train_action(action, entity = nil)
           @depot_train = action.train.from_depot?
           super
+          @game.post_train_buy
         end
 
         def buying_power(entity)

--- a/lib/engine/step/g_1867/dividend.rb
+++ b/lib/engine/step/g_1867/dividend.rb
@@ -12,7 +12,7 @@ module Engine
         include HalfPay
 
         def actions(entity)
-          return [] unless entity.type == :major
+          return [] if !entity.corporation? || entity.type == :minor
 
           super
         end

--- a/lib/engine/step/g_1867/major_trainless.rb
+++ b/lib/engine/step/g_1867/major_trainless.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G1867
+      class MajorTrainless < Base
+        ACTIONS = %w[pass choose].freeze
+
+        def actions(entity)
+          return [] unless trainless_major.include?(entity)
+
+          ACTIONS
+        end
+
+        def active_entities
+          [trainless_major&.first].compact
+        end
+
+        def active?
+          trainless_major&.any?
+        end
+
+        def description
+          'Choose if Major is nationalized'
+        end
+
+        def choice_name
+          'Nationalize Major?'
+        end
+
+        def choices
+          { nationalize: 'Nationalize' }
+        end
+
+        def process_pass(action)
+          @game.trainless_major.delete(action.entity)
+          @game.log << "#{action.entity.name} declines to nationalize"
+        end
+
+        def process_choose(action)
+          @game.trainless_major.delete(action.entity)
+          @game.nationalize!(action.entity)
+        end
+
+        def trainless_major
+          @game.trainless_major
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for 1867 trains (towns can count optionally)
Add support for 1867 Majors only being able to start in non-connected cities
Add support for 1867 rust events causing minors to nationalize and majors to optionally nationalize
Fix some minor bugs