### PR TITLE
add route for accessing fixtures in the web browser

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -67,7 +67,7 @@ class Api < Roda
   use Rack::Deflater unless PRODUCTION
 
   STANDARD_ROUTES = %w[
-    / about hotseat login map market new_game profile signup tiles tutorial forgot reset
+    / about hotseat login map market new_game profile signup tiles tutorial forgot reset fixture
   ].freeze
 
   Dir['./routes/*'].sort.each { |file| require file }

--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -55,7 +55,7 @@ class App < Snabberb::Component
       case @app_route
       when /new_game/
         h(View::CreateGame)
-      when /[^?](game|hotseat|tutorial)/
+      when /[^?](game|hotseat|tutorial|fixture)/
         render_game
       when /signup/
         h(View::User, type: :signup)
@@ -85,11 +85,13 @@ class App < Snabberb::Component
   end
 
   def render_game
-    match = @app_route.match(%r{(hotseat|game)\/((hs.*_)?\d+)})
+    match = @app_route.match(%r{(hotseat|game|fixture)\/((18.*\/)?(hs.*_)?\d+)})
 
     if !@game_data&.any? # this is a hotseat game
       if @app_route.include?('tutorial')
         enter_tutorial
+      elsif @app_route.include?('fixture')
+        enter_fixture(match[2])
       else
         enter_game(id: match[2], mode: match[1] == 'game' ? :muti : :hotseat, pin: @pin)
       end

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -40,6 +40,12 @@ module GameManager
     end
   end
 
+  def enter_fixture(path)
+    @connection.safe_get("/fixtures/#{path}.json", '') do |data|
+      store(:game_data, data, skip: false)
+    end
+  end
+
   def get_games(params = nil)
     params ||= `window.location.search`
 

--- a/public/fixtures
+++ b/public/fixtures
@@ -1,0 +1,1 @@
+../spec/fixtures


### PR DESCRIPTION
When a fixture fails, no more copy-pasting the JSON into the "import hotseat" field to see how it looks in the browser, just go to `/fixture/<title>/<id>`