### PR TITLE
18SJ: Redesign main line tile lay/upgrade checks (fixes #3143)

### DIFF
--- a/lib/engine/step/g_18_sj/track.rb
+++ b/lib/engine/step/g_18_sj/track.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../track'
+
+module Engine
+  module Step
+    module G18SJ
+      class Track < Track
+        def setup
+          super
+
+          @main_line_improvement = nil
+          @tile_lays = 0
+        end
+
+        def process_lay_tile(action)
+          super
+          return if action.entity.company?
+
+          improvement = @game.main_line_improvement(action)
+          @main_line_improvement = improvement if improvement
+          return if (@tile_lays += 1) == 1
+
+          raise GameError, 'Second tile lay or upgrade only allowed ' \
+            'if first or second improves main lines!' unless @main_line_improvement
+
+          @log << "#{action.entity.name} did get the 2nd tile lay/upgrade due to a main line upgrade"
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/18SJ/19.json
+++ b/spec/fixtures/18SJ/19.json
@@ -1,0 +1,9128 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 1,
+      "company": "SB",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 2,
+      "company": "KHJ",
+      "price": 145
+    },
+    {
+      "type": "bid",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 3,
+      "company": "KHJ",
+      "price": 150
+    },
+    {
+      "type": "bid",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 4,
+      "company": "NOHAB",
+      "price": 95
+    },
+    {
+      "type": "bid",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 5,
+      "company": "GC",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 6,
+      "company": "FRY",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 7,
+      "company": "KHJ",
+      "price": 155
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 8
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 9
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 10
+    },
+    {
+      "type": "bid",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 11,
+      "company": "NE",
+      "price": 220
+    },
+    {
+      "type": "par",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 12,
+      "corporation": "MÖJ",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "choose",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 13,
+      "choice": "wait"
+    },
+    {
+      "type": "par",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 14,
+      "corporation": "ÖSJ",
+      "share_price": "71,4,6"
+    },
+    {
+      "type": "par",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 15,
+      "corporation": "UGJ",
+      "share_price": "71,4,6"
+    },
+    {
+      "type": "par",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 16,
+      "corporation": "BJ",
+      "share_price": "67,5,6"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 17,
+      "shares": [
+        "ÖSJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 18,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 19,
+      "shares": [
+        "BJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 20,
+      "user": 7,
+      "shares": [
+        "ÖSJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 21,
+      "user": 7,
+      "shares": [
+        "UGJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 22,
+      "shares": [
+        "BJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 23,
+      "user": 7,
+      "shares": [
+        "ÖSJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 24,
+      "user": 7,
+      "shares": [
+        "UGJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 25,
+      "shares": [
+        "BJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 26,
+      "user": 7,
+      "shares": [
+        "ÖSJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 27,
+      "user": 7,
+      "shares": [
+        "UGJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 28,
+      "shares": [
+        "BJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 29,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 30
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 31,
+      "shares": [
+        "ÖSJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 32,
+      "shares": [
+        "BJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 33
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 34,
+      "shares": [
+        "UGJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 35
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 36
+    },
+    {
+      "id": 37,
+      "hex": "D13",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 4,
+      "entity_type": "minor",
+      "user": 6,
+      "created_at": 1609230455
+    },
+    {
+      "id": 38,
+      "type": "undo",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "user": 6,
+      "created_at": 1609230908
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 39,
+      "hex": "D13",
+      "tile": "8-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 40,
+      "user": 19,
+      "hex": "E12",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 41,
+      "user": 19,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "D15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 42,
+      "hex": "B3",
+      "tile": "7-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 43
+    },
+    {
+      "type": "place_token",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 44,
+      "city": "A2-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 45,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 46,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 47
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 48,
+      "hex": "F13",
+      "tile": "57-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 49,
+      "hex": "G12",
+      "tile": "8-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 50,
+      "city": "G10-0-3",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 51,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 52,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 53
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 54,
+      "hex": "B11",
+      "tile": "57-2",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 55,
+      "hex": "C12",
+      "tile": "6-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 56
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 57,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 58,
+      "train": "2-6",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 59,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 61,
+      "company": "FRY",
+      "price": 40
+    },
+    {
+      "type": "choose",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 62,
+      "choice": "wait"
+    },
+    {
+      "id": 63,
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609231999
+    },
+    {
+      "id": 64,
+      "type": "undo",
+      "entity": 6,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609232006
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 65
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 66,
+      "shares": [
+        "ÖSJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 67
+    },
+    {
+      "id": 68,
+      "type": "buy_shares",
+      "entity": 7,
+      "shares": [
+        "UGJ_7"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609232478
+    },
+    {
+      "id": 69,
+      "type": "sell_shares",
+      "entity": 7,
+      "shares": [
+        "UGJ_6",
+        "UGJ_7"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609232481
+    },
+    {
+      "id": 70,
+      "type": "sell_shares",
+      "entity": 7,
+      "shares": [
+        "BJ_1",
+        "BJ_2",
+        "BJ_3",
+        "BJ_4"
+      ],
+      "percent": 40,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609232502
+    },
+    {
+      "id": 71,
+      "type": "undo",
+      "entity": 7,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609232564
+    },
+    {
+      "id": 72,
+      "type": "undo",
+      "entity": 7,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609232567
+    },
+    {
+      "id": 73,
+      "type": "undo",
+      "entity": 7,
+      "entity_type": "player",
+      "user": 7,
+      "created_at": 1609232573
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 74,
+      "shares": [
+        "UGJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 75,
+      "shares": [
+        "BJ_1",
+        "BJ_2",
+        "BJ_3",
+        "BJ_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 76,
+      "corporation": "ÖKJ",
+      "share_price": "67,5,6"
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 77
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 78,
+      "shares": [
+        "BJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 79
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 80,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 81
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 82,
+      "shares": [
+        "BJ_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 83,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 84
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 85,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 86,
+      "shares": [
+        "BJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 87,
+      "shares": [
+        "BJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 88,
+      "shares": [
+        "BJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 89,
+      "shares": [
+        "BJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "id": 90,
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "user": 19,
+      "created_at": 1609234623
+    },
+    {
+      "id": 91,
+      "type": "undo",
+      "entity": 6,
+      "entity_type": "player",
+      "user": 19,
+      "created_at": 1609234660
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 92,
+      "shares": [
+        "BJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 93
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 94,
+      "shares": [
+        "BJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 95
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 96,
+      "user": 6,
+      "shares": [
+        "ÖKJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 97,
+      "user": 6
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 98
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 99
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 100,
+      "user": 6,
+      "shares": [
+        "ÖKJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 101,
+      "user": 6
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 102,
+      "user": 6
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 103
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 104,
+      "user": 6,
+      "shares": [
+        "ÖKJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 105,
+      "user": 6
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 106,
+      "user": 6
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 107
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 108,
+      "user": 6
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 109,
+      "hex": "E12",
+      "tile": "14-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 110
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 111,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "D15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 112,
+      "hex": "C12",
+      "tile": "15-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 113,
+      "hex": "D13",
+      "tile": "25-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 114,
+      "city": "14-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 115,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 116,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 117
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 118,
+      "hex": "A4",
+      "tile": "8-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 119,
+      "hex": "B5",
+      "tile": "5-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_company",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 120,
+      "company": "SB",
+      "price": 90
+    },
+    {
+      "type": "assign",
+      "entity": "SB",
+      "entity_type": "company",
+      "id": 121,
+      "target": "C2",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 122
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 123,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 124,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 125,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 126
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 127
+    },
+    {
+      "id": 128,
+      "type": "buy_shares",
+      "entity": "UGJ",
+      "shares": [
+        "UGJ_6"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 67,
+      "user": 6,
+      "created_at": 1609240579
+    },
+    {
+      "id": 129,
+      "hex": "F13",
+      "tile": "619-0",
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609240622
+    },
+    {
+      "id": 130,
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609240663
+    },
+    {
+      "id": 131,
+      "hex": "G10",
+      "tile": "298SJ-0",
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609240672
+    },
+    {
+      "id": 132,
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609240757
+    },
+    {
+      "id": 133,
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609240784
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 134
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 135,
+      "hex": "F13",
+      "tile": "619-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 136,
+      "hex": "E14",
+      "tile": "8-3",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 137,
+      "city": "15-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 138,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "F13",
+              "E12"
+            ]
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "C12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 139,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 140,
+      "train": "3-4",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 141
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 142
+    },
+    {
+      "id": 143,
+      "hex": "A12",
+      "tile": "9-0",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241143
+    },
+    {
+      "id": 144,
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241147
+    },
+    {
+      "id": 145,
+      "city": "57-2-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241148
+    },
+    {
+      "id": 146,
+      "type": "run_routes",
+      "entity": "BJ",
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C12",
+              "B11"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241184
+    },
+    {
+      "id": 147,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241221
+    },
+    {
+      "id": 148,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241245
+    },
+    {
+      "id": 149,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241246
+    },
+    {
+      "id": 150,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241248
+    },
+    {
+      "id": 151,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241250
+    },
+    {
+      "id": 152,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241252
+    },
+    {
+      "id": 153,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241257
+    },
+    {
+      "id": 154,
+      "type": "redo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241261
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 155,
+      "hex": "B9",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 156
+    },
+    {
+      "id": 157,
+      "city": "57-2-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241279
+    },
+    {
+      "id": 158,
+      "type": "run_routes",
+      "entity": "BJ",
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C12",
+              "B11"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241291
+    },
+    {
+      "id": 159,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241296
+    },
+    {
+      "id": 160,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241318
+    },
+    {
+      "id": 161,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241325
+    },
+    {
+      "id": 162,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241327
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 163
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 164,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "C12",
+              "B11"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 165,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241338
+    },
+    {
+      "id": 166,
+      "type": "buy_company",
+      "price": 59,
+      "entity": "BJ",
+      "company": "NOHAB",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241355
+    },
+    {
+      "id": 167,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241393
+    },
+    {
+      "id": 168,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609241394
+    },
+    {
+      "type": "buy_company",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 169,
+      "company": "NOHAB",
+      "price": 59,
+      "created_at": 1609241395
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 170,
+      "kind": "withhold",
+      "created_at": 1609241396
+    },
+    {
+      "type": "buy_train",
+      "entity": "NOHAB",
+      "entity_type": "company",
+      "id": 171,
+      "train": "4-0",
+      "price": 150,
+      "variant": "4",
+      "created_at": 1609241397
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 176,
+      "hex": "E16",
+      "tile": "7-1",
+      "rotation": 1,
+      "created_at": 1609241398
+    },
+    {
+      "type": "pass",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 177,
+      "created_at": 1609241399
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 178,
+      "hex": "B5",
+      "tile": "15-1",
+      "rotation": 2,
+      "created_at": 1609241400
+    },
+    {
+      "id": 179,
+      "hex": "C4",
+      "tile": "8-5",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609320649
+    },
+    {
+      "id": 180,
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609320665
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 181,
+      "hex": "B7",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "assign",
+      "entity": "SB",
+      "entity_type": "company",
+      "id": 182,
+      "target": "A6",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 183
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 184,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 185,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 186
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 187
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 188
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 189,
+      "hex": "G10",
+      "tile": "298SJ-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 190,
+      "hex": "E16",
+      "tile": "27-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 191,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 192,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 193
+    },
+    {
+      "type": "buy_company",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 194,
+      "company": "KHJ",
+      "price": 132
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 196,
+      "hex": "B11",
+      "tile": "14-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 197
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 198,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "B11",
+              "A10"
+            ],
+            [
+              "B11",
+              "C12"
+            ]
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 199,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 200
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 201
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 202,
+      "hex": "B7",
+      "tile": "23-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 203
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 204,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "B5",
+              "A4",
+              "A2"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 205,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 206
+    },
+    {
+      "type": "choose",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 207,
+      "choice": "wait"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 208,
+      "shares": [
+        "ÖSJ_1",
+        "ÖSJ_2",
+        "ÖSJ_3",
+        "ÖSJ_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 209,
+      "corporation": "SWB",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 210
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 211,
+      "shares": [
+        "ÖSJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "id": 212,
+      "type": "sell_shares",
+      "entity": 6,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "user": 6,
+      "created_at": 1609327602
+    },
+    {
+      "id": 213,
+      "type": "undo",
+      "entity": 6,
+      "entity_type": "player",
+      "user": 6,
+      "created_at": 1609328231
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 214,
+      "shares": [
+        "UGJ_1",
+        "UGJ_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 215,
+      "corporation": "SNJ",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 216
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 217,
+      "shares": [
+        "UGJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 218
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 219,
+      "shares": [
+        "SWB_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 220
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 221,
+      "shares": [
+        "SNJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 222
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 223,
+      "shares": [
+        "ÖSJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 224
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 225,
+      "shares": [
+        "SWB_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 226
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 227,
+      "shares": [
+        "SNJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 228
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 229,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 230
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 231,
+      "shares": [
+        "SWB_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 232,
+      "user": 6
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 233,
+      "shares": [
+        "SNJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 234
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 235,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 236
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 237,
+      "shares": [
+        "SWB_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 238
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 239,
+      "shares": [
+        "SNJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 240
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 241
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 242,
+      "shares": [
+        "ÖSJ_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 243,
+      "shares": [
+        "UGJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 244
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 245,
+      "shares": [
+        "UGJ_3",
+        "UGJ_4",
+        "UGJ_0"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 246,
+      "shares": [
+        "ÖKJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 247
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 248
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 249,
+      "shares": [
+        "SNJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 250
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 251,
+      "shares": [
+        "ÖKJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 252
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 253,
+      "user": 6
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 254,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 255
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 256,
+      "shares": [
+        "ÖKJ_5",
+        "ÖKJ_6"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 257,
+      "shares": [
+        "SNJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 258,
+      "shares": [
+        "MÖJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 259
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 260
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 261
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 262,
+      "shares": [
+        "MÖJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 263
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 264
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 265
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 266,
+      "shares": [
+        "MÖJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 267
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 268
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 269
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 270,
+      "shares": [
+        "MÖJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 271
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 272,
+      "shares": [
+        "MÖJ_1",
+        "MÖJ_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 273,
+      "shares": [
+        "ÖSJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 274
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 275
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 276
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 277,
+      "shares": [
+        "ÖSJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 278
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 279
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 280
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 281
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 282,
+      "hex": "F11",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 283,
+      "hex": "D15",
+      "tile": "619-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 284,
+      "city": "14-0-0",
+      "slot": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 285,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 286
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 287
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 288
+    },
+    {
+      "type": "buy_company",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 289,
+      "company": "GC",
+      "price": 140
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GC",
+      "entity_type": "company",
+      "id": 290,
+      "hex": "F27",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GC",
+      "entity_type": "company",
+      "id": 291,
+      "hex": "E28",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 292,
+      "hex": "D29",
+      "tile": "57-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 293,
+      "hex": "F25",
+      "tile": "9-4",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 294
+    },
+    {
+      "type": "buy_train",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 295,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 296
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 297
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 298,
+      "hex": "E8",
+      "tile": "57-4",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 299,
+      "hex": "D7",
+      "tile": "9-5",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 300,
+      "train": "4-3",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 301
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 302
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 303,
+      "hex": "C2",
+      "tile": "440-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 304
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 305
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 306,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 307,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 308,
+      "train": "5-0",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 309,
+      "hex": "G10",
+      "tile": "299SJ-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 310
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 311,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 312,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609353694
+    },
+    {
+      "id": 313,
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609353739
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 314,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 315,
+      "train": "3-1",
+      "price": 170
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 316
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 317,
+      "hex": "E12",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 318
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 319,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 320,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 321,
+      "train": "5-1",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 322,
+      "hex": "B5",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 323
+    },
+    {
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 324,
+      "city": "63-1-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 325,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "B5",
+              "A4",
+              "A2"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 326,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 327,
+      "hex": "E14",
+      "tile": "24-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 328,
+      "hex": "E18",
+      "tile": "9-6",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 329,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D15",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "H9",
+              "G10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 330,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 331,
+      "train": "3-0",
+      "price": 151
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 332
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 333,
+      "hex": "C30",
+      "tile": "9-7",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 334,
+      "hex": "E24",
+      "tile": "8-5",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 335,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 336,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 337
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 338
+    },
+    {
+      "id": 339,
+      "hex": "C6",
+      "tile": "9-8",
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355302
+    },
+    {
+      "id": 340,
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355367
+    },
+    {
+      "id": 341,
+      "city": "63-1-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355375
+    },
+    {
+      "id": 342,
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355393
+    },
+    {
+      "id": 343,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355395
+    },
+    {
+      "id": 344,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355401
+    },
+    {
+      "id": 345,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355405
+    },
+    {
+      "id": 346,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355410
+    },
+    {
+      "id": 347,
+      "city": "63-1-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355470
+    },
+    {
+      "id": 348,
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609355497
+    },
+    {
+      "id": 349,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402244
+    },
+    {
+      "id": 350,
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402369
+    },
+    {
+      "id": 351,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402371
+    },
+    {
+      "id": 352,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402564
+    },
+    {
+      "id": 353,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402569
+    },
+    {
+      "id": 354,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402579
+    },
+    {
+      "id": 355,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402594
+    },
+    {
+      "id": 356,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609402599
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 357,
+      "hex": "C6",
+      "tile": "9-8",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 358,
+      "hex": "B7",
+      "tile": "47-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 359,
+      "city": "63-1-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 360,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 361,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 362
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 363,
+      "hex": "D13",
+      "tile": "40-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 364,
+      "hex": "E20",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 365,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "E12",
+              "F13"
+            ],
+            [
+              "D15",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 366,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 367,
+      "hex": "C4",
+      "tile": "8-6",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 368
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 369,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "D5",
+              "C4",
+              "C2"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 370,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 371,
+      "hex": "F13",
+      "tile": "611-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 372,
+      "hex": "E22",
+      "tile": "9-9",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 373,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "F13",
+              "G12",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "D15"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "D15"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 374,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 375,
+      "hex": "C4",
+      "tile": "25-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 376
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 377
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 378,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ],
+            [
+              "C2",
+              "C4",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 379,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 380,
+      "train": "5-2",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "choose",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 381,
+      "choice": "activate"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 382,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 383,
+      "corporation": "TGOJ",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 384
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 385,
+      "shares": [
+        "BJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 386,
+      "shares": [
+        "ÖKJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 387
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 388,
+      "shares": [
+        "ÖKJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 389
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 390,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 391
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 392,
+      "shares": [
+        "ÖKJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 393
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 394,
+      "shares": [
+        "MÖJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 395
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 396,
+      "shares": [
+        "TGOJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 397
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 398,
+      "shares": [
+        "ÖSJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 399
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 400,
+      "shares": [
+        "BJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 401
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 402,
+      "shares": [
+        "TGOJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 403
+    },
+    {
+      "type": "message",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 404,
+      "message": "Gott nytt tågår!"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 405,
+      "shares": [
+        "ÖSJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 406
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 407,
+      "shares": [
+        "MÖJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 408
+    },
+    {
+      "type": "message",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 409,
+      "message": "Gott nytt tågår!"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 410,
+      "shares": [
+        "TGOJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 411
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 412,
+      "shares": [
+        "ÖSJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 413
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 415
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 416,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 417,
+      "shares": [
+        "ÖSJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 418
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 419
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 420,
+      "shares": [
+        "SNJ_2",
+        "SNJ_3",
+        "SNJ_4"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 421,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 422
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 423
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 424,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 425,
+      "shares": [
+        "ÖSJ_2",
+        "ÖSJ_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 426,
+      "corporation": "KFJ",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 427
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 428,
+      "shares": [
+        "TGOJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 429,
+      "shares": [
+        "TGOJ_5",
+        "TGOJ_6"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 430
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 431,
+      "shares": [
+        "BJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 432,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 433,
+      "corporation": "STJ",
+      "share_price": "67,5,6"
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 434
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 435
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 436,
+      "shares": [
+        "BJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 437
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 438
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 439
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 440,
+      "shares": [
+        "KFJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 441
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 442
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 443,
+      "shares": [
+        "KFJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 444
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 445,
+      "shares": [
+        "KFJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 446
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 447
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 448,
+      "shares": [
+        "SWB_1",
+        "SWB_2",
+        "SWB_3",
+        "SWB_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 449,
+      "shares": [
+        "STJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 450
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 451,
+      "shares": [
+        "KFJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 452
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 453
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 454,
+      "shares": [
+        "KFJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 455
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 456,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 458
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 459
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 460,
+      "shares": [
+        "KFJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 461
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 462,
+      "shares": [
+        "KFJ_1",
+        "KFJ_3",
+        "KFJ_4"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 463,
+      "shares": [
+        "SWB_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 464
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 465
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 466,
+      "shares": [
+        "STJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 467
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 468,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 469
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 470
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 471,
+      "shares": [
+        "STJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 472
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 473,
+      "shares": [
+        "SWB_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 474
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 475
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 476,
+      "shares": [
+        "SWB_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 477,
+      "shares": [
+        "STJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 478
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 479,
+      "shares": [
+        "SWB_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 480
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 481,
+      "shares": [
+        "STJ_1",
+        "STJ_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 482,
+      "shares": [
+        "SNJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 483
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 484,
+      "shares": [
+        "KFJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 485
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 487
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 488,
+      "shares": [
+        "SNJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 489,
+      "shares": [
+        "SNJ_1",
+        "SNJ_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 490
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 491
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 494
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 495,
+      "shares": [
+        "SWB_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 496
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+	"id": 497,
+	"shares": [
+	  "KFJ_6"
+	],
+	"percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 497.2
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 502,
+      "shares": [
+        "BJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 504
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 505
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 506
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 507
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 508
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 509,
+      "hex": "C2",
+      "tile": "466-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 510
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 511,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ],
+            [
+              "C2",
+              "C4",
+              "B5"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 512,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 513,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 514,
+      "hex": "E20",
+      "tile": "619-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 515
+    },
+    {
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 516,
+      "city": "G26-0-0",
+      "slot": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 517,
+      "train": "6-1",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "id": 518,
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609574627
+    },
+    {
+      "id": 519,
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609574959
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 520
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 521
+    },
+    {
+      "id": 522,
+      "hex": "E12",
+      "tile": "172-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580150
+    },
+    {
+      "id": 523,
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580155
+    },
+    {
+      "id": 524,
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580182
+    },
+    {
+      "id": 525,
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580196
+    },
+    {
+      "id": 526,
+      "hex": "E18",
+      "tile": "24-1",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580214
+    },
+    {
+      "id": 527,
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580218
+    },
+    {
+      "id": 528,
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580249
+    },
+    {
+      "id": 529,
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580252
+    },
+    {
+      "id": 530,
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580279
+    },
+    {
+      "id": 531,
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609580284
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 532,
+      "hex": "E12",
+      "tile": "172-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 533
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 534,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "E12",
+              "F13"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "H9",
+              "G10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 535,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 536
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 537,
+      "hex": "C16",
+      "tile": "5-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 538
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 539,
+      "train": "4-0",
+      "price": 999
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 540
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 541,
+      "hex": "C6",
+      "tile": "19-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 542
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 543,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B5",
+              "B7",
+              "C8"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 544,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 545
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 546
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 547,
+      "hex": "G10",
+      "tile": "131-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 548
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 549,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 550,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 551
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 552
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 553,
+      "hex": "E20",
+      "tile": "611-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 554
+    },
+    {
+      "type": "place_token",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 555,
+      "city": "611-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 556,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 557,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 558,
+      "train": "4-1",
+      "price": 48
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 559,
+      "hex": "D19",
+      "tile": "15-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 560
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 561
+    },
+    {
+      "id": 562,
+      "type": "buy_train",
+      "price": 421,
+      "train": "5-2",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582663
+    },
+    {
+      "id": 563,
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582708
+    },
+    {
+      "id": 564,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582732
+    },
+    {
+      "id": 565,
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582739
+    },
+    {
+      "id": 566,
+      "type": "buy_train",
+      "price": 471,
+      "train": "5-2",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582764
+    },
+    {
+      "id": 567,
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582775
+    },
+    {
+      "id": 568,
+      "type": "buy_shares",
+      "entity": "BJ",
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 40,
+      "user": 19,
+      "created_at": 1609582777
+    },
+    {
+      "id": 569,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582790
+    },
+    {
+      "id": 570,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582795
+    },
+    {
+      "id": 571,
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582800
+    },
+    {
+      "id": 572,
+      "type": "buy_train",
+      "price": 190,
+      "train": "5-2",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582968
+    },
+    {
+      "id": 573,
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582971
+    },
+    {
+      "id": 574,
+      "type": "buy_shares",
+      "entity": "BJ",
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 40,
+      "user": 19,
+      "created_at": 1609582972
+    },
+    {
+      "id": 575,
+      "hex": "B9",
+      "tile": "25-0",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609582991
+    },
+    {
+      "id": 576,
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609583025
+    },
+    {
+      "id": 577,
+      "city": "466-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609583054
+    },
+    {
+      "id": 578,
+      "type": "buy_train",
+      "price": 40,
+      "train": "4-0",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609583078
+    },
+    {
+      "id": 579,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586660
+    },
+    {
+      "id": 580,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586664
+    },
+    {
+      "id": 581,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586666
+    },
+    {
+      "id": 582,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586672
+    },
+    {
+      "id": 583,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586676
+    },
+    {
+      "id": 584,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586680
+    },
+    {
+      "id": 585,
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586687
+    },
+    {
+      "id": 586,
+      "type": "buy_train",
+      "price": 160,
+      "train": "5-2",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586693
+    },
+    {
+      "id": 587,
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586696
+    },
+    {
+      "id": 588,
+      "type": "buy_shares",
+      "entity": "BJ",
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 40,
+      "user": 19,
+      "created_at": 1609586713
+    },
+    {
+      "id": 589,
+      "hex": "C8",
+      "tile": "15-3",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586752
+    },
+    {
+      "id": 590,
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586756
+    },
+    {
+      "id": 591,
+      "city": "466-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586760
+    },
+    {
+      "id": 592,
+      "type": "buy_train",
+      "price": 40,
+      "train": "4-0",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609586809
+    },
+    {
+      "id": 593,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587378
+    },
+    {
+      "id": 594,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587381
+    },
+    {
+      "id": 595,
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587384
+    },
+    {
+      "id": 596,
+      "type": "buy_train",
+      "price": 40,
+      "train": "4-0",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587391
+    },
+    {
+      "id": 597,
+      "type": "buy_train",
+      "price": 1000,
+      "train": "D-0",
+      "entity": "BJ",
+      "variant": "E",
+      "exchange": "4-0",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587397
+    },
+    {
+      "id": 598,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587688
+    },
+    {
+      "id": 599,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587691
+    },
+    {
+      "id": 600,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587695
+    },
+    {
+      "id": 601,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587699
+    },
+    {
+      "id": 602,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587702
+    },
+    {
+      "id": 603,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587705
+    },
+    {
+      "id": 604,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587724
+    },
+    {
+      "id": 605,
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587733
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 606,
+      "train": "5-2",
+      "price": 190
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 607
+    },
+    {
+      "type": "buy_shares",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 608,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10,
+      "share_price": 40
+    },
+    {
+      "id": 609,
+      "hex": "C10",
+      "tile": "7-2",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587936
+    },
+    {
+      "id": 610,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609587999
+    },
+    {
+      "id": 611,
+      "hex": "C8",
+      "tile": "15-3",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609588012
+    },
+    {
+      "id": 612,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609588036
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 613,
+      "hex": "C8",
+      "tile": "619-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 614
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 615
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 616,
+      "train": "4-0",
+      "price": 40
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 617,
+      "train": "D-0",
+      "price": 1000,
+      "variant": "E",
+      "exchange": "4-0"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 618
+    },
+    {
+      "id": 619,
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609589411
+    },
+    {
+      "id": 620,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609589562
+    },
+    {
+      "id": 621,
+      "type": "buy_shares",
+      "entity": "MÖJ",
+      "shares": [
+        "MÖJ_1"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 82,
+      "user": 6,
+      "created_at": 1609589566
+    },
+    {
+      "id": 622,
+      "hex": "C6",
+      "tile": "45-0",
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609589661
+    },
+    {
+      "id": 623,
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609589663
+    },
+    {
+      "id": 624,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609589709
+    },
+    {
+      "id": 625,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609589711
+    },
+    {
+      "id": 626,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609589713
+    },
+    {
+      "type": "buy_shares",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 627,
+      "shares": [
+        "MÖJ_1"
+      ],
+      "percent": 10,
+      "share_price": 82
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 628,
+      "hex": "E8",
+      "tile": "15-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 629
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 630,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C8",
+              "B7",
+              "A6"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 631,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 632
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 633,
+      "hex": "F25",
+      "tile": "24-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 634
+    },
+    {
+      "id": 635,
+      "city": "131-0-0",
+      "slot": 3,
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609591209
+    },
+    {
+      "id": 636,
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609591251
+    },
+    {
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 637,
+      "city": "611-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 638,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 639,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 640
+    },
+    {
+      "id": 641,
+      "hex": "D7",
+      "tile": "24-2",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609595010
+    },
+    {
+      "id": 642,
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609595163
+    },
+    {
+      "id": 643,
+      "hex": "D7",
+      "tile": "24-2",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609595212
+    },
+    {
+      "id": 644,
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609595226
+    },
+    {
+      "id": 645,
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609595348
+    },
+    {
+      "id": 646,
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609595360
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 647,
+      "hex": "C10",
+      "tile": "7-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 648
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 649,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C8",
+              "B7",
+              "B5"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 650,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 651
+    },
+    {
+      "type": "buy_shares",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 652,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10,
+      "share_price": 70
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 653,
+      "hex": "F27",
+      "tile": "23-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 654
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 655,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 656,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 657
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 658
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 659,
+      "hex": "E10",
+      "tile": "9-10",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 660
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 661,
+      "train": "D-1",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "id": 662,
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609595683
+    },
+    {
+      "id": 663,
+      "type": "redo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609595692
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 664
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 665
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 666,
+      "hex": "D17",
+      "tile": "9-11",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 667
+    },
+    {
+      "type": "place_token",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 668,
+      "city": "619-1-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 669,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D19",
+              "E20"
+            ],
+            [
+              "D15",
+              "D17",
+              "D19"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 670,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 671
+    },
+    {
+      "type": "buy_shares",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 672,
+      "shares": [
+        "BJ_8"
+      ],
+      "percent": 10,
+      "share_price": 30
+    },
+    {
+      "id": 673,
+      "hex": "C10",
+      "tile": "29-0",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609595953
+    },
+    {
+      "id": 674,
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609596020
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 675,
+      "hex": "C10",
+      "tile": "29-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 676
+    },
+    {
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 677,
+      "city": "466-0-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 678,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "D19",
+              "E20"
+            ],
+            [
+              "D15",
+              "D17",
+              "D19"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "C8",
+              "C10",
+              "B11"
+            ],
+            [
+              "C8",
+              "B7",
+              "B5"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 679,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 680
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 681,
+      "hex": "E10",
+      "tile": "23-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 682
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 683,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "B5"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "C8",
+              "B7",
+              "A6"
+            ],
+            [
+              "C8",
+              "C10",
+              "B11"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 684,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 685
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 686,
+      "hex": "D17",
+      "tile": "23-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 687
+    },
+    {
+      "id": 688,
+      "city": "131-0-0",
+      "slot": 2,
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609603081
+    },
+    {
+      "id": 689,
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609603145
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 690
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 691,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 692,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 693
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 694,
+      "hex": "D7",
+      "tile": "24-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 695
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 696,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C8",
+              "B7",
+              "B5"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 697,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 698
+    },
+    {
+      "type": "buy_shares",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 699,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10,
+      "share_price": 70
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 700,
+      "hex": "C16",
+      "tile": "15-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 701
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 702,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 703,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 704
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 705,
+      "hex": "D21",
+      "tile": "5-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 706
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 707
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 708,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D19",
+              "E20"
+            ],
+            [
+              "D15",
+              "D17",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "E20",
+            "D19",
+            "D15"
+          ],
+          "revenue": 190,
+          "revenue_str": "B31-D29-E20-D19-D15"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 710,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 712
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 715,
+      "hex": "E18",
+      "tile": "18-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 716
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 717,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 718,
+      "kind": "payout"
+    },
+    {
+      "id": 719,
+      "hex": "B15",
+      "tile": "8-7",
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609610366
+    },
+    {
+      "id": 720,
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609610674
+    },
+    {
+      "id": 721,
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609610675
+    },
+    {
+      "id": 722,
+      "type": "redo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609610677
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 723,
+      "hex": "D21",
+      "tile": "14-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 724
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 725
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 726,
+      "train": "5-2",
+      "price": 41
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 732,
+      "hex": "B3",
+      "tile": "21-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 733
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 734,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "D15"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "C8",
+              "C10",
+              "B11"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "B5",
+              "B3",
+              "C2"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 735,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 736,
+      "train": "5-2",
+      "price": 398
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 737,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 738
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 739,
+      "shares": [
+        "BJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 740
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 741,
+      "shares": [
+        "STJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 742
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 743,
+      "shares": [
+        "STJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 744
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 745,
+      "shares": [
+        "SWB_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 746
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 747,
+      "shares": [
+        "SWB_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 748
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 749,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 750
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 751,
+      "shares": [
+        "SWB_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 752
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 753,
+      "shares": [
+        "SWB_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 754
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 755,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 756
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 757,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 758
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 759,
+      "shares": [
+        "TGOJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 760
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 761,
+      "shares": [
+        "MÖJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 762
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 763,
+      "shares": [
+        "TGOJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 764
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 765,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 766
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 767,
+      "shares": [
+        "ÖSJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 768
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 769,
+      "shares": [
+        "TGOJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 770
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 771,
+      "shares": [
+        "ÖSJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 772
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 773,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 774
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 775,
+      "shares": [
+        "STJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 776
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 777,
+      "shares": [
+        "STJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 778
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 779,
+      "shares": [
+        "STJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 780
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 781,
+      "shares": [
+        "MÖJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 782,
+      "shares": [
+        "KFJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 783
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 784,
+      "shares": [
+        "KFJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 785
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 787
+    },
+    {
+      "type": "buy_shares",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 788,
+      "shares": [
+        "MÖJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 789
+    },
+    {
+      "type": "pass",
+      "entity": 6,
+      "entity_type": "player",
+      "id": 790
+    },
+    {
+      "type": "pass",
+      "entity": 7,
+      "entity_type": "player",
+      "id": 791,
+      "user": 6
+    },
+    {
+      "type": "pass",
+      "entity": 19,
+      "entity_type": "player",
+      "id": 792,
+      "user": 6
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 794,
+      "hex": "F9",
+      "tile": "9-12",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 795
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 796,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 797,
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609677170
+    },
+    {
+      "id": 798,
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "user": 6,
+      "created_at": 1609677196
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 799,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 816.8
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 800,
+      "hex": "E20",
+      "tile": "172-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 801
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 802
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 803,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 804,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 805
+    },
+    {
+      "id": 806,
+      "hex": "D19",
+      "tile": "611-1",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609677773
+    },
+    {
+      "id": 807,
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609677780
+    },
+    {
+      "id": 808,
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609677816
+    },
+    {
+      "id": 809,
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609677841
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 810,
+      "hex": "D29",
+      "tile": "619-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 811
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 812,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": 813,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609677880
+    },
+    {
+      "id": 814,
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "user": 7,
+      "created_at": 1609678008
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 815,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 816
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 822,
+      "hex": "E18",
+      "tile": "43-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 823
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 824,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 825,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 825.1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 825.2
+    },
+    {
+      "type": "place_token",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 825.4,
+      "city": "15-3-0",
+      "slot": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 825.6,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "E8",
+              "D7",
+              "D5"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 825.7,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 825.8
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 826,
+      "hex": "E16",
+      "tile": "41-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 827
+    },
+    {
+      "type": "place_token",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 828,
+      "city": "15-1-0",
+      "slot": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 829,
+      "train": "D-2",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 830,
+      "hex": "A12",
+      "tile": "8-7",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 831
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 832,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "D15"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "C8",
+              "C10",
+              "B11"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "B5",
+              "B3",
+              "C2"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 833,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 834,
+      "hex": "D21",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 835
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 835.5
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 836,
+      "train": "5-2",
+      "price": 397
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 836.5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 837,
+      "hex": "B9",
+      "tile": "25-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 838
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 839,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "C8",
+              "B7",
+              "B5"
+            ],
+            [
+              "A10",
+              "B9",
+              "C10",
+              "C8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 840,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 841
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 842,
+      "hex": "D29",
+      "tile": "611-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 843
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 844
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 845,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 846,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 847
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 848
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 849,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 850,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 851
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 852,
+      "hex": "D11",
+      "tile": "5-3",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 853
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 854,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 855,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 856
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 856.5
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 857,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "E8",
+              "D7",
+              "D5"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 858,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 859
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 865,
+      "hex": "B17",
+      "tile": "8-8",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 866
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 866.5,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "E20",
+            "D21",
+            "D19",
+            "C16",
+            "A16"
+          ],
+          "revenue": 290,
+          "revenue_str": "B31-D29-E20-D21-D19-C16-A16"
+        }
+      ]
+    },   
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 868,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 868.2,
+      "hex": "A14",
+      "tile": "9-13",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 868.3
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 868.4,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "D15"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "C8",
+              "C10",
+              "B11"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "B5",
+              "B3",
+              "C2"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 868.4,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 868.5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 869,
+      "hex": "C18",
+      "tile": "9-14",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 870
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 871,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 872,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 873
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 876,
+      "hex": "F9",
+      "tile": "20-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 878
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 879,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "C8",
+              "B7",
+              "B5"
+            ],
+            [
+              "A10",
+              "B9",
+              "C10",
+              "C8"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 890,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 891
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 892
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 893
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 894,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 895,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 896
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 897
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 898,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 899,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 900
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 901,
+      "hex": "E10",
+      "tile": "45-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 902
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 903,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 904,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 904.5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 905
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 906,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "E8",
+              "D7",
+              "D5"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 907,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 908
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 913,
+      "hex": "C20",
+      "tile": "8-9",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 914
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 915,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "D15"
+            ],
+            [
+              "D19",
+              "D17",
+              "D15"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D21",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "B17",
+              "A16"
+            ],
+            [
+              "B11",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 916,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 916.2
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 916.3,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "D15"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "C8",
+              "C10",
+              "B11"
+            ],
+            [
+              "C8",
+              "C6",
+              "D5"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "B5",
+              "B3",
+              "C2"
+            ],
+            [
+              "B5",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7",
+              "A6"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 916.4,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 916.5
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 917
+    },
+    {
+      "id": 918,
+      "type": "run_routes",
+      "entity": "KFJ",
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D21",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ]
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609681816
+    },
+    {
+      "id": 919,
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "user": 19,
+      "created_at": 1609681825
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 920,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D29",
+              "C30",
+              "B31"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "D21",
+              "C20",
+              "C18",
+              "C16"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 921,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 922
+    }
+  ],
+  "id": "hs_jshbsjat_10",
+  "players": [
+    {
+      "id": 19,
+      "name": "Daisys Husse"
+    },
+    {
+      "id": 6,
+      "name": "Adrianos"
+    },
+    {
+      "id": 7,
+      "name": "NilsE"
+    }
+  ],
+  "title": "18SJ",
+  "description": "",
+  "max_players": 3,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 1667713396,
+    "unlisted": false,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "turn": 5,
+  "round": "Operating Round",
+  "acting": [
+    19,
+    6,
+    7
+  ],
+  "result": {
+    "NilsE": 6865,
+    "Adrianos": 6119,
+    "Daisys Husse": 8183
+  },
+  "loaded": true,
+  "created_at": "2021-01-04",
+  "updated_at": 1609681849,
+  "mode": "hotseat"
+}


### PR DESCRIPTION
Simplified main line checks, which should also speed up the game.

By using the icons in the tile hex the information if a hex is
a main line hex can be utilized to make a quicker decision.

For a main line hex, if tile lay/upgrade is a real improvement
we can now remove the icon, meaning the hex wont be checked
for main line improvement in the future.
And by just keeping track of number of improvements in each
main line we will know when a main line is completed.

By using process_tile_lay instead of process_action the code
was much simplified. The 18SJ track step now keeps most of
the knowledge of the tile lays' state.

This will probably break some alpha games as they might include incorrect tile lays. I suppose these games can be deleted as they have illegal actions, but pinned is OK as well.