### PR TITLE
1856 nationalization market shares

### DIFF
--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -499,7 +499,7 @@ module Engine
           @pre_national_percent_by_player[player] ||= 0
           @pre_national_percent_by_player[player] += num
         end
-        @pre_national_market_percent += (major.num_market_shares * 5)
+        @pre_national_market_percent += major.num_market_shares * 10
       end
 
       # Issue more shares
@@ -519,10 +519,6 @@ module Engine
           new_share = Share.new(national, percent: 5, index: num_shares + i, cert_size: 0.5)
           national.shares_by_corporation[national] << new_share
         end
-      end
-
-      def total_national_percent_issued
-        @pre_national_market_percent + @pre_national_percent_by_player.values.sum
       end
 
       def calculate_national_price
@@ -571,15 +567,17 @@ module Engine
         #  where the exact value doesn't really matter
         players_in_order = (0..@players.count - 1).to_a.sort { |i| i < index_for_trigger ? i + 10 : i }
         # Determine the president before exchanging shares for ease of distribution
-        shares_to_distribute = max_national_shares
+        shares_left_to_distribute = max_national_shares
         president_shares = 0
         president = nil
         players_in_order.each do |i|
           player = @players[i]
           next unless @pre_national_percent_by_player[player]
 
-          shares_awarded = [(@pre_national_percent_by_player[player] / 20).to_i, shares_to_distribute].min
-          shares_to_distribute -= shares_awarded
+          shares_awarded = [(@pre_national_percent_by_player[player] / 20).to_i, shares_left_to_distribute].min
+          # Single shares that are discarded to the market
+          @pre_national_market_percent += @pre_national_percent_by_player[player] % 20
+          shares_left_to_distribute -= shares_awarded
           @log << "#{player.name} gets #{shares_awarded} shares of #{national.name}"
 
           next unless shares_awarded > president_shares
@@ -597,21 +595,25 @@ module Engine
           president_shares = shares_awarded
           president = player
         end
+        # Determine how many market shares need to be issued; this may trigger a second issue of national shares
+        national_market_share_count = [(@pre_national_market_percent / 20).to_i, shares_left_to_distribute].min
+        shares_left_to_distribute -= national_market_share_count
         # More than 10 shares were issued so issue the second set
-        national_issue_shares! if shares_to_distribute < 10
+        national_issue_shares! if shares_left_to_distribute < 10
         national_share_index = 1
         players_in_order.each do |i|
           player = @players[i]
           player_national_shares = (@pre_national_percent_by_player[player] / 20).to_i
-          # Extra single shares are placed in the market
-          @pre_national_market_percent += (@pre_national_percent_by_player[player] % 20)
           # We will distribute shares from the national starting with the second, skipping the presidency
           next unless player_national_shares.positive?
 
           if player == president
             if @false_national_president
               # TODO: Handle this case properly.
-              puts 'TODO'
+              @log << "#{player.name} is the president of the #{national.name} but is only awarded 1 share}"
+              national.presidents_share.percent /= 2
+              @share_pool.buy_shares(player, national.presidents_share, exchange: :free, exchange_price: 0)
+              player_national_shares -= 1
             else # This player gets the presidency, which is 2 shares
               @share_pool.buy_shares(player, national.presidents_share, exchange: :free, exchange_price: 0)
               player_national_shares -= 2
@@ -634,6 +636,12 @@ module Engine
             end
           end
         end
+        # Distribute market shares to the market
+        @share_pool.buy_shares(
+          @share_pool,
+          ShareBundle.new(national.shares_by_corporation[national][-1 * national_market_share_count..-1]),
+          exchange: :free
+        )
       end
 
       def national_token_swap

--- a/lib/engine/round/g_1856/stock.rb
+++ b/lib/engine/round/g_1856/stock.rb
@@ -16,7 +16,7 @@ module Engine
         end
 
         def start_entity
-          players_unvested_holdings[current_entity] = nil
+          players_unvested_holdings[@entities[@entity_index]] = nil
           super
         end
       end


### PR DESCRIPTION
Fixed / Added a few 1856 things
Vesting was broken; If you bought a share of a different corp, the "unvested" corporation would switch but the "unvested" state wouldn't reset until the next SR. This fixes that

I added code to turn the presidency into a 1-share presidency but the code to force the player to buy back up in the SR still needs to happen in the future.

This also distributes national shares to the market, which I overlooked before

I also noticed that escrow funds count against the bank. The rules state that the escrow is held "by the bank" so that the escrow money shouldn't be "real" money and shouldn't count against that. That will complicate share buying when that gets fixed. Also the escrow money of nationalized corporations disappears from the game, but since the escrow money shouldn't be real money this can probably be ignored