### PR TITLE
[1856] Fix THB not being parrable

### DIFF
--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -324,6 +324,7 @@ module Engine
           Step::G1856::Loan,
           Step::SpecialTrack,
           Step::BuyCompany,
+          Step::HomeToken,
           Step::G1856::Track,
           Step::Token,
           Step::Route,


### PR DESCRIPTION
Noticed this when preparing a hotseat game to work on nationalization