### PR TITLE
18CO Corporation can actually take President's Share

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -140,12 +140,10 @@ module Engine
       @share_holders ||= Hash.new(0)
     end
 
-    def corporate_player_share_holders
-      share_holders.select { |s_h, _| s_h.player? || (s_h.corporation? && s_h != self) }
-    end
-
-    def player_share_holders
-      share_holders.select { |s_h, _| s_h.player? }
+    def player_share_holders(corporate: false)
+      share_holders.select do |s_h, _|
+        s_h.player? || (corporate && s_h.corporation? && s_h != self)
+      end
     end
 
     def corporate_share_holders

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -140,6 +140,10 @@ module Engine
       @share_holders ||= Hash.new(0)
     end
 
+    def corporate_player_share_holders
+      share_holders.select { |s_h, _| s_h.player? || (s_h.corporation? && s_h != self) }
+    end
+
     def player_share_holders
       share_holders.select { |s_h, _| s_h.player? }
     end

--- a/lib/engine/g_18_co/share_pool.rb
+++ b/lib/engine/g_18_co/share_pool.rb
@@ -18,6 +18,13 @@ module Engine
         # we want the bundle with the most shares, as higher percent in fewer shares in more valuable
         matching_bundles.max_by(&:size)
       end
+
+      def distance(entity_a, entity_b)
+        return 0 if !entity_a || !entity_b
+        return @game.players.size + 485 - entity_b.share_price.price if entity_b.corporation?
+
+        super
+      end
     end
   end
 end

--- a/lib/engine/g_18_co/share_pool.rb
+++ b/lib/engine/g_18_co/share_pool.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../share_pool'
+
+module Engine
+  module G18CO
+    class SharePool < SharePool
+      def totaling_num(shares, num_shares)
+        return [] if shares.empty?
+        return [] unless num_shares
+        return shares if shares.one?
+
+        percent = num_shares * shares.first.corporation.share_percent
+        matching_bundles = (1..shares.size).flat_map do |n|
+          shares.combination(n).to_a.select { |b| b.sum(&:percent) == percent }
+        end
+
+        # we want the bundle with the most shares, as higher percent in fewer shares in more valuable
+        matching_bundles.max_by(&:size)
+      end
+    end
+  end
+end

--- a/lib/engine/g_18_co/share_pool.rb
+++ b/lib/engine/g_18_co/share_pool.rb
@@ -5,7 +5,11 @@ require_relative '../share_pool'
 module Engine
   module G18CO
     class SharePool < SharePool
-      def totaling_num(shares, num_shares)
+      def presidency_check_shares(corporation)
+        corporation.player_share_holders(corporate: true)
+      end
+
+      def shares_for_presidency_swap(shares, num_shares)
         return [] if shares.empty?
         return [] unless num_shares
         return shares if shares.one?
@@ -21,7 +25,7 @@ module Engine
 
       def distance(entity_a, entity_b)
         return 0 if !entity_a || !entity_b
-        return @game.players.size + 485 - entity_b.share_price.price if entity_b.corporation?
+        return @game.players.size + @game.class::MAX_SHARE_VALUE - entity_b.share_price.price if entity_b.corporation?
 
         super
       end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../config/game/g_18_co'
+require_relative '../g_18_co/share_pool'
 require_relative '../g_18_co/stock_market'
 require_relative 'base'
 require_relative 'company_price_50_to_150_percent'
@@ -141,6 +142,10 @@ module Engine
         train = @depot.upcoming[0]
         train.buyable = false
         dsng.buy_train(train, :free)
+      end
+
+      def init_share_pool
+        Engine::G18CO::SharePool.new(self)
       end
 
       def init_stock_market

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -41,6 +41,7 @@ module Engine
       CORPORATE_BUY_SHARE_SINGLE_CORP_ONLY = true
       CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
       DISCARDED_TRAIN_DISCOUNT = 50
+      MAX_SHARE_VALUE = 485
 
       # Two tiles can be laid, only one upgrade
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded }].freeze

--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -50,7 +50,8 @@ module Engine
     def can_dump?(entity)
       return true unless presidents_share
 
-      (corporation.player_share_holders.reject { |k, _| k == entity }.values.max || 0) >= presidents_share.percent
+      sh = corporation.corporate_player_share_holders
+      (sh.reject { |k, _| k == entity }.values.max || 0) >= presidents_share.percent
     end
 
     def to_bundle

--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -50,7 +50,7 @@ module Engine
     def can_dump?(entity)
       return true unless presidents_share
 
-      sh = corporation.corporate_player_share_holders
+      sh = corporation.player_share_holders(corporate: true)
       (sh.reject { |k, _| k == entity }.values.max || 0) >= presidents_share.percent
     end
 

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -225,7 +225,6 @@ module Engine
 
     def distance(player_a, player_b)
       return 0 if !player_a || !player_b
-      return @game.players.size if player_b.corporation?
 
       entities = @game.players.reject(&:bankrupt)
       a = entities.find_index(player_a)

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -164,12 +164,9 @@ module Engine
       return unless allow_president_change
 
       # check if we need to change presidency
-      max_shares = corporation.corporate_player_share_holders.values.max
+      max_shares = presidency_check_shares(corporation).values.max
 
-      majority_share_holders = corporation
-        .corporate_player_share_holders
-        .select { |_, p| p == max_shares }
-        .keys
+      majority_share_holders = presidency_check_shares(corporation).select { |_, p| p == max_shares }.keys
 
       return if majority_share_holders.any? { |player| player == previous_president }
 
@@ -207,13 +204,17 @@ module Engine
 
       num_shares = presidents_share.percent / corporation.share_percent
 
-      totaling_num(possible_reorder(president.shares_of(corporation)), num_shares).each do |s|
+      shares_for_presidency_swap(possible_reorder(president.shares_of(corporation)), num_shares).each do |s|
         move_share(s, swap_to)
       end
       move_share(presidents_share, president)
     end
 
-    def totaling_num(shares, num_shares)
+    def presidency_check_shares(corporation)
+      corporation.player_share_holders
+    end
+
+    def shares_for_presidency_swap(shares, num_shares)
       shares.take(num_shares)
     end
 

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -164,10 +164,10 @@ module Engine
       return unless allow_president_change
 
       # check if we need to change presidency
-      max_shares = corporation.player_share_holders.values.max
+      max_shares = corporation.corporate_player_share_holders.values.max
 
       majority_share_holders = corporation
-        .player_share_holders
+        .corporate_player_share_holders
         .select { |_, p| p == max_shares }
         .keys
 
@@ -207,8 +207,14 @@ module Engine
 
       num_shares = presidents_share.percent / corporation.share_percent
 
-      possible_reorder(president.shares_of(corporation)).take(num_shares).each { |s| move_share(s, swap_to) }
+      totaling_num(possible_reorder(president.shares_of(corporation)), num_shares).each do |s|
+        move_share(s, swap_to)
+      end
       move_share(presidents_share, president)
+    end
+
+    def totaling_num(shares, num_shares)
+      shares.take(num_shares)
     end
 
     def possible_reorder(shares)
@@ -219,6 +225,7 @@ module Engine
 
     def distance(player_a, player_b)
       return 0 if !player_a || !player_b
+      return @game.players.size if player_b.corporation?
 
       entities = @game.players.reject(&:bankrupt)
       a = entities.find_index(player_a)

--- a/lib/engine/step/g_18_co/takeover.rb
+++ b/lib/engine/step/g_18_co/takeover.rb
@@ -98,24 +98,13 @@ module Engine
           return true if current_entity
 
           @game.corporations.dup.each do |source|
-            corporation = find_takeover_corporation(source)
-            execute_takeover!(source, corporation) if corporation
+            next unless source&.owner&.corporation?
+
+            execute_takeover!(source, source.owner)
             return true if current_entity
           end
 
           false
-        end
-
-        def find_takeover_corporation(source)
-          return unless source.floated?
-
-          president_share_count = source.owner.num_shares_of(source)
-          source.corporate_share_holders.each do |c_s_h|
-            corporation, corporate_share_percent = c_s_h
-            return corporation if president_share_count < (corporate_share_percent / source.share_percent)
-          end
-
-          nil
         end
 
         def execute_takeover!(source, destination)


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/2812 
Fixes https://github.com/tobymao/18xx/issues/2780
Fixes https://github.com/tobymao/18xx/issues/2817 

### Implementation Notes

Looking for a better name for the `corporate_player_share_holders` function if ya got one. It is the set of the corporate share holders and player share holders. For all other current games, it results in the same set as `player_share_holders`

Could also use a better name for `totaling_num`. This function creates an array of shares that have a total percentage matching the number of shares needed to do the swap. This is needed to allow for 20% shares being owned. The default assumes all shares have the same percentage, and thus doesn't even need to consider the share's percentage. The 18CO override finds a bundle totaling the number of shares needed, but swapping 10% shares if the entity owns them.

These changes allow the Corporation to actually obtain the President's certificate, rendering the initial implementation of `find_takeover_corporation` unnecessary. Instead, we can simply check if the corporation is owned by another corporation.
