### PR TITLE
1856 rights nationalization

### DIFF
--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -555,8 +555,26 @@ module Engine
         end
         # Leftover cash is transferred
         major.spend(major.cash, national) if major.cash.positive?
+
         # Tunnel / Bridge rights are transferred
-        # TODO: Implement tunnel / bridge rights
+        if tunnel?(major)
+          if tunnel?(national)
+            @log << "#{national.name} already has a tunnel token, the token is returned to the bank pool"
+            @available_tunnel_tokens += 1
+          else
+            @log << "#{national.name} gets #{major.name}'s tunnel token"
+            grant_right(national, :tunnel)
+          end
+        end
+        if bridge?(major)
+          if bridge?(national)
+            @log << "#{national.name} already has a bridge token, the token is returned to the bank pool"
+            @available_bridge_tokens += 1
+          else
+            @log << "#{national.name} gets #{major.name}'s bridge token"
+            grant_right(national, :bridge)
+          end
+        end
 
         # Tokens:
         # Remove reservations

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -96,7 +96,6 @@ module Engine
 
         revenue += 20 if route.corporation.assigned?(port.id) && stops.any? { |stop| stop.hex.assigned?(port.id) }
 
-        # TODO: Add bridge and tunnel private revenue modifiers
         route.corporation.companies.each do |company|
           abilities(company, :hex_bonus) do |ability|
             revenue += stops.map { |s| s.hex.id }.uniq.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
@@ -231,7 +230,7 @@ module Engine
         # they'd have to buy 2 shares in one action which is a no-no
         # nil: Presidency not awarded yet at all
         # true: 1-share false presidency has been awarded
-        # false: 2-sahre true presidency has been awarded
+        # false: 2-share true presidency has been awarded
         @false_national_president = nil
 
         # 1 of each right is reserved w/ the private when it gets bought in. This leaves 2 extra to sell.

--- a/lib/engine/step/g_18_sj/special_buy.rb
+++ b/lib/engine/step/g_18_sj/special_buy.rb
@@ -27,7 +27,7 @@ module Engine
 
         def setup
           super
-          @gkb_bonus_item = Item.new(description: 'GKB bonus', cost: 0)
+          @gkb_bonus_item ||= Item.new(description: 'GKB bonus', cost: 0)
           @gkb_bonus_bought = false
         end
 


### PR DESCRIPTION
The tunnel & bridge rights get transferred to the national during nationalization; duplicates get popped to the bank pool where other corporations may purchase them