### PR TITLE
1867 Bug Fixes

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -118,7 +118,7 @@ module View
 
         discountable_trains = @depot.discountable_trains_for(@corporation)
 
-        if discountable_trains.any?
+        if discountable_trains.any? && step.discountable_trains_allowed?(@corporation)
           children << h(:h3, h3_props, 'Exchange Trains')
 
           discountable_trains.each do |train, discount_train, variant, price|

--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -780,8 +780,17 @@ module Engine
       "events": [
         {"type": "signal_end_game"},
         {"type": "minors_nationalized"},
-        {"type": "trainless_nationalization"}
-      ]
+        {"type": "trainless_nationalization"},
+        {"type": "train_trade_allowed"}
+      ],
+      "discount": {
+        "5": 275,
+        "6": 325,
+        "7": 400,
+        "8": 500,
+        "2+2": 300,
+        "5+5E": 750
+      }
     },
     {
       "name": "2+2",
@@ -800,7 +809,15 @@ module Engine
       "multiplier":2,
       "price": 600,
       "num": 20,
-      "available_on": "8"
+      "available_on": "8",
+      "discount": {
+        "5": 275,
+        "6": 325,
+        "7": 400,
+        "8": 500,
+        "2+2": 300,
+        "5+5E": 750
+      }
     },
     {
       "name": "5+5E",
@@ -819,7 +836,15 @@ module Engine
       "multiplier": 2,
       "price": 1500,
       "num": 20,
-      "available_on": "8"
+      "available_on": "8",
+      "discount": {
+        "5": 275,
+        "6": 325,
+        "7": 400,
+        "8": 500,
+        "2+2": 300,
+        "5+5E": 750
+      }
     }
   ],
   "hexes": {

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -64,6 +64,9 @@ module Engine
                                             'nationalize_companies' =>
                                             ['Nationalize Companies',
                                              'All companies close paying their owner their value'],
+                                            'train_trade_allowed' =>
+                                            ['Train trade in allowed',
+                                             'Trains can be traded in for 50% towards Phase 8 trains'],
                                             'trainless_nationalization' =>
                                             ['Trainless Nationalization',
                                              'Operating Trainless Minors are nationalized'\
@@ -507,6 +510,10 @@ module Engine
         # Done elsewhere
       end
 
+      def event_train_trade_allowed!
+        # No-op
+      end
+
       def event_minors_cannot_start!
         @corporations, removed = @corporations.partition do |corporation|
           corporation.owned_by_player? || corporation.type != :minor
@@ -555,6 +562,8 @@ module Engine
         @log << '-- Event: Private companies are nationalized --'
 
         @companies.each do |company|
+          next if company.closed?
+
           if (ability = abilities(company, :close))
             next if ability.when == 'never' ||
               @phase.phases.any? { |phase| ability.when == phase[:name] }

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -510,9 +510,7 @@ module Engine
         # Done elsewhere
       end
 
-      def event_train_trade_allowed!
-        # No-op
-      end
+      def event_train_trade_allowed!; end
 
       def event_minors_cannot_start!
         @corporations, removed = @corporations.partition do |corporation|

--- a/lib/engine/round/g_1867/operating.rb
+++ b/lib/engine/round/g_1867/operating.rb
@@ -11,12 +11,8 @@ module Engine
           minors + majors
         end
 
-        def start_operating
-          super
-
-          # Skip closed minors
-          entity = @entities[@entity_index]
-          next_entity! unless @game.corporations.include?(entity)
+        def skip_entity?(entity)
+          !entity.floated? || !@game.corporations.include?(entity)
         end
       end
     end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -46,11 +46,15 @@ module Engine
         clear_cache!
       end
 
+      def skip_entity?(entity)
+        entity.closed?
+      end
+
       def next_entity!
         return if @entity_index == @entities.size - 1
 
         next_entity_index!
-        return next_entity! if @entities[@entity_index].closed?
+        return next_entity! if skip_entity?(@entities[@entity_index])
 
         @steps.each(&:unpass!)
         @steps.each(&:setup)

--- a/lib/engine/step/g_1817/track.rb
+++ b/lib/engine/step/g_1817/track.rb
@@ -2,11 +2,13 @@
 
 require_relative '../tracker'
 require_relative '../track'
+require_relative '../upgrade_track_max_exits'
 
 module Engine
   module Step
     module G1817
       class Track < Track
+        include UpgradeTrackMaxExits
         # Special track lays act as normal lays for 1817
         attr_accessor :laid_track
 
@@ -31,17 +33,6 @@ module Engine
           psm.remove_ability(ability)
           @game.log << "#{psm.name} closes as it can no longer be used"
           psm.close!
-        end
-
-        def upgradeable_tiles(_entity, hex)
-          return super if hex.tile.color != :green || hex.tile.cities.none?
-
-          tiles = super
-
-          # When upgrading normal cities to brown, players must use tiles with as many exits as will fit.
-          # Find maximum number of exits
-          max_edges = tiles.map { |t| t.edges.length }.max
-          tiles.select { |t| t.edges.length == max_edges }
         end
       end
     end

--- a/lib/engine/step/g_1867/buy_train.rb
+++ b/lib/engine/step/g_1867/buy_train.rb
@@ -27,6 +27,10 @@ module Engine
           super
         end
 
+        def discountable_trains_allowed?(_entity)
+          @game.phase.name.to_i == 8
+        end
+
         def can_sell?(_entity, _bundle)
           # Players cannot sell shares in EMR for 1867
           false

--- a/lib/engine/step/g_1867/merge.rb
+++ b/lib/engine/step/g_1867/merge.rb
@@ -33,6 +33,12 @@ module Engine
           'Merge'
         end
 
+        def pass_description
+          return 'Done Adding Corporations' if @merging
+
+          super
+        end
+
         def can_convert?(entity)
           entity.share_price.types.include?(:convert_range) && entity.type == :minor
         end

--- a/lib/engine/step/g_1867/track.rb
+++ b/lib/engine/step/g_1867/track.rb
@@ -2,6 +2,7 @@
 
 require_relative '../tracker'
 require_relative '../track'
+require_relative '../upgrade_track_max_exits'
 require_relative 'automatic_loan'
 
 module Engine
@@ -9,6 +10,7 @@ module Engine
     module G1867
       class Track < Track
         include AutomaticLoan
+        include UpgradeTrackMaxExits
         def setup
           super
           @hex = nil

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -16,9 +16,9 @@ module Engine
         can_buy_normal = room?(entity) &&
           buying_power(entity) >= @depot.min_price(entity)
 
-        can_buy_normal || @depot
+        can_buy_normal || (discountable_trains_allowed?(entity) && @depot
           .discountable_trains_for(entity)
-          .any? { |_, _, _, price| buying_power(entity) >= price }
+          .any? { |_, _, _, price| buying_power(entity) >= price })
       end
 
       def room?(entity, _shell = nil)
@@ -38,6 +38,10 @@ module Engine
       end
 
       def should_buy_train?(entity); end
+
+      def discountable_trains_allowed?(_entity)
+        true
+      end
 
       def buy_train_action(action, entity = nil)
         entity ||= action.entity

--- a/lib/engine/step/upgrade_track_max_exits.rb
+++ b/lib/engine/step/upgrade_track_max_exits.rb
@@ -12,7 +12,7 @@ module Engine
         # When upgrading normal cities to brown, players must use tiles with as many exits as will fit.
         # Find maximum number of exits
         max_edges = tiles.map { |t| t.edges.length }.max
-        tiles.select { |t| t.edges.length == max_edges }
+        tiles.select { |t| t.edges.size == max_edges }
       end
     end
   end

--- a/lib/engine/step/upgrade_track_max_exits.rb
+++ b/lib/engine/step/upgrade_track_max_exits.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Engine
+  module Step
+    module UpgradeTrackMaxExits
+      # Used by 1817 & 1867
+      def upgradeable_tiles(_entity, hex)
+        return super if hex.tile.color != :green || hex.tile.cities.none?
+
+        tiles = super
+
+        # When upgrading normal cities to brown, players must use tiles with as many exits as will fit.
+        # Find maximum number of exits
+        max_edges = tiles.map { |t| t.edges.length }.max
+        tiles.select { |t| t.edges.length == max_edges }
+      end
+    end
+  end
+end

--- a/migrate_game.rb
+++ b/migrate_game.rb
@@ -78,6 +78,11 @@ def repair(game, original_actions, actions, broken_action)
       actions.delete(broken_action)
       return
     end
+    if game.active_step.is_a?(Engine::Step::G1867::Merge)
+      # Remove corps passes that went into acquisition
+      actions.delete(broken_action)
+      return
+    end
     if game.active_step.is_a?(Engine::Step::G1817::Conversion)
       # Remove corps passes that went into acquisition
       actions.delete(broken_action)


### PR DESCRIPTION
Don't attempt to nationalize already closed company (fixes #3000)
Limit upgrades of brown to the one with most exits (fixes #2999)
Stop nationalized corps operating fully (fixes #2993)
Make pass button clearer in merges (fixes #2988)
Implement permament train buy in (fixes #2859)