### PR TITLE
Fix 2860 - 18CO Reservation Removal

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -443,7 +443,13 @@ module Engine
       def event_unreserve_home_stations!
         @log << '-- Event: Home station reservations removed --'
 
-        hexes.each { |h| h.tile.cities.each(&:remove_all_reservations!) }
+        @corporations.each do |corporation|
+          next if corporation.ipoed
+
+          tile = hex_by_id(corporation.coordinates).tile
+          city = tile.cities[corporation.city || 0]
+          city.remove_reservation!(corporation)
+        end
       end
 
       def tile_lays(_entity)


### PR DESCRIPTION
Fix: https://github.com/tobymao/18xx/issues/2860

It was possible for a corporation to be IPO'd then the Event Triggered before the corporation ever laid its home station. This allowed a different corp to block its home token, which isn't legal.