### PR TITLE
Make Nieuw Zeeland green in 1817WO until it is parrable

### DIFF
--- a/lib/engine/config/game/g_1817_wo.rb
+++ b/lib/engine/config/game/g_1817_wo.rb
@@ -447,7 +447,12 @@ module Engine
       "distance": 3,
       "price": 250,
       "rusts_on": "6",
-      "num": 7
+      "num": 7,
+      "events": [
+        {
+          "type": "nieuw_zeeland_available"
+        }
+      ]
     },
     {
       "name": "4",

--- a/lib/engine/game/g_1817_wo.rb
+++ b/lib/engine/game/g_1817_wo.rb
@@ -22,6 +22,7 @@ module Engine
         '1817 Rules' => 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view',
       }.freeze
       GAME_DESIGNER = 'Mark Voyer & Brennan Sheremeto'
+      EVENTS_TEXT = G1817::EVENTS_TEXT.merge('nieuw_zeeland_available' => ['Nieuw Zealand opens for new IPOs'])
 
       def self.title
         '1817WO'
@@ -30,6 +31,15 @@ module Engine
       def setup
         super
         @new_zealand_city = hexes.find { |hex| hex.location_name == 'Nieuw Zeeland' }.tile.cities[0]
+        # Put an 1867 style green token in the New Zealand hex
+        @green_token = Token.new(nil, price: 0, logo: '/logos/1817/nz.svg', type: :neutral)
+        @new_zealand_city.exchange_token(@green_token)
+      end
+
+      def event_nieuw_zeeland_available!
+        # Remove the 1867-style green token from the New Zealand hex
+        @log << 'Corporations can now be IPOed in Nieuw Zeeland'
+        @green_token.amp(&:remove!)
       end
 
       # Not genericifying 1817's loan logic just so it can be kept simpler, at least for now

--- a/lib/engine/game/g_1817_wo.rb
+++ b/lib/engine/game/g_1817_wo.rb
@@ -39,7 +39,7 @@ module Engine
       def event_nieuw_zeeland_available!
         # Remove the 1867-style green token from the New Zealand hex
         @log << 'Corporations can now be IPOed in Nieuw Zeeland'
-        @green_token.amp(&:remove!)
+        @green_token.remove!
       end
 
       # Not genericifying 1817's loan logic just so it can be kept simpler, at least for now

--- a/public/logos/1817/nz.svg
+++ b/public/logos/1817/nz.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   viewBox="0 0 13.62 13.62"
+   data-name="Layer 1"
+   id="Layer_1"
+   sodipodi:docname="neutral.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3696"
+     inkscape:window-height="2032"
+     id="namedview3765"
+     showgrid="false"
+     inkscape:zoom="130.76358"
+     inkscape:cx="6.8099999"
+     inkscape:cy="6.8099999"
+     inkscape:window-x="144"
+     inkscape:window-y="54"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1{fill:#fff;}.cls-2{fill:#231f20;}</style>
+  </defs>
+  <circle
+     style="fill:#44aa00"
+     id="circle6"
+     r="6.81"
+     cy="6.81"
+     cx="6.81"
+     class="cls-1" />
+</svg>

--- a/spec/fixtures/1817NA/20584.json
+++ b/spec/fixtures/1817NA/20584.json
@@ -1,0 +1,13753 @@
+{
+    "id": 20584,
+    "description": "Sunday18xx",
+    "user": {
+      "id": 1996,
+      "name": "SunnyD"
+    },
+    "players": [
+      {
+        "id": 2516,
+        "name": "LJHall"
+      },
+      {
+        "id": 78,
+        "name": "hamish"
+      },
+      {
+        "id": 2394,
+        "name": "Helen "
+      },
+      {
+        "id": 1996,
+        "name": "SunnyD"
+      }
+    ],
+    "max_players": 4,
+    "title": "1817NA",
+    "settings": {
+      "seed": 1302946917,
+      "unlisted": true,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "status": "finished",
+    "turn": 7,
+    "round": "Acquisition Round",
+    "acting": [
+      2394
+    ],
+    "result": {
+      "Helen ": 821,
+      "LJHall": 3134,
+      "SunnyD": 137,
+      "hamish": 5645
+    },
+    "actions": [
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1,
+        "company": "MINM",
+        "price": 10
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 2,
+        "company": "MINM",
+        "price": 15
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 3,
+        "company": "MINM",
+        "price": 20
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 4
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 5,
+        "company": "MINM",
+        "price": 25
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 6,
+        "company": "MINM",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 7,
+        "company": "MINM",
+        "price": 35
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 8,
+        "company": "MINM",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 9,
+        "company": "MINM",
+        "price": 45
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 10
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 11,
+        "company": "MINM",
+        "price": 50
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 12
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 13,
+        "company": "DTC",
+        "price": 5
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 14,
+        "company": "DTC",
+        "price": 10
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 15,
+        "company": "DTC",
+        "price": 15
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 16,
+        "company": "DTC",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 17,
+        "company": "DTC",
+        "price": 25
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 18,
+        "company": "DTC",
+        "price": 30
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 19
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 20
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 21
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 22,
+        "company": "MAJM",
+        "price": 0
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 23,
+        "company": "MAJM",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 24,
+        "company": "MAJM",
+        "price": 25
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 25,
+        "company": "MAJM",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 26,
+        "company": "MAJM",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 27,
+        "company": "MAJM",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 28,
+        "company": "MAJM",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 29,
+        "company": "MAJM",
+        "price": 65
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 30,
+        "company": "MAJM",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 31,
+        "company": "MAJM",
+        "price": 75
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 32
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 33,
+        "company": "MAJM",
+        "price": 80
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 34,
+        "company": "MAJM",
+        "price": 85
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 35
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 36,
+        "company": "MAJM",
+        "price": 90
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 37,
+        "company": "MAJM",
+        "price": 95
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 38
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 39,
+        "company": "TS",
+        "price": 0
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 40,
+        "company": "TS",
+        "price": 5
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 41,
+        "company": "TS",
+        "price": 10
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 42,
+        "company": "TS",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 43,
+        "company": "TS",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 44,
+        "company": "TS",
+        "price": 55
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 45
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 46
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 47
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 48,
+        "company": "ME",
+        "price": 0
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 49,
+        "company": "ME",
+        "price": 5
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 50,
+        "company": "ME",
+        "price": 10
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 51,
+        "company": "ME",
+        "price": 15
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 52
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 53,
+        "company": "ME",
+        "price": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 54
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 55,
+        "company": "ME",
+        "price": 25
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 56,
+        "company": "ME",
+        "price": 30
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 57
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 58,
+        "company": "MINC",
+        "price": 0
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 59,
+        "company": "MINC",
+        "price": 5
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 60,
+        "company": "MINC",
+        "price": 10
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 61,
+        "company": "MINC",
+        "price": 15
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 62,
+        "company": "MINC",
+        "price": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 63
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 64,
+        "company": "MINC",
+        "price": 25
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 65
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 66
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 67,
+        "company": "UBC",
+        "price": 15
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 68,
+        "company": "UBC",
+        "price": 30
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 69
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 70,
+        "company": "UBC",
+        "price": 35
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 71,
+        "company": "UBC",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 72,
+        "company": "UBC",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 73,
+        "company": "UBC",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 74,
+        "company": "UBC",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 75,
+        "company": "UBC",
+        "price": 60
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 76
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 77
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 78,
+        "company": "MAJC",
+        "price": 45
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 79
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 80,
+        "company": "MAJC",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 81,
+        "company": "MAJC",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 82,
+        "company": "MAJC",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 83,
+        "company": "MAJC",
+        "price": 65
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 84
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 85,
+        "company": "MAJC",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 86,
+        "company": "MAJC",
+        "price": 75
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 87
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 88,
+        "corporation": "SR",
+        "price": 140
+      },
+      {
+        "type": "place_token",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 89,
+        "city": "H10-6-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 90
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 91
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 92
+      },
+      {
+        "id": 93,
+        "type": "assign",
+        "entity": 2516,
+        "target": "MINM",
+        "entity_type": "player",
+        "target_type": "company",
+        "user": 2394,
+        "created_at": 1609326682
+      },
+      {
+        "id": 94,
+        "type": "undo",
+        "entity": 2516,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609326716
+      },
+      {
+        "id": 95,
+        "type": "assign",
+        "entity": 2516,
+        "target": "MINM",
+        "entity_type": "player",
+        "target_type": "company",
+        "user": 2394,
+        "created_at": 1609326738
+      },
+      {
+        "id": 96,
+        "type": "undo",
+        "entity": 2516,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609326744
+      },
+      {
+        "type": "assign",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 97,
+        "user": 2394,
+        "target": "MINM",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 98
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 99,
+        "corporation": "NYOW",
+        "price": 135
+      },
+      {
+        "type": "place_token",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 100,
+        "city": "F22-0-1",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 101
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 102
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 103
+      },
+      {
+        "type": "assign",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 104,
+        "target": "ME",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 105
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 106,
+        "corporation": "GT",
+        "price": 120
+      },
+      {
+        "type": "place_token",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 107,
+        "city": "F22-0-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 108
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 109
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 110,
+        "corporation": "GT",
+        "price": 140
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 111
+      },
+      {
+        "type": "assign",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 112,
+        "target": "MAJC",
+        "target_type": "company"
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 113,
+        "corporation": "UR",
+        "price": 105
+      },
+      {
+        "type": "place_token",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 114,
+        "city": "D16-1-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 115
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 116
+      },
+      {
+        "type": "assign",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 117,
+        "target": "UBC",
+        "target_type": "company"
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 118,
+        "corporation": "PLE",
+        "price": 140
+      },
+      {
+        "type": "place_token",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 119,
+        "city": "I15-0-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 120
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 121
+      },
+      {
+        "type": "assign",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 122,
+        "target": "TS",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 123
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 124,
+        "corporation": "H",
+        "price": 180
+      },
+      {
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 125,
+        "city": "I21-0-0",
+        "slot": 0
+      },
+      {
+        "type": "assign",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 126,
+        "target": "MAJM",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 127
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 128,
+        "corporation": "R",
+        "price": 160
+      },
+      {
+        "type": "place_token",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 129,
+        "city": "F20-5-0",
+        "slot": 0
+      },
+      {
+        "type": "assign",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 130,
+        "target": "MINC",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 131
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 132
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 133,
+        "corporation": "J",
+        "price": 100
+      },
+      {
+        "type": "place_token",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 134,
+        "city": "F14-4-0",
+        "slot": 0
+      },
+      {
+        "type": "assign",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 135,
+        "target": "DTC",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 136
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 137
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 138
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 139
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 140,
+        "hex": "J20",
+        "tile": "8-0",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 141,
+        "hex": "H20",
+        "tile": "8-1",
+        "rotation": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 142,
+        "loan": 0
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 143,
+        "loan": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 144,
+        "train": "2-0",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 145,
+        "train": "2-1",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 146,
+        "hex": "F20",
+        "tile": "5-0",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 147,
+        "hex": "G21",
+        "tile": "7-0",
+        "rotation": 2
+      },
+      {
+        "type": "buy_train",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 148,
+        "train": "2-2",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 149
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 150
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 151,
+        "hex": "H10",
+        "tile": "57-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 152,
+        "hex": "H12",
+        "tile": "8-2",
+        "rotation": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 153,
+        "loan": 2
+      },
+      {
+        "type": "take_loan",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 154,
+        "loan": 3
+      },
+      {
+        "type": "buy_train",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 155,
+        "train": "2-3",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 156,
+        "train": "2-4",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 157
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 158
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 159,
+        "loan": 4
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 160,
+        "train": "2-5",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 161
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 162
+      },
+      {
+        "id": 163,
+        "hex": "I13",
+        "tile": "6-0",
+        "type": "lay_tile",
+        "entity": "PLE",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609328391
+      },
+      {
+        "id": 164,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609328414
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 165,
+        "hex": "J16",
+        "tile": "8-3",
+        "rotation": 2
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 166,
+        "loan": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 167,
+        "loan": 6
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 168
+      },
+      {
+        "type": "buy_train",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 169,
+        "train": "2-6",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 170,
+        "train": "2-7",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 171
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 172,
+        "hex": "E23",
+        "tile": "9-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 173
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 174,
+        "loan": 7
+      },
+      {
+        "type": "buy_train",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 175,
+        "train": "2-8",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 176
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 177
+      },
+      {
+        "id": 178,
+        "hex": "D16",
+        "tile": "5-1",
+        "type": "lay_tile",
+        "entity": "UR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609328583
+      },
+      {
+        "id": 179,
+        "type": "undo",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609328588
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 180,
+        "hex": "D16",
+        "tile": "5-1",
+        "rotation": 0
+      },
+      {
+        "type": "assign",
+        "entity": "UBC",
+        "entity_type": "company",
+        "id": 181,
+        "target": "D16",
+        "target_type": "hex"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 182,
+        "hex": "D14",
+        "tile": "9-1",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 183,
+        "loan": 8
+      },
+      {
+        "type": "buy_train",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 184,
+        "train": "2-9",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 185
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 186
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DTC",
+        "entity_type": "company",
+        "id": 187,
+        "hex": "F14",
+        "tile": "X00-0",
+        "rotation": 2
+      },
+      {
+        "id": 188,
+        "hex": "E15",
+        "tile": "9-2",
+        "type": "lay_tile",
+        "entity": "J",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609328698
+      },
+      {
+        "id": 189,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609328703
+      },
+      {
+        "type": "lay_tile",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 190,
+        "hex": "E15",
+        "tile": "9-2",
+        "rotation": 0
+      },
+      {
+        "type": "take_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 191,
+        "loan": 9
+      },
+      {
+        "type": "take_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 192,
+        "loan": 10
+      },
+      {
+        "type": "buy_train",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 193,
+        "train": "2-10",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 194,
+        "train": "2-11",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 195
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 196
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 197
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 198
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 199
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 200
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 201
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 202
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 203
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 204
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 205
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 206
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 207
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 208
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MINC",
+        "entity_type": "company",
+        "id": 209,
+        "hex": "G19",
+        "tile": "9-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 210
+      },
+      {
+        "type": "run_routes",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 211,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F22",
+                "G21",
+                "F20"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 212,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609329283
+      },
+      {
+        "id": 213,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609329288
+      },
+      {
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 214,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 215
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 216
+      },
+      {
+        "id": 217,
+        "hex": "I19",
+        "tile": "8-4",
+        "type": "lay_tile",
+        "entity": "H",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609329308
+      },
+      {
+        "id": 218,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609329386
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 219
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 220,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "I21",
+                "J20",
+                "K21"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 221,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 222
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 223
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 224,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "F22",
+                "G21",
+                "F20"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 225,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 226
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 227
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 228,
+        "hex": "I13",
+        "tile": "6-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 229
+      },
+      {
+        "type": "run_routes",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 230,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "H10",
+                "H8"
+              ]
+            ]
+          },
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "H10",
+                "H12",
+                "I13"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 231,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 232
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 233,
+        "hex": "J18",
+        "tile": "6-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 234
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 235
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 236,
+        "routes": [
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "I15",
+                "I13"
+              ]
+            ]
+          },
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "I15",
+                "J16",
+                "J18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 237,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 238
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 239,
+        "hex": "D24",
+        "tile": "8-4",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 240
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 241,
+        "routes": [
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D26"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 242,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 243
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 244,
+        "loan": 7
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 245
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 246
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 247,
+        "routes": [
+          {
+            "train": "2-9",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 248,
+        "kind": "half"
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 249,
+        "loan": 11
+      },
+      {
+        "type": "buy_train",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 250,
+        "train": "2+-0",
+        "price": 100,
+        "variant": "2+"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 251
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 252
+      },
+      {
+        "type": "run_routes",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 253,
+        "routes": [
+          {
+            "train": "2-10",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 254,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 255
+      },
+      {
+        "type": "convert",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 256
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 257,
+        "shares": [
+          "R_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 258
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 259
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 260
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 261
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 262
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 263
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 264
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 265
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 266
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 267,
+        "corporation": "UR",
+        "price": 10
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 268,
+        "corporation": "UR",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 269,
+        "corporation": "UR",
+        "price": 30
+      },
+      {
+        "id": 270,
+        "type": "bid",
+        "price": 40,
+        "entity": 1996,
+        "corporation": "UR",
+        "entity_type": "player",
+        "user": 1996,
+        "created_at": 1609330581
+      },
+      {
+        "id": 271,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609330595
+      },
+      {
+        "id": 272,
+        "type": "bid",
+        "price": 40,
+        "entity": 1996,
+        "corporation": "UR",
+        "entity_type": "player",
+        "user": 1996,
+        "created_at": 1609330612
+      },
+      {
+        "id": 273,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609330625
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 274,
+        "corporation": "UR",
+        "price": 40
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 275
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 276
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 277
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 278
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 279
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 280
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 281,
+        "shares": [
+          "R_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 282,
+        "shares": [
+          "R_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 283
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 284
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 285
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 286
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 287
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 288,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "I21",
+                "J20",
+                "K21"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 289,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 290
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 291
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 292,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "F22",
+                "G21",
+                "F20"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 293,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 294
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 295
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 296,
+        "hex": "H18",
+        "tile": "6-2",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 297,
+        "hex": "I19",
+        "tile": "8-5",
+        "rotation": 2
+      },
+      {
+        "type": "place_token",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 298,
+        "city": "6-2-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 299,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F22",
+                "G21",
+                "F20"
+              ]
+            ]
+          },
+          {
+            "train": "2-9",
+            "connections": [
+              [
+                "D12",
+                "D14",
+                "D16"
+              ]
+            ]
+          },
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 300,
+        "kind": "half"
+      },
+      {
+        "type": "buy_train",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 301,
+        "train": "2+-2",
+        "price": 100,
+        "variant": "2+"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 302,
+        "loan": 8
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 303
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 304
+      },
+      {
+        "type": "run_routes",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 305,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "H10",
+                "H8"
+              ]
+            ]
+          },
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "H10",
+                "H12",
+                "I13"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 306,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 307
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 308,
+        "hex": "K19",
+        "tile": "8-6",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 309
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 310
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 311,
+        "routes": [
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "I15",
+                "I13"
+              ]
+            ]
+          },
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "I15",
+                "J16",
+                "J18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 312,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 313
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 314
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 315,
+        "routes": [
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D26"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 316,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 317
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 318
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 319
+      },
+      {
+        "type": "run_routes",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 320,
+        "routes": [
+          {
+            "train": "2-10",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 321,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 322
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 323
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 324
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 325
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 326
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 327
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 328
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 329
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 330
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 331
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 332
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 333
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 334
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 335,
+        "hex": "D16",
+        "tile": "14-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 336
+      },
+      {
+        "type": "run_routes",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 337,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F22",
+                "G21",
+                "F20"
+              ]
+            ]
+          },
+          {
+            "train": "2-9",
+            "connections": [
+              [
+                "D12",
+                "D14",
+                "D16"
+              ]
+            ]
+          },
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          },
+          {
+            "train": "2+-2",
+            "connections": [
+              [
+                "F20",
+                "G19",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 338,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 339,
+        "loan": 11
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 340
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 341,
+        "hex": "G21",
+        "tile": "83-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 342
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 343,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "I21",
+                "J20",
+                "K21"
+              ]
+            ]
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "I21",
+                "H20",
+                "G21",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 344,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609331934
+      },
+      {
+        "id": 345,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609331938
+      },
+      {
+        "id": 346,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609331953
+      },
+      {
+        "id": 347,
+        "type": "buy_train",
+        "price": 20,
+        "train": "2-10",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609331978
+      },
+      {
+        "id": 348,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609331984
+      },
+      {
+        "id": 349,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609332012
+      },
+      {
+        "id": 350,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609332034
+      },
+      {
+        "id": 351,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609332039
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 352,
+        "kind": "half"
+      },
+      {
+        "id": 353,
+        "type": "buy_train",
+        "price": 1,
+        "train": "2-10",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609332055
+      },
+      {
+        "id": 354,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609332058
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 355,
+        "train": "2-10",
+        "price": 50
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 356
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 357,
+        "hex": "F22",
+        "tile": "54-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 358
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 359,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "F22",
+                "G21",
+                "H20",
+                "I21"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 360,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 361
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 362,
+        "loan": 4
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 363
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 364,
+        "hex": "H10",
+        "tile": "15-0",
+        "rotation": 1
+      },
+      {
+        "id": 365,
+        "hex": "G11",
+        "tile": "9-4",
+        "type": "lay_tile",
+        "entity": "SR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609332339
+      },
+      {
+        "id": 366,
+        "type": "undo",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609332399
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 367
+      },
+      {
+        "type": "run_routes",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 368,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "H10",
+                "H8"
+              ]
+            ]
+          },
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "H10",
+                "H12",
+                "I13"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 369,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 370
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 371,
+        "loan": 2
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 372
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 373,
+        "hex": "I15",
+        "tile": "592-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 374
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 375
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 376,
+        "routes": [
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "I15",
+                "I13"
+              ]
+            ]
+          },
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "I15",
+                "J16",
+                "J18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 377,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 378
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 379,
+        "loan": 5
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 380
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 381,
+        "hex": "E21",
+        "tile": "8-7",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 382
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 383,
+        "routes": [
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D26"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 384,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332704
+      },
+      {
+        "id": 385,
+        "loan": 13,
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332713
+      },
+      {
+        "id": 386,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332725
+      },
+      {
+        "id": 387,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332731
+      },
+      {
+        "id": 388,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332736
+      },
+      {
+        "id": 389,
+        "loan": 13,
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332756
+      },
+      {
+        "id": 390,
+        "loan": 14,
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332761
+      },
+      {
+        "id": 391,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332774
+      },
+      {
+        "id": 392,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332777
+      },
+      {
+        "id": 393,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609332790
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 394,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 395,
+        "loan": 13
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 396,
+        "loan": 14
+      },
+      {
+        "type": "buy_train",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 397,
+        "train": "3-1",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 398
+      },
+      {
+        "type": "lay_tile",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 399,
+        "hex": "F14",
+        "tile": "592-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 400
+      },
+      {
+        "type": "run_routes",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 401,
+        "routes": [
+          {
+            "train": "2-11",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 402,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 403
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 404
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 405
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 406
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 407
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 408
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 409
+      },
+      {
+        "type": "convert",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 410
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 411,
+        "shares": [
+          "J_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 412
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 413
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 414
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 415
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 416
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 417
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 418
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 419
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 420
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 421
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 422,
+        "corporation": "WT",
+        "price": 200
+      },
+      {
+        "type": "place_token",
+        "entity": "WT",
+        "entity_type": "corporation",
+        "id": 423,
+        "city": "592-0-0",
+        "slot": 1
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 424
+      },
+      {
+        "id": 425,
+        "type": "choose",
+        "choice": 5,
+        "entity": 2394,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609333400
+      },
+      {
+        "id": 426,
+        "type": "undo",
+        "entity": 1996,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609333414
+      },
+      {
+        "type": "choose",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 427,
+        "choice": 2
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 428,
+        "corporation": "UR",
+        "price": 100
+      },
+      {
+        "type": "place_token",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 429,
+        "city": "D12-0-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 430
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 431,
+        "corporation": "UR",
+        "price": 150
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 432
+      },
+      {
+        "type": "choose",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 433,
+        "choice": 2
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 434,
+        "shares": [
+          "R_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 435,
+        "corporation": "ME",
+        "price": 200
+      },
+      {
+        "type": "place_token",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 436,
+        "city": "592-1-0",
+        "slot": 1
+      },
+      {
+        "type": "choose",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 437,
+        "choice": 5
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 438
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 439
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 440,
+        "corporation": "PSNR",
+        "price": 200
+      },
+      {
+        "type": "place_token",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 441,
+        "city": "14-0-0",
+        "slot": 1
+      },
+      {
+        "type": "choose",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 442,
+        "choice": 2
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 443,
+        "shares": [
+          "ME_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 444
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 445
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 446
+      },
+      {
+        "type": "take_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 447,
+        "loan": 15
+      },
+      {
+        "type": "buy_shares",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 448,
+        "shares": [
+          "R_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 449,
+        "shares": [
+          "J_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 450
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 451
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 452
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 453
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WT",
+        "entity_type": "corporation",
+        "id": 454,
+        "hex": "I13",
+        "tile": "14-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "WT",
+        "entity_type": "corporation",
+        "id": 455
+      },
+      {
+        "type": "take_loan",
+        "entity": "WT",
+        "entity_type": "corporation",
+        "id": 456,
+        "loan": 16
+      },
+      {
+        "type": "buy_train",
+        "entity": "WT",
+        "entity_type": "corporation",
+        "id": 457,
+        "train": "3-3",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "WT",
+        "entity_type": "corporation",
+        "id": 458
+      },
+      {
+        "type": "pass",
+        "entity": "WT",
+        "entity_type": "corporation",
+        "id": 459
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 460,
+        "hex": "G15",
+        "tile": "9-4",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 461
+      },
+      {
+        "type": "buy_train",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 462,
+        "train": "3-4",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 463
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 464
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 465,
+        "hex": "C17",
+        "tile": "9-5",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 466
+      },
+      {
+        "type": "buy_train",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 467,
+        "train": "2+-0",
+        "price": 150
+      },
+      {
+        "type": "buy_train",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 468,
+        "train": "2-2",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 469
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 470
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 471,
+        "hex": "H18",
+        "tile": "15-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 472,
+        "hex": "G17",
+        "tile": "9-6",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 473,
+        "routes": [
+          {
+            "train": "2-9",
+            "connections": [
+              [
+                "H18",
+                "G19",
+                "F20"
+              ]
+            ]
+          },
+          {
+            "train": "2+-2",
+            "connections": [
+              [
+                "F20",
+                "G21",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 474,
+        "kind": "half"
+      },
+      {
+        "type": "take_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 475,
+        "loan": 17
+      },
+      {
+        "type": "buy_train",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 476,
+        "train": "3-5",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 477
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 478
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 479,
+        "hex": "G17",
+        "tile": "83-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 480
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 481,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "I21",
+                "J20",
+                "K21"
+              ]
+            ]
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "I21",
+                "H20",
+                "G21",
+                "F22"
+              ]
+            ]
+          },
+          {
+            "train": "2-10",
+            "connections": [
+              [
+                "I21",
+                "I19",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 482,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 483
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 484,
+        "loan": 0
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 485
+      },
+      {
+        "id": 486,
+        "hex": "C11",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "UR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609335217
+      },
+      {
+        "id": 487,
+        "type": "undo",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609335271
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 488,
+        "hex": "C11",
+        "tile": "8-8",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 489
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 490,
+        "loan": 18
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 491,
+        "loan": 19
+      },
+      {
+        "type": "buy_train",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 492,
+        "train": "3-6",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 493
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 494,
+        "hex": "F20",
+        "tile": "619-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 495
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 496,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "F22",
+                "G21",
+                "H20",
+                "I21"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 497,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 498,
+        "loan": 20
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 499,
+        "loan": 21
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 500,
+        "train": "3-7",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 501
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 502,
+        "hex": "G11",
+        "tile": "9-7",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 503
+      },
+      {
+        "type": "run_routes",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 504,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "H10",
+                "H8"
+              ]
+            ]
+          },
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "H10",
+                "H12",
+                "I13"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 505,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609335783
+      },
+      {
+        "id": 506,
+        "type": "undo",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609335798
+      },
+      {
+        "type": "dividend",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 507,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 508
+      },
+      {
+        "type": "pass",
+        "entity": "SR",
+        "entity_type": "corporation",
+        "id": 509
+      },
+      {
+        "id": 510,
+        "hex": "J18",
+        "tile": "15-2",
+        "type": "lay_tile",
+        "entity": "PLE",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609335864
+      },
+      {
+        "id": 511,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609335872
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 512,
+        "hex": "H16",
+        "tile": "8-9",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 513
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 514
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 515,
+        "routes": [
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "I15",
+                "I13"
+              ]
+            ]
+          },
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "I15",
+                "H16",
+                "G15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 516,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 517
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 518,
+        "loan": 6
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 519
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 520,
+        "hex": "D22",
+        "tile": "6-3",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 521,
+        "hex": "C17",
+        "tile": "82-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 522,
+        "routes": [
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D26"
+              ]
+            ]
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "D22",
+                "C21",
+                "C19",
+                "C17",
+                "B18"
+              ],
+              [
+                "F22",
+                "E21",
+                "D22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 523,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609336082
+      },
+      {
+        "id": 524,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609336095
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 525,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 526
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 527,
+        "loan": 13
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 528
+      },
+      {
+        "type": "lay_tile",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 529,
+        "hex": "G15",
+        "tile": "83-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 530
+      },
+      {
+        "type": "place_token",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 531,
+        "city": "619-0-0",
+        "slot": 1
+      },
+      {
+        "id": 532,
+        "type": "run_routes",
+        "entity": "J",
+        "routes": [
+          {
+            "train": "2-11",
+            "connections": [
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ]
+            ]
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336317
+      },
+      {
+        "id": 533,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336319
+      },
+      {
+        "id": 534,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336328
+      },
+      {
+        "id": 535,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336495
+      },
+      {
+        "id": 536,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336625
+      },
+      {
+        "id": 537,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336630
+      },
+      {
+        "id": 538,
+        "loan": 22,
+        "type": "take_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336638
+      },
+      {
+        "id": 539,
+        "loan": 23,
+        "type": "take_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336653
+      },
+      {
+        "id": 540,
+        "loan": 24,
+        "type": "take_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336654
+      },
+      {
+        "id": 541,
+        "type": "buy_train",
+        "price": 400,
+        "train": "4-0",
+        "entity": "J",
+        "variant": "4",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336665
+      },
+      {
+        "id": 542,
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336672
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 543,
+        "message": "was hoping the game would buy the 3..."
+      },
+      {
+        "id": 544,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336750
+      },
+      {
+        "id": 545,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336755
+      },
+      {
+        "id": 546,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336765
+      },
+      {
+        "id": 547,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336767
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 548,
+        "message": "The 3s were some time ago."
+      },
+      {
+        "id": 549,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336800
+      },
+      {
+        "id": 550,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336841
+      },
+      {
+        "id": 551,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609336864
+      },
+      {
+        "type": "run_routes",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 552,
+        "routes": [
+          {
+            "train": "2-11",
+            "connections": [
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 553,
+        "message": "yeah the last one was my concern and it appears the UR got involved..."
+      },
+      {
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 554,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 555
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 556,
+        "loan": 9
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 557
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 558
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 559
+      },
+      {
+        "type": "merge",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 560,
+        "corporation": "WT"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 561,
+        "shares": [
+          "H_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 562
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 563
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 564
+      },
+      {
+        "type": "merge",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 565,
+        "corporation": "SR"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 566,
+        "shares": [
+          "PLE_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 567
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 568
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 569
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 570
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 571
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 572
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 573
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 574
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 575
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 576
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 577
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 578
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 579
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 580
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 581
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 582,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "I15",
+                "I13"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 583,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 584,
+        "loan": 22
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 585,
+        "train": "4-1",
+        "price": 400,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 586
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 587
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 588,
+        "hex": "G11",
+        "tile": "83-3",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 589
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 590
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 591,
+        "loan": 23
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 592,
+        "loan": 24
+      },
+      {
+        "type": "buy_train",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 593,
+        "train": "4-2",
+        "price": 400,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 594
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 595
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 596,
+        "hex": "E15",
+        "tile": "83-4",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 597
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 598
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 599,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 600,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609341040
+      },
+      {
+        "id": 601,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609341053
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 602,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 603
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 604
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 605,
+        "hex": "D18",
+        "tile": "7-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 606
+      },
+      {
+        "type": "run_routes",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 607,
+        "routes": [
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 608,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 609,
+        "train": "3-5",
+        "price": 135
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 610
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 611
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 612,
+        "hex": "F16",
+        "tile": "8-10",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 613,
+        "hex": "E17",
+        "tile": "9-6",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 614,
+        "routes": [
+          {
+            "train": "2+-2",
+            "connections": [
+              [
+                "F20",
+                "G21",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 615,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341402
+      },
+      {
+        "id": 616,
+        "loan": 26,
+        "type": "take_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341406
+      },
+      {
+        "id": 617,
+        "loan": 27,
+        "type": "take_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341408
+      },
+      {
+        "id": 618,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341425
+      },
+      {
+        "id": 619,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341429
+      },
+      {
+        "id": 620,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341439
+      },
+      {
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 621,
+        "kind": "withhold"
+      },
+      {
+        "id": 622,
+        "loan": 26,
+        "type": "take_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341448
+      },
+      {
+        "id": 623,
+        "loan": 27,
+        "type": "take_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341450
+      },
+      {
+        "id": 624,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341463
+      },
+      {
+        "id": 625,
+        "type": "undo",
+        "entity": "R",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609341530
+      },
+      {
+        "type": "buy_train",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 626,
+        "train": "3-5",
+        "price": 200
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 627
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 628
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 629,
+        "hex": "D22",
+        "tile": "15-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 630
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 631,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "F22",
+                "E21",
+                "D22"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 632,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 633
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 634
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 635,
+        "hex": "D12",
+        "tile": "592-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 636
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 637,
+        "routes": [
+          {
+            "train": "3-6",
+            "connections": [
+              [
+                "D12",
+                "D14",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 638,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 639
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 640
+      },
+      {
+        "type": "buy_train",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 641,
+        "train": "3-3",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 642
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 643
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 644,
+        "hex": "H20",
+        "tile": "81-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 645,
+        "routes": [
+          {
+            "train": "3-7",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 646,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 647
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 648
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 649
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 650
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 651
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 652
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 653
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 654
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 655
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 656
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 657
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 658
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 659
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 660
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 661
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 662
+      },
+      {
+        "type": "sell_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 663,
+        "shares": [
+          "R_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 664,
+        "corporation": "DL&W",
+        "price": 400
+      },
+      {
+        "type": "place_token",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 665,
+        "city": "592-2-0",
+        "slot": 1
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 666
+      },
+      {
+        "type": "take_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 667,
+        "loan": 27
+      },
+      {
+        "type": "buy_shares",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 668,
+        "shares": [
+          "R_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 669
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 670,
+        "shares": [
+          "J_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 671
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 672
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 673
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 674,
+        "shares": [
+          "R_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 675
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 676
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 677
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 678
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 679
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 680,
+        "hex": "C11",
+        "tile": "81-1",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 681,
+        "hex": "C9",
+        "tile": "6-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 682
+      },
+      {
+        "type": "take_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 683,
+        "loan": 28
+      },
+      {
+        "type": "buy_train",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 684,
+        "train": "4-4",
+        "price": 400,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 685
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 686
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 687
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 688,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "I21",
+                "I19",
+                "H18"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "I21"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 689,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609348834
+      },
+      {
+        "id": 690,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609348841
+      },
+      {
+        "id": 691,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609348854
+      },
+      {
+        "id": 692,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609348859
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 693,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 694
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 695,
+        "loan": 1
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 696
+      },
+      {
+        "id": 697,
+        "hex": "F12",
+        "tile": "8-11",
+        "type": "lay_tile",
+        "entity": "ME",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609348950
+      },
+      {
+        "id": 698,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609349007
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 699,
+        "hex": "D14",
+        "tile": "82-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 700
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 701
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 702,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D12",
+                "D14",
+                "E15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 703,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 704,
+        "loan": 29
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 705,
+        "loan": 30
+      },
+      {
+        "type": "buy_train",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 706,
+        "train": "4-5",
+        "price": 400,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 707
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 708
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 709,
+        "hex": "F10",
+        "tile": "9-8",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 710,
+        "hex": "E9",
+        "tile": "5-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 711
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 712,
+        "routes": [
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "I13",
+                "H12",
+                "H10"
+              ],
+              [
+                "I15",
+                "I13"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 713,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609349318
+      },
+      {
+        "id": 714,
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609349321
+      },
+      {
+        "id": 715,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609349329
+      },
+      {
+        "id": 716,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609349353
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 717,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 718
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 719,
+        "loan": 3
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 720
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 721,
+        "hex": "D18",
+        "tile": "83-5",
+        "rotation": 1
+      },
+      {
+        "id": 722,
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609349446
+      },
+      {
+        "id": 723,
+        "loan": 32,
+        "type": "take_loan",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609349448
+      },
+      {
+        "id": 724,
+        "loan": 33,
+        "type": "take_loan",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609349449
+      },
+      {
+        "id": 725,
+        "type": "undo",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609349462
+      },
+      {
+        "id": 726,
+        "type": "undo",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609349466
+      },
+      {
+        "id": 727,
+        "type": "undo",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "user": 1996,
+        "created_at": 1609349510
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 728,
+        "hex": "D20",
+        "tile": "9-5",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 729
+      },
+      {
+        "type": "pass",
+        "entity": "PSNR",
+        "entity_type": "corporation",
+        "id": 730
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 731,
+        "hex": "E21",
+        "tile": "82-2",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 732
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 733,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "F22",
+                "E21",
+                "D22"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 734,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 735
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 736
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 737,
+        "hex": "C9",
+        "tile": "15-3",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 738
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 739,
+        "routes": [
+          {
+            "train": "3-6",
+            "connections": [
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "F14",
+                "E15",
+                "D14",
+                "D12"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 740,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 741
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 742,
+        "hex": "E19",
+        "tile": "8-11",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 743,
+        "hex": "D20",
+        "tile": "83-6",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 744,
+        "routes": [
+          {
+            "train": "3-5",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 745,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 746
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 747,
+        "loan": 12
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 748
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 749,
+        "hex": "H16",
+        "tile": "80-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 750
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 751,
+        "routes": [
+          {
+            "train": "3-7",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 752,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 753
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 754
+      },
+      {
+        "type": "run_routes",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 755,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D12",
+                "D14",
+                "E15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 756,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 757
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 758
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 759
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 760
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 761
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 762,
+        "message": "Is everyone having fun?"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 763,
+        "message": "This game is soooo hard! My brain has melted :))"
+      },
+      {
+        "type": "merge",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 764,
+        "corporation": "UR"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 765,
+        "shares": [
+          "NYOW_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 766
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 767,
+        "message": "Fun... yeah something like that!"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 768
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 769
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 770,
+        "message": "I'm not sure if I should have merged my 2 loan ridden companies"
+      },
+      {
+        "type": "convert",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 771
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 772,
+        "message": "Ive managed to turtle myself into a horrible position"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 773,
+        "shares": [
+          "GT_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 774,
+        "message": "I don't understand what happened to Daves company ... I guess because you can't put in from hand?"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 775,
+        "message": "so is the comapny dead?"
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 776,
+        "message": "I chose not to buy a train so it went into liquidation"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 777,
+        "message": "Some bad person bought the 4 he wanted, so now the co. is up for sale at the end of this merger round."
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 778
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 779,
+        "message": "the assets of the company are available to buy and i am responsible for the liabilities"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 780,
+        "message": "The assets being the cash and token."
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 781,
+        "message": "oh dear, that was me ... I didn't know that would happen ..."
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 782
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 783
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 784
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 785,
+        "message": "what am I being asked now to bid on?"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 786,
+        "message": "So what happened to the $184?"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 787,
+        "message": "Are we just bidding on the token?"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 788,
+        "message": "it says what do I offer for the corporation?"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 789,
+        "message": "the token spot on the charter is grey"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 790,
+        "message": "the token still exists in D16 though"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 791,
+        "message": "It’s spot is in Winnipeg "
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 792,
+        "message": "You're bidding on assets (trains + stations)"
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 793,
+        "message": "The treasury and the sale price are divided amongst the shareholders"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 794,
+        "message": "yes, so am I offering personal cash to buy the token?"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 795,
+        "message": "or company cash?"
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 796,
+        "message": "for reference it's section 7.2.1 in the rules"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 797,
+        "message": "No, you are offering money from one of your companies."
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 798,
+        "message": "company"
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 799,
+        "corporation": "PSNR",
+        "price": 30
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 800,
+        "message": "my company has £31"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 801,
+        "message": "so I bid 30"
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 802,
+        "corporation": "PSNR",
+        "price": 40
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 803,
+        "message": "The cash is shared by share holders "
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 804,
+        "message": ":)"
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 805
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 806
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 807
+      },
+      {
+        "type": "merge",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 808,
+        "corporation": "GT"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 809
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 810
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 811
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 812
+      },
+      {
+        "type": "take_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 813,
+        "loan": 32
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 814,
+        "hex": "B8",
+        "tile": "9-4",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 815,
+        "hex": "A7",
+        "tile": "6-2",
+        "rotation": 5
+      },
+      {
+        "type": "place_token",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 816,
+        "city": "6-2-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 817,
+        "routes": [
+          {
+            "train": "4-4",
+            "connections": [
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "F14",
+                "E15",
+                "D14",
+                "D12"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 818,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 819
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 820
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 821
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 822,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "I21",
+                "I19",
+                "H18"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "I21"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 823,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 824
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 825,
+        "loan": 16
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 826
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 827,
+        "hex": "A7",
+        "tile": "15-4",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 828
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 829,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "F22",
+                "E21",
+                "D22"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          },
+          {
+            "train": "3-6",
+            "connections": [
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "F14",
+                "E15",
+                "D14",
+                "D12"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 830,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 831,
+        "loan": 33
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 832,
+        "loan": 34
+      },
+      {
+        "type": "buy_train",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 833,
+        "train": "5-1",
+        "price": 600,
+        "variant": "5"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 834,
+        "hex": "F14",
+        "tile": "593-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 835
+      },
+      {
+        "type": "place_token",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 836,
+        "city": "593-0-0",
+        "slot": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 837,
+        "routes": [
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "I15",
+                "I13"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 838,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 839
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 840,
+        "loan": 23
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 841
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 842,
+        "hex": "D12",
+        "tile": "593-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 843
+      },
+      {
+        "type": "place_token",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 844,
+        "city": "593-1-0",
+        "slot": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 845,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ]
+            ]
+          },
+          {
+            "train": "4-5",
+            "connections": [
+              [
+                "H18",
+                "H20",
+                "G21",
+                "F22"
+              ],
+              [
+                "F14",
+                "G15",
+                "G17",
+                "H18"
+              ],
+              [
+                "F14",
+                "E15",
+                "D14",
+                "D12"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 846,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 847
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 848,
+        "loan": 29
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 849
+      },
+      {
+        "type": "assign",
+        "entity": "UBC",
+        "entity_type": "company",
+        "id": 850,
+        "target": "H18",
+        "target_type": "hex"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 851,
+        "hex": "H18",
+        "tile": "63-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 852
+      },
+      {
+        "type": "run_routes",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 853,
+        "routes": [
+          {
+            "train": "3-5",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 854,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 855
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 856
+      },
+      {
+        "id": 857,
+        "hex": "C17",
+        "tile": "546-0",
+        "type": "lay_tile",
+        "entity": "GT",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609353226
+      },
+      {
+        "id": 858,
+        "hex": "B12",
+        "tile": "8-1",
+        "type": "lay_tile",
+        "entity": "GT",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609353230
+      },
+      {
+        "id": 859,
+        "city": "15-4-0",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609353233
+      },
+      {
+        "id": 860,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609353386
+      },
+      {
+        "id": 861,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609353394
+      },
+      {
+        "id": 862,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609353403
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 863,
+        "hex": "F22",
+        "tile": "62-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 864
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 865
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 866,
+        "routes": [
+          {
+            "train": "3-7",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 867,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 868
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 869,
+        "loan": 20
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 870
+      },
+      {
+        "type": "lay_tile",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 871,
+        "hex": "D20",
+        "tile": "545-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 872
+      },
+      {
+        "type": "run_routes",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 873,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 874,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 875
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 876,
+        "loan": 10
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 877
+      },
+      {
+        "type": "merge",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 878,
+        "corporation": "GT"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 879,
+        "shares": [
+          "DL&W_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 880
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 881
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 882
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 883
+      },
+      {
+        "id": 884,
+        "type": "merge",
+        "entity": "H",
+        "corporation": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609354188
+      },
+      {
+        "id": 885,
+        "type": "undo",
+        "entity": 1996,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609354280
+      },
+      {
+        "id": 886,
+        "type": "convert",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609354291
+      },
+      {
+        "id": 887,
+        "type": "undo",
+        "entity": 2394,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609354588
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 888
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 889
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 890,
+        "message": "This game is a bloody nightmare! I need a whole packet of headache tablets just to get through it!"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 891
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 892
+      },
+      {
+        "type": "convert",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 893
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 894,
+        "shares": [
+          "J_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 895,
+        "shares": [
+          "J_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 896,
+        "shares": [
+          "J_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 897,
+        "message": "I need some help I think, should I have gone to 0 shares? what happens to stock price?"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 898,
+        "message": "I passed on merging, was that my opportunity to convert as well that I passed on?"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 899,
+        "message": "or is convert next?"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 900,
+        "message": "It’s convert or merge"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 901,
+        "message": "oh"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 902,
+        "message": "You can always do it next time"
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 903
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 904
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 905
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 906
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 907,
+        "message": "Is Dave launching Grand Trunk I wonder? 🤔"
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 908
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 909
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 910
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 911
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 912
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 913
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 914
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 915
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 916,
+        "shares": [
+          "ME_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 917,
+        "message": "Can we start again from the beginning Dave?"
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 918
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 919,
+        "message": "Especially as Hamish is winning again 😖"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 920,
+        "message": "Bad bad Hamish 😠"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 921,
+        "message": "its very interesting but waaaay more complicated than I've seen before"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 922,
+        "message": "Yep it’s a whole different level 😝"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 923,
+        "message": "I’ve mucked up so much it hurts 😩"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 924,
+        "message": "Crazy Dave loves it 😂😂"
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 925,
+        "message": "i've messed this up too"
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 926,
+        "corporation": "UR",
+        "price": 300
+      },
+      {
+        "type": "place_token",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 927,
+        "city": "62-0-0",
+        "slot": 1
+      },
+      {
+        "type": "choose",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 928,
+        "choice": 5
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 929,
+        "shares": [
+          "NYOW_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 930
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 931
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 932
+      },
+      {
+        "type": "short",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 933,
+        "corporation": "H"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 934,
+        "shares": [
+          "UR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 935,
+        "shares": [
+          "DL&W_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 936
+      },
+      {
+        "id": 937,
+        "type": "short",
+        "entity": 2394,
+        "corporation": "R",
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609369727
+      },
+      {
+        "id": 938,
+        "type": "undo",
+        "entity": 1996,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609369779
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 939
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 940
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 941
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 942,
+        "hex": "D16",
+        "tile": "63-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 943
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 944
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 945,
+        "loan": 35
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 946,
+        "loan": 36
+      },
+      {
+        "type": "buy_train",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 947,
+        "train": "5-3",
+        "price": 600,
+        "variant": "5"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 948
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 949
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 950
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 951,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D26"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "E17",
+                "D18",
+                "D20",
+                "E21",
+                "F22"
+              ],
+              [
+                "I21",
+                "I19",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 952,
+        "kind": "half"
+      },
+      {
+        "type": "sell_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 953,
+        "shares": [
+          "R_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 954
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 955,
+        "loan": 22
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 956
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 957,
+        "hex": "I15",
+        "tile": "593-2",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 958,
+        "hex": "C13",
+        "tile": "8-1",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 959,
+        "city": "593-2-0",
+        "slot": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 960,
+        "routes": [
+          {
+            "train": "4-4",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "D16"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          },
+          {
+            "train": "3-7",
+            "connections": [
+              [
+                "H18",
+                "G17",
+                "G15",
+                "F14"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 961,
+        "kind": "half"
+      },
+      {
+        "type": "buy_train",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 962,
+        "train": "5-1",
+        "price": 497
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 963
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 964,
+        "hex": "C17",
+        "tile": "546-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 965,
+        "hex": "B12",
+        "tile": "7-0",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 966,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          },
+          {
+            "train": "3-6",
+            "connections": [
+              [
+                "D12",
+                "D14",
+                "E15",
+                "F14"
+              ],
+              [
+                "B18",
+                "C17",
+                "B16",
+                "B14",
+                "B12",
+                "C13",
+                "D12"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 967,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 968,
+        "train": "6-0",
+        "price": 750,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 969
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 970,
+        "hex": "F16",
+        "tile": "81-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 971
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 972,
+        "routes": [
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D26"
+              ],
+              [
+                "F14",
+                "F16",
+                "E17",
+                "D18",
+                "D20",
+                "E21",
+                "F22"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 973,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 974
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 975,
+        "loan": 24
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 976
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 977,
+        "hex": "C9",
+        "tile": "63-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 978
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 979,
+        "routes": [
+          {
+            "train": "4-5",
+            "connections": [
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D26"
+              ],
+              [
+                "F14",
+                "F16",
+                "E17",
+                "D18",
+                "D20",
+                "E21",
+                "F22"
+              ],
+              [
+                "D12",
+                "D14",
+                "E15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 980,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609429857
+      },
+      {
+        "id": 981,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609429939
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 982,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 983,
+        "train": "4-2",
+        "price": 382
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 984
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 985
+      },
+      {
+        "type": "place_token",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 986,
+        "city": "63-0-0",
+        "slot": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 987,
+        "train": "4-1",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 988
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 989,
+        "loan": 26
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 990
+      },
+      {
+        "type": "lay_tile",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 991,
+        "hex": "F20",
+        "tile": "63-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 992
+      },
+      {
+        "type": "buy_train",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 993,
+        "train": "5-3",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 994
+      },
+      {
+        "type": "pass",
+        "entity": "R",
+        "entity_type": "corporation",
+        "id": 995
+      },
+      {
+        "type": "convert",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 996
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 997
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 998,
+        "loan": 39
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 999
+      },
+      {
+        "type": "convert",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1000
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1001
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1002
+      },
+      {
+        "id": 1003,
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609431486
+      },
+      {
+        "id": 1004,
+        "type": "undo",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609431495
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1005,
+        "message": "when can I buy tokens?"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1006,
+        "message": "Once you are finished on loans, it will automatically buy the tokens."
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1007
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1008,
+        "message": "Oh thank you :)"
+      },
+      {
+        "type": "merge",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1009,
+        "corporation": "R"
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1010
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1011,
+        "shares": [
+          "UR_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1012
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1013
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1014
+      },
+      {
+        "type": "convert",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1015
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1016,
+        "shares": [
+          "ME_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1017,
+        "shares": [
+          "ME_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1018
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1019
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1020
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1021
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1022
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1023
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1024
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1025
+      },
+      {
+        "id": 1026,
+        "hex": "E11",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609434041
+      },
+      {
+        "id": 1027,
+        "loan": 40,
+        "type": "take_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609434049
+      },
+      {
+        "id": 1028,
+        "hex": "F12",
+        "tile": "9-7",
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609434067
+      },
+      {
+        "id": 1029,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609434093
+      },
+      {
+        "id": 1030,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609434102
+      },
+      {
+        "id": 1031,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609434110
+      },
+      {
+        "id": 1032,
+        "hex": "E11",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "MAJC",
+        "rotation": 3,
+        "entity_type": "company",
+        "user": 78,
+        "created_at": 1609434127
+      },
+      {
+        "id": 1033,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609434183
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MAJC",
+        "entity_type": "company",
+        "id": 1034,
+        "hex": "E11",
+        "tile": "8-8",
+        "rotation": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1035,
+        "loan": 40
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1036,
+        "hex": "F12",
+        "tile": "9-7",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1037,
+        "routes": [
+          {
+            "train": "4-4",
+            "connections": [
+              [
+                "D16",
+                "C17",
+                "B18"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "D16"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          },
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "D16",
+                "D14",
+                "D12"
+              ],
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1038,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1039,
+        "loan": 28
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1040,
+        "loan": 32
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1041,
+        "loan": 21
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1042
+      },
+      {
+        "id": 1043,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434578
+      },
+      {
+        "id": 1044,
+        "city": "62-0-1",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434580
+      },
+      {
+        "id": 1045,
+        "loan": 41,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434599
+      },
+      {
+        "id": 1046,
+        "loan": 42,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434600
+      },
+      {
+        "id": 1047,
+        "loan": 43,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434601
+      },
+      {
+        "id": 1048,
+        "loan": 44,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434602
+      },
+      {
+        "id": 1049,
+        "loan": 45,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434622
+      },
+      {
+        "id": 1050,
+        "loan": 46,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434624
+      },
+      {
+        "id": 1051,
+        "loan": 47,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434627
+      },
+      {
+        "id": 1052,
+        "type": "buy_train",
+        "price": 750,
+        "train": "6-2",
+        "entity": "H",
+        "variant": "6",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434637
+      },
+      {
+        "id": 1053,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434645
+      },
+      {
+        "id": 1054,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434659
+      },
+      {
+        "id": 1055,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434662
+      },
+      {
+        "id": 1056,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434775
+      },
+      {
+        "id": 1057,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434777
+      },
+      {
+        "id": 1058,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434779
+      },
+      {
+        "id": 1059,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434781
+      },
+      {
+        "id": 1060,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434784
+      },
+      {
+        "id": 1061,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434786
+      },
+      {
+        "id": 1062,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434788
+      },
+      {
+        "id": 1063,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434790
+      },
+      {
+        "id": 1064,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434793
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1065
+      },
+      {
+        "id": 1066,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434806
+      },
+      {
+        "id": 1067,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434826
+      },
+      {
+        "id": 1068,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434841
+      },
+      {
+        "id": 1069,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434872
+      },
+      {
+        "id": 1070,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434880
+      },
+      {
+        "id": 1071,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434885
+      },
+      {
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1072,
+        "city": "62-0-1",
+        "slot": 1
+      },
+      {
+        "id": 1073,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434894
+      },
+      {
+        "id": 1074,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434899
+      },
+      {
+        "id": 1075,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434919
+      },
+      {
+        "id": 1076,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609434925
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1077,
+        "train": "4-1",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1078
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1079
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1080,
+        "hex": "D22",
+        "tile": "63-4",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1081
+      },
+      {
+        "type": "place_token",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1082,
+        "city": "63-4-0",
+        "slot": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1083,
+        "loan": 41
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1084,
+        "loan": 42
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1085,
+        "loan": 43
+      },
+      {
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1086,
+        "loan": 44
+      },
+      {
+        "id": 1087,
+        "loan": 45,
+        "type": "take_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609437124
+      },
+      {
+        "id": 1088,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609437224
+      },
+      {
+        "type": "buy_train",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1089,
+        "train": "6-2",
+        "price": 750,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1090
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1091
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1092,
+        "hex": "H14",
+        "tile": "8-7",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1093,
+        "hex": "G13",
+        "tile": "9-2",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1094,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "A7",
+                "B6"
+              ],
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1095,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1096
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1097,
+        "loan": 14
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1098
+      },
+      {
+        "id": 1099,
+        "hex": "F12",
+        "tile": "82-3",
+        "type": "lay_tile",
+        "entity": "ME",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609438051
+      },
+      {
+        "id": 1100,
+        "hex": "B4",
+        "tile": "8-12",
+        "type": "lay_tile",
+        "entity": "ME",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609438076
+      },
+      {
+        "id": 1101,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609438094
+      },
+      {
+        "id": 1102,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609438102
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1103,
+        "hex": "D24",
+        "tile": "83-7",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1104,
+        "hex": "B4",
+        "tile": "8-12",
+        "rotation": 4
+      },
+      {
+        "type": "place_token",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1105,
+        "city": "63-4-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1106,
+        "routes": [
+          {
+            "train": "4-5",
+            "connections": [
+              [
+                "D12",
+                "E11",
+                "F12",
+                "G13",
+                "H14",
+                "H16",
+                "I15"
+              ],
+              [
+                "D22",
+                "C21",
+                "C19",
+                "C17",
+                "B16",
+                "B14",
+                "B12",
+                "C13",
+                "D12"
+              ],
+              [
+                "D26",
+                "D24",
+                "D22"
+              ]
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "D22",
+                "E21",
+                "F22"
+              ],
+              [
+                "F14",
+                "F16",
+                "E17",
+                "D18",
+                "D20",
+                "D22"
+              ],
+              [
+                "D12",
+                "D14",
+                "E15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1107,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1108,
+        "loan": 30
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1109,
+        "loan": 31
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1110
+      },
+      {
+        "id": 1111,
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609438654
+      },
+      {
+        "id": 1112,
+        "type": "undo",
+        "entity": "J",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609438675
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 1113
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 1114
+      },
+      {
+        "type": "pass",
+        "entity": "J",
+        "entity_type": "corporation",
+        "id": 1115
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1116,
+        "hex": "G15",
+        "tile": "544-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1117
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1118,
+        "routes": [
+          {
+            "train": "5-3",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "E17",
+                "D18",
+                "D16"
+              ],
+              [
+                "F20",
+                "G19",
+                "H18"
+              ],
+              [
+                "F22",
+                "G21",
+                "F20"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1119,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1120
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1121,
+        "loan": 35
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1122
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1123
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1124,
+        "corporation": "J",
+        "price": 10
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1125,
+        "message": "That’s an insult 😠"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1126,
+        "message": "Can bids be increased or just one shot?"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1127,
+        "message": "We keep bidding until all bar one drops out."
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1128,
+        "message": "its an opening bid..."
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1129,
+        "corporation": "J",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1130,
+        "corporation": "J",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1131,
+        "corporation": "J",
+        "price": 40
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1132,
+        "message": "It’s still an insult"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1133,
+        "message": "I’m truly hurt Dave 🤣🤣"
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1134,
+        "message": "ok I'll raise it then..."
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1135,
+        "corporation": "J",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1136,
+        "corporation": "J",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1137,
+        "corporation": "J",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1138,
+        "corporation": "J",
+        "price": 80
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1139,
+        "message": "Ok I forgive you Dave 🤩"
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1140
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1141,
+        "corporation": "J",
+        "price": 90
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1142,
+        "corporation": "J",
+        "price": 100
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1143,
+        "corporation": "J",
+        "price": 110
+      },
+      {
+        "type": "bid",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1144,
+        "corporation": "J",
+        "price": 120
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1145,
+        "corporation": "J",
+        "price": 130
+      },
+      {
+        "type": "bid",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1146,
+        "corporation": "J",
+        "price": 140
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1147
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1148
+      },
+      {
+        "id": 1149,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609446273
+      },
+      {
+        "id": 1150,
+        "type": "undo",
+        "entity": 2516,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609446310
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1151
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1152
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1153
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1154
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1155
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1156,
+        "shares": [
+          "ME_5"
+        ],
+        "percent": 10
+      },
+      {
+        "id": 1157,
+        "type": "buy_shares",
+        "entity": 2394,
+        "shares": [
+          "H_10"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609446519
+      },
+      {
+        "id": 1158,
+        "type": "undo",
+        "entity": 1996,
+        "entity_type": "player",
+        "user": 2394,
+        "created_at": 1609446570
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1159,
+        "shares": [
+          "H_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1160,
+        "shares": [
+          "H_10"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1161,
+        "shares": [
+          "ME_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1162,
+        "shares": [
+          "PLE_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1163
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1164
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1165,
+        "shares": [
+          "PLE_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1166,
+        "shares": [
+          "PLE_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1167
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1168
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1169
+      },
+      {
+        "type": "sell_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1170,
+        "shares": [
+          "ME_2",
+          "ME_4"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "sell_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1171,
+        "shares": [
+          "PLE_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1172,
+        "shares": [
+          "UR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1173
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1174
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1175,
+        "shares": [
+          "NYOW_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1176,
+        "shares": [
+          "ME_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1177,
+        "loan": 48
+      },
+      {
+        "type": "buy_shares",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1178,
+        "shares": [
+          "NYOW_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1179
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1180
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1181,
+        "shares": [
+          "UR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1182,
+        "shares": [
+          "PLE_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1183,
+        "shares": [
+          "UR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1184
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1185
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1186,
+        "shares": [
+          "PLE_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1187,
+        "shares": [
+          "H_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1188
+      },
+      {
+        "type": "sell_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1189,
+        "shares": [
+          "UR_1",
+          "UR_4",
+          "UR_5",
+          "UR_0"
+        ],
+        "percent": 50
+      },
+      {
+        "type": "short",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1190,
+        "corporation": "UR"
+      },
+      {
+        "type": "bid",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1191,
+        "corporation": "GT",
+        "price": 200
+      },
+      {
+        "type": "place_token",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1192,
+        "city": "63-2-0",
+        "slot": 0
+      },
+      {
+        "id": 1193,
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "user": 2516,
+        "created_at": 1609512273
+      },
+      {
+        "id": 1194,
+        "type": "undo",
+        "entity": 78,
+        "entity_type": "player",
+        "user": 2516,
+        "created_at": 1609512284
+      },
+      {
+        "type": "buy_shares",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1195,
+        "shares": [
+          "ME_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1196
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1197
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1198
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1199,
+        "shares": [
+          "GT_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1200
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1201
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1202
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1203,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1204
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1205
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1206
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1207,
+        "shares": [
+          "GT_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1208
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1209
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1210
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1211,
+        "shares": [
+          "GT_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1212
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1213
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1214
+      },
+      {
+        "id": 1215,
+        "type": "short",
+        "entity": 1996,
+        "corporation": "ME",
+        "entity_type": "player",
+        "user": 1996,
+        "created_at": 1609522957
+      },
+      {
+        "id": 1216,
+        "type": "undo",
+        "entity": 1996,
+        "entity_type": "player",
+        "user": 1996,
+        "created_at": 1609522982
+      },
+      {
+        "type": "short",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1217,
+        "corporation": "ME"
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1218
+      },
+      {
+        "type": "buy_shares",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1219,
+        "shares": [
+          "ME_10"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1220
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1221
+      },
+      {
+        "id": 1222,
+        "type": "undo",
+        "entity": 1996,
+        "entity_type": "player",
+        "user": 2516,
+        "created_at": 1609525531
+      },
+      {
+        "id": 1223,
+        "type": "redo",
+        "entity": 2394,
+        "entity_type": "player",
+        "user": 2516,
+        "created_at": 1609525534
+      },
+      {
+        "type": "short",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1224,
+        "corporation": "H"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1225,
+        "shares": [
+          "DL&W_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1226
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1227
+      },
+      {
+        "type": "buy_shares",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1228,
+        "shares": [
+          "H_10"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1229
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1230
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1231
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1232
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1233,
+        "hex": "F22",
+        "tile": "X30-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1234
+      },
+      {
+        "type": "run_routes",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1235,
+        "routes": [
+          {
+            "train": "4-4",
+            "connections": [
+              [
+                "D16",
+                "C17",
+                "B18"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "D16"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          },
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "D16",
+                "D14",
+                "D12"
+              ],
+              [
+                "F14",
+                "E15",
+                "D16"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1236,
+        "kind": "withhold"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1237,
+        "loan": 40
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1238
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1239,
+        "message": "withhold....sigh"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1240,
+        "message": "That’s what happens when your a leech 😂"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1241,
+        "hex": "D12",
+        "tile": "597-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1242
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1243
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1244,
+        "routes": [
+          {
+            "train": "4-5",
+            "connections": [
+              [
+                "D12",
+                "E11",
+                "F12",
+                "G13",
+                "H14",
+                "H16",
+                "I15"
+              ],
+              [
+                "D22",
+                "C21",
+                "C19",
+                "C17",
+                "B16",
+                "B14",
+                "B12",
+                "C13",
+                "D12"
+              ],
+              [
+                "D26",
+                "D24",
+                "D22"
+              ]
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "D22",
+                "E21",
+                "F22"
+              ],
+              [
+                "F14",
+                "F16",
+                "E17",
+                "D18",
+                "D20",
+                "D22"
+              ],
+              [
+                "D12",
+                "D14",
+                "E15",
+                "F14"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1245,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1246,
+        "loan": 49
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1247,
+        "loan": 50
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1248,
+        "loan": 51
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1249
+      },
+      {
+        "id": 1250,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609530353
+      },
+      {
+        "id": 1251,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609530362
+      },
+      {
+        "id": 1252,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609530376
+      },
+      {
+        "id": 1253,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609530384
+      },
+      {
+        "id": 1254,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609530392
+      },
+      {
+        "id": 1255,
+        "type": "redo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530399
+      },
+      {
+        "id": 1256,
+        "type": "redo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530401
+      },
+      {
+        "id": 1257,
+        "type": "redo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530404
+      },
+      {
+        "id": 1258,
+        "type": "redo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530416
+      },
+      {
+        "id": 1259,
+        "type": "redo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530419
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1260,
+        "hex": "E9",
+        "tile": "619-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1261,
+        "hex": "D8",
+        "tile": "8-9",
+        "rotation": 3
+      },
+      {
+        "id": 1262,
+        "city": "15-4-0",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530433
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1263,
+        "message": "I tried to undo but I think Helen came in, I don't want those loans if I can't buy a train .... sorry"
+      },
+      {
+        "id": 1264,
+        "type": "run_routes",
+        "entity": "H",
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "F14"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530492
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1265,
+        "message": "I expected it to offer me a train after taking loans ..."
+      },
+      {
+        "id": 1266,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530524
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1267,
+        "message": "You're at train limit in the ME"
+      },
+      {
+        "id": 1268,
+        "loan": 52,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530566
+      },
+      {
+        "id": 1269,
+        "loan": 53,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530567
+      },
+      {
+        "id": 1270,
+        "loan": 54,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530568
+      },
+      {
+        "id": 1271,
+        "loan": 55,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530569
+      },
+      {
+        "id": 1272,
+        "loan": 7,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530570
+      },
+      {
+        "id": 1273,
+        "loan": 8,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530571
+      },
+      {
+        "id": 1274,
+        "loan": 11,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530576
+      },
+      {
+        "id": 1275,
+        "loan": 4,
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530585
+      },
+      {
+        "id": 1276,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530602
+      },
+      {
+        "id": 1277,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530605
+      },
+      {
+        "id": 1278,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530608
+      },
+      {
+        "id": 1279,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530613
+      },
+      {
+        "id": 1280,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530616
+      },
+      {
+        "id": 1281,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530618
+      },
+      {
+        "id": 1282,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530620
+      },
+      {
+        "id": 1283,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530622
+      },
+      {
+        "id": 1284,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530625
+      },
+      {
+        "id": 1285,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530627
+      },
+      {
+        "id": 1286,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609530630
+      },
+      {
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1287,
+        "city": "15-4-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1288,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "F14",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "F14"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1289,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1290,
+        "loan": 52
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1291,
+        "loan": 53
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1292,
+        "loan": 54
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1293,
+        "loan": 55
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1294,
+        "loan": 7
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1295,
+        "loan": 8
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1296,
+        "loan": 11
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1297,
+        "loan": 4
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1298,
+        "train": "7-1",
+        "price": 900,
+        "variant": "7"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1299,
+        "hex": "E9",
+        "tile": "611-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1300
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1301,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "E9",
+                "F10",
+                "G11",
+                "H10"
+              ],
+              [
+                "C9",
+                "D8",
+                "E9"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1302,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1303
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1304,
+        "loan": 18
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1305
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1306
+      },
+      {
+        "type": "place_token",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1307,
+        "city": "15-0-0",
+        "slot": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1308,
+        "loan": 2
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1309,
+        "loan": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1310,
+        "loan": 0
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1311,
+        "loan": 6
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1312,
+        "loan": 13
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1313,
+        "loan": 9
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1314,
+        "loan": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1315,
+        "train": "8-0",
+        "price": 1100,
+        "variant": "8"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 1316
+      },
+      {
+        "id": 1317,
+        "hex": "B12",
+        "tile": "80-1",
+        "type": "lay_tile",
+        "entity": "PLE",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609532451
+      },
+      {
+        "id": 1318,
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609532466
+      },
+      {
+        "id": 1319,
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609532661
+      },
+      {
+        "id": 1320,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609532684
+      },
+      {
+        "id": 1321,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609532694
+      },
+      {
+        "id": 1322,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609532719
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1323,
+        "hex": "J18",
+        "tile": "15-5",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1324
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1325
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1326,
+        "routes": [
+          {
+            "train": "6-2",
+            "connections": [
+              [
+                "J18",
+                "K19",
+                "K21"
+              ],
+              [
+                "I15",
+                "J16",
+                "J18"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "F14"
+              ],
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1327,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1328
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1329,
+        "loan": 25
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1330,
+        "loan": 41
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1331
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1332,
+        "hex": "H14",
+        "tile": "83-6",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1333
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1334,
+        "routes": [
+          {
+            "train": "5-3",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "E17",
+                "D18",
+                "D16"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1335,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1336
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1337
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1338
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1339
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1340,
+        "message": "I don't understand what is happening to GT here?"
+      },
+      {
+        "type": "bid",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1341,
+        "corporation": "GT",
+        "price": 10
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1342,
+        "message": "I took enough loans (because I had to buy the 8 not the 7 as planned) which put it in acquisition"
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1343,
+        "message": "why would Hamish want 10 loans ?"
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1344,
+        "message": "I got an 8 Train."
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1345,
+        "loan": 2
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1346,
+        "loan": 5
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1347,
+        "loan": 0
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1348,
+        "loan": 6
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1349,
+        "loan": 13
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1350,
+        "message": "how do the loans get paid? "
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1351,
+        "loan": 9
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1352
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1353,
+        "message": "From DLW's treasury."
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1354
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1355
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1356
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1357
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1358
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1359,
+        "hex": "I15",
+        "tile": "597-1",
+        "rotation": 5
+      },
+      {
+        "id": 1360,
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609534419
+      },
+      {
+        "id": 1361,
+        "city": "611-0-0",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609534490
+      },
+      {
+        "id": 1362,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609534853
+      },
+      {
+        "id": 1363,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609535019
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MAJC",
+        "entity_type": "company",
+        "id": 1364,
+        "hex": "D10",
+        "tile": "8-13",
+        "rotation": 4
+      },
+      {
+        "type": "place_token",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1365,
+        "city": "611-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1366,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "E9",
+                "D8",
+                "C9"
+              ],
+              [
+                "D12",
+                "D10",
+                "E9"
+              ],
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "B18",
+                "C17",
+                "D16"
+              ]
+            ]
+          },
+          {
+            "train": "8-0",
+            "connections": [
+              [
+                "B6",
+                "B4",
+                "C3"
+              ],
+              [
+                "A7",
+                "B6"
+              ],
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "I15",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1367,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1368,
+        "loan": 1
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1369,
+        "loan": 3
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1370,
+        "loan": 12
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1371
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1372,
+        "message": "Another withhold..."
+      },
+      {
+        "type": "message",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1373,
+        "message": "I paid 41,"
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1374,
+        "message": "oh sorry missed it was half pay"
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1375,
+        "message": "still doesn't help me..."
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1376,
+        "hex": "G11",
+        "tile": "544-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1377
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1378,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "E9",
+                "F10",
+                "G11",
+                "H10"
+              ],
+              [
+                "C9",
+                "D8",
+                "E9"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1379,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1380
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1381,
+        "loan": 19
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1382
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1383,
+        "hex": "F14",
+        "tile": "597-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1384
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1385
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1386,
+        "loan": 23
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1387,
+        "loan": 29
+      },
+      {
+        "type": "buy_train",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1388,
+        "train": "8-2",
+        "price": 1100,
+        "variant": "8"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1389
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1390
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1391,
+        "hex": "J18",
+        "tile": "448-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1392
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1393
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1394,
+        "routes": [
+          {
+            "train": "6-2",
+            "connections": [
+              [
+                "J18",
+                "K19",
+                "K21"
+              ],
+              [
+                "I15",
+                "J16",
+                "J18"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "F14"
+              ],
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1395,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1396
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1397,
+        "loan": 42
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1398
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1399,
+        "hex": "H14",
+        "tile": "544-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1400
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1401,
+        "routes": [
+          {
+            "train": "5-3",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "E17",
+                "D18",
+                "D16"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1402,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1403
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1404
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1405
+      },
+      {
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1406,
+        "city": "63-2-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1407,
+        "routes": [
+          {
+            "train": "7-1",
+            "connections": [
+              [
+                "I15",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "F14"
+              ],
+              [
+                "I21",
+                "I19",
+                "H18"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "I21"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1408,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1409
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1410
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1411
+      },
+      {
+        "type": "sell_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1412,
+        "shares": [
+          "DL&W_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1413,
+        "shares": [
+          "UR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1414,
+        "message": "what happens to company loans at game end, if I haven't paid them off?"
+      },
+      {
+        "type": "message",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1415,
+        "message": "Nothing"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1416,
+        "shares": [
+          "DL&W_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1417,
+        "message": "Nothing - the share price is depressed when you take the loan"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1418,
+        "shares": [
+          "UR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1419,
+        "shares": [
+          "H_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1420,
+        "shares": [
+          "H_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1421,
+        "message": "Oh ooops should have full paid then :) LoL"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1422,
+        "shares": [
+          "H_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1423,
+        "shares": [
+          "ME_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1424,
+        "shares": [
+          "UR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1425,
+        "shares": [
+          "H_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1426,
+        "shares": [
+          "ME_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1427
+      },
+      {
+        "type": "sell_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1428,
+        "shares": [
+          "H_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1429,
+        "shares": [
+          "UR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1430,
+        "shares": [
+          "ME_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1431,
+        "shares": [
+          "ME_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1432
+      },
+      {
+        "id": 1433,
+        "type": "sell_shares",
+        "entity": 78,
+        "shares": [
+          "PLE_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 78,
+        "created_at": 1609542014
+      },
+      {
+        "id": 1434,
+        "type": "undo",
+        "entity": 78,
+        "entity_type": "player",
+        "user": 78,
+        "created_at": 1609542064
+      },
+      {
+        "type": "buy_shares",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1435,
+        "shares": [
+          "UR_5",
+          "UR_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1436,
+        "shares": [
+          "H_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1437
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1438
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1439,
+        "loan": 24
+      },
+      {
+        "type": "buy_shares",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1440,
+        "shares": [
+          "UR_6",
+          "UR_10"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1441
+      },
+      {
+        "type": "pass",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1442
+      },
+      {
+        "type": "pass",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1443
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1444
+      },
+      {
+        "id": 1445,
+        "hex": "H12",
+        "tile": "83-8",
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609543499
+      },
+      {
+        "id": 1446,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609543534
+      },
+      {
+        "id": 1447,
+        "type": "undo",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609543560
+      },
+      {
+        "id": 1448,
+        "type": "redo",
+        "entity": 78,
+        "entity_type": "player",
+        "user": 78,
+        "created_at": 1609543575
+      },
+      {
+        "type": "lay_tile",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1449,
+        "hex": "F12",
+        "tile": "82-3",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1450
+      },
+      {
+        "type": "run_routes",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1451,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "E9",
+                "D8",
+                "C9"
+              ],
+              [
+                "D12",
+                "D10",
+                "E9"
+              ],
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "B18",
+                "C17",
+                "D16"
+              ]
+            ]
+          },
+          {
+            "train": "8-0",
+            "connections": [
+              [
+                "B6",
+                "B4",
+                "C3"
+              ],
+              [
+                "A7",
+                "B6"
+              ],
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "I15",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1452,
+        "kind": "payout"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1453,
+        "loan": 16
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1454
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1455,
+        "hex": "H12",
+        "tile": "83-8",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1456
+      },
+      {
+        "id": 1457,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609544027
+      },
+      {
+        "id": 1458,
+        "type": "undo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609544051
+      },
+      {
+        "id": 1459,
+        "type": "redo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609544076
+      },
+      {
+        "id": 1460,
+        "type": "redo",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "user": 78,
+        "created_at": 1609544092
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1461,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "I13",
+                "I15"
+              ],
+              [
+                "E9",
+                "F10",
+                "G11",
+                "H12",
+                "I13"
+              ],
+              [
+                "D12",
+                "D10",
+                "E9"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1462,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1463
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1464
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1465,
+        "hex": "I13",
+        "tile": "63-5",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1466
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1467
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1468,
+        "routes": [
+          {
+            "train": "6-2",
+            "connections": [
+              [
+                "I13",
+                "H12",
+                "G11",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "I15",
+                "I13"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "F14"
+              ],
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1469,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1470
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1471
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1472,
+        "hex": "F12",
+        "tile": "546-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1473
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1474
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1475,
+        "routes": [
+          {
+            "train": "5-3",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "E17",
+                "D18",
+                "D16"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1476,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1477
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1478
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1479
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1480,
+        "routes": [
+          {
+            "train": "7-1",
+            "connections": [
+              [
+                "I15",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "F14"
+              ],
+              [
+                "I21",
+                "I19",
+                "H18"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "I21"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 1481,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544807
+      },
+      {
+        "id": 1482,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544816
+      },
+      {
+        "id": 1483,
+        "loan": 39,
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544823
+      },
+      {
+        "id": 1484,
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544828
+      },
+      {
+        "id": 1485,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544851
+      },
+      {
+        "id": 1486,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544856
+      },
+      {
+        "id": 1487,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544873
+      },
+      {
+        "id": 1488,
+        "type": "undo",
+        "entity": "H",
+        "entity_type": "corporation",
+        "user": 2394,
+        "created_at": 1609544879
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1489,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1490
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1491,
+        "loan": 39
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1492,
+        "loan": 26
+      },
+      {
+        "id": 1493,
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609544947
+      },
+      {
+        "id": 1494,
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609544949
+      },
+      {
+        "id": 1495,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545169
+      },
+      {
+        "id": 1496,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545178
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1497,
+        "hex": "J14",
+        "tile": "8-10",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1498
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1499
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1500,
+        "routes": [
+          {
+            "train": "8-2",
+            "connections": [
+              [
+                "F14",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "E9",
+                "F10",
+                "G11",
+                "F12",
+                "F14"
+              ],
+              [
+                "D12",
+                "D10",
+                "E9"
+              ],
+              [
+                "D22",
+                "C21",
+                "C19",
+                "C17",
+                "B16",
+                "B14",
+                "B12",
+                "C13",
+                "D12"
+              ],
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1501,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1502
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1503
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1504
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1505
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1506
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1507
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1508
+      },
+      {
+        "type": "run_routes",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1509,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "E9",
+                "F10",
+                "G11",
+                "F12",
+                "F14"
+              ],
+              [
+                "D12",
+                "D10",
+                "E9"
+              ],
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "B18",
+                "C17",
+                "D16"
+              ]
+            ]
+          },
+          {
+            "train": "8-0",
+            "connections": [
+              [
+                "B6",
+                "B4",
+                "C3"
+              ],
+              [
+                "A7",
+                "B6"
+              ],
+              [
+                "C9",
+                "B8",
+                "A7"
+              ],
+              [
+                "D12",
+                "C11",
+                "C9"
+              ],
+              [
+                "I15",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1510,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "DL&W",
+        "entity_type": "corporation",
+        "id": 1511
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1512
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1513,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "I13",
+                "I15"
+              ],
+              [
+                "E9",
+                "F10",
+                "G11",
+                "H12",
+                "I13"
+              ],
+              [
+                "D12",
+                "D10",
+                "E9"
+              ],
+              [
+                "F22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "G17",
+                "G15",
+                "H16",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1514,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1515
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1516,
+        "loan": 33
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1517
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1518,
+        "hex": "J16",
+        "tile": "82-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1519
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1520
+      },
+      {
+        "type": "run_routes",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1521,
+        "routes": [
+          {
+            "train": "6-2",
+            "connections": [
+              [
+                "I13",
+                "H12",
+                "G11",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "I15",
+                "I13"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "D22",
+                "E21",
+                "D20",
+                "D18",
+                "E17",
+                "F16",
+                "F14"
+              ],
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 1522,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545852
+      },
+      {
+        "id": 1523,
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545858
+      },
+      {
+        "id": 1524,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545869
+      },
+      {
+        "id": 1525,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545877
+      },
+      {
+        "id": 1526,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545886
+      },
+      {
+        "id": 1527,
+        "type": "undo",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "user": 2516,
+        "created_at": 1609545903
+      },
+      {
+        "type": "dividend",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1528,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1529
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1530,
+        "loan": 43
+      },
+      {
+        "type": "pass",
+        "entity": "PLE",
+        "entity_type": "corporation",
+        "id": 1531
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1532
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1533
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1534,
+        "routes": [
+          {
+            "train": "5-3",
+            "connections": [
+              [
+                "D16",
+                "E15",
+                "D14",
+                "D12"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "E17",
+                "D18",
+                "D16"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "H18"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1535,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1536
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 1537
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1538
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1539
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1540,
+        "routes": [
+          {
+            "train": "8-2",
+            "connections": [
+              [
+                "J18",
+                "K19",
+                "K21"
+              ],
+              [
+                "I13",
+                "J14",
+                "J16",
+                "J18"
+              ],
+              [
+                "F14",
+                "F12",
+                "G11",
+                "H12",
+                "I13"
+              ],
+              [
+                "D12",
+                "D14",
+                "E15",
+                "F14"
+              ],
+              [
+                "D22",
+                "C21",
+                "C19",
+                "C17",
+                "B16",
+                "B14",
+                "B12",
+                "C13",
+                "D12"
+              ],
+              [
+                "F22",
+                "E23",
+                "D24",
+                "D22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1541,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1542
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 1543
+      },
+      {
+        "type": "message",
+        "entity": 1996,
+        "entity_type": "player",
+        "id": 1544,
+        "message": "well played everyone (bar me)"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1545
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1546,
+        "routes": [
+          {
+            "train": "7-1",
+            "connections": [
+              [
+                "I15",
+                "H14",
+                "G13",
+                "F12",
+                "E11",
+                "D12"
+              ],
+              [
+                "F14",
+                "G15",
+                "H16",
+                "I15"
+              ],
+              [
+                "H18",
+                "G17",
+                "F16",
+                "F14"
+              ],
+              [
+                "I21",
+                "I19",
+                "H18"
+              ],
+              [
+                "F22",
+                "G21",
+                "H20",
+                "I21"
+              ],
+              [
+                "D26",
+                "D24",
+                "E23",
+                "F22"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1547,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1548
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1549,
+        "loan": 47
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 1550
+      },
+      {
+        "type": "pass",
+        "entity": "NYOW",
+        "entity_type": "corporation",
+        "id": 1551
+      },
+      {
+        "type": "pass",
+        "entity": 2394,
+        "entity_type": "player",
+        "id": 1552
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1553
+      },
+      {
+        "type": "pass",
+        "entity": 78,
+        "entity_type": "player",
+        "id": 1554
+      },
+      {
+        "type": "message",
+        "entity": 2516,
+        "entity_type": "player",
+        "id": 1555,
+        "message": "Well done Hamish!"
+      }
+    ],
+    "loaded": true,
+    "created_at": 1609323180,
+    "updated_at": 1609546484
+  }

--- a/spec/fixtures/1817WO/19926.json
+++ b/spec/fixtures/1817WO/19926.json
@@ -1,0 +1,7029 @@
+{
+    "id": 19926,
+    "description": "Live fast",
+    "user": {
+      "id": 2095,
+      "name": "Aolivei8"
+    },
+    "players": [
+      {
+        "id": 2541,
+        "name": "Kelly"
+      },
+      {
+        "id": 2095,
+        "name": "Aolivei8"
+      },
+      {
+        "id": 3763,
+        "name": "Foxrik"
+      }
+    ],
+    "max_players": 4,
+    "title": "1817WO",
+    "settings": {
+      "seed": 1284540394,
+      "unlisted": false,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "status": "finished",
+    "turn": 6,
+    "round": "Acquisition Round",
+    "acting": [
+      2095
+    ],
+    "result": {
+      "Kelly": 7983,
+      "Foxrik": 2653,
+      "Aolivei8": 8384
+    },
+    "actions": [
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 1,
+        "company": "OBC",
+        "price": 30
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 2,
+        "message": "Hello Kelly and Alvaro.  I trust you are keeping well"
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 3,
+        "message": "yep, staying safe"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 4,
+        "message": "Yep! Hope you as well! "
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 5
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 6,
+        "company": "OBC",
+        "price": 35
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 7
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 8,
+        "company": "PSM",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 9,
+        "company": "PSM",
+        "price": 35
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 11
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 12,
+        "company": "CM",
+        "price": 50
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 13
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 14
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 15,
+        "company": "TS",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 16,
+        "company": "TS",
+        "price": 55
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 17
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 18
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 19,
+        "company": "MINC",
+        "price": 25
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 21
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 22,
+        "company": "ME",
+        "price": 30
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 23
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 24
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 25
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 26
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 27
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 28,
+        "corporation": "UR",
+        "price": 120
+      },
+      {
+        "type": "place_token",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 29,
+        "city": "C4-0-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 30
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 31
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 32,
+        "corporation": "B&A",
+        "price": 130
+      },
+      {
+        "type": "place_token",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 33,
+        "city": "F1-0-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 34
+      },
+      {
+        "type": "assign",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 35,
+        "target": "MINC",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 36
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 37,
+        "corporation": "H",
+        "price": 110
+      },
+      {
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 38,
+        "city": "I6-2-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 39
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 40
+      },
+      {
+        "type": "assign",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 41,
+        "target": "PSM",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 42
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 43,
+        "corporation": "WC",
+        "price": 120
+      },
+      {
+        "type": "place_token",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 44,
+        "city": "C4-0-1",
+        "slot": 0
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 45,
+        "corporation": "WC",
+        "price": 140
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 46
+      },
+      {
+        "type": "assign",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 47,
+        "target": "TS",
+        "target_type": "company"
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 48
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 49,
+        "corporation": "Bess",
+        "price": 160
+      },
+      {
+        "type": "place_token",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 50,
+        "city": "K4-1-0",
+        "slot": 0
+      },
+      {
+        "type": "assign",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 51,
+        "target": "ME",
+        "target_type": "company"
+      },
+      {
+        "type": "assign",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 52,
+        "target": "CM",
+        "target_type": "company"
+      },
+      {
+        "type": "assign",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 53,
+        "target": "OBC",
+        "target_type": "company"
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 54,
+        "corporation": "GT",
+        "price": 120
+      },
+      {
+        "type": "place_token",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 55,
+        "city": "K8-3-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 56
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 57
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 58
+      },
+      {
+        "id": 59,
+        "hex": "K4",
+        "tile": "5-0",
+        "type": "lay_tile",
+        "entity": "Bess",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "user": 3763,
+        "created_at": 1608764167
+      },
+      {
+        "id": 60,
+        "type": "assign",
+        "entity": "OBC",
+        "target": "K4",
+        "entity_type": "company",
+        "target_type": "hex",
+        "user": 3763,
+        "created_at": 1608764180
+      },
+      {
+        "id": 61,
+        "type": "undo",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "user": 3763,
+        "created_at": 1608764270
+      },
+      {
+        "id": 62,
+        "type": "undo",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "user": 3763,
+        "created_at": 1608764273
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 63,
+        "hex": "K4",
+        "tile": "57-0",
+        "rotation": 0
+      },
+      {
+        "type": "assign",
+        "entity": "OBC",
+        "entity_type": "company",
+        "id": 64,
+        "target": "K4",
+        "target_type": "hex"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CM",
+        "entity_type": "company",
+        "id": 65,
+        "hex": "K6",
+        "tile": "8-0",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 66,
+        "loan": 0
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 67,
+        "loan": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 68,
+        "train": "2-0",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 69,
+        "train": "2-1",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 70,
+        "hex": "D5",
+        "tile": "7-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 71
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 72,
+        "loan": 2
+      },
+      {
+        "type": "buy_train",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 73,
+        "train": "2-2",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 74
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 75
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 76,
+        "message": "that answers my question about what tiles constitute \"ocean\" hexes"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 77,
+        "message": "ahh its the 15 dolar tiles"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MINC",
+        "entity_type": "company",
+        "id": 78,
+        "hex": "E2",
+        "tile": "9-0",
+        "rotation": 1
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 79,
+        "message": "it looks like it should be toi $10 thexes"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 80
+      },
+      {
+        "type": "buy_train",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 81,
+        "train": "2-3",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 82
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 83
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 84,
+        "hex": "B3",
+        "tile": "8-1",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 85
+      },
+      {
+        "type": "buy_train",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 86,
+        "train": "2-4",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 87
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 88
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 89,
+        "hex": "K8",
+        "tile": "5-0",
+        "rotation": 1
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 90,
+        "message": "the 10 dolar hexes are rivers"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 91,
+        "hex": "J7",
+        "tile": "7-1",
+        "rotation": 4
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 92,
+        "loan": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 93,
+        "loan": 4
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 94,
+        "train": "2-5",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 95,
+        "train": "2-6",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 96
+      },
+      {
+        "type": "lay_tile",
+        "entity": "PSM",
+        "entity_type": "company",
+        "id": 97,
+        "hex": "I6",
+        "tile": "X00-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 98,
+        "hex": "H5",
+        "tile": "9-1",
+        "rotation": 2
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 99,
+        "loan": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 100,
+        "loan": 6
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 101,
+        "train": "2-7",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 102,
+        "train": "2-8",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 103
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 104
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 105
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 106
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 107
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 108
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 109
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 110
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 111
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 112
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 113
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 114
+      },
+      {
+        "type": "run_routes",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 115,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "K4",
+                "K6",
+                "J7",
+                "K8"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 116,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 117
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 118,
+        "message": "I've had some geographic confusion myself ... but I'm committed to learning the hard way!"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 119,
+        "hex": "D3",
+        "tile": "8-2",
+        "rotation": 4
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 120,
+        "message": "nice"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 121
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 122
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 123,
+        "message": "who knew that new pitt was moon adjacent"
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 124,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F1",
+                "E2",
+                "D3",
+                "D5",
+                "C4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 125,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 126,
+        "loan": 7
+      },
+      {
+        "type": "buy_train",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 127,
+        "train": "2+-0",
+        "price": 100,
+        "variant": "2+"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 128
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 129,
+        "hex": "G2",
+        "tile": "8-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 130
+      },
+      {
+        "type": "run_routes",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 131,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "F1",
+                "E2",
+                "D3",
+                "D5",
+                "C4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 132,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 133,
+        "loan": 8
+      },
+      {
+        "type": "take_loan",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 134,
+        "loan": 9
+      },
+      {
+        "type": "buy_train",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 135,
+        "train": "2+-1",
+        "price": 100,
+        "variant": "2+"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 136
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 137,
+        "hex": "B1",
+        "tile": "7-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 138
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 139,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 140,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 141
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 142
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 143
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 144,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "K4",
+                "K6",
+                "J7",
+                "K8"
+              ]
+            ]
+          },
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "K8",
+                "J9"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 145,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 146
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 147,
+        "loan": 3
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 148
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 149,
+        "hex": "G4",
+        "tile": "6-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 150
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 151,
+        "routes": [
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "G4",
+                "H5",
+                "I6"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 152,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 153
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 154
+      },
+      {
+        "type": "merge",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 155,
+        "corporation": "GT"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 156,
+        "shares": [
+          "UR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 157
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 158
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 159
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 160
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 161
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 162
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 163
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 164
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 165
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 166,
+        "corporation": "Belt",
+        "price": 140
+      },
+      {
+        "id": 167,
+        "city": "L9-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608765298
+      },
+      {
+        "id": 168,
+        "type": "undo",
+        "entity": 2095,
+        "entity_type": "player",
+        "user": 2095,
+        "created_at": 1608765323
+      },
+      {
+        "type": "place_token",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 169,
+        "city": "6-0-0",
+        "slot": 0
+      },
+      {
+        "type": "choose",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 170,
+        "choice": 2
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 171
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 172
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 173
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 174
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 175,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          },
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "K8",
+                "J9"
+              ]
+            ]
+          },
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "K4",
+                "K6",
+                "J7",
+                "K8"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 176,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 177,
+        "loan": 10
+      },
+      {
+        "type": "buy_train",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 178,
+        "train": "3-1",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 179
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 180,
+        "hex": "G4",
+        "tile": "619-0",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 181,
+        "hex": "F5",
+        "tile": "9-2",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 182,
+        "loan": 11
+      },
+      {
+        "type": "take_loan",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 183,
+        "loan": 12
+      },
+      {
+        "type": "buy_train",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 184,
+        "train": "3-2",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 185
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 186,
+        "hex": "I6",
+        "tile": "592-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 187
+      },
+      {
+        "type": "place_token",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 188,
+        "city": "592-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 189,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F1",
+                "E2",
+                "D3",
+                "D5",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "I6",
+                "H5",
+                "G4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 190,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 191
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 192,
+        "hex": "K4",
+        "tile": "619-1",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 193,
+        "hex": "K2",
+        "tile": "8-4",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 194,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "L1",
+                "K2",
+                "K4"
+              ]
+            ]
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "K4",
+                "K6",
+                "J7",
+                "K8"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 195,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 196
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 197,
+        "loan": 0
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 198
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 199,
+        "hex": "C4",
+        "tile": "54-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 200
+      },
+      {
+        "type": "run_routes",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 201,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "C4",
+                "D5",
+                "D3",
+                "E2",
+                "F1"
+              ]
+            ]
+          },
+          {
+            "train": "2+-1",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 202,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 203
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 204,
+        "loan": 8
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 205
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 206,
+        "hex": "J5",
+        "tile": "9-3",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 207,
+        "routes": [
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "I6",
+                "H5",
+                "G4"
+              ]
+            ]
+          },
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 208,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 209
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 210,
+        "loan": 5
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 211
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 212
+      },
+      {
+        "type": "merge",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 213,
+        "corporation": "Belt"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 214,
+        "shares": [
+          "WC_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 215,
+        "shares": [
+          "WC_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 216
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 217
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 218
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 219
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 220
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 221
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 222
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 223,
+        "hex": "E6",
+        "tile": "8-5",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 224,
+        "hex": "D5",
+        "tile": "82-0",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 225,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F1",
+                "E2",
+                "D3",
+                "D5",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "I6",
+                "H5",
+                "G4"
+              ]
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "L1",
+                "K2",
+                "K4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 226,
+        "kind": "half"
+      },
+      {
+        "type": "buy_train",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 227,
+        "train": "3-4",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 228,
+        "loan": 2
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 229,
+        "loan": 7
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 230
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 231,
+        "hex": "C2",
+        "tile": "5-1",
+        "rotation": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 232,
+        "loan": 13
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 233,
+        "hex": "K8",
+        "tile": "15-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 234,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          },
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "C2",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "K8",
+                "J9"
+              ]
+            ]
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "K8",
+                "J7",
+                "K6",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 235,
+        "kind": "payout"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 236,
+        "loan": 4
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 237,
+        "loan": 10
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 238
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 239,
+        "hex": "D3",
+        "tile": "83-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 240
+      },
+      {
+        "type": "run_routes",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 241,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "C4",
+                "D5",
+                "D3",
+                "E2",
+                "F1"
+              ]
+            ]
+          },
+          {
+            "train": "2+-1",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 242,
+        "kind": "half"
+      },
+      {
+        "type": "buy_train",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 243,
+        "train": "3-2",
+        "price": 10
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 244
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 245
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 246,
+        "hex": "L5",
+        "tile": "8-6",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 247
+      },
+      {
+        "type": "run_routes",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 248,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "L1",
+                "K2",
+                "K4"
+              ]
+            ]
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 249,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 250
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 251
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 252,
+        "hex": "H5",
+        "tile": "83-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 253
+      },
+      {
+        "type": "run_routes",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 254,
+        "routes": [
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "I6",
+                "H5",
+                "G4"
+              ]
+            ]
+          },
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 255,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 256
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 257
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 258
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 259
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 260
+      },
+      {
+        "type": "merge",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 261,
+        "corporation": "H"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 262,
+        "shares": [
+          "Bess_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 263
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 264
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 265
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 266
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 267
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 268,
+        "corporation": "H",
+        "price": 280
+      },
+      {
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 269,
+        "city": "L9-0-0",
+        "slot": 0
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 270
+      },
+      {
+        "type": "choose",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 271,
+        "choice": 5
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 272,
+        "corporation": "Belt",
+        "price": 280
+      },
+      {
+        "type": "place_token",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 273,
+        "city": "619-0-0",
+        "slot": 1
+      },
+      {
+        "type": "choose",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 274,
+        "choice": 5
+      },
+      {
+        "type": "short",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 275,
+        "corporation": "Bess"
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 276,
+        "corporation": "ME",
+        "price": 330
+      },
+      {
+        "type": "place_token",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 277,
+        "city": "15-0-0",
+        "slot": 1
+      },
+      {
+        "type": "choose",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 278,
+        "choice": 5
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 279
+      },
+      {
+        "type": "place_token",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 280,
+        "city": "F1-0-0",
+        "slot": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 281,
+        "loan": 14
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 282,
+        "loan": 15
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 283,
+        "loan": 16
+      },
+      {
+        "type": "buy_shares",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 284,
+        "shares": [
+          "Bess_10"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 285
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 286
+      },
+      {
+        "type": "short",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 287,
+        "corporation": "Bess"
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 288
+      },
+      {
+        "type": "buy_shares",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 289,
+        "shares": [
+          "Bess_12"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 290
+      },
+      {
+        "type": "short",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 291,
+        "corporation": "Bess"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 292,
+        "shares": [
+          "ME_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 293,
+        "shares": [
+          "Bess_14"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 294,
+        "shares": [
+          "WC_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 295,
+        "shares": [
+          "Belt_1"
+        ],
+        "percent": 20
+      },
+      {
+        "id": 296,
+        "loan": 17,
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608767189
+      },
+      {
+        "id": 297,
+        "type": "undo",
+        "entity": 2095,
+        "entity_type": "player",
+        "user": 2095,
+        "created_at": 1608767199
+      },
+      {
+        "type": "short",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 298,
+        "corporation": "UR"
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 299
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 300
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 301
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 302
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 303,
+        "hex": "L7",
+        "tile": "8-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 304
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 305
+      },
+      {
+        "type": "buy_train",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 306,
+        "train": "3-6",
+        "price": 250,
+        "variant": "3"
+      },
+      {
+        "id": 307,
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608767424
+      },
+      {
+        "id": 308,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608767457
+      },
+      {
+        "id": 309,
+        "type": "buy_train",
+        "price": 95,
+        "train": "2-3",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608767478
+      },
+      {
+        "id": 310,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608767496
+      },
+      {
+        "type": "buy_train",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 311,
+        "train": "2-3",
+        "price": 65
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 312
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 313
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 314,
+        "hex": "J7",
+        "tile": "80-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 315
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 316,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F1",
+                "E2",
+                "D3",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "G4",
+                "F5",
+                "E6",
+                "D5",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "L1",
+                "K2",
+                "K4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 317,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 318,
+        "loan": 17
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 319,
+        "loan": 18
+      },
+      {
+        "type": "buy_train",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 320,
+        "train": "4-0",
+        "price": 400,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 321
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 322,
+        "hex": "F5",
+        "tile": "82-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 323
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 324,
+        "loan": 19
+      },
+      {
+        "type": "take_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 325,
+        "loan": 20
+      },
+      {
+        "type": "buy_train",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 326,
+        "train": "4-1",
+        "price": 400,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 327
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 328
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 329,
+        "hex": "G6",
+        "tile": "9-4",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 330
+      },
+      {
+        "type": "take_loan",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 331,
+        "loan": 21
+      },
+      {
+        "type": "buy_train",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 332,
+        "train": "4-2",
+        "price": 400,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 333
+      },
+      {
+        "type": "pass",
+        "entity": "Belt",
+        "entity_type": "corporation",
+        "id": 334
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 335,
+        "hex": "C2",
+        "tile": "15-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 336
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 337,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "C2",
+                "C4"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 338,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 339
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 340
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CM",
+        "entity_type": "company",
+        "id": 341,
+        "hex": "I8",
+        "tile": "7-3",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 342
+      },
+      {
+        "type": "buy_train",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 343,
+        "train": "4-1",
+        "price": 140
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 344
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 345,
+        "hex": "E6",
+        "tile": "81-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 346
+      },
+      {
+        "type": "run_routes",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 347,
+        "routes": [
+          {
+            "train": "2+-1",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ]
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "F1",
+                "E2",
+                "D3",
+                "C4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 348,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 349
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 350,
+        "loan": 9
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 351
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 352
+      },
+      {
+        "type": "merge",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 353,
+        "corporation": "Belt"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 354,
+        "shares": [
+          "UR_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 355
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 356
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 357
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 358
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 359
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 360
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 361
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 362
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 363
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 364
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 365,
+        "hex": "L5",
+        "tile": "83-2",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 366
+      },
+      {
+        "type": "place_token",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 367,
+        "city": "619-1-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 368,
+        "routes": [
+          {
+            "train": "3-6",
+            "connections": [
+              [
+                "L1",
+                "K2",
+                "K4"
+              ],
+              [
+                "J9",
+                "J7",
+                "K6",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 369,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 370
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 371
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 372,
+        "hex": "G8",
+        "tile": "6-1",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 373
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 374
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 375,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "C2",
+                "C4"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 376,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 377
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 378,
+        "loan": 13
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 379,
+        "loan": 21
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 380
+      },
+      {
+        "id": 381,
+        "hex": "E8",
+        "tile": "8-7",
+        "type": "lay_tile",
+        "entity": "WC",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608768361
+      },
+      {
+        "id": 382,
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608768376
+      },
+      {
+        "id": 383,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608768414
+      },
+      {
+        "id": 384,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608768419
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 385,
+        "hex": "G8",
+        "tile": "619-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 386
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 387,
+        "routes": [
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "F1",
+                "E2",
+                "D3",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ]
+            ]
+          },
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "G4",
+                "G2",
+                "F1"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 388,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 389
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 390,
+        "loan": 11
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 391,
+        "loan": 12
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 392
+      },
+      {
+        "type": "lay_tile",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 393,
+        "hex": "G2",
+        "tile": "82-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 394
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 395
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 396,
+        "loan": 19
+      },
+      {
+        "type": "pass",
+        "entity": "H",
+        "entity_type": "corporation",
+        "id": 397
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 398,
+        "hex": "E8",
+        "tile": "8-7",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 399
+      },
+      {
+        "type": "run_routes",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 400,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "F1",
+                "E2",
+                "D3",
+                "C4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 401,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 402
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 403
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 404,
+        "hex": "G6",
+        "tile": "82-3",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 405,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "J9",
+                "J7",
+                "K6",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 406,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 407
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 408
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 409
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 410
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 411
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 412,
+        "corporation": "H",
+        "price": 10
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 413,
+        "corporation": "H",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 414,
+        "corporation": "H",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 415,
+        "corporation": "H",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 416,
+        "corporation": "H",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 417,
+        "corporation": "H",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 418,
+        "corporation": "H",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 419,
+        "corporation": "H",
+        "price": 80
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 420,
+        "corporation": "H",
+        "price": 90
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 421,
+        "corporation": "H",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 422
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 423
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 424
+      },
+      {
+        "type": "assign",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 425,
+        "target": "B&A",
+        "target_type": "corporation"
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 426
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 427,
+        "corporation": "B&A",
+        "price": 220
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 428,
+        "message": "brb"
+      },
+      {
+        "type": "merge",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 429,
+        "corporation": "ME"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 430
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 431
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 432
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 433
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 434,
+        "shares": [
+          "WC_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 435,
+        "message": "As usual -- lots of options and most of them are wrong"
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 436,
+        "corporation": "B&A",
+        "price": 400
+      },
+      {
+        "type": "place_token",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 437,
+        "city": "15-1-0",
+        "slot": 1
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 438
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 439,
+        "message": "hehe yes"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 440,
+        "shares": [
+          "ME_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 441,
+        "shares": [
+          "B&A_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_tokens",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 442
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 443
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 444
+      },
+      {
+        "type": "buy_shares",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 445,
+        "shares": [
+          "WC_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 446
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 447
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 448
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 449,
+        "hex": "B1",
+        "tile": "80-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 450
+      },
+      {
+        "type": "take_loan",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 451,
+        "loan": 24
+      },
+      {
+        "type": "buy_train",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 452,
+        "train": "5-0",
+        "price": 600,
+        "variant": "5"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 453
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 454
+      },
+      {
+        "id": 455,
+        "hex": "C4",
+        "tile": "62-0",
+        "type": "lay_tile",
+        "entity": "WC",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608769250
+      },
+      {
+        "id": 456,
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608769265
+      },
+      {
+        "id": 457,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608769314
+      },
+      {
+        "id": 458,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608769318
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 459,
+        "hex": "J7",
+        "tile": "545-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 460
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 461,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "D9",
+                "E8",
+                "E6",
+                "D5",
+                "C4"
+              ],
+              [
+                "F1",
+                "E2",
+                "D3",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "J9",
+                "J7",
+                "I8",
+                "I6"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 462,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 463
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 464,
+        "loan": 17
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 465
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 466,
+        "hex": "I6",
+        "tile": "593-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 467
+      },
+      {
+        "type": "place_token",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 468,
+        "city": "593-0-0",
+        "slot": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 469,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "F1",
+                "E2",
+                "D3",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 470,
+        "loan": 25
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 471,
+        "loan": 26
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 472,
+        "loan": 27
+      },
+      {
+        "type": "take_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 473,
+        "loan": 28
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 474,
+        "kind": "half"
+      },
+      {
+        "type": "buy_train",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 475,
+        "train": "5-1",
+        "price": 600,
+        "variant": "5"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 476
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 477,
+        "hex": "C4",
+        "tile": "62-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 478
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 479,
+        "routes": [
+          {
+            "train": "3-6",
+            "connections": [
+              [
+                "C4",
+                "D5",
+                "E6",
+                "E8",
+                "D9"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ]
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "J9",
+                "J7",
+                "K6",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 480,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 481
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 482,
+        "loan": 23
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 483
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 484,
+        "hex": "G6",
+        "tile": "546-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 485
+      },
+      {
+        "type": "run_routes",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 486,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "J9",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "C4",
+                "D3",
+                "D5",
+                "E6",
+                "F5",
+                "G6",
+                "H5",
+                "I6"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 487,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 488
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 489,
+        "loan": 1
+      },
+      {
+        "id": 490,
+        "loan": 29,
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "user": 3763,
+        "created_at": 1608769711
+      },
+      {
+        "id": 491,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 3763,
+        "created_at": 1608769716
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 492,
+        "loan": 6
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 493
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 494
+      },
+      {
+        "type": "merge",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 495,
+        "corporation": "B&A"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 496,
+        "shares": [
+          "ME_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 497,
+        "shares": [
+          "ME_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 498
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 499
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 500
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 501
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 502
+      },
+      {
+        "id": 503,
+        "hex": "D3",
+        "tile": "546-1",
+        "type": "lay_tile",
+        "entity": "WC",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608769943
+      },
+      {
+        "id": 504,
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608769958
+      },
+      {
+        "id": 505,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770026
+      },
+      {
+        "id": 506,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770034
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 507,
+        "hex": "G4",
+        "tile": "63-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 508
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 509,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "C4",
+                "D5",
+                "E6",
+                "E8",
+                "D9"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ]
+            ]
+          },
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "G4",
+                "H5",
+                "I6"
+              ],
+              [
+                "I6",
+                "I8",
+                "J7",
+                "J9"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 510,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770055
+      },
+      {
+        "id": 511,
+        "type": "undo",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770075
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 512,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 513
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 514,
+        "loan": 18
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 515
+      },
+      {
+        "id": 516,
+        "hex": "D3",
+        "tile": "546-1",
+        "type": "lay_tile",
+        "entity": "ME",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770141
+      },
+      {
+        "id": 517,
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770144
+      },
+      {
+        "id": 518,
+        "city": "62-0-1",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770146
+      },
+      {
+        "id": 519,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770272
+      },
+      {
+        "id": 520,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770277
+      },
+      {
+        "id": 521,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608770283
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 522,
+        "hex": "H7",
+        "tile": "9-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 523
+      },
+      {
+        "type": "place_token",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 524,
+        "city": "62-0-1",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 525,
+        "routes": [
+          {
+            "train": "3-6",
+            "connections": [
+              [
+                "C4",
+                "C2"
+              ],
+              [
+                "A2",
+                "B1",
+                "C2"
+              ]
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "J9",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ]
+            ]
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G6",
+                "G8"
+              ],
+              [
+                "G8",
+                "H7",
+                "I6"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 526,
+        "kind": "payout"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 527,
+        "loan": 24
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 528
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 529,
+        "hex": "K4",
+        "tile": "63-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 530
+      },
+      {
+        "type": "run_routes",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 531,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "K4",
+                "K6",
+                "J7",
+                "J9"
+              ],
+              [
+                "K4",
+                "J5",
+                "I6"
+              ],
+              [
+                "C4",
+                "D3",
+                "D5",
+                "E6",
+                "F5",
+                "G6",
+                "H5",
+                "I6"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 532,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 533
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 534,
+        "loan": 14
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 535,
+        "loan": 15
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 536
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 537,
+        "hex": "K8",
+        "tile": "448-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 538
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 539,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "K8",
+                "L7",
+                "L5",
+                "K4"
+              ],
+              [
+                "K8",
+                "J9"
+              ]
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "G8",
+                "H7",
+                "I6"
+              ],
+              [
+                "G4",
+                "G6",
+                "G8"
+              ],
+              [
+                "G4",
+                "F5",
+                "E6",
+                "D5",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "K4",
+                "K6",
+                "J7",
+                "I8",
+                "I6"
+              ],
+              [
+                "G4",
+                "H5",
+                "I6"
+              ],
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 540,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 541,
+        "loan": 22
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 542,
+        "loan": 25
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 543,
+        "loan": 26
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 544
+      },
+      {
+        "type": "convert",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 545
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 546,
+        "shares": [
+          "WC_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 547,
+        "shares": [
+          "WC_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 548
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 549
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 550
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 551
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 552
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 553
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 554
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 555
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 556,
+        "shares": [
+          "UR_10"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 557,
+        "shares": [
+          "Bess_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "short",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 558,
+        "corporation": "Bess"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 559,
+        "shares": [
+          "UR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 560
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 561
+      },
+      {
+        "type": "short",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 562,
+        "corporation": "Bess"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 563,
+        "shares": [
+          "WC_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "short",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 564,
+        "corporation": "WC"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 565,
+        "shares": [
+          "UR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 566
+      },
+      {
+        "type": "buy_shares",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 567,
+        "shares": [
+          "WC_10"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "short",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 568,
+        "corporation": "WC"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 569,
+        "shares": [
+          "UR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 570
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 571,
+        "loan": 29
+      },
+      {
+        "type": "buy_shares",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 572,
+        "shares": [
+          "WC_12"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 573
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 574
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 575
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 576,
+        "hex": "G8",
+        "tile": "611-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 577
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 578,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "G8",
+                "H7",
+                "I6"
+              ],
+              [
+                "G8",
+                "G6",
+                "F5",
+                "E6",
+                "D5",
+                "C4"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "G4",
+                "G2",
+                "F1"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 579,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 580,
+        "loan": 30
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 581,
+        "loan": 31
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 582,
+        "loan": 32
+      },
+      {
+        "type": "buy_train",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 583,
+        "train": "6-1",
+        "price": 750,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 584
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 585,
+        "hex": "D3",
+        "tile": "546-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 586
+      },
+      {
+        "type": "place_token",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 587,
+        "city": "15-1-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 588,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G6",
+                "H5",
+                "I6"
+              ],
+              [
+                "I6",
+                "I8",
+                "J7",
+                "J9"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 589,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 590,
+        "loan": 33
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 591,
+        "loan": 34
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 592,
+        "loan": 35
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 593,
+        "loan": 36
+      },
+      {
+        "type": "buy_train",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 594,
+        "train": "7-0",
+        "price": 900,
+        "variant": "7"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 595
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 596,
+        "hex": "G2",
+        "tile": "546-2",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 597
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 598,
+        "routes": [
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "G8",
+                "H7",
+                "I6"
+              ],
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "G4",
+                "F5",
+                "E6",
+                "D5",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "K4",
+                "K6",
+                "J7",
+                "I8",
+                "I6"
+              ],
+              [
+                "G4",
+                "H5",
+                "I6"
+              ],
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 599,
+        "message": "silver track?"
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 600,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 601,
+        "loan": 27
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 602,
+        "loan": 28
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 603
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 604,
+        "hex": "C4",
+        "tile": "X30-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 605
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 606,
+        "message": "yes"
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 607,
+        "loan": 37
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 608,
+        "loan": 38
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 609,
+        "loan": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 610,
+        "loan": 0
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 611,
+        "message": "damm, those shorts pulled me down so much"
+      },
+      {
+        "type": "run_routes",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 612,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "J9"
+              ],
+              [
+                "C4",
+                "D3",
+                "D5",
+                "E6",
+                "F5",
+                "G6",
+                "H5",
+                "I6"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 613,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "Bess",
+        "entity_type": "corporation",
+        "id": 614,
+        "train": "7-1",
+        "price": 900,
+        "variant": "7"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 615,
+        "message": "i tought it was a great short since you where running less trains but "
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 616,
+        "message": "what just happened?"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 617,
+        "message": "bess liquidated"
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 618,
+        "message": "did he havew to?"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 619,
+        "message": "you want to undo rik/"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 620,
+        "message": "?"
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 621,
+        "message": "i think he can avoid no?"
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 622,
+        "message": "Nope.  I think this is best"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 623,
+        "message": "he can, if he doesnt buy a train"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 624,
+        "message": "but yes"
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 625,
+        "message": "ok, whatever"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 626,
+        "message": "it would go next round i think"
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 627,
+        "corporation": "Bess",
+        "price": 10
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 628,
+        "message": "I needed Kelly to play a silver on NY or Pitt"
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 629,
+        "message": "Then I would have just scraped by."
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 630,
+        "message": "forgot i could, sorry about that"
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 631,
+        "message": "Kelly should think about a big bid for Bess"
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 632,
+        "message": "i can pretty much outbid anything for it"
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 633,
+        "message": "Alvaro should just pass.  The 5 shorts for 0 are worth more than the 7 train"
+      },
+      {
+        "type": "bid",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 634,
+        "corporation": "Bess",
+        "price": 490
+      },
+      {
+        "type": "bid",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 635,
+        "corporation": "Bess",
+        "price": 600
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 636,
+        "message": "ah i see i should have passed yes"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 637,
+        "message": "oh well"
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 638
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 639
+      },
+      {
+        "type": "message",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 640,
+        "message": "gg, y'all.  Well played by at least 2 of us"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 641,
+        "hex": "I6",
+        "tile": "597-0",
+        "rotation": 0
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 642,
+        "message": "gg i enjoyed this version a lot"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 643
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 644,
+        "message": "second time i play"
+      },
+      {
+        "type": "place_token",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 645,
+        "city": "611-0-0",
+        "slot": 0
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 646,
+        "message": "kelly lets just ride this out quick i am curious to see who takes it"
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 647,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ],
+              [
+                "C4",
+                "C2"
+              ]
+            ]
+          },
+          {
+            "train": "7-1",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "I6",
+                "H7",
+                "G8"
+              ],
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 648,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 649
+      },
+      {
+        "id": 650,
+        "hex": "C2",
+        "tile": "448-1",
+        "type": "lay_tile",
+        "entity": "ME",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608771805
+      },
+      {
+        "id": 651,
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608771812
+      },
+      {
+        "id": 652,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608771901
+      },
+      {
+        "id": 653,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608771908
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 654,
+        "loan": 8
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 655,
+        "hex": "H3",
+        "tile": "9-2",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 656,
+        "hex": "I4",
+        "tile": "8-8",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 657,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "K4",
+                "K2",
+                "L1"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G6",
+                "F5",
+                "E6",
+                "D5",
+                "C4"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          },
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "I6",
+                "I4",
+                "H3",
+                "G2",
+                "F1"
+              ],
+              [
+                "I6",
+                "I8",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "K8",
+                "L7",
+                "L5",
+                "K4"
+              ],
+              [
+                "K8",
+                "J9"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 658,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 659
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 660,
+        "hex": "C2",
+        "tile": "448-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 661
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 662
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 663,
+        "routes": [
+          {
+            "train": "7-0",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "J9"
+              ],
+              [
+                "I6",
+                "H7",
+                "G8"
+              ],
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "C4",
+                "D3",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ],
+              [
+                "C2",
+                "C4"
+              ],
+              [
+                "C2",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 664,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 665
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 666,
+        "loan": 29
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 667
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 668,
+        "message": "@Foxrik you still there?"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 669,
+        "message": "if he left we can just close his shorts"
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 670,
+        "message": "sure, thats about all he can afford"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 671,
+        "user": 2541,
+        "shares": [
+          "WC_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 672,
+        "shares": [
+          "ME_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 673
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 674,
+        "user": 2095,
+        "shares": [
+          "WC_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 675,
+        "shares": [
+          "WC_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 676
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 677,
+        "user": 2095
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 678,
+        "shares": [
+          "WC_10"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 679
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 680,
+        "user": 2541
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 681,
+        "shares": [
+          "WC_12"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 682
+      },
+      {
+        "type": "pass",
+        "entity": 3763,
+        "entity_type": "player",
+        "id": 683,
+        "user": 2095
+      },
+      {
+        "type": "pass",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 684
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 685,
+        "hex": "H1",
+        "tile": "8-5",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 686
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 687,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ],
+              [
+                "C2",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "7-1",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "I6",
+                "H7",
+                "G8"
+              ],
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 688,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 689
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 690,
+        "hex": "I2",
+        "tile": "6-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 691,
+        "hex": "K2",
+        "tile": "81-1",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 692,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "L1",
+                "K2",
+                "K4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G6",
+                "F5",
+                "E6",
+                "D5",
+                "C4"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          },
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "I6",
+                "I4",
+                "H3",
+                "G2",
+                "F1"
+              ],
+              [
+                "I6",
+                "I8",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "K8",
+                "L7",
+                "L5",
+                "K4"
+              ],
+              [
+                "K8",
+                "J9"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 693,
+        "kind": "payout"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 694,
+        "loan": 30
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 695,
+        "loan": 31
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 696
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 697,
+        "hex": "I2",
+        "tile": "619-3",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 698
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 699
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 700,
+        "routes": [
+          {
+            "train": "7-0",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "J9"
+              ],
+              [
+                "I6",
+                "H7",
+                "G8"
+              ],
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "C4",
+                "D3",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ],
+              [
+                "C2",
+                "C4"
+              ],
+              [
+                "C2",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 701,
+        "kind": "half"
+      },
+      {
+        "type": "buy_train",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 702,
+        "train": "8-2",
+        "price": 1100,
+        "variant": "8"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 703,
+        "loan": 33
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 704
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 705,
+        "hex": "K2",
+        "tile": "546-3",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 706
+      },
+      {
+        "type": "run_routes",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 707,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ],
+              [
+                "C2",
+                "C4"
+              ]
+            ]
+          },
+          {
+            "train": "7-1",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "I6",
+                "H7",
+                "G8"
+              ],
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "G4",
+                "G2",
+                "F1"
+              ],
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 708,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UR",
+        "entity_type": "corporation",
+        "id": 709
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 710,
+        "hex": "I2",
+        "tile": "611-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 711
+      },
+      {
+        "type": "run_routes",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 712,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "L1",
+                "K2",
+                "K4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G6",
+                "F5",
+                "E6",
+                "D5",
+                "C4"
+              ],
+              [
+                "C4",
+                "B3",
+                "B1",
+                "A2"
+              ]
+            ]
+          },
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "C4",
+                "D3",
+                "E2",
+                "F1"
+              ],
+              [
+                "I6",
+                "I4",
+                "H3",
+                "G2",
+                "F1"
+              ],
+              [
+                "I6",
+                "I8",
+                "J7",
+                "K6",
+                "K4"
+              ],
+              [
+                "K8",
+                "L7",
+                "L5",
+                "K4"
+              ],
+              [
+                "K8",
+                "J9"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "id": 713,
+        "kind": "half",
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608772586
+      },
+      {
+        "id": 714,
+        "type": "undo",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "user": 2095,
+        "created_at": 1608772592
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 715,
+        "loan": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 716,
+        "loan": 2
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 717,
+        "loan": 7
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 718,
+        "loan": 4
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 719,
+        "loan": 10
+      },
+      {
+        "type": "take_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 720,
+        "loan": 9
+      },
+      {
+        "type": "dividend",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 721,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 722,
+        "loan": 32
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 723,
+        "loan": 8
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 724,
+        "loan": 5
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 725,
+        "loan": 2
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 726,
+        "loan": 7
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 727,
+        "loan": 4
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 728,
+        "loan": 10
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 729,
+        "loan": 9
+      },
+      {
+        "type": "pass",
+        "entity": "ME",
+        "entity_type": "corporation",
+        "id": 730
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 731,
+        "hex": "L3",
+        "tile": "8-6",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 732
+      },
+      {
+        "type": "place_token",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 733,
+        "city": "611-1-0",
+        "slot": 1
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 734,
+        "message": "gg, very close, thx for the game"
+      },
+      {
+        "type": "message",
+        "entity": 2541,
+        "entity_type": "player",
+        "id": 735,
+        "message": "just about 2.5 hrs"
+      },
+      {
+        "type": "run_routes",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 736,
+        "routes": [
+          {
+            "train": "7-0",
+            "connections": [
+              [
+                "I6",
+                "I8",
+                "J7",
+                "J9"
+              ],
+              [
+                "I6",
+                "H7",
+                "G8"
+              ],
+              [
+                "G8",
+                "G6",
+                "G4"
+              ],
+              [
+                "C4",
+                "D5",
+                "E6",
+                "F5",
+                "G4"
+              ],
+              [
+                "C2",
+                "C4"
+              ],
+              [
+                "C2",
+                "B1",
+                "A2"
+              ]
+            ]
+          },
+          {
+            "train": "8-2",
+            "connections": [
+              [
+                "I2",
+                "J1",
+                "K2",
+                "L1"
+              ],
+              [
+                "I2",
+                "H1",
+                "G2",
+                "G4"
+              ],
+              [
+                "I6",
+                "H5",
+                "G4"
+              ],
+              [
+                "I6",
+                "J5",
+                "K4"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 737,
+        "loan": 13
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 738,
+        "loan": 21
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 739,
+        "loan": 11
+      },
+      {
+        "type": "take_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 740,
+        "loan": 12
+      },
+      {
+        "type": "dividend",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 741,
+        "kind": "half"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 742,
+        "loan": 34
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 743,
+        "loan": 35
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 744,
+        "loan": 36
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 745,
+        "loan": 13
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 746,
+        "loan": 21
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 747,
+        "loan": 11
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 748,
+        "loan": 12
+      },
+      {
+        "type": "pass",
+        "entity": "WC",
+        "entity_type": "corporation",
+        "id": 749
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 750,
+        "message": "yes great timing short 17 experience"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 751,
+        "message": "thanks, very close"
+      },
+      {
+        "type": "message",
+        "entity": 2095,
+        "entity_type": "player",
+        "id": 752,
+        "message": "i bet on rik not being able to save bess , if he did, you would have won"
+      }
+    ],
+    "loaded": true,
+    "created_at": 1608761185,
+    "updated_at": 1608772848
+  }


### PR DESCRIPTION
The thought behind this is that since 1867 has city slots that are not IPOable until green that the same visual style should be used in 1817WO for Nieuw Zeeland because that hex is unIPOable until green (phase 3)
![image](https://user-images.githubusercontent.com/2993555/103449826-a225b280-4c7b-11eb-9cd8-f2dc4ba2a23f.png)
