### PR TITLE
1867: Bug fixes

### DIFF
--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -44,7 +44,7 @@ module Engine
       GAME_END_CHECK = { bank: :current_or, custom: :one_more_full_or_set }.freeze
 
       HEX_WITH_O_LABEL = %w[J12].freeze
-      HEX_UPGRADES_FOR_O = %w[201 202 203 207 208 622 623 801 X8].freeze
+      HEX_UPGRADES_FOR_O = %w[201 202 203 207 208 621 622 623 801 X8].freeze
 
       CERT_LIMIT_CHANGE_ON_BANKRUPTCY = true
 

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -235,9 +235,9 @@ module Engine
       # Pre-alpha spec
       'hs_ahjzadkh_19792' => {
         'Alice' => 610,
-        'scottredracecar2' => 615,
+        'scottredracecar2' => 655,
         'JenFreeman' => 590,
-        'ChrisRericha' => 425,
+        'ChrisRericha' => 465,
       },
     },
     GAMES_BY_TITLE['1860'] => {


### PR DESCRIPTION
Add missing Y tile for O (fixes #2838)
Close corporations after moving assets (fixes #2836)
Post-merger share price is sum of min and max not average (fixes #2835)
Minors are skipped after a merge (fixes #2834)
CN shouldn't show up on merges (fixes #2831)