### PR TITLE
No need to log when the player has taken both actions

### DIFF
--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -29,6 +29,7 @@ module Engine
 
       def log_pass(entity)
         return @log << "#{entity.name} passes" if @current_actions.empty?
+        return if bought? && sold?
 
         action = bought? ? 'to sell' : 'to buy'
         @log << "#{entity.name} declines #{action} shares"
@@ -226,6 +227,10 @@ module Engine
 
       def bought?
         @current_actions.any? { |x| self.class::PURCHASE_ACTIONS.include?(x.class) }
+      end
+
+      def sold?
+        @current_actions.any? { |x| x.class == Action::SellShares }
       end
 
       def process_buy_company(action)


### PR DESCRIPTION
This conversation will disappear eventually: https://18xxgames.slack.com/archives/C012K0CNY5C/p1608369677011200

Essentially, if the player took both buy and sell actions, it is superfluous and almost inaccurate to log that they did not continue to do those actions.

Sample Before:

```
tkspielt sells a 10% share of G&F and receives $50
G&F's share price changes from $50 to $45
tkspielt buys a 10% share of SAL from the IPO for $110
tkspielt sells a 10% share of G&F and receives $45
G&F's share price changes from $45 to $40
tkspielt declines to sell shares
cane buys a 10% share of W&A from the IPO for $110
cane declines to sell shares
```

After:
```
tkspielt sells a 10% share of G&F and receives $50
G&F's share price changes from $50 to $45
tkspielt buys a 10% share of SAL from the IPO for $110
tkspielt sells a 10% share of G&F and receives $45
G&F's share price changes from $45 to $40
cane buys a 10% share of W&A from the IPO for $110
cane declines to sell shares
```

The bike shed _will_ be painted red.