### PR TITLE
1856 black diesels

### DIFF
--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -27,6 +27,7 @@ module Lib
       green: '#71bf44',
       brown: '#cb7745',
       gray: '#bcbdc0',
+      black: '#000000',
       red: '#ec232a',
       blue: '#35A7FF',
     }.freeze

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -59,7 +59,7 @@ module View
         end
 
         game = @game.process_action(action)
-        raise game.exception if game.exeption
+        raise game.exception if game.exception
 
         @game_data[:actions] << action.to_h
         store(:game_data, @game_data, skip: true)

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -59,6 +59,8 @@ module View
         end
 
         game = @game.process_action(action)
+        raise game.exception if game.exeption
+
         @game_data[:actions] << action.to_h
         store(:game_data, @game_data, skip: true)
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -24,7 +24,7 @@ module View
     def render_broken_game(e)
       inner = [h(:div, "We're sorry this game cannot be continued due to #{e}")]
 
-      json = `JSON.stringify(#{@game.actions.last&.to_h&.to_n}, null, 2)`
+      json = `JSON.stringify(#{@game.broken_action&.to_h&.to_n}, null, 2)`
       inner << h(:div, "Broken action: #{json}")
 
       # don't ask for a link for hotseat games

--- a/lib/engine/config/game/g_1856.rb
+++ b/lib/engine/config/game/g_1856.rb
@@ -619,7 +619,7 @@ module Engine
   ],
   "hexes": {
     "red": {
-      "offboard=revenue:yellow_30|brown_50|gray_60;path=a:4,b:_0;path=a:5,b:_0": [
+      "offboard=revenue:yellow_30|brown_50|black_60;path=a:4,b:_0;path=a:5,b:_0": [
         "A20"
       ],
       "border=edge:4": [
@@ -628,22 +628,22 @@ module Engine
       "offboard=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:5,b:_0;border=edge:1": [
         "B13"
       ],
-      "offboard=revenue:yellow_30|brown_50|gray_40;path=a:0,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
+      "offboard=revenue:yellow_30|brown_50|black_40;path=a:0,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
         "H5"
       ],
       "offboard=revenue:yellow_20|brown_30;path=a:0,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
         "K2"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,hide:1,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;border=edge:5": [
+      "offboard=revenue:yellow_20|brown_30|black_50,hide:1,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;border=edge:5": [
         "N1"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0;border=edge:2": [
+      "offboard=revenue:yellow_20|brown_30|black_50,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0;border=edge:2": [
         "O2"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,groups:Lower Canada;path=a:1,b:_0;path=a:2,b:_0;border=edge:0": [
+      "offboard=revenue:yellow_20|brown_30|black_50,groups:Lower Canada;path=a:1,b:_0;path=a:2,b:_0;border=edge:0": [
         "Q8"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,hide:1,groups:Lower Canada;path=a:2,b:_0;border=edge:3": [
+      "offboard=revenue:yellow_20|brown_30|black_50,hide:1,groups:Lower Canada;path=a:2,b:_0;border=edge:3": [
         "Q10"
       ],
       "offboard=revenue:yellow_30|brown_40,hide:1,groups:Buffalo;path=a:2,b:_0;border=edge:3": [
@@ -675,7 +675,7 @@ module Engine
       ]
     },
     "gray": {
-      "town=revenue:yellow_30|brown_50|gray_40;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
+      "town=revenue:yellow_30|brown_50|black_40;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
         "F9"
       ]
     },
@@ -925,7 +925,8 @@ module Engine
         "yellow",
         "green",
         "brown",
-        "gray"
+        "gray",
+        "black"
         ],
         "status":[
         "fullcap",

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -614,10 +614,10 @@ module Engine
         end
 
         @last_processed_action = action.id
+        self
       rescue Engine::GameError => e
         @exception = e
         @actions |= [action]
-      ensure
         self
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -76,7 +76,7 @@ module Engine
                   :depot, :finished, :graph, :hexes, :id, :loading, :loans, :log, :minors,
                   :phase, :players, :operating_rounds, :round, :share_pool, :stock_market,
                   :tiles, :turn, :total_loans, :undo_possible, :redo_possible, :round_history, :all_tiles,
-                  :optional_rules, :exception, :last_processed_action
+                  :optional_rules, :exception, :last_processed_action, :broken_action
 
       DEV_STAGES = %i[production beta alpha prealpha].freeze
       DEV_STAGE = :prealpha
@@ -618,6 +618,7 @@ module Engine
       rescue Engine::GameError => e
         @exception = e
         @actions |= [action]
+        @broken_action = action
         self
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -577,9 +577,7 @@ module Engine
         action = action_from_h(action) if action.is_a?(Hash)
         action.id = current_action_id
         @actions << action
-        if action.is_a?(Action::Undo) || action.is_a?(Action::Redo)
-          return clone(@actions)
-        end
+        return clone(@actions) if action.is_a?(Action::Undo) || action.is_a?(Action::Redo)
 
         if action.user
           @log << "• Action(#{action.type}) via Master Mode by: #{player_by_id(action.user)&.name || 'Owner'}"

--- a/lib/engine/step/g_1817/acquire.rb
+++ b/lib/engine/step/g_1817/acquire.rb
@@ -454,7 +454,7 @@ module Engine
         end
 
         def auctioning_corporation
-          @offer || @auctioning || @winner&.corporation
+          @offer || @buyer || @auctioning || @winner&.corporation
         end
 
         def setup

--- a/lib/engine/step/g_1860/buy_train.rb
+++ b/lib/engine/step/g_1860/buy_train.rb
@@ -57,6 +57,10 @@ module Engine
           depot_trains + other_trains
         end
 
+        def president_may_contribute?(_entity, _shell = nil)
+          false
+        end
+
         def illegal_train_buy?(entity, train)
           @game.bankrupt?(train.owner) ||
             entity.receivership? ||

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -90,6 +90,7 @@ class Api
                 r.params['user'] = user.id
 
                 engine = engine.process_action(r.params)
+                halt(500, "Illegal action #{engine.exception}") if engine.exception
                 action = engine.actions.last.to_h
 
                 Action.create(


### PR DESCRIPTION
Add black hex color and make diesels black in 1856
This allows the UI to easily show the player that the offboards change on the D, not the 6T

This is distinctly different from 1889 in that *all* trains get the black value

![image](https://user-images.githubusercontent.com/2993555/103443522-23eeef00-4c2e-11eb-8a24-f099515984f0.png)
