### PR TITLE
Last/double cert funkiness

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -307,6 +307,7 @@ module View
             player.num_shares_of(@corporation, ceil: false),
             @game.round.active_step&.did_sell?(@corporation, player),
             !@corporation.holding_ok?(player, 1),
+            player.shares_of(@corporation).any?(&:last_cert),
           ]
         end
 
@@ -319,8 +320,8 @@ module View
         player_rows = player_info
           .select { |_, _, num_shares, did_sell| !num_shares.zero? || did_sell }
           .sort_by { |_, president, num_shares, _| [president ? 0 : 1, -num_shares] }
-          .map do |player, president, num_shares, did_sell, at_limit|
-            flags = (president ? '*' : '') + (at_limit ? 'L' : '')
+          .map do |player, president, num_shares, did_sell, at_limit, last_cert|
+            flags = (president ? '*' : '') + (last_cert ? 'd' : '') + (at_limit ? 'L' : '')
             h('tr.player', [
               h("td.left.name.nowrap.#{president ? 'president' : ''}", player.name),
               h('td.right', shares_props, "#{flags.empty? ? '' : flags + ' '}#{share_number_str(num_shares)}"),
@@ -354,10 +355,12 @@ module View
         if !num_ipo_shares.empty? && @corporation.capitalization != @game.class::CAPITALIZATION
           num_ipo_shares = '* ' + num_ipo_shares
         end
+        last_cert = @corporation.shares_of(@corporation).any?(&:last_cert)
         pool_rows = [
           h('tr.ipo', [
             h('td.left', @game.ipo_name(@corporation)),
-            h('td.right', shares_props, num_ipo_shares),
+            h('td.right', shares_props,
+              (last_cert ? 'd ' : '') + num_ipo_shares),
             h('td.padded_number', share_price_str(@corporation.par_price)),
           ]),
         ]
@@ -386,8 +389,9 @@ module View
 
         if player_rows.any? || @corporation.num_market_shares.positive?
           at_limit = @game.share_pool.bank_at_limit?(@corporation)
+          last_cert = @game.share_pool.shares_of(@corporation).any?(&:last_cert)
 
-          flags = (@corporation.receivership? ? '*' : '') + (at_limit ? 'L' : '')
+          flags = (@corporation.receivership? ? '*' : '') + (last_cert ? 'd' : '') + (at_limit ? 'L' : '')
 
           pool_rows << h('tr.market', market_tr_props, [
             h('td.left', 'Market'),

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -21,6 +21,7 @@ module View
               percent: bundle.percent,
             ))
           end
+          double_cert = bundle.shares.any?(&:last_cert) ? '[d]' : ''
           props = {
             style: {
               padding: '0.2rem 0',
@@ -31,7 +32,7 @@ module View
           h(
             'button.sell_share',
             props,
-            "Sell #{share_presentation(bundle)} (#{@game.format_currency(bundle.price)})"
+            "Sell #{share_presentation(bundle)}#{double_cert} (#{@game.format_currency(bundle.price)})"
           )
         end
 

--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -7,7 +7,7 @@ module Engine
   class Share
     include Ownable
 
-    attr_accessor :percent, :buyable, :counts_for_limit
+    attr_accessor :percent, :buyable, :counts_for_limit, :last_cert
     attr_reader :corporation, :president, :index
 
     def initialize(corporation, owner: nil, president: false, percent: 10, index: 0)
@@ -22,6 +22,9 @@ module Engine
 
       # counts_for_limit: set to false if share is disregarded for cert limit
       @counts_for_limit = true
+
+      # last_cert: set to true if share must be bought/issued last from its location
+      @last_cert = false
     end
 
     def id

--- a/lib/engine/step/g_1849/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1849/buy_sell_par_shares.rb
@@ -6,6 +6,10 @@ module Engine
   module Step
     module G1849
       class BuySellParShares < BuySellParShares
+        def can_buy?(entity, bundle)
+          super && @game.last_cert_last?(bundle)
+        end
+
         def can_buy_multiple?(entity, corp)
           super || (corp.owner == entity && just_parred(corp) && num_shares_bought(corp) < 2)
         end


### PR DESCRIPTION
This cert must be bought last from wherever it is (corporate treasury or
market), issued last, and redeemed last. It can be sold by a player into
the market as they please. The current location of the double share is
marked with a 'd' on the corporatation charter.

Not included in this commit is the optional swap for the last cert by
the outgoing president in exchange for the presidency.