### PR TITLE
map controls: prevent premature line breaks & horizontal scrolling

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -65,7 +65,7 @@ module View
         end
         @hexes.compact!
 
-        children = [render_map, render_controls]
+        children = [render_map]
 
         if current_entity && @tile_selector
           left = (@tile_selector.x + map_x) * @scale
@@ -134,7 +134,7 @@ module View
           },
         }
 
-        h(:div, props, children)
+        h(:div, [h(:div, props, children), render_controls])
       end
 
       def map_x

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -17,8 +17,8 @@ module View
           location_names_controls,
           hex_coord_controls,
           starting_map_controls,
-          *route_controls,
-          *map_zoom_controls,
+          route_controls,
+          map_zoom_controls,
         ].compact
 
         h(:div, children)
@@ -107,7 +107,7 @@ module View
         end
 
         @route_input = render_select(id: :route, on: { input: route_change }, children: operators)
-        ['Show Last Route For:', @route_input]
+        h('label.inline-block', ['Show Last Route For:', @route_input])
       end
 
       def render_select(id:, on: {}, children: [])
@@ -128,26 +128,21 @@ module View
           end
         end
 
-        [render_button('Zoom out', on_click.call(@map_zoom / 1.1)),
-         render_button('Default zoom', on_click.call(1)),
-         render_button('Zoom in', on_click.call(@map_zoom * 1.1))]
+        h('div.inline-block', [
+          render_button('Zoom out', on_click.call(@map_zoom / 1.1)),
+          render_button('Default zoom', on_click.call(1)),
+          render_button('Zoom in', on_click.call(@map_zoom * 1.1)),
+        ])
       end
 
       def render_button(text, action)
         props = {
-          style: {
-            top: '1rem',
-            # float: 'right',
-            borderRadius: '5px',
-            margin: '0 0.3rem',
-            padding: '0.2rem 0.5rem',
-          },
           on: {
             click: action,
           },
         }
 
-        h(:button, props, text)
+        h('button.small', props, text)
       end
     end
   end


### PR DESCRIPTION
[next try, please test before deploying if possible, but I think we are good this time]

Neither line breaks between label and select nor between zoom buttons.
Buttons always visible, only map scrolls horizontally.

ante:
![image](https://user-images.githubusercontent.com/33390595/104092344-ac4f3e80-5283-11eb-833f-d0144361f625.png)
post:
![image](https://user-images.githubusercontent.com/33390595/104092345-b07b5c00-5283-11eb-88f7-3cb869d331a6.png)

ante:
![image](https://user-images.githubusercontent.com/33390595/104092445-4ca56300-5284-11eb-8e72-9c2c8c4a9a91.png)
post:
![image](https://user-images.githubusercontent.com/33390595/104092458-68a90480-5284-11eb-9108-75b477c920b9.png)