### PR TITLE
Require permission checks to buy trains

### DIFF
--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -9,6 +9,7 @@ require 'view/about'
 require 'view/create_game'
 require 'view/invite_game'
 require 'view/home'
+require 'view/confirm'
 require 'view/flash'
 require 'view/game_page'
 require 'view/map_page'
@@ -39,6 +40,7 @@ class App < Snabberb::Component
     h(:div, props, [
       h(View::Navigation),
       h(View::Flash),
+      h(View::Confirm),
       render_content,
     ])
   end

--- a/assets/app/view/confirm.rb
+++ b/assets/app/view/confirm.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module View
+  class Confirm < Snabberb::Component
+    # confirm_opts can be passed as a string which will default to yellow
+    # if calling with a dictionary, you need to specify the skip or else
+    # the opal compiler will remove the value
+    # store(:confirm_opts, value = { message: 'test' }, skip: false)
+
+    # This is almost the same as flash_opts but changing flash opts
+    # twice from within the view and then from a callback causes the second
+    # not to show
+    needs :confirm_opts, default: {}, store: true
+
+    def render
+      @confirm_opts = { message: @confirm_opts } if @confirm_opts.is_a?(String)
+      return h(:div) unless @confirm_opts&.any?
+
+      `setTimeout(function() { self['$store']('confirm_opts', Opal.hash()) }, 3000)`
+
+      props = {
+        style: {
+          padding: '1em',
+          position: 'fixed',
+          cursor: 'pointer',
+          top: '0',
+          left: '0',
+          width: '100%',
+          zIndex: '10000',
+          textAlign: 'center',
+          backgroundColor: 'yellow',
+          color: 'black',
+        },
+        on: { click: -> { store(:confirm_opts, {}) } },
+      }
+
+      complete = lambda do
+        c = @confirm_opts[:click]
+        store(:confirm_opts, {})
+        c.call
+      end
+
+      h(:div, props, [
+        @confirm_opts[:message],
+        h(:button, { style: { marginLeft: '1rem' }, on: { click: complete } }, 'Confirm'),
+      ])
+    end
+  end
+end

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -10,6 +10,7 @@ module View
         base.needs :game_data, default: {}, store: true
         base.needs :game, store: true
         base.needs :flash_opts, default: {}, store: true
+        base.needs :confirm_opts, default: {}, store: true
         base.needs :connection, store: true, default: nil
         base.needs :user, store: true, default: nil
         base.needs :tile_selector, default: nil, store: true
@@ -31,6 +32,15 @@ module View
         return @participant if defined?(@participant)
 
         @participant = (@game.players.map(&:id) + [@game_data['user']['id']]).include?(@user&.dig('id'))
+      end
+
+      def check_consent(player, click)
+        opts = {
+          color: :yellow,
+          click: click,
+          message: "This action requires consent from #{player.name}!",
+        }
+        store(:confirm_opts, opts, skip: false)
       end
 
       def process_action(action)

--- a/assets/app/view/game/buy_companies.rb
+++ b/assets/app/view/game/buy_companies.rb
@@ -72,14 +72,22 @@ module View
           size: @corporation.cash.to_s.size,
         })
 
-        buy = lambda do
+        buy_click = lambda do
           price = input.JS['elm'].JS['value'].to_i
-          process_action(Engine::Action::BuyCompany.new(
-            @corporation,
-            company: @selected_company,
-            price: price,
-          ))
-          store(:selected_company, nil, skip: true)
+          buy = lambda do
+            process_action(Engine::Action::BuyCompany.new(
+              @corporation,
+              company: @selected_company,
+              price: price,
+            ))
+            store(:selected_company, nil, skip: true)
+          end
+
+          if !@selected_company.owner || @selected_company.owner == @corporation.owner
+            buy.call
+          else
+            check_consent(@selected_company.owner, buy)
+          end
         end
 
         props = {
@@ -91,7 +99,7 @@ module View
 
         h(:div, props, [
           input,
-          h(:button, { on: { click: buy } }, 'Buy'),
+          h(:button, { on: { click: buy_click } }, 'Buy'),
         ])
       end
     end

--- a/assets/app/view/game/buy_companies_at_face_value.rb
+++ b/assets/app/view/game/buy_companies_at_face_value.rb
@@ -34,7 +34,16 @@ module View
             price: price,
           ))
         end
-        h(:button, { on: { click: buy_company } }, "Buy (#{@game.format_currency(price)})")
+
+        buy = lambda do
+          if !company.owner || company.owner == @corporation.owner
+            buy_company.call
+          else
+            check_consent(company.owner, buy_company)
+          end
+        end
+
+        h(:button, { on: { click: buy } }, "Buy (#{@game.format_currency(price)})")
       end
     end
   end

--- a/assets/app/view/game/buy_company_from_other_player.rb
+++ b/assets/app/view/game/buy_company_from_other_player.rb
@@ -42,8 +42,11 @@ module View
             price: price,
           ))
         end
+
+        buy = -> { check_consent(company.owner, buy_company) }
+
         owner_name = company.owner.nil? ? 'the market' : company.owner.name
-        h(:button, { on: { click: buy_company } }, "Buy #{company.id} from #{owner_name}")
+        h(:button, { on: { click: buy } }, "Buy #{company.id} from #{owner_name}")
       end
     end
   end

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -215,14 +215,22 @@ module View
               attrs: price_range(group[0]),
             )
 
-            buy_train = lambda do
+            buy_train_click = lambda do
               price = input.JS['elm'].JS['value'].to_i
-              process_action(Engine::Action::BuyTrain.new(
-                @corporation,
-                train: group[0],
-                price: price,
-                shell: @active_shell,
-              ))
+              buy_train = lambda do
+                process_action(Engine::Action::BuyTrain.new(
+                  @corporation,
+                  train: group[0],
+                  price: price,
+                  shell: @active_shell,
+                ))
+              end
+
+              if other.owner == @corporation.owner
+                buy_train.call
+              else
+                check_consent(other.owner, buy_train)
+              end
             end
 
             count = group.size
@@ -231,7 +239,7 @@ module View
               [h(:div, name),
                h('div.nowrap', "#{other.name} (#{count > 1 ? "#{count}, " : ''}#{other.owner.name})"),
                input,
-               h('button.no_margin', { on: { click: buy_train } }, 'Buy')]
+               h('button.no_margin', { on: { click: buy_train_click } }, 'Buy')]
             else
               hidden_trains = true
               nil

--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -157,10 +157,21 @@ module View
         def render_merge(corporation)
           merge = lambda do
             if @selected_corporation
-              process_action(Engine::Action::Merge.new(
-                corporation,
-                corporation: @selected_corporation,
-              ))
+              do_merge = lambda do
+                process_action(Engine::Action::Merge.new(
+                  corporation,
+                  corporation: @selected_corporation,
+                ))
+              end
+
+              if @step.show_other_players ||
+                !@selected_corporation.owner ||
+                @selected_corporation.owner == corporation.owner
+                do_merge.call
+              else
+                check_consent(@selected_corporation.owner, do_merge)
+              end
+
             else
               store(:flash_opts, 'Select a corporation to merge with')
             end


### PR DESCRIPTION
This covers trains, privates and mergers

fixes #1619

Flash_opts had a bug which meant that errors wouldn't flash when buying privates, so i've had to effectively clone the flash code
![Screenshot from 2021-01-08 22-35-20](https://user-images.githubusercontent.com/71923/104071992-23dc8980-5202-11eb-8f7e-7c4d864a3e1d.png)
