### PR TITLE
2672 - Stock Round - Denote corps with no actions

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -30,7 +30,8 @@ module View
 
         children << h(SellShares, player: @current_entity, corporation: @corporation)
 
-        h(:div, children.compact)
+        children = children.compact
+        h(:div, children) if children.any?
       end
 
       def render_buy_shares

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -31,7 +31,7 @@ module View
         children << h(SellShares, player: @current_entity, corporation: @corporation)
 
         children = children.compact
-        h(:div, children) if children.any?
+        return h(:div, children) if children.any?
 
         nil
       end

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -32,6 +32,8 @@ module View
 
         children = children.compact
         h(:div, children) if children.any?
+
+        nil
       end
 
       def render_buy_shares

--- a/assets/app/view/game/corporate_sell_shares.rb
+++ b/assets/app/view/game/corporate_sell_shares.rb
@@ -26,7 +26,7 @@ module View
               player: @entity,
               corporation: source,
               action: Engine::Action::CorporateSellShares),
-          ]
+        ].compact
         end
       end
     end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -39,10 +39,16 @@ module View
         card_style = {
           cursor: 'pointer',
         }
-        card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
+
         card_style[:display] = @display
 
-        card_style[:backgroundColor] = '#ededed' unless interactive?
+        unless interactive?
+          factor = Native(`window.matchMedia('(prefers-color-scheme: dark)').matches`) ? 0.8 : 0.5
+          card_style[:backgroundColor] = convert_hex_to_rgba(color_for(:bg2), factor)
+          card_style[:border] = '1px dashed'
+        end
+
+        card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
 
         if selected?
           card_style[:backgroundColor] = 'lightblue'

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -18,6 +18,7 @@ module View
       needs :game, store: true
       needs :display, default: 'inline-block'
       needs :selectable, default: true
+      needs :interactive, default: true
 
       def render
         select_corporation = lambda do
@@ -40,6 +41,8 @@ module View
         }
         card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
         card_style[:display] = @display
+
+        card_style[:backgroundColor] = '#ededed' unless interactive?
 
         if selected?
           card_style[:backgroundColor] = 'lightblue'
@@ -566,6 +569,10 @@ module View
 
       def selected?
         @corporation == @selected_corporation
+      end
+
+      def interactive?
+        @interactive
       end
 
       def can_assign_corporation?

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -42,8 +42,8 @@ module View
 
         card_style[:display] = @display
 
-        unless interactive?
-          factor = Native(`window.matchMedia('(prefers-color-scheme: dark)').matches`) ? 0.8 : 0.5
+        unless @interactive
+          factor = color_for(:bg2).to_s[1].to_i(16) > 7 ? 0.3 : 0.6
           card_style[:backgroundColor] = convert_hex_to_rgba(color_for(:bg2), factor)
           card_style[:border] = '1px dashed'
         end
@@ -575,10 +575,6 @@ module View
 
       def selected?
         @corporation == @selected_corporation
-      end
-
-      def interactive?
-        @interactive
       end
 
       def can_assign_corporation?

--- a/assets/app/view/game/emergency_money.rb
+++ b/assets/app/view/game/emergency_money.rb
@@ -20,7 +20,7 @@ module View
           corp = [h(Corporation, corporation: corporation)]
           corp << h(SellShares, player: player, corporation: corporation)
 
-          children << h(:div, props, corp)
+          children << h(:div, props, corp.compact)
         end
 
         if @game.round.actions_for(entity).include?('bankrupt') &&

--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -43,7 +43,7 @@ module View
             children << h(Corporation, corporation: corporation)
             children << h(BuySellShares, corporation: corporation)
             children << h(Player, game: @game, player: entity) if entity.player?
-            return h(:div, children)
+            return h(:div, children.compact)
           end
 
           buttons = []

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -81,21 +81,13 @@ module View
 
             children = []
             children.concat(render_subsidiaries)
-            children << h(Corporation, corporation: corporation)
 
-            if @game.corporation_available?(corporation)
-              input = render_input(corporation)
-            end
+            input = render_input(corporation) if @game.corporation_available?(corporation)
             choose = h(Choose) if @current_actions.include?('choose') && @step.choice_available?(corporation)
 
-            if input || choose
-              props['style']['opacity'] = '1.0'
-              children << input if input && @selected_corporation == corporation
-              children << choose if choose
-            else
-              props['style']['opacity'] = '0.6'
-            end
-
+            children << h(Corporation, corporation: corporation, interactive: input || choose)
+            children << input if input && @selected_corporation == corporation
+            children << choose if choose
 
             h(:div, props, children)
           end.compact
@@ -107,9 +99,7 @@ module View
             render_loan(corporation),
             render_buy_tokens(corporation),
           ]
-          if @step.actions(corporation).include?('buy_shares')
-            inputs << h(IssueShares, entity: corporation)
-          end
+          inputs << h(IssueShares, entity: corporation) if @step.actions(corporation).include?('buy_shares')
           inputs = inputs.compact
           h('div.margined_bottom', { style: { width: '20rem' } }, inputs) if inputs.any?
         end
@@ -120,9 +110,7 @@ module View
           when :par
             return h(Par, corporation: corporation) if @current_actions.include?('par')
           when :bid
-            if @current_actions.include?('bid')
-              return h(Bid, entity: @current_entity, corporation: corporation)
-            end
+            return h(Bid, entity: @current_entity, corporation: corporation) if @current_actions.include?('bid')
           when String
             return h(:div, type)
           end

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -46,7 +46,8 @@ module View
           end
         end
 
-        h(:div, buttons.compact)
+        buttons = buttons.compact
+        h(:div, buttons) if buttons.any?
       end
 
       private

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -48,6 +48,8 @@ module View
 
         buttons = buttons.compact
         h(:div, buttons) if buttons.any?
+
+        nil
       end
 
       private

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -47,7 +47,7 @@ module View
         end
 
         buttons = buttons.compact
-        h(:div, buttons) if buttons.any?
+        return h(:div, buttons) if buttons.any?
 
         nil
       end


### PR DESCRIPTION
Closes https://github.com/tobymao/18xx/issues/2672

The active player has no buy/sell/choose actions for the corps with a light gray background.

<img width="1357" alt="Screen Shot 2020-12-29 at 11 29 40 AM" src="https://user-images.githubusercontent.com/15675400/103318534-f4e93b00-49eb-11eb-8c9a-70e2e821c6d8.png">

We could do more with this like disable selectable and turn the cursor hand to pointer, but I didn't want to make assumptions about why someone might need to select a corp..