### PR TITLE
🐞 Fix 2852 - 18CO Sell Order of Certs

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -540,7 +540,7 @@ module Engine
           shares.combination(n).to_a.map { |ss| Engine::ShareBundle.new(ss) }
         end
 
-        bundles.uniq(&:percent).sort_by(&:percent)
+        bundles.sort_by { |b| [b.presidents_share ? 1 : 0, b.percent, -b.shares.size] }.uniq(&:percent)
       end
 
       def purchasable_companies(entity = nil)


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/2852

This ensures that when selling, bundles with 10% shares are preferred, then 20% shares, then the presidency.

Otherwise you wind up with something weird like:

<img width="612" alt="Screen Shot 2020-12-28 at 10 32 53 AM" src="https://user-images.githubusercontent.com/15675400/103239206-0f4ae800-490a-11eb-9db2-0538d5f8ab83.png">
