### PR TITLE
don't store the broken action in the main actions array

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -622,6 +622,7 @@ module Engine
         @actions.pop
         @exception = e
         @broken_action = action
+        @actions.delete(action)
         self
       end
 


### PR DESCRIPTION
This was breaking the views handling errors; the cloned game also had the broken action in it.

[Fixes #3049]
[Fixes #3040]