### PR TITLE
Let RSA+AFG place home token

### DIFF
--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -211,7 +211,7 @@ module Engine
         index = @corporations.index(corporation)
 
         @corporations[index + 1].next_to_par = true unless @corporations.last == corporation
-        place_home_token(corporation)
+        place_home_token(corporation) if @round.stock?
       end
 
       def home_token_locations(corporation)
@@ -284,8 +284,12 @@ module Engine
         super
       end
 
+      def afg
+        @afg ||= @corporations.find { |corp| corp.id == 'AFG' }
+      end
+
       def stock_round
-        Round::Stock.new(self, [
+        Round::G1849::Stock.new(self, [
           Step::DiscardTrain,
           Step::HomeToken,
           Step::G1849::SwapChoice,

--- a/lib/engine/round/g_1849/stock.rb
+++ b/lib/engine/round/g_1849/stock.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../stock'
+
+module Engine
+  module Round
+    module G1849
+      class Stock < Stock
+        def setup
+          afg = @game.afg
+          @game.place_home_token(afg) if afg&.floated? && afg.unplaced_tokens.size == 3
+
+          super
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3175 

Auction rounds aren't well equipped to handle token placement so this is a little hack to delay it until the beginning of the stock round.