### PR TITLE
Corporate Share Fixes

### DIFF
--- a/assets/app/view/game/corporate_buy_shares.rb
+++ b/assets/app/view/game/corporate_buy_shares.rb
@@ -46,7 +46,7 @@ module View
         return unless @step.current_actions.include?('corporate_buy_shares')
 
         input = player.shares.group_by(&:corporation).values.map do |corp_shares|
-          render_buttons(corp_shares.group_by(&:percent).values.map(&:first),
+          render_buttons(corp_shares.reject(&:president).group_by(&:percent).values.map(&:first),
                          source: corp_shares.first.corporation.name)
         end.compact
 

--- a/lib/engine/step/corporate_buy_shares.rb
+++ b/lib/engine/step/corporate_buy_shares.rb
@@ -81,7 +81,7 @@ module Engine
       def source_list(entity)
         source = if @game.class::CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY && bought?(entity)
                    @game.sorted_corporations.select do |corp|
-                     corp == @bought.last &&
+                     corp == last_bought(entity) &&
                        !corp.num_market_shares.zero? &&
                        can_buy_corp_from_market?(entity, corp)
                    end

--- a/lib/engine/step/corporate_sell_shares.rb
+++ b/lib/engine/step/corporate_sell_shares.rb
@@ -62,7 +62,7 @@ module Engine
           next if bought?(entity, share.corporation)
 
           share.corporation
-        end.compact
+        end.compact.uniq
       end
 
       def bought?(entity, corporation)


### PR DESCRIPTION
Update Corp Share Buy to use Function - This was changed during dev but never updated.

---

Corporate Share Sales - Fix Duplicate corps if multiple owned shares.

Before:
<img width="681" alt="Screen Shot 2020-12-18 at 10 36 40 AM" src="https://user-images.githubusercontent.com/15675400/102647809-a2726980-4123-11eb-9fb4-fd879040d5d8.png">

---

If the President Share was the same percentage as the next share ( ie both 20% ) the President would be first and render an Undefined.

Before:
<img width="360" alt="Screen Shot 2020-12-18 at 4 51 43 PM" src="https://user-images.githubusercontent.com/15675400/102673583-a4ebb800-4151-11eb-8546-b0bece4f3a70.png">

After:
<img width="376" alt="Screen Shot 2020-12-18 at 4 51 17 PM" src="https://user-images.githubusercontent.com/15675400/102673645-a87f3f00-4151-11eb-93db-a5cda1fd88db.png">
