### PR TITLE
Allow for the Train Limit Ability to Stack

### DIFF
--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -137,8 +137,7 @@ module Engine
     private
 
     def train_limit_increase(entity)
-      @game.abilities(entity, :train_limit) { |ability| return ability.increase if ability.increase }
-      0
+      Array(@game.abilities(entity, :train_limit)).sum(&:increase)
     end
 
     def train_limit_constant(entity)


### PR DESCRIPTION
Fixes: https://github.com/tobymao/18xx/issues/2872

18CO grants a +1 limit for each takeover and thus a corporation can have multiple limit abilities.

After (with train limit 2):

<img width="227" alt="Screen Shot 2020-12-28 at 8 19 09 PM" src="https://user-images.githubusercontent.com/15675400/103292955-26421680-49ac-11eb-9381-f1470e363d8e.png">
