### PR TITLE
Enforce that every old city corresponds to exactly one new city

### DIFF
--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -253,6 +253,7 @@ module Engine
         new_exits = tile.exits
         new_ctedges = tile.city_town_edges
         extra_cities = [0, new_ctedges.size - old_ctedges.size].max
+        multi_city_upgrade = new_ctedges.size > 1 && old_ctedges.size > 1
 
         new_exits.all? { |edge| hex.neighbors[edge] } &&
           (new_exits & available_hex(entity, hex)).any? &&
@@ -260,7 +261,9 @@ module Engine
           # Count how many cities on the new tile that aren't included by any of the old tile.
           # Make sure this isn't more than the number of new cities added.
           # 1836jr30 D6 -> 54 adds more cities
-          extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } }
+          extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } } &&
+          # 1867: Does every old city correspond to exactly one new city?
+          (!multi_city_upgrade || old_ctedges.all? { |oldct| new_ctedges.one? { |newct| (oldct & newct) == oldct } })
       end
 
       def legal_tile_rotations(entity, hex, tile)

--- a/validate.rb
+++ b/validate.rb
@@ -104,8 +104,12 @@ def revalidate_broken(filename)
   File.write("revalidate.json", JSON.pretty_generate(data))
 end
 
-def validate_json(filename)
-  Engine::Game.load(filename).maybe_raise!
+def validate_json(filename, strict: false)
+  game = Engine::Game.load(filename, strict: strict)
+  if game.exception
+    puts game.broken_action.to_h
+  end
+  game.maybe_raise!
 end
 
 def pin_games(pin_version, game_ids)


### PR DESCRIPTION
This fixes the invalid lays that were occuring with 1867 X* tiles

fixes #3123