### PR TITLE
Fix text color for GW, GT, TGB icons in 1856

### DIFF
--- a/public/logos/1856/GT.svg
+++ b/public/logos/1856/GT.svg
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -38,7 +38,7 @@
      id="namedview3749"
      showgrid="false"
      inkscape:zoom="24.985302"
-     inkscape:cx="18.885189"
+     inkscape:cx="12.221271"
      inkscape:cy="18.427318"
      inkscape:window-x="1912"
      inkscape:window-y="-8"
@@ -66,11 +66,11 @@
        class="cls-3"
        d="m 38.280259,16.759859 a 20.84,20.84 0 1 1 -20.84,-20.8300002 20.83,20.83 0 0 1 20.84,20.8300002 z"
        id="path3740"
-       style="fill:#78cf29;fill-opacity:0.18431373"
+       style="fill:#78c292;fill-opacity:1"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;"
        x="8.7251291"
        y="21.372566"
        id="text4564"><tspan

--- a/public/logos/1856/GW.svg
+++ b/public/logos/1856/GW.svg
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -38,7 +38,7 @@
      id="namedview3749"
      showgrid="false"
      inkscape:zoom="24.985302"
-     inkscape:cx="18.885189"
+     inkscape:cx="12.221271"
      inkscape:cy="18.427318"
      inkscape:window-x="1912"
      inkscape:window-y="-8"
@@ -70,7 +70,7 @@
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;"
        x="6.563858"
        y="21.372566"
        id="text4564"><tspan

--- a/public/logos/1856/TGB.svg
+++ b/public/logos/1856/TGB.svg
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -38,7 +38,7 @@
      id="namedview3749"
      showgrid="false"
      inkscape:zoom="24.985302"
-     inkscape:cx="18.885189"
+     inkscape:cx="12.221271"
      inkscape:cy="18.427318"
      inkscape:window-x="1912"
      inkscape:window-y="-8"
@@ -70,7 +70,7 @@
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;"
        x="5.0029402"
        y="21.372566"
        id="text4564"><tspan


### PR DESCRIPTION
GT, GW, TGB logos were black text on color background when the text should've been white. This is fixed and now matches the corporation charter colors
Before:
![image](https://user-images.githubusercontent.com/2993555/102743666-e9c84800-4325-11eb-8d70-986f17f52df6.png)

After
![image](https://user-images.githubusercontent.com/2993555/102743630-d4ebb480-4325-11eb-9a32-a545ea723d15.png)
