### PR TITLE
Display Emergency Issue instead of Issue when emergency issuing shares

### DIFF
--- a/assets/app/view/game/issue_shares.rb
+++ b/assets/app/view/game/issue_shares.rb
@@ -6,8 +6,14 @@ module View
   module Game
     class IssueShares < Snabberb::Component
       include Actionable
-
       needs :entity, default: nil
+
+      def emergency?
+        return false unless @game.round.active_step.respond_to?(:must_buy_train?)
+
+        @game.round.active_step.must_buy_train?(@entity)
+      end
+
       def render
         @step = @game.round.active_step
         @entity ||= @game.current_entity
@@ -16,7 +22,8 @@ module View
 
         if @current_actions.include?('sell_shares')
           if (step = @game.round.step_for(@entity, 'sell_shares'))
-            children << render_shares('Issue', step.issuable_shares(@entity), Engine::Action::SellShares)
+            issue_text = emergency? ? 'Emergency Issue' : 'Issue'
+            children << render_shares(issue_text, step.issuable_shares(@entity), Engine::Action::SellShares)
           end
         end
 

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -197,6 +197,7 @@ describe 'Assets' do
       ['1846', 'hs_sudambau_1600037415', 41, 'buy_train_issuing',
        ['B&amp;O has $120',
         'B&amp;O can issue shares to raise up to $40',
+        'Emergency Issue',
         '!!Bankruptcy']],
       ['1846', 'hs_sudambau_1600037415', 50, 'buy_train_president_cash',
        ['B&amp;O has $146',


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/1813

Before
![image](https://user-images.githubusercontent.com/2993555/102654560-b9728500-413e-11eb-87c6-5cc09446d771.png)

After
![image](https://user-images.githubusercontent.com/2993555/102654536-aa8bd280-413e-11eb-96c7-813b20b17202.png)

After (normal issue)
![image](https://user-images.githubusercontent.com/2993555/102654582-c3948380-413e-11eb-811e-fa4c48c87ad7.png)
