### PR TITLE
make Engine::Game.load gentler on the db and more selective about kwargs

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -31,38 +31,44 @@ require_relative '../player_info'
 
 module Engine
   module Game
-    def self.load(data, at_action: nil, **kwargs)
-      game_data =
-        case data
-        when String
-          return load(JSON.parse(File.exist?(data) ? File.read(data) : data), at_action: at_action, **kwargs)
-        when Hash
-          {
-            title: data['title'],
-            names: data['players'].map { |p| [p['id'] || p['name'], p['name']] }.to_h,
-            id: data['id'],
-            actions: data['actions'] || [],
-            pin: data.dig('settings', 'pin'),
-            optional_rules: data.dig('settings', 'optional_rules') || [],
-          }
-        when Integer
-          return load(::Game[data], at_action: at_action, **kwargs)
-        when ::Game
-          {
-            title: data.title,
-            names: data.ordered_players.map { |u| [u.id, u.name] }.to_h,
-            id: data.id,
-            actions: data.actions.map(&:to_h),
-            pin: data.settings['pin'],
-            optional_rules: data.settings['optional_rules'] || [],
-          }
-        end
-      title = game_data.delete(:title)
-      names = game_data.delete(:names)
-      game_data.merge!(kwargs)
-      game_data[:actions] = game_data[:actions].take(at_action) if at_action
+    def self.load(data, at_action: nil, actions: nil, pin: nil, optional_rules: nil, **kwargs)
+      case data
+      when String
+        parsed_data = JSON.parse(File.exist?(data) ? File.read(data) : data)
+        return load(parsed_data,
+                    at_action: at_action,
+                    actions: actions,
+                    pin: pin,
+                    optional_rules: optional_rules,
+                    **kwargs)
+      when Hash
+        title = data['title']
+        names = data['players'].map { |p| [p['id'] || p['name'], p['name']] }.to_h
+        id = data['id']
+        actions ||= data['actions'] || []
+        pin ||= data.dig('settings', 'pin')
+        optional_rules ||= data.dig('settings', 'optional_rules') || []
+      when Integer
+        return load(::Game[data],
+                    at_action: at_action,
+                    actions: actions,
+                    pin: pin,
+                    optional_rules: optional_rules,
+                    **kwargs)
+      when ::Game
+        title = data.title
+        names = data.ordered_players.map { |u| [u.id, u.name] }.to_h
+        id = data.id
+        actions ||= data.actions.map(&:to_h)
+        pin ||= data.settings['pin']
+        optional_rules ||= data.settings['optional_rules'] || []
+      end
 
-      Engine::GAMES_BY_TITLE[title].new(names, **game_data)
+      actions = actions.take(at_action) if at_action
+
+      Engine::GAMES_BY_TITLE[title].new(
+        names, id: id, actions: actions, pin: pin, optional_rules: optional_rules, **kwargs
+      )
     end
 
     class Base


### PR DESCRIPTION
* if a param is given (like actions), no need to hit the db
* don't allow users to pass in arbitrary title, names, or id, it doesn't make
  any sense to load a game while changing those params