### PR TITLE
1856 bankruptcy

### DIFF
--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -32,7 +32,7 @@ module Engine
                       brown: '#7b352a')
 
       load_from_json(Config::Game::G1856::JSON)
-      attr_reader :post_nationalization
+      attr_reader :post_nationalization, :bankrupted
       DEV_STAGE = :prealpha
 
       # These plain city hexes upgrade to L tiles in brown
@@ -204,6 +204,8 @@ module Engine
 
         @pre_national_market_prices = {}
         @nationalized_corps = []
+
+        @bankrupted = false
 
         # Is the president of the national a "false" president?
         # A false president gets the presidency with only one share; in this case the president gets
@@ -683,6 +685,11 @@ module Engine
 
         @log << "#{national.name} has #{remaining_tokens} spare #{format_currency(national_token_price)} tokens"
         remaining_tokens.times { national.tokens << Engine::Token.new(@national, price: national_token_price) }
+      end
+
+      def declare_bankrupt(player)
+        @bankrupted = true
+        super
       end
 
       # Called regardless of if president saved or merged corp

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -96,6 +96,7 @@ module Engine
         step.acted = true
         step.send("process_#{action.type}", action)
 
+        after_process_before_skip(action)
         skip_steps
         clear_cache!
         after_process(action)
@@ -163,6 +164,8 @@ module Engine
       end
 
       def before_process(_action); end
+
+      def after_process_before_skip(_action); end
 
       def after_process(_action); end
     end

--- a/lib/engine/round/g_1856/operating.rb
+++ b/lib/engine/round/g_1856/operating.rb
@@ -38,13 +38,18 @@ module Engine
           super
         end
 
-        def after_process(_action)
+        def after_process_before_skip(_action)
           # Keep track of last_player for Cash Crisis
           entity = @entities[@entity_index]
           @cash_crisis_player = entity.player
           pay_interest!(entity)
           force_repay_loans!(entity)
           super
+        end
+
+        def skip_steps
+          # We must be careful not to skip through Dividends because the game can end between Route and Dividends
+          super unless @cash_crisis_player&.cash&.negative? || @game.bankrupted
         end
 
         def force_repay_loans!(entity)

--- a/lib/engine/step/g_1856/bankrupt.rb
+++ b/lib/engine/step/g_1856/bankrupt.rb
@@ -21,6 +21,22 @@ module Engine
 
           @log << "-- #{player.name} goes bankrupt --"
           # TODO: Implement
+
+          player.shares_by_corporation.each do |corporation, _|
+            next unless corporation.share_price # if a corporation has not parred
+
+            # Do a potential repeated sell of bundles. This is important for NdM in 18MEX
+            # which might have 5% bundle(s) besides the 10%+ bundles.
+            # Most other titles this will just sell one, the largest, bundle.
+            while (bundle = @game.sellable_bundles(player, corporation).max_by(&:price))
+              @game.sell_shares_and_change_price(bundle)
+            end
+          end
+          @round.recalculate_order if @round.respond_to?(:recalculate_order)
+
+          player.spend(player.cash, @game.bank, check_positive: false) 
+
+          @game.declare_bankrupt(player)
         end
       end
     end

--- a/lib/engine/step/g_1856/bankrupt.rb
+++ b/lib/engine/step/g_1856/bankrupt.rb
@@ -20,7 +20,6 @@ module Engine
           player = action.entity
 
           @log << "-- #{player.name} goes bankrupt --"
-          # TODO: Implement
 
           player.shares_by_corporation.each do |corporation, _|
             next unless corporation.share_price # if a corporation has not parred
@@ -34,7 +33,7 @@ module Engine
           end
           @round.recalculate_order if @round.respond_to?(:recalculate_order)
 
-          player.spend(player.cash, @game.bank, check_positive: false) 
+          player.spend(player.cash, @game.bank, check_positive: false)
 
           @game.declare_bankrupt(player)
         end


### PR DESCRIPTION
This implements bankruptcy in 1856, including how a player can go bankrupt from interest *before* the corporation can fall back for not paying interest