### PR TITLE
Fix/Refactor Emergency Money + Issuable Shares

### DIFF
--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -17,41 +17,47 @@ module Engine
 
       def can_sell?(_entity, bundle)
         return false unless sellable_bundle?(bundle)
+        return true if @game.class::EBUY_SELL_MORE_THAN_NEEDED
 
-        # Can only sell as much as you need to afford the train
-        player = bundle.owner
-        unless @game.class::EBUY_SELL_MORE_THAN_NEEDED
-          total_cash = bundle.price + available_cash(player)
-          return false if total_cash >= needed_cash(player) + bundle.price_per_share
-        end
+        selling_minimum_shares?(bundle)
+      end
 
-        true
+      def selling_minimum_shares?(bundle)
+        seller = bundle.owner
+        total_cash = bundle.price + available_cash(seller)
+        total_cash < needed_cash(seller) + bundle.price_per_share
       end
 
       def sellable_bundle?(bundle)
-        player = bundle.owner
-        # Can't sell president's share
-        return false unless bundle.can_dump?(player)
+        seller = bundle.owner
+        return false unless bundle.can_dump?(seller)
 
         # Can't oversaturate the market
         return false unless @game.share_pool.fit_in_bank?(bundle)
 
-        # Can't swap presidency
         corporation = bundle.corporation
-        if corporation.president?(player) &&
-            (!@game.class::EBUY_PRES_SWAP || corporation == current_entity)
-          share_holders = corporation.player_share_holders
-          remaining = share_holders[player] - bundle.percent
-          next_highest = share_holders.reject { |k, _| k == player }.values.max || 0
-          return false if remaining < next_highest
-        end
+        return true unless corporation.president?(seller)
+        return true unless president_swap_concern?(corporation)
 
-        # Otherwise we're good
-        true
+        !causes_president_swap?(corporation, bundle)
       end
 
-      def issuable_shares
-        []
+      def president_swap_concern?(corporation)
+        !@game.class::EBUY_PRES_SWAP || corporation == current_entity
+      end
+
+      def causes_president_swap?(corporation, bundle)
+        seller = bundle.owner
+        share_holders = corporation.player_share_holders
+        remaining = share_holders[seller] - bundle.percent
+        next_highest = share_holders.reject { |k, _| k == seller }.values.max || 0
+        remaining < next_highest
+      end
+
+      def issuable_shares(entity)
+        return [] unless entity.corporation?
+
+        @game.emergency_issuable_bundles(entity)
       end
     end
   end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -80,25 +80,27 @@ module Engine
         pass! unless can_buy_train?(entity)
       end
 
-      def can_sell?(_entity, bundle)
+      def can_sell?(entity, bundle)
         return false if @game.class::MUST_SELL_IN_BLOCKS && @corporations_sold.include?(bundle.corporation)
-        return false if must_issue_before_ebuy?(current_entity)
+        return false if current_entity != entity && must_issue_before_ebuy?(current_entity)
 
         super
       end
 
       def process_sell_shares(action)
-        @last_share_sold_price = action.bundle.price_per_share
+        @last_share_sold_price = action.bundle.price_per_share unless action.entity == current_entity
         super
-        @corporations_sold << action.bundle.corporation
+        @corporations_sold << action.bundle.corporation unless action.entity == current_entity
       end
 
       def needed_cash(_entity)
         @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST ? @depot.min_depot_price : @depot.max_depot_price
       end
 
-      def available_cash(player)
-        player.cash + current_entity.cash
+      def available_cash(entity)
+        return current_entity.cash if entity == current_entity
+
+        entity.cash + current_entity.cash
       end
 
       def buyable_trains(entity)
@@ -140,10 +142,6 @@ module Engine
         @last_share_sold_price = nil
         @last_share_issued_price = nil
         @corporations_sold = []
-      end
-
-      def issuable_shares
-        []
       end
 
       def must_issue_before_ebuy?(corporation)

--- a/spec/fixtures/18_ms/17510.json
+++ b/spec/fixtures/18_ms/17510.json
@@ -1,0 +1,4580 @@
+{
+  "id": 17510,
+  "description": "Round 2",
+  "user": {
+    "id": 506,
+    "name": "Toast_AUS"
+  },
+  "players": [
+    {
+      "id": 506,
+      "name": "Toast_AUS"
+    },
+    {
+      "id": 1745,
+      "name": "Jrod"
+    },
+    {
+      "id": 1020,
+      "name": "dishwasherlove"
+    },
+    {
+      "id": 2300,
+      "name": "julianda"
+    }
+  ],
+  "max_players": 4,
+  "title": "18MS",
+  "settings": {
+    "seed": 102051025,
+    "unlisted": true,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 5,
+  "round": "Operating Round",
+  "acting": [
+    506,
+    1745,
+    1020,
+    2300
+  ],
+  "result": {
+    "Jrod": 2991,
+    "julianda": 1899,
+    "Toast_AUS": 3154,
+    "dishwasherlove": 3275
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 1,
+      "company": "AGS",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 2,
+      "company": "BS",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 3,
+      "company": "MC",
+      "price": 60
+    },
+    {
+      "id": 4,
+      "type": "bid",
+      "price": 70,
+      "entity": 506,
+      "company": "M&O",
+      "entity_type": "player",
+      "user": 506,
+      "created_at": 1606865289
+    },
+    {
+      "id": 5,
+      "type": "undo",
+      "entity": 506,
+      "entity_type": "player",
+      "user": 506,
+      "created_at": 1606865319
+    },
+    {
+      "type": "bid",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 6,
+      "company": "M&M",
+      "price": 50
+    },
+    {
+      "type": "par",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 7,
+      "corporation": "L&N",
+      "share_price": "75,1,3"
+    },
+    {
+      "type": "par",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 8,
+      "corporation": "WRA",
+      "share_price": "75,1,3"
+    },
+    {
+      "type": "par",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 9,
+      "corporation": "Fr",
+      "share_price": "80,1,4"
+    },
+    {
+      "type": "par",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 10,
+      "corporation": "GMO",
+      "share_price": "75,1,3"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 11,
+      "shares": [
+        "L&N_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 12,
+      "user": 506,
+      "shares": [
+        "WRA_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 13,
+      "user": 506,
+      "shares": [
+        "Fr_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 14,
+      "shares": [
+        "GMO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "id": 15,
+      "type": "buy_shares",
+      "entity": 506,
+      "shares": [
+        "GMO_2"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 506,
+      "created_at": 1606868067
+    },
+    {
+      "id": 16,
+      "type": "undo",
+      "entity": 1745,
+      "entity_type": "player",
+      "user": 506,
+      "created_at": 1606868073
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 17,
+      "shares": [
+        "L&N_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 18,
+      "user": 506,
+      "shares": [
+        "WRA_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 19,
+      "user": 506,
+      "shares": [
+        "Fr_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 20,
+      "user": 506,
+      "shares": [
+        "GMO_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 21,
+      "shares": [
+        "L&N_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 22,
+      "user": 506,
+      "shares": [
+        "WRA_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 23,
+      "user": 506,
+      "shares": [
+        "Fr_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 24,
+      "user": 506,
+      "shares": [
+        "GMO_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 25,
+      "shares": [
+        "L&N_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 26,
+      "user": 506,
+      "shares": [
+        "WRA_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 27,
+      "user": 506,
+      "shares": [
+        "Fr_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 28,
+      "user": 506,
+      "shares": [
+        "GMO_4"
+      ],
+      "percent": 10
+    },
+    {
+      "id": 29,
+      "hex": "E3",
+      "tile": "9-0",
+      "type": "lay_tile",
+      "entity": "Fr",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872004
+    },
+    {
+      "id": 30,
+      "hex": "E5",
+      "tile": "6-0",
+      "type": "lay_tile",
+      "entity": "Fr",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872019
+    },
+    {
+      "id": 31,
+      "type": "buy_company",
+      "price": 40,
+      "entity": "Fr",
+      "company": "BS",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872034
+    },
+    {
+      "id": 32,
+      "type": "undo",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872053
+    },
+    {
+      "id": 33,
+      "type": "undo",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872055
+    },
+    {
+      "id": 34,
+      "type": "undo",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872056
+    },
+    {
+      "type": "buy_company",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 35,
+      "company": "BS",
+      "price": 40
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 36,
+      "hex": "E3",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "id": 37,
+      "hex": "E5",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "Fr",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872076
+    },
+    {
+      "id": 38,
+      "type": "undo",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606872116
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 39,
+      "hex": "E5",
+      "tile": "6-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BS",
+      "entity_type": "company",
+      "id": 40,
+      "hex": "F2",
+      "tile": "8-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BS",
+      "entity_type": "company",
+      "id": 41,
+      "hex": "G1",
+      "tile": "8-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 42
+    },
+    {
+      "type": "buy_train",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 43,
+      "train": "2+-0",
+      "price": 80,
+      "variant": "2+"
+    },
+    {
+      "type": "buy_train",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 44,
+      "train": "2+-1",
+      "price": 80,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 45
+    },
+    {
+      "id": 46,
+      "hex": "C9",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "L&N",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606873417
+    },
+    {
+      "id": 47,
+      "hex": "D8",
+      "tile": "9-1",
+      "type": "lay_tile",
+      "entity": "L&N",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606873439
+    },
+    {
+      "id": 48,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606873456
+    },
+    {
+      "id": 49,
+      "hex": "D8",
+      "tile": "8-2",
+      "type": "lay_tile",
+      "entity": "L&N",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606873459
+    },
+    {
+      "id": 50,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606873482
+    },
+    {
+      "id": 51,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606873606
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 52,
+      "hex": "C9",
+      "tile": "6-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 53,
+      "hex": "C7",
+      "tile": "6-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 54
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 55,
+      "train": "2+-2",
+      "price": 80,
+      "variant": "2+"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 56,
+      "train": "2+-3",
+      "price": 80,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 57
+    },
+    {
+      "id": 58,
+      "hex": "E11",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "WRA",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876165
+    },
+    {
+      "id": 59,
+      "hex": "E9",
+      "tile": "5-0",
+      "type": "lay_tile",
+      "entity": "WRA",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876178
+    },
+    {
+      "id": 60,
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876211
+    },
+    {
+      "id": 61,
+      "type": "buy_train",
+      "price": 180,
+      "train": "3+-0",
+      "entity": "WRA",
+      "variant": "3+",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876221
+    },
+    {
+      "id": 62,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876228
+    },
+    {
+      "id": 63,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876230
+    },
+    {
+      "id": 64,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876269
+    },
+    {
+      "id": 65,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876278
+    },
+    {
+      "id": 66,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876304
+    },
+    {
+      "id": 67,
+      "type": "redo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606876368
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 68,
+      "hex": "E11",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 69,
+      "hex": "E9",
+      "tile": "5-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 70
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 71,
+      "train": "3+-0",
+      "price": 180,
+      "variant": "3+"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 72
+    },
+    {
+      "id": 73,
+      "hex": "H6",
+      "tile": "57-1",
+      "type": "lay_tile",
+      "entity": "GMO",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 2300,
+      "created_at": 1606879188
+    },
+    {
+      "id": 74,
+      "hex": "H4",
+      "tile": "4-0",
+      "type": "lay_tile",
+      "entity": "GMO",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 2300,
+      "created_at": 1606879260
+    },
+    {
+      "id": 75,
+      "type": "undo",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "user": 2300,
+      "created_at": 1606879336
+    },
+    {
+      "id": 76,
+      "type": "undo",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "user": 2300,
+      "created_at": 1606879339
+    },
+    {
+      "id": 77,
+      "type": "undo",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "user": 2300,
+      "created_at": 1606879358
+    },
+    {
+      "id": 78,
+      "type": "redo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 2300,
+      "created_at": 1606879361
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 79,
+      "hex": "H6",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "buy_company",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 80,
+      "company": "AGS",
+      "price": 30
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 81,
+      "hex": "H4",
+      "tile": "4-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AGS",
+      "entity_type": "company",
+      "id": 82,
+      "user": 1020,
+      "hex": "H2",
+      "tile": "8-2",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 83,
+      "city": "I1-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 84,
+      "train": "3+-1",
+      "price": 180,
+      "variant": "3+"
+    },
+    {
+      "type": "pass",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 85
+    },
+    {
+      "id": 86,
+      "hex": "H2",
+      "tile": "25-0",
+      "type": "lay_tile",
+      "entity": "Fr",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606884790
+    },
+    {
+      "id": 87,
+      "type": "undo",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606884805
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 88,
+      "hex": "D6",
+      "tile": "4-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 89,
+      "city": "6-2-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 90,
+      "routes": [
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "D6",
+              "E5"
+            ],
+            [
+              "E5",
+              "E3",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "C7",
+              "C9"
+            ],
+            [
+              "D6",
+              "C7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 91,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 92
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 93,
+      "hex": "C7",
+      "tile": "14-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 94,
+      "city": "6-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_company",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 95,
+      "company": "M&M",
+      "price": 75
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 96,
+      "routes": [
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "C7",
+              "C9"
+            ]
+          ]
+        },
+        {
+          "train": "2+-3",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 97,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 98
+    },
+    {
+      "type": "buy_company",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 99,
+      "company": "MC",
+      "price": 90
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 100,
+      "hex": "D10",
+      "tile": "8-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 101
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 102,
+      "routes": [
+        {
+          "train": "3+-0",
+          "connections": [
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 103,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 104
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 105,
+      "hex": "H8",
+      "tile": "4-2",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 106,
+      "routes": [
+        {
+          "train": "3+-1",
+          "connections": [
+            [
+              "I1"
+            ],
+            [
+              "H4",
+              "H2",
+              "I1"
+            ],
+            [
+              "H4",
+              "H6"
+            ],
+            [
+              "H8",
+              "H6"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 107,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 108
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 109,
+      "shares": [
+        "GMO_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 110
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 111,
+      "shares": [
+        "GMO_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 112
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 113,
+      "shares": [
+        "GMO_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 114
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 115,
+      "shares": [
+        "GMO_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 116
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 117,
+      "shares": [
+        "WRA_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 118
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 119,
+      "shares": [
+        "L&N_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 120
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 121
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 122,
+      "shares": [
+        "Fr_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 123
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 124
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 125
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 126
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 127
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 128,
+      "hex": "H2",
+      "tile": "25-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 129,
+      "routes": [
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "I1",
+              "H2",
+              "G1",
+              "F2",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "C7",
+              "D6"
+            ],
+            [
+              "C7",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 130,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 131,
+      "train": "3+-2",
+      "price": 180,
+      "variant": "3+"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 132,
+      "hex": "E5",
+      "tile": "14-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 133,
+      "city": "E1-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 134,
+      "routes": [
+        {
+          "train": "3+-1",
+          "connections": [
+            [
+              "I1",
+              "H2",
+              "H4"
+            ],
+            [
+              "H4",
+              "H6"
+            ],
+            [
+              "H8",
+              "H6"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 135,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 136,
+      "train": "3+-3",
+      "price": 180,
+      "variant": "3+"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 137,
+      "train": "4+-0",
+      "price": 300,
+      "variant": "4+"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 138,
+      "hex": "B10",
+      "tile": "8-4",
+      "rotation": 4
+    },
+    {
+      "id": 139,
+      "city": "14-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902387
+    },
+    {
+      "id": 140,
+      "type": "run_routes",
+      "entity": "L&N",
+      "routes": [
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "B12",
+              "B10",
+              "C9"
+            ]
+          ]
+        },
+        {
+          "train": "2+-3",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902420
+    },
+    {
+      "id": 141,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902427
+    },
+    {
+      "id": 142,
+      "type": "buy_train",
+      "price": 300,
+      "train": "4+-1",
+      "entity": "L&N",
+      "variant": "4+",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902452
+    },
+    {
+      "id": 143,
+      "hex": "C9",
+      "tile": "619-0",
+      "type": "lay_tile",
+      "entity": "WRA",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606902461
+    },
+    {
+      "id": 144,
+      "city": "619-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606902479
+    },
+    {
+      "id": 145,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902482
+    },
+    {
+      "id": 146,
+      "city": "619-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 1745,
+      "created_at": 1606902496
+    },
+    {
+      "id": 147,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902544
+    },
+    {
+      "id": 148,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902546
+    },
+    {
+      "id": 149,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902556
+    },
+    {
+      "id": 150,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902560
+    },
+    {
+      "id": 151,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902562
+    },
+    {
+      "id": 152,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902565
+    },
+    {
+      "id": 153,
+      "city": "14-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902596
+    },
+    {
+      "id": 154,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606902612
+    },
+    {
+      "type": "place_token",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 155,
+      "city": "14-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 156,
+      "routes": [
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "B12",
+              "B10",
+              "C9"
+            ]
+          ]
+        },
+        {
+          "train": "2+-3",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 157,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 158,
+      "train": "4+-1",
+      "price": 300,
+      "variant": "4+"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 159,
+      "hex": "C9",
+      "tile": "619-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 160,
+      "city": "619-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 161,
+      "routes": [
+        {
+          "train": "3+-0",
+          "connections": [
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15"
+            ]
+          ]
+        },
+        {
+          "train": "2+-4",
+          "connections": [
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 162,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 163
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 164,
+      "hex": "B8",
+      "tile": "8-5",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 165
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 166,
+      "routes": [
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "I1",
+              "H2",
+              "G1",
+              "F2",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "E5",
+              "D6"
+            ],
+            [
+              "E5",
+              "E3",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "3+-2",
+          "connections": [
+            [
+              "C9",
+              "C7"
+            ],
+            [
+              "C7",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 167,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 168,
+      "hex": "D6",
+      "tile": "87-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 169,
+      "routes": [
+        {
+          "train": "3+-1",
+          "connections": [
+            [
+              "H8",
+              "H6"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ]
+        },
+        {
+          "train": "3+-3",
+          "connections": [
+            [
+              "H4",
+              "H6"
+            ]
+          ]
+        },
+        {
+          "train": "4+-0",
+          "connections": [
+            [
+              "I1"
+            ],
+            [
+              "I1",
+              "H2",
+              "G1",
+              "F2",
+              "E1"
+            ],
+            [
+              "E5",
+              "E3",
+              "E1"
+            ],
+            [
+              "D6",
+              "E5"
+            ],
+            [
+              "D6",
+              "C7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 170,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 171,
+      "hex": "E11",
+      "tile": "619-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 172,
+      "routes": [
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        },
+        {
+          "train": "2+-3",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "4+-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E11",
+              "E9"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 173,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 174,
+      "hex": "E9",
+      "tile": "619-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 175
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 176,
+      "routes": [
+        {
+          "train": "3+-0",
+          "connections": [
+            [
+              "C9",
+              "C7"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        },
+        {
+          "train": "2+-4",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 177,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 178
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 179,
+      "shares": [
+        "Fr_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 180
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 181,
+      "shares": [
+        "Fr_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 182
+    },
+    {
+      "id": 183,
+      "type": "buy_shares",
+      "entity": 1020,
+      "shares": [
+        "Fr_8"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1606940929
+    },
+    {
+      "id": 184,
+      "type": "undo",
+      "entity": 1020,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1606941111
+    },
+    {
+      "id": 185,
+      "type": "sell_shares",
+      "entity": 1020,
+      "shares": [
+        "Fr_1",
+        "Fr_2"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1606941164
+    },
+    {
+      "id": 186,
+      "type": "par",
+      "entity": 1020,
+      "corporation": "IC",
+      "entity_type": "player",
+      "share_price": "80,1,4",
+      "user": 1020,
+      "created_at": 1606941203
+    },
+    {
+      "id": 187,
+      "type": "undo",
+      "entity": 2300,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1606941232
+    },
+    {
+      "id": 188,
+      "type": "undo",
+      "entity": 1020,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1606941236
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 189,
+      "shares": [
+        "Fr_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 190,
+      "corporation": "IC",
+      "share_price": "80,1,4"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 191,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 192
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 193,
+      "shares": [
+        "WRA_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 194
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 195,
+      "shares": [
+        "WRA_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 196
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 197,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 198
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 199,
+      "shares": [
+        "WRA_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 200,
+      "shares": [
+        "Fr_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 201
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 202,
+      "shares": [
+        "L&N_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 203
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 204,
+      "shares": [
+        "L&N_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 205
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 206,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 207
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 208,
+      "shares": [
+        "IC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 209
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 210
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 211
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 212,
+      "shares": [
+        "L&N_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 213
+    },
+    {
+      "id": 214,
+      "type": "sell_shares",
+      "entity": 2300,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 2300,
+      "created_at": 1606954044
+    },
+    {
+      "id": 215,
+      "type": "undo",
+      "entity": 2300,
+      "entity_type": "player",
+      "user": 2300,
+      "created_at": 1606954057
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 216,
+      "shares": [
+        "IC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 217
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 218
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 219
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 220
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 221
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 222,
+      "hex": "H8",
+      "tile": "87-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 223,
+      "routes": [
+        {
+          "train": "3+-1",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ],
+            [
+              "D6",
+              "E5"
+            ],
+            [
+              "D6",
+              "C7"
+            ]
+          ]
+        },
+        {
+          "train": "3+-3",
+          "connections": [
+            [
+              "I1"
+            ],
+            [
+              "I1",
+              "H2",
+              "G1",
+              "F2",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "4+-0",
+          "connections": [
+            [
+              "H4",
+              "H6"
+            ],
+            [
+              "H8",
+              "H6"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 224,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 225,
+      "hex": "E7",
+      "tile": "8-6",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 226,
+      "routes": [
+        {
+          "train": "4+-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "E9",
+              "D10",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 227,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 228
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 229,
+      "hex": "E7",
+      "tile": "24-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 230,
+      "city": "14-1-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 231,
+      "routes": [
+        {
+          "train": "3+-0",
+          "connections": [
+            [
+              "C9",
+              "C7"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 232,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 233
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 234,
+      "hex": "B10",
+      "tile": "24-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 235,
+      "routes": [
+        {
+          "train": "3+-2",
+          "connections": [
+            [
+              "B12",
+              "B10",
+              "B8",
+              "C7"
+            ],
+            [
+              "D6",
+              "C7"
+            ],
+            [
+              "D6",
+              "E5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 236,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606964069
+    },
+    {
+      "id": 237,
+      "type": "undo",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606964080
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 238,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 239,
+      "train": "4+-2",
+      "price": 300,
+      "variant": "4+"
+    },
+    {
+      "type": "pass",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 240
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 241,
+      "hex": "B2",
+      "tile": "4-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 242
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 243,
+      "train": "3+-2",
+      "price": 800
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 244,
+      "hex": "G9",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 245,
+      "routes": [
+        {
+          "train": "3+-1",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "3+-3",
+          "connections": [
+            [
+              "I1"
+            ],
+            [
+              "I1",
+              "H2",
+              "G1",
+              "F2",
+              "E1"
+            ]
+          ]
+        },
+        {
+          "train": "4+-0",
+          "connections": [
+            [
+              "H4",
+              "H6"
+            ],
+            [
+              "H8",
+              "H6"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 246,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 247,
+      "hex": "D8",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 248,
+      "routes": [
+        {
+          "train": "4+-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "E9",
+              "D10",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 249,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 250
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 251,
+      "hex": "F4",
+      "tile": "8-7",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 252,
+      "routes": [
+        {
+          "train": "3+-0",
+          "connections": [
+            [
+              "C9",
+              "C7"
+            ],
+            [
+              "B12",
+              "B10",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 253,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 254,
+      "train": "5-0",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 255,
+      "hex": "F2",
+      "tile": "23-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 256,
+      "routes": [
+        {
+          "train": "4+-2",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ],
+            [
+              "E1",
+              "F2",
+              "G1",
+              "H2",
+              "I1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 257,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 258,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "buy_train",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 259,
+      "train": "6-0",
+      "price": 550,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 260,
+      "hex": "B4",
+      "tile": "8-8",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 261,
+      "routes": [
+        {
+          "train": "3+-2",
+          "connections": [
+            [
+              "B2",
+              "A1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 262,
+      "kind": "payout"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 263,
+      "shares": [
+        "GMO_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 264,
+      "shares": [
+        "Fr_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 265,
+      "shares": [
+        "GMO_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 266,
+      "shares": [
+        "Fr_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 267,
+      "shares": [
+        "IC_2",
+        "IC_3",
+        "IC_0"
+      ],
+      "percent": 30
+    },
+    {
+      "id": 268,
+      "type": "buy_shares",
+      "entity": 1020,
+      "shares": [
+        "GMO_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1606967361
+    },
+    {
+      "id": 269,
+      "type": "undo",
+      "entity": 2300,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1606967404
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 270,
+      "shares": [
+        "Fr_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 271
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 272
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 273
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 274,
+      "shares": [
+        "GMO_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 275
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 276
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 277
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 278
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 279,
+      "shares": [
+        "GMO_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 280
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 281,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 282
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 283
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 284
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 285
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 286
+    },
+    {
+      "id": 287,
+      "hex": "C9",
+      "tile": "63-0",
+      "type": "lay_tile",
+      "entity": "L&N",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606974869
+    },
+    {
+      "id": 288,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975009
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 289,
+      "hex": "C9",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 290,
+      "routes": [
+        {
+          "train": "4+-1",
+          "connections": [
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 291,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975150
+    },
+    {
+      "id": 292,
+      "type": "buy_train",
+      "price": 500,
+      "train": "2D-0",
+      "entity": "L&N",
+      "variant": "2D",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975169
+    },
+    {
+      "id": 293,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975188
+    },
+    {
+      "id": 294,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975195
+    },
+    {
+      "id": 295,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975200
+    },
+    {
+      "id": 296,
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975201
+    },
+    {
+      "id": 297,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975205
+    },
+    {
+      "id": 298,
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975213
+    },
+    {
+      "id": 299,
+      "type": "undo",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975252
+    },
+    {
+      "id": 300,
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "user": 506,
+      "created_at": 1606975292
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 301,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 302,
+      "train": "2D-0",
+      "price": 500,
+      "variant": "2D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 303,
+      "hex": "E9",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 304,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ],
+            [
+              "E9",
+              "E7",
+              "E5"
+            ],
+            [
+              "E9",
+              "D10",
+              "C9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 305,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 306
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 307,
+      "hex": "C9",
+      "tile": "446-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 308,
+      "routes": [
+        {
+          "train": "4+-2",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ],
+            [
+              "E1",
+              "F2",
+              "G1",
+              "H2",
+              "I1"
+            ]
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "C7"
+            ]
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D6",
+              "E5"
+            ],
+            [
+              "D6",
+              "C7"
+            ],
+            [
+              "B12",
+              "B10",
+              "B8",
+              "C7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 309,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 310,
+      "hex": "F10",
+      "tile": "8-9",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 311,
+      "city": "446-0-0",
+      "slot": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 312,
+      "routes": [
+        {
+          "train": "4+-0",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H8",
+              "G9",
+              "F10",
+              "E9"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 313,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 314,
+      "train": "6-1",
+      "price": 550,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 315,
+      "hex": "B6",
+      "tile": "9-3",
+      "rotation": 1
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 316,
+      "shares": [
+        "WRA_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 317,
+      "shares": [
+        "IC_5",
+        "IC_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 318,
+      "shares": [
+        "GMO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 319,
+      "train": "2D-1",
+      "price": 500,
+      "variant": "2D"
+    },
+    {
+      "id": 320,
+      "hex": "B8",
+      "tile": "28-0",
+      "type": "lay_tile",
+      "entity": "Fr",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606979710
+    },
+    {
+      "id": 321,
+      "type": "undo",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "user": 1020,
+      "created_at": 1606979766
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 322,
+      "hex": "C7",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 323,
+      "routes": [
+        {
+          "train": "4+-2",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "E1"
+            ],
+            [
+              "E1",
+              "F2",
+              "G1",
+              "H2",
+              "I1"
+            ]
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "C7",
+              "C9"
+            ]
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D6",
+              "E5"
+            ],
+            [
+              "C7",
+              "D6"
+            ],
+            [
+              "C7",
+              "B8",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 324,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 325,
+      "hex": "F2",
+      "tile": "45-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 326,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E5",
+              "F4",
+              "F2",
+              "G1",
+              "H2",
+              "I1"
+            ],
+            [
+              "E9",
+              "E7",
+              "E5"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 327,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 328
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 329,
+      "hex": "E11",
+      "tile": "63-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 330,
+      "routes": [
+        {
+          "train": "4+-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E11",
+              "E9"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ]
+          ]
+        },
+        {
+          "train": "2D-0",
+          "connections": [
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 331,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 332,
+      "hex": "B8",
+      "tile": "16-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 333,
+      "routes": [
+        {
+          "train": "4+-0",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H8",
+              "H6"
+            ],
+            [
+              "H4",
+              "H6"
+            ],
+            [
+              "I1",
+              "H2",
+              "H4"
+            ],
+            [
+              "I1"
+            ]
+          ]
+        },
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E11",
+              "E9"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 334,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 335
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 336,
+      "hex": "B8",
+      "tile": "43-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 337,
+      "routes": [
+        {
+          "train": "2D-1",
+          "connections": [
+            [
+              "A1",
+              "A3",
+              "B4",
+              "B6",
+              "B8",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 338,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 339
+    },
+    {
+      "type": "sell_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 340,
+      "shares": [
+        "WRA_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 341,
+      "shares": [
+        "GMO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 342,
+      "shares": [
+        "L&N_5",
+        "L&N_7"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 343,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 344,
+      "shares": [
+        "L&N_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 345
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 346,
+      "shares": [
+        "IC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 347
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 348,
+      "shares": [
+        "IC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 349
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 350,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 351
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 352,
+      "shares": [
+        "IC_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 353
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 354,
+      "shares": [
+        "IC_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 355
+    },
+    {
+      "type": "buy_shares",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 356,
+      "shares": [
+        "IC_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 357
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 358
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 359
+    },
+    {
+      "id": 360,
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "user": 2300,
+      "created_at": 1607030688
+    },
+    {
+      "id": 361,
+      "type": "undo",
+      "entity": 506,
+      "entity_type": "player",
+      "user": 2300,
+      "created_at": 1607030728
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 362,
+      "shares": [
+        "L&N_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 363
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 364
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 365
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 366
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 367,
+      "shares": [
+        "WRA_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 368
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 369
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 370,
+      "shares": [
+        "Fr_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 371
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 372,
+      "shares": [
+        "L&N_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 373,
+      "shares": [
+        "Fr_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 374
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 375
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 376,
+      "shares": [
+        "Fr_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 377
+    },
+    {
+      "id": 378,
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1607040097
+    },
+    {
+      "id": 379,
+      "type": "undo",
+      "entity": 2300,
+      "entity_type": "player",
+      "user": 1020,
+      "created_at": 1607040104
+    },
+    {
+      "type": "pass",
+      "entity": 1020,
+      "entity_type": "player",
+      "id": 380
+    },
+    {
+      "type": "pass",
+      "entity": 2300,
+      "entity_type": "player",
+      "id": 381
+    },
+    {
+      "type": "pass",
+      "entity": 506,
+      "entity_type": "player",
+      "id": 382
+    },
+    {
+      "type": "pass",
+      "entity": 1745,
+      "entity_type": "player",
+      "id": 383
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 384,
+      "hex": "E5",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 385,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E5",
+              "F4",
+              "F2",
+              "G1",
+              "H2",
+              "I1"
+            ],
+            [
+              "E5",
+              "E7",
+              "E9"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 386,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 387
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 388,
+      "hex": "D8",
+      "tile": "20-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 389,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E11",
+              "E9"
+            ],
+            [
+              "C7",
+              "D8",
+              "E9"
+            ]
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "B12",
+              "B10",
+              "B8",
+              "C7"
+            ],
+            [
+              "C7",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 390,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 391
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 392,
+      "hex": "H6",
+      "tile": "15-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 393,
+      "routes": [
+        {
+          "train": "2D-0",
+          "connections": [
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 394,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 395
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 396,
+      "hex": "H6",
+      "tile": "X31b-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 397,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E11",
+              "D12",
+              "E13",
+              "E15"
+            ],
+            [
+              "E11",
+              "E9"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 398,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 399
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 400
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 401,
+      "routes": [
+        {
+          "train": "2D-1",
+          "connections": [
+            [
+              "A1",
+              "A3",
+              "B4",
+              "B6",
+              "B8",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 402,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 403
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 404
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 405,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E5",
+              "F4",
+              "F2",
+              "G1",
+              "H2",
+              "I1"
+            ],
+            [
+              "E5",
+              "E7",
+              "E9"
+            ],
+            [
+              "C9",
+              "D10",
+              "E9"
+            ],
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 406,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 407
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 408,
+      "hex": "D10",
+      "tile": "23-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 409,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B12",
+              "B10",
+              "B8",
+              "C7"
+            ],
+            [
+              "C7",
+              "C9"
+            ]
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "I1",
+              "H2",
+              "H4"
+            ],
+            [
+              "H6",
+              "H4"
+            ],
+            [
+              "H6",
+              "H8"
+            ],
+            [
+              "H8",
+              "G9",
+              "F10",
+              "E9"
+            ],
+            [
+              "C7",
+              "D8",
+              "E9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 410,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "Fr",
+      "entity_type": "corporation",
+      "id": 411
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 412,
+      "hex": "E7",
+      "tile": "42-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 413,
+      "routes": [
+        {
+          "train": "2D-0",
+          "connections": [
+            [
+              "C9",
+              "B10",
+              "B12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 414,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 415
+    },
+    {
+      "type": "pass",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 416
+    },
+    {
+      "type": "run_routes",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 417,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E9",
+              "E7",
+              "D8",
+              "C9"
+            ],
+            [
+              "H8",
+              "G9",
+              "F10",
+              "E9"
+            ],
+            [
+              "H6",
+              "H8"
+            ],
+            [
+              "H6",
+              "H4"
+            ],
+            [
+              "I1",
+              "H2",
+              "H4"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 418,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GMO",
+      "entity_type": "corporation",
+      "id": 419
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 420
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 421,
+      "routes": [
+        {
+          "train": "2D-1",
+          "connections": [
+            [
+              "A1",
+              "A3",
+              "B4",
+              "B6",
+              "B8",
+              "C9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 422,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 423
+    }
+  ],
+  "loaded": true,
+  "created_at": 1606826794,
+  "updated_at": 1607042437
+}


### PR DESCRIPTION
See original https://github.com/tobymao/18xx/pull/2634 for a complete list of refactor/change explanations.

I've pulled out just the fixes/refactor to this PR, saving game specific changes and view improvements for later.

The problem with my first PR was emergency_money > can_sell? finished with an "unless" statement, thus the passing case returned nil instead of true. I've refactored that function this time so as to not have a trailing true. This only affected 18MS as that's the only game with @game.class::EBUY_SELL_MORE_THAN_NEEDED, so I have included a new fixture that addresses that path.

Relevant to https://github.com/tobymao/18xx/issues/2609