### PR TITLE
Connections performance improvement

### DIFF
--- a/lib/engine/connection.rb
+++ b/lib/engine/connection.rb
@@ -5,39 +5,25 @@ module Engine
     attr_reader :paths
 
     def self.connect!(hex)
-      connections = {}
-      node_paths = []
-      hex_edges = {}
-
       hex.tile.paths.each do |path|
-        path.walk { |p| node_paths << p if p.node? }
-      end
-
-      node_paths.uniq.each do |node_path|
-        node_path.walk(chain: []) do |chain|
+        path.walk(chain: []) do |chain|
           next unless valid_connection?(chain)
 
-          connection = Connection.new(chain)
-          connections[connection] = true
+          path = chain[0]
 
-          [chain[0], chain[-1]].each do |path|
-            hex = path.hex
-            if path.exits.empty?
-              hex_edges[[hex, :internal]] = true
-              hex.connections[:internal] << connection
-            else
-              path.exits.each do |edge|
-                hex_edges[[hex, edge]] = true
-                hex.connections[edge] << connection
-              end
+          connection = Connection.new(chain)
+
+          if path.exits.empty?
+            hex.connections_cached[:internal] << connection
+          else
+            path.exits.each do |edge|
+              hex.connections_cached[edge] << connection
             end
           end
         end
       end
 
-      hex_edges.keys.each do |hex_, edge|
-        connections = hex_.connections[edge]
-        connections.select!(&:valid?)
+      hex.connections_cached.values.each do |connections|
         connections.uniq!(&:hash)
       end
     end

--- a/lib/engine/connection.rb
+++ b/lib/engine/connection.rb
@@ -14,16 +14,16 @@ module Engine
           connection = Connection.new(chain)
 
           if path.exits.empty?
-            hex.connections_cached[:internal] << connection
+            hex.connections[:internal] << connection
           else
             path.exits.each do |edge|
-              hex.connections_cached[edge] << connection
+              hex.connections[edge] << connection
             end
           end
         end
       end
 
-      hex.connections_cached.values.each do |connections|
+      hex.connections.values.each do |connections|
         connections.uniq!(&:hash)
       end
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1554,8 +1554,6 @@ module Engine
             hex.neighbors[direction] = neighbor
           end
         end
-
-        @hexes.select { |h| h.tile.cities.any? || h.tile.exits.any? }.each(&:connect!)
       end
 
       def total_rounds(name)

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -8,7 +8,7 @@ module Engine
     include Assignable
 
     attr_accessor :x, :y, :ignore_for_axes, :location_name
-    attr_reader :connections, :coordinates, :empty, :layout, :neighbors, :tile, :original_tile
+    attr_reader :coordinates, :empty, :layout, :neighbors, :tile, :original_tile
 
     DIRECTIONS = {
       flat: {
@@ -72,6 +72,7 @@ module Engine
       @x, @y = self.class.init_x_y(@coordinates, axes)
       @neighbors = {}
       @connections = Hash.new { |h, k| h[k] = [] }
+      @connected = false
       @location_name = location_name
       tile.location_name = location_name
       @original_tile = @tile = tile
@@ -181,32 +182,40 @@ module Engine
 
       @tile = tile
 
-      @connections.clear
+      invalidate_connections
+      invalidate_connected
       @paths = nil
-
-      connect!
     end
 
-    def lay_downgrade(tile)
+    def invalidate_connected
       hexes = []
-
-      @tile.paths.each do |path|
-        path.walk { |p| hexes << p.hex if p.node? }
-      end
-
-      lay(tile)
-
-      hexes.uniq.each do |hex|
-        hex.connections.each do |_, connections|
-          connections.select!(&:valid?)
+      tile.paths.each do |path|
+        path.walk do |p|
+          hexes << p.hex
         end
       end
 
-      tile.restore_borders
+      hexes.uniq.each(&:invalidate_connections)
     end
 
-    def connect!
-      Connection.connect!(self)
+    def invalidate_connections
+      @connected = false
+      @connections.clear
+    end
+
+    def connections
+      connect unless @connected
+      @connections
+    end
+
+    def connections_cached
+      @connections
+    end
+
+    def lay_downgrade(tile)
+      lay(tile)
+
+      tile.restore_borders
     end
 
     def paths
@@ -223,7 +232,7 @@ module Engine
     end
 
     def all_connections
-      @connections.values.flatten.uniq.select(&:valid?)
+      connections.values.flatten.uniq.select(&:valid?)
     end
 
     def neighbor_direction(other)
@@ -256,6 +265,13 @@ module Engine
 
     def inspect
       "<#{self.class.name}: #{name}, tile: #{@tile.name}>"
+    end
+
+    private
+
+    def connect
+      @connected = true
+      Connection.connect!(self)
     end
   end
 end

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -208,10 +208,6 @@ module Engine
       @connections
     end
 
-    def connections_cached
-      @connections
-    end
-
     def lay_downgrade(tile)
       lay(tile)
 

--- a/spec/lib/engine/connection_spec.rb
+++ b/spec/lib/engine/connection_spec.rb
@@ -95,10 +95,10 @@ module Engine
 
         ritsurin_connection = subject.connections[2][1]
         expect(ritsurin_connection.nodes).to eq([
-          ritsurin.tile.towns[0],
           subject.tile.cities[0],
+          ritsurin.tile.towns[0],
         ])
-        expect(ritsurin_connection.hexes.map(&:name)).to eq(%w[J5 I6 I8 J7 K8])
+        expect(ritsurin_connection.hexes.map(&:name)).to eq(%w[K8 J7 I8 I6 J5])
         expect(game.hex_by_id('J7').all_connections).to be_empty
       end
 


### PR DESCRIPTION
Change connections calculation to on-demand rather than when connected.

When a tile is layed, it walks the paths invalidating the cache of connected tiles
When route requests the connections at that point it calculates them if the cache is not already calculated.

This also simplifies the downgrade case as it invalidates it anyway

Stackprof goes from 138.76 seconds for 100 runs to 103.32 on 15528 (25% reduction)
The connect! goes from 33.92% of CPU to 16% (3.117% disconnect + 12.848% connect)
Loading unoptimized goes from 16.47 seconds to 14.23 seconds (15% reduction)

improves #2533, I'm sure we can do extra improvements