### PR TITLE
[1882] make it more clear that P2 closes on phase 6

### DIFF
--- a/lib/engine/config/game/g_1882.rb
+++ b/lib/engine/config/game/g_1882.rb
@@ -467,7 +467,10 @@ module Engine
       "name": "6",
       "distance": 6,
       "price": 630,
-      "num": 3
+      "num": 3,
+      "events": [
+        {"type": "close_remaining_companies"}
+      ]
     },
     {
       "name": "D",

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -31,6 +31,10 @@ module Engine
       TRACK_RESTRICTION = :permissive
       DISCARDED_TRAINS = :remove
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+        'close_companies' => ['Most Companies Close',
+                              'Private companies (except Saskatchewan Central) are removed from the game'],
+        'close_remaining_companies' => ['Saskatchewan Central Closes',
+                                        'Saskatchewan Central is removed from the game'],
         'nwr' => ['North West Rebellion',
                   'Remove all yellow tiles from NWR-marked hexes. Station markers remain']
       ).freeze

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -184,7 +184,7 @@ module Engine
       end
 
       def event_close_remaining_companies!
-        event_close_companies!
+        true
       end
 
       def revenue_for(route, stops)

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -183,6 +183,10 @@ module Engine
         @graph.clear_graph_for_all
       end
 
+      def event_close_remaining_companies!
+        event_close_companies!
+      end
+
       def revenue_for(route, stops)
         revenue = super
 


### PR DESCRIPTION
P2 wasn't being closed since `close_companies()` was only called once, at phase 5

This patch creates a new event on phase 6 that calls `close_companies()` again to close P2

Also added more detail in the event copy to clarify those differences

![Screenshot 2021-01-02 at 11 04 29 PM](https://user-images.githubusercontent.com/1711810/103473562-f3eb3d00-4d4e-11eb-9091-4ea21db26b33.png)
