### PR TITLE
18CO Takeover - Remove Redundant Tokens from Hex not City

### DIFF
--- a/lib/engine/step/g_18_co/takeover.rb
+++ b/lib/engine/step/g_18_co/takeover.rb
@@ -154,13 +154,13 @@ module Engine
           return if source.placed_tokens.empty?
           return if destination.unplaced_tokens.empty?
 
-          destination_cities = destination.tokens.map(&:city).compact
+          destination_hexes = destination.tokens.map { |token| token&.city&.hex }.compact
 
           source.tokens.each do |token|
             next unless token.used
 
             token.city&.remove_reservation!(source)
-            token.remove! if destination_cities.include?(token.city)
+            token.remove! if destination_hexes.include?(token.city.hex)
           end
         end
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/2903 and will definitely break that game.

Remove any owned Station Tokens in hexes containing the owning Corporation’s Station tokens.

The original code was only examining the city, not the hex.