### PR TITLE
18CO Ability to swap sell DSNG's 20% shares

### DIFF
--- a/lib/engine/step/g_18_co/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_co/buy_sell_par_shares.rb
@@ -29,6 +29,23 @@ module Engine
 
           super
         end
+
+        def swap_sell(player, corporation, bundle, pool_share)
+          return if pool_share.percent != corporation.share_percent
+          return if bundle.percent == pool_share.percent
+          return unless bundle.shares.find { |s| s.percent != corporation.share_percent && !s.president }
+
+          can_sell?(player, bundle_reduced_percent(bundle.shares)) ? pool_share : nil
+        end
+
+        private
+
+        def bundle_reduced_percent(shares)
+          # Dup is needed to avoid affecting the actual percentage in the original bundle
+          updated_bundle = Engine::ShareBundle.new(shares.map(&:dup))
+          updated_bundle.shares.first.percent -= shares.first.corporation.share_percent
+          updated_bundle
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/2787

### Implementation Notes

Changes to 18CO `sell_shares_and_change_price` - This prevents a swap sale from dropping the share price an extra space

Changes to 18CO `all_bundles_for_corporation` - This allows for all possible share combos, not just those involving the first share



### After this update

Case 1: Player only has a 20% share, and no shares in the market for a swap

<img width="713" alt="Screen Shot 2020-12-27 at 10 41 17 AM" src="https://user-images.githubusercontent.com/15675400/103176627-975cbf00-4830-11eb-9d73-d9257ee9a756.png">

---

Case 2: Player only has a 20% share, and there is a 10% share in the market for a swap

<img width="720" alt="Screen Shot 2020-12-27 at 10 42 32 AM" src="https://user-images.githubusercontent.com/15675400/103176631-99bf1900-4830-11eb-8838-a8f860f93eb9.png">

---

Case 3: Player has (2) 20% shares, and there is only a 20% share in the market ( no swap possible )

<img width="928" alt="Screen Shot 2020-12-27 at 10 48 42 AM" src="https://user-images.githubusercontent.com/15675400/103176695-29fd5e00-4831-11eb-9d62-de35d33da6d5.png">

---

Case 4: Player has 20%P, 20%, 10% shares and can sell any number to market cap

<img width="708" alt="Screen Shot 2020-12-27 at 10 41 39 AM" src="https://user-images.githubusercontent.com/15675400/103176629-988dec00-4830-11eb-88da-e5e9241b3fd5.png">

---

Case 5: Player has 20%P, 20%, 10% shares and can sell any number to market cap with a swap

<img width="754" alt="Screen Shot 2020-12-27 at 10 42 15 AM" src="https://user-images.githubusercontent.com/15675400/103176630-99268280-4830-11eb-81c1-65eb91bf94c7.png">

