### PR TITLE
Make 1856 Diesel black so that offboards can change on D, not 6 and add black hex color

### DIFF
--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -27,6 +27,7 @@ module Lib
       green: '#71bf44',
       brown: '#cb7745',
       gray: '#bcbdc0',
+      black: '#000000',
       red: '#ec232a',
       blue: '#35A7FF',
     }.freeze

--- a/lib/engine/config/game/g_1856.rb
+++ b/lib/engine/config/game/g_1856.rb
@@ -619,7 +619,7 @@ module Engine
   ],
   "hexes": {
     "red": {
-      "offboard=revenue:yellow_30|brown_50|gray_60;path=a:4,b:_0;path=a:5,b:_0": [
+      "offboard=revenue:yellow_30|brown_50|black_60;path=a:4,b:_0;path=a:5,b:_0": [
         "A20"
       ],
       "border=edge:4": [
@@ -628,22 +628,22 @@ module Engine
       "offboard=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:5,b:_0;border=edge:1": [
         "B13"
       ],
-      "offboard=revenue:yellow_30|brown_50|gray_40;path=a:0,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
+      "offboard=revenue:yellow_30|brown_50|black_40;path=a:0,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
         "H5"
       ],
       "offboard=revenue:yellow_20|brown_30;path=a:0,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
         "K2"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,hide:1,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;border=edge:5": [
+      "offboard=revenue:yellow_20|brown_30|black_50,hide:1,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;border=edge:5": [
         "N1"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0;border=edge:2": [
+      "offboard=revenue:yellow_20|brown_30|black_50,groups:Canadian West;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0;border=edge:2": [
         "O2"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,groups:Lower Canada;path=a:1,b:_0;path=a:2,b:_0;border=edge:0": [
+      "offboard=revenue:yellow_20|brown_30|black_50,groups:Lower Canada;path=a:1,b:_0;path=a:2,b:_0;border=edge:0": [
         "Q8"
       ],
-      "offboard=revenue:yellow_20|brown_30|gray_50,hide:1,groups:Lower Canada;path=a:2,b:_0;border=edge:3": [
+      "offboard=revenue:yellow_20|brown_30|black_50,hide:1,groups:Lower Canada;path=a:2,b:_0;border=edge:3": [
         "Q10"
       ],
       "offboard=revenue:yellow_30|brown_40,hide:1,groups:Buffalo;path=a:2,b:_0;border=edge:3": [
@@ -675,7 +675,7 @@ module Engine
       ]
     },
     "gray": {
-      "town=revenue:yellow_30|brown_50|gray_40;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
+      "town=revenue:yellow_30|brown_50|black_40;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0;icon=image:port,sticky:1": [
         "F9"
       ]
     },
@@ -925,7 +925,8 @@ module Engine
         "yellow",
         "green",
         "brown",
-        "gray"
+        "gray",
+        "black"
         ],
         "status":[
         "fullcap",


### PR DESCRIPTION
The offboards in 1856 change on the D, not the 6 so I added a new color to distinguish this
![image](https://user-images.githubusercontent.com/2993555/103449855-28da8f80-4c7c-11eb-8730-4b18018d7a00.png)
