### PR TITLE
Allow for Phase Jumping

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -110,7 +110,7 @@ module View
 
           h(:tr, [
             h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
-            h(:td, phase[:on]),
+            h(:td, Array(phase[:on]).first),
             h(:td, phase[:operating_rounds]),
             h(:td, train_limit),
             h(:td, phase_props, phase_color.capitalize),

--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -1284,7 +1284,7 @@ module Engine
 		},
 		{
 			"name": "6b",
-			"on": "5D",
+			"on": ["5D", "E"],
 			"train_limit": 2,
 			"tiles": [
 				"yellow",

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -16,7 +16,7 @@ module Engine
     end
 
     def buying_train!(entity, train)
-      next! if train.sym == @next_on
+      next! while @next_on.include?(train.sym)
 
       train.events.each do |event|
         @game.send("event_#{event['type']}!")
@@ -57,7 +57,7 @@ module Engine
       @events = phase[:events] || []
       @status = phase[:status] || []
       @corporation_sizes = phase[:corporation_sizes]
-      @next_on = @phases[@index + 1]&.dig(:on)
+      @next_on = Array(@phases[@index + 1]&.dig(:on))
 
       @log << "-- Phase #{@name} " \
         "(Operating Rounds: #{@operating_rounds}, Train Limit: #{@train_limit}, "\


### PR DESCRIPTION
### Background

18CO phase 6 starts when a "6" train is bought. This opens up purchase of both "5D" and "E".
Buying a "5D" moves to phase 6b.
Buying a "E" moves to phase 7, which rusts the "5" trains and reduces tile lay.

This update allows the phase to move straight from phase 6 to phase 7, skipping 6b, when an E is purchased. Without this change, the phase stays at "6" when an "E" is bought, because `next_on` is only looking for a "5D"

### Implementation Notes

While this works for all implemented titles as well as 18CO, I have a concern that some day in the future someone will use a similar scheme and be confused when the skipped train's rust/events don't happen.

For Reference:

<img width="528" alt="Screen Shot 2020-12-21 at 6 36 51 PM" src="https://user-images.githubusercontent.com/15675400/102838478-8852b880-43bb-11eb-8bfa-565cc7d16a87.png">
