### PR TITLE
Bug Fix - 18TN: prevent corporations from buying multiple companies in OR1

### DIFF
--- a/lib/engine/step/g_18_tn/buy_company.rb
+++ b/lib/engine/step/g_18_tn/buy_company.rb
@@ -8,7 +8,9 @@ module Engine
       class BuyCompany < BuyCompany
         def can_buy_company?(entity)
           return true if super
-          return false if entity != current_entity || !@game.allowed_to_buy_during_operation_round_one?
+          return false if entity != current_entity ||
+                          entity.companies.any? ||
+                          !@game.allowed_to_buy_during_operation_round_one?
 
           companies = @game.purchasable_companies
           companies.any? && companies.map(&:value).min <= entity.cash


### PR DESCRIPTION
Fortunately it appears no one bought 2 companies in the games in the database, so no pins needed.

From the rulebook, section 4.2.6, page 8:

During the first operating round of the game only, each major company may purchase a single private company from a player for exactly the face value of the private company (maximum of one private company total per player on the first operating round). Any major company that chooses not to use this option at this time must wait until phase 3 to purchase private companies from players.