### PR TITLE
18CO - Transferred trains should reset

### DIFF
--- a/lib/engine/step/g_18_co/takeover.rb
+++ b/lib/engine/step/g_18_co/takeover.rb
@@ -186,6 +186,7 @@ module Engine
         def transfer_trains(source, destination)
           return unless source.trains.any?
 
+          source.trains.each { |train| train.operated = false }
           transferred = source.transfer(:trains, destination)
 
           @game.log << "#{destination.name} takes #{transferred.map(&:name).join(', ')}"\


### PR DESCRIPTION
There is no rule in 18CO that a train transferred during a takeover cannot run again. It would be very unusual and probably not in a player's interest to takeover a higher value corporation.