### PR TITLE
Allow moving bids up to available cash

### DIFF
--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -65,6 +65,10 @@ module Engine
         raise NotImplementedError
       end
 
+      def max_place_bid(entity, company)
+        max_bid(entity, company)
+      end
+
       def max_bid(_entity, _company)
         # Maximum that a bid can be increased to by an entity
         raise NotImplementedError


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/2815

This update fixes the problem where the user cannot move their bid because they cannot afford to place a brand new bid, even though they have enough to move the bid. It also removes the place bid button from the UI when the user cannot afford a Place Bid while still showing the move bid options if they can move a bid. Lastly, it removes Move Bid buttons where the user cannot add enough cash to make a valid move bid.

**Implementation Notes**

I originally tried this with an optional parameter on the max_bid / min_bid and I found it way less readable.

Can afford everything
<img width="673" alt="Screen Shot 2021-01-09 at 9 23 11 AM" src="https://user-images.githubusercontent.com/15675400/104102880-616e0080-525c-11eb-8fd8-7b2926836f57.png">

Can only afford ONE move bid, not all.
<img width="885" alt="Screen Shot 2021-01-08 at 8 29 01 AM" src="https://user-images.githubusercontent.com/15675400/104074741-17d6d480-51ce-11eb-8c87-0532eede02de.png">

Can only afford to MOVE bids
<img width="378" alt="Screen Shot 2021-01-09 at 9 23 31 AM" src="https://user-images.githubusercontent.com/15675400/104102886-6c289580-525c-11eb-8371-b7613cbbb129.png">

Can only afford to place a bid
<img width="269" alt="Screen Shot 2021-01-09 at 9 23 38 AM" src="https://user-images.githubusercontent.com/15675400/104102888-73e83a00-525c-11eb-8eac-e536746435da.png">


Can't afford any bids.
<img width="301" alt="Screen Shot 2021-01-08 at 8 34 01 AM" src="https://user-images.githubusercontent.com/15675400/104074743-19080180-51ce-11eb-9852-a7f308268bf8.png">
