### PR TITLE
Fix for 1817 coal mine on track lay connecting to a town, closes #2846

### DIFF
--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -56,11 +56,12 @@ module Engine
             ntile = neighbor&.tile
             next false unless ntile
 
-            # The neighbouring tile must have a city or offboard
+            # The neighbouring tile must have a city or offboard or town
             # That neighbouring tile must either connect to an edge on the tile or
             # potentially be updated in future.
             (ntile.cities&.any? ||
-             ntile.offboards&.any?) &&
+             ntile.offboards&.any? ||
+             ntile.towns&.any?) &&
             (ntile.exits.any? { |e| e == Hex.invert(exit) } ||
              potential_future_tiles(entity, neighbor).any?)
           end


### PR DESCRIPTION
See Issue for details, essentially this is a fix to allow laying coal on track heading into a town (klondike) which is likely marked as such for visual purposes.

![area](https://user-images.githubusercontent.com/2993555/103253508-8a82bd00-494f-11eb-9585-2a85c873b984.png)