### PR TITLE
Allow for increased control over who can use a company

### DIFF
--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -13,13 +13,15 @@ module View
       ABILITIES = %i[tile_lay teleport assign_hexes assign_corporation token exchange].freeze
 
       def render
-        companies = @game.companies.select { |company| !company.closed? && actions_for(company).any? && company.owner }
+        companies = @game.companies.select do |company|
+          !company.closed? &&
+            actions_for(company).any? &&
+            company.owner &&
+            @game.entity_can_use_company?(@game.current_entity, company)
+        end
         return h(:div) if companies.empty? || @game.round.current_entity.company?
 
         current, others = companies.partition { |company| @game.current_entity.player == company.player }
-        others = others.select { |other_company| @game.company_available_for_other_corps(other_company) }
-
-        return h(:div) if current.empty? && others.empty?
 
         children = [
           h('h3.inline', { style: { marginRight: '0.5rem' } }, 'Abilities:'),

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1302,7 +1302,7 @@ module Engine
         active_abilities
       end
 
-      def company_available_for_other_corps(_company)
+      def entity_can_use_company?(_entity, _company)
         true
       end
 

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -519,8 +519,8 @@ module Engine
         end
       end
 
-      def company_available_for_other_corps(_company)
-        false
+      def entity_can_use_company?(entity, company)
+        entity.corporation? && entity == company.owner
       end
     end
   end


### PR DESCRIPTION
I should have slept on the previous PR because I literally woke up inspired this morning with this addition!

---

This update allows for filtering not only companies owned by other players, but also those owned by your other corporations.

Some games allow using the ability of a company another of your corporations own. 18CO only allows you to utilize your own owned companies.

Both those options could probably wind up within the ability config and implemented in the game/base function here.