### PR TITLE
Corporation ordering

### DIFF
--- a/assets/app/view/game/entities.rb
+++ b/assets/app/view/game/entities.rb
@@ -26,9 +26,9 @@ module View
 
         player_owned, bank_owned = (@game.corporations + @game.minors)
           .reject(&:closed?)
-          .sort_by(&:name)
           .partition(&:owner)
-        player_owned = player_owned.group_by(&:owner)
+        player_owned = player_owned.sort_by(&:name).group_by(&:owner)
+        bank_owned = @game.bank_sort(bank_owned)
 
         children = players.map do |p|
           corps = player_owned[p]&.map { |c| h(Corporation, corporation: c) }

--- a/lib/engine/g_1849/corporation.rb
+++ b/lib/engine/g_1849/corporation.rb
@@ -6,7 +6,7 @@ module Engine
   module G1849
     class Corporation < Corporation
       attr_reader :token_fee
-      attr_accessor :next_to_par, :closed_recently
+      attr_accessor :next_to_par, :closed_recently, :slot_open
 
       def initialize(sym:, name:, **opts)
         super

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1965,6 +1965,10 @@ module Engine
         []
       end
 
+      def bank_sort(corporations)
+        corporations.sort_by(&:name)
+      end
+
       def ability_right_type?(ability, type)
         !type || (ability.type == type)
       end

--- a/lib/engine/step/g_1849/token.rb
+++ b/lib/engine/step/g_1849/token.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../token'
+
+module Engine
+  module Step
+    module G1849
+      class Token < Token
+        def process_place_token(action)
+          entity = action.entity
+
+          place_token(entity, action.city, action.token)
+
+          index = @game.corporations.index { |c| c.name == 'AFG' }
+          afg = index ? @game.corporations[index] : nil
+          if afg && !afg.floated? && @game.home_token_locations(afg).empty?
+            if afg.next_to_par && afg != @game.corporations.last
+              @game.corporations[index + 1].next_to_par = true
+              afg.next_to_par = false
+            end
+            afg.slot_open = false
+            @game.corporations.delete(afg)
+            @game.corporations << afg
+            @log << 'AFG has no home token locations and cannot be opened until one becomes available.'
+          end
+
+          pass!
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1849/track.rb
+++ b/lib/engine/step/g_1849/track.rb
@@ -11,6 +11,14 @@ module Engine
           action.tile.upgrades = action.hex.tile.upgrades
           super
         end
+
+        def process_lay_tile(action)
+          lay_tile_action(action)
+
+          @game.update_garibaldi
+
+          pass!
+        end
       end
     end
   end


### PR DESCRIPTION
Sort unopened corps on the entites tab in the order in which they'll be
opened. Also handle when AFG can't open.

When there are no free token slots in any of the hexes in which AFG can start, it is removed from the ordering and cannot be opened until a spot becomes free, which can occur either when a different corporation closes or when a relevant city is upgraded.