### PR TITLE
1860 fix for upgrading plain track

### DIFF
--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -131,6 +131,9 @@ module Engine
             return true if hex.tile.cities.any? && reachable_city?(path_distances[npath], max_distance)
             return true if hex.tile.towns.any? { |t| !t.halt? } && reachable_town?(path_distances[npath], max_distance)
             return true if hex.tile.towns.any?(&:halt?) && reachable_halt?(path_distances[npath], max_distance)
+            if hex.tile.cities.empty? && hex.tile.towns.empty? && reachable_halt?(path_distances[npath], max_distance)
+              return true
+            end
           end
 
           false

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -131,9 +131,7 @@ module Engine
             return true if hex.tile.cities.any? && reachable_city?(path_distances[npath], max_distance)
             return true if hex.tile.towns.any? { |t| !t.halt? } && reachable_town?(path_distances[npath], max_distance)
             return true if hex.tile.towns.any?(&:halt?) && reachable_halt?(path_distances[npath], max_distance)
-            if hex.tile.cities.empty? && hex.tile.towns.empty? && reachable_halt?(path_distances[npath], max_distance)
-              return true
-            end
+            return true if hex.tile.nodes.empty? && reachable_halt?(path_distances[npath], max_distance)
           end
 
           false


### PR DESCRIPTION
I biffed refactoring available_hex when I refactored path_distances, node_distances and hex_distances to support the first edition town routing rules.

Fixes #2858 