### PR TITLE
EBuy - Don't show issue message if no shares to issue ( one liner )

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -133,7 +133,8 @@ module View
         children << remaining_trains
 
         children << h(:div, "#{@corporation.name} has #{@game.format_currency(@corporation.cash)}.")
-        if (issuable_cash = @game.emergency_issuable_cash(@corporation)).positive?
+        if step.issuable_shares(@corporation).any? &&
+           (issuable_cash = @game.emergency_issuable_cash(@corporation)).positive?
           children << h(:div, "#{@corporation.name} can issue shares to raise up to "\
                               "#{@game.format_currency(issuable_cash)} (the corporation "\
                               'must issue shares before the president may contribute).')


### PR DESCRIPTION
The text "DPAC can issue shares to raise..." was showing regardless of whether there were shares to issue.
<img width="561" alt="Screen Shot 2020-12-13 at 11 05 37 AM" src="https://user-images.githubusercontent.com/15675400/102020283-66ab5e80-3d35-11eb-9fec-d1f3584bbfd6.png">

After the change the paragraph no longer renders since it is irrelevant
<img width="494" alt="Screen Shot 2020-12-13 at 11 05 25 AM" src="https://user-images.githubusercontent.com/15675400/102020320-b722bc00-3d35-11eb-9c69-f0858ca3b75b.png">


Note: I think the underlying code could be refactored to be better by rolling into a single step-based emergency_issuable_cash function, but I'd prefer to tackle that refactor in the future.