### PR TITLE
Repar values are not highlighted in 1860

### DIFF
--- a/lib/engine/share_price.rb
+++ b/lib/engine/share_price.rb
@@ -24,7 +24,7 @@ module Engine
     }.freeze
 
     # Types which are info only and shouldn't
-    NON_HIGHLIGHT_TYPES = %i[par safe_par par_1 par_2 safe_par convert_range max_price].freeze
+    NON_HIGHLIGHT_TYPES = %i[par safe_par par_1 par_2 safe_par convert_range max_price repar].freeze
 
     def self.from_code(code, row, column, unlimited_types, multiple_buy_types: [])
       return nil if !code || code == ''


### PR DESCRIPTION
Fixes 2680
https://github.com/tobymao/18xx/issues/2680
Before
![image](https://user-images.githubusercontent.com/2993555/102416042-29f69600-3fc7-11eb-8051-33a0328a166d.png)

After
![image](https://user-images.githubusercontent.com/2993555/102416105-3aa70c00-3fc7-11eb-9e1b-9cbe64cc121d.png)

