### PR TITLE
Allow for generic tile cost discount and use in 18CO

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -69,7 +69,7 @@ to specify that the blocking ends when the company is bought in by a
 corporation.
 
 - `partition_type`: The name of the partition type that is to be
-blocked, akin to terrain and border types.
+  blocked, akin to terrain and border types.
 
 ## close
 
@@ -155,7 +155,7 @@ Lay a tile and place a station token without connectivity
 Discount the cost for laying tiles in the specified terrain type
 
 - `discount`: Discount amount
-- `terrain`: Type of terrain for which discount is provided
+- `terrain`: If set, type of terrain for which discount is provided, otherwise the discount is off the total cost
 - `hexes`: If not specified, all applicable hexes qualifies for
   the discount. If specified, only specified hexes qualify
 

--- a/lib/engine/ability/tile_discount.rb
+++ b/lib/engine/ability/tile_discount.rb
@@ -6,9 +6,10 @@ module Engine
   module Ability
     class TileDiscount < Base
       attr_reader :terrain, :discount, :hexes
-      def setup(terrain:, discount:, hexes: nil)
-        @terrain = terrain.to_sym
+
+      def setup(discount:, terrain: nil, hexes: nil)
         @discount = discount
+        @terrain = terrain&.to_sym
         @hexes = hexes
       end
     end

--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -415,8 +415,7 @@ module Engine
 			"abilities": [
 				{
 					"type": "tile_discount",
-					"discount": 20,
-					"terrain": "mountain"
+					"discount": 20
 				}
 			]
 		},

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1041,18 +1041,30 @@ module Engine
           (!a.hexes || a.hexes.include?(hex.name))
         end
 
-        tile.upgrades.sum do |upgrade|
+        cost = tile.upgrades.sum do |upgrade|
           discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
 
-          if discount.positive?
-            @log << "#{entity.name} receives a discount of "\
-              "#{format_currency(discount)} from "\
-              "#{ability.owner.name}"
-          end
+          log_tile_cost_discount(entity, ability, discount)
 
           total_cost = upgrade.cost - discount
           total_cost
         end
+
+        if ability && ability.terrain.nil?
+          log_tile_cost_discount(entity, ability, discount)
+
+          cost -= ability.discount
+        end
+
+        cost
+      end
+
+      def log_tile_cost_discount(entity, ability, discount)
+        return unless discount.positive?
+
+        @log << "#{entity.name} receives a discount of "\
+                "#{format_currency(discount)} from "\
+                "#{ability.owner.name}"
       end
 
       def declare_bankrupt(player)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -171,6 +171,7 @@ module Engine
 
           ability = entity.all_abilities.find do |a|
             (a.type == :tile_discount) &&
+             a.terrain &&
              (border.type == a.terrain) &&
              (!a.hexes || a.hexes.include?(hex.name))
           end


### PR DESCRIPTION
**Saguache​ ​&​ ​San​ ​Juan Toll​ ​Road​ ​Company**
An​ ​owning​ ​Corporation​ ​receives​ ​a​ ​$20​ ​discount​ ​on​ ​the​ ​cost​ ​of​ ​tile​ ​lays.​ ​Closes​ ​on purchase​ ​of​ ​"5"​ ​train.

https://18xxgames.slack.com/archives/C012K0CNY5C/p1608399860033700

---

Base - add overall discount when terrain nil
tile_discount - set default terrain nil
Tracker - require terrain for ability to apply to a border
Update Readme
18CO config - remove terrain