### PR TITLE
18CO Phase 7 - Reduced Tile Lay, Remove buying companies from other players

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -1199,10 +1199,7 @@ module Engine
 			"tiles": [
 				"yellow"
 			],
-			"operating_rounds": 2,
-			"status": [
-				"can_buy_companies_from_other_players"
-			]
+			"operating_rounds": 2
 		},
 		{
 			"name": "3",
@@ -1213,8 +1210,7 @@ module Engine
 				"green"
 			],
 			"status": [
-				"can_buy_companies",
-				"can_buy_companies_from_other_players"
+				"can_buy_companies"
 			],
 			"operating_rounds": 2
 		},
@@ -1227,8 +1223,7 @@ module Engine
 				"green"
 			],
 			"status": [
-				"can_buy_companies",
-				"can_buy_companies_from_other_players"
+				"can_buy_companies"
 			],
 			"operating_rounds": 2
 		},
@@ -1284,6 +1279,9 @@ module Engine
 				"yellow",
 				"green",
 				"brown"
+			],
+			"status":[
+				"reduced_tile_lay"
 			],
 			"operating_rounds": 2
 		}

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -39,8 +39,8 @@ module Engine
       DISCARDED_TRAIN_DISCOUNT = 50
 
       # Two tiles can be laid, only one upgrade
-      # TODO: This changes in phase E to a single tile lay
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: false }].freeze
+      REDUCED_TILE_LAYS = [{ lay: true, upgrade: true }].freeze
 
       # First 3 are Denver, Second 3 are CO Springs
       TILES_FIXED_ROTATION = %w[co1 co2 co3 co5 co6 co7].freeze
@@ -86,6 +86,10 @@ module Engine
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(
           'remove_mines' => ['Mines Close', 'Mine tokens removed from board and corporations']
         ).freeze
+
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        'reduced_tile_lay' => ['Reduced Tile Lay', 'Corporations place only one tile per OR.']
+      ).freeze
 
       include CompanyPrice50To150Percent
 
@@ -306,6 +310,12 @@ module Engine
         @corporations.each do |corporation|
           mines_remove(corporation)
         end
+      end
+
+      def tile_lays(_entity)
+        return REDUCED_TILE_LAYS if @phase.status.include?('reduced_tile_lay')
+
+        super
       end
 
       def sell_shares_and_change_price(bundle)


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/2609

When the Experimental train is purchased, corporations can only lay one tile per turn for the remainder of the game.
Remove the "Companies can buy from other players" as that is not in the RAW.