### PR TITLE
18SJ: Fix premature close (fixes #3172)

### DIFF
--- a/lib/engine/config/game/g_18_sj.rb
+++ b/lib/engine/config/game/g_18_sj.rb
@@ -475,7 +475,7 @@ module Engine
         },
         {
           "type": "close",
-          "when": "never",
+          "on_phase": "never",
           "owner_type": "player"
         }
       ]


### PR DESCRIPTION
Incorrect configuration caused private Nils Ericsson Första Tjing
to close when phase 5 started (if still around).