### PR TITLE
1824: Emergency buy

### DIFF
--- a/assets/app/view/game/loans.rb
+++ b/assets/app/view/game/loans.rb
@@ -17,7 +17,7 @@ module View
           children << h(
             :button,
             { on: { click: lambda do
-              process_action(Engine::Action::TakeLoan.new(@corporation, loan: @game.loans[0]))
+              process_action(Engine::Action::TakeLoan.new(@corporation, loan: @game.head_loan))
             end } },
             'Take Loan',
           )

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -160,7 +160,7 @@ module View
           take_loan = lambda do
             process_action(Engine::Action::TakeLoan.new(
               corporation,
-              loan: @game.loans[0],
+              loan: @game.head_loan,
             ))
           end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1515,6 +1515,10 @@ module Engine
         0
       end
 
+      def head_loan
+        @loans.first
+      end
+
       def corporation_opts
         {}
       end

--- a/lib/engine/game/interest_on_loans.rb
+++ b/lib/engine/game/interest_on_loans.rb
@@ -9,7 +9,7 @@ module InterestOnLoans
     owed = interest_owed(entity)
 
     while owed > entity.cash &&
-        (loan = loans[0]) &&
+        (loan = head_loan) &&
         entity.loans.size < maximum_loans(entity)
       take_loan(entity, loan)
       owed = interest_owed(entity)

--- a/lib/engine/step/g_1824/buy_train.rb
+++ b/lib/engine/step/g_1824/buy_train.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../buy_train'
+
+module Engine
+  module Step
+    module G1824
+      class BuyTrain < BuyTrain
+        def process_buy_train(action)
+          entity = action.entity
+          price = action.price
+          train = action.train
+          previous_owner = train.owner
+          emergency = @game.emergency(entity)
+
+          super
+
+          return if !emergency || !previous_owner.player? || previous_owner == entity.player
+
+          raise GameError, 'Emergency buy of train from other player cannot exceed face value' if price > train.price
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1824/loan.rb
+++ b/lib/engine/step/g_1824/loan.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G1824
+      class Loan < Base
+        def actions(entity)
+          return [] if !entity.corporation? ||
+            entity != current_entity ||
+            !@game.emergency?(entity) ||
+            !@game.head_loan.positive?
+
+          ['take_loan']
+        end
+
+        def description
+          'Take Loan'
+        end
+
+        def process_take_loan(action)
+          entity = action.entity
+          @game.take_loan(entity, action.loan)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some special things for 1824 emergency buy
- A player cannot go bankrupt - if needed a player can take a loan
  with 50% direct interest, and 50% of current debt after each SR
- A player can take the loan during emergency buy even though
  still owning sellable shares
- If emergency buy, if buying train from other player's corporation
  the price cannot exceed face value of train bought
- Presidency change not allowed during emergency buy

This code has not been tested in action. That will have to
wait until more functionality has been implemented - so therefor
it is a draft commit.