### PR TITLE
Fix Issue 2781 - Negative Discount Logged

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1054,7 +1054,7 @@ module Engine
             (!a.hexes || a.hexes.include?(hex.name))
         end
 
-        cost = tile.upgrades.sum do |upgrade|
+        tile.upgrades.sum do |upgrade|
           discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
 
           log_cost_discount(entity, ability, discount)
@@ -1062,8 +1062,6 @@ module Engine
           total_cost = upgrade.cost - discount
           total_cost
         end
-
-        cost
       end
 
       def tile_cost_with_discount(_tile, hex, entity, cost)
@@ -1078,8 +1076,7 @@ module Engine
         discount = [cost, ability.discount].min
         log_cost_discount(entity, ability, discount)
 
-        end_cost = cost - discount
-        end_cost
+        cost - discount
       end
 
       def log_cost_discount(entity, ability, discount)

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -384,7 +384,7 @@ module Engine
         ], round_num: round_num)
       end
 
-      def tile_cost(tile, hex, entity)
+      def upgrade_cost(tile, hex, entity)
         [TILE_COST, super].max
       end
 

--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -346,7 +346,7 @@ module Engine
         false
       end
 
-      def tile_cost(tile, hex, entity)
+      def upgrade_cost(tile, hex, entity)
         return 0 if tile.upgrades.empty?
 
         upgrade = tile.upgrades[0]

--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -110,7 +110,7 @@ module Engine
             else
               border, border_types = border_cost(tile, entity)
               terrain += border_types if border.positive?
-              @game.tile_cost(old_tile, hex, entity) + border + extra_cost - discount
+              @game.upgrade_cost(old_tile, hex, entity) + border + extra_cost - discount
             end
 
           if @game.insolvent?(spender) && cost.positive?

--- a/lib/engine/step/g_18_mex/track.rb
+++ b/lib/engine/step/g_18_mex/track.rb
@@ -35,7 +35,7 @@ module Engine
           return super unless entity.minor?
 
           home_hex = @game.hex_by_id(entity.coordinates)
-          return @game.tile_cost(home_hex.tile, home_hex, entity) <= entity.cash if home_hex.tile.color == :white
+          return @game.upgrade_cost(home_hex.tile, home_hex, entity) <= entity.cash if home_hex.tile.color == :white
 
           super
         end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -115,7 +115,8 @@ module Engine
           else
             border, border_types = border_cost(tile, entity)
             terrain += border_types if border.positive?
-            @game.tile_cost(old_tile, hex, entity) + border + extra_cost - discount
+            base_cost = @game.upgrade_cost(old_tile, hex, entity) + border + extra_cost - discount
+            @game.tile_cost_with_discount(tile, hex, entity, base_cost)
           end
 
         try_take_loan(spender, cost)


### PR DESCRIPTION
FIxes https://github.com/tobymao/18xx/issues/2781

https://18xx.games/game/19885

Log incorrectly stated -$20. CS did not gain money ( correct )

<img width="612" alt="Screen Shot 2020-12-23 at 11 22 02 AM" src="https://user-images.githubusercontent.com/15675400/103026414-1c826400-4511-11eb-8b29-f6d62a4b7d8d.png">

---

Showing correct log on an upgrade and a no-cost hex.

<img width="466" alt="Screen Shot 2020-12-23 at 6 27 30 PM" src="https://user-images.githubusercontent.com/15675400/103049066-e44d4680-454d-11eb-8dc7-d7f9a5ac39dc.png">

And correctly logging with one upgrade and one border.

<img width="452" alt="Screen Shot 2020-12-23 at 6 33 16 PM" src="https://user-images.githubusercontent.com/15675400/103049063-e1525600-454d-11eb-85f9-6f3eb126e6ad.png">
