### PR TITLE
Add train_limit ability for constant train limit

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -206,6 +206,7 @@ Modify train limit in some way.
 
 - `increase`: If positive, this will increase the train limit with this
   amount in all faces. Default 0.
+- `constant`: If positive, this is the train limit used. Default 0.
 
 ## token
 

--- a/lib/engine/ability/train_limit.rb
+++ b/lib/engine/ability/train_limit.rb
@@ -5,9 +5,10 @@ require_relative 'base'
 module Engine
   module Ability
     class TrainLimit < Base
-      attr_reader :increase
-      def setup(increase: nil)
+      attr_reader :increase, :constant
+      def setup(increase: nil, constant: nil)
         @increase = increase
+        @constant = constant
       end
     end
   end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -32,6 +32,9 @@ module Engine
     end
 
     def train_limit(entity)
+      limit = train_limit_constant(entity)
+      return limit if limit.positive?
+
       limit =
         if @train_limit.is_a?(Hash)
           @train_limit[entity.type] || 0
@@ -134,7 +137,12 @@ module Engine
     private
 
     def train_limit_increase(entity)
-      @game.abilities(entity, :train_limit) { |ability| return ability.increase }
+      @game.abilities(entity, :train_limit) { |ability| return ability.increase if ability.increase }
+      0
+    end
+
+    def train_limit_constant(entity)
+      @game.abilities(entity, :train_limit) { |ability| return ability.constant if ability.constant }
       0
     end
   end


### PR DESCRIPTION
Is typically used for minors that have a set train limit of one
or two all through the game.