### PR TITLE
18Mag: starting draft

### DIFF
--- a/lib/engine/action/bid.rb
+++ b/lib/engine/action/bid.rb
@@ -5,12 +5,13 @@ require_relative 'base'
 module Engine
   module Action
     class Bid < Base
-      attr_reader :company, :corporation, :price
+      attr_reader :company, :corporation, :minor, :price
 
-      def initialize(entity, price:, company: nil, corporation: nil)
+      def initialize(entity, price:, company: nil, corporation: nil, minor: nil)
         @entity = entity
         @company = company
         @corporation = corporation
+        @minor = minor
         @price = price
       end
 
@@ -18,6 +19,7 @@ module Engine
         {
           company: game.company_by_id(h['company']),
           corporation: game.corporation_by_id(h['corporation']),
+          minor: game.minor_by_id(h['minor']),
           price: h['price'],
         }
       end
@@ -26,6 +28,7 @@ module Engine
         {
           'company' => @company&.id,
           'corporation' => @corporation&.id,
+          'minor' => @minor&.id,
           'price' => @price,
         }
       end

--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -420,7 +420,7 @@ module Engine
     },
     {
       "sym": "G&C",
-      "name": "Ganz &amp; Cie",
+      "name": "Ganz & Cie",
       "logo": "18_mag/GC",
       "float_percent": 0,
       "max_ownership_percent": 60,
@@ -434,7 +434,7 @@ module Engine
     },
     {
       "sym": "SNW",
-      "name": "Schlick-Nicholson&#39;sche Waggon-Fabrik A.-G.",
+      "name": "Schlick-Nicholsonsche Waggon-Fabrik A.-G.",
       "logo": "18_mag/SNW",
       "float_percent": 0,
       "max_ownership_percent": 60,

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -23,12 +23,14 @@ module Engine
       SELL_BUY_ORDER = :sell_buy
       MARKET_SHARE_LIMIT = 100
 
+      START_PRICES = [60, 60, 65, 65, 70, 70, 75, 75, 80, 80].freeze
+      MINOR_STARTING_CASH = 50
+
       def setup
         # start with first minor tokens placed (as opposed to just reserved)
         @mine = @minors.find { |m| m.name == 'mine' }
-        @minors.reject! { |m| m.name == 'mine' }.each do |minor|
-          train = @depot.upcoming[0]
-          minor.buy_train(train, :free)
+        @minors.delete(@mine)
+        @minors.each do |minor|
           hex = hex_by_id(minor.coordinates)
           hex.tile.cities[minor.city || 0].place_token(minor, minor.next_token)
         end
@@ -40,6 +42,38 @@ module Engine
           hex.tile.cities[0].place_token(@mine, @mine.next_token)
         end
         @mine.tokens.each { |t| t.type = :neutral }
+
+        # IPO and float all corporations with semi-randomly chosen prices
+        # They will start off in receivership with all shares in market
+        prices = START_PRICES.dup
+        rand_prices = @corporations.size.times.map do |_|
+          prices.rotate!(rand % prices.size)
+          prices.pop
+        end
+        @corporations.each do |corp|
+          share_price = @stock_market.par_prices.find { |p| p.price == rand_prices[0] }
+          rand_prices.shift
+          @stock_market.set_par(corp, share_price)
+          corp.ipoed = true
+
+          corp.ipo_shares.each do |share|
+            bundle = ShareBundle.new([share])
+            @share_pool.transfer_shares(
+              bundle,
+              share_pool,
+              spender: share_pool,
+              receiver: @bank,
+              price: 0
+            )
+          end
+          corp.owner = @share_pool
+        end
+      end
+
+      def float_minor(minor)
+        train = @depot.upcoming[0]
+        minor.buy_train(train, :free)
+        @bank.spend(MINOR_STARTING_CASH, minor)
       end
 
       def init_starting_cash(players, bank)
@@ -49,6 +83,49 @@ module Engine
         players.each do |player|
           bank.spend(cash, player, check_positive: false)
         end
+      end
+
+      def new_auction_round
+        Round::Draft.new(self, [Step::G18Mag::SimpleDraft],
+                         rotating_order: (players.size <= 4),
+                         snake_order: (players.size > 4))
+      end
+
+      def operating_round(round_num)
+        Round::Operating.new(self, [
+          Step::Exchange,
+          Step::DiscardTrain,
+          Step::Track,
+          Step::Token,
+          Step::Route,
+          Step::Dividend,
+          Step::BuyTrain,
+        ], round_num: round_num)
+      end
+
+      def next_round!
+        @round =
+          case @round
+          when Round::Stock
+            @operating_rounds = @phase.operating_rounds
+            reorder_players
+            new_operating_round
+          when Round::Operating
+            if @round.round_num < @operating_rounds
+              or_round_finished
+              new_operating_round(@round.round_num + 1)
+            else
+              @turn += 1
+              or_round_finished
+              or_set_finished
+              new_stock_round
+            end
+          when init_round.class
+            @operating_rounds = @phase.operating_rounds
+            init_round_finished
+            reorder_players
+            new_operating_round
+          end
       end
     end
   end

--- a/lib/engine/round/draft.rb
+++ b/lib/engine/round/draft.rb
@@ -8,6 +8,7 @@ module Engine
       def initialize(game, steps, **opts)
         @reverse_order = opts[:reverse_order] || false
         @snake_order = opts[:snake_order] || false
+        @rotating_order = opts[:rotating_order] || false
         @snaking_up = true
 
         super
@@ -31,6 +32,7 @@ module Engine
       end
 
       def next_entity_index!
+        @entities.rotate! if @rotating_order && @entity_index == (@entities.size - 1)
         return super unless @snake_order
 
         if (@snaking_up && @entity_index == (@entities.size - 1)) ||

--- a/lib/engine/step/g_18_mag/simple_draft.rb
+++ b/lib/engine/step/g_18_mag/simple_draft.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G18Mag
+      class SimpleDraft < Base
+        ACTIONS = %w[bid].freeze
+        MAX_NUM_MINORS = {
+          3 => 4,
+          4 => 3,
+          5 => 2,
+          6 => 1,
+        }.freeze
+
+        MAX_NUM_SHARES = {
+          3 => 2,
+          4 => 1,
+          5 => 2,
+          6 => 2,
+        }.freeze
+
+        LEFTOVER_NUM_MINORS = {
+          3 => 1,
+          4 => 1,
+          5 => 3,
+          6 => 1,
+        }.freeze
+
+        LEFTOVER_NUM_SHARES = {
+          3 => 1,
+          4 => 3,
+          5 => 4,
+          6 => 2,
+        }.freeze
+
+        def setup
+          @minors = @game.minors.reject { |m| m.name == 'mine' }.sort_by { |m| m.name.to_i }
+          @minor_count = Hash.new(0)
+          @share_count = Hash.new(0)
+          @max_minors = MAX_NUM_MINORS[@game.players.size]
+          @max_shares = MAX_NUM_SHARES[@game.players.size]
+          @leftover_minors = LEFTOVER_NUM_MINORS[@game.players.size]
+          @leftover_shares = LEFTOVER_NUM_SHARES[@game.players.size]
+
+          @shares_a = @game.corporations.dup
+          @shares_b = @game.players.size > 4 ? @game.corporations.dup : []
+        end
+
+        def available
+          avail = []
+          avail.concat(@minors) if @minor_count[current_entity] < @max_minors
+          avail.concat((@shares_a + @shares_b).uniq.sort) if @share_count[current_entity] < @max_shares
+          avail
+        end
+
+        def may_choose?(_company)
+          true
+        end
+
+        def auctioning; end
+
+        def bids
+          {}
+        end
+
+        def visible?
+          true
+        end
+
+        def players_visible?
+          true
+        end
+
+        def name
+          'Draft'
+        end
+
+        def description
+          'Draft a Company or Share'
+        end
+
+        def finished?
+          @minors.size == @leftover_minors && (@shares_a + @shares_b).size == @leftover_shares
+        end
+
+        def actions(entity)
+          return [] if finished?
+
+          entity == current_entity ? ACTIONS : []
+        end
+
+        def process_bid(action)
+          player = action.entity
+
+          if action.minor
+            assign_minor(player, action.minor)
+          elsif action.corporation
+            assign_ipo_share(player, action.corporation)
+          else
+            raise GameError, 'Logic error: must specify minor or corporation on bid action'
+          end
+
+          @round.next_entity_index!
+          action_finalized
+        end
+
+        def assign_minor(player, minor)
+          minor.owner = player
+          @minors.delete(minor)
+          @minor_count[player] += 1
+
+          @log << "#{player.name} chooses Minor #{minor.name} (#{minor.full_name})"
+
+          @game.float_minor(minor)
+        end
+
+        def assign_ipo_share(player, corp)
+          @share_count[player] += 1
+          if @shares_a.include?(corp)
+            @shares_a.delete(corp)
+          else
+            @shares_b.delete(corp)
+          end
+
+          normal_share = @game.share_pool.shares_of(corp).find { |s| s.percent == 10 }
+          bundle = ShareBundle.new([normal_share])
+
+          @log << "#{player.name} chooses share of #{corp.name} (#{corp.full_name})"
+
+          @game.share_pool.transfer_shares(
+            bundle,
+            player,
+            spender: player,
+            receiver: @game.bank,
+            price: 0
+          )
+        end
+
+        def action_finalized
+          return unless finished?
+
+          @minors.each do |minor|
+            @log << "Minor #{minor.name} is removed from the game"
+            hex = @game.hex_by_id(minor.coordinates)
+            hex.tile.cities[minor.city || 0].remove_tokens!
+
+            @game.minors.delete(minor)
+          end
+          @round.reset_entity_index!
+        end
+
+        def committed_cash(_player, _show_hidden = false)
+          0
+        end
+
+        def min_bid(company)
+          return unless company
+
+          company.value
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add starting draft for 18Mag.
Start corps parred with all stock in pool (all in receivership).

Common file changes:
- action::bid: add ability to bid on minors
- round::draft: add "rotating" draft type
- UI::round::auction: add ability to bid on minors and on parred corp stocks