### PR TITLE
Two bug fixes for 1817

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -166,6 +166,7 @@ module Engine
 
       # when can a share holder sell shares
       # first           -- after first stock round
+      # after_ipo       -- after stock round in which company is opened
       # operate         -- after operation
       # p_any_operate   -- pres any time, share holders after operation
       # any_time        -- at any time
@@ -778,6 +779,8 @@ module Engine
         case self.class::SELL_AFTER
         when :first
           @turn > 1 || @round.operating?
+        when :after_ipo
+          corporation.operated? || @round.operating?
         when :operate
           corporation.operated?
         when :p_any_operate

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -48,7 +48,7 @@ module Engine
       POOL_SHARE_DROP = :each
       SELL_MOVEMENT = :none
       ALL_COMPANIES_ASSIGNABLE = true
-      SELL_AFTER = :operate
+      SELL_AFTER = :after_ipo
       DEV_STAGE = :production
       OBSOLETE_TRAINS_COUNT_FOR_LIMIT = true
 

--- a/lib/engine/round/g_1817/stock.rb
+++ b/lib/engine/round/g_1817/stock.rb
@@ -26,7 +26,7 @@ module Engine
 
         def sold_out_stock_movement(corp)
           @game.stock_market.move_up(corp)
-          @game.stock_market.move_up(corp) if @game.option_short_squeeze?
+          @game.stock_market.move_up(corp) if @game.option_short_squeeze? && corp.player_share_holders.values.sum > 100
         end
 
         def sold_out?(corporation)


### PR DESCRIPTION
Fixes short squeeze to only jump a second time if player ownership
exceeds 100%. Also changes corp share sale timing restriction to be
not-in-stock-round-floated rather than after-operation.

Fixes #3012