### PR TITLE
Presidency swap for double cert

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -23,7 +23,8 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent, :capitalization, :max_share_price
-    attr_reader :companies, :min_price, :name, :full_name, :fraction_shares, :type, :id, :needs_token_to_par
+    attr_reader :companies, :min_price, :name, :full_name, :fraction_shares, :type, :id, :needs_token_to_par,
+                :presidents_share
     attr_writer :par_price, :share_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze


### PR DESCRIPTION
If the heir to the presidency holds only the double cert,
the president cannot sell down to 10% because the heir lacks a 10% cert
to exchange with the president.

Also, render token fee instead of % to float.

Here's the odd case:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/1501322/103578769-07e88900-4e8c-11eb-81df-66733d84cdb7.png">

Player 3 could get a 10% cert from Player 1, but not Player 2. Since Player 2 is to the immediate left of Player 3 and would become president, Player 3 must sell down to nothing in order to lose the presidency. The double cert ends up in the market:

<img width="332" alt="image" src="https://user-images.githubusercontent.com/1501322/103578971-5ac24080-4e8c-11eb-80dc-af25c91627b7.png">

Bonus token fee render:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/1501322/103579013-69105c80-4e8c-11eb-9472-99a53e6a3bea.png">
