### PR TITLE
1867 Bug fixes

### DIFF
--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -179,9 +179,9 @@ module Engine
       "120pC",
       "135pC",
       "150zC",
-      "165zC",
-      "180zC",
-      "200zCm",
+      "165zCm",
+      "180z",
+      "200z",
       "220",
       "245",
       "270",
@@ -740,7 +740,7 @@ module Engine
       "price": 650,
       "num": 2,
       "events":[
-        {"type": "close_companies"},
+        {"type": "nationalize_companies"},
         {"type": "trainless_nationalization"}
       ]
     },
@@ -799,7 +799,7 @@ module Engine
       ],
       "multiplier":2,
       "price": 600,
-      "num": 6,
+      "num": 20,
       "available_on": "8"
     },
     {
@@ -818,7 +818,7 @@ module Engine
       ],
       "multiplier": 2,
       "price": 1500,
-      "num": 7,
+      "num": 20,
       "available_on": "8"
     }
   ],

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -61,6 +61,9 @@ module Engine
                                             'majors_can_ipo' => ['Majors can be ipoed'],
                                             'minors_cannot_start' => ['Minors cannot start'],
                                             'minors_nationalized' => ['Minors are nationalized'],
+                                            'nationalize_companies' =>
+                                            ['Nationalize Companies',
+                                             'All companies close paying their owner their value'],
                                             'trainless_nationalization' =>
                                             ['Trainless Nationalization',
                                              'Operating Trainless Minors are nationalized'\
@@ -229,6 +232,8 @@ module Engine
           city = token.city
           token.remove!
 
+          next if city.tile.cities.any? { |c| c.tokened_by?(@cn_corporation) }
+
           new_token = @cn_corporation.next_token
           next unless new_token
 
@@ -248,6 +253,17 @@ module Engine
         else
           reset_corporation(corporation)
         end
+      end
+
+      def place_cn_montreal_token(tile)
+        return unless @cn_reservations.any?
+        return if tile.cities.any? { |c| c.tokened_by?(@cn_corporation) }
+        return unless (new_token = @cn_corporation.next_token)
+
+        @log << 'CN lays token on Montreal'
+        @cn_reservations.delete(tile.hex.id)
+        # Montreal only has the one city, given it should be reserved then next token should be valid
+        tile.cities.first.place_token(@cn_corporation, new_token, check_tokenable: false)
       end
 
       def revenue_for(route, stops)
@@ -364,6 +380,8 @@ module Engine
           Step::G1867::Token,
           Step::Route,
           Step::G1867::Dividend,
+          # The blocking buy company needs to be before loan operations
+          [Step::BuyCompany, blocks: true],
           Step::G1867::LoanOperations,
           Step::DiscardTrain,
           Step::G1867::BuyTrain,
@@ -531,6 +549,23 @@ module Engine
 
         @trainless_major = @trainless_major.sort.reverse
         @trainless_nationalization = false
+      end
+
+      def event_nationalize_companies!
+        @log << '-- Event: Private companies are nationalized --'
+
+        @companies.each do |company|
+          if (ability = abilities(company, :close))
+            next if ability.when == 'never' ||
+              @phase.phases.any? { |phase| ability.when == phase[:name] }
+          end
+
+          if company != @hidden_company
+            @bank.spend(company.value, company.owner)
+            @log << "#{company.name} nationalized from #{company.owner.name} for #{format_currency(company.value)}"
+          end
+          company.close!
+        end
       end
     end
   end

--- a/lib/engine/round/g_1867/operating.rb
+++ b/lib/engine/round/g_1867/operating.rb
@@ -10,6 +10,14 @@ module Engine
           minors, majors = @game.corporations.select(&:floated?).sort.partition { |c| c.type == :minor }
           minors + majors
         end
+
+        def start_operating
+          super
+
+          # Skip closed minors
+          entity = @entities[@entity_index]
+          next_entity! unless @game.corporations.include?(entity)
+        end
       end
     end
   end

--- a/lib/engine/step/g_1867/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1867/buy_sell_par_shares.rb
@@ -10,7 +10,7 @@ module Engine
         include PassableAuction
         TOKEN_COST = 50
         MIN_BID = 100
-        MAX_BID = 270
+        MAX_MINOR_PAR = 135
         MAJOR_PHASE = 4
 
         def actions(entity)
@@ -80,7 +80,7 @@ module Engine
           price = winner.price
 
           @log << "#{entity.name} wins bid on #{corporation.name} for #{@game.format_currency(price)}"
-          par_price = price / 2
+          par_price = [price / 2, MAX_MINOR_PAR].min
 
           share_price = @game.find_share_price(par_price)
 
@@ -97,6 +97,9 @@ module Engine
           entity.spend(price, corporation)
 
           @auctioning = nil
+
+          # Player to the right of the winner is the new player
+          @round.goto_entity!(winner.entity)
           pass!
         end
 

--- a/lib/engine/step/g_1867/track.rb
+++ b/lib/engine/step/g_1867/track.rb
@@ -18,6 +18,7 @@ module Engine
           raise GameError, 'Cannot lay and upgrade the same tile in the same turn' if action.hex == @hex
 
           super
+          @game.place_cn_montreal_token(action.hex.tile) if action.tile.name == '639'
           @hex = action.hex
         end
 

--- a/migrate_game.rb
+++ b/migrate_game.rb
@@ -8,6 +8,8 @@ Dir['./models/**/*.rb'].sort.each { |file| require file }
 Sequel.extension :pg_json_ops
 require_relative 'lib/engine'
 
+$broken = {}
+
 def switch_actions(actions, first, second)
   first_idx = actions.index(first)
   second_idx = actions.index(second)
@@ -48,6 +50,11 @@ def repair(game, original_actions, actions, broken_action)
     actions.insert(action_idx, pass.to_h)
     return
   elsif game.active_step.is_a?(Engine::Step::G1817::Acquire)
+    pass = Engine::Action::Pass.new(game.active_step.current_entity)
+    pass.user = pass.entity.player.id
+    actions.insert(action_idx, pass.to_h)
+    return
+  elsif game.active_step.is_a?(Engine::Step::BuySellParShares) && game.is_a?(Engine::Game::G1867) && broken_action['type']=='bid'
     pass = Engine::Action::Pass.new(game.active_step.current_entity)
     pass.user = pass.entity.player.id
     actions.insert(action_idx, pass.to_h)
@@ -211,7 +218,7 @@ def repair(game, original_actions, actions, broken_action)
   raise Exception, "Cannot fix http://18xx.games/game/#{game.id}?action=#{action}"
 end
 
-def attempt_repair(actions)
+def attempt_repair(actions, debug)
   repairs = []
   rewritten = false
   ever_repaired = false
@@ -228,7 +235,7 @@ def attempt_repair(actions)
       begin
         game.process_action(action)
       rescue Exception => e
-        puts e.backtrace
+        puts e.backtrace if debug
         puts "Break at #{e} #{action}"
         ever_repaired = true
         inplace_actions = repair(game, actions, filtered_actions, action)
@@ -256,7 +263,7 @@ end
 
 def migrate_data(data)
   begin
-    data['actions'], repairs = attempt_repair(data['actions']) do
+    data['actions'], repairs = attempt_repair(data['actions'], true) do
       Engine::Game.load(data, actions: [], disable_user_errors: true)
     end
   rescue Exception => e
@@ -286,13 +293,13 @@ def migrate_db_actions_in_mem(data)
   return original_actions
 end
 
-def migrate_db_actions(data, pin, dry_run=false)
-  raise Exception, "pin is not valid" unless pin
+def migrate_db_actions(data, pin, dry_run=false, delete=false, debug=false)
+  raise Exception, "pin is not valid" unless pin || delete
 
   original_actions = data.actions.map(&:to_h)
   engine = Engine::GAMES_BY_TITLE[data.title]
   begin
-    actions, repairs = attempt_repair(original_actions) do
+    actions, repairs = attempt_repair(original_actions, debug) do
       Engine::Game.load(data, actions: [], disable_user_errors: true)
     end
     if actions && !dry_run
@@ -323,11 +330,19 @@ def migrate_db_actions(data, pin, dry_run=false)
     end
     return actions || original_actions
   rescue Exception => e
+    $broken[data.id]=true
     puts 'Something went wrong', e
     if !dry_run
-      puts "Pinning #{data.id} to #{pin}"
-      data.settings['pin']=pin
-      data.save
+      if pin
+        puts "Pinning #{data.id} to #{pin}"
+        data.settings['pin']=pin
+        data.save
+      elsif delete
+        puts "Deleting #{data.id}"
+        data.destroy
+      end
+    else
+      puts "Needs pinning #{data.id}"
     end
   end
   return original_actions
@@ -356,17 +371,17 @@ def migrate_db_to_json(id, filename)
   File.write(filename, JSON.pretty_generate(json))
 end
 
-def migrate_title(title, pin, dry_run=false)
+def migrate_title(title, pin, dry_run=false, delete = false, debug = false)
   DB[:games].order(:id).where(Sequel.pg_jsonb_op(:settings).has_key?('pin') => false, status: %w[active finished], title: title).select(:id).paged_each(rows_per_fetch: 1) do |game|
     games = Game.eager(:user, :players, :actions).where(id: [game[:id]]).all
     games.each {|data|
-      migrate_db_actions(data, pin, dry_run)
+      migrate_db_actions(data, pin, dry_run, delete, debug)
     }
 
   end
 end
 
-def migrate_all(pin, dry_run=false, game_ids: nil)
+def migrate_all(pin, dry_run=false, delete = false, debug = false, game_ids: nil)
   where_args = {
     Sequel.pg_jsonb_op(:settings).has_key?('pin') => false,
     status: %w[active finished],
@@ -376,7 +391,7 @@ def migrate_all(pin, dry_run=false, game_ids: nil)
   DB[:games].order(:id).where(**where_args).select(:id).paged_each(rows_per_fetch: 1) do |game|
     games = Game.eager(:user, :players, :actions).where(id: [game[:id]]).all
     games.each {|data|
-      migrate_db_actions(data, pin, dry_run)
+      migrate_db_actions(data, pin, dry_run, delete, debug)
     }
 
   end

--- a/spec/fixtures/1867/hs_ahjzadkh_19792.json
+++ b/spec/fixtures/1867/hs_ahjzadkh_19792.json
@@ -2057,10 +2057,18 @@
       "original_id": 238
     },
     {
+      "type": "pass",
+      "entity": "OP",
+      "entity_type": "corporation",
+      "user": 6120,
+      "original_id": null,
+      "id": 231
+    },
+    {
       "type": "lay_tile",
       "entity": "PM",
       "entity_type": "corporation",
-      "id": 231,
+      "id": 232,
       "hex": "M9",
       "tile": "619-0",
       "rotation": 4,
@@ -2070,14 +2078,22 @@
       "type": "pass",
       "entity": "PM",
       "entity_type": "corporation",
-      "id": 232,
+      "id": 233,
       "original_id": 240
+    },
+    {
+      "type": "pass",
+      "entity": "PM",
+      "entity_type": "corporation",
+      "user": 671,
+      "original_id": null,
+      "id": 234
     },
     {
       "type": "buy_train",
       "entity": "PM",
       "entity_type": "corporation",
-      "id": 233,
+      "id": 235,
       "train": "3-1",
       "price": 225,
       "variant": "3",
@@ -2087,21 +2103,21 @@
       "type": "pass",
       "entity": "PM",
       "entity_type": "corporation",
-      "id": 234,
+      "id": 236,
       "original_id": 242
     },
     {
       "type": "pass",
       "entity": "PM",
       "entity_type": "corporation",
-      "id": 235,
+      "id": 237,
       "original_id": 243
     },
     {
       "type": "lay_tile",
       "entity": "CA",
       "entity_type": "corporation",
-      "id": 236,
+      "id": 238,
       "hex": "I13",
       "tile": "24-0",
       "rotation": 4,
@@ -2111,14 +2127,14 @@
       "type": "pass",
       "entity": "CA",
       "entity_type": "corporation",
-      "id": 237,
+      "id": 239,
       "original_id": 245
     },
     {
       "type": "run_routes",
       "entity": "CA",
       "entity_type": "corporation",
-      "id": 238,
+      "id": 240,
       "routes": [
         {
           "train": "2-3",
@@ -2150,7 +2166,7 @@
       "type": "message",
       "entity": 6126,
       "entity_type": "player",
-      "id": 239,
+      "id": 241,
       "message": "What is \"Skip companies\" step?",
       "original_id": 247
     },
@@ -2158,14 +2174,14 @@
       "type": "pass",
       "entity": "CA",
       "entity_type": "corporation",
-      "id": 240,
+      "id": 242,
       "original_id": 248
     },
     {
       "type": "message",
       "entity": 6124,
       "entity_type": "player",
-      "id": 241,
+      "id": 243,
       "message": "Buy a company",
       "original_id": 249
     },
@@ -2173,15 +2189,23 @@
       "type": "message",
       "entity": 6126,
       "entity_type": "player",
-      "id": 242,
+      "id": 244,
       "message": "ok, I privates, forgot",
       "original_id": 250
+    },
+    {
+      "type": "pass",
+      "entity": "CA",
+      "entity_type": "corporation",
+      "user": 6126,
+      "original_id": null,
+      "id": 245
     },
     {
       "type": "lay_tile",
       "entity": "CS",
       "entity_type": "corporation",
-      "id": 243,
+      "id": 246,
       "hex": "O7",
       "tile": "207-0",
       "rotation": 5,
@@ -2191,14 +2215,14 @@
       "type": "pass",
       "entity": "CS",
       "entity_type": "corporation",
-      "id": 244,
+      "id": 247,
       "original_id": 252
     },
     {
       "type": "run_routes",
       "entity": "CS",
       "entity_type": "corporation",
-      "id": 245,
+      "id": 248,
       "routes": [
         {
           "train": "2-4",
@@ -2216,21 +2240,29 @@
       "type": "pass",
       "entity": "CS",
       "entity_type": "corporation",
-      "id": 246,
+      "id": 249,
       "original_id": 254
     },
     {
       "type": "pass",
       "entity": "CS",
       "entity_type": "corporation",
-      "id": 247,
+      "id": 250,
       "original_id": 255
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "user": 671,
+      "original_id": null,
+      "id": 251
     },
     {
       "type": "lay_tile",
       "entity": "NO",
       "entity_type": "corporation",
-      "id": 248,
+      "id": 252,
       "hex": "D16",
       "tile": "622-0",
       "rotation": 1,
@@ -2240,14 +2272,14 @@
       "type": "pass",
       "entity": "NO",
       "entity_type": "corporation",
-      "id": 249,
+      "id": 253,
       "original_id": 257
     },
     {
       "type": "run_routes",
       "entity": "NO",
       "entity_type": "corporation",
-      "id": 250,
+      "id": 254,
       "routes": [
         {
           "train": "2-6",
@@ -2265,21 +2297,29 @@
       "type": "pass",
       "entity": "NO",
       "entity_type": "corporation",
-      "id": 251,
+      "id": 255,
       "original_id": 259
     },
     {
       "type": "pass",
       "entity": "NO",
       "entity_type": "corporation",
-      "id": 252,
+      "id": 256,
       "original_id": 260
+    },
+    {
+      "type": "pass",
+      "entity": "NO",
+      "entity_type": "corporation",
+      "user": 6126,
+      "original_id": null,
+      "id": 257
     },
     {
       "type": "lay_tile",
       "entity": "BO",
       "entity_type": "corporation",
-      "id": 253,
+      "id": 258,
       "hex": "C17",
       "tile": "619-1",
       "rotation": 1,
@@ -2289,14 +2329,14 @@
       "type": "pass",
       "entity": "BO",
       "entity_type": "corporation",
-      "id": 254,
+      "id": 259,
       "original_id": 262
     },
     {
       "type": "run_routes",
       "entity": "BO",
       "entity_type": "corporation",
-      "id": 255,
+      "id": 260,
       "routes": [
         {
           "train": "2-9",
@@ -2318,21 +2358,29 @@
       "type": "pass",
       "entity": "BO",
       "entity_type": "corporation",
-      "id": 256,
+      "id": 261,
       "original_id": 264
     },
     {
       "type": "pass",
       "entity": "BO",
       "entity_type": "corporation",
-      "id": 257,
+      "id": 262,
       "original_id": 265
+    },
+    {
+      "type": "pass",
+      "entity": "BO",
+      "entity_type": "corporation",
+      "user": 6120,
+      "original_id": null,
+      "id": 263
     },
     {
       "type": "lay_tile",
       "entity": "KP",
       "entity_type": "corporation",
-      "id": 258,
+      "id": 264,
       "hex": "E9",
       "tile": "8-1",
       "rotation": 2,
@@ -2342,7 +2390,7 @@
       "type": "lay_tile",
       "entity": "KP",
       "entity_type": "corporation",
-      "id": 259,
+      "id": 265,
       "hex": "D8",
       "tile": "57-0",
       "rotation": 2,
@@ -2352,7 +2400,7 @@
       "type": "run_routes",
       "entity": "KP",
       "entity_type": "corporation",
-      "id": 260,
+      "id": 266,
       "routes": [
         {
           "train": "2-2",
@@ -2371,21 +2419,29 @@
       "type": "pass",
       "entity": "KP",
       "entity_type": "corporation",
-      "id": 261,
+      "id": 267,
       "original_id": 269
     },
     {
       "type": "pass",
       "entity": "KP",
       "entity_type": "corporation",
-      "id": 262,
+      "id": 268,
       "original_id": 270
+    },
+    {
+      "type": "pass",
+      "entity": "KP",
+      "entity_type": "corporation",
+      "user": 671,
+      "original_id": null,
+      "id": 269
     },
     {
       "type": "lay_tile",
       "entity": "TN",
       "entity_type": "corporation",
-      "id": 263,
+      "id": 270,
       "hex": "F16",
       "tile": "120-0",
       "rotation": 1,
@@ -2395,14 +2451,14 @@
       "type": "pass",
       "entity": "TN",
       "entity_type": "corporation",
-      "id": 264,
+      "id": 271,
       "original_id": 272
     },
     {
       "type": "run_routes",
       "entity": "TN",
       "entity_type": "corporation",
-      "id": 265,
+      "id": 272,
       "routes": [
         {
           "train": "2-7",
@@ -2420,7 +2476,7 @@
       "type": "message",
       "entity": 671,
       "entity_type": "player",
-      "id": 266,
+      "id": 273,
       "message": "hit another bug, gotta go for a while",
       "original_id": 274
     },
@@ -2428,7 +2484,7 @@
       "type": "message",
       "entity": 671,
       "entity_type": "player",
-      "id": 267,
+      "id": 274,
       "message": "grab dinner and fight the supermarkets :(",
       "original_id": 275
     },
@@ -2436,7 +2492,7 @@
       "type": "pass",
       "entity": "TN",
       "entity_type": "corporation",
-      "id": 268,
+      "id": 275,
       "user": 671,
       "original_id": 276
     },
@@ -2446,13 +2502,21 @@
       "entity_type": "corporation",
       "user": 6126,
       "original_id": null,
-      "id": 269
+      "id": 276
+    },
+    {
+      "type": "pass",
+      "entity": "TN",
+      "entity_type": "corporation",
+      "user": 6126,
+      "original_id": null,
+      "id": 277
     },
     {
       "type": "merge",
       "entity": "AE",
       "entity_type": "corporation",
-      "id": 270,
+      "id": 278,
       "user": 671,
       "corporation": "CV",
       "original_id": 277
@@ -2461,7 +2525,7 @@
       "type": "merge",
       "entity": "AE",
       "entity_type": "corporation",
-      "id": 271,
+      "id": 279,
       "user": 671,
       "corporation": "CA",
       "original_id": 278
@@ -2470,7 +2534,7 @@
       "type": "merge",
       "entity": "AE",
       "entity_type": "corporation",
-      "id": 272,
+      "id": 280,
       "user": 671,
       "corporation": "TN",
       "original_id": 279
@@ -2479,7 +2543,7 @@
       "type": "merge",
       "entity": "AE",
       "entity_type": "corporation",
-      "id": 273,
+      "id": 281,
       "user": 671,
       "corporation": "CNR",
       "original_id": 282
@@ -2488,7 +2552,7 @@
       "type": "buy_shares",
       "entity": 6124,
       "entity_type": "player",
-      "id": 274,
+      "id": 282,
       "user": 671,
       "shares": [
         "CNR_1"
@@ -2500,7 +2564,7 @@
       "type": "buy_shares",
       "entity": 6126,
       "entity_type": "player",
-      "id": 275,
+      "id": 283,
       "user": 671,
       "shares": [
         "CNR_2"
@@ -2512,7 +2576,7 @@
       "type": "buy_shares",
       "entity": 6126,
       "entity_type": "player",
-      "id": 276,
+      "id": 284,
       "user": 671,
       "shares": [
         "CNR_3"
@@ -2524,7 +2588,7 @@
       "type": "buy_shares",
       "entity": 671,
       "entity_type": "player",
-      "id": 277,
+      "id": 285,
       "shares": [
         "CNR_4"
       ],
@@ -2535,7 +2599,7 @@
       "type": "buy_shares",
       "entity": 6120,
       "entity_type": "player",
-      "id": 278,
+      "id": 286,
       "user": 671,
       "shares": [
         "CNR_5"
@@ -2547,7 +2611,7 @@
       "type": "remove_token",
       "entity": "CNR",
       "entity_type": "corporation",
-      "id": 279,
+      "id": 287,
       "user": 671,
       "city": "L12-0-0",
       "slot": 0,
@@ -2557,7 +2621,7 @@
       "type": "remove_token",
       "entity": "CNR",
       "entity_type": "corporation",
-      "id": 280,
+      "id": 288,
       "user": 671,
       "city": "202-1-0",
       "slot": 0,
@@ -2567,7 +2631,7 @@
       "type": "discard_train",
       "entity": "CNR",
       "entity_type": "corporation",
-      "id": 281,
+      "id": 289,
       "user": 671,
       "train": "2-3",
       "original_id": 290
@@ -2576,7 +2640,7 @@
       "type": "discard_train",
       "entity": "CNR",
       "entity_type": "corporation",
-      "id": 282,
+      "id": 290,
       "user": 671,
       "train": "2-5",
       "original_id": 291
@@ -2585,7 +2649,7 @@
       "type": "end_game",
       "entity": 671,
       "entity_type": "player",
-      "id": 283,
+      "id": 291,
       "original_id": 292
     }
   ],


### PR DESCRIPTION
Skip nationalized corporations (fixes #2893)
Add blocking buy private step before interest payment (fixes #2888)
Nationalizing privates should pay owner (fixes #2905)
Increase number of 2+2 and 5+5E trains (fixes #2915)
Don't place CN tokens when nationalizing if they already are on the hex (fixes #2891)
Limit market price of minor to $135 (fixes #2953)
Player after Minor auction is to the right of the winner (fixes #2950)
CN token should be placed on 639 (fixes #2917)
Correct max share price for minors (fixes #2954)