### PR TITLE
Fix 2779 - 18CO Upgrade Timing

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -42,7 +42,7 @@ module Engine
       DISCARDED_TRAIN_DISCOUNT = 50
 
       # Two tiles can be laid, only one upgrade
-      TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: false }].freeze
+      TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded }].freeze
       REDUCED_TILE_LAYS = [{ lay: true, upgrade: true }].freeze
 
       # First 3 are Denver, Second 3 are CO Springs

--- a/lib/engine/step/g_18_co/track.rb
+++ b/lib/engine/step/g_18_co/track.rb
@@ -9,6 +9,12 @@ module Engine
       class Track < Track
         include Tracker
 
+        def setup
+          @previous_laid_hexes = []
+
+          super
+        end
+
         def process_lay_tile(action)
           lay_tile_action(action)
           clear_upgrade_icon(action.hex.tile)
@@ -25,6 +31,16 @@ module Engine
           end
 
           super
+        end
+
+        def lay_tile_action(action)
+          if @previous_laid_hexes.include?(action.hex)
+            @game.game_error("#{action.hex.id} cannot be upgraded as the tile was just laid")
+          end
+
+          super
+
+          @previous_laid_hexes << action.hex
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/2779

Corporation can place an upgrade either first or second, as long as the upgrade on the second tile placement is the not tile they just placed with their first tile lay.

<img width="189" alt="Screen Shot 2020-12-24 at 12 20 46 PM" src="https://user-images.githubusercontent.com/15675400/103104117-a817f580-45e2-11eb-9c60-0437107670a3.png">

<img width="164" alt="Screen Shot 2020-12-24 at 12 20 52 PM" src="https://user-images.githubusercontent.com/15675400/103104118-a8b08c00-45e2-11eb-80dd-ed65b817b8f9.png">

<img width="383" alt="Screen Shot 2020-12-24 at 12 23 04 PM" src="https://user-images.githubusercontent.com/15675400/103104148-cd0c6880-45e2-11eb-8607-5ac841a6b13a.png">
