### PR TITLE
Minor tile_lay ability tweaks

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -182,13 +182,16 @@ normal tile lay actions.
   labels and city count. Default true.
 - `connect`: If true, and `count` is greater than 1, tiles laid must
   connect to each other. Default true.
-- `blocks`: If true and `count` is greater than 1, all tile lays must
-  be performed at once.
+- `blocks`: If true and `when` is `sold`, then the step
+  `TrackLayWhenCompanySold` will require a tile lay. Default false.
 - `reachable`: If true, when tile layed, a check is done if one of the
   controlling corporation's station tokens are reachable; if not a game
   error is triggered. Default false.
-- `must_lay_together`: If true, all the tile lays must happen at the same
-  time. Default false.
+- `must_lay_together`: If true and `count` is greater than 1, all the tile lays
+  must happen at the same time. Default false.
+- `must_lay_all`: If true and `count` is greater than 1 and `must_lay_together`
+  is true, all the tile lays must be used; if false, then some tile lays may be
+  forfeited. Default false.
 
 ## train_buy
 

--- a/lib/engine/ability/tile_lay.rb
+++ b/lib/engine/ability/tile_lay.rb
@@ -5,19 +5,22 @@ require_relative 'base'
 module Engine
   module Ability
     class TileLay < Base
-      attr_reader :hexes, :tiles, :free, :discount, :special, :connect, :blocks, :reachable, :must_lay_together, :cost
+      attr_reader :hexes, :tiles, :free, :discount, :special, :connect, :blocks,
+                  :reachable, :must_lay_together, :cost, :must_lay_all
 
       def setup(tiles:, hexes: nil, free: false, discount: nil, special: nil,
-                connect: nil, blocks: nil, reachable: nil, must_lay_together: false, cost: 0)
+                connect: nil, blocks: nil, reachable: nil, must_lay_together: nil, cost: 0,
+                must_lay_all: nil)
         @hexes = hexes
         @tiles = tiles
         @free = free
         @discount = discount || 0
         @special = special.nil? ? true : special
         @connect = connect.nil? ? true : connect
-        @blocks = blocks.nil? ? true : blocks
+        @blocks = !!blocks
         @reachable = !!reachable
-        @must_lay_together = must_lay_together
+        @must_lay_together = !!must_lay_together
+        @must_lay_all = @must_lay_together && !!must_lay_all
         @cost = cost
       end
     end

--- a/lib/engine/config/game/g_1828.rb
+++ b/lib/engine/config/game/g_1828.rb
@@ -536,6 +536,7 @@ module Engine
                     "type": "tile_lay",
                     "owner_type": "corporation",
                     "when": "sold",
+                    "blocks": true,
                     "count": 1,
                     "hexes": [
                         "E7"

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -366,7 +366,6 @@ module Engine
               "8",
               "9"
             ],
-           "blocks":false,
            "count": 2
         }
       ]
@@ -401,7 +400,6 @@ module Engine
               "8",
               "9"
             ],
-           "blocks": false,
            "count": 2
         }
       ]

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -284,8 +284,7 @@ module Engine
           ],
           "when": "sold",
           "owner_type": "corporation",
-          "count": 1,
-          "blocks": false
+          "count": 1
         }
       ]
     },

--- a/lib/engine/config/game/g_18_chesapeake.rb
+++ b/lib/engine/config/game/g_18_chesapeake.rb
@@ -274,6 +274,7 @@ module Engine
           "type": "tile_lay",
           "owner_type": "corporation",
           "must_lay_together": true,
+          "must_lay_all": true,
           "hexes": [
             "H2",
             "I3"
@@ -306,6 +307,7 @@ module Engine
           "type": "tile_lay",
           "owner_type": "corporation",
           "must_lay_together": true,
+          "must_lay_all": true,
           "hexes": [
             "F4",
             "G5"

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -304,7 +304,6 @@ module Engine
               "8",
               "9"
             ],
-           "blocks":false,
            "count": 1
         }
       ]
@@ -336,7 +335,6 @@ module Engine
               "8",
               "9"
             ],
-           "blocks": false,
            "count": 1
         }
       ]

--- a/lib/engine/config/game/g_18_ms.rb
+++ b/lib/engine/config/game/g_18_ms.rb
@@ -200,8 +200,7 @@ module Engine
              ],
              "tiles": [
              ],
-             "when":"track",
-             "blocks": false
+             "when":"track"
            }
          ]
       },

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -31,6 +31,12 @@ module Engine
       end
 
       def process_lay_tile(action)
+        if @company && (@company != action.entity) &&
+           (ability = @game.abilities(@company, :tile_lay, time: 'track')) &&
+           ability.must_lay_together && ability.must_lay_all
+          @game.game_error("Cannot interrupt #{@company.name}'s tile lays")
+        end
+
         ability = tile_lay_abilities(action.entity)
         lay_tile(action, spender: action.entity.owner)
         check_connect(action, ability)


### PR DESCRIPTION
* fix docs and default for `blocks` attr
* add attr `must_lay_all` for abilities that must lay all of their tiles
  together and cannot be interrupted by other actions (i.e., prevent C-P from
  illegally interrupting B&S at https://18xx.games/game/1273?action=165)