### PR TITLE
18CO Remove City Reservations, Close Corp w/o Homes, Re-reserve Newly Parred Corps

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -104,7 +104,7 @@ module Engine
 		"co5": {
 			"count": 1,
 			"color": "yellow",
-			"code": "city=revenue:20;city=revenue:20,hide:1;path=a:0,b:_0;path=a:_0,b:5;path=a:2,b:_1;path=a:_1,b:4;label=CS;"
+			"code": "city=revenue:20;city=revenue:20,hide:1;path=a:0,b:_0;path=a:_0,b:5;path=a:2,b:_1;path=a:_1,b:4;label=C;"
 		},
 		"14": 4,
 		"15": 4,
@@ -145,7 +145,7 @@ module Engine
 		"co6": {
 			"count": 1,
 			"color": "green",
-			"code": "city=revenue:40,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=CS;"
+			"code": "city=revenue:40,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=C;"
 		},
 		"39": 1,
 		"40": 2,
@@ -170,7 +170,7 @@ module Engine
 		"co7": {
 			"count": 1,
 			"color": "brown",
-			"code": "city=revenue:60,slots:3;path=a:0,b:_0,;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=CS;"
+			"code": "city=revenue:60,slots:3;path=a:0,b:_0,;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=C;"
 		}
 	},
 	"market": [
@@ -801,6 +801,9 @@ module Engine
 			"events": [
 				{
 					"type": "close_companies"
+				},
+				{
+					"type": "unreserve_home_stations"
 				}
 			],
 			"price": 500,
@@ -973,7 +976,7 @@ module Engine
 				"C15",
 				"K17"
 			],
-			"city=revenue:10;path=a:5,b:_0;path=a:_0,b:0;label=CS;border=edge:1,type:mountain,cost:40;": [
+			"city=revenue:10;path=a:5,b:_0;path=a:_0,b:0;label=C;border=edge:1,type:mountain,cost:40;": [
 				"G17"
 			],
 			"city=revenue:10;city=revenue:0,loc:7;city=revenue:10;path=a:5,b:_0;path=a:3,b:_2;label=D;border=edge:0,type:mountain,cost:40;border=edge:1,type:mountain,cost:40;": [
@@ -1246,6 +1249,9 @@ module Engine
 				"green",
 				"brown"
 			],
+			"status": [
+				"closable_corporations"
+			],
 			"operating_rounds": 2
 		},
 		{
@@ -1256,6 +1262,9 @@ module Engine
 				"yellow",
 				"green",
 				"brown"
+			],
+			"status": [
+				"closable_corporations"
 			],
 			"operating_rounds": 2
 		},
@@ -1268,6 +1277,9 @@ module Engine
 				"green",
 				"brown"
 			],
+			"status": [
+				"closable_corporations"
+			],
 			"operating_rounds": 2
 		},
 		{
@@ -1278,6 +1290,9 @@ module Engine
 				"yellow",
 				"green",
 				"brown"
+			],
+			"status": [
+				"closable_corporations"
 			],
 			"operating_rounds": 2
 		},
@@ -1291,6 +1306,7 @@ module Engine
 				"brown"
 			],
 			"status":[
+				"closable_corporations",
 				"reduced_tile_lay"
 			],
 			"operating_rounds": 2

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -50,6 +50,7 @@ module Engine
       GREEN_TOWN_TILES = %w[co8 co9 co10].freeze
       GREEN_CITY_TILES = %w[14 15].freeze
       BROWN_CITY_TILES = %w[co4 63].freeze
+      MAX_CITY_TILES = %w[14 15 co1 co2 co3 co4 co7 63].freeze
 
       STOCKMARKET_COLORS = {
         par: :yellow,
@@ -91,11 +92,20 @@ module Engine
           'presidents_choice' => [
             'President\'s Choice Triggered',
             'President\'s choice round will occur at the beginning of the next Stock Round',
+          ],
+          'unreserve_home_stations' => [
+            'Remove Reservations',
+            'Home stations are no longer reserved for unparred corporations.',
           ]
         ).freeze
 
       STATUS_TEXT = Base::STATUS_TEXT.merge(
-        'reduced_tile_lay' => ['Reduced Tile Lay', 'Corporations place only one tile per OR.']
+        'reduced_tile_lay' => ['Reduced Tile Lay', 'Corporations place only one tile per OR.'],
+        'closable_corporations' => [
+          'Closable Corporations',
+          'Unparred corporations are removed if there is no station available to place their home token. '\
+          'Parring a corporation restores its home token reservation.',
+        ]
       ).freeze
 
       include CompanyPrice50To150Percent
@@ -191,7 +201,7 @@ module Engine
         Step::Bankrupt,
         Step::G18CO::Takeover,
         Step::DiscardTrain,
-        Step::HomeToken,
+        Step::G18CO::HomeToken,
         Step::G18CO::ReturnToken,
         Step::BuyCompany,
         Step::G18CO::RedeemShares,
@@ -266,7 +276,42 @@ module Engine
         case action
         when Action::BuyCompany
           mine_update_text(action.entity) if action.company == imc && action.entity.corporation?
+        when Action::PlaceToken
+          remove_corporations_if_no_home(action.city) if @phase.status.include?('closable_corporations')
+        when Action::Par
+          rereserve_home_station(action.corporation) if @phase.status.include?('closable_corporations')
         end
+      end
+
+      def remove_corporations_if_no_home(city)
+        tile = city.tile
+
+        return unless tile_has_max_cities(tile)
+
+        @corporations.dup.reject(&:ipoed).each do |corp|
+          next unless corp.coordinates == tile.hex.name
+
+          next if city.tokenable?(corp, free: true)
+
+          log << "#{corp.name} closes as its home station can never be available"
+          close_corporation(corp, quiet: true)
+          corp.close!
+        end
+      end
+
+      def tile_has_max_cities(tile)
+        tile.color == :red || MAX_CITY_TILES.include?(tile.hex.name)
+      end
+
+      def rereserve_home_station(corporation)
+        return unless corporation.coordinates
+
+        tile = hex_by_id(corporation.coordinates).tile
+        city = tile.cities[corporation.city || 0]
+        slot = city.get_slot(corporation)
+        tile.add_reservation!(corporation, slot ? corporation.city : nil, slot)
+        log << "#{corporation.name} reserves station on #{tile.hex.name}"\
+          "#{slot ? '' : " which must be upgraded to place the #{corporation.name} home station"}"
       end
 
       def check_distance(route, visits)
@@ -355,6 +400,12 @@ module Engine
         @corporations.each do |corporation|
           mines_remove(corporation)
         end
+      end
+
+      def event_unreserve_home_stations!
+        @log << '-- Event: Home station reservations removed --'
+
+        hexes.map { |h| h.tile.cities.map(&:remove_all_reservations!) }
       end
 
       def tile_lays(_entity)

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -288,7 +288,8 @@ module Engine
 
         return unless tile_has_max_cities(tile)
 
-        @corporations.dup.reject(&:ipoed).each do |corp|
+        @corporations.dup.each do |corp|
+          next if corp.ipoed
           next unless corp.coordinates == tile.hex.name
 
           next if city.tokenable?(corp, free: true)
@@ -405,7 +406,7 @@ module Engine
       def event_unreserve_home_stations!
         @log << '-- Event: Home station reservations removed --'
 
-        hexes.map { |h| h.tile.cities.map(&:remove_all_reservations!) }
+        hexes.each { |h| h.tile.cities.each(&:remove_all_reservations!) }
       end
 
       def tile_lays(_entity)

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -62,7 +62,7 @@ module Engine
       end
 
       def remove_all_reservations!
-        @reservations = []
+        @reservations.clear
       end
 
       def city?

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -61,6 +61,10 @@ module Engine
         @reservations.delete(entity)
       end
 
+      def remove_all_reservations!
+        @reservations = []
+      end
+
       def city?
         true
       end

--- a/lib/engine/step/g_18_co/home_token.rb
+++ b/lib/engine/step/g_18_co/home_token.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../home_token'
+
+module Engine
+  module Step
+    module G18CO
+      class HomeToken < HomeToken
+        def active?
+          pending_entity && multiple_home_slot(pending_entity)
+        end
+
+        def multiple_home_slot(entity)
+          return false unless entity.corporation?
+
+          tile = @game.hex_by_id(entity.coordinates).tile
+          city = tile.cities.find { |c| c.reserved_by?(entity) }
+          return tile.available_slot? unless city
+
+          place_token(
+            pending_entity,
+            city,
+            token,
+            teleport: true,
+          )
+          @round.pending_tokens.shift
+
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/special_track.rb
+++ b/lib/engine/step/g_18_co/special_track.rb
@@ -19,6 +19,7 @@ module Engine
 
           clear_upgrade_icon(action.hex.tile)
           collect_mines(action.entity.owner, action.hex)
+          migrate_reservations(action.hex.tile)
 
           return if ability.count.positive?
 

--- a/lib/engine/step/g_18_co/track.rb
+++ b/lib/engine/step/g_18_co/track.rb
@@ -13,8 +13,18 @@ module Engine
           lay_tile_action(action)
           clear_upgrade_icon(action.hex.tile)
           collect_mines(action.entity, action.hex)
+          migrate_reservations(action.hex.tile)
+          # place_home_token(action.hex.tile, pending_token[:token]) if pending_token
 
           pass! unless can_lay_tile?(action.entity)
+        end
+
+        def available_hex(entity, hex)
+          if pending_token(entity)
+            return hex == @game.hex_by_id(entity.coordinates) ? hex.tile.exits : nil
+          end
+
+          super
         end
       end
     end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -279,11 +279,12 @@ module Engine
       @reservations.any? { |r| [r, r.owner].include?(corporation) }
     end
 
-    def add_reservation!(entity, city, slot = 0)
+    def add_reservation!(entity, city, slot = nil)
       # Single city, assume the first
-      city = 0 if @cities.one? && available_slot?
+      city = 0 if @cities.one?
+      slot = @cities[city].get_slot(entity) if city && slot.nil?
 
-      if city
+      if city && slot
         @cities[city].add_reservation!(entity, slot)
       else
         @reservations << entity

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -281,7 +281,7 @@ module Engine
 
     def add_reservation!(entity, city, slot = 0)
       # Single city, assume the first
-      city = 0 if @cities.one?
+      city = 0 if @cities.one? && available_slot?
 
       if city
         @cities[city].add_reservation!(entity, slot)
@@ -466,6 +466,10 @@ module Engine
         neighbor = @hex.neighbors[edge]&.tile
         neighbor&.restore_borders([Hex.invert(edge)])
       end
+    end
+
+    def available_slot?
+      cities.sum(&:available_slots).positive?
     end
 
     private


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/1836

From phase 5 onward, cities are no longer reserved.
If a corporation can never place its home token, it is removed from the game.
Once a corporation is parred, its reservation is returned to the hex.
A hex might be a single city, but the corporation may upgrade it to place its home token.

**Implementation Notes**

Tile label for Colorado Springs changed from **CS** to **C** to avoid confusion over the Corporation CS if it needs re-reservation.

I feel like once again I have a side effect inside a ? function, similar to the takeover. I don't know how to avoid that and still get the nice automation this provides. Its the same kind of reason: its the Home Token placement step, and if it can find a suitable automatic placement (in this case when a tile placement opens up a slot), it executes it automatically, otherwise it prompts the player to make the choice.

### In Action

CS was not parred. CM placed a token on CS home hex once "closable corporations" was in play. Later, CS was parred, placing a reservation on the yellow hex (rereserve_home_station), as it can be upgraded to green, which has two slots.
<img width="132" alt="Screen Shot 2020-12-16 at 2 52 43 PM" src="https://user-images.githubusercontent.com/15675400/102451453-bcae2980-3ff5-11eb-8db1-8b36f7bd8176.png">

In the next OR, CM considered upgrading the tile to green. The reservation moves from the tile to the city ( migrate_reservations function ).
<img width="158" alt="Screen Shot 2020-12-16 at 10 20 42 PM" src="https://user-images.githubusercontent.com/15675400/102451467-c3d53780-3ff5-11eb-9106-c3804658f6ff.png">

CM undid its tile lay. When it became CS's turn to operate, HomeToken was not active at first because there was no available slot, so CS proceeded to Track. Its only option was to lay the green tile. This triggered the migrate_reservations, which assigned a slot, and thus HomeToken's multiple_home_slot ran and placed the token in the newly added slot automatically.
<img width="219" alt="Screen Shot 2020-12-16 at 11 09 20 PM" src="https://user-images.githubusercontent.com/15675400/102451434-b5871b80-3ff5-11eb-9d3a-192ecca8c018.png">

In this SR, CS and DPAC were parred. DPAC's station was still open, so it doesn't have to worry about placing track on its first OR, while CS must upgrade to place its token.
<img width="576" alt="Screen Shot 2020-12-16 at 11 36 19 PM" src="https://user-images.githubusercontent.com/15675400/102452413-8c678a80-3ff7-11eb-844d-b3ff8aeda34f.png">

