### PR TITLE
1860: Fix errors on empty routes, nationalization

### DIFF
--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -306,13 +306,17 @@ module Engine
         @corporations.select { |c| c.ipoed && !c.receivership? }.all? { |c| c.trains.any? }
       end
 
+      def get_or_revenue(info)
+        info.dividend.kind == 'withhold' ? 0 : info.revenue
+      end
+
       # OR has just finished, find two lowest revenues and nationalize the corporations
       # associated with each
       def nationalize_corps!
         revenues = @corporations.select { |c| c.floated? && !nationalized?(c) }
-          .map { |c| [c, c.operating_history[c.operating_history.keys.max].revenue] }.to_h
+          .map { |c| [c, get_or_revenue(c.operating_history[c.operating_history.keys.max])] }.to_h
 
-        sorted_corps = revenues.keys.sort_by { |c| c.operating_history[c.operating_history.keys.max].revenue }
+        sorted_corps = revenues.keys.sort_by { |c| revenues[c] }
 
         if sorted_corps.size < 3
           # if two or less corps left, they are both nationalized

--- a/lib/engine/round/g_1860/operating.rb
+++ b/lib/engine/round/g_1860/operating.rb
@@ -16,7 +16,7 @@ module Engine
           if (entity = @entities[@entity_index]).receivership? || @game.insolvent?(entity)
             case action
             when Engine::Action::RunRoutes
-              process_action(Engine::Action::Dividend.new(entity, kind: 'withhold'))
+              process_action(Engine::Action::Dividend.new(entity, kind: 'withhold')) if action.routes.any?
             end
           elsif @game.nationalization
             case action

--- a/lib/engine/step/g_1860/route.rb
+++ b/lib/engine/step/g_1860/route.rb
@@ -58,6 +58,11 @@ module Engine
           entity = action.entity
           @round.routes = action.routes
 
+          if @round.routes.empty? && @game.legal_route?(entity) && (entity.trains.any? || @game.insolvent?(entity)) &&
+              (!entity.receivership? || !@game.nationalization)
+            @game.game_error('Must run a route')
+          end
+
           # the following two checks must be made here, after all routes have been defined
           if @round.routes.reject { |r| r.connections.empty? }.any?
             @game.check_home_token(entity, @round.routes)


### PR DESCRIPTION
Throw error when submitting an empty route when corp has train and a valid route
Fix bug with Nationalization not treating withheld runs as zero revenue

This will cause at least one completed game to fail. There is only a very small window where a running game would be impacted.

Fixes #2697 
Fixes #2696 