### PR TITLE
Game based allow/disallow cross corp abilities

### DIFF
--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -17,6 +17,9 @@ module View
         return h(:div) if companies.empty? || @game.round.current_entity.company?
 
         current, others = companies.partition { |company| @game.current_entity.player == company.player }
+        others = others.select { |other_company| @game.company_available_for_other_corps(other_company) }
+
+        return h(:div) if current.empty? && others.empty?
 
         children = [
           h('h3.inline', { style: { marginRight: '0.5rem' } }, 'Abilities:'),

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1293,6 +1293,10 @@ module Engine
         active_abilities
       end
 
+      def company_available_for_other_corps(_company)
+        true
+      end
+
       private
 
       def init_bank

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -518,6 +518,10 @@ module Engine
             !abilities(company, :no_buy)
         end
       end
+
+      def company_available_for_other_corps(_company)
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
I want to prevent players from using abilities they shouldn't be able to use. There are no companies in 18CO with an ability that can be used by other corporations, so I never want the option to show. Other games might have specific companies that can be used by third parties (this is a fact of some game on the site, I just don't remember which), and this function allows for that to be implemented.

Defaulting to true in game base so as to not break any production games. In the future, I'd propose adding a flag on the ability that toggles whether it can be used cross-corp, but that can be iterated on top of this base.

Before

<img width="785" alt="Screen Shot 2020-12-21 at 8 22 33 AM" src="https://user-images.githubusercontent.com/15675400/102832808-b1b81800-43ac-11eb-8567-6c37cee721ea.png">


After

<img width="781" alt="Screen Shot 2020-12-21 at 8 19 50 AM" src="https://user-images.githubusercontent.com/15675400/102832818-b8df2600-43ac-11eb-8526-33204d5b5ebd.png">
