### PR TITLE
18CO - Fix detection of the end of the President's Choice round on Ruby

### DIFF
--- a/lib/engine/round/g_18_co/presidents_choice.rb
+++ b/lib/engine/round/g_18_co/presidents_choice.rb
@@ -23,9 +23,9 @@ module Engine
         end
 
         def after_process(action)
-          return if action.type == :message
+          return if action.free?
 
-          if action.type == :pass
+          if action.pass?
             @entities.delete(action.entity)
             return finish_round if finished?
 
@@ -58,7 +58,7 @@ module Engine
         end
 
         def finished?
-          @game.finished || @entities.empty?
+          @game.finished || @game.presidents_choice == :done || @entities.empty?
         end
 
         private

--- a/spec/fixtures/18CO/21298.json
+++ b/spec/fixtures/18CO/21298.json
@@ -1,0 +1,8931 @@
+{
+  "id": 21298,
+  "description": "Open, Quick, Live",
+  "user": {
+    "id": 333,
+    "name": "vizcacha"
+  },
+  "players": [
+    {
+      "id": 512,
+      "name": "DrAwesome"
+    },
+    {
+      "id": 1739,
+      "name": "wheresvic"
+    },
+    {
+      "id": 333,
+      "name": "vizcacha"
+    }
+  ],
+  "max_players": 5,
+  "title": "18CO",
+  "settings": {
+    "seed": 1962990154,
+    "unlisted": false,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 7,
+  "round": "President's Choice Round",
+  "acting": [
+    1739
+  ],
+  "result": {
+    "DrAwesome": 5503,
+    "vizcacha": 5008,
+    "wheresvic": 3816
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 1,
+      "company": "IMC",
+      "price": 30,
+      "original_id": 1
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 2,
+      "message": "https://discord.gg/WuSN6azf",
+      "original_id": 2
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 3,
+      "company": "DPRT",
+      "price": 100,
+      "original_id": 3
+    },
+    {
+      "type": "bid",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 4,
+      "company": "DRGR",
+      "price": 120,
+      "original_id": 4
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 5,
+      "company": "DNP",
+      "price": 50,
+      "original_id": 5
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 6,
+      "company": "IMC",
+      "price": 35,
+      "original_id": 6
+    },
+    {
+      "type": "bid",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 7,
+      "company": "LNPW",
+      "price": 70,
+      "original_id": 7
+    },
+    {
+      "type": "move_bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 8,
+      "company": "GJGR",
+      "price": 40,
+      "from_company": "IMC",
+      "from_price": 30,
+      "original_id": 8
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 9,
+      "company": "Toll",
+      "price": 60,
+      "original_id": 9
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 10,
+      "original_id": 10
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 11,
+      "company": "DRGR",
+      "price": 150,
+      "original_id": 11
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 12,
+      "original_id": 12
+    },
+    {
+      "type": "bid",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 13,
+      "company": "DRGR",
+      "price": 155,
+      "original_id": 13
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 14,
+      "company": "DRGR",
+      "price": 160,
+      "original_id": 14
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 15,
+      "original_id": 15
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 16,
+      "message": "I still do not know how to play with DSNG",
+      "original_id": 16
+    },
+    {
+      "type": "bid",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 17,
+      "company": "DRGR",
+      "price": 165,
+      "original_id": 17
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 18,
+      "company": "DPRT",
+      "price": 115,
+      "original_id": 18
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 19,
+      "message": "I've only played once, but the DSNG seemed to work out nicely for its owner",
+      "original_id": 19
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 20,
+      "company": "DPRT",
+      "price": 120,
+      "original_id": 20
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 21,
+      "original_id": 21
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 22,
+      "company": "DPRT",
+      "price": 125,
+      "original_id": 22
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 23,
+      "company": "DPRT",
+      "price": 135,
+      "original_id": 23
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 24,
+      "original_id": 24
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 25,
+      "original_id": 25
+    },
+    {
+      "type": "move_bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 26,
+      "company": "GJGR",
+      "price": 45,
+      "from_company": "IMC",
+      "from_price": 35,
+      "original_id": 26
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 27,
+      "original_id": 27
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 28,
+      "company": "DPRT",
+      "price": 140,
+      "original_id": 28
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 29,
+      "original_id": 29
+    },
+    {
+      "type": "bid",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 30,
+      "company": "IMC",
+      "price": 30,
+      "original_id": 30
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 31,
+      "company": "DRGR",
+      "price": 170,
+      "original_id": 31
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 32,
+      "original_id": 32
+    },
+    {
+      "type": "bid",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 33,
+      "company": "DRGR",
+      "price": 175,
+      "original_id": 33
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 34,
+      "company": "Toll",
+      "price": 65,
+      "original_id": 34
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 35,
+      "original_id": 35
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 36,
+      "original_id": 36
+    },
+    {
+      "type": "bid",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 37,
+      "company": "IMC",
+      "price": 35,
+      "original_id": 37
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 38,
+      "original_id": 38
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 39,
+      "original_id": 39
+    },
+    {
+      "type": "par",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 40,
+      "corporation": "DSNG",
+      "share_price": "75,3,2",
+      "original_id": 41
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 41,
+      "message": "You could start DRG lol",
+      "original_id": 42
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 42,
+      "message": "haha true",
+      "original_id": 45
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 43,
+      "message": "hmm I'm thinking I am already toast lol",
+      "original_id": 49
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 44,
+      "message": "not floating the KPAC, or just waiting?",
+      "original_id": 50
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 45,
+      "message": "I will steal DSNG",
+      "original_id": 51
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 46,
+      "message": "damn girl. That was hot.",
+      "original_id": 56
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 47,
+      "message": "well I dunno wtf is going on to be honest",
+      "original_id": 57
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 48,
+      "message": "and now what",
+      "original_id": 58
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 49,
+      "message": "lol",
+      "original_id": 59
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 50,
+      "message": "actually sorry can I get the double share instead",
+      "original_id": 60
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 51,
+      "message": "Wait so you didn't float the kpac?",
+      "original_id": 69
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 52,
+      "message": "ah ok looks like I mistread the rules",
+      "original_id": 71
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 53,
+      "message": "I thought I could eat KPAC right away",
+      "original_id": 73
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 54,
+      "message": "no, he stole my company instead",
+      "original_id": 74
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 55,
+      "message": "but you cannot if it is not floated",
+      "original_id": 75
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 56,
+      "message": "bah sorry",
+      "original_id": 76
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 57,
+      "message": "oh well, i still get paid the same",
+      "original_id": 77
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 58,
+      "message": "we can continue or restart?",
+      "original_id": 78
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 59,
+      "message": "we should go back to the stock round",
+      "original_id": 82
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 60,
+      "message": "sure ok",
+      "original_id": 83
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 61,
+      "message": "fine",
+      "original_id": 84
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 62,
+      "message": "I'm on discord btw :)",
+      "original_id": 105
+    },
+    {
+      "type": "par",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 63,
+      "corporation": "KPAC",
+      "share_price": "50,5,2",
+      "original_id": 106
+    },
+    {
+      "type": "par",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 64,
+      "corporation": "DPAC",
+      "share_price": "60,4,2",
+      "original_id": 107
+    },
+    {
+      "type": "par",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 65,
+      "corporation": "CM",
+      "share_price": "60,4,2",
+      "original_id": 108
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 66,
+      "shares": [
+        "KPAC_1"
+      ],
+      "percent": 10,
+      "original_id": 109
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 67,
+      "shares": [
+        "DPAC_1"
+      ],
+      "percent": 10,
+      "original_id": 110
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 68,
+      "shares": [
+        "CM_2"
+      ],
+      "percent": 10,
+      "original_id": 111
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 69,
+      "shares": [
+        "KPAC_2"
+      ],
+      "percent": 10,
+      "original_id": 112
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 70,
+      "shares": [
+        "DPAC_2"
+      ],
+      "percent": 10,
+      "original_id": 113
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 71,
+      "shares": [
+        "DSNG_2"
+      ],
+      "percent": 20,
+      "original_id": 114
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 72,
+      "shares": [
+        "DSNG_1"
+      ],
+      "percent": 10,
+      "original_id": 115
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 73,
+      "shares": [
+        "KPAC_1"
+      ],
+      "percent": 10,
+      "original_id": 116
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 74,
+      "shares": [
+        "KPAC_2"
+      ],
+      "percent": 10,
+      "original_id": 117
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 75,
+      "original_id": 118
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 76,
+      "original_id": 119
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 77,
+      "original_id": 120
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 78,
+      "original_id": 121
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 79,
+      "hex": "E15",
+      "tile": "co1-0",
+      "rotation": 0,
+      "original_id": 122
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 80,
+      "hex": "D16",
+      "tile": "8-0",
+      "rotation": 0,
+      "original_id": 123
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 81,
+      "train": "2-0",
+      "price": 100,
+      "variant": "2",
+      "original_id": 124
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 82,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2",
+      "original_id": 125
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 83,
+      "original_id": 126
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 84,
+      "hex": "H16",
+      "tile": "7-0",
+      "rotation": 2,
+      "original_id": 141
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 85,
+      "hex": "H18",
+      "tile": "9-0",
+      "rotation": 2,
+      "original_id": 142
+    },
+    {
+      "type": "buy_train",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 86,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2",
+      "original_id": 143
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 87,
+      "original_id": 144
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 88,
+      "original_id": 145
+    },
+    {
+      "type": "pass",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 89,
+      "original_id": 146
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 90,
+      "hex": "E25",
+      "tile": "9-1",
+      "rotation": 2,
+      "original_id": 147
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 91,
+      "hex": "D24",
+      "tile": "58a-0",
+      "rotation": 3,
+      "original_id": 148
+    },
+    {
+      "type": "buy_train",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 92,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2",
+      "original_id": 149
+    },
+    {
+      "type": "pass",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 93,
+      "original_id": 150
+    },
+    {
+      "type": "pass",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 94,
+      "original_id": 151
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 95,
+      "original_id": 152
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 96,
+      "original_id": 153
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 97,
+      "original_id": 154
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 98,
+      "original_id": 155
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 99,
+      "hex": "C15",
+      "tile": "6-0",
+      "rotation": 3,
+      "original_id": 156
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 100,
+      "hex": "B16",
+      "tile": "9-2",
+      "rotation": 0,
+      "original_id": 157
+    },
+    {
+      "type": "place_token",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 101,
+      "city": "6-0-0",
+      "slot": 0,
+      "original_id": 158
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 102,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "B16",
+              "A17"
+            ]
+          ],
+          "hexes": [
+            "A17",
+            "C15"
+          ],
+          "revenue": 60,
+          "revenue_str": "A17-C15"
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "C15",
+              "D16",
+              "E15"
+            ]
+          ],
+          "hexes": [
+            "E15",
+            "C15"
+          ],
+          "revenue": 50,
+          "revenue_str": "E15-C15"
+        }
+      ],
+      "original_id": 159
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 103,
+      "kind": "payout",
+      "original_id": 160
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 104,
+      "original_id": 161
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 105,
+      "original_id": 162
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 106,
+      "hex": "I19",
+      "tile": "8-1",
+      "rotation": 2,
+      "original_id": 167
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 107,
+      "hex": "I21",
+      "tile": "4a-0",
+      "rotation": 1,
+      "original_id": 168
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 108,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ]
+          ],
+          "hexes": [
+            "I21",
+            "G17"
+          ],
+          "revenue": 20,
+          "revenue_str": "I21-G17"
+        }
+      ],
+      "original_id": 169
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 109,
+      "kind": "payout",
+      "original_id": 170
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 110,
+      "original_id": 171
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 111,
+      "original_id": 172
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 112,
+      "shares": [
+        "DSNG_1"
+      ],
+      "percent": 10,
+      "original_id": 173
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 113,
+      "hex": "C25",
+      "tile": "9-3",
+      "rotation": 0,
+      "original_id": 174
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 114,
+      "hex": "F24",
+      "tile": "4a-1",
+      "rotation": 1,
+      "original_id": 175
+    },
+    {
+      "type": "run_routes",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 115,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D24",
+              "C25",
+              "B26"
+            ],
+            [
+              "E27",
+              "F26",
+              "E25",
+              "D24"
+            ]
+          ],
+          "hexes": [
+            "B26",
+            "D24",
+            "E27"
+          ],
+          "revenue": 110,
+          "revenue_str": "B26-D24-E27"
+        }
+      ],
+      "original_id": 176
+    },
+    {
+      "type": "dividend",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 116,
+      "kind": "payout",
+      "original_id": 177
+    },
+    {
+      "type": "pass",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 117,
+      "original_id": 178
+    },
+    {
+      "type": "pass",
+      "entity": "KPAC",
+      "entity_type": "corporation",
+      "id": 118,
+      "original_id": 179
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 119,
+      "shares": [
+        "DPAC_3"
+      ],
+      "percent": 10,
+      "original_id": 180
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 120,
+      "shares": [
+        "DPAC_4"
+      ],
+      "percent": 10,
+      "original_id": 181
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 121,
+      "shares": [
+        "DSNG_3"
+      ],
+      "percent": 20,
+      "original_id": 182
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 122,
+      "shares": [
+        "KPAC_3"
+      ],
+      "percent": 10,
+      "original_id": 183
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 123,
+      "original_id": 184
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 124,
+      "shares": [
+        "KPAC_0"
+      ],
+      "percent": 20,
+      "original_id": 185
+    },
+    {
+      "type": "place_token",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 125,
+      "city": "E27-0-0",
+      "slot": 0,
+      "original_id": 186
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 126,
+      "shares": [
+        "DSNG_1"
+      ],
+      "percent": 10,
+      "original_id": 187
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 127,
+      "original_id": 188
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 128,
+      "message": "well that KPAC share was a mistake",
+      "original_id": 189
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 129,
+      "message": "live and learn",
+      "original_id": 190
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 130,
+      "original_id": 191
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 131,
+      "message": "yes this game is bonkers to be honest",
+      "original_id": 192
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 132,
+      "message": "and I am sorry if I pissed you off here mate",
+      "original_id": 193
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 133,
+      "message": "I didn't expect you to do that so early",
+      "original_id": 194
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 134,
+      "message": "I just wanted to try this strategy",
+      "original_id": 195
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 135,
+      "message": "you didn't piss me off",
+      "original_id": 196
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 136,
+      "message": "no worries",
+      "original_id": 197
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 137,
+      "message": "just unexpected",
+      "original_id": 198
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 138,
+      "message": "cool yeah just testing the edges of the game",
+      "original_id": 199
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 139,
+      "shares": [
+        "DPAC_5"
+      ],
+      "percent": 10,
+      "original_id": 200
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 140,
+      "original_id": 201
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 141,
+      "original_id": 202
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 142,
+      "shares": [
+        "DPAC_5"
+      ],
+      "percent": 10,
+      "original_id": 203
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 143,
+      "shares": [
+        "CM_3"
+      ],
+      "percent": 10,
+      "original_id": 204
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 144,
+      "original_id": 205
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 145,
+      "original_id": 206
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 146,
+      "shares": [
+        "CM_4"
+      ],
+      "percent": 10,
+      "original_id": 207
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 147,
+      "original_id": 208
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 148,
+      "message": "wait",
+      "original_id": 211
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 149,
+      "message": "I didn't see that vic had bought 2 shares",
+      "original_id": 214
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 150,
+      "message": "I was expecting to pass through",
+      "original_id": 215
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 151,
+      "message": "okok",
+      "original_id": 216
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 152,
+      "message": "2 shares in what?",
+      "original_id": 217
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 153,
+      "message": "CM",
+      "original_id": 218
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 154,
+      "message": "ah",
+      "original_id": 219
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 155,
+      "message": "I made a mistake too not sure why I bought DP lol",
+      "original_id": 220
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 156,
+      "original_id": 221
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 157,
+      "shares": [
+        "CM_3",
+        "CM_4"
+      ],
+      "percent": 20,
+      "original_id": 222
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 158,
+      "original_id": 223
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 159,
+      "original_id": 224
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 160,
+      "shares": [
+        "CM_3"
+      ],
+      "percent": 10,
+      "original_id": 225
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 161,
+      "original_id": 226
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 162,
+      "original_id": 227
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 163,
+      "original_id": 228
+    },
+    {
+      "type": "buy_shares",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 164,
+      "shares": [
+        "DPAC_5"
+      ],
+      "percent": 10,
+      "original_id": 229
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 165,
+      "shares": [
+        "CM_4"
+      ],
+      "percent": 10,
+      "original_id": 230
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 166,
+      "hex": "E17",
+      "tile": "8-2",
+      "rotation": 5,
+      "original_id": 231
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 167,
+      "hex": "F18",
+      "tile": "8-3",
+      "rotation": 2,
+      "original_id": 232
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 168,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "B16",
+              "A17"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "A17"
+          ],
+          "revenue": 60,
+          "revenue_str": "C15-A17"
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "C15",
+              "D16",
+              "E15"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "E15"
+          ],
+          "revenue": 50,
+          "revenue_str": "C15-E15"
+        }
+      ],
+      "original_id": 233
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 169,
+      "kind": "payout",
+      "original_id": 234
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 170,
+      "original_id": 235
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 171,
+      "original_id": 236
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 172,
+      "hex": "F22",
+      "tile": "9-4",
+      "rotation": 1,
+      "original_id": 237
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 173,
+      "hex": "F20",
+      "tile": "4a-2",
+      "rotation": 1,
+      "original_id": 240
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 174,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "D24",
+              "C25",
+              "B26"
+            ],
+            [
+              "E27",
+              "F26",
+              "E25",
+              "D24"
+            ]
+          ],
+          "hexes": [
+            "B26",
+            "D24",
+            "E27"
+          ],
+          "revenue": 110,
+          "revenue_str": "B26-D24-E27"
+        }
+      ],
+      "original_id": 241
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 175,
+      "kind": "payout",
+      "original_id": 242
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 176,
+      "original_id": 245
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 177,
+      "original_id": 246
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 178,
+      "original_id": 247
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 179,
+      "hex": "I23",
+      "tile": "4a-3",
+      "rotation": 1,
+      "original_id": 248
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 180,
+      "hex": "I25",
+      "tile": "8-4",
+      "rotation": 5,
+      "original_id": 249
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 181,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "I23",
+              "I25",
+              "J26"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "I21",
+            "I23",
+            "J26"
+          ],
+          "revenue": 70,
+          "revenue_str": "G17-I21-I23-J26"
+        }
+      ],
+      "original_id": 250
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 182,
+      "kind": "payout",
+      "original_id": 251
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 183,
+      "original_id": 252
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 184,
+      "original_id": 253
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 185,
+      "original_id": 254
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 186,
+      "original_id": 255
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 187,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "B16",
+              "A17"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "A17"
+          ],
+          "revenue": 60,
+          "revenue_str": "C15-A17"
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "E27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "E15",
+              "E17",
+              "F18",
+              "F20"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "F24",
+            "F20",
+            "E15"
+          ],
+          "revenue": 100,
+          "revenue_str": "E27-F24-F20-E15"
+        }
+      ],
+      "original_id": 256
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 188,
+      "kind": "payout",
+      "original_id": 257
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 189,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2",
+      "original_id": 258
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 190,
+      "original_id": 259
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 191,
+      "original_id": 260
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 192,
+      "original_id": 261
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 193,
+      "original_id": 262
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 194,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "D24",
+              "C25",
+              "B26"
+            ],
+            [
+              "E27",
+              "F26",
+              "E25",
+              "D24"
+            ]
+          ],
+          "hexes": [
+            "B26",
+            "D24",
+            "E27"
+          ],
+          "revenue": 110,
+          "revenue_str": "B26-D24-E27"
+        }
+      ],
+      "original_id": 263
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 195,
+      "kind": "payout",
+      "original_id": 264
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 196,
+      "original_id": 265
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 197,
+      "original_id": 266
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 198,
+      "original_id": 267
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 199,
+      "hex": "G17",
+      "tile": "co5-0",
+      "rotation": 0,
+      "original_id": 268
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 200,
+      "hex": "G15",
+      "tile": "7-1",
+      "rotation": 5,
+      "original_id": 269
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 201,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "I23",
+              "I25",
+              "J26"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "I21",
+            "I23",
+            "J26"
+          ],
+          "revenue": 80,
+          "revenue_str": "G17-I21-I23-J26"
+        }
+      ],
+      "original_id": 270
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 202,
+      "kind": "payout",
+      "original_id": 271
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 203,
+      "original_id": 272
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 204,
+      "original_id": 273
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 205,
+      "shares": [
+        "CM_5"
+      ],
+      "percent": 10,
+      "original_id": 274
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 206,
+      "message": "I dont know what to do lol",
+      "original_id": 275
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 207,
+      "message": "I could start something but then again why bother",
+      "original_id": 276
+    },
+    {
+      "type": "par",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 208,
+      "corporation": "CS",
+      "share_price": "60,4,2",
+      "original_id": 277
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 209,
+      "shares": [
+        "DPAC_6"
+      ],
+      "percent": 10,
+      "original_id": 278
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 210,
+      "shares": [
+        "CM_6"
+      ],
+      "percent": 10,
+      "original_id": 279
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 211,
+      "shares": [
+        "CS_1"
+      ],
+      "percent": 10,
+      "original_id": 280
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 212,
+      "shares": [
+        "DSNG_4"
+      ],
+      "percent": 10,
+      "original_id": 281
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 213,
+      "shares": [
+        "CM_7"
+      ],
+      "percent": 10,
+      "original_id": 282
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 214,
+      "shares": [
+        "CS_2"
+      ],
+      "percent": 10,
+      "original_id": 283
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 215,
+      "original_id": 284
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 216,
+      "shares": [
+        "CM_8"
+      ],
+      "percent": 10,
+      "original_id": 285
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 217,
+      "original_id": 286
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 218,
+      "original_id": 287
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 219,
+      "shares": [
+        "CS_3"
+      ],
+      "percent": 10,
+      "original_id": 288
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 220,
+      "original_id": 289
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 221,
+      "original_id": 290
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 222,
+      "original_id": 291
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 223,
+      "original_id": 292
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 224,
+      "original_id": 293
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 225,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "B16",
+              "A17"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "A17"
+          ],
+          "revenue": 60,
+          "revenue_str": "C15-A17"
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "E27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "E15",
+              "E17",
+              "F18",
+              "F20"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "F24",
+            "F20",
+            "E15"
+          ],
+          "revenue": 100,
+          "revenue_str": "E27-F24-F20-E15"
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C15",
+              "D16",
+              "E15"
+            ]
+          ],
+          "hexes": [
+            "E15",
+            "C15"
+          ],
+          "revenue": 50,
+          "revenue_str": "E15-C15"
+        }
+      ],
+      "original_id": 294
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 226,
+      "kind": "payout",
+      "original_id": 295
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 227,
+      "original_id": 296
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 228,
+      "original_id": 297
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 229,
+      "original_id": 298
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 230,
+      "shares": [
+        "CS_3"
+      ],
+      "percent": 10,
+      "original_id": 299
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 231,
+      "original_id": 300
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 232,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "D24",
+              "C25",
+              "B26"
+            ],
+            [
+              "E27",
+              "F26",
+              "E25",
+              "D24"
+            ]
+          ],
+          "hexes": [
+            "B26",
+            "D24",
+            "E27"
+          ],
+          "revenue": 110,
+          "revenue_str": "B26-D24-E27"
+        }
+      ],
+      "original_id": 301
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 233,
+      "kind": "payout",
+      "original_id": 302
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 234,
+      "original_id": 303
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 235,
+      "original_id": 304
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 236,
+      "original_id": 305
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 237,
+      "hex": "H14",
+      "tile": "58a-1",
+      "rotation": 1,
+      "original_id": 306
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 238,
+      "hex": "H12",
+      "tile": "58a-2",
+      "rotation": 2,
+      "original_id": 307
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 239,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "I23",
+              "I25",
+              "J26"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "I21",
+            "I23",
+            "J26"
+          ],
+          "revenue": 80,
+          "revenue_str": "G17-I21-I23-J26"
+        }
+      ],
+      "original_id": 308
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 240,
+      "kind": "withhold",
+      "original_id": 309
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 241,
+      "original_id": 310
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 242,
+      "message": "This game is hilarious",
+      "original_id": 311
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 243,
+      "original_id": 312
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 244,
+      "hex": "K17",
+      "tile": "57-0",
+      "rotation": 2,
+      "original_id": 313
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 245,
+      "hex": "J16",
+      "tile": "8-5",
+      "rotation": 3,
+      "original_id": 314
+    },
+    {
+      "type": "buy_train",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 246,
+      "train": "2-5",
+      "price": 100,
+      "variant": "2",
+      "original_id": 315
+    },
+    {
+      "type": "buy_train",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 247,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3",
+      "original_id": 316
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 248,
+      "original_id": 317
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 249,
+      "original_id": 318
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 250,
+      "original_id": 319
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 251,
+      "original_id": 320
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 252,
+      "hex": "E15",
+      "tile": "co2-0",
+      "rotation": 0,
+      "original_id": 321
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 253,
+      "original_id": 322
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 254,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "B16",
+              "A17"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "A17"
+          ],
+          "revenue": 60,
+          "revenue_str": "C15-A17"
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "E27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "E15",
+              "E17",
+              "F18",
+              "F20"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "F24",
+            "F20",
+            "E15"
+          ],
+          "revenue": 120,
+          "revenue_str": "E27-F24-F20-E15"
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C15",
+              "D16",
+              "E15"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "E15"
+          ],
+          "revenue": 70,
+          "revenue_str": "C15-E15"
+        }
+      ],
+      "original_id": 323
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 255,
+      "kind": "payout",
+      "original_id": 324
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 256,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3",
+      "original_id": 325
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 257,
+      "original_id": 326
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 258,
+      "original_id": 327
+    },
+    {
+      "type": "buy_company",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 259,
+      "company": "LNPW",
+      "price": 105,
+      "original_id": 328
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 260,
+      "original_id": 329
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 261,
+      "shares": [
+        "CM_5"
+      ],
+      "percent": 10,
+      "original_id": 330
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 262,
+      "shares": [
+        "CM_6"
+      ],
+      "percent": 10,
+      "original_id": 331
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 263,
+      "shares": [
+        "CM_7"
+      ],
+      "percent": 10,
+      "original_id": 332
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 264,
+      "shares": [
+        "CM_8"
+      ],
+      "percent": 10,
+      "original_id": 333
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 265,
+      "hex": "K5",
+      "tile": "14-0",
+      "rotation": 0,
+      "original_id": 338
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 266,
+      "hex": "J6",
+      "tile": "58a-3",
+      "rotation": 4,
+      "original_id": 339
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 267,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 120,
+          "revenue_str": "E15-F20-F24-E27"
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "K5",
+              "L4",
+              "L2"
+            ]
+          ],
+          "hexes": [
+            "L2",
+            "K5"
+          ],
+          "revenue": 50,
+          "revenue_str": "L2-K5"
+        }
+      ],
+      "original_id": 340
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 268,
+      "kind": "payout",
+      "original_id": 341
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 269,
+      "original_id": 342
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 270,
+      "original_id": 343
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 271,
+      "original_id": 344
+    },
+    {
+      "type": "buy_company",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 272,
+      "company": "GJGR",
+      "price": 60,
+      "original_id": 345
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 273,
+      "original_id": 346
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 274,
+      "original_id": 347
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 275,
+      "hex": "G17",
+      "tile": "co6-0",
+      "rotation": 0,
+      "original_id": 348
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 276,
+      "hex": "F16",
+      "tile": "9-5",
+      "rotation": 2,
+      "original_id": 349
+    },
+    {
+      "type": "place_token",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 277,
+      "city": "co2-0-0",
+      "slot": 2,
+      "original_id": 350
+    },
+    {
+      "type": "buy_company",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 278,
+      "company": "IMC",
+      "price": 45,
+      "original_id": 361
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 279,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "E27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "E15",
+              "E17",
+              "F18",
+              "F20"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "F24",
+            "F20",
+            "E15"
+          ],
+          "revenue": 120,
+          "revenue_str": "E27-F24-F20-E15"
+        }
+      ],
+      "original_id": 362
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 280,
+      "kind": "withhold",
+      "original_id": 363
+    },
+    {
+      "type": "buy_train",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 281,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3",
+      "original_id": 364
+    },
+    {
+      "type": "buy_train",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 282,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3",
+      "original_id": 365
+    },
+    {
+      "type": "buy_company",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 283,
+      "company": "DNP",
+      "price": 75,
+      "original_id": 368
+    },
+    {
+      "type": "buy_company",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 284,
+      "company": "DPRT",
+      "price": 142,
+      "original_id": 369
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 285,
+      "hex": "I17",
+      "tile": "57-1",
+      "rotation": 0,
+      "original_id": 370
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 286,
+      "hex": "K17",
+      "tile": "14-1",
+      "rotation": 1,
+      "original_id": 373
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 287,
+      "original_id": 374
+    },
+    {
+      "type": "run_routes",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 288,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "K17",
+              "L18",
+              "L20"
+            ]
+          ],
+          "hexes": [
+            "L20",
+            "K17"
+          ],
+          "revenue": 60,
+          "revenue_str": "L20-K17"
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "K17",
+              "J16",
+              "I17"
+            ]
+          ],
+          "hexes": [
+            "I17",
+            "K17"
+          ],
+          "revenue": 50,
+          "revenue_str": "I17-K17"
+        }
+      ],
+      "original_id": 375
+    },
+    {
+      "type": "dividend",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 289,
+      "kind": "payout",
+      "original_id": 376
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 290,
+      "original_id": 377
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 291,
+      "original_id": 378
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 292,
+      "original_id": 379
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 293,
+      "message": "So I stand corrected",
+      "original_id": 380
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 294,
+      "message": "DSNG is amazing",
+      "original_id": 381
+    },
+    {
+      "type": "par",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 295,
+      "corporation": "DRG",
+      "share_price": "80,3,3",
+      "original_id": 382
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 296,
+      "message": "jesus",
+      "original_id": 383
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 297,
+      "shares": [
+        "DPAC_4",
+        "DPAC_6"
+      ],
+      "percent": 20,
+      "original_id": 384
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 298,
+      "shares": [
+        "DSNG_4"
+      ],
+      "percent": 10,
+      "original_id": 385
+    },
+    {
+      "type": "par",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 299,
+      "corporation": "ATSF",
+      "share_price": "145,1,5",
+      "original_id": 386
+    },
+    {
+      "type": "par",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 300,
+      "corporation": "DSL",
+      "share_price": "80,3,3",
+      "original_id": 387
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 301,
+      "shares": [
+        "DRG_1"
+      ],
+      "percent": 10,
+      "original_id": 388
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 302,
+      "shares": [
+        "ATSF_1"
+      ],
+      "percent": 10,
+      "original_id": 389
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 303,
+      "shares": [
+        "DSL_1"
+      ],
+      "percent": 10,
+      "original_id": 390
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 304,
+      "shares": [
+        "DRG_2"
+      ],
+      "percent": 10,
+      "original_id": 391
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 305,
+      "shares": [
+        "ATSF_2"
+      ],
+      "percent": 10,
+      "original_id": 392
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 306,
+      "message": "I think Andy is going to buy ALL the trains",
+      "original_id": 393
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 307,
+      "shares": [
+        "DSL_2"
+      ],
+      "percent": 10,
+      "original_id": 394
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 308,
+      "shares": [
+        "DRG_3"
+      ],
+      "percent": 10,
+      "original_id": 395
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 309,
+      "shares": [
+        "ATSF_3"
+      ],
+      "percent": 10,
+      "original_id": 396
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 310,
+      "shares": [
+        "DSL_3"
+      ],
+      "percent": 10,
+      "original_id": 397
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 311,
+      "shares": [
+        "DRG_4"
+      ],
+      "percent": 10,
+      "original_id": 398
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 312,
+      "shares": [
+        "ATSF_4"
+      ],
+      "percent": 10,
+      "original_id": 399
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 313,
+      "shares": [
+        "DSNG_4"
+      ],
+      "percent": 10,
+      "original_id": 400
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 314,
+      "original_id": 401
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 315,
+      "original_id": 402
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 316,
+      "original_id": 403
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 317,
+      "original_id": 404
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 318,
+      "hex": "G19",
+      "tile": "8-6",
+      "rotation": 1,
+      "original_id": 405
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 319,
+      "hex": "F20",
+      "tile": "co9-0",
+      "rotation": 1,
+      "original_id": 406
+    },
+    {
+      "type": "place_token",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 320,
+      "city": "co6-0-0",
+      "slot": 1,
+      "original_id": 407
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 321,
+      "train": "2-2",
+      "price": 250,
+      "original_id": 412
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 322,
+      "train": "3-4",
+      "price": 180,
+      "variant": "3",
+      "original_id": 413
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 323,
+      "train": "4-0",
+      "price": 280,
+      "variant": "4",
+      "original_id": 414
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 324,
+      "original_id": 415
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 325,
+      "original_id": 416
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 326,
+      "original_id": 417
+    },
+    {
+      "type": "buy_shares",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 327,
+      "shares": [
+        "DPAC_4"
+      ],
+      "percent": 10,
+      "original_id": 418
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 328,
+      "hex": "C15",
+      "tile": "14-2",
+      "rotation": 2,
+      "original_id": 419
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 329,
+      "original_id": 420
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 330,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 170,
+          "revenue_str": "G17-E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 421
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 331,
+      "kind": "payout",
+      "original_id": 422
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 332,
+      "train": "3-0",
+      "price": 130,
+      "original_id": 423
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 333,
+      "original_id": 424
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 334,
+      "original_id": 425
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 335,
+      "original_id": 426
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 336,
+      "original_id": 427
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 337,
+      "shares": [
+        "DPAC_6"
+      ],
+      "percent": 10,
+      "original_id": 428
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 338,
+      "hex": "D14",
+      "tile": "58a-4",
+      "rotation": 3,
+      "original_id": 429
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 339,
+      "hex": "D24",
+      "tile": "co8-0",
+      "rotation": 2,
+      "original_id": 430
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 340,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 130,
+          "revenue_str": "E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 431
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 341,
+      "kind": "payout",
+      "original_id": 432
+    },
+    {
+      "type": "buy_train",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 342,
+      "train": "4-1",
+      "price": 280,
+      "variant": "4",
+      "original_id": 433
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 343,
+      "original_id": 434
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 344,
+      "original_id": 435
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 345,
+      "original_id": 436
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 346,
+      "original_id": 437
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 347,
+      "shares": [
+        "CS_1"
+      ],
+      "percent": 10,
+      "original_id": 438
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 348,
+      "shares": [
+        "CS_2"
+      ],
+      "percent": 10,
+      "original_id": 439
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 349,
+      "hex": "G19",
+      "tile": "23-0",
+      "rotation": 3,
+      "original_id": 440
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 350,
+      "original_id": 441
+    },
+    {
+      "type": "place_token",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 351,
+      "city": "14-2-0",
+      "slot": 1,
+      "original_id": 442
+    },
+    {
+      "type": "buy_train",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 352,
+      "train": "4-2",
+      "price": 280,
+      "variant": "4",
+      "original_id": 443
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 353,
+      "original_id": 444
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 354,
+      "original_id": 445
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 355,
+      "original_id": 446
+    },
+    {
+      "type": "pass",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 356,
+      "original_id": 447
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 357,
+      "hex": "E13",
+      "tile": "8-7",
+      "rotation": 4,
+      "original_id": 448
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 358,
+      "hex": "F12",
+      "tile": "4a-4",
+      "rotation": 0,
+      "original_id": 449
+    },
+    {
+      "type": "buy_train",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 359,
+      "train": "4-3",
+      "price": 280,
+      "variant": "4",
+      "original_id": 450
+    },
+    {
+      "type": "pass",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 360,
+      "original_id": 451
+    },
+    {
+      "type": "pass",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 361,
+      "original_id": 452
+    },
+    {
+      "type": "pass",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 362,
+      "original_id": 453
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 363,
+      "original_id": 454
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 364,
+      "hex": "H18",
+      "tile": "20-0",
+      "rotation": 2,
+      "original_id": 455
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 365,
+      "original_id": 456
+    },
+    {
+      "type": "place_token",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 366,
+      "city": "57-1-0",
+      "slot": 0,
+      "original_id": 457
+    },
+    {
+      "type": "buy_train",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 367,
+      "train": "3-0",
+      "price": 164,
+      "original_id": 466
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 368,
+      "original_id": 467
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 369,
+      "original_id": 468
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 370,
+      "original_id": 469
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 371,
+      "original_id": 470
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 372,
+      "hex": "G11",
+      "tile": "9-6",
+      "rotation": 2,
+      "original_id": 471
+    },
+    {
+      "type": "buy_company",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 373,
+      "company": "Toll",
+      "price": 90,
+      "original_id": 472
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 374,
+      "hex": "F10",
+      "tile": "8-8",
+      "rotation": 5,
+      "original_id": 473
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 375,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "I23",
+              "I25",
+              "J26"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "E15",
+              "F16",
+              "G17"
+            ]
+          ],
+          "hexes": [
+            "J26",
+            "I23",
+            "I21",
+            "G17",
+            "E15"
+          ],
+          "revenue": 150,
+          "revenue_str": "J26-I23-I21-G17-E15"
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "E27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "E15",
+              "E17",
+              "F18",
+              "F20"
+            ],
+            [
+              "C15",
+              "D16",
+              "E15"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "F24",
+            "F20",
+            "E15",
+            "C15"
+          ],
+          "revenue": 160,
+          "revenue_str": "E27-F24-F20-E15-C15"
+        }
+      ],
+      "original_id": 474
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 376,
+      "kind": "payout",
+      "original_id": 475
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 377,
+      "original_id": 476
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 378,
+      "original_id": 478
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 379,
+      "hex": "F8",
+      "tile": "4a-5",
+      "rotation": 1,
+      "original_id": 479
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 380,
+      "hex": "F6",
+      "tile": "9-7",
+      "rotation": 1,
+      "original_id": 480
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 381,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "I23",
+              "I25",
+              "J26"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "E15",
+              "F16",
+              "G17"
+            ]
+          ],
+          "hexes": [
+            "J26",
+            "I23",
+            "I21",
+            "G17",
+            "E15"
+          ],
+          "revenue": 150,
+          "revenue_str": "J26-I23-I21-G17-E15"
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H12",
+              "G11",
+              "F10",
+              "F8"
+            ],
+            [
+              "H14",
+              "H12"
+            ],
+            [
+              "G17",
+              "H16",
+              "G15",
+              "H14"
+            ],
+            [
+              "F20",
+              "G19",
+              "G17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "F8",
+            "H12",
+            "H14",
+            "G17",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 150,
+          "revenue_str": "F8-H12-H14-G17-F20-F24-E27"
+        }
+      ],
+      "original_id": 481
+    },
+    {
+      "type": "dividend",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 382,
+      "kind": "payout",
+      "original_id": 482
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 383,
+      "original_id": 483
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 384,
+      "original_id": 484
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 385,
+      "original_id": 486
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 386,
+      "hex": "I17",
+      "tile": "14-3",
+      "rotation": 0,
+      "original_id": 487
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 387,
+      "original_id": 488
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 388,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 170,
+          "revenue_str": "G17-E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 489
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 389,
+      "kind": "payout",
+      "original_id": 490
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 390,
+      "original_id": 491
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 391,
+      "original_id": 492
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 392,
+      "original_id": 493
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 393,
+      "shares": [
+        "DSL_1"
+      ],
+      "percent": 10,
+      "original_id": 495
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 394,
+      "shares": [
+        "DSL_2"
+      ],
+      "percent": 10,
+      "original_id": 496
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 395,
+      "hex": "J16",
+      "tile": "24-0",
+      "rotation": 3,
+      "original_id": 497
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 396,
+      "original_id": 498
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 397,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "K5",
+              "L4",
+              "L2"
+            ]
+          ],
+          "hexes": [
+            "L2",
+            "K5"
+          ],
+          "revenue": 50,
+          "revenue_str": "L2-K5"
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "K17",
+              "L18",
+              "L20"
+            ],
+            [
+              "I17",
+              "J16",
+              "K17"
+            ],
+            [
+              "F20",
+              "G19",
+              "H18",
+              "I17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "L20",
+            "K17",
+            "I17",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 170,
+          "revenue_str": "L20-K17-I17-F20-F24-E27"
+        }
+      ],
+      "original_id": 499
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 398,
+      "kind": "payout",
+      "original_id": 500
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 399,
+      "original_id": 501
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 400,
+      "original_id": 502
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 401,
+      "original_id": 503
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 402,
+      "original_id": 505
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 403,
+      "hex": "F4",
+      "tile": "9-8",
+      "rotation": 1,
+      "original_id": 506
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 404,
+      "hex": "F2",
+      "tile": "8-9",
+      "rotation": 2,
+      "original_id": 507
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 405,
+      "original_id": 508
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 406,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 170,
+          "revenue_str": "G17-E15-F20-F24-E27"
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "I23",
+              "I25",
+              "J26"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "H14",
+              "G15",
+              "H16",
+              "G17"
+            ],
+            [
+              "H12",
+              "H14"
+            ],
+            [
+              "F8",
+              "F10",
+              "G11",
+              "H12"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "F6",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "J26",
+            "I23",
+            "I21",
+            "G17",
+            "H14",
+            "H12",
+            "F8",
+            "E1"
+          ],
+          "revenue": 280,
+          "revenue_str": "J26-I23-I21-G17-H14-H12-F8-E1 + E/W"
+        }
+      ],
+      "original_id": 509
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 407,
+      "kind": "payout",
+      "original_id": 510
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 408,
+      "original_id": 511
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 409,
+      "hex": "F24",
+      "tile": "co8-1",
+      "rotation": 1,
+      "original_id": 513
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 410,
+      "original_id": 514
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 411,
+      "original_id": 515
+    },
+    {
+      "type": "run_routes",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 412,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "C15",
+              "B16",
+              "A17"
+            ],
+            [
+              "E15",
+              "D16",
+              "C15"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "A17",
+            "C15",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 210,
+          "revenue_str": "A17-C15-E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 516
+    },
+    {
+      "type": "dividend",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 413,
+      "kind": "payout",
+      "original_id": 517
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 414,
+      "original_id": 518
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 415,
+      "original_id": 519
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 416,
+      "original_id": 520
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 417,
+      "hex": "F12",
+      "tile": "co9-1",
+      "rotation": 0,
+      "original_id": 522
+    },
+    {
+      "type": "pass",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 418,
+      "original_id": 523
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 419,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "E15",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14",
+            "E15"
+          ],
+          "revenue": 90,
+          "revenue_str": "C15-D14-E15"
+        }
+      ],
+      "original_id": 524
+    },
+    {
+      "type": "dividend",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 420,
+      "kind": "payout",
+      "original_id": 525
+    },
+    {
+      "type": "pass",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 421,
+      "original_id": 526
+    },
+    {
+      "type": "pass",
+      "entity": "DSL",
+      "entity_type": "corporation",
+      "id": 422,
+      "original_id": 527
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 423,
+      "message": "man the track building in this game is whack",
+      "original_id": 529
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 424,
+      "message": "I have no idea what is legal and what not",
+      "original_id": 530
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 425,
+      "original_id": 531
+    },
+    {
+      "type": "run_routes",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 426,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "I17",
+              "J16",
+              "K17"
+            ],
+            [
+              "F20",
+              "G19",
+              "H18",
+              "I17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "K17",
+            "I17",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 150,
+          "revenue_str": "K17-I17-F20-F24-E27"
+        }
+      ],
+      "original_id": 532
+    },
+    {
+      "type": "dividend",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 427,
+      "kind": "payout",
+      "original_id": 533
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 428,
+      "original_id": 534
+    },
+    {
+      "type": "pass",
+      "entity": "CS",
+      "entity_type": "corporation",
+      "id": 429,
+      "original_id": 535
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 430,
+      "message": "You can upgrade like normal into dits and cities",
+      "original_id": 537
+    },
+    {
+      "type": "sell_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 431,
+      "shares": [
+        "CS_0"
+      ],
+      "percent": 20,
+      "original_id": 538
+    },
+    {
+      "type": "place_token",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 432,
+      "city": "14-3-0",
+      "slot": 0,
+      "original_id": 539
+    },
+    {
+      "type": "place_token",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 433,
+      "city": "14-1-0",
+      "slot": 0,
+      "original_id": 540
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 434,
+      "shares": [
+        "DPAC_7"
+      ],
+      "percent": 10,
+      "original_id": 541
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 435,
+      "shares": [
+        "DRG_5"
+      ],
+      "percent": 10,
+      "original_id": 542
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 436,
+      "shares": [
+        "DSL_3",
+        "DSL_0"
+      ],
+      "percent": 30,
+      "original_id": 543
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 437,
+      "shares": [
+        "DRG_6"
+      ],
+      "percent": 10,
+      "original_id": 544
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 438,
+      "shares": [
+        "DSNG_5"
+      ],
+      "percent": 10,
+      "original_id": 545
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 439,
+      "shares": [
+        "DRG_7"
+      ],
+      "percent": 10,
+      "original_id": 546
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 440,
+      "shares": [
+        "DRG_8"
+      ],
+      "percent": 10,
+      "original_id": 547
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 441,
+      "shares": [
+        "DSNG_6"
+      ],
+      "percent": 10,
+      "original_id": 548
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 442,
+      "shares": [
+        "DPAC_8"
+      ],
+      "percent": 10,
+      "original_id": 549
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 443,
+      "shares": [
+        "ATSF_5"
+      ],
+      "percent": 10,
+      "original_id": 550
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 444,
+      "shares": [
+        "ATSF_6"
+      ],
+      "percent": 10,
+      "original_id": 551
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 445,
+      "shares": [
+        "DPAC_5"
+      ],
+      "percent": 10,
+      "original_id": 552
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 446,
+      "shares": [
+        "ATSF_7"
+      ],
+      "percent": 10,
+      "original_id": 553
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 447,
+      "original_id": 554
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 448,
+      "shares": [
+        "DPAC_4"
+      ],
+      "percent": 10,
+      "original_id": 555
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 449,
+      "original_id": 556
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 450,
+      "original_id": 557
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 451,
+      "message": "smash it",
+      "original_id": 558
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 452,
+      "original_id": 559
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 453,
+      "message": "lolol",
+      "original_id": 560
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 454,
+      "original_id": 561
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 455,
+      "message": "wait why did I lose the DSL token?!",
+      "original_id": 562
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 456,
+      "message": "you can keep up to 2",
+      "original_id": 564
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 457,
+      "message": "it should have had you pick the ones you wanted to keep when the merger happened",
+      "original_id": 565
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 458,
+      "message": "You don't have any more tokens to put down with the DSNG",
+      "original_id": 566
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 459,
+      "message": "but I cannot choose?",
+      "original_id": 567
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 460,
+      "message": "heh ok",
+      "original_id": 568
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 461,
+      "message": "You have to use existing tokens to replace the acquired company",
+      "original_id": 569
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 462,
+      "message": "I really should read the rules once",
+      "original_id": 570
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 463,
+      "message": "lol",
+      "original_id": 571
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 464,
+      "message": "fine",
+      "original_id": 572
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 465,
+      "message": "meh, rules are overrated",
+      "original_id": 573
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 466,
+      "message": "haha yeah I would not have sold DSL then",
+      "original_id": 575
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 467,
+      "hex": "I19",
+      "tile": "23-1",
+      "rotation": 4,
+      "original_id": 576
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 468,
+      "original_id": 577
+    },
+    {
+      "type": "place_token",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 469,
+      "city": "14-3-0",
+      "slot": 1,
+      "original_id": 578
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 470,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "F8",
+              "F6",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H12",
+              "G11",
+              "F10",
+              "F8"
+            ],
+            [
+              "H14",
+              "H12"
+            ],
+            [
+              "G17",
+              "H16",
+              "G15",
+              "H14"
+            ],
+            [
+              "I21",
+              "I19",
+              "H18",
+              "G17"
+            ],
+            [
+              "I23",
+              "I21"
+            ],
+            [
+              "J26",
+              "I25",
+              "I23"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "F8",
+            "H12",
+            "H14",
+            "G17",
+            "I21",
+            "I23",
+            "J26"
+          ],
+          "revenue": 280,
+          "revenue_str": "E1-F8-H12-H14-G17-I21-I23-J26 + E/W"
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "K17",
+              "L18",
+              "L20"
+            ],
+            [
+              "I17",
+              "J16",
+              "K17"
+            ],
+            [
+              "F20",
+              "G19",
+              "H18",
+              "I17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "L20",
+            "K17",
+            "I17",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 180,
+          "revenue_str": "L20-K17-I17-F20-F24-E27"
+        }
+      ],
+      "original_id": 579
+    },
+    {
+      "type": "dividend",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 471,
+      "kind": "payout",
+      "original_id": 580
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 472,
+      "original_id": 581
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 473,
+      "original_id": 582
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 474,
+      "original_id": 584
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 475,
+      "hex": "E13",
+      "tile": "24-1",
+      "rotation": 4,
+      "original_id": 585
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 476,
+      "hex": "E11",
+      "tile": "4a-2",
+      "rotation": 1,
+      "original_id": 586
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 477,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 180,
+          "revenue_str": "G17-E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 587
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 478,
+      "kind": "payout",
+      "original_id": 588
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNPW",
+      "entity_type": "company",
+      "id": 479,
+      "hex": "E9",
+      "tile": "9-9",
+      "rotation": 1,
+      "original_id": 589
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 480,
+      "train": "5-0",
+      "price": 500,
+      "variant": "5",
+      "original_id": 590
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 481,
+      "original_id": 591
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 482,
+      "original_id": 592
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 483,
+      "shares": [
+        "ATSF_5"
+      ],
+      "percent": 10,
+      "original_id": 593
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 484,
+      "shares": [
+        "ATSF_7"
+      ],
+      "percent": 10,
+      "original_id": 594
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 485,
+      "hex": "G17",
+      "tile": "co7-0",
+      "rotation": 0,
+      "original_id": 595
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 486,
+      "hex": "J8",
+      "tile": "9-10",
+      "rotation": 1,
+      "original_id": 596
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 487,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "K5",
+              "L4",
+              "L2"
+            ]
+          ],
+          "hexes": [
+            "L2",
+            "K5"
+          ],
+          "revenue": 60,
+          "revenue_str": "L2-K5"
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "F8",
+              "F6",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H12",
+              "G11",
+              "F10",
+              "F8"
+            ],
+            [
+              "H14",
+              "H12"
+            ],
+            [
+              "G17",
+              "H16",
+              "G15",
+              "H14"
+            ],
+            [
+              "F20",
+              "G19",
+              "G17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "F8",
+            "H12",
+            "H14",
+            "G17",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 330,
+          "revenue_str": "E1-F8-H12-H14-G17-F20-F24-E27 + E/W"
+        }
+      ],
+      "original_id": 597
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 488,
+      "kind": "payout",
+      "original_id": 598
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 489,
+      "original_id": 599
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 490,
+      "original_id": 600
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 491,
+      "original_id": 601
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 492,
+      "hex": "E15",
+      "tile": "co3-0",
+      "rotation": 0,
+      "original_id": 602
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 493,
+      "hex": "E7",
+      "tile": "4a-1",
+      "rotation": 1,
+      "original_id": 603
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 494,
+      "original_id": 604
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 495,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 200,
+          "revenue_str": "G17-E15-F20-F24-E27"
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "I23",
+              "I25",
+              "J26"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "H14",
+              "G15",
+              "H16",
+              "G17"
+            ],
+            [
+              "H12",
+              "H14"
+            ],
+            [
+              "F8",
+              "F10",
+              "G11",
+              "H12"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "F6",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "J26",
+            "I23",
+            "I21",
+            "G17",
+            "H14",
+            "H12",
+            "F8",
+            "E1"
+          ],
+          "revenue": 300,
+          "revenue_str": "J26-I23-I21-G17-H14-H12-F8-E1 + E/W"
+        }
+      ],
+      "original_id": 605
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 496,
+      "kind": "withhold",
+      "original_id": 606
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 497,
+      "message": "I think DSNG wins this game",
+      "original_id": 608
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 498,
+      "message": "LOL",
+      "original_id": 609
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 499,
+      "message": "it owns 40% of Andy",
+      "original_id": 610
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 500,
+      "message": "stop",
+      "original_id": 615
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 501,
+      "message": "hold on",
+      "original_id": 616
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 502,
+      "message": "ok",
+      "original_id": 618
+    },
+    {
+      "type": "buy_train",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 503,
+      "train": "4D-0",
+      "price": 650,
+      "variant": "4D",
+      "original_id": 623
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 504,
+      "original_id": 624
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 505,
+      "original_id": 625
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 506,
+      "hex": "E5",
+      "tile": "58a-5",
+      "rotation": 4,
+      "original_id": 626
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 507,
+      "hex": "F4",
+      "tile": "24-2",
+      "rotation": 1,
+      "original_id": 627
+    },
+    {
+      "type": "place_token",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 508,
+      "city": "co7-0-0",
+      "slot": 2,
+      "original_id": 628
+    },
+    {
+      "type": "run_routes",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 509,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "F8",
+              "F6",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H12",
+              "G11",
+              "F10",
+              "F8"
+            ],
+            [
+              "H14",
+              "H12"
+            ],
+            [
+              "G17",
+              "H16",
+              "G15",
+              "H14"
+            ],
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "F8",
+            "H12",
+            "H14",
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 400,
+          "revenue_str": "E1-F8-H12-H14-G17-E15-F20-F24-E27 + E/W"
+        }
+      ],
+      "original_id": 629
+    },
+    {
+      "type": "dividend",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 510,
+      "kind": "withhold",
+      "original_id": 634
+    },
+    {
+      "type": "buy_train",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 511,
+      "train": "4D-1",
+      "price": 650,
+      "variant": "4D",
+      "original_id": 635
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 512,
+      "original_id": 636
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 513,
+      "original_id": 637
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 514,
+      "hex": "E5",
+      "tile": "co9-2",
+      "rotation": 1,
+      "original_id": 638
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 515,
+      "hex": "E3",
+      "tile": "8-10",
+      "rotation": 2,
+      "original_id": 639
+    },
+    {
+      "type": "place_token",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 516,
+      "city": "co3-0-0",
+      "slot": 3,
+      "original_id": 640
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 517,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F8",
+              "F6",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H12",
+              "G11",
+              "F10",
+              "F8"
+            ],
+            [
+              "H14",
+              "H12"
+            ],
+            [
+              "G17",
+              "H16",
+              "G15",
+              "H14"
+            ],
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "F8",
+            "H12",
+            "H14",
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 400,
+          "revenue_str": "E1-F8-H12-H14-G17-E15-F20-F24-E27 + E/W"
+        }
+      ],
+      "original_id": 641
+    },
+    {
+      "type": "dividend",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 518,
+      "kind": "withhold",
+      "original_id": 642
+    },
+    {
+      "type": "buy_train",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 519,
+      "train": "4D-2",
+      "price": 650,
+      "variant": "4D",
+      "original_id": 643
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 520,
+      "original_id": 644
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 521,
+      "shares": [
+        "DRG_6"
+      ],
+      "percent": 10,
+      "original_id": 645
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 522,
+      "hex": "J10",
+      "tile": "8-11",
+      "rotation": 5,
+      "original_id": 646
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 523,
+      "hex": "K11",
+      "tile": "9-11",
+      "rotation": 2,
+      "original_id": 647
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 524,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "K5",
+              "L4",
+              "L2"
+            ]
+          ],
+          "hexes": [
+            "L2",
+            "K5"
+          ],
+          "revenue": 60,
+          "revenue_str": "L2-K5"
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "J6",
+              "J8",
+              "J10",
+              "K11",
+              "L12",
+              "L14"
+            ],
+            [
+              "K5",
+              "J6"
+            ]
+          ],
+          "hexes": [
+            "L14",
+            "J6",
+            "K5"
+          ],
+          "revenue": 90,
+          "revenue_str": "L14-J6-K5"
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 140,
+          "revenue_str": "E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 648
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 525,
+      "kind": "payout",
+      "original_id": 649
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 526,
+      "original_id": 650
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 527,
+      "original_id": 651
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 528,
+      "original_id": 652
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 529,
+      "hex": "C15",
+      "tile": "co4-0",
+      "rotation": 2,
+      "original_id": 653
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 530,
+      "hex": "C17",
+      "tile": "4a-4",
+      "rotation": 1,
+      "original_id": 654
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 531,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "E27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "E15",
+              "E17",
+              "F18",
+              "F20"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15"
+            ],
+            [
+              "E7",
+              "E9",
+              "E11"
+            ],
+            [
+              "E5",
+              "E7"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "F24",
+            "F20",
+            "E15",
+            "E11",
+            "E7",
+            "E5",
+            "E1"
+          ],
+          "revenue": 350,
+          "revenue_str": "E27-F24-F20-E15-E11-E7-E5-E1 + E/W"
+        }
+      ],
+      "original_id": 655
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 532,
+      "kind": "payout",
+      "original_id": 656
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 533,
+      "original_id": 657
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 534,
+      "original_id": 658
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 535,
+      "original_id": 659
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 536,
+      "hex": "D2",
+      "tile": "7-2",
+      "rotation": 5,
+      "original_id": 660
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 537,
+      "hex": "H14",
+      "tile": "co10-0",
+      "rotation": 1,
+      "original_id": 661
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 538,
+      "original_id": 662
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 539,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "D2",
+              "E1"
+            ],
+            [
+              "E7",
+              "E5"
+            ],
+            [
+              "E11",
+              "E9",
+              "E7"
+            ],
+            [
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "G17",
+              "F16",
+              "E15"
+            ],
+            [
+              "F20",
+              "G19",
+              "G17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "G27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "E5",
+            "E7",
+            "E11",
+            "E15",
+            "G17",
+            "F20",
+            "F24",
+            "G27"
+          ],
+          "revenue": 560,
+          "revenue_str": "E1-E5-E7-E11-E15-G17-F20-F24-G27 + E/W"
+        }
+      ],
+      "original_id": 663
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 540,
+      "kind": "payout",
+      "original_id": 664
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 541,
+      "original_id": 665
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 542,
+      "original_id": 666
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 543,
+      "hex": "C19",
+      "tile": "9-12",
+      "rotation": 1,
+      "original_id": 667
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 544,
+      "hex": "C21",
+      "tile": "58a-0",
+      "rotation": 1,
+      "original_id": 668
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 545,
+      "original_id": 669
+    },
+    {
+      "type": "run_routes",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 546,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "F8",
+              "F6",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H12",
+              "G11",
+              "F10",
+              "F8"
+            ],
+            [
+              "H14",
+              "H12"
+            ],
+            [
+              "G17",
+              "H16",
+              "G15",
+              "H14"
+            ],
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "F8",
+            "H12",
+            "H14",
+            "G17",
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 410,
+          "revenue_str": "E1-F8-H12-H14-G17-E15-F20-F24-E27 + E/W"
+        },
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "D2",
+              "E1"
+            ],
+            [
+              "E7",
+              "E5"
+            ],
+            [
+              "E11",
+              "E9",
+              "E7"
+            ],
+            [
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "C15",
+              "D16",
+              "E15"
+            ],
+            [
+              "A17",
+              "B16",
+              "C15"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "E5",
+            "E7",
+            "E11",
+            "E15",
+            "C15",
+            "A17"
+          ],
+          "revenue": 480,
+          "revenue_str": "E1-E5-E7-E11-E15-C15-A17"
+        }
+      ],
+      "original_id": 670
+    },
+    {
+      "type": "dividend",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 547,
+      "kind": "payout",
+      "original_id": 671
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 548,
+      "original_id": 672
+    },
+    {
+      "type": "par",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 549,
+      "corporation": "ROCK",
+      "share_price": "160,1,6",
+      "original_id": 673
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 550,
+      "shares": [
+        "ATSF_8"
+      ],
+      "percent": 10,
+      "original_id": 674
+    },
+    {
+      "type": "sell_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 551,
+      "shares": [
+        "DPAC_8",
+        "DPAC_5",
+        "DPAC_4"
+      ],
+      "percent": 30,
+      "original_id": 675
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 552,
+      "message": ":(",
+      "original_id": 676
+    },
+    {
+      "type": "par",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 553,
+      "corporation": "CBQ",
+      "share_price": "160,1,6",
+      "original_id": 677
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 554,
+      "message": "well it is between the 2 of you",
+      "original_id": 678
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 555,
+      "message": "I am just watching lol",
+      "original_id": 679
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 556,
+      "message": "however I am really enjoying it",
+      "original_id": 680
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 557,
+      "message": "I like 18CO",
+      "original_id": 681
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 558,
+      "message": "It's definitely its own game",
+      "original_id": 682
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 559,
+      "message": "somehow I find it is very imbalanced",
+      "original_id": 683
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 560,
+      "message": "I mean I enjoy playing it just for the chaos",
+      "original_id": 684
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 561,
+      "message": "timing seems to be a huge part of this game",
+      "original_id": 685
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 562,
+      "message": "but I can see how it would not be appealing to many",
+      "original_id": 686
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 563,
+      "message": "timing is huge in all 18xx to be fair",
+      "original_id": 687
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 564,
+      "message": "It seems to be appealing to many, actually.",
+      "original_id": 688
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 565,
+      "message": "yes, but here it seems to be ramped up",
+      "original_id": 689
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 566,
+      "message": "really",
+      "original_id": 690
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 567,
+      "message": "cool",
+      "original_id": 691
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 568,
+      "message": "Vic are you thinking?",
+      "original_id": 692
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 569,
+      "message": "I think there are definitely some things that could be improved",
+      "original_id": 693
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 570,
+      "message": "sorry it is showing your turn andy",
+      "original_id": 694
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 571,
+      "message": "ah my bad",
+      "original_id": 695
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 572,
+      "message": "was desynced",
+      "original_id": 696
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 573,
+      "shares": [
+        "ROCK_1"
+      ],
+      "percent": 10,
+      "original_id": 697
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 574,
+      "shares": [
+        "ROCK_2"
+      ],
+      "percent": 10,
+      "original_id": 698
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 575,
+      "shares": [
+        "CBQ_1"
+      ],
+      "percent": 10,
+      "original_id": 699
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 576,
+      "shares": [
+        "DPAC_8"
+      ],
+      "percent": 10,
+      "original_id": 700
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 577,
+      "shares": [
+        "CBQ_2"
+      ],
+      "percent": 10,
+      "original_id": 701
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 578,
+      "shares": [
+        "CBQ_3"
+      ],
+      "percent": 10,
+      "original_id": 702
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 579,
+      "shares": [
+        "DPAC_8"
+      ],
+      "percent": 10,
+      "original_id": 703
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 580,
+      "shares": [
+        "ROCK_3"
+      ],
+      "percent": 10,
+      "original_id": 704
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 581,
+      "original_id": 705
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 582,
+      "message": "lol I dunno why I keep buying the wrong share",
+      "original_id": 706
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 583,
+      "shares": [
+        "CBQ_4"
+      ],
+      "percent": 10,
+      "original_id": 707
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 584,
+      "shares": [
+        "ROCK_4"
+      ],
+      "percent": 10,
+      "original_id": 708
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 585,
+      "original_id": 709
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 586,
+      "message": "damn vizchacha is at cert limit!",
+      "original_id": 710
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 587,
+      "message": "lol",
+      "original_id": 711
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 588,
+      "shares": [
+        "CBQ_5"
+      ],
+      "percent": 10,
+      "original_id": 712
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 589,
+      "shares": [
+        "ROCK_5"
+      ],
+      "percent": 10,
+      "original_id": 713
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 590,
+      "message": "yeah, but DrA cleaned my clock last time, cert limit be damned",
+      "original_id": 714
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 591,
+      "original_id": 715
+    },
+    {
+      "type": "buy_shares",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 592,
+      "shares": [
+        "ROCK_6"
+      ],
+      "percent": 10,
+      "original_id": 716
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 593,
+      "message": "well actually if you wnated to attack him you should have bought cbq and smashed it",
+      "original_id": 717
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 594,
+      "shares": [
+        "CBQ_6"
+      ],
+      "percent": 10,
+      "original_id": 720
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 595,
+      "message": "it's such a small effect",
+      "original_id": 721
+    },
+    {
+      "type": "pass",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 596,
+      "original_id": 722
+    },
+    {
+      "type": "pass",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 597,
+      "original_id": 723
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 598,
+      "message": "the drops int he market are huge",
+      "original_id": 724
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 599,
+      "original_id": 725
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 600,
+      "message": "the first share by a non-president doesn't drop the price",
+      "original_id": 726
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 601,
+      "shares": [
+        "DPAC_5"
+      ],
+      "percent": 10,
+      "original_id": 727
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 602,
+      "shares": [
+        "DPAC_4"
+      ],
+      "percent": 10,
+      "original_id": 728
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 603,
+      "shares": [
+        "DPAC_8"
+      ],
+      "percent": 10,
+      "original_id": 729
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 604,
+      "message": "plus, there are \"double\" jumps when operating",
+      "original_id": 730
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 605,
+      "message": "yeah win some lose some",
+      "original_id": 731
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 606,
+      "hex": "F18",
+      "tile": "23-2",
+      "rotation": 4,
+      "original_id": 732
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 607,
+      "hex": "E23",
+      "tile": "9-13",
+      "rotation": 2,
+      "original_id": 733
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 608,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "K5",
+              "L4",
+              "L2"
+            ]
+          ],
+          "hexes": [
+            "K5",
+            "L2"
+          ],
+          "revenue": 60,
+          "revenue_str": "K5-L2"
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "J6",
+              "J8",
+              "J10",
+              "K11",
+              "L12",
+              "L14"
+            ],
+            [
+              "K5",
+              "J6"
+            ]
+          ],
+          "hexes": [
+            "L14",
+            "J6",
+            "K5"
+          ],
+          "revenue": 90,
+          "revenue_str": "L14-J6-K5"
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 140,
+          "revenue_str": "E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 734
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 609,
+      "kind": "payout",
+      "original_id": 735
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 610,
+      "original_id": 736
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 611,
+      "original_id": 737
+    },
+    {
+      "type": "pass",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 612,
+      "original_id": 738
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 613,
+      "hex": "H14",
+      "tile": "co4-1",
+      "rotation": 0,
+      "original_id": 739
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 614,
+      "message": "how do you upgrade that town",
+      "original_id": 740
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 615,
+      "message": "I tried and it would not let me",
+      "original_id": 741
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 616,
+      "message": "I tried upgrading boulder",
+      "original_id": 742
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 617,
+      "message": "was only showing me towns",
+      "original_id": 743
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 618,
+      "message": "the track laying rules here are awful",
+      "original_id": 744
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 619,
+      "message": "you have to already be able to run to the existing track",
+      "original_id": 745
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 620,
+      "hex": "G13",
+      "tile": "9-14",
+      "rotation": 2,
+      "original_id": 746
+    },
+    {
+      "type": "place_token",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 621,
+      "city": "co4-1-0",
+      "slot": 0,
+      "original_id": 747
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 622,
+      "message": "yea but that was with DSL",
+      "original_id": 748
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 623,
+      "message": "hmm",
+      "original_id": 749
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 624,
+      "message": "I was trying to upgrade boulder and I had direct access to it",
+      "original_id": 750
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 625,
+      "message": "it was only showing me towns",
+      "original_id": 751
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 626,
+      "message": "I wanted to run my 4T up there",
+      "original_id": 752
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 627,
+      "message": "anyways",
+      "original_id": 753
+    },
+    {
+      "type": "run_routes",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 628,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "E27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "G17",
+              "G19",
+              "F20"
+            ],
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15"
+            ],
+            [
+              "E7",
+              "E9",
+              "E11"
+            ],
+            [
+              "E5",
+              "E7"
+            ],
+            [
+              "E1",
+              "D2",
+              "E3",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "F24",
+            "F20",
+            "G17",
+            "E15",
+            "E11",
+            "E7",
+            "E5",
+            "E1"
+          ],
+          "revenue": 410,
+          "revenue_str": "E27-F24-F20-G17-E15-E11-E7-E5-E1 + E/W"
+        },
+        {
+          "train": "4D-2",
+          "connections": [
+            [
+              "I23",
+              "I25",
+              "J26"
+            ],
+            [
+              "I21",
+              "I23"
+            ],
+            [
+              "G17",
+              "H18",
+              "I19",
+              "I21"
+            ],
+            [
+              "H14",
+              "G15",
+              "H16",
+              "G17"
+            ],
+            [
+              "H12",
+              "H14"
+            ],
+            [
+              "F8",
+              "F10",
+              "G11",
+              "H12"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "F6",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "J26",
+            "I23",
+            "I21",
+            "G17",
+            "H14",
+            "H12",
+            "F8",
+            "E1"
+          ],
+          "revenue": 500,
+          "revenue_str": "J26-I23-I21-G17-H14-H12-F8-E1 + E/W"
+        }
+      ],
+      "original_id": 754
+    },
+    {
+      "type": "dividend",
+      "entity": "ATSF",
+      "entity_type": "corporation",
+      "id": 629,
+      "kind": "payout",
+      "original_id": 755
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 630,
+      "original_id": 756
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 631,
+      "hex": "G11",
+      "tile": "26-0",
+      "rotation": 5,
+      "original_id": 757
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 632,
+      "original_id": 758
+    },
+    {
+      "type": "place_token",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 633,
+      "city": "co4-1-0",
+      "slot": 1,
+      "original_id": 759
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 634,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "D2",
+              "E1"
+            ],
+            [
+              "E7",
+              "E5"
+            ],
+            [
+              "E11",
+              "E9",
+              "E7"
+            ],
+            [
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "G17",
+              "F16",
+              "E15"
+            ],
+            [
+              "F20",
+              "G19",
+              "G17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "G27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "E5",
+            "E7",
+            "E11",
+            "E15",
+            "G17",
+            "F20",
+            "F24",
+            "G27"
+          ],
+          "revenue": 560,
+          "revenue_str": "E1-E5-E7-E11-E15-G17-F20-F24-G27 + E/W"
+        }
+      ],
+      "original_id": 760
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 635,
+      "kind": "payout",
+      "original_id": 761
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 636,
+      "original_id": 762
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 637,
+      "original_id": 763
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 638,
+      "hex": "B22",
+      "tile": "3a-0",
+      "rotation": 5,
+      "original_id": 764
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 639,
+      "hex": "C23",
+      "tile": "9-15",
+      "rotation": 2,
+      "original_id": 765
+    },
+    {
+      "type": "run_routes",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 640,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "D24",
+              "E25",
+              "F26",
+              "E27"
+            ],
+            [
+              "B22",
+              "C23",
+              "D24"
+            ],
+            [
+              "C21",
+              "B22"
+            ],
+            [
+              "C17",
+              "C19",
+              "C21"
+            ],
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "E15",
+              "D14"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15"
+            ],
+            [
+              "E7",
+              "E9",
+              "E11"
+            ],
+            [
+              "E5",
+              "E7"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "D24",
+            "B22",
+            "C21",
+            "C17",
+            "C15",
+            "D14",
+            "E15",
+            "E11",
+            "E7",
+            "E5",
+            "E1"
+          ],
+          "revenue": 420,
+          "revenue_str": "E27-D24-B22-C21-C17-C15-D14-E15-E11-E7-E5-E1 + E/W"
+        }
+      ],
+      "original_id": 766
+    },
+    {
+      "type": "dividend",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 641,
+      "kind": "withhold",
+      "original_id": 767
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 642,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5",
+      "original_id": 768
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 643,
+      "original_id": 769
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 644,
+      "original_id": 770
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 645,
+      "hex": "C17",
+      "tile": "co9-3",
+      "rotation": 1,
+      "original_id": 771
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 646,
+      "original_id": 776
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 647,
+      "original_id": 777
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 648,
+      "message": "just payout so the game will end next OR",
+      "original_id": 778
+    },
+    {
+      "type": "run_routes",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 649,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D24",
+              "E25",
+              "F26",
+              "E27"
+            ],
+            [
+              "B22",
+              "C23",
+              "D24"
+            ],
+            [
+              "C21",
+              "B22"
+            ],
+            [
+              "C17",
+              "C19",
+              "C21"
+            ],
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "E15",
+              "D14"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15"
+            ],
+            [
+              "E7",
+              "E9",
+              "E11"
+            ],
+            [
+              "E5",
+              "E7"
+            ],
+            [
+              "E1",
+              "D2",
+              "E3",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "E27",
+            "D24",
+            "B22",
+            "C21",
+            "C17",
+            "C15",
+            "D14",
+            "E15",
+            "E11",
+            "E7",
+            "E5",
+            "E1"
+          ],
+          "revenue": 430,
+          "revenue_str": "E27-D24-B22-C21-C17-C15-D14-E15-E11-E7-E5-E1 + E/W"
+        },
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "E15",
+              "D16",
+              "C15"
+            ],
+            [
+              "G17",
+              "F16",
+              "E15"
+            ],
+            [
+              "H14",
+              "G15",
+              "H16",
+              "G17"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "E15",
+            "G17",
+            "H14"
+          ],
+          "revenue": 460,
+          "revenue_str": "C15-E15-G17-H14"
+        }
+      ],
+      "original_id": 779
+    },
+    {
+      "type": "dividend",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 650,
+      "kind": "payout",
+      "original_id": 780
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 651,
+      "original_id": 781
+    },
+    {
+      "type": "pass",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 652,
+      "original_id": 782
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 653,
+      "hex": "F16",
+      "tile": "20-1",
+      "rotation": 1,
+      "original_id": 783
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 654,
+      "hex": "D22",
+      "tile": "9-16",
+      "rotation": 2,
+      "original_id": 784
+    },
+    {
+      "type": "buy_train",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 655,
+      "train": "4-1",
+      "price": 340,
+      "original_id": 785
+    },
+    {
+      "type": "buy_train",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 656,
+      "train": "6-0",
+      "price": 720,
+      "variant": "6",
+      "original_id": 786
+    },
+    {
+      "type": "pass",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 657,
+      "original_id": 787
+    },
+    {
+      "type": "pass",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 658,
+      "original_id": 788
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 659,
+      "shares": [
+        "ATSF_1"
+      ],
+      "percent": 10,
+      "original_id": 789
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 660,
+      "shares": [
+        "ATSF_2"
+      ],
+      "percent": 10,
+      "original_id": 790
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 661,
+      "shares": [
+        "ATSF_3"
+      ],
+      "percent": 10,
+      "original_id": 791
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 662,
+      "shares": [
+        "ATSF_4"
+      ],
+      "percent": 10,
+      "original_id": 792
+    },
+    {
+      "type": "place_token",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 663,
+      "city": "co3-0-0",
+      "slot": 3,
+      "original_id": 793
+    },
+    {
+      "type": "place_token",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 664,
+      "city": "co7-0-0",
+      "slot": 1,
+      "original_id": 794
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 665,
+      "hex": "C17",
+      "tile": "63-0",
+      "rotation": 0,
+      "original_id": 795
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 666,
+      "hex": "B18",
+      "tile": "8-12",
+      "rotation": 0,
+      "original_id": 796
+    },
+    {
+      "type": "place_token",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 667,
+      "city": "co4-1-0",
+      "slot": 0,
+      "original_id": 803
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 668,
+      "routes": [
+        {
+          "train": "4D-2",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "D2",
+              "E1"
+            ],
+            [
+              "E7",
+              "E5"
+            ],
+            [
+              "E11",
+              "E9",
+              "E7"
+            ],
+            [
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "G17",
+              "F16",
+              "E15"
+            ],
+            [
+              "F20",
+              "G19",
+              "G17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "E5",
+            "E7",
+            "E11",
+            "E15",
+            "G17",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 560,
+          "revenue_str": "E1-E5-E7-E11-E15-G17-F20-F24-E27 + E/W"
+        }
+      ],
+      "original_id": 804
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 669,
+      "kind": "payout",
+      "original_id": 805
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 670,
+      "original_id": 806
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 671,
+      "original_id": 807
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 672,
+      "original_id": 808
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 673,
+      "message": "fuck this track",
+      "original_id": 810
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 674,
+      "hex": "F14",
+      "tile": "8-13",
+      "rotation": 4,
+      "original_id": 812
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 675,
+      "message": "haha",
+      "original_id": 813
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 676,
+      "hex": "G13",
+      "tile": "19-0",
+      "rotation": 5,
+      "original_id": 814
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 677,
+      "message": "I really like some aspects of this game. The track laying rules is not one of those aspects",
+      "original_id": 815
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 678,
+      "message": "It takes a little getting used to.",
+      "original_id": 816
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 679,
+      "message": "I wanted to sneak through next to dillon",
+      "original_id": 817
+    },
+    {
+      "type": "run_routes",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 680,
+      "routes": [
+        {
+          "train": "2P-0",
+          "connections": [
+            [
+              "F20",
+              "F18",
+              "E17",
+              "E15"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E15",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 140,
+          "revenue_str": "E15-F20-F24-E27"
+        }
+      ],
+      "original_id": 818
+    },
+    {
+      "type": "dividend",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 681,
+      "kind": "payout",
+      "original_id": 819
+    },
+    {
+      "type": "buy_train",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 682,
+      "train": "5D-0",
+      "price": 850,
+      "variant": "5D",
+      "original_id": 820
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 683,
+      "original_id": 821
+    },
+    {
+      "type": "pass",
+      "entity": "DSNG",
+      "entity_type": "corporation",
+      "id": 684,
+      "original_id": 822
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 685,
+      "original_id": 823
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 686,
+      "hex": "G19",
+      "tile": "41-0",
+      "rotation": 0,
+      "original_id": 824
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 687,
+      "original_id": 825
+    },
+    {
+      "type": "pass",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 688,
+      "original_id": 826
+    },
+    {
+      "type": "run_routes",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 689,
+      "routes": [
+        {
+          "train": "4D-0",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "D2",
+              "E1"
+            ],
+            [
+              "E7",
+              "E5"
+            ],
+            [
+              "E11",
+              "E9",
+              "E7"
+            ],
+            [
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "G17",
+              "F16",
+              "E15"
+            ],
+            [
+              "F20",
+              "G19",
+              "G17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "G27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "E5",
+            "E7",
+            "E11",
+            "E15",
+            "G17",
+            "F20",
+            "F24",
+            "G27"
+          ],
+          "revenue": 560,
+          "revenue_str": "E1-E5-E7-E11-E15-G17-F20-F24-G27 + E/W"
+        }
+      ],
+      "original_id": 827
+    },
+    {
+      "type": "dividend",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 690,
+      "kind": "withhold",
+      "original_id": 828
+    },
+    {
+      "type": "buy_train",
+      "entity": "CM",
+      "entity_type": "corporation",
+      "id": 691,
+      "train": "5D-1",
+      "price": 850,
+      "variant": "5D",
+      "original_id": 829
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 692,
+      "original_id": 830
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 693,
+      "hex": "E13",
+      "tile": "42-0",
+      "rotation": 1,
+      "original_id": 831
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 694,
+      "original_id": 832
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 695,
+      "original_id": 833
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 696,
+      "routes": [
+        {
+          "train": "4D-2",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "D2",
+              "E1"
+            ],
+            [
+              "E7",
+              "E5"
+            ],
+            [
+              "E11",
+              "E9",
+              "E7"
+            ],
+            [
+              "E15",
+              "E13",
+              "E11"
+            ],
+            [
+              "G17",
+              "F16",
+              "E15"
+            ],
+            [
+              "F20",
+              "G19",
+              "G17"
+            ],
+            [
+              "F24",
+              "F22",
+              "F20"
+            ],
+            [
+              "E27",
+              "F26",
+              "F24"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "E5",
+            "E7",
+            "E11",
+            "E15",
+            "G17",
+            "F20",
+            "F24",
+            "E27"
+          ],
+          "revenue": 560,
+          "revenue_str": "E1-E5-E7-E11-E15-G17-F20-F24-E27 + E/W"
+        }
+      ],
+      "original_id": 834
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 697,
+      "kind": "withhold",
+      "original_id": 835
+    },
+    {
+      "type": "buy_train",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 698,
+      "train": "E-0",
+      "price": 1000,
+      "variant": "E",
+      "original_id": 836
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 699,
+      "original_id": 837
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 700,
+      "original_id": 838
+    },
+    {
+      "type": "corporate_buy_shares",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 701,
+      "shares": [
+        "DPAC_1"
+      ],
+      "percent": 10,
+      "original_id": 841
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 702,
+      "original_id": 842
+    },
+    {
+      "type": "run_routes",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 703,
+      "routes": [
+        {
+          "train": "4D-1",
+          "connections": [
+            [
+              "F24",
+              "F26",
+              "G27"
+            ],
+            [
+              "F20",
+              "F22",
+              "F24"
+            ],
+            [
+              "G17",
+              "G19",
+              "F20"
+            ],
+            [
+              "E15",
+              "F16",
+              "G17"
+            ],
+            [
+              "E11",
+              "E13",
+              "E15"
+            ],
+            [
+              "E7",
+              "E9",
+              "E11"
+            ],
+            [
+              "E5",
+              "E7"
+            ],
+            [
+              "E1",
+              "D2",
+              "E3",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "G27",
+            "F24",
+            "F20",
+            "G17",
+            "E15",
+            "E11",
+            "E7",
+            "E5",
+            "E1"
+          ],
+          "revenue": 560,
+          "revenue_str": "G27-F24-F20-G17-E15-E11-E7-E5-E1 + E/W"
+        }
+      ],
+      "original_id": 843
+    },
+    {
+      "type": "dividend",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 704,
+      "kind": "withhold",
+      "original_id": 846
+    },
+    {
+      "type": "pass",
+      "entity": "DRG",
+      "entity_type": "corporation",
+      "id": 705,
+      "original_id": 847
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 706,
+      "original_id": 848
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 707,
+      "hex": "C21",
+      "tile": "co8-2",
+      "rotation": 0,
+      "original_id": 851
+    },
+    {
+      "type": "buy_train",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 708,
+      "train": "6-1",
+      "price": 720,
+      "variant": "6",
+      "original_id": 852
+    },
+    {
+      "type": "pass",
+      "entity": "DPAC",
+      "entity_type": "corporation",
+      "id": 709,
+      "original_id": 853
+    },
+    {
+      "type": "pass",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 710,
+      "original_id": 854
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 711,
+      "hex": "G11",
+      "tile": "44-0",
+      "rotation": 1,
+      "original_id": 855
+    },
+    {
+      "type": "place_token",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 712,
+      "city": "14-3-0",
+      "slot": 1,
+      "original_id": 856
+    },
+    {
+      "type": "run_routes",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 713,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "K17",
+              "L18",
+              "L20"
+            ],
+            [
+              "I17",
+              "J16",
+              "K17"
+            ],
+            [
+              "F20",
+              "G19",
+              "H18",
+              "I17"
+            ],
+            [
+              "E15",
+              "E17",
+              "F18",
+              "F20"
+            ]
+          ],
+          "hexes": [
+            "L20",
+            "K17",
+            "I17",
+            "F20",
+            "E15"
+          ],
+          "revenue": 200,
+          "revenue_str": "L20-K17-I17-F20-E15"
+        }
+      ],
+      "original_id": 857
+    },
+    {
+      "type": "dividend",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 714,
+      "kind": "payout",
+      "original_id": 858
+    },
+    {
+      "type": "pass",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 715,
+      "original_id": 859
+    },
+    {
+      "type": "pass",
+      "entity": "ROCK",
+      "entity_type": "corporation",
+      "id": 716,
+      "original_id": 860
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 717,
+      "shares": [
+        "CM_4"
+      ],
+      "percent": 10,
+      "original_id": 861
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 718,
+      "message": "also suddenly its only 1 track lay",
+      "original_id": 862
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 719,
+      "message": "lol",
+      "original_id": 863
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 720,
+      "shares": [
+        "CM_5"
+      ],
+      "percent": 10,
+      "original_id": 864
+    },
+    {
+      "type": "buy_shares",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 721,
+      "shares": [
+        "DPAC_1"
+      ],
+      "percent": 10,
+      "original_id": 865
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 722,
+      "shares": [
+        "CM_6"
+      ],
+      "percent": 10,
+      "original_id": 866
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 723,
+      "original_id": 867
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 724,
+      "message": "hmm",
+      "original_id": 868
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 725,
+      "message": "You can also buy from company treasuries",
+      "original_id": 869
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 726,
+      "message": "Of stocks the company has purchased of other companies",
+      "original_id": 870
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 727,
+      "message": "I get an error when I try to buy CBQ",
+      "original_id": 871
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 728,
+      "message": "buying from company?",
+      "original_id": 872
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 729,
+      "message": "Illegal action Blocking step Buy Shares cannot process action 873",
+      "original_id": 873
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 730,
+      "message": "yeah",
+      "original_id": 874
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 731,
+      "message": "try buying CM from DSNG",
+      "original_id": 875
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 732,
+      "message": "Illegal action Blocking step Buy Shares cannot process action 876",
+      "original_id": 876
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 733,
+      "message": "heh",
+      "original_id": 877
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 734,
+      "message": "???",
+      "original_id": 878
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 735,
+      "message": "yeah its a bug",
+      "original_id": 879
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 736,
+      "message": "but I think Andy won anyways",
+      "original_id": 880
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 737,
+      "message": "what do you think?",
+      "original_id": 881
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 738,
+      "message": "I think I can't buy anything",
+      "original_id": 882
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 739,
+      "message": "even ROCK gives an error",
+      "original_id": 883
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 740,
+      "message": "yeah there's that but even if we could buy stuff",
+      "original_id": 884
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 741,
+      "message": "but yeah, I'm fine calling it",
+      "original_id": 885
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 742,
+      "message": "Andy will tear it apart",
+      "original_id": 886
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 743,
+      "message": "actually I think DSNG wins the game",
+      "original_id": 887
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 744,
+      "message": "I think I've got this yeah",
+      "original_id": 888
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 745,
+      "message": "lol",
+      "original_id": 889
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 746,
+      "message": "ok gg gentlemen",
+      "original_id": 890
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 747,
+      "message": "have a good night!",
+      "original_id": 891
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 748,
+      "message": "thanks for playing",
+      "original_id": 892
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 749,
+      "message": "good game",
+      "original_id": 893
+    },
+    {
+      "type": "message",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 750,
+      "message": "need to copy the game log",
+      "original_id": 896
+    },
+    {
+      "type": "message",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 751,
+      "message": "ok",
+      "original_id": 897
+    },
+    {
+      "type": "message",
+      "entity": 512,
+      "entity_type": "player",
+      "id": 752,
+      "message": "well played btw--this is a tricky game",
+      "original_id": 898
+    },
+    {
+      "type": "end_game",
+      "entity": 333,
+      "entity_type": "player",
+      "id": 753
+    }
+  ],
+  "loaded": true,
+  "created_at": 1609833618,
+  "updated_at": 1609844257
+}


### PR DESCRIPTION
Fix: https://github.com/tobymao/18xx/issues/3073
Fix: https://github.com/tobymao/18xx/issues/3094

Can this really be this simple? I feel like I saw :pass used elsewhere, but running the original sample game as a spec ( which has gone poof on 18xx.games ), the President's choice round never ended as the `@entities.delete(action.entity)` was never triggered because nothing matched :pass. Switching to a string worked in both ruby and browser.