### PR TITLE
Fix to make it possible to exchange for variant

### DIFF
--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -135,7 +135,7 @@ module Engine
       end
 
       def buyable_train_variants(train, entity)
-        return [] unless train_among_buyable?(entity, train)
+        return [] unless buyable_trains(entity).any? { |bt| bt.variants[bt.name] }
 
         variants = train.variants.values
         return variants if train.owned_by_corporation?
@@ -192,11 +192,6 @@ module Engine
       def face_value_ability?(entity)
         @game.abilities(entity, :train_buy) { |ability| return ability.face_value }
         false
-      end
-
-      def train_among_buyable?(entity, train)
-        candidates = buyable_trains(entity)
-        candidates.include?(train) || candidates.any? { |c| c.variants.keys.include?(train.name) }
       end
     end
   end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -135,10 +135,9 @@ module Engine
       end
 
       def buyable_train_variants(train, entity)
-        return [] unless buyable_trains(entity).include?(train)
+        return [] unless train_among_buyable?(entity, train)
 
         variants = train.variants.values
-
         return variants if train.owned_by_corporation?
 
         variants.reject! { |v| entity.cash < v[:price] } if must_issue_before_ebuy?(entity)
@@ -193,6 +192,11 @@ module Engine
       def face_value_ability?(entity)
         @game.abilities(entity, :train_buy) { |ability| return ability.face_value }
         false
+      end
+
+      def train_among_buyable?(entity, train)
+        candidates = buyable_trains(entity)
+        candidates.include?(train) || candidates.any? { |c| c.variants.keys.include?(train.name) }
       end
     end
   end


### PR DESCRIPTION
In case there is a variant of a purchasable train we need to look
among the variants to allow it.

Before the change, when attempting to exchange for the variant train, it was not among the buyable_train_variants as the base variant was checked against.