### PR TITLE
18CO Restrictive Track Lay

### DIFF
--- a/lib/engine/step/g_18_co/tracker.rb
+++ b/lib/engine/step/g_18_co/tracker.rb
@@ -24,6 +24,59 @@ module Engine
 
           @log << "#{corporation.name} collects a mine token from #{hex.name}"
         end
+
+        def check_track_restrictions!(entity, old_tile, new_tile)
+          super(entity, old_tile, new_tile)
+
+          return if new_tile.color == :yellow # not an upgrade
+          return if old_tile.city_towns.any? # not plain track
+          return if new_tile.color == :green && new_tile.exits.size == 4 # no new junctions, cheap short circuit
+
+          brand_new_exit_junctions = new_exit_junctions(old_tile, new_tile)
+          return if brand_new_exit_junctions.empty?
+
+          old_connected_paths = prior_connected_paths(entity, new_tile, old_tile)
+          return if all_prior_paths_accessible?(old_tile.paths, old_connected_paths)
+
+          @game.game_error('Must have route to access existing track') if old_connected_paths.empty?
+
+          return if accessible_new_path_creates_new_exit?(brand_new_exit_junctions)
+          return if all_new_paths_have_new_exits?(brand_new_exit_junctions)
+
+          @game.game_error('Must have route to access both ends of at least one path of new track')
+        end
+
+        def new_exit_junctions(old_tile, new_tile)
+          brand_new_paths = new_tile.paths.reject { |path| old_tile.paths.find { |p| path <= p } }
+
+          brand_new_paths.map do |bnp|
+            new_exit_junctions = bnp.exits & old_tile.exits
+            next if new_exit_junctions.empty?
+
+            [bnp, new_exit_junctions]
+          end.compact
+        end
+
+        def prior_connected_paths(entity, new_tile, old_tile)
+          @game.graph.connected_paths(entity).map do |connected_path, _b|
+            next unless connected_path.hex == new_tile.hex
+
+            old_tile.paths.find { |op| op <= connected_path }
+          end.compact
+        end
+
+        def all_prior_paths_accessible?(old_paths, old_connected_paths)
+          old_connected_paths.size == old_paths.size
+        end
+
+        def accessible_new_path_creates_new_exit?(brand_new_exit_junctions)
+          brand_new_exit_junctions.flat_map { |_bnp, new_exit_junctions| new_exit_junctions }.one?
+        end
+
+        def all_new_paths_have_new_exits?(brand_new_exit_junctions)
+          brand_new_exit_junctions.size >=
+            brand_new_exit_junctions.sum { |_bnp, new_exit_junctions| new_exit_junctions.size }
+        end
       end
     end
   end


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/1836

A plain track tile with a junction cannot be placed unless the corporation can already trace a route to the path that contains the new junction. When multiple new paths are present, only one new path's junctions must be reachable.

### Implementation Notes

This one is a bit of a doozy. I think it will be easiest to represent in pictures. There may be optimizations to this code. It was hard enough for me to put the rule into words.

### In Practice

`return if new_tile.color == :green && new_tile.exits.size == 4 # no new junctions, cheap short circuit`

<img width="556" alt="Screen Shot 2020-12-14 at 9 23 49 AM" src="https://user-images.githubusercontent.com/15675400/102106694-1c39e880-3dee-11eb-9244-f0fff7f23c3c.png">

All the green tiles with 4 exits have paths that don't connect. The only reason you couldn't place these would be handled by the default track restriction of "Must use new track"

Here we can see CM was able to place one of these tiles regardless of the fact they did not have access to the straight path between Limon and Burlington

<img width="335" alt="Screen Shot 2020-12-14 at 9 09 23 AM" src="https://user-images.githubusercontent.com/15675400/102106969-6e7b0980-3dee-11eb-9605-13f50cee8d3b.png">

`return if brand_new_exit_junctions.empty?`

This is the non-short-circuit code for the above case.

`return if all_prior_paths_accessible?(old_tile.paths, old_connected_paths)`

Seems self-explanatory, but if the corporation can trace a route to all the track on the tile before the new tile is laid, then naturally they can place the tile.

Here we can see KPAC can trace a route to both paths on the green X
<img width="495" alt="Screen Shot 2020-12-14 at 9 34 28 AM" src="https://user-images.githubusercontent.com/15675400/102108008-9d45af80-3def-11eb-9f26-420eeaebe910.png">

Therefore the brown tile placement is legal
<img width="501" alt="Screen Shot 2020-12-14 at 9 33 41 AM" src="https://user-images.githubusercontent.com/15675400/102107904-7edfb400-3def-11eb-945d-1628fee89572.png">

`@game.game_error('Must have route to access existing track') if old_connected_paths.empty?`

The shallow curve path was laid in yellow. Neither of the corporations in Denver can trace a route to the shallow curve, and thus the upgrade here adding the straight track is not legal.
<img width="471" alt="Screen Shot 2020-12-14 at 9 32 07 AM" src="https://user-images.githubusercontent.com/15675400/102108093-b9495100-3def-11eb-9521-6b507e6241f6.png">

`return if accessible_new_path_creates_new_exit?(brand_new_exit_junctions)`

Here we see Colorado Midland does not have a route to the straight track in the tile East of Denver.
<img width="478" alt="Screen Shot 2020-12-14 at 9 39 32 AM" src="https://user-images.githubusercontent.com/15675400/102108792-966b6c80-3df0-11eb-9936-1ed4da6f5efb.png">

They can still lay this tile though, as the new path from Denver crossing the straight track is accessible.
<img width="266" alt="Screen Shot 2020-12-14 at 9 39 46 AM" src="https://user-images.githubusercontent.com/15675400/102108933-bdc23980-3df0-11eb-82bf-4bb23294a4ba.png">

`return if all_new_paths_have_new_exits?(brand_new_exit_junctions)`

In this same scenario, this check will fail because none of the new paths create new exits, and CM doesn't have a route to create the junction on the straight track.
<img width="572" alt="Screen Shot 2020-12-14 at 9 44 08 AM" src="https://user-images.githubusercontent.com/15675400/102109113-f104c880-3df0-11eb-87ab-c4f549fef2e2.png">
