### PR TITLE
Add missing methods (fixes #3098)

### DIFF
--- a/lib/engine/step/g_18_sj/choose_priority.rb
+++ b/lib/engine/step/g_18_sj/choose_priority.rb
@@ -79,6 +79,12 @@ module Engine
           !@round.choice_done && entity&.player? && entity == chooser && entity != @game.players.first
         end
 
+        def can_sell?
+          false
+        end
+
+        def ipo_type(_entity) end
+
         private
 
         def chooser


### PR DESCRIPTION
Got errors for missing methods can_sell? and ipo_type from ChoosePriority
in 18SJ so have added these giving default values.