### PR TITLE
add location name when laying tiles

### DIFF
--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -136,7 +136,8 @@ module Engine
           @log << "#{spender.name}"\
             "#{cost.zero? ? '' : " spends #{@game.format_currency(cost)} and"}"\
             " lays tile ##{tile.name}"\
-            " with rotation #{rotation} on #{hex.name}"
+            " with rotation #{rotation} on #{hex.name}"\
+            "#{tile.location_name.to_s.empty? ? '' : " (#{tile.location_name})"}"
 
           return unless terrain.any?
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -142,7 +142,8 @@ module Engine
           "#{spender == entity ? '' : " (#{entity.sym})"}"\
           "#{cost.zero? ? '' : " spends #{@game.format_currency(cost)} and"}"\
           " lays tile ##{tile.name}"\
-          " with rotation #{rotation} on #{hex.name}"
+          " with rotation #{rotation} on #{hex.name}"\
+          "#{tile.location_name.to_s.empty? ? '' : " (#{tile.location_name})"}"
 
         return unless terrain.any?
 


### PR DESCRIPTION
This adds the `location_name` in parentheses when appropriate

![Screenshot 2021-01-06 at 5 50 52 PM](https://user-images.githubusercontent.com/1711810/103841140-c6044200-5047-11eb-9f53-b2be7b2a73dc.png)

closes #3052 