### PR TITLE
18SJ: Remove incorrect short cut (fixes #3126)

### DIFF
--- a/lib/engine/game/g_18_sj.rb
+++ b/lib/engine/game/g_18_sj.rb
@@ -436,12 +436,6 @@ module Engine
         end
       end
 
-      def check_connected(route, token)
-        return if route.train.name == 'E'
-
-        super
-      end
-
       private
 
       def check_second_lay(action)


### PR DESCRIPTION
This shortcut made E train pass through blocked cities.