### PR TITLE
Fix 18CO highest_player_bid

### DIFF
--- a/lib/engine/step/g_18_co/moving_bid_auction.rb
+++ b/lib/engine/step/g_18_co/moving_bid_auction.rb
@@ -120,7 +120,7 @@ module Engine
         def highest_player_bid(player, company)
           return unless (company_bids = @bids[company])
 
-          company_bids&.select { |b| b.entity == player }&.max(&:price)
+          company_bids&.select { |b| b.entity == player }&.max { |a, b| a[:price] <=> b[:price] }
         end
 
         def current_bid_amount(player, company)

--- a/spec/fixtures/18CO/21422.json
+++ b/spec/fixtures/18CO/21422.json
@@ -1,0 +1,581 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1609943185,
+      "company": "Toll",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1609947702,
+      "company": "LNPW",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1609949526,
+      "company": "DNP",
+      "price": 50
+    },
+    {
+      "id": 4,
+      "type": "bid",
+      "price": 120,
+      "entity": 3158,
+      "company": "DRGR",
+      "entity_type": "player",
+      "user": 3158,
+      "created_at": 1609949706
+    },
+    {
+      "id": 5,
+      "type": "undo",
+      "entity": 2359,
+      "entity_type": "player",
+      "user": 3158,
+      "created_at": 1609949709
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1609949715,
+      "company": "IMC",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1609952590,
+      "company": "GJGR",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1609952985,
+      "company": "DRGR",
+      "price": 120
+    },
+    {
+      "id": 9,
+      "type": "bid",
+      "price": 125,
+      "entity": 1739,
+      "company": "DRGR",
+      "entity_type": "player",
+      "user": 1739,
+      "created_at": 1609957523
+    },
+    {
+      "id": 10,
+      "type": "undo",
+      "entity": 3158,
+      "entity_type": "player",
+      "user": 1739,
+      "created_at": 1609957557
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1609957562,
+      "company": "DPRT",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1609957799,
+      "company": "DPRT",
+      "price": 105
+    },
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1609958530,
+      "company": "DPRT",
+      "price": 110
+    },
+    {
+      "type": "pass",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1609959266
+    },
+    {
+      "type": "move_bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1609959294,
+      "company": "DRGR",
+      "price": 125,
+      "from_company": "DPRT",
+      "from_price": 100
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1609959360,
+      "company": "Toll",
+      "price": 65
+    },
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1609960654,
+      "company": "Toll",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1609967253,
+      "company": "DRGR",
+      "price": 130
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1609973730,
+      "company": "DRGR",
+      "price": 135
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1610008579,
+      "company": "Toll",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1610026885,
+      "company": "Toll",
+      "price": 80
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1610027131,
+      "company": "DRGR",
+      "price": 140
+    },
+    {
+      "id": 23,
+      "type": "bid",
+      "price": 145,
+      "entity": 1739,
+      "company": "DRGR",
+      "entity_type": "player",
+      "user": 1739,
+      "created_at": 1610028080
+    },
+    {
+      "id": 24,
+      "type": "undo",
+      "entity": 3158,
+      "entity_type": "player",
+      "user": 1739,
+      "created_at": 1610028088
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1610028091,
+      "company": "DRGR",
+      "price": 150
+    },
+    {
+      "type": "pass",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1610028475
+    },
+    {
+      "type": "pass",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1610028681
+    },
+    {
+      "id": 28,
+      "type": "move_bid",
+      "price": 155,
+      "entity": 3574,
+      "company": "DRGR",
+      "from_price": 70,
+      "entity_type": "player",
+      "from_company": "LNPW",
+      "user": 3574,
+      "created_at": 1610042334
+    },
+    {
+      "id": 29,
+      "type": "undo",
+      "entity": 1739,
+      "entity_type": "player",
+      "user": 3574,
+      "created_at": 1610042337
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1610042342,
+      "company": "DRGR",
+      "price": 155
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1610043618,
+      "company": "DRGR",
+      "price": 160
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1610044655,
+      "company": "LNPW",
+      "price": 75
+    },
+    {
+      "type": "pass",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1610044916
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1610050605,
+      "company": "DRGR",
+      "price": 165
+    },
+    {
+      "type": "bid",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1610062615,
+      "company": "DRGR",
+      "price": 170
+    },
+    {
+      "id": 36,
+      "type": "undo",
+      "entity": 3158,
+      "entity_type": "player",
+      "user": 1739,
+      "created_at": 1610091146
+    },
+    {
+      "id": 37,
+      "type": "redo",
+      "entity": 1739,
+      "entity_type": "player",
+      "user": 1739,
+      "created_at": 1610091181
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1610095008,
+      "company": "LNPW",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1610115733
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1610116612,
+      "company": "LNPW",
+      "price": 85
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1610116655
+    },
+    {
+      "type": "move_bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1610117587,
+      "company": "Toll",
+      "price": 85,
+      "from_company": "LNPW",
+      "from_price": 80
+    },
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1610118119,
+      "company": "Toll",
+      "price": 90
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1610118878,
+      "company": "IMC",
+      "price": 35
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 45,
+      "created_at": 1610118884
+    },
+    {
+      "type": "move_bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 46,
+      "created_at": 1610119801,
+      "company": "DPRT",
+      "price": 115,
+      "from_company": "Toll",
+      "from_price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 47,
+      "created_at": 1610121794,
+      "company": "DPRT",
+      "price": 120
+    },
+    {
+      "id": 48,
+      "type": "move_bid",
+      "price": 175,
+      "entity": 3574,
+      "company": "DRGR",
+      "from_price": 85,
+      "entity_type": "player",
+      "from_company": "LNPW",
+      "user": 3574,
+      "created_at": 1610126634
+    },
+    {
+      "id": 49,
+      "type": "undo",
+      "entity": 1739,
+      "entity_type": "player",
+      "user": 3574,
+      "created_at": 1610126637
+    },
+    {
+      "type": "pass",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1610126647
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1610127152
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1610127496,
+      "company": "IMC",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1610129306
+    },
+    {
+      "type": "bid",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1610135831,
+      "company": "DNP",
+      "price": 55
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1610136767
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1610137013,
+      "company": "Toll",
+      "price": 95
+    },
+    {
+      "type": "bid",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1610138006,
+      "company": "Toll",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": 3574,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1610138124
+    },
+    {
+      "type": "pass",
+      "entity": 1739,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1610138907
+    },
+    {
+      "type": "bid",
+      "entity": 3158,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1610282375,
+      "company": "DPRT",
+      "price": 125
+    },
+    {
+      "type": "end_game",
+      "entity": 2359,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1610282930
+    }
+  ],
+  "id": "hs_cjsbrvzg_21422",
+  "players": [
+    {
+      "id": 2359,
+      "name": "oz"
+    },
+    {
+      "id": 3574,
+      "name": "caffeine"
+    },
+    {
+      "id": 1739,
+      "name": "wheresvic"
+    },
+    {
+      "id": 3158,
+      "name": "captainobi"
+    }
+  ],
+  "title": "18CO",
+  "description": "18co-rocking-the-stock",
+  "max_players": 4,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 1920117333,
+    "unlisted": true,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "turn": 1,
+  "round": "Auction Round",
+  "acting": [
+    2359
+  ],
+  "result": {
+    "captainobi": 375,
+    "wheresvic": 375,
+    "caffeine": 375,
+    "oz": 375
+  },
+  "loaded": true,
+  "created_at": "2021-01-10",
+  "updated_at": 1610282930,
+  "mode": "hotseat"
+}


### PR DESCRIPTION
Fix captainobi trying to bid on DPTC in https://www.18xx.games/game/21422

The previous code works in javascript but not in ruby. As soon as there were multiple bids on one private, the error 

```
     Failure/Error: puts "#{company_bids&.select { |b| b.entity == player }.max.price}\n\n"
     
     NoMethodError:
       undefined method `price' for nil:NilClass
     # ./lib/engine/step/g_18_co/moving_bid_auction.rb:123:in `highest_player_bid'
     # ./lib/engine/step/g_18_co/moving_bid_auction.rb:129:in `current_bid_amount'
```

occurs. This code works in both ruby and javascript.