### PR TITLE
18Mag: double-sided tiles, K-tiles

### DIFF
--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -8,7 +8,7 @@ module View
       needs :game
       needs :tile_selector, default: nil, store: true
 
-      def render_tile_selector(remaining, tile)
+      def render_tile_selector(remaining, tile, shift: 0)
         return [] unless @tile_selector
         return [] if @tile_selector.role != :tile_page || @tile_selector.hex&.tile&.name != tile.name
 
@@ -20,7 +20,7 @@ module View
         props = {
          style: {
            position: 'absolute',
-           left: "#{WIDTH / 2}px",
+           left: "#{WIDTH * shift + WIDTH / 2}px",
            top: "#{(WIDTH / 2) - 1}px",
          },
         }
@@ -46,18 +46,58 @@ module View
       def render
         remaining = @game.tiles.group_by(&:name)
 
-        children = @game.all_tiles.sort.group_by(&:name).flat_map do |name, tiles|
-          num = remaining[name]&.size || 0
-          unavailable = num.positive? ? nil : 'None Left'
-          tile = tiles.first
+        if !@game.class::DOUBLE_SIDED_TILES
+          children = @game.all_tiles.sort.group_by(&:name).flat_map do |name, tiles|
+            num = remaining[name]&.size || 0
+            unavailable = num.positive? ? nil : 'None Left'
+            tile = tiles.first
 
-          render_tile_blocks(name,
-                             tile: tile,
-                             num: num,
-                             unavailable: unavailable,
-                             layout: @game.layout,
-                             clickable: true,
-                             extra_children: render_tile_selector(remaining, tile))
+            render_tile_blocks(name,
+                               tile: tile,
+                               num: num,
+                               unavailable: unavailable,
+                               layout: @game.layout,
+                               clickable: true,
+                               extra_children: render_tile_selector(remaining, tile))
+          end
+        else
+          all_tiles = @game.all_tiles.sort.group_by(&:name)
+          children = @game.tile_groups.flat_map do |group|
+            if group.one?
+              name = group.first
+              num = remaining[name]&.size || 0
+              unavailable = num.positive? ? nil : 'None Left'
+              tile = all_tiles[name].first
+
+              render_tile_blocks(name,
+                                 tile: tile,
+                                 num: num,
+                                 unavailable: unavailable,
+                                 layout: @game.layout,
+                                 clickable: true,
+                                 extra_children: render_tile_selector(remaining, tile))
+            else
+              name_a, name_b = group
+              num = remaining[name_a]&.size || 0
+
+              unavailable = num.positive? ? nil : 'None Left'
+
+              tile_a = all_tiles[name_a].first
+              tile_b = all_tiles[name_b].first
+
+              render_tile_sides(name_a,
+                                name_b,
+                                tile_a: tile_a,
+                                tile_b: tile_b,
+                                num: num,
+                                unavailable: unavailable,
+                                layout: @game.layout,
+                                clickable: true,
+                                extra_children_a: render_tile_selector(remaining, tile_a),
+                                extra_children_b: render_tile_selector(remaining, tile_b, shift: 1))
+
+            end
+          end
         end
 
         props = {

--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -46,7 +46,7 @@ module View
       def render
         remaining = @game.tiles.group_by(&:name)
 
-        if !@game.class::DOUBLE_SIDED_TILES
+        if @game.tile_groups.empty?
           children = @game.all_tiles.sort.group_by(&:name).flat_map do |name, tiles|
             num = remaining[name]&.size || 0
             unavailable = num.positive? ? nil : 'None Left'

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -68,5 +68,91 @@ module View
         ])
       end
     end
+
+    def render_tile_sides(
+      name_a,
+      name_b,
+      layout: nil,
+      num: nil,
+      tile_a: nil,
+      tile_b: nil,
+      scale: 1.0,
+      unavailable: nil,
+      clickable: false,
+      extra_children_a: [],
+      extra_children_b: []
+    )
+      props = {
+        style: {
+          width: "#{2 * WIDTH * scale}px",
+          height: "#{HEIGHT * scale}px",
+        },
+      }
+
+      tile_a ||= Engine::Tile.for(name_a)
+      tile_b ||= Engine::Tile.for(name_b)
+
+      rotations = [0]
+
+      rotations.map do |rotation|
+        tile_a.rotate!(rotation)
+        tile_b.rotate!(rotation)
+
+        text_a = tile_a.preprinted ? '' : '#'
+        text_a += name_a
+        text_a += "-#{rotation}" unless rotations == [0]
+
+        text_b = tile_b.preprinted ? '' : '#'
+        text_b += name_b
+        text_b += "-#{rotation}" unless rotations == [0]
+
+        text = "#{text_a} / #{text_b}"
+        if tile_b.unlimited
+          text += ' × ∞'
+        elsif num
+          text += " × #{num}"
+        end
+
+        hex_a = Engine::Hex.new('A1',
+                                layout: layout,
+                                tile: tile_a)
+        hex_a.x = 0
+        hex_a.y = 0
+
+        hex_b = Engine::Hex.new('A1',
+                                layout: layout,
+                                tile: tile_b)
+        hex_b.x = 0
+        hex_b.y = 0
+
+        h('div.tile__block', props, [
+            *extra_children_a,
+            *extra_children_b,
+            h(:div, { style: { textAlign: 'center', fontSize: '12px' } }, text),
+            h(:svg, { style: { width: '50%', height: '100%' } }, [
+              h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
+                h(
+                  Game::Hex,
+                  hex: hex_a,
+                  role: :tile_page,
+                  unavailable: unavailable,
+                  clickable: clickable,
+                ),
+              ]),
+            ]),
+            h(:svg, { style: { width: '50%', height: '100%' } }, [
+              h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
+                h(
+                  Game::Hex,
+                  hex: hex_b,
+                  role: :tile_page,
+                  unavailable: unavailable,
+                  clickable: clickable,
+                ),
+              ]),
+            ]),
+        ])
+      end
+    end
   end
 end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -74,7 +74,7 @@ module Engine
     class Base
       attr_reader :actions, :bank, :cert_limit, :cities, :companies, :corporations,
                   :depot, :finished, :graph, :hexes, :id, :loading, :loans, :log, :minors,
-                  :phase, :players, :operating_rounds, :round, :share_pool, :stock_market,
+                  :phase, :players, :operating_rounds, :round, :share_pool, :stock_market, :tile_groups,
                   :tiles, :turn, :total_loans, :undo_possible, :redo_possible, :round_history, :all_tiles,
                   :optional_rules, :exception, :last_processed_action, :broken_action
 
@@ -225,8 +225,6 @@ module Engine
       CLOSED_CORP_RESERVATIONS = :removed # remain or removed?
 
       MUST_BUY_TRAIN = :route # When must the company buy a train if it doesn't have one (route, never, always)
-
-      DOUBLE_SIDED_TILES = false # if true, requires @tile_groups to be set
 
       # Default tile lay, one tile either upgrade or lay at zero cost
       # allows multiple lays, value must be either true, false or :not_if_upgraded
@@ -454,6 +452,7 @@ module Engine
         @tiles = init_tiles
         @all_tiles = init_tiles
         optional_tiles
+        @tile_groups = []
         @cert_limit = init_cert_limit
         @removals = []
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -226,6 +226,8 @@ module Engine
 
       MUST_BUY_TRAIN = :route # When must the company buy a train if it doesn't have one (route, never, always)
 
+      DOUBLE_SIDED_TILES = false # if true, requires @tile_groups to be set
+
       # Default tile lay, one tile either upgrade or lay at zero cost
       # allows multiple lays, value must be either true, false or :not_if_upgraded
       TILE_LAYS = [{ lay: true, upgrade: true, cost: 0 }].freeze

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -25,8 +25,6 @@ module Engine
       SELL_BUY_ORDER = :sell_buy
       MARKET_SHARE_LIMIT = 100
 
-      DOUBLE_SIDED_TILES = true
-
       START_PRICES = [60, 60, 65, 65, 70, 70, 75, 75, 80, 80].freeze
       MINOR_STARTING_CASH = 50
 
@@ -136,8 +134,8 @@ module Engine
             tile_a = tile_by_id("#{name_a}-#{idx}")
             tile_b = tile_by_id("#{name_b}-#{idx}")
 
-            tile_a.opposite!(tile_b)
-            tile_b.opposite!(tile_a)
+            tile_a.opposite = tile_b
+            tile_b.opposite = tile_a
           end
         end
       end

--- a/lib/engine/step/g_18_mag/dividend.rb
+++ b/lib/engine/step/g_18_mag/dividend.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../dividend'
+require_relative '../minor_half_pay'
+
+module Engine
+  module Step
+    module G18Mag
+      class Dividend < Dividend
+        include MinorHalfPay
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../track'
+
+module Engine
+  module Step
+    module G18Mag
+      class Track < Track
+        K_HEXES = %w[I1 H23 H27].freeze
+
+        def process_lay_tile(action)
+          old_tile = action.hex.tile
+          super
+          return unless K_HEXES.include?(action.hex.coordinates)
+
+          # Handle special upgrade rules from K hexes
+          action.tile.label = 'K' if action.tile.color == 'yellow'
+          old_tile.label = nil if old_tile.color == 'yellow'
+        end
+
+        def update_tile_lists(tile, old_tile)
+          @game.add_extra_tile(tile) if tile.unlimited # probably not compatible with double-sided tiles
+
+          @game.tiles.delete(tile)
+          if tile.opposite
+            @game.tiles.delete(tile.opposite)
+            @game.unused_tiles << tile.opposite
+          end
+
+          return if old_tile.preprinted
+
+          @game.tiles << old_tile
+          return unless old_tile.opposite
+
+          @game.unused_tiles.delete(old_tile.opposite)
+          @game.tiles << old_tile.opposite
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -66,10 +66,7 @@ module Engine
           raise GameError, "#{old_tile.name} is not legally rotated for #{tile.name}"
         end
 
-        @game.add_extra_tile(tile) if tile.unlimited
-
-        @game.tiles.delete(tile)
-        @game.tiles << old_tile unless old_tile.preprinted
+        update_tile_lists(tile, old_tile)
 
         hex.lay(tile)
 
@@ -155,6 +152,13 @@ module Engine
               " for the #{ability.terrain} tile built by #{company.name}"
           end
         end
+      end
+
+      def update_tile_lists(tile, old_tile)
+        @game.add_extra_tile(tile) if tile.unlimited
+
+        @game.tiles.delete(tile)
+        @game.tiles << old_tile unless old_tile.preprinted
       end
 
       def border_cost(tile, entity)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -17,7 +17,7 @@ module Engine
     attr_accessor :hex, :icons, :index, :legal_rotations, :location_name, :name, :reservations, :upgrades
     attr_reader :blocks_lay, :borders, :cities, :color, :edges, :junction, :nodes, :label,
                 :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
-                :city_towns, :unlimited, :stubs, :partitions, :id, :frame
+                :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :opposite
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -190,6 +190,7 @@ module Engine
       @blocks_lay = nil
       @reservation_blocks = opts[:reservation_blocks] || false
       @unlimited = opts[:unlimited] || false
+      @opposite = nil
       @id = "#{@name}-#{@index}"
 
       separate_parts
@@ -241,6 +242,10 @@ module Engine
 
     def terrain
       @upgrades.flat_map(&:terrains).uniq
+    end
+
+    def opposite!(tile)
+      @opposite = tile
     end
 
     # if tile has more than one intra-tile paths, connections using those paths

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -14,10 +14,10 @@ module Engine
   class Tile
     include Config::Tile
 
-    attr_accessor :hex, :icons, :index, :legal_rotations, :location_name, :name, :reservations, :upgrades
+    attr_accessor :hex, :icons, :index, :legal_rotations, :location_name, :name, :opposite, :reservations, :upgrades
     attr_reader :blocks_lay, :borders, :cities, :color, :edges, :junction, :nodes, :label,
                 :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
-                :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :opposite
+                :city_towns, :unlimited, :stubs, :partitions, :id, :frame
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -242,10 +242,6 @@ module Engine
 
     def terrain
       @upgrades.flat_map(&:terrains).uniq
-    end
-
-    def opposite!(tile)
-      @opposite = tile
     end
 
     # if tile has more than one intra-tile paths, connections using those paths


### PR DESCRIPTION
- Double-sided tiles, which is basically pairing up certain tiles. When one is used the other is put on a separate list.
- Support for laying plain yellow track on K-hexes.

Common file changes:
UI::tile_manifest, UI::tiles - support for double-sided manifest
Game::base - DOUBLE_SIDED_TILE flag
Step::tracker - broke tile list updates out to allow overriding
Engine::tile - added "opposite" method and instance var

![18Mag_Manifest](https://user-images.githubusercontent.com/8494213/103842420-22b92a00-5053-11eb-9ab9-73ecb46f4381.png)
