### PR TITLE
Don't tell the player the company value in 1817 variants will move beyond end of market

### DIFF
--- a/lib/engine/step/g_1817/dividend.rb
+++ b/lib/engine/step/g_1817/dividend.rb
@@ -8,6 +8,8 @@ module Engine
     module G1817
       class Dividend < Dividend
         DIVIDEND_TYPES = %i[payout half withhold].freeze
+        PENULTIMATE_PRICE = 540
+        FINAL_PRICE = 600
         include HalfPay
 
         def half_pay_withhold_amount(entity, revenue)
@@ -21,8 +23,8 @@ module Engine
           return { share_direction: :left, share_times: 1 } unless revenue.positive?
 
           times = 0
-          times = 1 if revenue >= price
-          times = 2 if revenue >= price * 2
+          times = 1 if revenue >= price && price < FINAL_PRICE
+          times = 2 if revenue >= price * 2 && price < PENULTIMATE_PRICE
           if times.positive?
             { share_direction: :right, share_times: times }
           else


### PR DESCRIPTION
fixes #3013

Before this if a company is at the highest values in the market with accordingly high dividends the game will falsely tell the player that the stock price will move beyond the end of the market