### PR TITLE
[HOLD] MVP Title Page - Showing info for a specific Game title

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -100,6 +100,11 @@ class Api < Roda
       render_with_games
     end
 
+    r.on 'title', String do |title|
+      request.params['title'] = title
+      render(pin: request.params['pin'], games: Game.home_games(user, **request.params).map(&:to_h))
+    end
+
     r.on 'game', Integer do |id|
       halt(404, 'Game not found') unless (game = Game[id])
 

--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -10,6 +10,7 @@ require 'view/create_game'
 require 'view/invite_game'
 require 'view/home'
 require 'view/confirm'
+require 'view/title_page'
 require 'view/flash'
 require 'view/game_page'
 require 'view/map_page'
@@ -76,6 +77,8 @@ class App < Snabberb::Component
         h(View::MapPage, route: @app_route)
       when /market/
         h(View::MarketPage, route: @app_route)
+      when /title/
+        h(View::TitlePage, route: @app_route, user: @user)
       else
         h(View::Home, user: @user)
       end

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -4,6 +4,7 @@ require 'lib/color'
 require 'lib/settings'
 require 'lib/publisher'
 require 'lib/text'
+require 'view/game/game_meta'
 
 module View
   module Game
@@ -32,7 +33,7 @@ module View
         children.concat(discarded_trains) if @depot.discarded.any?
         children.concat(phases)
         children.concat(timeline) if timeline
-        children.concat(game_info)
+        children << h(GameMeta, game: @game)
       end
 
       def timeline
@@ -42,40 +43,6 @@ module View
 
         @game.timeline.each do |line|
           children << h(:p, line)
-        end
-
-        children
-      end
-
-      def game_info
-        children = [h(:h3, 'Game Info')]
-
-        if (publisher = @game.class::GAME_PUBLISHER)
-          children << h(:p, [
-              'Published by ',
-              *Lib::Publisher.link_list(component: self, publishers: Array(publisher)),
-            ])
-        end
-        children << h(:p, "Designed by #{@game.class::GAME_DESIGNER}") if @game.class::GAME_DESIGNER
-        children << h(:p, "Implemented by #{@game.class::GAME_IMPLEMENTER}") if @game.class::GAME_IMPLEMENTER
-        if @game.class::GAME_RULES_URL.is_a?(Hash)
-          @game.class::GAME_RULES_URL.each do |desc, url|
-            children << h(:p, [h(:a, { attrs: { href: url, target: '_blank' } }, desc)])
-          end
-        else
-          children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_RULES_URL, target: '_blank' } }, 'Rules')])
-        end
-        if @game.optional_rules.any?
-          children << h(:h3, 'Optional Rules Used')
-          @game.class::OPTIONAL_RULES.each do |o_r|
-            next unless @game.optional_rules.include?(o_r[:sym])
-
-            children << h(:p, " * #{o_r[:short_name]}: #{o_r[:desc]}")
-          end
-        end
-
-        if @game.class::GAME_INFO_URL
-          children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_INFO_URL, target: '_blank' } }, 'More info')])
         end
 
         children

--- a/assets/app/view/game/game_meta.rb
+++ b/assets/app/view/game/game_meta.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module View
+  class GameMeta < Snabberb::Component
+    needs :game
+
+    def render
+      children = [h(:h3, 'Game Info')]
+
+      if (publisher = @game.class::GAME_PUBLISHER)
+        children << h(:p, [
+            'Published by ',
+            *Lib::Publisher.link_list(component: self, publishers: Array(publisher)),
+          ])
+      end
+      children << h(:p, "Designed by #{@game.class::GAME_DESIGNER}") if @game.class::GAME_DESIGNER
+      children << h(:p, "Implemented by #{@game.class::GAME_IMPLEMENTER}") if @game.class::GAME_IMPLEMENTER
+      if @game.class::GAME_RULES_URL.is_a?(Hash)
+        @game.class::GAME_RULES_URL.each do |desc, url|
+          children << h(:p, [h(:a, { attrs: { href: url, target: '_blank' } }, desc)])
+        end
+      else
+        children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_RULES_URL, target: '_blank' } }, 'Rules')])
+      end
+      if @game.optional_rules.any?
+        children << h(:h3, 'Optional Rules Used')
+        @game.class::OPTIONAL_RULES.each do |o_r|
+          next unless @game.optional_rules.include?(o_r[:sym])
+
+          children << h(:p, " * #{o_r[:short_name]}: #{o_r[:desc]}")
+        end
+      end
+
+      if @game.class::GAME_INFO_URL
+        children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_INFO_URL, target: '_blank' } }, 'More info')])
+      end
+
+      h(:div, children)
+    end
+  end
+end

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -11,6 +11,7 @@ module View
     needs :game_row_games
     needs :user
     needs :type
+    needs :title, default: nil
 
     LIMIT = 12
 
@@ -26,8 +27,8 @@ module View
       children = [h(:h2, header)]
       p = page.to_i
       @offset = @type == :hotseat ? (p * @limit) : 0
-      children << render_more('Prev', "?#{@type}=#{p - 1}") if p.positive?
-      children << render_more('Next', "?#{@type}=#{p + 1}") if @game_row_games.size > @offset + @limit
+      children << render_more('Prev', page_params(p - 1)) if p.positive?
+      children << render_more('Next', page_params(p + 1)) if @game_row_games.size > @offset + @limit
 
       props = {
         style: {
@@ -39,6 +40,14 @@ module View
       }
 
       h('div.card_header', props, children)
+    end
+
+    def page_params(page)
+      params = {}
+      params[@type] = page
+      params[:title] = @title if @title
+
+      "?#{params.map { |k, v| "#{k}=#{v}" }.join('&')}"
     end
 
     def render_more(text, params)

--- a/assets/app/view/title_page.rb
+++ b/assets/app/view/title_page.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'game_manager'
+require 'lib/settings'
+require 'lib/storage'
+require 'view/chat'
+require 'view/game_row'
+require 'view/game/game_meta'
+
+module View
+  class TitlePage < Snabberb::Component
+    include GameManager
+    include Lib::Settings
+
+    needs :user
+    needs :route
+    needs :refreshing, default: nil, store: true
+
+    ROUTE_FORMAT = %r{/title/([^/?]*)/?}.freeze
+
+    def render
+      @game_title = @route.match(ROUTE_FORMAT)[1].gsub('%20', ' ')
+
+      your_games, other_games = @games
+        .partition { |game| user_in_game?(@user, game) || user_owns_game?(@user, game) }
+
+      children = [
+        render_game_info,
+        h(Chat, user: @user, connection: @connection),
+      ]
+
+      # these will show up in the profile page
+      your_games.reject! { |game| game['status'] == 'finished' }
+
+      grouped = other_games.group_by { |game| game['status'] }
+
+      # Ready, then active, then unstarted, then completed
+      your_games.sort_by! do |game|
+        [
+          user_is_acting?(@user, game) ? -game['updated_at'] : 0,
+          game['status'] == 'active' ? -game['updated_at'] : 0,
+          game['status'] == 'new' ? -game['created_at'] : 0,
+          -game['updated_at'],
+        ]
+      end
+
+      render_row(children, 'Your Games', your_games, :personal) if @user
+      render_row(children, 'New Games', grouped['new'], :new) if @user
+      render_row(children, 'Active Games', grouped['active'], :active)
+      render_row(children, 'Finished Games', grouped['finished'], :finished)
+
+      game_refresh
+
+      acting = your_games.any? { |game| user_is_acting?(@user, game) }
+      `document.title = #{(acting ? '* ' : '') + '18xx.Games'}`
+      change_favicon(acting)
+      change_tab_color(acting)
+
+      destroy = lambda do
+        `clearTimeout(#{@refreshing})`
+        store(:refreshing, nil, skip: true)
+      end
+
+      props = {
+        key: 'title_page',
+        hook: {
+          destroy: destroy,
+        },
+      }
+
+      h('div#titlepage', props, children)
+    end
+
+    def game_refresh
+      return unless @user
+      return if @refreshing
+
+      timeout = %x{
+        setTimeout(function(){
+          self['$get_games']()
+          self['$store']('refreshing', nil, Opal.hash({skip: true}))
+        }, 10000)
+      }
+
+      store(:refreshing, timeout, skip: true)
+    end
+
+    def render_row(children, header, games, type)
+      return unless games&.any?
+
+      children << h(
+        GameRow,
+        header: header,
+        game_row_games: games,
+        type: type,
+        user: @user,
+        title: @game_title,
+      )
+    end
+
+    def render_game_info
+      game_klass = Engine::GAMES_BY_TITLE[@game_title]
+      players = Engine.player_range(game_klass).max.times.map { |n| "Player #{n + 1}" }
+      game = game_klass.new(players)
+
+      children = [
+        h(:h1, @game_title),
+        h(GameMeta, game: game),
+        h(:p, [h(:a, { attrs: { href: "/map/#{@game_title}", target: '_blank' } }, 'Sample Map')]),
+        h(:p, [h(:a, { attrs: { href: "/market/#{@game_title}", target: '_blank' } }, 'Sample Market')]),
+      ]
+
+      h('div.half', children)
+    end
+  end
+end

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -30,6 +30,7 @@ module Engine
       GAME_LOCATION = 'Colorado, USA'
       GAME_RULES_URL = 'https://drive.google.com/open?id=0B3lRHMrbLMG_eEp4elBZZ0toYnM'
       GAME_DESIGNER = 'R. Ryan Driskel'
+      GAME_IMPLEMENTER = 'R. Ryan Driskel'
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18CO:-Rock-&-Stock'
 
       SELL_BUY_ORDER = :sell_buy

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -109,6 +109,35 @@ describe 'Assets' do
       end
     end
 
+    context '/title' do
+      {
+        '1846' => [
+          'GMT Games',
+          'Golden Spike Games',
+          'Designed by Thomas Lehmann',
+          'Rules',
+          'Sample Market',
+          'Sample Map',
+        ],
+        '18CO' => [
+          'Ryan Driskel',
+          'Rules',
+          'Sample Market',
+          'Sample Map',
+        ],
+      }.each do |game_title, expected_strings|
+        context game_title do
+          it 'renders title' do
+            rendered = render(app_route: "/title/#{game_title}")
+
+            aggregate_failures 'expected strings' do
+              expected_strings.each { |s| expect(rendered).to include(s) }
+            end
+          end
+        end
+      end
+    end
+
     it 'renders new_game' do
       expect(render(app_route: '/new_game')).to include('Create New Game')
     end


### PR DESCRIPTION
Title page, eg https://18xx.games/title/1889

Place where a user can see basic information ( stuff from Game Info, link to rules ) about a particular title ( 1846, 1889, etc), games open / in progress / complete / etc for that title, stats on that title ( number of completed games, popular player counts ? ), link to create a game for ( with the title already specified ), link to map / market, same chat as homepage.

This PR does not incorporate all of those features, but gives a starting point to build on top. A bonus feature is that game developers can easily find alpha/beta games in progress/completed for reference.

**I could use someone with a large local db of games to verify everything works as expected with a larger set of games.**

Some examples of title pages ( without many games listed because I don't have much locally beyond hotseat )

<img width="949" alt="Screen Shot 2021-01-09 at 10 57 34 AM" src="https://user-images.githubusercontent.com/15675400/104105465-828a1d80-526b-11eb-8bf2-1c3c45da25b9.png">
<img width="953" alt="Screen Shot 2021-01-09 at 11 09 32 AM" src="https://user-images.githubusercontent.com/15675400/104105466-8322b400-526b-11eb-81e3-8f36a9297ed7.png">

<img width="272" alt="Screen Shot 2021-01-09 at 11 14 06 AM" src="https://user-images.githubusercontent.com/15675400/104105525-fb897500-526b-11eb-97fe-0185df1989b8.png">

I also added links to the title pages for each game.

<img width="483" alt="Screen Shot 2021-01-09 at 11 17 11 AM" src="https://user-images.githubusercontent.com/15675400/104105558-40ada700-526c-11eb-902e-60c1b9f99602.png">


I verified the in-game info is still working as expected.

<img width="507" alt="Screen Shot 2021-01-09 at 11 11 21 AM" src="https://user-images.githubusercontent.com/15675400/104105467-83bb4a80-526b-11eb-8ae7-734795b4fb3c.png">
