### PR TITLE
1867 bug sweep

### DIFF
--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -790,8 +790,7 @@ module Engine
         {
           "nodes": ["city", "offboard"],
           "pay": 2,
-          "visit": 2,
-          "multiplier":2
+          "visit": 2
         },
         {
           "nodes": ["town"],
@@ -799,6 +798,7 @@ module Engine
           "visit": 99
         }
       ],
+      "multiplier":2,
       "price": 600,
       "num": 6,
       "available_on": "8"

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -144,7 +144,7 @@ module Engine
     "X5": {
       "count": 1,
       "color": "brown",
-      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:3,b:_1;path=a:_0,b:_1;label=M"
+      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_1;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_1;path=a:4,b:_0;path=a:5,b:_0;label=M"
     },
     "X6": {
       "count": 1,
@@ -154,7 +154,7 @@ module Engine
     "X7": {
       "count": 1,
       "color": "brown",
-      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:2,b:_1;path=a:4,b:_1;label=M"
+      "code": "city=revenue:70,slots:2;city=revenue:70;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_0;path=a:4,b:_1;path=a:5,b:_0;label=M"
     },
     "X8": {
       "count": 1,
@@ -293,6 +293,7 @@ module Engine
       "name": "Canadian Northern Railway",
       "logo": "1867/CNR",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -306,6 +307,7 @@ module Engine
       "name": "Canadian Pacific Railway",
       "logo": "1867/CPR",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -319,6 +321,7 @@ module Engine
       "name": "Chesapeake and Ohio Railway",
       "logo": "1867/CO",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -332,6 +335,7 @@ module Engine
       "name": "Grand Trunk Railway",
       "logo": "1867/GTR",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -345,6 +349,7 @@ module Engine
       "name": "Great Western Railway",
       "logo": "1867/GWR",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -358,6 +363,7 @@ module Engine
       "name": "Intercolonial Railway",
       "logo": "1867/ICR",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -371,6 +377,7 @@ module Engine
       "name": "National Transcontinental Railway",
       "logo": "1867/NTR",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -384,6 +391,7 @@ module Engine
       "name": "New York Central Railroad",
       "logo": "1867/NYC",
       "float_percent": 20,
+      "always_market_price": true,
       "tokens": [
         0,
         20,
@@ -397,6 +405,7 @@ module Engine
       "name": "Buffalo, Brantford, and Goderich",
       "logo": "1867/BBG",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -410,6 +419,7 @@ module Engine
       "name": "Brockville and Ottawa",
       "logo": "1867/BO",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -423,6 +433,7 @@ module Engine
       "name": "Canada Southern",
       "logo": "1867/CS",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -436,6 +447,7 @@ module Engine
       "name": "Credit Valley Railway",
       "logo": "1867/CV",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -449,6 +461,7 @@ module Engine
       "name": "Kingston and Pembroke",
       "logo": "1867/KP",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -462,6 +475,7 @@ module Engine
       "name": "London and Port Stanley",
       "logo": "1867/LPS",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -475,6 +489,7 @@ module Engine
       "name": "Ottawa and Prescott",
       "logo": "1867/OP",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -488,6 +503,7 @@ module Engine
       "name": "St. Lawrence and Atlantic",
       "logo": "1867/SLA",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -501,6 +517,7 @@ module Engine
       "name": "Toronto, Grey, and Bruce",
       "logo": "1867/TGB",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -514,6 +531,7 @@ module Engine
       "name": "Toronto and Nipissing",
       "logo": "1867/TN",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -527,6 +545,7 @@ module Engine
       "name": "Algoma Eastern Railway",
       "logo": "1867/AE",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -540,6 +559,7 @@ module Engine
       "name": "Canada Atlantic Railway",
       "logo": "1867/CA",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -553,6 +573,7 @@ module Engine
       "name": "New York and Ottawa",
       "logo": "1867/NO",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -566,6 +587,7 @@ module Engine
       "name": "Pere Marquette Railway",
       "logo": "1867/PM",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -579,6 +601,7 @@ module Engine
       "name": "Quebec and Lake St. John",
       "logo": "1867/QLS",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -592,6 +615,7 @@ module Engine
       "name": "Toronto, Hamilton and Buffalo",
       "logo": "1867/THB",
       "float_percent": 100,
+      "always_market_price": true,
       "tokens": [
         0
       ],
@@ -793,6 +817,7 @@ module Engine
           "visit": 99
         }
       ],
+      "multiplier": 2,
       "price": 1500,
       "num": 7,
       "available_on": "8"

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -256,7 +256,7 @@ module Engine
 
         route.corporation.companies.each do |company|
           abilities(company, :hex_bonus) do |ability|
-            revenue += stops.map { |s| s.hex.id }.uniq.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
+            revenue += stops.map { |s| s.hex.id }.uniq&.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
           end
         end
 
@@ -447,12 +447,10 @@ module Engine
           case hex.id
           when 'D2'
             token = Token.new(@cn_corporation, price: 0, logo: '/logos/1867/neutral.svg', type: :neutral)
-            @cn_corporation.tokens << token
             hex.tile.cities.first.exchange_token(token)
             @green_tokens << token
           when 'L12'
             token = Token.new(@cn_corporation, price: 0, logo: '/logos/1867/neutral.svg', type: :neutral)
-            @cn_corporation.tokens << token
             hex.tile.cities.last.exchange_token(token)
             @green_tokens << token
           when 'F16'

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -175,7 +175,7 @@ module Engine
         return entity.cash unless entity.corporation?
 
         # Loans are actually generate $5 less than when taken out.
-        entity.cash + ((maximum_loans(entity) - entity.loans.size) * @loan_value - 5)
+        entity.cash + ((maximum_loans(entity) - entity.loans.size) * (@loan_value - 5))
       end
 
       def unstarted_corporation_summary

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -34,7 +34,7 @@ module Engine
       HOME_TOKEN_TIMING = :float
       MUST_BID_INCREMENT_MULTIPLE = true
       MUST_BUY_TRAIN = :always # mostly true, needs custom code
-      POOL_SHARE_DROP = :each
+      POOL_SHARE_DROP = :none
       SELL_MOVEMENT = :left_block_pres
       ALL_COMPANIES_ASSIGNABLE = true
       SELL_AFTER = :operate

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -265,7 +265,7 @@ module Engine
         # Timmins
         timmins = stops.find { |stop| stop.hex.name == 'D2' }
 
-        revenue += 40 if capitals && timmins
+        revenue += 40 * (route.train.multiplier || 1) if capitals && timmins
 
         revenue
       end
@@ -316,8 +316,10 @@ module Engine
 
         remaining_stops = mandatory_distance['pay'] - mandatory_stops.size
 
-        # Allocate optional stops
-        stops, revenue = optional_stops.combination(remaining_stops.to_i).map do |stops|
+        # Allocate optional stops, combination returns nothing if stops doesn't cover the remaining stops
+        combinations = optional_stops.combination(remaining_stops.to_i).to_a
+        combinations = [optional_stops] if combinations.empty?
+        stops, revenue = combinations.map do |stops|
           # Make sure this set of stops is legal
           # 1) At least one stop must have a token (for 5+5E train)
           next if need_token && stops.none? { |stop| stop.tokened_by?(route.corporation) }

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -371,6 +371,7 @@ module Engine
       def or_round_finished
         current_phase = phase.name.to_i
         depot.export! if current_phase >= 4 && current_phase <= 7
+        post_train_buy
       end
 
       def new_or!

--- a/lib/engine/step/g_1867/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1867/buy_sell_par_shares.rb
@@ -121,7 +121,7 @@ module Engine
         end
 
         def max_bid(player, _corporation = nil)
-          [MAX_BID, player.cash].min
+          player.cash
         end
 
         def pass_description

--- a/lib/engine/step/g_1867/merge.rb
+++ b/lib/engine/step/g_1867/merge.rb
@@ -64,13 +64,14 @@ module Engine
           owner = corporation.owner
 
           @converting = nil
-          @game.close_corporation(corporation)
 
           share = target.shares.first
           @game.share_pool.buy_shares(owner, share.to_bundle, exchange: :free)
 
           move_tokens(corporation, target)
           receiving = move_assets(corporation, target)
+
+          @game.close_corporation(corporation)
 
           @log << "#{corporation.name} converts into #{target.name} receiving #{receiving.join(', ')}"
 


### PR DESCRIPTION
Maybe a few too many fixes :)

Share price should always be market price (fixes #2890)
Bidding for minors has no max price (fixes #2886)
5+5E train isn't doubled (fixes #2880)
Don't lay green tokens (fixes #2879)
Minor conversion shouldn't close minor (fixes #2874)
X5 and X7 are incorrect (fixes #2861)
Correct share drop behavior (fixes #2894)
Run nationalization code at export (fixes #2899)
Fix liquidity calculation (fixes #2889)
Fix selecting 5+5E paths when number of stops < 5 (fixes #2882)
Fix doubling of Timmons on multiplier 2 trains (fixes #2881)