### PR TITLE
Various UI tweaks:

### DIFF
--- a/assets/app/view/game/bank.rb
+++ b/assets/app/view/game/bank.rb
@@ -68,6 +68,12 @@ module View
             h('td.right', @game.format_currency(@game.round.active_step.seed_money)),
           ])
         end
+        if @game.respond_to?(:unstarted_corporation_summary)
+          trs << h(:tr, [
+            h(:td, 'Unstarted corporations'),
+            h('td.right', @game.unstarted_corporation_summary),
+          ])
+        end
 
         return unless trs.any?
 

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -61,7 +61,7 @@ module View
         children << render_abilities(abilities_to_display) if abilities_to_display.any?
 
         extras = []
-        extras.concat(render_loans) if @corporation.loans.any?
+        extras.concat(render_loans) if @game.total_loans&.nonzero?
         if @corporation.corporation? && @corporation.floated? &&
               @game.total_loans.positive? && @corporation.can_buy?
           extras << render_buying_power
@@ -72,7 +72,6 @@ module View
         if @corporation.corporation? && @corporation.respond_to?(:escrow) && @corporation.escrow
           extras << render_escrow_account
         end
-        extras << render_corporation_size if @game.show_corporation_size?
         if extras.any?
           props = { style: { borderCollapse: 'collapse' } }
           children << h('table.center', props, [h(:tbody, extras)])
@@ -540,13 +539,6 @@ module View
         h('tr.ipo', [
           h('td.right', 'Buying Power'),
           h('td.padded_number', @game.format_currency(@game.buying_power(@corporation, true)).to_s),
-        ])
-      end
-
-      def render_corporation_size
-        h('tr.ipo', [
-          h('td.right', 'Corporation Size'),
-          h('td.padded_number', @corporation.total_shares),
         ])
       end
 

--- a/assets/app/view/game/entities.rb
+++ b/assets/app/view/game/entities.rb
@@ -39,10 +39,15 @@ module View
           ])
         end
 
+        extra_bank = []
+        unless @game.respond_to?(:unstarted_corporation_summary)
+          extra_bank += bank_owned.map { |c| h(Corporation, corporation: c) }
+        end
         children << h(:div, [
           h(Bank, game: @game),
+          h(GameInfo, game: @game, layout: 'upcoming_trains'),
           *@game.corporations.select(&:receivership?).map { |c| h(Corporation, corporation: c) },
-          *bank_owned.map { |c| h(Corporation, corporation: c) },
+          *extra_bank,
         ].compact)
 
         children = children.concat(bankrupt_players.map { |p| h(:div, [h(Player, player: p, game: @game)]) })

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -20,6 +20,8 @@ module View
 
         if @layout == :discarded_trains
           @depot.discarded.empty? ? '' : discarded_trains
+        elsif @layout == :upcoming_trains
+          upcoming_trains_card
         else
           h('div#game_info', render_body)
         end
@@ -160,7 +162,7 @@ module View
         ]
       end
 
-      def upcoming_trains
+      def rust_obsolete_schedule
         rust_schedule = {}
         obsolete_schedule = {}
         @depot.trains.group_by(&:name).each do |name, trains|
@@ -168,8 +170,63 @@ module View
           rust_schedule[first.rusts_on] = Array(rust_schedule[first.rusts_on]).append(name)
           obsolete_schedule[first.obsolete_on] = Array(obsolete_schedule[first.obsolete_on]).append(name)
         end
+        [rust_schedule, obsolete_schedule]
+      end
+
+      def upcoming_trains_card
+        title_props = {
+          style: {
+            padding: '0.4rem',
+            backgroundColor: color_for(:bg2),
+            color: color_for(:font2),
+          },
+        }
+        body_props = {
+          style: {
+            margin: '0.3rem 0.5rem 0.4rem',
+            display: 'grid',
+            grid: 'auto / 1fr',
+            gap: '0.5rem',
+            justifyItems: 'center',
+          },
+        }
+        info_props = {
+          style: {
+            verticalAlign: 'top',
+          },
+        }
+
+        rust_schedule, obsolete_schedule = rust_obsolete_schedule
+        trs = @game.depot.upcoming.group_by(&:name).map do |name, trains|
+          train = trains.first
+          names_to_prices = train.names_to_prices
+          summary = [h(:div,
+                       "#{trains.size} at " + names_to_prices.values.map { |p| @game.format_currency(p) }.join(', '))]
+          summary << h(:div, ' rusts ' + rust_schedule[name].join(',')) if rust_schedule[name]
+          summary << h(:div, ' obsoletes ' + obsolete_schedule[name].join(',')) if obsolete_schedule[name]
+
+          h(:tr, [
+            h(:td, info_props, names_to_prices.keys.join(', ')),
+            h('td.right', summary),
+])
+        end
+
+        return unless trs.any?
+
+        h('div.bank.card', [
+          h('div.title.nowrap', title_props, [h(:em, 'Upcoming Trains')]),
+          h(:div, body_props, [
+            h(:table, trs),
+          ]),
+        ])
+      end
+
+      def upcoming_trains
+        rust_schedule, obsolete_schedule = rust_obsolete_schedule
 
         show_obsolete_schedule = obsolete_schedule.keys.any?
+        show_upgrade = @depot.upcoming.any?(&:discount)
+        show_available = @depot.upcoming.any?(&:available_on)
         events = []
 
         rows = @depot.upcoming.group_by(&:name).map do |name, trains|
@@ -203,12 +260,11 @@ module View
             h(:td, trains.size),
           ]
           upcoming_train_content << h(:td, obsolete_schedule[name]&.join(', ') || 'None') if show_obsolete_schedule
-          upcoming_train_content.concat([
-            h(:td, rust_schedule[name]&.join(', ') || 'None'),
-            h(:td, discounts&.join(' ')),
-            h(:td, train.available_on),
-            h(:td, event_text.join(', ')),
-])
+          upcoming_train_content << h(:td, rust_schedule[name]&.join(', ') || 'None')
+
+          upcoming_train_content << h(:td, discounts&.join(' ')) if show_upgrade
+          upcoming_train_content << h(:td, train.available_on) if show_available
+          upcoming_train_content << h(:td, event_text.join(', '))
           h(:tr, upcoming_train_content)
         end
 
@@ -237,12 +293,15 @@ module View
         ]
 
         upcoming_train_header << h(:th, 'Phases out') if show_obsolete_schedule
-        upcoming_train_header.concat([
-          h(:th, 'Rusts'),
-          h(:th, 'Upgrade Discount'),
-          h(:th, { attrs: { title: 'Available after purchase of first train of type' } }, 'Available'),
-          h(:th, 'Events'),
-        ])
+        upcoming_train_header << h(:th, 'Rusts')
+        upcoming_train_header << h(:th, 'Upgrade Discount') if show_upgrade
+        if show_available
+          upcoming_train_header << h(:th,
+                                     { attrs: { title: 'Available after purchase of first train of type' } },
+                                     'Available')
+        end
+        upcoming_train_header << h(:th, 'Events')
+
         [
           h(:h3, 'Upcoming Trains'),
           h(:div, { style: { overflowX: 'auto' } }, [

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -23,7 +23,20 @@ module View
         @delta_value = Lib::Storage['delta_value']
 
         children = []
-        children << h(Bank, game: @game)
+
+        top_line_props = {
+          style: {
+            display: 'grid',
+            grid: 'auto / repeat(auto-fill, minmax(20rem, 1fr))',
+            gap: '3rem 1.2rem',
+          },
+        }
+        top_line = h(:div, top_line_props, [
+          h(Bank, game: @game),
+          h(GameInfo, game: @game, layout: 'upcoming_trains'),
+        ])
+
+        children << top_line
         children << render_table
         children << render_spreadsheet_controls
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1825,7 +1825,7 @@ module Engine
         :small
       end
 
-      def show_corporation_size?(_entity)
+      def show_loans?(_entity)
         false
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1825,10 +1825,6 @@ module Engine
         :small
       end
 
-      def show_loans?(_entity)
-        false
-      end
-
       def status_str(_corporation); end
 
       # Override this, and add elements (paragraphs of text) here to display it on Info page.

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -429,6 +429,10 @@ module Engine
         entity.cash + ((maximum_loans(entity) - entity.loans.size) * @loan_value)
       end
 
+      def unstarted_corporation_summary
+        (@corporations.count { |c| !c.ipoed }).to_s
+      end
+
       def liquidate!(corporation)
         @owner_when_liquidated[corporation] = corporation.owner
         @stock_market.move(corporation, 0, 0, force: true)
@@ -467,10 +471,6 @@ module Engine
       def corporation_size(entity)
         # For display purposes is a corporation small, medium or large
         CORPORATION_SIZES[entity.total_shares]
-      end
-
-      def show_corporation_size?(_entity)
-        true
       end
 
       private

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -169,6 +169,11 @@ module Engine
         entity.cash + ((maximum_loans(entity) - entity.loans.size) * @loan_value - 5)
       end
 
+      def unstarted_corporation_summary
+        minor, major = @corporations.reject(&:ipoed).partition { |c| c.type == :minor }
+        "#{minor.size} minor, #{major.size} major"
+      end
+
       def nationalize!(corporation)
         @log << "#{corporation.name} is nationalized"
 

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -298,6 +298,7 @@ text.number {
   margin: 0.5rem 0.5rem 0 0;
   border: 1px solid gainsboro;
   border-radius: 0.7rem;
+  align-self: start;
 }
 .game.card {
   margin: 0 0.5rem 0.5rem 0;


### PR DESCRIPTION

![Screenshot from 2020-12-23 14-34-29](https://user-images.githubusercontent.com/71923/103010065-96c1e100-452f-11eb-8b2b-5b8594feba88.png)

Add the simplified train roster to entity and spreadsheet (fixes #2541)
Hide non-started corporations in 1817/1867 since they don't really matter (also #2541)
Always show loan amounts on 17 & 67 (also #2541)
Remove corporation size (also #2541)
Hide discount and available fields if they are unused (fixes #1792)