### PR TITLE
1846, 18 Los Angeles: fix ability timing

### DIFF
--- a/lib/engine/config/game/g_1846.rb
+++ b/lib/engine/config/game/g_1846.rb
@@ -189,7 +189,7 @@ module Engine
       "abilities": [
         {
           "type": "token",
-          "when": ["owning_corp_or_turn", "other_or"],
+          "when": "owning_corp_or_turn",
           "owner_type":"corporation",
           "hexes": [
             "D6"
@@ -246,7 +246,7 @@ module Engine
       "abilities": [
         {
           "type": "assign_hexes",
-          "when": ["owning_corp_or_turn", "owning_player_sr_turn", "other_or"],
+          "when": "owning_corp_or_turn",
           "hexes": [
             "I1",
             "D6"
@@ -279,16 +279,18 @@ module Engine
             "G19"
           ],
           "count_per_or": 1,
+          "when": "or_start",
           "owner_type": "player"
         },
         {
           "type": "assign_corporation",
           "count_per_or": 1,
+          "when": "or_start",
           "owner_type": "player"
         },
         {
           "type": "assign_hexes",
-          "when": ["owning_corp_or_turn", "other_or", "owning_player_sr_turn"],
+          "when": "owning_corp_or_turn",
           "hexes": [
             "B8",
             "C5",
@@ -316,7 +318,7 @@ module Engine
       "abilities": [
         {
            "type":"tile_lay",
-           "when": ["owning_corp_or_turn", "other_or"],
+           "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
            "hexes":[
@@ -353,7 +355,7 @@ module Engine
         },
         {
            "type":"tile_lay",
-           "when": ["owning_corp_or_turn", "other_or"],
+           "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
            "must_lay_together": true,
@@ -387,7 +389,7 @@ module Engine
         },
         {
            "type":"tile_lay",
-           "when": ["owning_corp_or_turn", "other_or"],
+           "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
            "must_lay_together": true,

--- a/lib/engine/config/game/g_18_los_angeles.rb
+++ b/lib/engine/config/game/g_18_los_angeles.rb
@@ -151,7 +151,7 @@ module Engine
       "abilities": [
         {
           "type": "token",
-          "when": ["owning_corp_or_turn", "other_or"],
+          "when": "owning_corp_or_turn",
           "owner_type":"corporation",
           "hexes": [
             "E8"
@@ -208,7 +208,7 @@ module Engine
       "abilities": [
         {
           "type": "assign_hexes",
-          "when": ["owning_corp_or_turn", "other_or"],
+          "when": "owning_corp_or_turn",
           "hexes": [
             "C14",
             "F7"
@@ -233,7 +233,7 @@ module Engine
       "abilities": [
         {
           "type": "assign_hexes",
-          "when": ["owning_corp_or_turn", "other_or"],
+          "when": "owning_corp_or_turn",
           "hexes": [
             "B1",
             "C2",
@@ -260,7 +260,7 @@ module Engine
       "abilities": [
         {
            "type":"tile_lay",
-           "when": ["owning_corp_or_turn", "other_or"],
+           "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
            "hexes":[
@@ -293,7 +293,7 @@ module Engine
         },
         {
            "type":"tile_lay",
-           "when": ["owning_corp_or_turn", "other_or"],
+           "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
            "hexes":[
@@ -324,7 +324,7 @@ module Engine
         },
         {
            "type":"tile_lay",
-           "when": ["owning_corp_or_turn", "other_or"],
+           "when": "owning_corp_or_turn",
            "owner_type":"corporation",
            "free":true,
            "hexes":[

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -630,6 +630,7 @@ module Engine
             next_round!
 
             # Finalize round setup (for things that need round correctly set like place_home_token)
+            @round.at_start = true
             @round.setup
             @round_history << current_action_id
           end
@@ -2079,17 +2080,23 @@ module Engine
             @round.stock? && @round.current_entity == ability.player
           when 'other_or'
             @round.operating? && @round.current_operator != ability.corporation
+          when 'or_start'
+            ability_time_is_or_start?
           else
             false
           end
         end
       end
 
+      def ability_time_is_or_start?
+        @round.operating? && @round.at_start
+      end
+
       def ability_blocking_step
         @round.steps.find do |step|
           # currently, abilities only care about Tracker, the is_a? check could
           # be expanded to a list of possible classes/modules when needed
-          step.blocks? && !step.passed? && step.is_a?(Step::Tracker)
+          step.is_a?(Step::Tracker) && !step.passed? && step.blocks?
         end
       end
 

--- a/lib/engine/game/g_1846.rb
+++ b/lib/engine/game/g_1846.rb
@@ -73,7 +73,7 @@ module Engine
       MEAT_REVENUE_DESC = 'Meat-Packing'
 
       TILE_COST = 20
-      EVENTS_TEXT = Base::EVENTS_TEXT.merge('remove_tokens' => ['Remove Tokens', 'Remove Steamboat and Meat Packing tokens']).freeze
+      EVENTS_TEXT = Base::EVENTS_TEXT.merge('remove_tokens' => ['Remove Tokens', 'Remove Steamboat and Meat Packing markers']).freeze
 
       ASSIGNMENT_TOKENS = {
         'MPC' => '/icons/1846/mpc_token.svg',
@@ -586,6 +586,10 @@ module Engine
 
       def train_buying_power(entity)
         buying_power(entity) + potential_minor_cash(entity, allowed_trains: (1..2))
+      end
+
+      def ability_time_is_or_start?
+        active_step.is_a?(Step::G1846::Assign) || super
       end
     end
   end

--- a/lib/engine/game/g_18_los_angeles.rb
+++ b/lib/engine/game/g_18_los_angeles.rb
@@ -147,7 +147,7 @@ module Engine
       def operating_round(round_num)
         Round::G1846::Operating.new(self, [
           Step::G1846::Bankrupt,
-          Step::G1846::Assign,
+          Step::Assign,
           Step::G18LosAngeles::SpecialToken,
           Step::SpecialTrack,
           Step::G1846::BuyCompany,

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -11,7 +11,7 @@ module Engine
   module Round
     class Base
       attr_reader :entities, :entity_index, :round_num, :steps
-      attr_accessor :last_to_act, :pass_order
+      attr_accessor :last_to_act, :pass_order, :at_start
 
       DEFAULT_STEPS = [
         Step::EndGame,
@@ -95,6 +95,8 @@ module Engine
 
         step.acted = true
         step.send("process_#{action.type}", action)
+
+        @at_start = false
 
         after_process_before_skip(action)
         skip_steps

--- a/lib/engine/step/g_1846/assign.rb
+++ b/lib/engine/step/g_1846/assign.rb
@@ -46,13 +46,13 @@ module Engine
         end
 
         def steamboat_assignable_to_corp?
-          return false unless @game.abilities(@steamboat, :assign_corporation, time: 'any')
+          return false unless @game.abilities(@steamboat, :assign_corporation, time: 'or_start')
 
           !assignable_corporations(@steamboat).empty?
         end
 
         def steamboat_assignable_to_hex?
-          return false unless @game.abilities(@steamboat, :assign_hexes, time: 'any')
+          return false unless @game.abilities(@steamboat, :assign_hexes, time: 'or_start')
           return true if steamboat_assigned_corp
 
           steamboat_assignable_to_corp?
@@ -104,7 +104,7 @@ module Engine
         def process_pass(action)
           raise GameError, "Not #{action.entity.name}'s turn: #{action.to_h}" unless action.entity == @steamboat
 
-          if (ability = @game.abilities(@steamboat, :assign_hexes, time: 'any'))
+          if (ability = @game.abilities(@steamboat, :assign_hexes, time: 'or_start'))
             ability.use!
             @log <<
               if (hex = steamboat_assigned_hex)
@@ -114,7 +114,7 @@ module Engine
               end
           end
 
-          if (ability = @game.abilities(@steamboat, :assign_corporation, time: 'any'))
+          if (ability = @game.abilities(@steamboat, :assign_corporation, time: 'or_start'))
             ability.use!
             @log <<
               if (corp = steamboat_assigned_corp)


### PR DESCRIPTION
* prevent abilities from being used on other corporations' turns or during stock rounds

* at attr `at_start` for rounds to tell when no actions have been processed; my
  first inclination was to have an array of the actions which have been
  performed in this round, checking if empty; that sounds theoretically useful
  but also overkill for this case

* 1846 needs an override for `ability_time_is_or_start?` since it should still
  be at the "or_start" after one of the possible assign actions has been
  taken (player-owned Steamboat can assign to hex and to a corporation/minor)

* change 18LA to not use 46's Assign step; LA Steamship cannot be assigned while
  owned by a player, so it is a little different from Steamboat Company and can
  use the basic Assign step

* update 1846 phase text to use "marker" instead of token, per
  https://boardgamegeek.com/thread/2565191/article/36594885#36594885

[Fixes #1794]