### PR TITLE
[1860] add direct link to rules pdf

### DIFF
--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -21,7 +21,7 @@ module Engine
       load_from_json(Config::Game::G1860::JSON)
 
       GAME_LOCATION = 'Isle of Wight'
-      GAME_RULES_URL = 'https://boardgamegeek.com/filepage/79633/second-edition-rules'
+      GAME_RULES_URL = 'https://www.dropbox.com/s/usfbqtdjzx6ug8f/1860-rules.pdf'
       GAME_DESIGNER = 'Mike Hutton'
       GAME_PUBLISHER = nil
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1860'


### PR DESCRIPTION
Previously the rules link was to BGG, which requires login to view the PDF

This is on my personal dropbox as a shared file, can change to something else if we want