### PR TITLE
Feat(Tile): Added frame option

### DIFF
--- a/TILES.md
+++ b/TILES.md
@@ -88,7 +88,9 @@ game config/code:
     - **sticky** - `1` indicates the icon should remain visible when a tile
       upgrade is placed on this hex
     - **blocks_lay** - indicates this tile cannot be laid normally
-  but can only be laid by special ability, such as a private company's ability.
+      but can only be laid by special ability, such as a private company's ability.
+- **frame**
+    - **color** - *required* - the color of the frame
 
 #### Town/City/Offboard sub parts
 

--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -30,5 +30,11 @@ module Lib
       red: '#ec232a',
       blue: '#35A7FF',
     }.freeze
+
+    def self.points(scale: 1.0)
+      "#{X_R * scale},#{Y_M * scale} #{X_M_R * scale},#{Y_B * scale} "\
+      "#{X_M_L * scale},#{Y_B * scale} #{X_L * scale},#{Y_M * scale} "\
+      "#{X_M_L * scale},#{Y_T * scale} #{X_M_R * scale},#{Y_T * scale}"
+    end
   end
 end

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -62,9 +62,9 @@ module View
         children << h(TriangularGrid) if Lib::Params['grid']
         children << h(TileUnavailable, unavailable: @unavailable, layout: @hex.layout) if @unavailable
 
-        if @tile&.frame && @tile&.frame.color
+        if (color = @tile&.frame&.color)
           attrs = {
-            stroke: @tile&.frame.color,
+            stroke: color,
             'stroke-width': FRAME_COLOR_STROKE_WIDTH,
             points: FRAME_COLOR_POINTS,
           }

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -16,6 +16,9 @@ module View
 
       SIZE = 100
 
+      FRAME_COLOR_STROKE_WIDTH = 10
+      FRAME_COLOR_POINTS = Lib::Hex.points(scale: 1 - ((FRAME_COLOR_STROKE_WIDTH + 1) / 2) / Lib::Hex::Y_B).freeze
+
       LAYOUT = {
         flat: [SIZE * 3 / 2, SIZE * Math.sqrt(3) / 2],
         pointy: [SIZE * Math.sqrt(3) / 2, SIZE * 3 / 2],
@@ -58,6 +61,15 @@ module View
         end
         children << h(TriangularGrid) if Lib::Params['grid']
         children << h(TileUnavailable, unavailable: @unavailable, layout: @hex.layout) if @unavailable
+
+        if @tile&.frame && @tile&.frame.color
+          attrs = {
+            stroke: @tile&.frame.color,
+            'stroke-width': FRAME_COLOR_STROKE_WIDTH,
+            points: FRAME_COLOR_POINTS,
+          }
+          children.insert(1, h(:polygon, attrs: attrs))
+        end
 
         props = {
           key: @hex.id,

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -101,6 +101,10 @@ module Engine
         false
       end
 
+      def frame?
+        false
+      end
+
       def partition?
         false
       end

--- a/lib/engine/part/frame.rb
+++ b/lib/engine/part/frame.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Part
+    class Frame < Base
+      attr_reader :color
+
+      def initialize(color)
+        @color = color
+      end
+
+      def frame?
+        true
+      end
+
+    end
+  end
+end

--- a/lib/engine/part/frame.rb
+++ b/lib/engine/part/frame.rb
@@ -14,7 +14,6 @@ module Engine
       def frame?
         true
       end
-
     end
   end
 end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -17,7 +17,7 @@ module Engine
     attr_accessor :hex, :icons, :index, :legal_rotations, :location_name, :name, :reservations, :upgrades
     attr_reader :blocks_lay, :borders, :cities, :color, :edges, :junction, :nodes, :label,
                 :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
-                :city_towns, :unlimited, :stubs, :partitions, :id
+                :city_towns, :unlimited, :stubs, :partitions, :id, :frame
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -144,6 +144,8 @@ module Engine
         Part::Stub.new(params['edge'].to_i)
       when 'partition'
         Part::Partition.new(params['a'], params['b'], params['type'], params['restrict'])
+      when 'frame'
+        Part::Frame.new(params['color'])
       end
     end
 
@@ -176,6 +178,7 @@ module Engine
       @nodes = nil
       @stops = nil
       @edges = nil
+      @frame = nil
       @junction = nil
       @icons = []
       @location_name = location_name
@@ -507,6 +510,8 @@ module Engine
           @stubs << part
         elsif part.partition?
           @partitions << part
+        elsif part.frame?
+          @frame = part
         else
           raise "Part #{part} not separated."
         end


### PR DESCRIPTION
Adds an Option to the tile code to add an colored frame to a tile, which is needed for 18CZ.

You can add the code `frame=color:purple` to get a ourple frame.

It looks like that:
![image](https://user-images.githubusercontent.com/7661170/103178339-3a89f480-4882-11eb-9ed8-ec94b8be501b.png)
