### PR TITLE
Refactor reorder_corps, make distance not private

### DIFF
--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -388,7 +388,7 @@ module Engine
 
         same_spot.each do |sp, corps|
           current_order = corps.sort.map(&:name)
-          reordered = corps.sort_by { |c| @old_operating_order.index(c) }
+          reordered = corps.sort_by { |c| old_operating_order.index(c) }
           new_order = reordered.map(&:name)
           next if current_order == new_order
 
@@ -398,7 +398,6 @@ module Engine
           sp.corporations.clear
           sp.corporations.concat(reordered)
         end
-        @old_operating_order = nil
       end
 
       def issuable_shares(entity)
@@ -542,13 +541,13 @@ module Engine
       end
 
       def event_green_par!
-        @log << "-- Event: #{EVENTS_TEXT['green_par'][1]} --"
+        @log << "-- Event: #{EVENTS_TEXT[:green_par][1]} --"
         stock_market.enable_par_price(144)
         update_cache(:share_prices)
       end
 
       def event_brown_par!
-        @log << "-- Event: #{EVENTS_TEXT['brown_par'][1]} --"
+        @log << "-- Event: #{EVENTS_TEXT[:brown_par][1]} --"
         stock_market.enable_par_price(216)
         update_cache(:share_prices)
       end

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -222,8 +222,6 @@ module Engine
       shares
     end
 
-    private
-
     def distance(player_a, player_b)
       return 0 if !player_a || !player_b
 
@@ -232,6 +230,8 @@ module Engine
       b = entities.find_index(player_b)
       a < b ? b - a : b - (a - entities.size)
     end
+
+    private
 
     def move_share(share, to_entity)
       corporation = share.corporation

--- a/lib/engine/step/g_1849/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1849/buy_sell_par_shares.rb
@@ -16,16 +16,23 @@ module Engine
           @log << "#{action.entity.name} may buy up to two additional shares."
         end
 
+        def process_sell_shares(action)
+          super
+          @sold_any = true
+        end
+
         def pass!
           @passed = true
           if @current_actions.empty?
             @round.pass_order |= [current_entity]
             current_entity.pass!
           else
-            @game.reorder_corps
+            @game.reorder_corps if @sold_any
             @round.pass_order.delete(current_entity)
             current_entity.unpass!
           end
+          @game.old_operating_order = @game.corporations.sort
+          @sold_any = false
         end
 
         def can_buy?(entity, bundle)

--- a/lib/engine/step/g_1849/buy_train.rb
+++ b/lib/engine/step/g_1849/buy_train.rb
@@ -8,13 +8,12 @@ module Engine
       class BuyTrain < BuyTrain
         def setup
           super
-          @game.old_operating_order = @game.corporations.sort
-          @sold_any = false
         end
 
         def pass!
           super
           @game.reorder_corps if @sold_any
+          @sold_any = false
         end
 
         def process_sell_shares(action)

--- a/lib/engine/step/g_1849/dividend.rb
+++ b/lib/engine/step/g_1849/dividend.rb
@@ -18,6 +18,11 @@ module Engine
             { share_direction: :right, share_times: 1 }
           end
         end
+
+        def pass!
+          super
+          @game.old_operating_order = @game.corporations.sort
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #3177
Fixes #3178
Fixes #3181

The bugs were:
- Using a string instead of a symbol to access a hash.
- Calling a private method.
- Bad timing for `old_operating_order` stuff.

The new idea in this is that the operating order needs to be updated right before the two times that shares can be sold - `buy_trains` and `buy_sell_par_shares`. "Right before" in this case means "right after the previous step", which are in this case `dividend` and `buy_sell_par_shares`, respectively.

This also fixes an unreported bug which reordered a corporation that had just operated after other shares were sold during an ebuy.