### PR TITLE
18SJ: Handle priority deal chooser ability as a company (fixes #3144)

### DIFF
--- a/lib/engine/config/game/g_18_sj.rb
+++ b/lib/engine/config/game/g_18_sj.rb
@@ -451,7 +451,7 @@ module Engine
       "name": "Nils Ericson",
       "value": 220,
       "revenue": 25,
-      "desc": "Receive president's share in a corporation randomly determined before auction. Buying player may once during the game take the priority deal at the beginning of one stock round. Cannot be bought by any corporation. Closes when the connected corporation buys its first train. The priority deal overtake remains until it is used, even if this company is closed.",
+      "desc": "Receive president's share in a corporation randomly determined before auction. Buying player may once during the game take the priority deal at the beginning of one stock round (and this ability is not lost even if this private is closed). Cannot be bought by any corporation. Closes when the connected corporation buys its first train.",
       "sym": "NE",
       "abilities": [
         {
@@ -460,6 +460,23 @@ module Engine
         },
         {
            "type":"no_buy"
+        }
+      ]
+    },
+    {
+      "name": "Nils Ericson Första Tjing",
+      "value": 0,
+      "revenue": 0,
+      "desc": "This represents the ability to once during the game take over the priority deal at the beginning of a stock round. Cannot be bought by any corporation. This 'company' remains through the whole game, or until the ability is used.",
+      "sym": "NEFT",
+      "abilities": [
+        {
+           "type":"no_buy"
+        },
+        {
+          "type": "close",
+          "when": "never",
+          "owner_type": "player"
         }
       ]
     },

--- a/lib/engine/step/g_18_sj/choose_priority.rb
+++ b/lib/engine/step/g_18_sj/choose_priority.rb
@@ -48,7 +48,7 @@ module Engine
         def help
           return super unless choice_available?(chooser)
 
-          "Do you want to activate the ability of #{@game.nils_ericsson.name} to become priority dealer?"
+          "Do you want to use the one-time ability of #{@game.priority_deal_chooser.name} to become priority dealer?"
         end
 
         def active?
@@ -66,13 +66,14 @@ module Engine
         def process_choose(action)
           @round.choice_done = true
           if action.choice == 'wait'
-            @log << "#{chooser.name} declines to use the #{@game.nils_ericsson.name} ability for now"
+            @log << "#{chooser.name} declines to use the #{@game.priority_deal_chooser.name} ability for now"
             return
           end
 
-          @log << "#{chooser.name} becomes the new priority dealer by using #{@game.nils_ericsson.name} ability"
+          @log << "#{chooser.name} becomes the new priority dealer by using the "\
+            "#{@game.priority_deal_chooser.name} ability"
           @round.goto_entity!(chooser)
-          @game.priority_deal_chooser = nil
+          @game.priority_deal_chooser.close!
         end
 
         def choice_available?(entity)
@@ -85,10 +86,12 @@ module Engine
 
         def ipo_type(_entity) end
 
+        def swap_sell(_player, _corporation, _bundle, _pool_share); end
+
         private
 
         def chooser
-          @game.priority_deal_chooser
+          @game.priority_deal_chooser&.owner
         end
       end
     end

--- a/lib/engine/step/g_18_sj/waterfall_auction.rb
+++ b/lib/engine/step/g_18_sj/waterfall_auction.rb
@@ -6,11 +6,24 @@ module Engine
   module Step
     module G18SJ
       class WaterfallAuction < WaterfallAuction
+        def setup
+          super
+
+          # Remove any 0 value companies - they are not part of
+          # the auction, but used for player abilities.
+          @companies.select! { |c| c.value.positive? }
+          @cheapest = @companies.first
+        end
+
         def buy_company(player, company, price)
           super
 
-          # Give the buyer a one time priority deal steal if buying Nils Ericsson
-          @game.priority_deal_chooser = player if company.id == 'NE'
+          if company.id == 'NE'
+            # Give the buyer a one time priority deal steal
+            pdc = @game.company_by_id('NEFT')
+            pdc.owner = player
+            player.companies << pdc
+          end
 
           minor = @game.minor_khj
 


### PR DESCRIPTION
The PDC is handled as a company, with value 0, which is not part
of the initial auction, but instead given to the purchaser of Nils
Ericsson. It is handled as a no-buy company that is not counted
towards certificate limit, which only closes when the priority
deal choice ability is used.

This means that the "company" will appear in the player charter
and stay their for the rest of the game (until it is used) as
a reminder to the player.