### PR TITLE
fix bug when building yellow OO tile

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1084,9 +1084,7 @@ module Engine
         return false if !from.label && from.cities.size != to.cities.size
 
         # handle case where we are laying a yellow OO tile and want to exclude single-city tiles
-        if (from.color == :white) && from.label == Engine::Part::Label.new('OO') && from.cities.size != to.cities.size
-          return false
-        end
+        return false if (from.color == :white) && from.label.to_s == 'OO' && from.cities.size != to.cities.size
 
         true
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1083,6 +1083,11 @@ module Engine
         return false if from.towns.size != to.towns.size
         return false if !from.label && from.cities.size != to.cities.size
 
+        # handle case where we are laying a yellow OO tile and want to exclude single-city tiles
+        if (from.color == :white) && from.label == Engine::Part::Label.new('OO') && from.cities.size != to.cities.size
+          return false
+        end
+
         true
       end
 


### PR DESCRIPTION
When laying a yellow OO tile, the code was incorrectly allowing single-city tiles as an option

So far 1848 is the only case that doesn't have pre-printed yellow tiles, but this covers other games with similar "lay a yellow OO tile" cases (e.g. 18CZ)