### PR TITLE
18AL Bonus Revenue Display and Logging

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -109,7 +109,7 @@ module View
             else
               children << h('td.right', td_props, revenue)
             end
-            children << h(:td, @game.revenue_str(route, routes: @routes))
+            children << h(:td, @game.revenue_str(route))
           elsif !selected
             style[:border] = '1px solid'
             style[:padding] = '5px 8px'

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -109,7 +109,7 @@ module View
             else
               children << h('td.right', td_props, revenue)
             end
-            children << h(:td, route.hexes.map(&:name).join(' '))
+            children << h(:td, @game.revenue_str(route, routes: @routes))
           elsif !selected
             style[:border] = '1px solid'
             style[:padding] = '5px 8px'

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -220,7 +220,7 @@ module Engine
         @game.game_error("Cannot use group #{key} more than once") unless group.one?
       end
 
-      @game.revenue_for(self, stops)
+      @game.revenue_for(self, stops, routes: @routes)
     end
 
     def subsidy

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -220,7 +220,7 @@ module Engine
         @game.game_error("Cannot use group #{key} more than once") unless group.one?
       end
 
-      @game.revenue_for(self, stops, routes: @routes)
+      @game.revenue_for(self, stops)
     end
 
     def subsidy

--- a/lib/engine/step/g_18_al/buy_company.rb
+++ b/lib/engine/step/g_18_al/buy_company.rb
@@ -11,7 +11,7 @@ module Engine
 
           return unless action.company.sym == 'M&C'
 
-          rob_bonus, pan_bonus = @game.route_bonuses
+          rob_bonus, pan_bonus = @game.route_bonuses.keys
           action.entity.add_ability(create_hexes_bonus_ability(rob_bonus, 'Robert E. Lee', %w[G8 G4], 20))
           action.entity.add_ability(create_hexes_bonus_ability(pan_bonus, 'Pan American', %w[Q2 A4], 40))
         end

--- a/lib/engine/step/g_18_al/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_al/buy_sell_par_shares.rb
@@ -28,7 +28,7 @@ module Engine
 
         def route_bonus_ability
           @game.corporations.each do |corporation|
-            @game.abilities(corporation, @game.route_bonuses.first) do |ability|
+            @game.abilities(corporation, @game.route_bonuses.keys.first) do |ability|
               return ability
             end
           end

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -38,7 +38,7 @@ module Engine
 
           trains[train] = true
           revenue = @game.format_currency(route.revenue)
-          revenue_str = @game.revenue_str(route, routes: @round.routes)
+          revenue_str = @game.revenue_str(route)
           @log << "#{entity.name} runs a #{train.name} train for #{revenue}: #{revenue_str}"
         end
         pass!

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -29,6 +29,7 @@ module Engine
         entity = action.entity
         @round.routes = action.routes
         trains = {}
+
         @round.routes.each do |route|
           train = route.train
           @game.game_error("Cannot run another corporation's train. refresh") if train.owner && train.owner != entity
@@ -36,8 +37,9 @@ module Engine
           @game.game_error('Cannot run train that operated') if train.operated
 
           trains[train] = true
-          @log << "#{entity.name} runs a #{train.name} train for "\
-            "#{@game.format_currency(route.revenue)}: #{@game.revenue_str(route)}"
+          revenue = @game.format_currency(route.revenue)
+          revenue_str = @game.revenue_str(route, routes: @round.routes)
+          @log << "#{entity.name} runs a #{train.name} train for #{revenue}: #{revenue_str}"
         end
         pass!
       end


### PR DESCRIPTION
Fixes: https://github.com/tobymao/18xx/issues/1302

---

There are a series of titles that award bonuses for stops at certain hexes or hitting specific routes. We may be able to make some generic functionality for this. In the meantime, I am tackling the titles missing this data in the route selector and logs.

---

<img width="467" alt="Screen Shot 2020-12-20 at 2 45 31 PM" src="https://user-images.githubusercontent.com/15675400/102725927-c9719c80-42d7-11eb-99e9-2c492863cfc3.png">

<img width="864" alt="Screen Shot 2020-12-20 at 2 45 48 PM" src="https://user-images.githubusercontent.com/15675400/102725928-ca0a3300-42d7-11eb-8074-885e31e22dd6.png">

<img width="824" alt="Screen Shot 2020-12-20 at 2 46 26 PM" src="https://user-images.githubusercontent.com/15675400/102725930-caa2c980-42d7-11eb-90fb-4da945321eed.png">

<img width="848" alt="Screen Shot 2020-12-20 at 2 46 39 PM" src="https://user-images.githubusercontent.com/15675400/102725931-cb3b6000-42d7-11eb-9708-72fd53c5cbb0.png">
