### PR TITLE
[18CZ] Feat(Company): Value is changeing from round to round

### DIFF
--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -10,8 +10,8 @@ module Engine
     include Entity
     include Ownable
 
-    attr_accessor :desc, :max_price, :min_price, :revenue, :discount
-    attr_reader :name, :sym, :value, :min_auction_price, :treasury
+    attr_accessor :desc, :max_price, :min_price, :revenue, :discount, :value
+    attr_reader :name, :sym, :min_auction_price, :treasury
 
     def initialize(sym:, name:, value:, revenue: 0, desc: '', abilities: [], **opts)
       @sym = sym


### PR DESCRIPTION
In 18CZ the values of companies is changing from round to round, so I have to change it during the game. 

Thus, it needs to be writable. 

Usage can be seen here:
https://github.com/Zwergenpunk/18xx/blob/c42b57cbc42c3cbd436d1637f3e69915cda67bf7/lib/engine/game/g_18_cz.rb#L91