### PR TITLE
Add player choose to stock view

### DIFF
--- a/assets/app/view/game/choose.rb
+++ b/assets/app/view/game/choose.rb
@@ -28,7 +28,7 @@ module View
 
         div_class = choice_buttons.size < 5 ? '.inline' : ''
         h(:div, [
-          h("div#{div_class}", { style: { marginTop: '0.5rem' } }, "#{@game.round.active_step.choice_name}:"),
+          h("div#{div_class}", { style: { marginTop: '0.5rem' } }, "#{@game.round.active_step.choice_name}: "),
           *choice_buttons,
         ])
       end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -37,6 +37,9 @@ module View
           end
 
           children = []
+
+          children << h(Choose) if @current_actions.include?('choose') && @step.choice_available?(@current_entity)
+
           if @step.respond_to?(:must_sell?) && @step.must_sell?(@current_entity)
             children << if @game.num_certs(@current_entity) > @game.cert_limit
                           h('div.margined', 'Must sell stock: above certificate limit')
@@ -80,7 +83,7 @@ module View
             if @selected_corporation == corporation && @game.corporation_available?(corporation)
               children << render_input
             end
-            children << h(Choose) if @current_actions.include?('choose')
+            children << h(Choose) if @current_actions.include?('choose') && @step.choice_available?(corporation)
             h(:div, props, children)
           end.compact
         end

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -409,6 +409,10 @@ module Engine
           super
           @corporate_action = nil
         end
+
+        def choice_available?(entity)
+          entity.corporation?
+        end
       end
     end
   end

--- a/lib/engine/step/g_1867/major_trainless.rb
+++ b/lib/engine/step/g_1867/major_trainless.rb
@@ -47,6 +47,10 @@ module Engine
         def trainless_major
           @game.trainless_major
         end
+
+        def choice_available?(entity)
+          entity.corporation?
+        end
       end
     end
   end


### PR DESCRIPTION
Make it possible to control from a step if choose should appear
in the view. It is useful in case there are several choose.

The main usage for this is in 18SJ where it is possible for a player
to trigger priority deal "stealing" due to an ability.

This commit contains the general code update needed to accomplish this.
Should not affect 1867 or 1817 which are the titles using choose so far.