### PR TITLE
[1846] slight changes to corp colors / names

### DIFF
--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -429,7 +429,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "PRR",
-      "name": "Pennsylvania",
+      "name": "Pennsylvania Railroad",
       "logo": "1846/PRR",
       "tokens": [
         0,
@@ -455,7 +455,7 @@ module Engine
         }
       ],
       "coordinates": "F20",
-      "color": "red",
+      "color": "#FF0000",
       "always_market_price": true
     },
     {
@@ -517,14 +517,14 @@ module Engine
         80
       ],
       "coordinates": "I15",
-      "color": "lightBlue",
+      "color": "#ADD8E6",
       "text_color": "black",
       "always_market_price": true
     },
     {
       "float_percent": 20,
       "sym": "ERIE",
-      "name": "Erie",
+      "name": "Erie Railroad",
       "logo": "1846/ERIE",
       "tokens": [
         0,
@@ -550,7 +550,7 @@ module Engine
         }
       ],
       "coordinates": "E21",
-      "color": "yellow",
+      "color": "#FFF500",
       "text_color": "black",
       "always_market_price": true
     },

--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -461,7 +461,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "NYC",
-      "name": "New York Central",
+      "name": "New York Central Railroad",
       "logo": "1846/NYC",
       "tokens": [
         0,
@@ -476,7 +476,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "B&O",
-      "name": "Baltimore & Ohio",
+      "name": "Baltimore & Ohio Railroad",
       "logo": "1846/BO",
       "tokens": [
         0,
@@ -508,7 +508,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "C&O",
-      "name": "Chesapeake & Ohio",
+      "name": "Chesapeake & Ohio Railroad",
       "logo": "1846/CO",
       "tokens": [
         0,
@@ -557,7 +557,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "GT",
-      "name": "Grand Trunk",
+      "name": "Grand Trunk Railway",
       "logo": "1846/GT",
       "tokens": [
         0,
@@ -571,7 +571,7 @@ module Engine
     {
       "float_percent": 20,
       "sym": "IC",
-      "name": "Illinois Central",
+      "name": "Illinois Central Railroad",
       "logo": "1846/IC",
       "tokens": [
         0,


### PR DESCRIPTION
Some ocd changes to make the corp card colors match the token colors

Also make corp names consistently two words (e.g. "Erie Railroad" instead of "Erie")