### PR TITLE
1860 endgame - feature complete for 1860

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -100,7 +100,7 @@ module View
         trs.concat([
           h(:tr, [
             h(:td, 'Value'),
-            h('td.right', @game.format_currency(@player.value)),
+            h('td.right', @game.format_currency(@game.player_value(@player))),
           ]),
           h(:tr, [
             h(:td, 'Liquidity'),

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -329,7 +329,7 @@ module View
       def render_player_value
         h(:tr, zebra_props(true), [
           h('th.left', 'Value'),
-          *@game.players.map { |p| h('td.padded_number', @game.format_currency(p.value)) },
+          *@game.players.map { |p| h('td.padded_number', @game.format_currency(@game.player_value(p))) },
         ])
       end
 

--- a/lib/engine/config/game/g_1860.rb
+++ b/lib/engine/config/game/g_1860.rb
@@ -698,7 +698,10 @@ module Engine
         }
       ],
       "price": 700,
-      "num": 1
+      "num": 1,
+      "events": [
+        {"type": "relax_cert_limit"}
+      ]
     },
     {
       "name": "9+5",
@@ -715,7 +718,10 @@ module Engine
         }
       ],
       "price": 800,
-      "num": 6
+      "num": 6,
+      "events": [
+        {"type": "southern_forms"}
+      ]
     }
   ],
   "hexes": {

--- a/lib/engine/g_1860/bank.rb
+++ b/lib/engine/g_1860/bank.rb
@@ -10,9 +10,9 @@ module Engine
         @broken = false
       end
 
-      def check_cash(amount)
-        return unless (@game.bank_cash - amount).negative?
+      def check_cash(amount); end
 
+      def break!
         @log << '-- The bank has broken --' unless @broken
         @broken = true
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -442,7 +442,7 @@ module Engine
         @players
           .sort_by(&:value)
           .reverse
-          .map { |p| [p.name, p.value] }
+          .map { |p| [p.name, player_value(p)] }
           .to_h
       end
 
@@ -561,7 +561,7 @@ module Engine
 
       def store_player_info
         @players.each do |p|
-          p.history << PlayerInfo.new(@round.class.short_name, turn, @round.round_num, p)
+          p.history << PlayerInfo.new(@round.class.short_name, turn, @round.round_num, player_value(p))
         end
       end
 
@@ -643,6 +643,10 @@ module Engine
         @companies.select do |company|
           company.owner&.player? && entity != company.owner && !company.abilities(:no_buy)
         end
+      end
+
+      def player_value(player)
+        player.value
       end
 
       def liquidity(player, emergency: false)

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -35,6 +35,8 @@ module Engine
       TRAIN_PRICE_MIN = 10
       TRAIN_PRICE_MULTIPLE = 10
 
+      COMPANY_SALE_FEE = 30
+
       SOLD_OUT_INCREASE = false
 
       STOCKMARKET_COLORS = {
@@ -246,6 +248,22 @@ module Engine
 
       def check_bank_broken!
         @bank.break! if !@nationalization && bank_cash.negative?
+      end
+
+      def player_value(player)
+        player.cash +
+          player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.any? }.sum(&:price) +
+          player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.none? }.sum { |s| (s.price / 2).to_i } +
+          player.companies.sum(&:value)
+      end
+
+      def liquidity(player)
+        company_value = turn > 1 ? player.companies.sum { |c| c.value - COMPANY_SALE_FEE } : 0
+
+        player.cash +
+          player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.any? }.sum(&:price) +
+          player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.none? }.sum { |s| (s.price / 2).to_i } +
+          company_value
       end
 
       def event_fishbourne_to_bank!

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -23,7 +23,7 @@ module Engine
       GAME_LOCATION = 'Isle of Wight'
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/79633/second-edition-rules'
       GAME_DESIGNER = 'Mike Hutton'
-      GAME_PUBLISHER = :zman_games
+      GAME_PUBLISHER = nil
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1860'
 
       EBUY_PRES_SWAP = false # allow presidential swaps of other corps when ebuying
@@ -889,8 +889,10 @@ module Engine
         return 0 if visits.empty? || ignore_halts?
 
         cities = visits.select { |node| node.city? || node.offboard? }
+        towns = visits.select { |node| node.town? && !node.halt? }
         halts = visits.select(&:halt?)
         th_allowance = route.train.distance[-1]['pay'] + route.train.distance[0]['pay'] - cities.size
+        th_allowance = [th_allowance - towns.size, 0].max if maximize_revenue
         [halts.size, th_allowance].min
       end
 
@@ -936,7 +938,7 @@ module Engine
         end
 
         # update route halts
-        route.halts = num_halts if halts.any? && !ignore_halts? && !ignore_halt_subsidies?(route) && !maximize_revenue?
+        route.halts = num_halts if halts.any? && !ignore_halts? && !ignore_halt_subsidies?(route)
 
         stops
       end

--- a/lib/engine/player_info.rb
+++ b/lib/engine/player_info.rb
@@ -5,11 +5,11 @@ module Engine
   class PlayerInfo
     attr_reader :round_name, :turn, :round_no, :value
 
-    def initialize(round_name, turn, round_no, player)
+    def initialize(round_name, turn, round_no, player_value)
       @round_name = round_name
       @turn = turn
       @round_no = round_no
-      @value = player.value
+      @value = player_value
     end
 
     def round

--- a/lib/engine/round/g_1860/operating.rb
+++ b/lib/engine/round/g_1860/operating.rb
@@ -8,11 +8,20 @@ module Engine
   module Round
     module G1860
       class Operating < Operating
+        def select_entities
+          @game.corporations.select { |c| c.floated? && !@game.nationalized?(c) }.sort
+        end
+
         def after_process(action)
           if (entity = @entities[@entity_index]).receivership? || @game.insolvent?(entity)
             case action
             when Engine::Action::RunRoutes
               process_action(Engine::Action::Dividend.new(entity, kind: 'withhold'))
+            end
+          elsif @game.nationalization
+            case action
+            when Engine::Action::RunRoutes
+              process_action(Engine::Action::Dividend.new(entity, kind: 'payout'))
             end
           end
 

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -67,6 +67,12 @@ module Engine
           @game.check_new_layer
         end
 
+        def process_sell_shares(action)
+          super
+
+          @game.check_bank_broken!
+        end
+
         def process_buy_company(action)
           player = action.entity
           company = action.company
@@ -135,6 +141,7 @@ module Engine
 
           sell_company(player, company, action.price)
           @round.last_to_act = player
+          @game.check_bank_broken!
         end
 
         def sell_price(entity)

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -147,7 +147,7 @@ module Engine
         def sell_price(entity)
           return 0 unless can_sell_company?(entity)
 
-          entity.value - 30
+          entity.value - @game.class::COMPANY_SALE_FEE
         end
 
         def can_sell_any_companies?(entity)

--- a/lib/engine/step/g_1860/buy_train.rb
+++ b/lib/engine/step/g_1860/buy_train.rb
@@ -9,6 +9,7 @@ module Engine
         def actions(entity)
           return [] if entity.receivership? && entity.trains.any?
           return [] if entity != current_entity || buyable_trains(entity).empty?
+          return [] if @game.bankrupt?(entity)
           return %w[buy_train] if must_buy_train?(entity)
 
           super
@@ -37,6 +38,7 @@ module Engine
 
         def must_buy_train?(entity)
           entity.trains.empty? &&
+            !@game.bankrupt?(entity) &&
             @game.depot.min_depot_price.positive? &&
             entity.cash > @game.depot.min_depot_price &&
             @game.can_run_route?(entity)
@@ -48,7 +50,7 @@ module Engine
 
           depot_trains = [] if entity.cash < @depot.min_depot_price
 
-          other_trains = [] if entity.cash < @game.class::TRAIN_PRICE_MIN
+          other_trains = [] if entity.cash < @game.class::TRAIN_PRICE_MIN || @game.nationalization
 
           other_trains.reject! { |t| illegal_train_buy?(entity, t) }
 

--- a/lib/engine/step/g_1860/dividend.rb
+++ b/lib/engine/step/g_1860/dividend.rb
@@ -36,12 +36,10 @@ module Engine
           @round.routes = []
 
           log_run_payout(entity, kind, revenue, subsidy, action, payout)
-
           @game.bank.spend(payout[:corporation], entity) if payout[:corporation].positive?
-
           payout_shares(entity, revenue) if payout[:per_share].positive?
-
           change_share_price(entity, payout)
+          @game.check_bank_broken!
 
           pass!
         end

--- a/lib/engine/step/g_1860/token.rb
+++ b/lib/engine/step/g_1860/token.rb
@@ -7,7 +7,7 @@ module Engine
     module G1860
       class Token < Token
         def actions(entity)
-          return [] if entity.receivership? || @game.insolvent?(entity)
+          return [] if entity.receivership? || @game.insolvent?(entity) || @game.sr_after_southern
 
           super
         end

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -13,6 +13,7 @@ module Engine
         def actions(entity)
           return [] if entity.company? || !can_lay_tile?(entity)
           return [] if entity.receivership?
+          return [] if @game.sr_after_southern
 
           entity == current_entity ? ACTIONS : []
         end


### PR DESCRIPTION
Last set of changes to make 1860 feature complete:

Game now ends on
- Bank breaking
- Corp reaching rightmost stock price
- Nationalization

Implements 8+4 event
Implements 9+5 event - triggering Southern formation
Implements Nationalization

Moves player value calculation into Game::base

Common file changes:
- UI::Player - now calls @game.player_value(player)
- UI::Spreadsheet - now calls @game.player_value(player)
- Game::Base - implements player_value(player), modified call to PlayerInfo
- Engine::PlayerInfo - takes player value directly from calling parameters

Fixes #2451 