### PR TITLE
allow games to catch and store exceptions when processing actions

### DIFF
--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -34,6 +34,13 @@ module View
       def process_action(action)
         hotseat = @game_data[:mode] == :hotseat
 
+        if @game.exception
+          msg = 'This game is broken and cannot accept any new actions. If '\
+                'this issue has not already been reported, please follow the '\
+                'instructions at the top of the page to report it.'
+          return store(:flash_opts, msg)
+        end
+
         if Lib::Params['action']
           return store(:flash_opts, 'You cannot make changes while browsing history.
             Press >| to navigate to the current game action.')

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -30,10 +30,18 @@ module View
             end
           divs << history_link('<<', 'Previous Round', last_round, style_extra) if last_round
 
-          divs << history_link('<', 'Previous Action', cursor ? cursor - 1 : @num_actions - 1, style_extra)
+          prev_action =
+            if @game.exception
+              @game.last_processed_action
+            elsif cursor
+              cursor - 1
+            else
+              @num_actions - 1
+            end
+          divs << history_link('<', 'Previous Action', prev_action, style_extra)
         end
 
-        if cursor
+        if cursor && !@game.exception
           divs << history_link('>', 'Next Action', cursor + 1 < @num_actions ? cursor + 1 : nil, style_extra)
           store(:round_history, @game.round_history, skip: true) unless @round_history
           next_round = @round_history[@game.round_history.size]

--- a/lib/engine/g_1856/share_pool.rb
+++ b/lib/engine/g_1856/share_pool.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../game_error'
 require_relative '../share_pool'
 
 module Engine
@@ -9,7 +10,7 @@ module Engine
         bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
 
         if !@game.class::CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT && shares.owner.player?
-          @game.game_error('Cannot buy share from player')
+          raise GameError, 'Cannot buy share from player'
         end
 
         corporation = bundle.corporation

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -265,7 +265,7 @@ module Engine
 
         tracks_by_type.each do |_type, tracks|
           tracks.group_by(&:itself).each do |k, v|
-            @game.game_error("Route cannot reuse track on #{k[0].id}") if v.size > 1
+            raise GameError, "Route cannot reuse track on #{k[0].id}" if v.size > 1
           end
         end
       end

--- a/lib/engine/game_error.rb
+++ b/lib/engine/game_error.rb
@@ -2,10 +2,5 @@
 
 module Engine
   class GameError < RuntimeError
-    attr_accessor :action_id
-    def initialize(msg, action_id = nil)
-      @action_id = action_id
-      super(msg)
-    end
   end
 end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -91,7 +91,7 @@ module Engine
 
           blocking || process
         end
-        @game.game_error("No step found for action #{type} at #{action.id}: #{action.to_h}") unless step
+        raise GameError, "No step found for action #{type} at #{action.id}: #{action.to_h}" unless step
 
         step.acted = true
         step.send("process_#{action.type}", action)

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -85,7 +85,9 @@ module Engine
 
           process = s.actions(action.entity).include?(type)
           blocking = s.blocking?
-          @game.game_error("Step #{s.description} cannot process #{action.to_h}") if blocking && !process
+          if blocking && !process
+            raise GameError, "Blocking step #{s.description} cannot process action #{action['id']}"
+          end
 
           blocking || process
         end

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -156,7 +156,7 @@ module Engine
       @connections.each do |c|
         right = c[:right]
         cycles[c[:left]] = true
-        @game.game_error("Cannot use #{right.hex.name} twice") if cycles[right]
+        raise GameError, "Cannot use #{right.hex.name} twice" if cycles[right]
 
         cycles[right] = true
       end
@@ -180,7 +180,7 @@ module Engine
     def check_terminals!
       return if paths.size < 3
 
-      @game.game_error('Route cannot pass through terminal') if ordered_paths[1..-2].any?(&:terminal?)
+      raise GameError, 'Route cannot pass through terminal' if ordered_paths[1..-2].any?(&:terminal?)
     end
 
     def distance
@@ -204,9 +204,9 @@ module Engine
       return @override[:revenue] if @override
 
       visited = visited_stops
-      @game.game_error('Route must have at least 2 stops') if @connections.any? && visited.size < 2
+      raise GameError, 'Route must have at least 2 stops' if @connections.any? && visited.size < 2
       unless (token = visited.find { |stop| @game.city_tokened_by?(stop, corporation) })
-        @game.game_error('Route must contain token')
+        raise GameError, 'Route must contain token'
       end
 
       check_distance!(visited)
@@ -217,7 +217,7 @@ module Engine
       check_other!
 
       visited.flat_map(&:groups).flatten.group_by(&:itself).each do |key, group|
-        @game.game_error("Cannot use group #{key} more than once") unless group.one?
+        raise GameError, "Cannot use group #{key} more than once" unless group.one?
       end
 
       @game.revenue_for(self, stops)

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -32,7 +32,7 @@ module Engine
       bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
 
       if !@game.class::CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT && shares.owner.player?
-        @game.game_error('Cannot buy share from player')
+        raise GameError, 'Cannot buy share from player'
       end
 
       corporation = bundle.corporation

--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -85,13 +85,14 @@ module Engine
         entity = bid.entity
         price = bid.price
         min = min_bid(company)
-        @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{company.name}") if price < min
+        raise GameError, "Minimum bid is #{@game.format_currency(min)} for #{company.name}" if price < min
         if @game.class::MUST_BID_INCREMENT_MULTIPLE && ((price - min) % @game.class::MIN_BID_INCREMENT).nonzero?
-          @game.game_error("Must increase bid by a multiple of #{@game.class::MIN_BID_INCREMENT}")
+          raise GameError, "Must increase bid by a multiple of #{@game.class::MIN_BID_INCREMENT}"
         end
         if price > max_bid(entity, company)
-          @game.game_error("Cannot afford bid. Maximum possible bid is #{max_bid(entity, company)}")
+          raise GameError, "Cannot afford bid. Maximum possible bid is #{max_bid(entity, company)}"
         end
+
         bids = @bids[company]
         bids.reject! { |b| b.entity == entity }
         bids << bid

--- a/lib/engine/step/bankrupt.rb
+++ b/lib/engine/step/bankrupt.rb
@@ -32,7 +32,7 @@ module Engine
           msg = "Cannot go bankrupt. #{corp.name}'s cash plus #{player.name}'s cash and "\
                 "sellable shares total #{buying_power}, and the cheapest train in the "\
                 "Depot costs #{price}."
-          @game.game_error(msg)
+          raise GameError, msg
         end
 
         @log << "-- #{player.name} goes bankrupt and sells remaining shares --"

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -51,12 +51,12 @@ module Engine
         price = action.price
         owner = company.owner
 
-        @game.game_error("Cannot buy #{company.name} from #{owner.name}") if owner.is_a?(Corporation)
+        raise GameError, "Cannot buy #{company.name} from #{owner.name}" if owner.is_a?(Corporation)
 
         min = company.min_price
         max = company.max_price
         unless price.between?(min, max)
-          @game.game_error("Price must be between #{@game.format_currency(min)} and #{@game.format_currency(max)}")
+          raise GameError, "Price must be between #{@game.format_currency(min)} and #{@game.format_currency(max)}"
         end
 
         log_later = []

--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -41,12 +41,12 @@ module Engine
         if action.train.owned_by_corporation?
           min, max = spend_minmax(action.entity, action.train)
           unless (min..max).include?(action.price)
-            @game.game_error("#{action.entity.name} may not spend "\
+            raise GameError, "#{action.entity.name} may not spend "\
                              "#{@game.format_currency(action.price)} on "\
                              "#{action.train.owner.name}'s #{action.train.name} "\
                              'train; may only spend between '\
                              "#{@game.format_currency(min)} and "\
-                             "#{@game.format_currency(max)}.")
+                             "#{@game.format_currency(max)}."
           end
         end
 

--- a/lib/engine/step/corporate_sell_shares.rb
+++ b/lib/engine/step/corporate_sell_shares.rb
@@ -52,7 +52,7 @@ module Engine
       end
 
       def sell_shares(entity, shares, swap: nil)
-        @game.game_error("Cannot sell shares of #{shares.corporation.name}") if !can_sell?(entity, shares) && !swap
+        raise GameError, "Cannot sell shares of #{shares.corporation.name}" if !can_sell?(entity, shares) && !swap
 
         @game.sell_shares_and_change_price(shares, swap: swap)
       end

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -7,7 +7,7 @@ module Engine
     module EmergencyMoney
       def process_sell_shares(action)
         unless can_sell?(action.entity, action.bundle)
-          @game.game_error("Cannot sell shares of #{action.bundle.corporation.name}")
+          raise GameError, "Cannot sell shares of #{action.bundle.corporation.name}"
         end
 
         @game.sell_shares_and_change_price(action.bundle)

--- a/lib/engine/step/exchange.rb
+++ b/lib/engine/step/exchange.rb
@@ -24,7 +24,7 @@ module Engine
         company = action.entity
         bundle = action.bundle
         unless can_exchange?(company, bundle)
-          @game.game_error("Cannot exchange #{action.entity.id} for #{bundle.corporation.id}")
+          raise GameError, "Cannot exchange #{action.entity.id} for #{bundle.corporation.id}"
         end
 
         buy_shares(company.owner, bundle, exchange: company)

--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -192,12 +192,10 @@ module Engine
           acquired_corp = @winner.corporation
 
           if !buyer || !mergeable(acquired_corp).include?(buyer)
-            @game.game_error("Choose a corporation to acquire #{acquired_corp.name}")
+            raise GameError, "Choose a corporation to acquire #{acquired_corp.name}"
           end
 
-          if buyer.owner != @winner.entity
-            @game.game_error("Target corporation must be owned by #{@winner.entity.name}")
-          end
+          raise GameError, "Target corporation must be owned by #{@winner.entity.name}" if buyer.owner != @winner.entity
 
           @buyer = buyer
 
@@ -436,7 +434,8 @@ module Engine
           corporation = action.corporation
           price = action.price
 
-          @game.game_error("Bid #{price} is not a multple of 10") unless (price % 10).zero?
+          raise GameError, "Bid #{price} is not a multple of 10" unless (price % 10).zero?
+
           @log << "#{entity.name} bids #{@game.format_currency(price)} for #{corporation.name}"
           add_bid(action)
           resolve_bids
@@ -444,8 +443,8 @@ module Engine
 
         def process_assign(action)
           corporation = action.target
-          @game.game_error("Can only assign if offering for sale #{corporation.name}") unless @mode == :offered
-          @game.game_error("Can only offer up #{@offer.name}") unless corporation == @offer
+          raise GameError, "Can only assign if offering for sale #{corporation.name}" unless @mode == :offered
+          raise GameError, "Can only offer up #{@offer.name}" unless corporation == @offer
 
           @game.log << "#{corporation.name} is offered at auction, buying corporation will receive "\
             "#{@game.format_currency(treasury_share_compensation(corporation))} for treasury shares"

--- a/lib/engine/step/g_1817/assign.rb
+++ b/lib/engine/step/g_1817/assign.rb
@@ -11,13 +11,14 @@ module Engine
           target = action.target
 
           unless (ability = @game.abilities(company, :assign_hexes))
-            @game.game_error("Could not assign #{company.name} to #{target.name}; :assign_hexes ability not found")
+            raise GameError, "Could not assign #{company.name} to #{target.name}; :assign_hexes ability not found"
           end
 
           case company.id
           when 'UBC', 'OBC'
             id = 'bridge'
-            @game.game_error("Bridge already on #{target.name}") if target.assigned?(id)
+            raise GameError, "Bridge already on #{target.name}" if target.assigned?(id)
+
             target.assign!(id)
             ability.use!
             @log << "#{company.name} builds bridge on #{target.name}"

--- a/lib/engine/step/g_1817/conversion.rb
+++ b/lib/engine/step/g_1817/conversion.rb
@@ -66,7 +66,7 @@ module Engine
           target = action.corporation
 
           if !target || !mergeable(corporation).include?(target)
-            @game.game_error("Choose a corporation to merge with #{corporation.name}")
+            raise GameError, "Choose a corporation to merge with #{corporation.name}"
           end
 
           receiving = []

--- a/lib/engine/step/g_1817/loan.rb
+++ b/lib/engine/step/g_1817/loan.rb
@@ -45,7 +45,7 @@ module Engine
           entity = action.entity
           loan = action.loan
           amount = loan.amount
-          @game.game_error("Loan doesn't belong to that entity") unless entity.loans.include?(loan)
+          raise GameError, "Loan doesn't belong to that entity" unless entity.loans.include?(loan)
 
           @log << "#{entity.name} pays off a loan for #{@game.format_currency(amount)}"
           entity.spend(amount, @game.bank)

--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -17,7 +17,8 @@ module Engine
             owner = action.entity.owner
             tile_lay = step.get_tile_lay(owner)
             tile = action.tile
-            @game.game_error('Cannot lay an yellow now') if tile.color == :yellow && !tile_lay[:lay]
+            raise GameError, 'Cannot lay an yellow now' if tile.color == :yellow && !tile_lay[:lay]
+
             # Subtract 15 from the cost cancelling the terrain cost
             lay_tile(action, extra_cost: tile_lay[:cost] - 15, entity: owner, spender: owner)
             tile.hex.assign!('mine')
@@ -56,12 +57,11 @@ module Engine
             ntile = neighbor&.tile
             next false unless ntile
 
-            # The neighbouring tile must have a city or offboard or town
+            # The neighbouring tile must have a city or offboard
             # That neighbouring tile must either connect to an edge on the tile or
             # potentially be updated in future.
             (ntile.cities&.any? ||
-             ntile.offboards&.any? ||
-             ntile.towns&.any?) &&
+             ntile.offboards&.any?) &&
             (ntile.exits.any? { |e| e == Hex.invert(exit) } ||
              potential_future_tiles(entity, neighbor).any?)
           end

--- a/lib/engine/step/g_1817/track.rb
+++ b/lib/engine/step/g_1817/track.rb
@@ -16,8 +16,9 @@ module Engine
         end
 
         def lay_tile(action, extra_cost: 0, entity: nil)
-          @game.game_error('Cannot lay and upgrade the same tile in the same turn') if action.hex == @hex
-          @game.game_error('Cannot upgrade mines') if action.hex.assigned?('mine')
+          raise GameError, 'Cannot lay and upgrade the same tile in the same turn' if action.hex == @hex
+          raise GameError, 'Cannot upgrade mines' if action.hex.assigned?('mine')
+
           super
           @hex = action.hex
 

--- a/lib/engine/step/g_1817_wo/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817_wo/buy_sell_par_shares.rb
@@ -9,9 +9,10 @@ module Engine
         def process_choose(action)
           size = action.choice
           entity = action.entity
-          @game.game_error('Corporation size is invalid') unless choices.include?(size)
+          raise GameError, 'Corporation size is invalid' unless choices.include?(size)
+
           corporation = @winning_bid.corporation
-          @game.game_error('Corporation in Nieuw Zeeland must be 5 or 10 share corporation') if
+          raise GameError, 'Corporation in Nieuw Zeeland must be 5 or 10 share corporation' if
             @game.corp_has_new_zealand?(corporation) && size == 2
 
           size_corporation(size)
@@ -28,7 +29,8 @@ module Engine
         def process_buy_tokens(action)
           # Buying tokens is not an 'action' and so can be done with player actions
           entity = action.entity
-          @game.game_error('Cannot buy tokens') unless can_buy_tokens?(entity)
+          raise GameError, 'Cannot buy tokens' unless can_buy_tokens?(entity)
+
           tokens = @game.tokens_needed(entity)
           token_cost = tokens * TOKEN_COST
           entity.spend(token_cost, @game.bank)

--- a/lib/engine/step/g_1828/buy_special.rb
+++ b/lib/engine/step/g_1828/buy_special.rb
@@ -16,7 +16,7 @@ module Engine
 
         def process_buy_special(action)
           item = action.item
-          @game.game_error("Cannot buy unknown item: #{item.description}") if item != @items.first
+          raise GameError, "Cannot buy unknown item: #{item.description}" if item != @items.first
 
           @game.buy_coal_marker(action.entity)
         end

--- a/lib/engine/step/g_1828/route.rb
+++ b/lib/engine/step/g_1828/route.rb
@@ -8,11 +8,11 @@ module Engine
       class Route < Route
         def process_run_routes(action)
           if route_includes_coalfields?(action.routes) && !@game.coal_marker?(action.entity)
-            @game.game_error('Cannot run to Virginia Coalfields without a Coal Marker')
+            raise GameError, 'Cannot run to Virginia Coalfields without a Coal Marker'
           end
 
           if action.entity.id == 'C&P' && !route_uses_tile_lay(action.routes)
-            @game.game_error("#{action.entity.name} must use laid tile in route")
+            raise GameError, "#{action.entity.name} must use laid tile in route"
           end
 
           super

--- a/lib/engine/step/g_1828/special_token.rb
+++ b/lib/engine/step/g_1828/special_token.rb
@@ -39,7 +39,7 @@ module Engine
         def process_pass(action)
           entity = action.entity
           ability = @game.abilities(@company, :token, time: 'sold')
-          @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+          raise GameError, "Not #{entity.name}'s turn: #{action.to_h}" unless entity == @company
 
           hex = @game.hex_by_id(ability.hexes.first)
           @log << "#{entity.owner.name} passes placing a token on #{hex.name} (#{hex.location_name})"

--- a/lib/engine/step/g_1828/special_track.rb
+++ b/lib/engine/step/g_1828/special_track.rb
@@ -14,7 +14,8 @@ module Engine
         def process_lay_tile(action)
           if action.entity.id == 'E&K' && !@company
             track_step = @round.steps.find { |step| step.is_a?(Track) }
-            @game.game_error("Cannot use #{action.entity.name} after a tile upgrade") if track_step.upgraded
+            raise GameError, "Cannot use #{action.entity.name} after a tile upgrade" if track_step.upgraded
+
             track_step.no_upgrades = true
           end
 

--- a/lib/engine/step/g_1828/token.rb
+++ b/lib/engine/step/g_1828/token.rb
@@ -10,11 +10,9 @@ module Engine
         include TokenTracker
 
         def place_token(entity, city, token, teleport: false)
-          if city.hex.name == Engine::Game::G1828::VA_COALFIELDS_HEX
-            @game.game_error("#{city.hex.location_name} may not be tokened")
-          else
-            super
-          end
+          return super if city.hex.name != Engine::Game::G1828::VA_COALFIELDS_HEX
+
+          raise GameError, "#{city.hex.location_name} may not be tokened"
         end
       end
     end

--- a/lib/engine/step/g_1846/assign.rb
+++ b/lib/engine/step/g_1846/assign.rb
@@ -102,7 +102,7 @@ module Engine
         end
 
         def process_pass(action)
-          @game.game_error("Not #{action.entity.name}'s turn: #{action.to_h}") unless action.entity == @steamboat
+          raise GameError, "Not #{action.entity.name}'s turn: #{action.to_h}" unless action.entity == @steamboat
 
           if (ability = @game.abilities(@steamboat, :assign_hexes))
             ability.use!

--- a/lib/engine/step/g_1846/bankrupt.rb
+++ b/lib/engine/step/g_1846/bankrupt.rb
@@ -18,7 +18,7 @@ module Engine
                   "sellable shares total #{buying_power}, and the cheapest train in the "\
                   "Depot costs #{price}."
 
-            @game.game_error(msg)
+            raise GameError, msg
           end
 
           @log << "-- #{player.name} goes bankrupt and sells remaining shares --"

--- a/lib/engine/step/g_1846/buy_company.rb
+++ b/lib/engine/step/g_1846/buy_company.rb
@@ -29,7 +29,7 @@ module Engine
           company = action.company
           return unless (minor = @game.minor_by_id(company.id))
 
-          @game.game_error('Cannot buy minor because train tight') unless room?(entity)
+          raise GameError, 'Cannot buy minor because train tight' unless room?(entity)
 
           cash = minor.cash
           minor.spend(cash, entity) if cash.positive?

--- a/lib/engine/step/g_1846/buy_train.rb
+++ b/lib/engine/step/g_1846/buy_train.rb
@@ -40,7 +40,7 @@ module Engine
           return process_issue_shares(action) if action.entity.corporation?
 
           if can_issue?(@round.current_entity)
-            @game.game_error('President may not sell shares while corporation can issues shares.')
+            raise GameError, 'President may not sell shares while corporation can issues shares.'
           end
 
           super
@@ -71,7 +71,7 @@ module Engine
           bundle_index = issuable.index(bundle)
 
           if !can_issue?(corporation) || !bundle_index
-            @game.game_error("#{corporation.name} cannot issue share bundle: #{bundle.shares}")
+            raise GameError, "#{corporation.name} cannot issue share bundle: #{bundle.shares}"
           end
 
           @last_share_issued_price = if bundle_index.zero?

--- a/lib/engine/step/g_1846/draft_2p_distribution.rb
+++ b/lib/engine/step/g_1846/draft_2p_distribution.rb
@@ -37,7 +37,7 @@ module Engine
 
         def process_pass(action)
           return super if only_one_company?
-          raise @game.game_error 'Cannot pass on first turn' if @game.companies.none?(&:owned_by_player?)
+          raise GameError, 'Canno pass on first turn' if @game.companies.none?(&:owned_by_player?)
 
           @log << "#{action.entity.name} passes"
           @round.next_entity_index!
@@ -50,7 +50,7 @@ module Engine
         end
 
         def choose_company(player, company)
-          raise @game.game_error "Cannot buy #{company.name}" unless @companies.include?(company)
+          raise GameError, "Cannot buy #{company.name}" unless @companies.include?(company)
 
           @companies.delete(company)
           company.owner = player

--- a/lib/engine/step/g_1846/draft_distribution.rb
+++ b/lib/engine/step/g_1846/draft_distribution.rb
@@ -80,7 +80,7 @@ module Engine
         end
 
         def process_pass(_action)
-          @game.game_error('Cannot pass') unless only_one_company?
+          raise GameError, 'Cannot pass' unless only_one_company?
 
           company = @companies[0]
           old_price = company.min_bid
@@ -106,7 +106,7 @@ module Engine
         def choose_company(player, company)
           available_companies = available
 
-          raise @game.game_error "Cannot choose #{company.name}" unless available_companies.include?(company)
+          raise GameError, "Cannot choose #{company.name}" unless available_companies.include?(company)
 
           @choices[player] << company
 

--- a/lib/engine/step/g_1856/assign.rb
+++ b/lib/engine/step/g_1856/assign.rb
@@ -11,8 +11,9 @@ module Engine
           target = action.target
 
           unless (ability = @game.abilities(company, :assign_hexes))
-            @game.game_error("Could not assign #{company.name} to #{target.name}; :assign_hexes ability not found")
+            raise GameError, "Could not assign #{company.name} to #{target.name}; :assign_hexes ability not found"
           end
+
           case company.id
           when 'GLSC'
             target.assign!(company.id)

--- a/lib/engine/step/g_1856/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1856/buy_sell_par_shares.rb
@@ -26,7 +26,7 @@ module Engine
           share_price = action.share_price
           corporation = action.corporation
           entity = action.entity
-          @game.game_error("#{corporation} cannot be parred") unless corporation.can_par?(entity)
+          raise GameError, "#{corporation} cannot be parred" unless corporation.can_par?(entity)
 
           corporation.par!
           @log << "#{corporation.name} is parred as a #{corporation.capitalization_type_desc} cap corporation"

--- a/lib/engine/step/g_1856/loan.rb
+++ b/lib/engine/step/g_1856/loan.rb
@@ -41,7 +41,7 @@ module Engine
           entity = action.entity
           loan = action.loan
           amount = loan.amount
-          @game.game_error("Loan doesn't belong to that entity") unless entity.loans.include?(loan)
+          raise GameError, "Loan doesn't belong to that entity" unless entity.loans.include?(loan)
 
           @log << "#{entity.name} pays off a loan for #{@game.format_currency(amount)}"
           entity.spend(amount, @game.bank)

--- a/lib/engine/step/g_1860/buy_cert.rb
+++ b/lib/engine/step/g_1860/buy_cert.rb
@@ -70,7 +70,7 @@ module Engine
           share_price = action.share_price
           corporation = action.corporation
           entity = action.entity
-          @game.game_error("#{corporation} cannot be parred") unless corporation.can_par?(entity)
+          raise GameError, "#{corporation} cannot be parred" unless corporation.can_par?(entity)
 
           @game.stock_market.set_par(corporation, share_price)
           shares = corporation.shares.first
@@ -102,10 +102,10 @@ module Engine
             buy_company(player, action.company, price)
           else
             if price > max_player_bid(player)
-              @game.game_error("Cannot afford bid. Maximum possible bid is #{max_player_bid(player)}")
+              raise GameError, "Cannot afford bid. Maximum possible bid is #{max_player_bid(player)}"
             end
 
-            @game.game_error("Must bid at least #{min_player_bid}") if price < min_player_bid
+            raise GameError, "Must bid at least #{min_player_bid}" if price < min_player_bid
 
             @log << "#{player.name} bids #{@game.format_currency(price)}"
 

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -81,7 +81,7 @@ module Engine
           price = action.price
           owner = company.owner
 
-          @game.game_error("Cannot buy #{company.name} from #{owner.name}") unless owner == @game.bank
+          raise GameError, "Cannot buy #{company.name} from #{owner.name}" unless owner == @game.bank
 
           company.owner = player
 
@@ -139,7 +139,7 @@ module Engine
         def process_sell_company(action)
           company = action.company
           player = action.entity
-          @game.game_error("Cannot sell #{company.id}") unless can_sell_company?(company)
+          raise GameError, "Cannot sell #{company.id}" unless can_sell_company?(company)
 
           sell_company(player, company, action.price)
           @round.last_to_act = player

--- a/lib/engine/step/g_1860/buy_train.rb
+++ b/lib/engine/step/g_1860/buy_train.rb
@@ -19,16 +19,16 @@ module Engine
           if action.train.owned_by_corporation?
             min, max = spend_minmax(action.entity, action.train)
             unless (min..max).include?(action.price)
-              @game.game_error("#{action.entity.name} may not spend "\
+              raise GameError, "#{action.entity.name} may not spend "\
                                "#{@game.format_currency(action.price)} on "\
                                "#{action.train.owner.name}'s #{action.train.name} "\
                                'train; may only spend between '\
                                "#{@game.format_currency(min)} and "\
-                               "#{@game.format_currency(max)}.")
+                               "#{@game.format_currency(max)}."
             end
             unless (action.price % @game.class::TRAIN_PRICE_MULTIPLE).zero?
-              @game.game_error('Train purchase price must be a multiple of '\
-                               "#{@game.format_currency(@game.class::TRAIN_PRICE_MULTIPLE)}")
+              raise GameError, 'Train purchase price must be a multiple of '\
+                               "#{@game.format_currency(@game.class::TRAIN_PRICE_MULTIPLE)}"
             end
           end
 

--- a/lib/engine/step/g_1860/exchange.rb
+++ b/lib/engine/step/g_1860/exchange.rb
@@ -25,8 +25,9 @@ module Engine
           company = action.entity
           bundle = action.bundle
           unless can_exchange?(company, bundle)
-            @game.game_error("Cannot exchange #{action.entity.id} for #{bundle.corporation.id}")
+            raise GameError, "Cannot exchange #{action.entity.id} for #{bundle.corporation.id}"
           end
+
           corporation = bundle.corporation
           floated = corporation.floated?
 

--- a/lib/engine/step/g_1860/route.rb
+++ b/lib/engine/step/g_1860/route.rb
@@ -60,7 +60,7 @@ module Engine
 
           if @round.routes.empty? && @game.legal_route?(entity) && (entity.trains.any? || @game.insolvent?(entity)) &&
               (!entity.receivership? || !@game.nationalization)
-            @game.game_error('Must run a route')
+            raise GameError, 'Must run a route'
           end
 
           # the following two checks must be made here, after all routes have been defined
@@ -74,10 +74,11 @@ module Engine
             train = route.train
             leased = ' '
             if train.owner && @game.train_owner(train) != entity
-              @game.game_error("Cannot run another corporation's train. refresh")
-              @game.game_error('Cannot run train that operated') if train.operated
+              raise GameError, "Cannot run another corporation's train. refresh"
             end
-            @game.game_error('Cannot run train twice') if trains[train]
+            raise GameError, 'Cannot run train that operated' if train.operated
+            raise GameError, 'Cannot run train twice' if trains[train]
+
             leased = ' (leased) ' if @game.insolvent?(entity)
 
             trains[train] = true

--- a/lib/engine/step/g_1867/buy_train.rb
+++ b/lib/engine/step/g_1867/buy_train.rb
@@ -62,7 +62,7 @@ module Engine
               else
                 'as do not need to buy'
               end
-            @game.game_error("Not able to take loan to purchase at #{@game.format_currency(cost)}, " + reason)
+            raise GameError, "Not able to take loan to purchase at #{@game.format_currency(cost)}, " + reason
           end
         end
       end

--- a/lib/engine/step/g_1867/merge.rb
+++ b/lib/engine/step/g_1867/merge.rb
@@ -57,7 +57,7 @@ module Engine
           target = action.corporation
 
           if !target || !mergeable(corporation).include?(target)
-            @game.game_error("Choose a corporation to merge with #{corporation.name}")
+            raise GameError, "Choose a corporation to merge with #{corporation.name}"
           end
 
           @game.stock_market.set_par(target, corporation.share_price)
@@ -138,7 +138,7 @@ module Engine
           players = players.rotate(players.index(initiator))
 
           if players.none? { |player| player.cash >= merged_par.price || owners.count(player) >= 2 }
-            @game.game_error('Merge impossible, no player can become president')
+            raise GameError, 'Merge impossible, no player can become president'
           end
 
           @game.stock_market.set_par(target, merged_par)
@@ -205,7 +205,7 @@ module Engine
           return finish_merge_to_major(action) if @merge_major
 
           unless mergeable(action.entity).include?(action.corporation)
-            @game.game_error("Cannot merge with t#{action.corporation.name}")
+            raise GameError, "Cannot merge with t#{action.corporation.name}"
           end
 
           @merging ||= [action.entity]

--- a/lib/engine/step/g_1867/track.rb
+++ b/lib/engine/step/g_1867/track.rb
@@ -15,7 +15,8 @@ module Engine
         end
 
         def lay_tile(action, extra_cost: 0, entity: nil)
-          @game.game_error('Cannot lay and upgrade the same tile in the same turn') if action.hex == @hex
+          raise GameError, 'Cannot lay and upgrade the same tile in the same turn' if action.hex == @hex
+
           super
           @hex = action.hex
         end

--- a/lib/engine/step/g_1870/special_track.rb
+++ b/lib/engine/step/g_1870/special_track.rb
@@ -13,7 +13,7 @@ module Engine
           owner = action.entity.owner
           tile = action.tile
           tile_lay = step.get_tile_lay(owner)
-          @game.game_error('Can only be used to lay yellow tiles') if tile.color != :yellow || !tile_lay[:lay]
+          raise GameError, 'Can only be used to lay yellow tiles' if tile.color != :yellow || !tile_lay[:lay]
 
           extra_cost = tile_lay[:cost] - 40
           extra_cost -= 20 if owner == @game.ssw_corporation && action.hex.name == 'H17'

--- a/lib/engine/step/g_1870/track.rb
+++ b/lib/engine/step/g_1870/track.rb
@@ -8,7 +8,7 @@ module Engine
     module G1870
       class Track < Track
         def lay_tile(action, extra_cost: 0, entity: nil)
-          @game.game_error('Cannot upgrade the tile in the same turn') if action.hex == @round.river_special_tile_lay
+          raise GameError, 'Cannot upgrade the tile in the same turn' if action.hex == @round.river_special_tile_lay
 
           super
         end

--- a/lib/engine/step/g_1882/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1882/buy_sell_par_shares.rb
@@ -36,7 +36,7 @@ module Engine
           if action.corporation.id == 'SC'
             share_price = action.share_price
             corporation = action.corporation
-            @game.game_error("#{corporation} cannot be parred") unless corporation.can_par?(action.entity)
+            raise GameError, "#{corporation} cannot be parred" unless corporation.can_par?(action.entity)
 
             @game.stock_market.set_par(corporation, share_price)
             share = corporation.shares.first

--- a/lib/engine/step/g_1882/home_token.rb
+++ b/lib/engine/step/g_1882/home_token.rb
@@ -15,7 +15,7 @@ module Engine
         def process_place_token(action)
           token = action.city.tokens[action.slot]
           if token
-            @game.game_error("Cannot replace #{token.corporation.name} token") unless token.corporation.name == 'CN'
+            raise GameError, "Cannot replace #{token.corporation.name} token" unless token.corporation.name == 'CN'
 
             @log << "#{action.entity.name} removes neutral token from #{action.city.hex.name}"
             # CN may no longer have a valid route.

--- a/lib/engine/step/g_1882/special_nwr.rb
+++ b/lib/engine/step/g_1882/special_nwr.rb
@@ -68,7 +68,7 @@ module Engine
           @entity = action.entity
           owner = @entity.owner
           token = action.city.tokens[action.slot]
-          @game.game_error("Cannot remove #{token.corporation.name} token") unless token.corporation == @entity.owner
+          raise GameError, "Cannot remove #{token.corporation.name} token" unless token.corporation == @entity.owner
 
           home_token = owner.tokens.first == token
           token.remove!

--- a/lib/engine/step/g_1889/special_track.rb
+++ b/lib/engine/step/g_1889/special_track.rb
@@ -14,7 +14,7 @@ module Engine
 
           entity = action.entity
           ability = @game.abilities(@company, :tile_lay, time: 'sold')
-          @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+          raise GameError, "Not #{entity.name}'s turn: #{action.to_h}" unless entity == @company
 
           lay_tile(action, spender: @round.company_sellers[@company])
           check_connect(action, ability)

--- a/lib/engine/step/g_18_al/assign.rb
+++ b/lib/engine/step/g_18_al/assign.rb
@@ -8,14 +8,14 @@ module Engine
       class Assign < Assign
         def process_assign(action)
           company = action.entity
-          @game.game_error("#{company.owner.name} is not SNAR") if company != @game.south_and_north_alabama_railroad
-          @game.game_error("#{company.owner.name} owns no trains") if company.owner.trains.empty?
+          raise GameError, "#{company.owner.name} is not SNAR" if company != @game.south_and_north_alabama_railroad
+          raise GameError, "#{company.owner.name} owns no trains" if company.owner.trains.empty?
 
           target = action.target
           hexes = @game.abilities(company, :assign_hexes)&.hexes
           location = @game.get_location_name(target.id)
           if !@game.loading && @game.graph.reachable_hexes(company.owner).find { |h, _| h.id == target.id }.nil?
-            @game.game_error("#{location} is not reachable")
+            raise GameError, "#{location} is not reachable"
           end
 
           super

--- a/lib/engine/step/g_18_co/acquisition_auction.rb
+++ b/lib/engine/step/g_18_co/acquisition_auction.rb
@@ -45,7 +45,7 @@ module Engine
           price = action.price
           min = min_bid(corporation)
 
-          @game.game_error("#{entity.name} must bid at least #{@game.format_currency(min)}") if price < min
+          raise GameError, "#{entity.name} must bid at least #{@game.format_currency(min)}" if price < min
 
           @log << "#{entity.name} bids #{@game.format_currency(price)} for #{corporation.name}"
           @round.next_entity_index!
@@ -124,7 +124,7 @@ module Engine
           corporation = bid.corporation
           price = bid.price
           min = min_bid(corporation)
-          @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{corporation.name}") if price < min
+          raise GameError, "Minimum bid is #{@game.format_currency(min)} for #{corporation.name}" if price < min
 
           @bids[corporation] << bid
 

--- a/lib/engine/step/g_18_co/moving_bid_auction.rb
+++ b/lib/engine/step/g_18_co/moving_bid_auction.rb
@@ -176,13 +176,14 @@ module Engine
           price = bid.price
           min = min_bid(company)
 
-          @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{company.name}") if price < min
+          raise GameError, "Minimum bid is #{@game.format_currency(min)} for #{company.name}" if price < min
           if @game.class::MUST_BID_INCREMENT_MULTIPLE && ((price - min) % min_increment).nonzero?
-            @game.game_error("Must increase bid by a multiple of #{@game.format_currency(min_increment)}")
+            raise GameError, "Must increase bid by a multiple of #{@game.format_currency(min_increment)}"
           end
+
           if price > max_bid(entity, company)
-            @game.game_error("Cannot afford bid. Maximum possible bid is
-              #{@game.format_currency(max_bid(entity, company))}")
+            raise GameError, 'Cannot afford bid. Maximum possible bid is '\
+              "#{@game.format_currency(max_bid(entity, company))}"
           end
 
           bids = @bids[company]
@@ -201,17 +202,18 @@ module Engine
           from_price = bid.from_price
           min = min_bid(company)
 
-          @game.game_error("Minimum bid is #{@game.format_currency(min)} for #{company.name}") if price < min
+          raise GameError, "Minimum bid is #{@game.format_currency(min)} for #{company.name}" if price < min
           if @game.class::MUST_BID_INCREMENT_MULTIPLE && ((price - min) % min_increment).nonzero?
-            @game.game_error("Must increase bid by a multiple of #{@game.format_currency(min_increment)}")
+            raise GameError, "Must increase bid by a multiple of #{@game.format_currency(min_increment)}"
           end
+
           if price > max_bid(entity, company)
-            @game.game_error("Cannot afford bid. Maximum possible bid is
-              #{@game.format_currency(max_bid(entity, company))}")
+            raise GameError, 'Cannot afford bid. Maximum possible bid is '\
+              "#{@game.format_currency(max_bid(entity, company))}"
           end
           if price < from_price + min_increment
-            @game.game_error("Bid movement must increase original bid by a multiple of
-              #{@game.format_currency(min_increment)}")
+            raise GameError, 'Bid movement must increase original bid by a multiple of '\
+              "#{@game.format_currency(min_increment)}"
           end
 
           @bids[from_company].reject! { |b| b.entity == entity && b.price == from_price }

--- a/lib/engine/step/g_18_co/takeover.rb
+++ b/lib/engine/step/g_18_co/takeover.rb
@@ -76,7 +76,7 @@ module Engine
           entity = action.entity
 
           unless available_hex(entity, action.city.hex)
-            @game.game_error("Cannot place a token on #{action.city.hex.name}")
+            raise GameError, "Cannot place a token on #{action.city.hex.name}"
           end
 
           old_token = taken_entity.tokens.find { |t| t.city == action.city }
@@ -154,13 +154,13 @@ module Engine
           return if source.placed_tokens.empty?
           return if destination.unplaced_tokens.empty?
 
-          destination_hexes = destination.tokens.map { |token| token&.city&.hex }.compact
+          destination_cities = destination.tokens.map(&:city).compact
 
           source.tokens.each do |token|
             next unless token.used
 
             token.city&.remove_reservation!(source)
-            token.remove! if destination_hexes.include?(token.city.hex)
+            token.remove! if destination_cities.include?(token.city)
           end
         end
 
@@ -249,10 +249,6 @@ module Engine
 
         def close_corporation(entity)
           @game.close_corporation(entity)
-          if entity == @game.dsng && !@game.drgr&.closed?
-            @game.log << "#{@game.drgr.name} closes due to takeover of #{@game.dsng.name}"
-            @game.drgr.close!
-          end
           entity.close!
           @round.pending_takeover = nil
         end

--- a/lib/engine/step/g_18_co/track.rb
+++ b/lib/engine/step/g_18_co/track.rb
@@ -35,7 +35,7 @@ module Engine
 
         def lay_tile_action(action)
           if @previous_laid_hexes.include?(action.hex)
-            @game.game_error("#{action.hex.id} cannot be upgraded as the tile was just laid")
+            raise GameError, "#{action.hex.id} cannot be upgraded as the tile was just laid"
           end
 
           super

--- a/lib/engine/step/g_18_co/tracker.rb
+++ b/lib/engine/step/g_18_co/tracker.rb
@@ -40,12 +40,12 @@ module Engine
           old_connected_paths = prior_connected_paths(entity, new_tile, old_tile)
           return if all_prior_paths_accessible?(old_tile.paths, old_connected_paths)
 
-          @game.game_error('Must have route to access existing track') if old_connected_paths.empty?
+          raise GameError, 'Must have route to access existing track' if old_connected_paths.empty?
 
           return if accessible_new_path_creates_new_exit?(brand_new_exit_junctions)
           return if all_new_paths_have_new_exits?(brand_new_exit_junctions)
 
-          @game.game_error('Must have route to access both ends of at least one path of new track')
+          raise GameError, 'Must have route to access both ends of at least one path of new track'
         end
 
         def new_exit_junctions(old_tile, new_tile)

--- a/lib/engine/step/g_18_ga/special_token.rb
+++ b/lib/engine/step/g_18_ga/special_token.rb
@@ -25,7 +25,8 @@ module Engine
         def process_place_token(action)
           target = action.city.hex.name
           allowed = ability(action.entity).hexes
-          @game.game_error("#{target} not allowed for token. Only allowed: #{allowed}.") unless allowed.include?(target)
+          raise GameError, "#{target} not allowed for token. Only allowed: #{allowed}." unless allowed.include?(target)
+
           super
         end
 

--- a/lib/engine/step/g_18_ga/track.rb
+++ b/lib/engine/step/g_18_ga/track.rb
@@ -15,7 +15,8 @@ module Engine
         end
 
         def process_lay_tile(action)
-          @game.game_error('Cannot do normal tile lay') unless can_lay_tile?(action.entity)
+          raise GameError, 'Cannot do normal tile lay' unless can_lay_tile?(action.entity)
+
           lay_tile_action(action)
           pass! unless remaining_tile_lay?(action.entity)
         end

--- a/lib/engine/step/g_18_los_angeles/special_token.rb
+++ b/lib/engine/step/g_18_los_angeles/special_token.rb
@@ -8,8 +8,8 @@ module Engine
       class SpecialToken < SpecialToken
         def process_place_token(action)
           if (action.entity == @game.dch) && action.city.tokenable?(action.entity.owner)
-            @game.game_error('Dewey, Cheatham, and Howe can only place a token in '\
-                             'a city (other than Long Beach) with no open slots.')
+            raise GameError, 'Dewey, Cheatham, and Howe can only place a token in '\
+                             'a city (other than Long Beach) with no open slots.'
           end
 
           super

--- a/lib/engine/step/g_18_mex/track.rb
+++ b/lib/engine/step/g_18_mex/track.rb
@@ -19,7 +19,8 @@ module Engine
 
         def process_lay_tile(action)
           @mexico_city_double_hex_lay = false
-          @game.game_error('Cannot do normal tile lay') unless can_lay_tile?(action.entity)
+          raise GameError, 'Cannot do normal tile lay' unless can_lay_tile?(action.entity)
+
           lay_tile_action(action)
           lay_in_other_hex_of_double_hex(action) if MEXICO_CITY_DOUBLE_HEX.include?(action.hex.id)
           pass! unless remaining_tile_lay?(action.entity)

--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -29,11 +29,11 @@ module Engine
           if price > available_funds && must_buy_train?(entity)
 
             if can_sell_anything?(player, entity)
-              @game.game_error("#{player.name} may not loan money as long as #{entity.name} has shares to sell")
+              raise GameError, "#{player.name} may not loan money as long as #{entity.name} has shares to sell"
             end
 
             cheapest = @game.depot.min_depot_train
-            @game.game_error("#{player.name} may not loan money when affordable trains exist") if
+            raise GameError, "#{player.name} may not loan money when affordable trains exist" if
               cheapest.price <= available_funds
 
             # Prepare to take a loan

--- a/lib/engine/step/g_18_ms/track.rb
+++ b/lib/engine/step/g_18_ms/track.rb
@@ -16,7 +16,8 @@ module Engine
         end
 
         def process_lay_tile(action)
-          @game.game_error('Cannot do normal tile lay') unless can_lay_tile?(action.entity)
+          raise GameError, 'Cannot do normal tile lay' unless can_lay_tile?(action.entity)
+
           lay_tile_action(action)
           pass! unless remaining_tile_lay?(action.entity)
         end

--- a/lib/engine/step/g_18_tn/track.rb
+++ b/lib/engine/step/g_18_tn/track.rb
@@ -16,7 +16,8 @@ module Engine
         end
 
         def process_lay_tile(action)
-          @game.game_error('Cannot do normal tile lay') unless can_lay_tile?(action.entity)
+          raise GameError, 'Cannot do normal tile lay' unless can_lay_tile?(action.entity)
+
           lay_tile_action(action)
           pass! unless remaining_tile_lay?(action.entity)
         end

--- a/lib/engine/step/home_token.rb
+++ b/lib/engine/step/home_token.rb
@@ -62,7 +62,7 @@ module Engine
       def process_place_token(action)
         # the action is faked and doesn't represent the actual token laid
         hex = action.city.hex
-        @game.game_error("Cannot place token on #{hex.name}") unless available_hex(action.entity, hex)
+        raise GameError, "Cannot place token on #{hex.name}" unless available_hex(action.entity, hex)
 
         place_token(
           token.corporation,

--- a/lib/engine/step/reduce_tokens.rb
+++ b/lib/engine/step/reduce_tokens.rb
@@ -44,7 +44,7 @@ module Engine
       def process_remove_token(action)
         entity = action.entity
         token = action.city.tokens[action.slot]
-        @game.game_error("Cannot remove #{token.corporation.name} token") unless available_hex(entity, token.city.hex)
+        raise GameError, "Cannot remove #{token.corporation.name} token" unless available_hex(entity, token.city.hex)
 
         token.remove!
         @log << "#{action.entity.name} removes token from #{action.city.hex.name}"

--- a/lib/engine/step/return_token.rb
+++ b/lib/engine/step/return_token.rb
@@ -21,18 +21,18 @@ module Engine
         company = action.entity
         corporation = action.entity.owner
 
-        @game.game_error("#{company.name} must be owned by a corporation") unless corporation.corporation?
+        raise GameError, "#{company.name} must be owned by a corporation" unless corporation.corporation?
 
         last_used_token = available_tokens(corporation).first
 
-        @game.game_error("#{corporation.name} cannot return its only placed token") unless last_used_token
+        raise GameError, "#{corporation.name} cannot return its only placed token" unless last_used_token
 
         selected_city = action.city
         hex = selected_city.hex
 
         city_string = hex.tile.cities.size > 1 ? " city #{selected_city.index}" : ''
         unless available_city(corporation, selected_city)
-          @game.game_error("Cannot return token from #{hex.name}#{city_string} to #{corporation.name}")
+          raise GameError, "Cannot return token from #{hex.name}#{city_string} to #{corporation.name}"
         end
 
         last_city = last_used_token.city

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -32,9 +32,9 @@ module Engine
 
         @round.routes.each do |route|
           train = route.train
-          @game.game_error("Cannot run another corporation's train. refresh") if train.owner && train.owner != entity
-          @game.game_error('Cannot run train twice') if trains[train]
-          @game.game_error('Cannot run train that operated') if train.operated
+          raise GameError, "Cannot run another corporation's train. refresh" if train.owner && train.owner != entity
+          raise GameError, 'Cannot run train twice' if trains[train]
+          raise GameError, 'Cannot run train that operated' if train.operated
 
           trains[train] = true
           revenue = @game.format_currency(route.revenue)

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -6,7 +6,7 @@ module Engine
   module Step
     module ShareBuying
       def buy_shares(entity, shares, exchange: nil, swap: nil)
-        @game.game_error("Cannot buy a share of #{shares&.corporation&.name}") if !can_buy?(entity, shares) && !swap
+        raise GameError, "Cannot buy a share of #{shares&.corporation&.name}" if !can_buy?(entity, shares) && !swap
 
         @game.share_pool.buy_shares(entity, shares, exchange: exchange, swap: swap)
         corporation = shares.corporation

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -25,7 +25,7 @@ module Engine
 
         hex = action.city.hex
         city_string = hex.tile.cities.size > 1 ? " city #{action.city.index}" : ''
-        @game.game_error("Cannot place token on #{hex.name}#{city_string}") unless available_hex(entity, hex)
+        raise GameError, "Cannot place token on #{hex.name}#{city_string}" unless available_hex(entity, hex)
 
         place_token(
           entity.owner,

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -36,7 +36,7 @@ module Engine
         if @company && (@company != action.entity) &&
            (ability = @game.abilities(@company, :tile_lay, time: 'track')) &&
            ability.must_lay_together && ability.must_lay_all
-          @game.game_error("Cannot interrupt #{@company.name}'s tile lays")
+          raise GameError, "Cannot interrupt #{@company.name}'s tile lays"
         end
 
         ability = tile_lay_abilities(action.entity)
@@ -50,7 +50,7 @@ module Engine
       def process_pass(action)
         entity = action.entity
         ability = tile_lay_abilities(entity)
-        @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+        raise GameError, "Not #{entity.name}'s turn: #{action.to_h}" unless entity == @company
 
         entity.remove_ability(ability)
         @log << "#{entity.owner.name} passes laying additional track with #{entity.name}"
@@ -94,7 +94,7 @@ module Engine
           @game.hex_by_id(hex_id).tile.paths
         end.uniq
 
-        @game.game_error('Paths must be connected') if paths.size != paths[0].select(paths).size
+        raise GameError, 'Paths must be connected' if paths.size != paths[0].select(paths).size
       end
     end
   end

--- a/lib/engine/step/token_merger.rb
+++ b/lib/engine/step/token_merger.rb
@@ -54,7 +54,7 @@ module Engine
           new_token.city&.hex&.id
         end
 
-        @game.game_error('Used token above limit') if used.size > @game.class::LIMIT_TOKENS_AFTER_MERGER
+        raise GameError, 'Used token above limit' if used.size > @game.class::LIMIT_TOKENS_AFTER_MERGER
 
         surviving.tokens.clear
         surviving_tokens = used + unused

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -26,15 +26,15 @@ module Engine
         hex = city.hex
         if !@game.loading && !teleport && !@game.graph.connected_nodes(entity)[city]
           city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
-          @game.game_error("Cannot place token on #{hex.name}#{city_string} because it is not connected")
+          raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
         end
 
         if special_ability&.city && (special_ability.city != city.index)
-          @game.game_error("#{special_ability.owner.name} can only place token on #{hex.name} city "\
-                           "#{special_ability.city}, not on city #{city.index}")
+          raise GameError, "#{special_ability.owner.name} can only place token on #{hex.name} city "\
+                           "#{special_ability.city}, not on city #{city.index}"
         end
 
-        @game.game_error('Token is already used') if token.used
+        raise GameError, 'Token is already used' if token.used
 
         token, ability = adjust_token_price_ability!(entity, token, hex, city, special_ability)
         tokener = entity.name

--- a/lib/engine/step/track_lay_when_company_sold.rb
+++ b/lib/engine/step/track_lay_when_company_sold.rb
@@ -23,7 +23,7 @@ module Engine
 
         entity = action.entity
         ability = @game.abilities(@company, :tile_lay, time: 'sold')
-        @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+        raise GameError, "Not #{entity.name}'s turn: #{action.to_h}" unless entity == @company
 
         lay_tile(action, spender: entity.owner)
         check_connect(action, ability)
@@ -35,7 +35,7 @@ module Engine
       def process_pass(action)
         entity = action.entity
         ability = @game.abilities(@company, :tile_lay, time: 'sold')
-        @game.game_error("Not #{entity.name}'s turn: #{action.to_h}") unless entity == @company
+        raise GameError, "Not #{entity.name}'s turn: #{action.to_h}" unless entity == @company
 
         @company.remove_ability(ability)
         @log << "#{entity.name} passes lay track"

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -30,8 +30,8 @@ module Engine
       def lay_tile_action(action)
         tile = action.tile
         tile_lay = get_tile_lay(action.entity)
-        @game.game_error('Cannot lay an upgrade now') if tile.color != :yellow && !tile_lay[:upgrade]
-        @game.game_error('Cannot lay an yellow now') if tile.color == :yellow && !tile_lay[:lay]
+        raise GameError, 'Cannot lay an upgrade now' if tile.color != :yellow && !tile_lay[:upgrade]
+        raise GameError, 'Cannot lay an yellow now' if tile.color == :yellow && !tile_lay[:lay]
 
         lay_tile(action, extra_cost: tile_lay[:cost])
         @upgraded = true if action.tile.color != :yellow
@@ -54,15 +54,16 @@ module Engine
           next if company.closed?
           next unless (ability = @game.abilities(company, :blocks_hexes))
 
-          @game.game_error("#{hex.id} is blocked by #{company.name}") if ability.hexes.include?(hex.id)
+          raise GameError, "#{hex.id} is blocked by #{company.name}" if ability.hexes.include?(hex.id)
         end
 
         tile.rotate!(rotation)
 
-        @game.game_error("#{old_tile.name} is not upgradeable to #{tile.name}")\
-          unless @game.upgrades_to?(old_tile, tile, entity.company?)
+        unless @game.upgrades_to?(old_tile, tile, entity.company?)
+          raise GameError, "#{old_tile.name} is not upgradeable to #{tile.name}"
+        end
         if !@game.loading && !legal_tile_rotation?(entity, hex, tile)
-          @game.game_error("#{old_tile.name} is not legally rotated for #{tile.name}")
+          raise GameError, "#{old_tile.name} is not legally rotated for #{tile.name}"
         end
 
         @game.add_extra_tile(tile) if tile.unlimited
@@ -81,7 +82,7 @@ module Engine
           next if ability.owner != entity
           next if ability.hexes.any? && (!ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name))
 
-          @game.game_error("Track laid must be connected to one of #{spender.id}'s stations") if ability.reachable &&
+          raise GameError, "Track laid must be connected to one of #{spender.id}'s stations" if ability.reachable &&
             hex.name != spender.coordinates &&
             !@game.loading &&
             !@game.graph.reachable_hexes(spender)[hex]
@@ -211,11 +212,11 @@ module Engine
         when :permissive
           true
         when :city_permissive
-          @game.game_error('Must be city tile or use new track') if new_tile.cities.none? && !used_new_track
+          raise GameError, 'Must be city tile or use new track' if new_tile.cities.none? && !used_new_track
         when :restrictive
-          @game.game_error('Must use new track') unless used_new_track
+          raise GameError, 'Must use new track' unless used_new_track
         when :semi_restrictive
-          @game.game_error('Must use new track or change city value') if !used_new_track && !changed_city
+          raise GameError, 'Must use new track or change city value' if !used_new_track && !changed_city
         else
           raise
         end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -41,20 +41,20 @@ module Engine
         @game.queue_log! { @game.phase.buying_train!(entity, train) }
 
         # Check if the train is actually buyable in the current situation
-        @game.game_error('Not a buyable train') unless buyable_train_variants(train, entity).include?(train.variant)
-        @game.game_error('Must pay face value') if must_pay_face_value?(train, entity, price)
+        raise GameError, 'Not a buyable train' unless buyable_train_variants(train, entity).include?(train.variant)
+        raise GameError, 'Must pay face value' if must_pay_face_value?(train, entity, price)
 
         remaining = price - buying_power(entity)
         if remaining.positive? && must_buy_train?(entity)
           cheapest = @depot.min_depot_train
-          @game.game_error("Cannot purchase #{train.name} train: #{cheapest.name} train available") if
+          raise GameError, "Cannot purchase #{train.name} train: #{cheapest.name} train available" if
             train != cheapest &&
             @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST &&
             (!@game.class::EBUY_OTHER_VALUE || train.from_depot?)
 
-          @game.game_error('Cannot contribute funds when exchanging') if exchange
-          @game.game_error('Cannot buy for more than cost') if price > train.price
-          @game.game_error('Cannot contribute funds when affordable trains exist') if cheapest.price <= entity.cash
+          raise GameError, 'Cannot contribute funds when exchanging' if exchange
+          raise GameError, 'Cannot buy for more than cost' if price > train.price
+          raise GameError, 'Cannot contribute funds when affordable trains exist' if cheapest.price <= entity.cash
 
           player = entity.owner
           player.spend(remaining, entity)

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -168,9 +168,9 @@ module Engine
 
       def buy_company(player, company, price)
         if (available = max_bid(player, company)) < price
-          @game.game_error("#{player.name} has #{@game.format_currency(available)} "\
+          raise GameError, "#{player.name} has #{@game.format_currency(available)} "\
                            'available and cannot spend '\
-                           "#{@game.format_currency(price)}")
+                           "#{@game.format_currency(price)}"
         end
 
         company.owner = player

--- a/migrate_game.rb
+++ b/migrate_game.rb
@@ -257,7 +257,7 @@ end
 def migrate_data(data)
   begin
     data['actions'], repairs = attempt_repair(data['actions']) do
-      Engine::Game.load(data, actions: [])
+      Engine::Game.load(data, actions: [], disable_user_errors: true)
     end
   rescue Exception => e
     puts 'Failed to fix :(', e
@@ -274,7 +274,7 @@ def migrate_db_actions_in_mem(data)
   engine = Engine::GAMES_BY_TITLE[data.title]
   begin
     actions, repairs = attempt_repair(original_actions) do
-      Engine::Game.load(data, actions: [])
+      Engine::Game.load(data, actions: [], disable_user_errors: true)
     end
     puts repairs
     return actions || original_actions
@@ -293,7 +293,7 @@ def migrate_db_actions(data, pin, dry_run=false)
   engine = Engine::GAMES_BY_TITLE[data.title]
   begin
     actions, repairs = attempt_repair(original_actions) do
-      Engine::Game.load(data, actions: [])
+      Engine::Game.load(data, actions: [], disable_user_errors: true)
     end
     if actions && !dry_run
       if repairs
@@ -306,7 +306,7 @@ def migrate_db_actions(data, pin, dry_run=false)
       else # Full rewrite.
         DB.transaction do
           Action.where(game: data).delete
-          game = Engine::Game.load(data, actions: [])
+          game = Engine::Game.load(data, actions: [], disable_user_errors: true)
           actions.each do |action|
             game.process_action(action)
             Action.create(

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -19,9 +19,9 @@ module Engine
           data = JSON.parse(File.read(fixture))
           result = data['result']
 
-          expect(Engine::Game.load(data).result).to eq(result)
+          expect(Engine::Game.load(data, disable_user_errors: true).result).to eq(result)
 
-          rungame = Engine::Game.load(data, strict: true)
+          rungame = Engine::Game.load(data, disable_user_errors: true, strict: true)
           expect(rungame.result).to eq(result)
           expect(rungame.finished).to eq(true)
         end

--- a/validate.rb
+++ b/validate.rb
@@ -19,7 +19,7 @@ def run_game(game, actions = nil)
   begin
     $total += 1
     time = Time.now
-    engine = Engine::Game.load(game)
+    engine = Engine::Game.load(game, disable_user_errors: true)
     time = Time.now - time
     $total_time += time
     data['finished']=true
@@ -104,7 +104,7 @@ def revalidate_broken(filename)
 end
 
 def validate_json(filename)
-  Engine::Game.load(filename)
+  Engine::Game.load(filename, disable_user_errors: true)
 end
 
 def pin_games(pin_version, game_ids)


### PR DESCRIPTION
Use this to show more when rendering a broken game:

* always show the broken action
* provide full link to the broken point in the game
* show the game as it was at the last valid action

Validate/migrate scripts still expect the exception to be raised, but now they
could be modified to get more info on broken games for faster debugging (e.g.,
right now the produced validate.json just shows the exception message, not the
broken action or a link for the last valid action or anything like that).

-----

I originally added `game_error` so that more error messages could link to the last valid action without needing to pass it in everywhere a GameError was raised. With this change, the game page can show the error message, the broken action, and the last valid game state for *all* errors, not just those occurring in a scope with access to a Game instance.

~I do have another commit that actually gets rid of all `game_error` calls, but left it off this PR for now because it's both large and not very interesting - https://github.com/tobymao/18xx/commit/93b77954732bc4aeb7826c29df3b9de6bb5ee733 (though there is one interesting bit, rubocop caught an unreachable line: at https://github.com/tobymao/18xx/commit/93b77954732bc4aeb7826c29df3b9de6bb5ee733#diff-4240657053470220def50bb227cd5b94d88ab4d805eec718b0f3327c85816406L78)~

I went ahead and added that commit to this PR, doesn't seem worth it to leave `game_error()` around if it's not doing anything any more. I kept the commits separate so that the first one with the actual interesting changes can still be examined by itself.

### Old

![Screenshot (1)](https://user-images.githubusercontent.com/1045173/103390114-e3795f00-4acf-11eb-95c7-2f1603394cf2.png)

### New

![Screenshot (2)](https://user-images.githubusercontent.com/1045173/103390118-e7a57c80-4acf-11eb-95fc-72a557453070.png)

### New with `?debug=1`

![Screenshot (3)](https://user-images.githubusercontent.com/1045173/103390198-5b478980-4ad0-11eb-8ce8-de031d72e628.png)

