### PR TITLE
1860 add first two options, fix map UI to allow missing row/column

### DIFF
--- a/assets/app/view/game/axis.rb
+++ b/assets/app/view/game/axis.rb
@@ -15,6 +15,7 @@ module View
       needs :gap
       needs :map_x, default: 0
       needs :map_y, default: 0
+      needs :start_pos, default: [1, 1]
 
       X_OFFSET = 100
       LETTERS = ('A'..'Z').to_a.freeze
@@ -44,7 +45,7 @@ module View
         hex_x, hex_y = hex_size
 
         labels = @cols.map do |col|
-          x = hex_x * (col.to_i - 1)
+          x = hex_x * (col.to_i - @start_pos[0])
 
           label =
             if @axes[:x] == :letter
@@ -79,7 +80,7 @@ module View
         hex_x, hex_y = hex_size
 
         labels = @rows.map do |row|
-          multiplier = row.to_i
+          multiplier = row.to_i - @start_pos[1] + 1
           multiplier -= 0.5 if @layout == :pointy
           y = hex_y * multiplier
 

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -34,6 +34,7 @@ module View
       needs :show_coords, default: nil
       needs :show_location_names, default: true
       needs :routes, default: []
+      needs :start_pos, default: [1, 1]
 
       def render
         return nil if @hex.empty
@@ -98,13 +99,13 @@ module View
         "translate(#{x}, #{y})"
       end
 
-      def self.coordinates(hex)
+      def self.coordinates(hex, start_pos = [1, 1])
         t_x, t_y = LAYOUT[hex.layout]
-        [(t_x * hex.x + SIZE).round(2), (t_y * hex.y + SIZE).round(2)]
+        [(t_x * (hex.x - start_pos[0] + 1) + SIZE).round(2), (t_y * (hex.y - start_pos[1] + 1) + SIZE).round(2)]
       end
 
       def coordinates
-        self.class.coordinates(@hex)
+        self.class.coordinates(@hex, @start_pos)
       end
 
       def transform

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -32,6 +32,7 @@ module View
         @hexes = @show_starting_map ? @game.init_hexes(@game.companies, @game.corporations) : @game.hexes.dup
         @cols = @hexes.reject(&:ignore_for_axes).map(&:x).uniq.sort.map(&:next)
         @rows = @hexes.reject(&:ignore_for_axes).map(&:y).uniq.sort.map(&:next)
+        @start_pos = [@cols.first, @rows.first]
         @layout = @game.layout
 
         @scale = SCALE * map_zoom
@@ -58,7 +59,8 @@ module View
             actions: actions,
             show_coords: show_coords,
             show_location_names: show_location_names,
-            routes: routes
+            routes: routes,
+            start_pos: @start_pos
           )
         end
         @hexes.compact!
@@ -179,7 +181,8 @@ module View
               font_size: FONT_SIZE,
               gap: GAP,
               map_x: map_x,
-              map_y: map_y),
+              map_y: map_y,
+              start_pos: @start_pos),
           ]),
         ])
       end

--- a/lib/engine/config/game/g_1860.rb
+++ b/lib/engine/config/game/g_1860.rb
@@ -34,7 +34,7 @@ module Engine
     "F2": "Cowes",
     "J2": "Ryde Pier",
     "G3": "Whippingham",
-    "I3": "Ryde",
+    "I3": "Ryde Esp",
     "B4": "Yarmouth",
     "F4": "Cement Mills",
     "H4": "Wooton & Havenstreet",
@@ -492,7 +492,7 @@ module Engine
     },
     {
       "sym": "IWNJ",
-      "name": "Isle of Wight, Newport Juntion",
+      "name": "Isle of Wight, Newport Junction",
       "logo": "1860/IWNJ",
       "float_percent": 50,
       "max_ownership_percent": 100,

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -253,6 +253,14 @@ module Engine
         end
       end
 
+      # use to modify hexes based on optional rules
+      def optional_hexes
+        self.class::HEXES
+      end
+
+      # use to modify tiles based on optional rules
+      def optional_tiles; end
+
       def self.title
         name.split('::').last.slice(1..-1)
       end
@@ -388,6 +396,7 @@ module Engine
         @bank = init_bank
         @tiles = init_tiles
         @all_tiles = init_tiles
+        optional_tiles
         @cert_limit = init_cert_limit
         @removals = []
 
@@ -1409,7 +1418,7 @@ module Engine
           end
         end
 
-        self.class::HEXES.map do |color, hexes|
+        optional_hexes.map do |color, hexes|
           hexes.map do |coords, tile_string|
             coords.map.with_index do |coord, index|
               next Hex.new(coord, layout: layout, axes: axes, empty: true) if color == :empty
@@ -1442,7 +1451,7 @@ module Engine
               Hex.new(coord, layout: layout, axes: axes, tile: tile, location_name: location_name)
             end
           end
-        end.flatten
+        end.flatten.compact
       end
 
       def init_tiles

--- a/lib/engine/step/g_1860/route.rb
+++ b/lib/engine/step/g_1860/route.rb
@@ -72,14 +72,17 @@ module Engine
 
           @round.routes.each do |route|
             train = route.train
+            leased = ' '
             if train.owner && @game.train_owner(train) != entity
               @game.game_error("Cannot run another corporation's train. refresh")
               @game.game_error('Cannot run train that operated') if train.operated
+            else
+              leased = ' (leased) '
             end
             @game.game_error('Cannot run train twice') if trains[train]
 
             trains[train] = true
-            @log << "#{entity.name} runs a #{train.name} train for "\
+            @log << "#{entity.name} runs a #{train.name} train#{leased}for "\
               "#{@game.format_currency(route.revenue)}: #{@game.revenue_str(route)}"
           end
           pass!


### PR DESCRIPTION
Add two options to 1860: 2-3 player map, and original (first edition) insolvency rules

When testing 2-3 player map, rendering of map was broken due to the lack of hexes in column "A". There was some code in UI:Map that tries to deal with axes not starting with "A" or "0", but it wasn't complete. I modified UI::Map, Hex and Axis to allow shifting the display of hexes.

New 2-3 player map and rendering:
![optional_map](https://user-images.githubusercontent.com/8494213/102815854-4e1cf300-438a-11eb-8f64-aad2aab7498e.png)
