### PR TITLE
Enforce sale timing restrictions during ebuy

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -753,6 +753,21 @@ module Engine
         value
       end
 
+      def check_sale_timing(entity, corporation)
+        case self.class::SELL_AFTER
+        when :first
+          @turn > 1 || @round.operating?
+        when :operate
+          corporation.operated?
+        when :p_any_operate
+          corporation.operated? || corporation.president?(entity)
+        when :any_time
+          true
+        else
+          raise NotImplementedError
+        end
+      end
+
       def value_for_sellable(player, corporation)
         max_bundle = sellable_bundles(player, corporation).max_by(&:price)
         max_bundle&.price || 0

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -95,19 +95,7 @@ module Engine
 
         corporation = bundle.corporation
 
-        timing =
-          case @game.class::SELL_AFTER
-          when :first
-            @game.turn > 1
-          when :operate
-            corporation.operated?
-          when :p_any_operate
-            corporation.operated? || corporation.president?(entity)
-          when :any_time
-            true
-          else
-            raise NotImplementedError
-          end
+        timing = @game.check_sale_timing(entity, corporation)
 
         timing &&
           !(@game.class::MUST_SELL_IN_BLOCKS && @round.players_sold[entity][corporation] == :now) &&

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -15,7 +15,8 @@ module Engine
         @round.recalculate_order if @round.respond_to?(:recalculate_order)
       end
 
-      def can_sell?(_entity, bundle)
+      def can_sell?(entity, bundle)
+        return false unless @game.check_sale_timing(entity, bundle.corporation)
         return false unless sellable_bundle?(bundle)
         return true if @game.class::EBUY_SELL_MORE_THAN_NEEDED
 


### PR DESCRIPTION
Previously timing restrictions were not respected during emergency
fundraising. This will likely break a bunch of games.