### PR TITLE
Fix for route_selector when switching entities, but not steps

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -12,6 +12,8 @@ module View
       include Lib::Color
       include Lib::Settings
 
+      needs :last_entity, store: true, default: nil
+      needs :last_round, store: true, default: nil
       needs :routes, store: true, default: []
       needs :selected_route, store: true, default: nil
 
@@ -39,7 +41,15 @@ module View
       end
 
       def render
-        trains = @game.route_trains(@game.round.current_entity)
+        current_entity = @game.round.current_entity
+        # this is needed for the rare case when moving directly between run_routes steps
+        if @last_entity != current_entity || @last_round != @game.round
+          cleanup
+          store(:last_entity, current_entity)
+          store(:last_round, @game.round)
+        end
+
+        trains = @game.route_trains(current_entity)
 
         train_help =
           if (helps = @game.train_help(trains)).any?

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -45,8 +45,8 @@ module View
         # this is needed for the rare case when moving directly between run_routes steps
         if @last_entity != current_entity || @last_round != @game.round
           cleanup
-          store(:last_entity, current_entity)
-          store(:last_round, @game.round)
+          store(:last_entity, current_entity, skip: true)
+          store(:last_round, @game.round, skip: true)
         end
 
         trains = @game.route_trains(current_entity)


### PR DESCRIPTION
Fixes #2762 

Add logic to route_selector to clear stored route when switching between corps/rounds with the same run_routes action.