### PR TITLE
18CO - Fix detection of city having max stations

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -50,7 +50,7 @@ module Engine
       GREEN_TOWN_TILES = %w[co8 co9 co10].freeze
       GREEN_CITY_TILES = %w[14 15].freeze
       BROWN_CITY_TILES = %w[co4 63].freeze
-      MAX_CITY_TILES = %w[14 15 co1 co2 co3 co4 co7 63].freeze
+      MAX_STATION_TILES = %w[14 15 co1 co2 co3 co4 co7 63].freeze
 
       STOCKMARKET_COLORS = {
         par: :yellow,
@@ -306,7 +306,7 @@ module Engine
       def remove_corporations_if_no_home(city)
         tile = city.tile
 
-        return unless tile_has_max_cities(tile)
+        return unless tile_has_max_stations(tile)
 
         @corporations.dup.each do |corp|
           next if corp.ipoed
@@ -320,8 +320,8 @@ module Engine
         end
       end
 
-      def tile_has_max_cities(tile)
-        tile.color == :red || MAX_CITY_TILES.include?(tile.hex.name)
+      def tile_has_max_stations(tile)
+        tile.color == :red || MAX_STATION_TILES.include?(tile.name)
       end
 
       def rereserve_home_station(corporation)


### PR DESCRIPTION
Corp closing worked fine on red tiles but not in places like Denver as the check is based on the tile being laid, not the hex it is laid in. Not sure how this made it through final checks before.

Tweaking the variable/function names to be more accurate.

---

After

<img width="481" alt="Screen Shot 2020-12-19 at 10 35 02 AM" src="https://user-images.githubusercontent.com/15675400/102695641-e0d05d00-41e5-11eb-9f46-0a87d4141778.png">
