### PR TITLE
18CO Acquisition Round

### DIFF
--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -112,7 +112,7 @@ module View
           end
 
           right = []
-          right << h(Map, game: @game) if actions.include?('remove_token')
+          right << h(Map, game: @game) if actions.include?('remove_token') || actions.include?('place_token')
           # Switch to the OR mode layout
           if right.any?
             left_props = {

--- a/lib/engine/round/g_18_co/acquisition.rb
+++ b/lib/engine/round/g_18_co/acquisition.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../merger'
+
+module Engine
+  module Round
+    module G18CO
+      class Acquisition < Merger
+        attr_reader :entities
+
+        def self.short_name
+          'AR'
+        end
+
+        def name
+          'Acquisition Round'
+        end
+
+        def offer
+          @offering || []
+        end
+
+        def select_entities
+          @offering = @game.acquirable_corporations.sort.reverse
+          (@game.corporations - @offering).select(&:floated?).sort
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/acquisition_auction.rb
+++ b/lib/engine/step/g_18_co/acquisition_auction.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require_relative '../base.rb'
+require_relative '../auctioner.rb'
+
+module Engine
+  module Step
+    module G18CO
+      class AcquisitionAuction < Base
+        include Auctioner
+
+        ACTIONS = %w[bid pass].freeze
+
+        def actions(entity)
+          return [] unless @auctioning
+          return [] unless can_bid?(entity)
+
+          ACTIONS
+        end
+
+        def description
+          'Acquire Corporations'
+        end
+
+        def pass_description
+          'Pass (Bid)'
+        end
+
+        def log_pass(entity)
+          @log << "#{entity.name} passes bidding on #{@auctioning.name}"
+        end
+
+        def log_skip(entity)
+          if same_president(entity)
+            @log << "#{entity.name} has the same president as #{@auctioning.name} and cannot participate"
+            return
+          end
+
+          @log << "#{entity.name} cannot afford bidding on #{@auctioning.name}"
+        end
+
+        def process_bid(action)
+          entity = action.entity
+          corporation = action.corporation
+          price = action.price
+          min = min_bid(corporation)
+
+          @game.game_error("#{entity.name} must bid at least #{@game.format_currency(min)}") if price < min
+
+          @log << "#{entity.name} bids #{@game.format_currency(price)} for #{corporation.name}"
+          @round.next_entity_index!
+          add_bid(action)
+        end
+
+        def process_pass(action)
+          log_pass(action.entity)
+          action.entity.pass!
+          @round.next_entity_index!
+          resolve_bids
+        end
+
+        def same_president(entity)
+          entity.owner == @auctioning.owner
+        end
+
+        def can_bid?(entity)
+          return unless entity.corporation?
+          return if same_president(entity)
+          return if @bids[@auctioning].any? { |b| b.entity == entity }
+
+          min_bid(@auctioning) < max_bid(entity, @auctioning)
+        end
+
+        def starting_bid(_corporation)
+          1
+        end
+
+        def min_increment
+          1
+        end
+
+        def min_bid(corporation)
+          if (bid = highest_bid(corporation)&.price)
+            bid + min_increment
+          else
+            starting_bid(corporation)
+          end
+        end
+
+        def max_bid(corporation, _entity)
+          corporation.cash
+        end
+
+        def setup
+          setup_auction
+        end
+
+        def auctioning_corporation
+          @auctioning
+        end
+
+        def merge_target
+          current_entity
+        end
+
+        def buyer
+          current_entity
+        end
+
+        def setup_auction
+          super
+          @auctioning = @round.offer.first
+          resolve_bids
+        end
+
+        def committed_cash(_player, _show_hidden = false)
+          0
+        end
+
+        protected
+
+        def add_bid(bid)
+          bidder = bid.entity
+          corporation = bid.corporation
+          price = bid.price
+          min = min_bid(corporation)
+          @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{corporation.name}") if price < min
+
+          @bids[corporation] << bid
+
+          bidder.pass!
+          resolve_bids
+        end
+
+        def resolve_bids
+          return unless @auctioning
+
+          entities.each do |participant|
+            next if participant.passed?
+
+            unless can_bid?(participant)
+              log_skip(participant)
+              participant.pass!
+            end
+          end
+
+          return unless entities.all?(&:passed?)
+
+          entity = @auctioning
+          winning_bid = highest_bid(entity)
+
+          win_bid(winning_bid, entity)
+
+          @bids.clear
+          @round.offer.delete(entity)
+          entities.each(&:unpass!)
+          @round.reset_entity_index!
+          @auctioning = @round.offer.first
+        end
+
+        def win_bid(winning_bid, entity)
+          return nobody_wanted_me(entity) unless winning_bid&.entity
+
+          corporation = winning_bid.entity
+          price = winning_bid.price
+          @log << "#{corporation.name} wins the auction for #{entity.name}"\
+                  " with a bid of #{@game.format_currency(price)}"
+
+          corporation.spend(price, @game.bank)
+
+          @round.pending_acquisition = { source: entity, corporation: corporation }
+        end
+
+        def nobody_wanted_me(entity)
+          @log << "#{entity.name} is closed due to no bids during the acquisition round"
+          @game.close_corporation(entity, quiet: true)
+          entity.close!
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/acquisition_takeover.rb
+++ b/lib/engine/step/g_18_co/acquisition_takeover.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'takeover'
+
+module Engine
+  module Step
+    module G18CO
+      class AcquisitionTakeover < Takeover
+        def round_state
+          {
+            pending_takeover: nil,
+            pending_acquisition: nil,
+          }
+        end
+
+        def takeover_in_progress
+          return true if current_entity
+          return false unless (pa = @round.pending_acquisition)
+
+          execute_takeover!(pa[:source], pa[:corporation])
+          @round.pending_acquisition = nil
+
+          current_entity
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/takeover.rb
+++ b/lib/engine/step/g_18_co/takeover.rb
@@ -26,6 +26,10 @@ module Engine
           takeover_in_progress
         end
 
+        def active_entities
+          [current_entity]
+        end
+
         def current_entity
           pending_takeover[:destination_corp]
         end
@@ -77,7 +81,8 @@ module Engine
 
           old_token = taken_entity.tokens.find { |t| t.city == action.city }
           new_token = entity.unplaced_tokens.last
-          old_token.swap!(new_token)
+          old_token.remove!
+          action.city.exchange_token(new_token)
           pending_takeover[:place_count] -= 1
 
           @game.log << "#{current_entity.name} replaces #{taken_entity.name} token on #{action.city.hex.name}"


### PR DESCRIPTION
The **Final Feature** From: https://github.com/tobymao/18xx/issues/1836

At​ ​the​ ​beginning​ ​of​ ​every​ ​Stock​ ​Round​ ​starting​ ​with​ ​the​ ​second​ ​Stock​ ​Round,​ ​do the following with​ ​all​ ​Corporations​ ​with​ ​Stock​ ​Tokens​ ​in​ ​the​ ​red zone​ ​near​ ​the​ ​bottom​ ​of​ ​the​ ​Stock​ ​Market​ ​in​ ​Operating​ ​order.
- In​ ​Operating​ ​order,​ ​each​ ​Corporation​ ​that​ ​is​ ​not​ ​up​ ​for​ ​acquisition​ ​and​ ​does​ ​not​ ​have​ ​the​ ​same​ ​President​ ​as​ ​the Corporation​ ​currently​ ​being​ ​liquidated​ ​may​ ​either​ ​place​ ​a​ ​single​ ​bid​ ​of​ ​at​ ​least​ ​$1​ ​or​ ​pass.
- The​ ​Corporation​ ​with​ ​the​ ​highest​ ​bid​ ​wins​ ​the​ ​auction,​ ​and​ ​pays​ ​their​ ​bid​ ​money​ ​from​ ​their​ ​Treasury​ ​to​ ​the​ ​Bank.
- The​ ​winning​ ​Corporation​ ​executes​ ​a​ ​Takeover​ ​on​ ​the​ ​liquidated​ ​Corporation.
- In​ ​the​ ​unlikely​ ​event​ ​that​ ​all​ ​Corporations​ ​pass​ ​in​ ​a​ ​liquidation​ ​auction,​ ​discard​ ​the​ ​liquidated​ ​Corporation’s​ ​trains​ ​to​ ​the
Market​ ​and​ ​return​ ​its​ ​treasury​ ​cash​ ​to​ ​the​ ​bank.​ ​Remove​ ​its​ ​Charter,​ ​Shares,​ ​Tokens​ ​and​ ​all​ ​of​ ​its​ ​other​ ​assets​ ​from​ ​the game.

### Implementation Notes

Update the Merger view to allow placing tokens, not just removing them.
Add a new round to 18CO - Acquisition Round
Add a new step to 18CO - Acquisition Auction, where corporations bid on takeover rights when a corp is in the red zone of the stock market
Add a new step to 18CO for acquisition takeovers, as these aren't triggered by share ownership but rather an auction

I could probably play with the view a bit to get better information display in the game page, notably the Bidding Corporation's information, but I don't want to mess up 1817, it can be added later and it would only make this PR longer. Despite this being complex, it happens very infrequently in actual gameplay. I almost eliminated it from the rules entirely.

### In Action

The initial kick off. KPAC passes.
<img width="638" alt="Screen Shot 2020-12-17 at 4 32 06 PM" src="https://user-images.githubusercontent.com/15675400/102556247-b4053400-4085-11eb-8045-107e4edbffd9.png">

DSL bids $160, which is more than other corporations have, and thus wins the auction and executes the takeover. It is in the Token replacement step.
<img width="960" alt="Screen Shot 2020-12-17 at 4 32 19 PM" src="https://user-images.githubusercontent.com/15675400/102556245-b2d40700-4085-11eb-86b6-ee2c7b287467.png">

Later in the game CS is dissolved because nobody bids on it.
<img width="447" alt="Screen Shot 2020-12-17 at 4 14 37 PM" src="https://user-images.githubusercontent.com/15675400/102556250-b4053400-4085-11eb-82b6-ad983627b320.png">

