### PR TITLE
publish commit hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /vendor/
 /public/assets/*
 /public/pinned/*
+/public/commit
 
 .tags
 .DS_STORE

--- a/Rakefile
+++ b/Rakefile
@@ -113,6 +113,7 @@ task :precompile do
   pin_dir = Assets::OUTPUT_BASE + Assets::PIN_DIR
   FileUtils.mkdir_p(pin_dir)
   FileUtils.cp("#{bundle}.gz", "#{pin_dir}/#{git_rev}.js.gz")
+  sh("echo #{git_rev} > #{Assets::OUTPUT_BASE}/commit")
 end
 
 desc 'Profile loading data'


### PR DESCRIPTION
Low level and definitely not as nice as showing deployed version in /about, but it works fine locally. You have to decide if this works with the current deploy process though.
.gitignore addition to prevent annoying mishaps.
This would fix #1609 – sort of. Triggered by https://18xxgames.slack.com/archives/C012K0CNY5C/p1610272399481100