### PR TITLE
Allow coal to connect to gray towns; this allows coal to Klondike in 1817NA

### DIFF
--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -60,10 +60,10 @@ module Engine
             # The neighbouring tile must have a city or offboard
             # That neighbouring tile must either connect to an edge on the tile or
             # potentially be updated in future.
-            (ntile.cities&.any? ||
-             ntile.offboards&.any?) &&
-            (ntile.exits.any? { |e| e == Hex.invert(exit) } ||
-             potential_future_tiles(entity, neighbor).any?)
+            # 1817 doesn't have any coal next to towns but 1817NA does and
+            #  Marc Voyer confirmed that coal should be able to connect to the gray pre-printed town
+            (ntile.cities&.any? || ntile.offboards&.any? || ntile.towns&.any?) &&
+            (ntile.exits.any? { |e| e == Hex.invert(exit) } || potential_future_tiles(entity, neighbor).any?)
           end
         end
       end


### PR DESCRIPTION
This allows this
![image](https://user-images.githubusercontent.com/2993555/103420741-d9ef0600-4b66-11eb-9f36-af2f311ed4b1.png)
https://github.com/tobymao/18xx/pull/2904 fixed this but the fix got lost unfortunately