### PR TITLE
skip implicit use of tile-laying abilities

### DIFF
--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -78,6 +78,7 @@ module Engine
         teleport = false
 
         tile_lay_abilities(entity) do |ability|
+          next if ability.owner != entity
           next if ability.hexes.any? && (!ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name))
 
           @game.game_error("Track laid must be connected to one of #{spender.id}'s stations") if ability.reachable &&


### PR DESCRIPTION
[Fixes #2818]

Implicitly using tile lay abilities from companies allows the benefit of the ability to be applied without `use!`-ing the ability. With this change, in order for a company's tile laying ability to be used during a corporation's OR turn, the ability button must be pressed.