### PR TITLE
1860 home tile placement and priority deal fixes

### DIFF
--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -191,6 +191,7 @@ module Engine
         @log << "#{player.name} has #{reason}"
 
         @players.rotate!(@players.index(player))
+        @log << "#{@players.first.name} has priority deal"
       end
 
       def new_stock_round
@@ -224,7 +225,6 @@ module Engine
             end
           when init_round.class
             init_round_finished
-            reorder_players
             new_stock_round
           end
       end
@@ -266,6 +266,13 @@ module Engine
           player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.any? }.sum(&:price) +
           player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.none? }.sum { |s| (s.price / 2).to_i } +
           company_value
+      end
+
+      def place_home_token(corporation)
+        # will this break the game?
+        return if sr_after_southern
+
+        super
       end
 
       def event_fishbourne_to_bank!

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -60,10 +60,12 @@ module Engine
         end
 
         def process_buy_shares(action)
+          corporation = action.bundle.corporation
+          floated = corporation.floated?
+
           super
 
-          corporation = action.bundle.corporation
-          place_home_track(corporation) if corporation.floated?
+          place_home_track(corporation) if corporation.floated? && !floated && !@game.sr_after_southern
           @game.check_new_layer
         end
 

--- a/lib/engine/step/g_1860/exchange.rb
+++ b/lib/engine/step/g_1860/exchange.rb
@@ -27,11 +27,14 @@ module Engine
           unless can_exchange?(company, bundle)
             @game.game_error("Cannot exchange #{action.entity.id} for #{bundle.corporation.id}")
           end
+          corporation = bundle.corporation
+          floated = corporation.floated?
 
           bundle.corporation.shares.each { |share| share.buyable = true }
 
           buy_shares(company.owner, bundle, exchange: company)
           company.close!
+          place_home_track(corporation) if corporation.floated? && !floated && !@game.sr_after_southern
           @game.check_new_layer
         end
 
@@ -56,6 +59,23 @@ module Engine
           shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
 
           shares.any? { |s| can_gain?(entity.owner, s&.to_bundle, exchange: true) }
+        end
+
+        def place_home_track(corporation)
+          hex = @game.hex_by_id(corporation.coordinates)
+          tile = hex.tile
+
+          # skip if a tile is already in home location
+          return unless tile.color == :white
+
+          @log << "#{corporation.name} (#{corporation.owner.name}) must choose tile for home location"
+
+          @round.pending_tracks << {
+            entity: corporation,
+            hexes: [hex],
+          }
+
+          @round.clear_cache!
         end
       end
     end

--- a/lib/engine/step/g_1860/home_track.rb
+++ b/lib/engine/step/g_1860/home_track.rb
@@ -9,9 +9,11 @@ module Engine
       class HomeTrack < Base
         include Tracker
         ACTIONS = %w[lay_tile].freeze
+        ALL_ACTIONS = %w[pass lay_tile].freeze
 
         def actions(entity)
           return [] unless entity == pending_entity
+          return ALL_ACTIONS unless any_tiles?(entity)
 
           ACTIONS
         end
@@ -44,6 +46,17 @@ module Engine
 
         def description
           "Lay home track for #{pending_entity.name}"
+        end
+
+        def any_tiles?(entity)
+          hex = pending_track[:hexes].first
+          upgradeable_tiles(entity, hex).any?
+        end
+
+        def process_pass(action)
+          log_pass(action.entity)
+          @round.pending_tracks.shift
+          pass!
         end
 
         def process_lay_tile(action)


### PR DESCRIPTION
Fixes #2709 
Fixes #2712 
Fixes #2718 

This also fixes an issue I thought of: home token and home tile lays are no longer allowed after the SR after the Southern forms. This may cause a problem when it happens, but it should be extremely rare and given how hard it is to construct a case where it happens, I'm just going to cross that bridge when someone tries to cross it.