### PR TITLE
18CO - Par Group on Corp Card

### DIFF
--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -749,6 +749,10 @@ module Engine
 				{
 					"type": "description",
 					"description": "Pars @ $75(C) via DRG Silverton Branch"
+				},
+        {
+					"type": "base",
+					"description": "Shares: 2P/2/2/1/1/1/1"
 				}
 			]
 		}

--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -508,7 +508,13 @@ module Engine
 				100
 			],
 			"coordinates": "E27",
-			"color": "brown"
+			"color": "brown",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - C"
+				}
+			]
 		},
 		{
 			"sym": "CM",
@@ -524,7 +530,13 @@ module Engine
 				100
 			],
 			"coordinates": "G17",
-			"color": "lightBlue"
+			"color": "lightBlue",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - C"
+				}
+			]
 		},
 		{
 			"sym": "CS",
@@ -540,7 +552,13 @@ module Engine
 				100
 			],
 			"coordinates": "K17",
-			"color": "black"
+			"color": "black",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - C"
+				}
+			]
 		},
 		{
 			"sym": "DPAC",
@@ -555,7 +573,13 @@ module Engine
 			],
 			"city": 2,
 			"coordinates": "E15",
-			"color": "purple"
+			"color": "purple",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - C"
+				}
+			]
 		},
 		{
 			"sym": "DSL",
@@ -570,7 +594,13 @@ module Engine
 			],
 			"city": 1,
 			"coordinates": "E15",
-			"color": "green"
+			"color": "green",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - C"
+				}
+			]
 		},
 		{
 			"sym": "DRG",
@@ -590,7 +620,13 @@ module Engine
 			"city": 0,
 			"coordinates": "E15",
 			"color": "yellow",
-			"text_color": "black"
+			"text_color": "black",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - B"
+				}
+			]
 		},
 		{
 			"sym": "ATSF",
@@ -608,7 +644,13 @@ module Engine
 				100
 			],
 			"coordinates": "J26",
-			"color": "blue"
+			"color": "blue",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - B"
+				}
+			]
 		},
 		{
 			"sym": "CBQ",
@@ -628,7 +670,13 @@ module Engine
 			],
 			"coordinates": "B26",
 			"color": "orange",
-			"text_color": "black"
+			"text_color": "black",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - A"
+				}
+			]
 		},
 		{
 			"sym": "ROCK",
@@ -648,7 +696,13 @@ module Engine
 				100
 			],
 			"coordinates": "G27",
-			"color": "red"
+			"color": "red",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - A"
+				}
+			]
 		},
 		{
 			"sym": "UP",
@@ -669,7 +723,13 @@ module Engine
 			],
 			"coordinates": "A17",
 			"color": "white",
-			"text_color": "black"
+			"text_color": "black",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Par Group - A"
+				}
+			]
 		},
 		{
 			"sym": "DSNG",
@@ -684,7 +744,13 @@ module Engine
 				40
 			],
 			"coordinates": "K5",
-			"color": "pink"
+			"color": "pink",
+			"abilities": [
+				{
+					"type": "description",
+					"description": "Pars @ $75(C) via DRG Silverton Branch"
+				}
+			]
 		}
 	],
 	"trains": [

--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -350,7 +350,7 @@ module Engine
 			"name": "Grand Junction and Grand River Valley Railway",
 			"value": 40,
 			"revenue": 10,
-			"desc": "An owning Corporation may upgrade a yellow town to a green city in additional to its normal tile lay at any time during its turn. Action closes the company or closes on purchase of “5” train.",
+			"desc": "An owning Corporation may upgrade a yellow town to a green city in additional to its normal tile lay at any time during its turn. This tile does not need to be reachable by the corporation's trains. Action closes the company or closes on purchase of “5” train.",
 			"abilities": [
 				{
 					"type": "tile_lay",
@@ -424,7 +424,7 @@ module Engine
 			"name": "Laramie, North Park and Western Railroad",
 			"value": 70,
 			"revenue": 15,
-			"desc": "When laying track tiles, an owning Corporation may lay an extra tile at no cost in addition to its normal tile lay. Action closes the company or closes on purchase of “5” train.",
+			"desc": "When laying track tiles, an owning Corporation may lay an extra yellow tile at no cost in addition to its normal tile lay. Action closes the company or closes on purchase of “5” train.",
 			"abilities": [
 				{
 					"type": "tile_lay",

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -304,7 +304,14 @@ module Engine
           remove_corporations_if_no_home(action.city) if @phase.status.include?('closable_corporations')
         when Action::Par
           rereserve_home_station(action.corporation) if @phase.status.include?('closable_corporations')
+          remove_par_group_ability(action.corporation)
         end
+      end
+
+      def remove_par_group_ability(corporation)
+        par_group = abilities(corporation, :description)
+
+        corporation.remove_ability(par_group) if par_group
       end
 
       def remove_corporations_if_no_home(city)


### PR DESCRIPTION
While not what the user asked for, this is the real fix https://github.com/tobymao/18xx/issues/2811 as combined with showing the par groups on the stock market ( done earlier this week ), this correlates which corporations can be parred in which group. Also item 3 on https://github.com/tobymao/18xx/issues/2671

The text is removed when a corporation is parred.

<img width="228" alt="Screen Shot 2020-12-26 at 8 39 35 AM" src="https://user-images.githubusercontent.com/15675400/103154631-e97ce200-4755-11eb-998a-30ef35bee349.png">


Unintentionally threw in the fix https://github.com/tobymao/18xx/issues/2810 but its just config so whatever

Put in a simple implementation of DSNG special shares from https://github.com/tobymao/18xx/issues/2671
<img width="249" alt="Screen Shot 2020-12-26 at 8 51 11 AM" src="https://user-images.githubusercontent.com/15675400/103154831-92780c80-4757-11eb-83f5-7e395b962fcb.png">
