### PR TITLE
Properly remove reservations when a token is placed, fix cert limit in 1846 games

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -93,6 +93,9 @@ module Engine
       # Does the cert limit decrease when a player becomes bankrupt?
       CERT_LIMIT_CHANGE_ON_BANKRUPTCY = false
       CERT_LIMIT_INCLUDES_PRIVATES = true
+      # Does the cert limit care about how many players started the game or how
+      # many remain?
+      CERT_LIMIT_COUNTS_BANKRUPTED = false
 
       MULTIPLE_BUY_TYPES = %i[multiple_buy].freeze
 
@@ -1326,7 +1329,10 @@ module Engine
 
       def init_cert_limit
         cert_limit = self.class::CERT_LIMIT
-        cert_limit = cert_limit[players.reject(&:bankrupt).length] if cert_limit.is_a?(Hash)
+        if cert_limit.is_a?(Hash)
+          player_count = (self.class::CERT_LIMIT_COUNTS_BANKRUPTED ? players : players.reject(&:bankrupt)).size
+          cert_limit = cert_limit[player_count]
+        end
         cert_limit = cert_limit.reject { |k, _| k.to_i < @corporations.size }
                        .min_by(&:first)&.last || cert_limit.first.last if cert_limit.is_a?(Hash)
         cert_limit || @cert_limit

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -36,6 +36,7 @@ module Engine
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = true
       HOME_TOKEN_TIMING = :float
       MUST_BUY_TRAIN = :always
+      CERT_LIMIT_COUNTS_BANKRUPTED = true
 
       ORANGE_GROUP = [
         'Lake Shore Line',

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -58,7 +58,9 @@ module Engine
       end
 
       def remove_reservation!(entity)
-        @reservations.delete(entity)
+        return unless (index = @reservations.index(entity))
+
+        @reservations[index] = nil
       end
 
       def remove_all_reservations!
@@ -105,6 +107,7 @@ module Engine
 
         exchange_token(token, cheater: cheater)
         tile.reservations.delete(corporation)
+        remove_reservation!(corporation)
       end
 
       def exchange_token(token, cheater: false)

--- a/spec/fixtures/1846/19962.json
+++ b/spec/fixtures/1846/19962.json
@@ -1,0 +1,4635 @@
+{
+  "id": 19962,
+  "description": "Live - Open",
+  "user": {
+    "id": 512,
+    "name": "DrAwesome"
+  },
+  "players": [
+    {
+      "id": 4338,
+      "name": "EAB"
+    },
+    {
+      "id": 3739,
+      "name": "Random Guy"
+    },
+    {
+      "id": 512,
+      "name": "DrAwesome"
+    },
+    {
+      "id": 762,
+      "name": "Talbatross"
+    }
+  ],
+  "max_players": 5,
+  "title": "1846",
+  "settings": {
+    "seed": 1198354547,
+    "unlisted": false,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 5,
+  "round": "Operating Round",
+  "acting": [
+    4338,
+    3739,
+    512
+  ],
+  "result": {
+    "EAB": 1828,
+    "DrAwesome": 1910,
+    "Random Guy": 1918,
+    "Talbatross": 0
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 1,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 2,
+      "company": "SC",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 3,
+      "company": "Pass (4)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 4,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 5,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 6,
+      "company": "Pass (1)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 7,
+      "company": "BIG4",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 8,
+      "company": "MPC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 9,
+      "company": "Pass (3)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 10,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 11,
+      "company": "Pass (2)",
+      "price": 0
+    },
+    {
+      "id": 12,
+      "type": "bid",
+      "price": 80,
+      "entity": 4338,
+      "company": "MAIL",
+      "entity_type": "player",
+      "user": 4338,
+      "created_at": 1608782398
+    },
+    {
+      "id": 13,
+      "type": "undo",
+      "entity": 4338,
+      "entity_type": "player",
+      "user": 4338,
+      "created_at": 1608782444
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 14
+    },
+    {
+      "type": "bid",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 15,
+      "company": "MAIL",
+      "price": 80
+    },
+    {
+      "type": "par",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 16,
+      "corporation": "NYC",
+      "share_price": "40,0,4"
+    },
+    {
+      "type": "par",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 17,
+      "corporation": "B&O",
+      "share_price": "60,0,6"
+    },
+    {
+      "id": 18,
+      "type": "par",
+      "entity": 512,
+      "corporation": "GT",
+      "entity_type": "player",
+      "share_price": "70,0,7",
+      "user": 512,
+      "created_at": 1608782755
+    },
+    {
+      "id": 19,
+      "type": "undo",
+      "entity": 762,
+      "entity_type": "player",
+      "user": 512,
+      "created_at": 1608782834
+    },
+    {
+      "type": "par",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 20,
+      "corporation": "IC",
+      "share_price": "70,0,7"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 21,
+      "message": "sorry, still thinking"
+    },
+    {
+      "type": "par",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 22,
+      "corporation": "ERIE",
+      "share_price": "50,0,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 23,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 24,
+      "shares": [
+        "B&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 25,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 26,
+      "shares": [
+        "ERIE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 27,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 28,
+      "shares": [
+        "B&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 29
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 30,
+      "shares": [
+        "ERIE_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 31,
+      "shares": [
+        "NYC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 32,
+      "shares": [
+        "B&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 33
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 34,
+      "shares": [
+        "ERIE_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 35,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 36
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 37
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 38
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 39,
+      "shares": [
+        "NYC_1",
+        "NYC_2",
+        "NYC_3",
+        "NYC_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 40,
+      "corporation": "PRR",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 41
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 42
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 43
+    },
+    {
+      "type": "assign",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 44,
+      "target": "MS",
+      "target_type": "minor"
+    },
+    {
+      "type": "assign",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 45,
+      "target": "D14",
+      "target_type": "hex"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 46,
+      "hex": "C13",
+      "tile": "7-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 47,
+      "hex": "D14",
+      "tile": "5-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 48,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "C15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 49,
+      "type": "pass",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "user": 3739,
+      "created_at": 1608783461
+    },
+    {
+      "id": 50,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608783463
+    },
+    {
+      "id": 51,
+      "hex": "G9",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "rotation": 1,
+      "entity_type": "minor",
+      "user": 3739,
+      "created_at": 1608783469
+    },
+    {
+      "id": 52,
+      "type": "undo",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "user": 3739,
+      "created_at": 1608783483
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 53,
+      "hex": "G9",
+      "tile": "6-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 54,
+      "hex": "G11",
+      "tile": "8-0",
+      "rotation": 5
+    },
+    {
+      "id": 55,
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783622
+    },
+    {
+      "id": 56,
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-2",
+      "entity": "NYC",
+      "variant": "2",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783623
+    },
+    {
+      "id": 57,
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-3",
+      "entity": "NYC",
+      "variant": "2",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783624
+    },
+    {
+      "id": 58,
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-4",
+      "entity": "NYC",
+      "variant": "2",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783624
+    },
+    {
+      "id": 59,
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783633
+    },
+    {
+      "id": 60,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783636
+    },
+    {
+      "id": 61,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783639
+    },
+    {
+      "id": 62,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608783640
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 63
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 64,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 65,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 66,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 67,
+      "hex": "E19",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 68,
+      "hex": "E17",
+      "tile": "291-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 69
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 70,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 71
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 72
+    },
+    {
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 73,
+      "city": "H12-0-0",
+      "slot": 0
+    },
+    {
+      "id": 74,
+      "hex": "H12",
+      "tile": "292-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608783873
+    },
+    {
+      "id": 75,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608783917
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 76,
+      "hex": "H12",
+      "tile": "292-0",
+      "rotation": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 77,
+      "shares": [
+        "B&O_4"
+      ],
+      "percent": 10,
+      "share_price": 50
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 78
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 79,
+      "train": "2-6",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 80,
+      "train": "2-7",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 81
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 82
+    },
+    {
+      "id": 83,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784003
+    },
+    {
+      "id": 84,
+      "type": "redo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784013
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 85,
+      "hex": "J4",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 86,
+      "hex": "H6",
+      "tile": "8-1",
+      "rotation": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 87,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10,
+      "share_price": 60
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 88
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 89,
+      "train": "4-0",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 90
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 91
+    },
+    {
+      "type": "sell_shares",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 92,
+      "shares": [
+        "PRR_1",
+        "PRR_2"
+      ],
+      "percent": 20,
+      "share_price": 90
+    },
+    {
+      "type": "buy_company",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 93,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 94,
+      "company": "MPC",
+      "price": 60
+    },
+    {
+      "type": "place_token",
+      "entity": "C&WI",
+      "entity_type": "company",
+      "id": 95,
+      "city": "D6-0-3",
+      "slot": 0
+    },
+    {
+      "type": "assign",
+      "entity": "MPC",
+      "entity_type": "company",
+      "id": 96,
+      "target": "D6",
+      "target_type": "hex"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 97,
+      "hex": "D6",
+      "tile": "298-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 98,
+      "hex": "E7",
+      "tile": "9-2",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 99
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 100,
+      "train": "2-2",
+      "price": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 101,
+      "train": "2-3",
+      "price": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 102,
+      "train": "2-4",
+      "price": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 103,
+      "train": "4-1",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 104
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 105
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 106,
+      "hex": "D12",
+      "tile": "9-3",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 107,
+      "hex": "D10",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 108,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "C15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 109,
+      "type": "undo",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "user": 3739,
+      "created_at": 1608784411
+    },
+    {
+      "id": 110,
+      "type": "redo",
+      "entity": "MS",
+      "entity_type": "minor",
+      "user": 3739,
+      "created_at": 1608784414
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 111,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H12",
+              "G11",
+              "G9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 112,
+      "hex": "F8",
+      "tile": "9-5",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 113,
+      "hex": "G9",
+      "tile": "15-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 114,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "F20",
+              "F22"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "F20",
+              "G21"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G9",
+              "G11",
+              "H12"
+            ],
+            [
+              "G9",
+              "F8",
+              "E7",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 115,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 116
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 117,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 118,
+      "hex": "D8",
+      "tile": "9-6",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 119,
+      "hex": "C15",
+      "tile": "294-0",
+      "rotation": 0
+    },
+    {
+      "id": 120,
+      "type": "buy_company",
+      "price": 40,
+      "entity": "IC",
+      "company": "SC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784635
+    },
+    {
+      "id": 121,
+      "type": "assign",
+      "entity": "SC",
+      "target": "C5",
+      "entity_type": "company",
+      "target_type": "hex",
+      "user": 512,
+      "created_at": 1608784645
+    },
+    {
+      "id": 122,
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784653
+    },
+    {
+      "id": 123,
+      "type": "run_routes",
+      "entity": "IC",
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C15",
+              "C13",
+              "D14"
+            ],
+            [
+              "C15",
+              "C17"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784665
+    },
+    {
+      "id": 124,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784668
+    },
+    {
+      "id": 125,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784712
+    },
+    {
+      "id": 126,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784715
+    },
+    {
+      "id": 127,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784719
+    },
+    {
+      "id": 128,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784721
+    },
+    {
+      "id": 129,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608784727
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 130,
+      "company": "SC",
+      "price": 17
+    },
+    {
+      "type": "assign",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 131,
+      "target": "C5",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 132
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 133,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C15",
+              "C13",
+              "D14"
+            ],
+            [
+              "C15",
+              "C17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 134,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 135,
+      "train": "4-2",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 136
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 137
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 138,
+      "hex": "I11",
+      "tile": "9-7",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 139
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 140,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "G9",
+              "G11",
+              "H12"
+            ]
+          ]
+        },
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "J10",
+              "I11",
+              "H12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 141,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784858
+    },
+    {
+      "id": 142,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784860
+    },
+    {
+      "id": 143,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784865
+    },
+    {
+      "id": 144,
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784877
+    },
+    {
+      "id": 145,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784879
+    },
+    {
+      "id": 146,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784880
+    },
+    {
+      "id": 147,
+      "kind": "half",
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784889
+    },
+    {
+      "id": 148,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608784897
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 149,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 150
+    },
+    {
+      "type": "buy_company",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 151,
+      "company": "BIG4",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 152
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 153,
+      "hex": "D20",
+      "tile": "619-0",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 154,
+      "city": "619-0-0",
+      "slot": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 155,
+      "hex": "D18",
+      "tile": "8-2",
+      "rotation": 4
+    },
+    {
+      "type": "buy_company",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 156,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSL",
+      "entity_type": "company",
+      "id": 157,
+      "hex": "E17",
+      "tile": "294-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 158,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 159,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 160,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 161
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 162
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 163,
+      "message": "been a long time since I played"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 164,
+      "message": "shares in market affect stock price?"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 165,
+      "message": "at the end of the SR"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 166,
+      "message": "drops by 1 if any shares are in market"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 167,
+      "message": "also drops by one if the director sells"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 168,
+      "shares": [
+        "B&O_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 169,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 170,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 171,
+      "shares": [
+        "PRR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 172,
+      "shares": [
+        "IC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 173,
+      "shares": [
+        "IC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 174,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 175,
+      "shares": [
+        "IC_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 176
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 177,
+      "shares": [
+        "IC_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 178
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 179
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 180
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 181
+    },
+    {
+      "type": "place_token",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 182,
+      "city": "E11-1-0",
+      "slot": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 183,
+      "hex": "E11",
+      "tile": "5-1",
+      "rotation": 2
+    },
+    {
+      "id": 184,
+      "hex": "D12",
+      "tile": "24-0",
+      "type": "lay_tile",
+      "entity": "PRR",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608785418
+    },
+    {
+      "id": 185,
+      "type": "undo",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608785421
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 186,
+      "hex": "D10",
+      "tile": "23-0",
+      "rotation": 1
+    },
+    {
+      "type": "buy_shares",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 187,
+      "shares": [
+        "PRR_2"
+      ],
+      "percent": 10,
+      "share_price": 112
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 188,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "F20",
+              "G21"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G9",
+              "G11",
+              "H12"
+            ],
+            [
+              "G9",
+              "F8",
+              "E7",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 189,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 190
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 191,
+      "hex": "D14",
+      "tile": "619-1",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 192,
+      "hex": "E15",
+      "tile": "8-3",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 193,
+      "city": "619-1-0",
+      "slot": 1
+    },
+    {
+      "type": "assign",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 194,
+      "target": "D14",
+      "target_type": "hex"
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 195,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ],
+            [
+              "D14",
+              "D12",
+              "D10",
+              "D8",
+              "D6"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "C15",
+              "C17"
+            ]
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "D14",
+              "E15",
+              "E17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 196,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 197,
+      "train": "4-3",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 198
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 199,
+      "hex": "H12",
+      "tile": "295-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 200
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 201,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "H12",
+              "G11",
+              "G9"
+            ]
+          ]
+        },
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "F8",
+              "E7",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 202,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608785632
+    },
+    {
+      "id": 203,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608785652
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 204,
+      "kind": "payout"
+    },
+    {
+      "id": 205,
+      "type": "buy_train",
+      "price": 160,
+      "train": "4-4",
+      "entity": "B&O",
+      "variant": "3/5",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608785668
+    },
+    {
+      "id": 206,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608785683
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 207
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 208
+    },
+    {
+      "id": 209,
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "shares": [
+        "ERIE_4",
+        "ERIE_5",
+        "ERIE_6",
+        "ERIE_7",
+        "ERIE_8"
+      ],
+      "percent": 50,
+      "entity_type": "corporation",
+      "share_price": 50,
+      "user": 762,
+      "created_at": 1608785712
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 210,
+      "message": "no rust 2day :D"
+    },
+    {
+      "id": 211,
+      "hex": "E19",
+      "tile": "24-0",
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785721
+    },
+    {
+      "id": 212,
+      "type": "buy_company",
+      "price": 80,
+      "entity": "ERIE",
+      "company": "MAIL",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785727
+    },
+    {
+      "id": 213,
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785739
+    },
+    {
+      "id": 214,
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785740
+    },
+    {
+      "id": 215,
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785742
+    },
+    {
+      "id": 216,
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785749
+    },
+    {
+      "id": 217,
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785780
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 218,
+      "shares": [
+        "ERIE_4",
+        "ERIE_5"
+      ],
+      "percent": 20,
+      "share_price": 50
+    },
+    {
+      "type": "place_token",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 219,
+      "city": "619-1-0",
+      "slot": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 220,
+      "hex": "D8",
+      "tile": "23-1",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 221,
+      "hex": "F16",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 222,
+      "hex": "F14",
+      "tile": "8-5",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 223
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 224,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 225,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785895
+    },
+    {
+      "id": 226,
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "user": 762,
+      "created_at": 1608785898
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 227,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 228,
+      "company": "MAIL",
+      "price": 64
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 229,
+      "hex": "E11",
+      "tile": "619-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 230,
+      "hex": "F10",
+      "tile": "9-8",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 231,
+      "city": "15-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 232,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E11",
+              "D10",
+              "D8",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "G9",
+              "F10",
+              "E11"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ],
+            [
+              "H12",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "F8",
+              "E7",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 233,
+      "kind": "payout"
+    },
+    {
+      "id": 234,
+      "hex": "F14",
+      "tile": "25-0",
+      "type": "lay_tile",
+      "entity": "IC",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786129
+    },
+    {
+      "id": 235,
+      "hex": "E13",
+      "tile": "8-6",
+      "type": "lay_tile",
+      "entity": "IC",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786137
+    },
+    {
+      "id": 236,
+      "city": "619-2-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786140
+    },
+    {
+      "id": 237,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786183
+    },
+    {
+      "id": 238,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786187
+    },
+    {
+      "id": 239,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786190
+    },
+    {
+      "id": 240,
+      "hex": "G13",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "IC",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786203
+    },
+    {
+      "id": 241,
+      "hex": "B16",
+      "tile": "6-1",
+      "type": "lay_tile",
+      "entity": "IC",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786247
+    },
+    {
+      "id": 242,
+      "city": "298-0-2",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786251
+    },
+    {
+      "id": 243,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786306
+    },
+    {
+      "id": 244,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786308
+    },
+    {
+      "id": 245,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608786311
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 246,
+      "hex": "B16",
+      "tile": "6-1",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 247,
+      "city": "298-0-2",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 248
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 249,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "B16",
+              "C15"
+            ],
+            [
+              "B16",
+              "B18"
+            ]
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D14",
+              "D12",
+              "D10",
+              "D8",
+              "D6"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "D14",
+              "E15",
+              "E17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 250,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 251
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 252,
+      "hex": "H10",
+      "tile": "8-6",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 253,
+      "hex": "I9",
+      "tile": "8-7",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 254
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 255,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "H12",
+              "G11",
+              "G9"
+            ]
+          ]
+        },
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H12",
+              "H10",
+              "I9",
+              "J10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 256,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 257,
+      "train": "4-4",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 258
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 259,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 260,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 261
+    },
+    {
+      "id": 262,
+      "type": "sell_shares",
+      "entity": 762,
+      "shares": [
+        "ERIE_1",
+        "ERIE_2",
+        "ERIE_3"
+      ],
+      "percent": 30,
+      "entity_type": "player",
+      "user": 762,
+      "created_at": 1608786527
+    },
+    {
+      "id": 263,
+      "type": "sell_shares",
+      "entity": 762,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 762,
+      "created_at": 1608786558
+    },
+    {
+      "id": 264,
+      "type": "undo",
+      "entity": 762,
+      "entity_type": "player",
+      "user": 762,
+      "created_at": 1608786582
+    },
+    {
+      "id": 265,
+      "type": "undo",
+      "entity": 762,
+      "entity_type": "player",
+      "user": 762,
+      "created_at": 1608786584
+    },
+    {
+      "type": "sell_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 266,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 267,
+      "shares": [
+        "ERIE_1",
+        "ERIE_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 268,
+      "corporation": "GT",
+      "share_price": "150,0,14"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 269,
+      "message": "what's the operation order again?"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 270,
+      "shares": [
+        "PRR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 271,
+      "message": "which corp operates first?"
+    },
+    {
+      "type": "message",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 272,
+      "message": "by stock price, high to low, right?"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 273,
+      "shares": [
+        "PRR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 274,
+      "message": "high to low"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 275,
+      "message": "it's only low to high in the 1st OR"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 276,
+      "shares": [
+        "PRR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 277,
+      "shares": [
+        "PRR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 278,
+      "shares": [
+        "PRR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 279,
+      "shares": [
+        "PRR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 280,
+      "shares": [
+        "PRR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 281,
+      "shares": [
+        "PRR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 282,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 283
+    },
+    {
+      "id": 284,
+      "type": "sell_shares",
+      "entity": 3739,
+      "shares": [
+        "IC_4"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786817
+    },
+    {
+      "id": 285,
+      "type": "undo",
+      "entity": 3739,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786822
+    },
+    {
+      "id": 286,
+      "type": "sell_shares",
+      "entity": 3739,
+      "shares": [
+        "B&O_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786824
+    },
+    {
+      "id": 287,
+      "type": "undo",
+      "entity": 3739,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786828
+    },
+    {
+      "id": 288,
+      "type": "sell_shares",
+      "entity": 3739,
+      "shares": [
+        "B&O_1",
+        "B&O_2"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786829
+    },
+    {
+      "id": 289,
+      "type": "buy_shares",
+      "entity": 3739,
+      "shares": [
+        "PRR_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786838
+    },
+    {
+      "id": 290,
+      "type": "undo",
+      "entity": 512,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786850
+    },
+    {
+      "id": 291,
+      "type": "undo",
+      "entity": 3739,
+      "entity_type": "player",
+      "user": 3739,
+      "created_at": 1608786854
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 292,
+      "shares": [
+        "B&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 293,
+      "shares": [
+        "PRR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 294,
+      "shares": [
+        "B&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 295,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 296
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 297,
+      "message": "so is erie going to liquidate?"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 298,
+      "message": "probably not"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 299,
+      "message": "it has a friend"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 300,
+      "message": "how does that work again?"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 301,
+      "shares": [
+        "ERIE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 302,
+      "shares": [
+        "B&O_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 303
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 304
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 305
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 306,
+      "shares": [
+        "ERIE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 307
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 308
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 309
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 310,
+      "shares": [
+        "ERIE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 311,
+      "shares": [
+        "B&O_6",
+        "B&O_7"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 312,
+      "shares": [
+        "PRR_5",
+        "PRR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 313,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 314,
+      "shares": [
+        "GT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 315
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 316
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 317
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 318,
+      "shares": [
+        "GT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 319
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 320
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 321
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 322,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 323,
+      "message": "talb buy 1 share GT"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 324,
+      "message": "i'll buy other"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 325,
+      "message": "I can't"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 326,
+      "message": "sell IC+Erie"
+    },
+    {
+      "type": "message",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 327,
+      "message": "he can't sell more erie"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 328,
+      "message": "can't sell Erie"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 329,
+      "message": "ah ok"
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 330
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 331
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 332
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 333,
+      "shares": [
+        "GT_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 334
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 335
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 336
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 337,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 338,
+      "shares": [
+        "GT_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 339
+    },
+    {
+      "type": "pass",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 340
+    },
+    {
+      "type": "pass",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 341
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 342
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 343,
+      "hex": "C13",
+      "tile": "29-0",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 344,
+      "city": "294-0-0",
+      "slot": 1
+    },
+    {
+      "id": 345,
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787525
+    },
+    {
+      "id": 346,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787579
+    },
+    {
+      "type": "sell_shares",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 347,
+      "shares": [
+        "GT_8"
+      ],
+      "percent": 10,
+      "share_price": 137
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 348
+    },
+    {
+      "id": 349,
+      "type": "buy_train",
+      "price": 800,
+      "train": "4-0",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787600
+    },
+    {
+      "id": 350,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787611
+    },
+    {
+      "id": 351,
+      "type": "buy_train",
+      "price": 700,
+      "train": "4-0",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787645
+    },
+    {
+      "id": 352,
+      "type": "buy_train",
+      "price": 500,
+      "train": "5-0",
+      "entity": "GT",
+      "variant": "5",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787649
+    },
+    {
+      "id": 353,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787718
+    },
+    {
+      "id": 354,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 512,
+      "created_at": 1608787729
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 355,
+      "train": "4-0",
+      "price": 200
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 356,
+      "train": "5-0",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 357,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 358,
+      "hex": "D6",
+      "tile": "299-0",
+      "rotation": 0
+    },
+    {
+      "id": 359,
+      "hex": "G13",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "PRR",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608787773
+    },
+    {
+      "id": 360,
+      "city": "294-1-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608787813
+    },
+    {
+      "id": 361,
+      "type": "buy_shares",
+      "entity": "PRR",
+      "shares": [
+        "PRR_5",
+        "PRR_2"
+      ],
+      "percent": 20,
+      "entity_type": "corporation",
+      "share_price": 150,
+      "user": 4338,
+      "created_at": 1608787837
+    },
+    {
+      "id": 362,
+      "type": "undo",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608787861
+    },
+    {
+      "id": 363,
+      "type": "undo",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608787863
+    },
+    {
+      "id": 364,
+      "type": "undo",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "user": 4338,
+      "created_at": 1608787867
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 365,
+      "message": "So it seems much better to use big 10 as teleport than to teleport for $100"
+    },
+    {
+      "type": "place_token",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 366,
+      "city": "295-0-0",
+      "slot": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 367,
+      "hex": "E13",
+      "tile": "9-9",
+      "rotation": 1
+    },
+    {
+      "type": "buy_shares",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 368,
+      "shares": [
+        "PRR_5",
+        "PRR_2"
+      ],
+      "percent": 20,
+      "share_price": 150
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 369,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "E11",
+              "D10",
+              "D8",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H12",
+              "H10",
+              "I9",
+              "J10"
+            ],
+            [
+              "H12",
+              "G11",
+              "G9"
+            ],
+            [
+              "D6",
+              "E7",
+              "F8",
+              "G9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 370,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 371,
+      "train": "5-2",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 372,
+      "train": "5-3",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "id": 373,
+      "type": "buy_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_5",
+        "B&O_1"
+      ],
+      "percent": 20,
+      "entity_type": "corporation",
+      "share_price": 100,
+      "user": 3739,
+      "created_at": 1608787939
+    },
+    {
+      "id": 374,
+      "hex": "H12",
+      "tile": "297-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608787947
+    },
+    {
+      "id": 375,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608787970
+    },
+    {
+      "id": 376,
+      "type": "run_routes",
+      "entity": "B&O",
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D6",
+              "E7",
+              "F8",
+              "G9"
+            ]
+          ]
+        },
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H12",
+              "H10",
+              "I9",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "D6",
+              "C7",
+              "D8",
+              "D10",
+              "E11"
+            ],
+            [
+              "G9",
+              "F10",
+              "E11"
+            ],
+            [
+              "H12",
+              "G11",
+              "G9"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608787988
+    },
+    {
+      "id": 377,
+      "kind": "half",
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608787998
+    },
+    {
+      "id": 378,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788004
+    },
+    {
+      "id": 379,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788009
+    },
+    {
+      "id": 380,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788013
+    },
+    {
+      "id": 381,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788031
+    },
+    {
+      "id": 382,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788035
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 383,
+      "message": "think I'm like 30 short"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 384,
+      "message": "oh not if I issue"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 385,
+      "shares": [
+        "B&O_8"
+      ],
+      "percent": 10,
+      "share_price": 80
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 386,
+      "hex": "H12",
+      "tile": "297-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 387
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 388,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D6",
+              "E7",
+              "F8",
+              "G9"
+            ]
+          ]
+        },
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H12",
+              "H10",
+              "I9",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E11",
+              "D10",
+              "D8",
+              "D6"
+            ],
+            [
+              "G9",
+              "F10",
+              "E11"
+            ],
+            [
+              "H12",
+              "G11",
+              "G9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 389,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 390,
+      "train": "6-0",
+      "price": 800,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 391
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 392,
+      "hex": "D12",
+      "tile": "20-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 393,
+      "shares": [
+        "IC_1",
+        "IC_2"
+      ],
+      "percent": 20,
+      "share_price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 394
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 395,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "C15",
+              "C13",
+              "D14"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "D14",
+              "E15",
+              "E17"
+            ],
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 396,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 397,
+      "train": "5-0",
+      "price": 20
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 398
+    },
+    {
+      "type": "buy_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 399,
+      "shares": [
+        "ERIE_4",
+        "ERIE_5",
+        "ERIE_1"
+      ],
+      "percent": 30,
+      "share_price": 70
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 400,
+      "hex": "D20",
+      "tile": "611-0",
+      "rotation": 3
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 401,
+      "shares": [
+        "ERIE_8",
+        "ERIE_4"
+      ],
+      "percent": 20,
+      "share_price": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 402,
+      "shares": [
+        "GT_1",
+        "GT_2",
+        "GT_3",
+        "GT_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "sell_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 403,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 404,
+      "shares": [
+        "ERIE_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "bankrupt",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 405
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 406,
+      "hex": "E15",
+      "tile": "23-2",
+      "rotation": 4
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 407,
+      "message": "gg talb"
+    },
+    {
+      "type": "message",
+      "entity": 762,
+      "entity_type": "player",
+      "id": 408,
+      "message": "gg]"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 409,
+      "hex": "G13",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 410
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 411,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H12",
+              "H10",
+              "I9",
+              "J10"
+            ],
+            [
+              "H12",
+              "G11",
+              "G9"
+            ],
+            [
+              "D6",
+              "E7",
+              "F8",
+              "G9"
+            ]
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "D6",
+              "C7",
+              "D8",
+              "D10",
+              "E11"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "5-3",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ],
+            [
+              "G13",
+              "H12"
+            ],
+            [
+              "G13",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "E17",
+              "E19",
+              "E21"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 412,
+      "kind": "payout"
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 413,
+      "city": "619-2-0",
+      "slot": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 414,
+      "hex": "C15",
+      "tile": "297-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 415
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 416,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ],
+            [
+              "B16",
+              "B18"
+            ]
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "C7",
+              "D8",
+              "D10",
+              "E11"
+            ],
+            [
+              "C15",
+              "C13",
+              "D12",
+              "E11"
+            ],
+            [
+              "C15",
+              "C17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 417,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 418
+    },
+    {
+      "type": "buy_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 419,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10,
+      "share_price": 124
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 420,
+      "hex": "C15",
+      "tile": "290-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 421
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 422,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C15",
+              "D14"
+            ],
+            [
+              "C15",
+              "C17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 423,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 424
+    },
+    {
+      "id": 425,
+      "hex": "E17",
+      "tile": "297-1",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788869
+    },
+    {
+      "id": 426,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788881
+    },
+    {
+      "id": 427,
+      "hex": "G11",
+      "tile": "25-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788902
+    },
+    {
+      "id": 428,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788904
+    },
+    {
+      "id": 429,
+      "type": "run_routes",
+      "entity": "B&O",
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "H12",
+              "H10",
+              "I9",
+              "J10"
+            ],
+            [
+              "G9",
+              "G11",
+              "H12"
+            ],
+            [
+              "D6",
+              "E7",
+              "F8",
+              "G9"
+            ]
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "G13",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "G13",
+              "H12"
+            ],
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788924
+    },
+    {
+      "id": 430,
+      "kind": "half",
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788934
+    },
+    {
+      "id": 431,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788941
+    },
+    {
+      "id": 432,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788963
+    },
+    {
+      "id": 433,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608788969
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 434,
+      "message": "best to ignore chicago run"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 435,
+      "message": "focus on local optima"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 436,
+      "message": "as only 3 ORs remain"
+    },
+    {
+      "type": "message",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 437,
+      "message": "or less"
+    },
+    {
+      "id": 438,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 3739,
+      "created_at": 1608789007
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 439,
+      "hex": "G13",
+      "tile": "15-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 440
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 441,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "H12",
+              "H10",
+              "I9",
+              "J10"
+            ],
+            [
+              "H12",
+              "G11",
+              "G9"
+            ],
+            [
+              "D6",
+              "E7",
+              "F8",
+              "G9"
+            ]
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "G13",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "G13",
+              "H12"
+            ],
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 442,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 443
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4338,
+      "entity_type": "player",
+      "id": 444,
+      "shares": [
+        "PRR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "end_game",
+      "entity": 3739,
+      "entity_type": "player",
+      "id": 445
+    }
+  ],
+  "loaded": true,
+  "created_at": 1608781803,
+  "updated_at": 1608790489
+}

--- a/spec/fixtures/1846_2p_variant/11098.json
+++ b/spec/fixtures/1846_2p_variant/11098.json
@@ -1,0 +1,4237 @@
+{
+  "id": 11098,
+  "description": "Open",
+  "user": {
+    "id": 195,
+    "name": "yrael (GMT +0)"
+  },
+  "players": [
+    {
+      "id": 377,
+      "name": "Claramity"
+    },
+    {
+      "id": 195,
+      "name": "yrael (GMT +0)"
+    }
+  ],
+  "max_players": 2,
+  "title": "1846 2p Variant",
+  "settings": {
+    "seed": 3.7073594743834483e+36
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 5,
+  "round": "Operating Round",
+  "acting": [
+    377,
+    195
+  ],
+  "result": {
+    "yrael": 7331,
+    "Claramity": 7624
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 1,
+      "company": "MPC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 2,
+      "user": 195,
+      "company": "BIG4",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 3,
+      "company": "MAIL",
+      "price": 80
+    },
+    {
+      "type": "bid",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 4,
+      "user": 195,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 5,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 6,
+      "user": 195,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 7,
+      "company": "TBC",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 8,
+      "user": 195
+    },
+    {
+      "type": "bid",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 9,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "par",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 10,
+      "user": 195,
+      "corporation": "NYC",
+      "share_price": "90,0,9"
+    },
+    {
+      "type": "par",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 11,
+      "corporation": "IC",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "par",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 12,
+      "user": 195,
+      "corporation": "ERIE",
+      "share_price": "70,0,7"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 13,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 14
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 15,
+      "user": 195,
+      "hex": "C13",
+      "tile": "7-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 16,
+      "user": 195,
+      "hex": "D14",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 17,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "C15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 18,
+      "user": 195,
+      "hex": "G9",
+      "tile": "6-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 19,
+      "user": 195,
+      "hex": "G7",
+      "tile": "6-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 20,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 21,
+      "user": 195,
+      "hex": "E19",
+      "tile": "7-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 22,
+      "user": 195,
+      "hex": "D18",
+      "tile": "8-0",
+      "rotation": 4
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 23,
+      "user": 195,
+      "shares": [
+        "ERIE_1",
+        "ERIE_2"
+      ],
+      "percent": 20,
+      "share_price": 60
+    },
+    {
+      "type": "place_token",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 24,
+      "user": 195,
+      "city": "D20-0-0",
+      "slot": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 25,
+      "user": 195,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 26,
+      "user": 195,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 27,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 28,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 29,
+      "user": 195,
+      "hex": "E17",
+      "tile": "292-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 30,
+      "user": 195,
+      "hex": "E15",
+      "tile": "8-1",
+      "rotation": 2
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 31,
+      "user": 195,
+      "shares": [
+        "NYC_1",
+        "NYC_2"
+      ],
+      "percent": 20,
+      "share_price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 32,
+      "user": 195
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 33,
+      "user": 195,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 34,
+      "user": 195,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 35,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 36,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 37,
+      "hex": "J4",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 38,
+      "hex": "I3",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "sell_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 39,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10,
+      "share_price": 90
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 40,
+      "city": "I5-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 41,
+      "train": "2-6",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 42,
+      "train": "4-0",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 43,
+      "company": "MAIL",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 44
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 45
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 46,
+      "user": 195,
+      "hex": "C15",
+      "tile": "295-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 47,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 48,
+      "user": 195,
+      "hex": "H10",
+      "tile": "9-2",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 49,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 50,
+      "company": "MPC",
+      "price": 60
+    },
+    {
+      "type": "sell_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 51,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10,
+      "share_price": 80
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 52,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "place_token",
+      "entity": "C&WI",
+      "entity_type": "company",
+      "id": 53,
+      "city": "D6-0-3",
+      "slot": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 54,
+      "hex": "D6",
+      "tile": "298-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 55,
+      "hex": "I7",
+      "tile": "9-3",
+      "rotation": 1
+    },
+    {
+      "type": "assign",
+      "entity": "MPC",
+      "entity_type": "company",
+      "id": 56,
+      "target": "D6",
+      "target_type": "hex"
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 57,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "K3",
+              "J4",
+              "I5"
+            ],
+            [
+              "I1",
+              "I3",
+              "I5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 58,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 59
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 61,
+      "user": 195,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSL",
+      "entity_type": "company",
+      "id": 62,
+      "user": 195,
+      "hex": "E17",
+      "tile": "294-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 63,
+      "user": 195,
+      "city": "57-0-0",
+      "slot": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 64,
+      "user": 195,
+      "hex": "D14",
+      "tile": "14-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 65,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D14",
+              "E15",
+              "E17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 66,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 67,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 68,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 69,
+      "user": 195,
+      "hex": "D20",
+      "tile": "619-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 70,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D20",
+              "D18",
+              "E17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 71,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 72,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 73,
+      "user": 195
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 74,
+      "user": 195,
+      "shares": [
+        "ERIE_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 75,
+      "shares": [
+        "IC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 76,
+      "user": 195,
+      "shares": [
+        "NYC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 77,
+      "shares": [
+        "IC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 78,
+      "user": 195
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 79,
+      "shares": [
+        "IC_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 80,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 81
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 82,
+      "user": 195,
+      "hex": "C13",
+      "tile": "29-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 83,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 84,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 85,
+      "user": 195,
+      "hex": "I11",
+      "tile": "8-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 86,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "J10",
+              "I11",
+              "H10",
+              "G9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 87,
+      "hex": "I9",
+      "tile": "8-3",
+      "rotation": 5
+    },
+    {
+      "type": "buy_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 88,
+      "shares": [
+        "IC_2",
+        "IC_3"
+      ],
+      "percent": 20,
+      "share_price": 112
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 89
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 90,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "J10",
+              "I9",
+              "I7",
+              "I5"
+            ],
+            [
+              "I1",
+              "I3",
+              "I5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 91,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 92,
+      "train": "4-1",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 93
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 94
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 95,
+      "user": 195,
+      "hex": "D12",
+      "tile": "8-4",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 96,
+      "user": 195,
+      "hex": "E13",
+      "tile": "8-5",
+      "rotation": 2
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 97,
+      "user": 195,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10,
+      "share_price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 98,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 99,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D14",
+              "E15",
+              "E17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 100,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 101,
+      "user": 195,
+      "train": "4-2",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 102,
+      "user": 195
+    },
+    {
+      "type": "buy_company",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 103,
+      "user": 195,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 104,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 105,
+      "user": 195,
+      "hex": "E15",
+      "tile": "23-0",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 106,
+      "user": 195,
+      "city": "295-0-0",
+      "slot": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 107,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 108,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "E17",
+              "E15",
+              "E13",
+              "D12",
+              "C13",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 109,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 110,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 111,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 112,
+      "user": 195,
+      "hex": "G9",
+      "tile": "619-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 113,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 114,
+      "hex": "H6",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 115,
+      "hex": "G7",
+      "tile": "619-2",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 116,
+      "city": "619-1-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 117,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "J10",
+              "I9",
+              "I7",
+              "I5"
+            ],
+            [
+              "I1",
+              "I3",
+              "I5"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G7",
+              "H6",
+              "I5"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 118,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 119,
+      "company": "TBC",
+      "price": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 120,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 121,
+      "hex": "F16",
+      "tile": "9-5",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 122,
+      "hex": "F14",
+      "tile": "9-6",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 123
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 124
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 125,
+      "user": 195,
+      "hex": "E13",
+      "tile": "16-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 126,
+      "user": 195,
+      "hex": "E11",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 127,
+      "user": 195,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10,
+      "share_price": 112
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 128,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ]
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E17",
+              "E15",
+              "D14"
+            ],
+            [
+              "E11",
+              "E13",
+              "D14"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 129,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 130,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 131,
+      "user": 195,
+      "hex": "E19",
+      "tile": "30-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 132,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 133,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D12",
+              "E13",
+              "E15",
+              "E17"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 134,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 135,
+      "user": 195,
+      "train": "4-3",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 136,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 137,
+      "user": 195
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 138,
+      "user": 195,
+      "shares": [
+        "ERIE_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 139,
+      "shares": [
+        "NYC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 140,
+      "user": 195,
+      "shares": [
+        "NYC_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 141,
+      "corporation": "PRR",
+      "share_price": "90,0,9"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 142,
+      "user": 195,
+      "shares": [
+        "ERIE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 143,
+      "shares": [
+        "PRR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 144,
+      "user": 195,
+      "shares": [
+        "ERIE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 145,
+      "shares": [
+        "PRR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 146,
+      "user": 195
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 147,
+      "shares": [
+        "PRR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 148,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 149
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 150,
+      "user": 195,
+      "hex": "F10",
+      "tile": "8-6",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 151,
+      "user": 195,
+      "hex": "F12",
+      "tile": "9-7",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 152,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 153,
+      "hex": "E7",
+      "tile": "8-7",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 154,
+      "hex": "F6",
+      "tile": "8-8",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 155
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 156,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "D6",
+              "E7",
+              "F6",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "J10",
+              "I9",
+              "I7",
+              "I5"
+            ],
+            [
+              "I1",
+              "I3",
+              "I5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 157,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 158
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 159
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 160,
+      "user": 195,
+      "hex": "E11",
+      "tile": "15-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 161,
+      "user": 195,
+      "hex": "D10",
+      "tile": "8-9",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 162,
+      "user": 195
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 163,
+      "user": 195,
+      "shares": [
+        "NYC_2",
+        "NYC_4"
+      ],
+      "percent": 20,
+      "share_price": 124
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 164,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D20",
+              "E19",
+              "E17"
+            ]
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E17",
+              "E15",
+              "D14"
+            ],
+            [
+              "E11",
+              "E13",
+              "D14"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 165,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 166,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 167,
+      "user": 195,
+      "hex": "F16",
+      "tile": "24-0",
+      "rotation": 1
+    },
+    {
+      "type": "buy_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 168,
+      "user": 195,
+      "shares": [
+        "ERIE_1",
+        "ERIE_2"
+      ],
+      "percent": 20,
+      "share_price": 112
+    },
+    {
+      "type": "buy_company",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 169,
+      "user": 195,
+      "company": "BIG4",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 170,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 171,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D20",
+              "E19",
+              "E17"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D20",
+              "D18",
+              "E17"
+            ]
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "G9",
+              "F10",
+              "F12",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "C15",
+              "C13",
+              "D12",
+              "E13",
+              "E15",
+              "E17"
+            ],
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 172,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 173,
+      "hex": "F18",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 174,
+      "hex": "F10",
+      "tile": "25-0",
+      "rotation": 4
+    },
+    {
+      "type": "sell_shares",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 175,
+      "shares": [
+        "PRR_4",
+        "PRR_5",
+        "PRR_6",
+        "PRR_7",
+        "PRR_8"
+      ],
+      "percent": 50,
+      "share_price": 80
+    },
+    {
+      "type": "place_token",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 176,
+      "city": "15-0-0",
+      "slot": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 177,
+      "train": "4-4",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 178,
+      "train": "5-0",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 179
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 180,
+      "hex": "D6",
+      "tile": "299-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 181,
+      "hex": "G5",
+      "tile": "8-10",
+      "rotation": 4
+    },
+    {
+      "type": "sell_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 182,
+      "shares": [
+        "IC_7",
+        "IC_8"
+      ],
+      "percent": 20,
+      "share_price": 165
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 183,
+      "city": "294-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 184,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "D6",
+              "E7",
+              "F6",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "J10",
+              "I9",
+              "I7",
+              "I5"
+            ],
+            [
+              "I1",
+              "I3",
+              "I5"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 185,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 186,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 187,
+      "user": 195,
+      "hex": "D8",
+      "tile": "9-9",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 188,
+      "user": 195,
+      "city": "299-0-2",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 189,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 190,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ]
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ]
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "C15",
+              "C13",
+              "D12",
+              "E13",
+              "E15",
+              "E17"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 191,
+      "user": 195,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 192,
+      "user": 195,
+      "train": "5-2",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 193,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 194,
+      "user": 195,
+      "hex": "E9",
+      "tile": "9-10",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 195,
+      "user": 195,
+      "hex": "D8",
+      "tile": "20-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 196,
+      "user": 195,
+      "city": "299-0-1",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 197,
+      "user": 195,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D6",
+              "C7",
+              "D8",
+              "E9",
+              "F10",
+              "F12",
+              "F14",
+              "F16",
+              "E17"
+            ]
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D6",
+              "E7",
+              "F6",
+              "G7"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 198,
+      "user": 195,
+      "shares": [
+        "ERIE_7",
+        "ERIE_8"
+      ],
+      "percent": 20,
+      "share_price": 112
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 199,
+      "user": 195,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 200,
+      "user": 195,
+      "train": "6-0",
+      "price": 900,
+      "variant": "7/8"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 201,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 202,
+      "hex": "E13",
+      "tile": "43-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 203
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 204,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "F20",
+              "G21"
+            ],
+            [
+              "D6",
+              "C7",
+              "D8",
+              "E9",
+              "F10",
+              "F12",
+              "F14",
+              "F16",
+              "F18",
+              "F20"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15",
+              "E17"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 205,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 206
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 207,
+      "user": 195,
+      "shares": [
+        "NYC_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 208,
+      "shares": [
+        "ERIE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 209,
+      "user": 195,
+      "shares": [
+        "NYC_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 210,
+      "corporation": "B&O",
+      "share_price": "150,0,14"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 211,
+      "user": 195,
+      "shares": [
+        "ERIE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 212,
+      "shares": [
+        "B&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 213,
+      "user": 195,
+      "shares": [
+        "PRR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 214,
+      "shares": [
+        "B&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 215,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 216
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 217,
+      "hex": "D6",
+      "tile": "300-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 218,
+      "hex": "H4",
+      "tile": "8-11",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 219,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D6",
+              "C7",
+              "D8",
+              "E9",
+              "F10",
+              "F12",
+              "F14",
+              "F16",
+              "E17"
+            ]
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15",
+              "E17"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ]
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "D6",
+              "E7",
+              "F6",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 220,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 221
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 222,
+      "user": 195,
+      "hex": "D8",
+      "tile": "47-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 223,
+      "user": 195
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 224,
+      "user": 195,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10,
+      "share_price": 137
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 225,
+      "user": 195,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "E11",
+              "E13",
+              "D14"
+            ],
+            [
+              "E11",
+              "D10",
+              "D8",
+              "C7",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "D6",
+              "D8",
+              "E9",
+              "F10",
+              "F12",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 226,
+      "user": 195,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 227,
+      "user": 195,
+      "train": "6-1",
+      "price": 800,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 228,
+      "hex": "G19",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 229,
+      "city": "H12-0-0",
+      "slot": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 230,
+      "shares": [
+        "B&O_3",
+        "B&O_4",
+        "B&O_5",
+        "B&O_6"
+      ],
+      "percent": 40,
+      "share_price": 137
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 231,
+      "hex": "H12",
+      "tile": "292-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 232,
+      "train": "6-2",
+      "price": 900,
+      "variant": "7/8"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 233
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 234,
+      "user": 195,
+      "hex": "E17",
+      "tile": "297-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 235,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 236,
+      "user": 195,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "E9",
+              "D8",
+              "D6"
+            ],
+            [
+              "E17",
+              "E19",
+              "D20"
+            ],
+            [
+              "D20",
+              "C21"
+            ]
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "E21",
+              "E23"
+            ],
+            [
+              "D20",
+              "E21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "E11",
+              "D10",
+              "D8",
+              "C7",
+              "D6"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 237,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 238,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 239,
+      "hex": "F18",
+      "tile": "23-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 240,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "F20",
+              "G21"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 241,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 242
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 243,
+      "hex": "F18",
+      "tile": "47-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 244,
+      "hex": "G11",
+      "tile": "8-12",
+      "rotation": 5
+    },
+    {
+      "type": "sell_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 245,
+      "shares": [
+        "IC_2",
+        "IC_3"
+      ],
+      "percent": 20,
+      "share_price": 230
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 246,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "D6",
+              "E7",
+              "F6",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 247,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 248,
+      "train": "5-0",
+      "price": 603
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 249,
+      "user": 195,
+      "hex": "D20",
+      "tile": "611-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 250,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 251,
+      "user": 195,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "E9",
+              "D8",
+              "C7",
+              "D6"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D20",
+              "D22"
+            ]
+          ]
+        },
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 252,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 253,
+      "hex": "E9",
+      "tile": "19-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 254,
+      "hex": "F8",
+      "tile": "9-11",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 255,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G19",
+              "G21"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 256,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 257
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 258,
+      "user": 195,
+      "hex": "G7",
+      "tile": "611-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 259,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 260,
+      "user": 195,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "G9"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "G7",
+              "F8",
+              "E9",
+              "E11"
+            ],
+            [
+              "E11",
+              "D10",
+              "D8",
+              "C7",
+              "D6"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 261,
+      "user": 195,
+      "shares": [
+        "ERIE_8"
+      ],
+      "percent": 10,
+      "share_price": 137
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 262,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 263,
+      "user": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 264,
+      "hex": "F6",
+      "tile": "23-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 265,
+      "hex": "E5",
+      "tile": "8-13",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 266,
+      "city": "300-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 267,
+      "train": "6-3",
+      "price": 800,
+      "variant": "6"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 268,
+      "user": 195,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 269,
+      "shares": [
+        "B&O_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 270,
+      "user": 195,
+      "shares": [
+        "B&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 271,
+      "shares": [
+        "PRR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 272,
+      "user": 195,
+      "shares": [
+        "IC_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 273,
+      "shares": [
+        "IC_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 274,
+      "user": 195,
+      "shares": [
+        "PRR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 275,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 276,
+      "user": 195,
+      "shares": [
+        "PRR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 277
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 278,
+      "user": 195,
+      "shares": [
+        "PRR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 279
+    },
+    {
+      "type": "buy_shares",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 280,
+      "user": 195,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 195,
+      "entity_type": "player",
+      "id": 281
+    },
+    {
+      "type": "pass",
+      "entity": 377,
+      "entity_type": "player",
+      "id": 282,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 283,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "G7",
+              "F6",
+              "E7",
+              "D6"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 284,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 285,
+      "user": 195,
+      "hex": "D12",
+      "tile": "24-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 286,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 287,
+      "user": 195,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "D6",
+              "D8",
+              "E9",
+              "F10",
+              "F12",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E17",
+              "E15",
+              "D14"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "C15",
+              "C13",
+              "D12",
+              "E11"
+            ],
+            [
+              "G7",
+              "F8",
+              "E9",
+              "E11"
+            ],
+            [
+              "D6",
+              "E5",
+              "F6",
+              "G7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 288,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 289,
+      "user": 195,
+      "hex": "E9",
+      "tile": "45-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 290,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 291,
+      "user": 195,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "D20",
+              "D18",
+              "E17"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "G9"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "D6",
+              "C7",
+              "D8",
+              "E9",
+              "F8",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 292,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 293,
+      "user": 195
+    },
+    {
+      "type": "buy_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 294,
+      "shares": [
+        "B&O_4"
+      ],
+      "percent": 10,
+      "share_price": 165
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 295,
+      "hex": "H2",
+      "tile": "8-14",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 296,
+      "hex": "E17",
+      "tile": "290-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 297,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I1",
+              "I3",
+              "I5"
+            ],
+            [
+              "G7",
+              "H6",
+              "I5"
+            ],
+            [
+              "E11",
+              "E9",
+              "F8",
+              "G7"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G19",
+              "G21"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 298,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 299
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 300,
+      "routes": [
+        {
+          "train": "6-3",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "E11",
+              "E9",
+              "F8",
+              "G7"
+            ],
+            [
+              "G7",
+              "G5",
+              "H4",
+              "H2",
+              "I1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 301,
+      "kind": "payout"
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 302,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "G7",
+              "F6",
+              "E7",
+              "D6"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "E11"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 303,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 304,
+      "user": 195,
+      "hex": "D14",
+      "tile": "611-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 305,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 306,
+      "user": 195,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "E9",
+              "D8",
+              "D6"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        },
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "D14",
+              "E15",
+              "E17"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "C15",
+              "C13",
+              "D12",
+              "E11"
+            ],
+            [
+              "E11",
+              "E9",
+              "F8",
+              "G7"
+            ],
+            [
+              "D6",
+              "E5",
+              "F6",
+              "G7"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 307,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 308,
+      "user": 195,
+      "hex": "G9",
+      "tile": "611-3",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 309,
+      "user": 195
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 310,
+      "user": 195,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "G9",
+              "F10",
+              "F12",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "G9",
+              "G7"
+            ],
+            [
+              "D6",
+              "C7",
+              "D8",
+              "E9",
+              "F8",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 311,
+      "user": 195,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 312,
+      "user": 195
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 313
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 314,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I1",
+              "I3",
+              "I5"
+            ],
+            [
+              "G7",
+              "H6",
+              "I5"
+            ],
+            [
+              "E11",
+              "E9",
+              "F8",
+              "G7"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G19",
+              "G21"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 315,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 316
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 317,
+      "routes": [
+        {
+          "train": "6-3",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "E11",
+              "E9",
+              "F8",
+              "G7"
+            ],
+            [
+              "G7",
+              "G5",
+              "H4",
+              "H2",
+              "I1"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 318,
+      "kind": "payout"
+    }
+  ],
+  "loaded": true,
+  "created_at": 1601361252,
+  "updated_at": 1602775890
+}

--- a/spec/game_state_spec.rb
+++ b/spec/game_state_spec.rb
@@ -24,17 +24,75 @@ module Engine
     end
 
     describe '1846' do
-      describe 11_181 do
-        it 'is in the Stock Round' do
-          game = game_at_action(game_data, 51)
-
-          expect(game.round).to be_a(Round::Stock)
+      describe 19_962 do
+        it 'removes the reservation when a token is placed' do
+          game = game_at_action(game_data, 154)
+          city = game.hex_by_id('D20').tile.cities.first
+          corp = game.corporation_by_id('ERIE')
+          expect(city.reserved_by?(corp)).to be(false)
         end
 
-        it 'is in the Operating Round' do
-          game = game_at_action(game_data, 52)
+        it 'has correct reservations and tokens after NYC closes' do
+          game = game_at_action(game_data, 162)
+          city = game.hex_by_id('D20').tile.cities.first
+          erie = game.corporation_by_id('ERIE')
 
-          expect(game.round).to be_a(Round::Operating)
+          expect(city.reservations).to eq([nil, nil])
+          expect(city.tokens.map { |t| t&.corporation }).to eq([nil, erie])
+        end
+
+        it 'has a cert limit of 12 at the start of a 4p game' do
+          game = game_at_action(game_data, 0)
+          expect(game.cert_limit).to be(12)
+        end
+
+        it 'has a cert limit of 10 after a corporation closes' do
+          game = game_at_action(game_data, 162)
+          expect(game.cert_limit).to be(10)
+        end
+
+        it 'has a cert limit of 10 after a corporation closes and then a player is bankrupt' do
+          game = game_at_action(game_data, 405)
+          expect(game.cert_limit).to be(10)
+        end
+
+        it 'has a cert limit of 8 after a corporation closes, then a player is '\
+           'bankrupt, and then another corporation closes' do
+          game = game_at_action(game_data, 443)
+          expect(game.cert_limit).to be(8)
+        end
+      end
+    end
+
+    describe '1846 2p Variant' do
+      describe 11_098 do
+        it 'has both reservations at the start of the game' do
+          game = game_at_action(game_data, 0)
+          city = game.hex_by_id('D20').tile.cities.first
+          erie = game.corporation_by_id('ERIE')
+          nyc = game.corporation_by_id('NYC')
+
+          expect(city.reservations).to eq([nyc, erie])
+        end
+
+        it 'keeps the second slot reserved for ERIE when NYC floats' do
+          game = game_at_action(game_data, 11)
+          city = game.hex_by_id('D20').tile.cities.first
+          erie = game.corporation_by_id('ERIE')
+          nyc = game.corporation_by_id('NYC')
+
+          expect(city.reservations).to eq([nil, erie])
+          expect(city.tokens.map { |t| t&.corporation }).to eq([nyc, nil])
+        end
+
+        it 'ERIE\'s token does not replace NYC\'s when ERIE uses its reserved spot' do
+          game = game_at_action(game_data, 24)
+          city = game.hex_by_id('D20').tile.cities.first
+          erie = game.corporation_by_id('ERIE')
+          nyc = game.corporation_by_id('NYC')
+
+          expect(city.reservations).to eq([nil, nil])
+          expect(city.tokens.map { |t| t&.corporation }).to eq([nyc, erie])
         end
       end
     end

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -53,6 +53,12 @@ module Engine
         'Player 2' => 508,
         'Player 3' => 0,
       },
+      19_962 => {
+        'EAB' => 1828,
+        'DrAwesome' => 1910,
+        'Random Guy' => 1918,
+        'Talbatross' => 0,
+      },
     },
     GAMES_BY_TITLE['1846 2p Variant'] => {
       # This fixture tests all of the following behaviors, and should be
@@ -65,6 +71,10 @@ module Engine
       'hs_pzdxtics_1601680033' => {
         'A' => 4312,
         'B' => 2264,
+      },
+      11_098 => {
+        'yrael (GMT +0)' => 7331,
+        'Claramity' => 7624,
       },
     },
     GAMES_BY_TITLE['18 Los Angeles'] => {


### PR DESCRIPTION
Game 19962 is broken by the cert limit change, so for the fixture, instead of
allowing actions that violate the cert limit, add an `end_game` action and
remove the rest of the game's actions

[Fixes #2799]
[Fixes #2800]

This will require a small handful of games to be pinned; like the one reported in issues #2799 and #2800, they are 1846 games involving a bankruptcy and then corporation closure resulting in incorrect cert limit.