### PR TITLE
game title sorting tweaks

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -269,7 +269,8 @@ module Engine
       end
 
       def self.<=>(other)
-        [DEV_STAGES.index(self::DEV_STAGE), title] <=> [DEV_STAGES.index(other::DEV_STAGE), other.title]
+        [DEV_STAGES.index(self::DEV_STAGE), title.sub(/18\s+/, '18').downcase] <=>
+          [DEV_STAGES.index(other::DEV_STAGE), other.title.sub(/18\s+/, '18').downcase]
       end
 
       def self.register_colors(colors)


### PR DESCRIPTION
* moves 18 Los Angeles to where "18LosAngeles" would fit
* ignore case, so 18Chesapeake is before 18CO