### PR TITLE
1867: Finish merger

### DIFF
--- a/lib/engine/step/g_1867/post_merger_shares.rb
+++ b/lib/engine/step/g_1867/post_merger_shares.rb
@@ -21,28 +21,62 @@ module Engine
 
         def process_buy_shares(action)
           player = action.entity
+          bundle = action.bundle
+          target = bundle.corporation
 
-          # @todo: this needs to catch the 10% -> 20% presidency case
-          buy_shares(player, action.bundle)
+          # 20% still remains, they buy that instead.
+          if target.shares.first.president && player.percent_of(target) == 10
+            # give the 10% back, so they don't exceed cert limit
+            presidency = target.shares.first
+            player.shares_of(target).first.transfer(presidency.owner)
+
+            # Buy the share (so logging is correct), then give it back
+            buy_shares(player, bundle)
+            player.shares_of(target).first.transfer(presidency.owner)
+
+            # grab the presidency
+            @game.share_pool.buy_shares(player, presidency.to_bundle, exchange: :free)
+          else
+            buy_shares(player, bundle)
+          end
 
           player.pass! if !@round.share_dealing_multiple.include?(player) || !can_buy_any?(player)
 
-          # @todo: need to cover rule 9.2 D
+          check_merge
+        end
+
+        def check_merge
+          return unless active_entities.none?
+
+          if corporation.shares.first&.president
+            @broken_merge = true
+            # This could theoretically undo the merge cleanly,
+            # but it's easier to let the players press the Undo button.
+            @log << 'Merge failed as no player has 20%, please undo'
+          elsif @round.share_dealing_multiple.any?
+            # Rule 9.2 D - All players can buy 10% after involved players can buy up to 60%
+            @round.share_dealing_players.each(&:unpass!)
+            @round.share_dealing_players = @game.players.rotate(@game.players.index(corporation.owner))
+            @round.share_dealing_multiple.clear
+          end
         end
 
         def process_pass(action)
           log_pass(action.entity)
           action.entity.pass!
+          check_merge
         end
 
         def can_buy_any?(entity)
-          can_buy?(entity, corporation.shares[0])
+          # Can't buy the 20% share directly, so check the first two shares.
+          can_buy?(entity, corporation.shares[0]) || can_buy?(entity, corporation.shares[1])
         end
 
         def can_buy?(entity, bundle)
           return unless bundle
 
           corporation == bundle.corporation &&
+            bundle.percent == 10 &&
             bundle.owner != @game.share_pool &&
             entity.cash >= bundle.price &&
             can_gain?(entity, bundle)
@@ -53,7 +87,9 @@ module Engine
         end
 
         def description
-          'Buy Shares Post Conversion'
+          return 'Failed merge, please undo' if @broken_merge
+
+          'Buy Shares Post Merge'
         end
 
         def corporation
@@ -66,6 +102,7 @@ module Engine
 
         def active_entities
           return [] unless corporation
+          return @game.players if @broken_merge
 
           [@round.share_dealing_players
           .select { |p| p.active? && can_buy_any?(p) }.first].compact


### PR DESCRIPTION
Allow for buying presidency share at the share stage
Allow for second round of buying single shares
Correct order of merging so the initiator should end up with presidency
Error when the merge fails