### PR TITLE
fix assignments being called on nil

### DIFF
--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -25,7 +25,7 @@ module View
         end
 
         def load_from_tile
-          @assignments = @tile.hex.assignments
+          @assignments = @tile.hex&.assignments || {}
         end
 
         def render_part

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -51,9 +51,9 @@ module View
         children = []
 
         render_revenue = should_render_revenue?
-        children << render_tile_part(Part::Track, routes: @routes) if @tile.paths.any? || @tile.stubs.any?
-        children << render_tile_part(Part::Cities, show_revenue: !render_revenue) if @tile.cities.any?
-        children << render_tile_part(Part::Towns, routes: @routes) if @tile.towns.any?
+        children << render_tile_part(Part::Track, routes: @routes) if !@tile.paths.empty? || !@tile.stubs.empty?
+        children << render_tile_part(Part::Cities, show_revenue: !render_revenue) unless @tile.cities.empty?
+        children << render_tile_part(Part::Towns, routes: @routes) unless @tile.towns.empty?
 
         borders = render_tile_part(Part::Borders) if @tile.borders.any?(&:type)
         # OO tiles have different rules...
@@ -62,16 +62,16 @@ module View
         children << render_tile_part(Part::Revenue) if render_revenue
         children << render_tile_part(Part::Label) if @tile.label
 
-        children << render_tile_part(Part::Upgrades) if @tile.upgrades.any?
+        children << render_tile_part(Part::Upgrades) unless @tile.upgrades.empty?
         children << render_tile_part(Part::Blocker)
         rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
         @tile.reservations.each { |x| children << render_tile_part(Part::Reservation, reservation: x) }
-        children << render_tile_part(Part::Icons) if @tile.icons.any?
+        children << render_tile_part(Part::Icons) unless @tile.icons.empty?
 
-        children << render_tile_part(Part::Assignments) if @tile.hex.assignments.any?
+        children << render_tile_part(Part::Assignments) unless @tile.hex&.assignments&.empty?
         # borders should always be the top layer
         children << borders if borders
-        children << render_tile_part(Part::Partitions) if @tile.partitions.any?
+        children << render_tile_part(Part::Partitions) unless @tile.partitions.empty?
 
         children << rendered_loc_name if rendered_loc_name && @show_location_names
         children << render_coords if @show_coords

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -238,6 +238,11 @@ describe 'Assets' do
           'train from the Depot. B&amp;O must buy a train from another corporation, or Player 3 '\
           'must declare bankruptcy.',
           'Declare Bankruptcy']]]],
+      ['1846',
+       '22071',
+       [[451,
+         'after_lay',
+         ['ERIE spends $20 and lays tile #25 with rotation 3 on G11']]]],
       ['18AL',
        4714,
        [[nil, 'endgame', '18AL: Operating Round 7.2 (of 3) - Game Over - Company hit max stock value']]],

--- a/spec/fixtures/1846/22071.json
+++ b/spec/fixtures/1846/22071.json
@@ -1,0 +1,5357 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1610313802,
+      "message": "Hello and GL all!\n"
+    },
+    {
+      "type": "bid",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1610313843,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1610313967,
+      "message": "hi\n"
+    },
+    {
+      "type": "bid",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1610313970,
+      "company": "Pass (3)",
+      "price": 0
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1610314163,
+      "message": "sync check\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1610314182,
+      "message": "DJ are you here?\n"
+    },
+    {
+      "type": "bid",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1610314251,
+      "company": "SC",
+      "price": 40
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1610314255,
+      "message": "sorry guys\n"
+    },
+    {
+      "type": "bid",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1610314270,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1610314277,
+      "message": "np\n"
+    },
+    {
+      "type": "bid",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1610314284,
+      "company": "Pass (2)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1610314330,
+      "company": "Pass (4)",
+      "price": 0
+    },
+    {
+      "type": "message",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1610314331,
+      "message": "Howdy all, and I need the luck.\n"
+    },
+    {
+      "type": "bid",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1610314357,
+      "company": "Pass (1)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1610314408,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1610314460,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1610314511,
+      "company": "BIG4",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1610314601,
+      "company": "TBC",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1610314606
+    },
+    {
+      "type": "pass",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1610314615
+    },
+    {
+      "type": "pass",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1610314631
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1610314711,
+      "message": "Wish the MC was priced a bit lower. I hate it for $80\n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1610314751,
+      "message": "it just slows down your start, and this game is about as close to a pure race as these go\n"
+    },
+    {
+      "type": "pass",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1610314756
+    },
+    {
+      "type": "message",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1610314769,
+      "message": "how about $40? LOL\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1610314778,
+      "message": "Gotta be worth $40! \n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1610314780,
+      "message": "absolute steal for 40\n"
+    },
+    {
+      "type": "bid",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1610314784,
+      "company": "MAIL",
+      "price": 80
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1610314788,
+      "message": "happy birthday\n"
+    },
+    {
+      "type": "par",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1610314810,
+      "corporation": "NYC",
+      "share_price": "112,0,11"
+    },
+    {
+      "type": "par",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1610314855,
+      "corporation": "B&O",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1610314867,
+      "message": "thinkin\n"
+    },
+    {
+      "type": "par",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1610314953,
+      "corporation": "IC",
+      "share_price": "50,0,5"
+    },
+    {
+      "type": "par",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1610314975,
+      "corporation": "GT",
+      "share_price": "90,0,9"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1610314982,
+      "shares": [
+        "B&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1610314995,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1610314999
+    },
+    {
+      "type": "buy_shares",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1610315006,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1610315018
+    },
+    {
+      "type": "buy_shares",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1610315024,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1610315039
+    },
+    {
+      "type": "buy_shares",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1610315044,
+      "shares": [
+        "IC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1610315055
+    },
+    {
+      "type": "pass",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1610315060
+    },
+    {
+      "type": "assign",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 45,
+      "created_at": 1610315064,
+      "target": "G19",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 46,
+      "created_at": 1610315068
+    },
+    {
+      "id": 47,
+      "type": "undo",
+      "entity": "MS",
+      "entity_type": "minor",
+      "user": 6095,
+      "created_at": 1610315128
+    },
+    {
+      "id": 48,
+      "type": "redo",
+      "entity": "SC",
+      "entity_type": "company",
+      "user": 6095,
+      "created_at": 1610315132
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 49,
+      "created_at": 1610315145,
+      "hex": "B16",
+      "tile": "6-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 50,
+      "created_at": 1610315152,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ]
+          ],
+          "hexes": [
+            "B16",
+            "C15"
+          ],
+          "revenue": 60,
+          "revenue_str": "B16-C15"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 51,
+      "created_at": 1610315191,
+      "hex": "G9",
+      "tile": "6-1",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 52,
+      "created_at": 1610315203,
+      "hex": "G7",
+      "tile": "6-2",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 53,
+      "created_at": 1610315208,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "G7"
+            ]
+          ],
+          "hexes": [
+            "G7",
+            "G9"
+          ],
+          "revenue": 40,
+          "revenue_str": "G7-G9"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1610315218,
+      "hex": "J4",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1610315226,
+      "hex": "I3",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 56,
+      "created_at": 1610315228,
+      "city": "I5-0-0",
+      "slot": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 57,
+      "created_at": 1610315238,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 58,
+      "created_at": 1610315238,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 59,
+      "created_at": 1610315239,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 60,
+      "created_at": 1610315262
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 61,
+      "created_at": 1610315289
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1610315292,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1610315293,
+      "train": "2-6",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1610315294
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 65,
+      "created_at": 1610315319
+    },
+    {
+      "id": 66,
+      "city": "H12-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315352
+    },
+    {
+      "id": 67,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315355
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1610315372
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1610315374,
+      "train": "2-7",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1610315381,
+      "train": "4-0",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1610315388
+    },
+    {
+      "id": 72,
+      "type": "buy_company",
+      "price": 60,
+      "entity": "B&O",
+      "company": "TBC",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315396
+    },
+    {
+      "id": 73,
+      "type": "sell_shares",
+      "entity": "NYC",
+      "shares": [
+        "NYC_1",
+        "NYC_2"
+      ],
+      "percent": 20,
+      "entity_type": "corporation",
+      "share_price": 100,
+      "user": 2363,
+      "created_at": 1610315400
+    },
+    {
+      "id": 74,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315403
+    },
+    {
+      "id": 75,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315405
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1610315410
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1610315414,
+      "shares": [
+        "NYC_1",
+        "NYC_2"
+      ],
+      "percent": 20,
+      "share_price": 100
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1610315439,
+      "hex": "E19",
+      "tile": "8-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1610315442,
+      "hex": "E17",
+      "tile": "291-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1610315457
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1610315460,
+      "train": "4-1",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1610315461,
+      "train": "4-2",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1610315465
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1610315469
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 85,
+      "created_at": 1610315478
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 86,
+      "created_at": 1610315532,
+      "hex": "B16",
+      "tile": "619-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 87,
+      "created_at": 1610315537,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "B16"
+          ],
+          "revenue": 70,
+          "revenue_str": "C15-B16"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 88,
+      "created_at": 1610315559,
+      "hex": "H10",
+      "tile": "8-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 89,
+      "created_at": 1610315561,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "G7"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "G7"
+          ],
+          "revenue": 40,
+          "revenue_str": "G9-G7"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1610315604,
+      "hex": "D20",
+      "tile": "14-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1610315608,
+      "hex": "D18",
+      "tile": "8-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1610315616
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1610315631,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17"
+          ],
+          "revenue": 100,
+          "revenue_str": "C21-D20-E17"
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "E17",
+              "E19",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "D22",
+            "D20",
+            "E17"
+          ],
+          "revenue": 100,
+          "revenue_str": "D22-D20-E17"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 94,
+      "created_at": 1610315635,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 95,
+      "created_at": 1610315654,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 96,
+      "created_at": 1610315656,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "buy_company",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1610315679,
+      "company": "MAIL",
+      "price": 44
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1610315684
+    },
+    {
+      "id": 99,
+      "hex": "G19",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315695
+    },
+    {
+      "id": 100,
+      "type": "sell_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_2",
+        "B&O_3"
+      ],
+      "percent": 20,
+      "entity_type": "corporation",
+      "share_price": 80,
+      "user": 1491,
+      "created_at": 1610315703
+    },
+    {
+      "id": 101,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315707
+    },
+    {
+      "id": 102,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315709
+    },
+    {
+      "type": "sell_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1610315716,
+      "shares": [
+        "B&O_2",
+        "B&O_3"
+      ],
+      "percent": 20,
+      "share_price": 80
+    },
+    {
+      "type": "buy_company",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1610315720,
+      "company": "SC",
+      "price": 40
+    },
+    {
+      "type": "buy_company",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1610315722,
+      "company": "TBC",
+      "price": 60
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1610315727,
+      "hex": "G19",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "id": 107,
+      "hex": "F18",
+      "tile": "9-2",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315731
+    },
+    {
+      "id": 108,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610315743
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1610315748,
+      "hex": "F18",
+      "tile": "9-2",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1610315751
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1610315763,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G21",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "G19",
+            "G21"
+          ],
+          "revenue": 100,
+          "revenue_str": "G19-G21 + Port"
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H20",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "G19",
+            "H20"
+          ],
+          "revenue": 90,
+          "revenue_str": "G19-H20 + Port"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1610315770,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1610315778
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 114,
+      "created_at": 1610315783,
+      "message": "I hope they fixed that bug where you had to use the C&WI power immediately after buying it in....\n"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1610315784
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1610315792
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1610315802,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "B16",
+              "B18"
+            ]
+          ],
+          "hexes": [
+            "B18",
+            "B16"
+          ],
+          "revenue": 60,
+          "revenue_str": "B18-B16"
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ]
+          ],
+          "hexes": [
+            "B16",
+            "C15"
+          ],
+          "revenue": 70,
+          "revenue_str": "B16-C15"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1610315808,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1610315814
+    },
+    {
+      "type": "buy_company",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1610315835,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1610315840,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1610315844
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1610315875,
+      "company": "BIG4",
+      "price": 30
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1610315880,
+      "hex": "I9",
+      "tile": "8-3",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1610315892,
+      "hex": "G7",
+      "tile": "619-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1610315899
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1610315914,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "I5",
+              "I3",
+              "I1"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "I5"
+          ],
+          "revenue": 60,
+          "revenue_str": "I1-I5"
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "G7"
+          ],
+          "revenue": 50,
+          "revenue_str": "G9-G7"
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9"
+          ],
+          "revenue": 70,
+          "revenue_str": "J10-G9"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1610315916,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1610315942,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 130,
+      "created_at": 1610315963,
+      "shares": [
+        "NYC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 131,
+      "created_at": 1610315969,
+      "shares": [
+        "B&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 132,
+      "created_at": 1610315995,
+      "message": "2 dollars short\n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 133,
+      "created_at": 1610315997,
+      "message": "savage\n"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 134,
+      "created_at": 1610316019,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 135,
+      "created_at": 1610316030,
+      "message": "shoulda issued one\n"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 136,
+      "created_at": 1610316035,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 137,
+      "created_at": 1610316065,
+      "shares": [
+        "B&O_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1610316078,
+      "shares": [
+        "GT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 139,
+      "created_at": 1610316092
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 140,
+      "created_at": 1610316096,
+      "shares": [
+        "IC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 141,
+      "created_at": 1610316101
+    },
+    {
+      "type": "pass",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 142,
+      "created_at": 1610316106
+    },
+    {
+      "type": "pass",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 143,
+      "created_at": 1610316110
+    },
+    {
+      "type": "pass",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 144,
+      "created_at": 1610316113
+    },
+    {
+      "type": "place_token",
+      "entity": "C&WI",
+      "entity_type": "company",
+      "id": 145,
+      "created_at": 1610316132,
+      "city": "D6-0-3",
+      "slot": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 146,
+      "created_at": 1610316150,
+      "hex": "F16",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 147,
+      "created_at": 1610316154,
+      "hex": "F14",
+      "tile": "9-3",
+      "rotation": 1
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1610316190,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10,
+      "share_price": 124
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1610316208,
+      "hex": "E17",
+      "tile": "295-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1610316232
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1610316251,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17"
+          ],
+          "revenue": 110,
+          "revenue_str": "C21-D20-E17"
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "E17",
+              "E19",
+              "D20"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "D22",
+            "D20",
+            "E17",
+            "G19"
+          ],
+          "revenue": 150,
+          "revenue_str": "D22-D20-E17-(G19) + Mail Contract"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1610316258,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1610316282
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1610316313,
+      "hex": "F12",
+      "tile": "8-5",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1610316320,
+      "hex": "G11",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "id": 156,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316333
+    },
+    {
+      "id": 157,
+      "type": "run_routes",
+      "entity": "B&O",
+      "routes": [
+        {
+          "hexes": [
+            "H20",
+            "G19"
+          ],
+          "train": "2-7",
+          "revenue": 90,
+          "connections": [
+            [
+              "G19",
+              "H20"
+            ]
+          ],
+          "revenue_str": "H20-G19 + Port"
+        },
+        {
+          "hexes": [
+            "D20",
+            "E17",
+            "G19",
+            "G21"
+          ],
+          "train": "4-0",
+          "revenue": 150,
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "G19",
+              "F18",
+              "E17"
+            ],
+            [
+              "G21",
+              "G19"
+            ]
+          ],
+          "revenue_str": "D20-E17-G19-(G21) + Port"
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316372
+    },
+    {
+      "id": 158,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316375
+    },
+    {
+      "id": 159,
+      "type": "buy_train",
+      "price": 180,
+      "train": "4-3",
+      "entity": "B&O",
+      "variant": "4",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316385
+    },
+    {
+      "id": 160,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316389
+    },
+    {
+      "id": 161,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316393
+    },
+    {
+      "id": 162,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316394
+    },
+    {
+      "id": 163,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316396
+    },
+    {
+      "id": 164,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316398
+    },
+    {
+      "id": 165,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316399
+    },
+    {
+      "type": "buy_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1610316401,
+      "shares": [
+        "B&O_3"
+      ],
+      "percent": 10,
+      "share_price": 112
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1610316406
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1610316421,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G19",
+              "H20"
+            ]
+          ],
+          "hexes": [
+            "H20",
+            "G19"
+          ],
+          "revenue": 90,
+          "revenue_str": "H20-G19 + Port"
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "G19",
+              "F18",
+              "E17"
+            ],
+            [
+              "G21",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17",
+            "G19",
+            "G21"
+          ],
+          "revenue": 150,
+          "revenue_str": "D20-E17-G19-(G21) + Port"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1610316423,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1610316425,
+      "train": "4-3",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1610316430
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1610316432
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1610316439,
+      "hex": "C15",
+      "tile": "295-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1610316443,
+      "hex": "D14",
+      "tile": "6-3",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSL",
+      "entity_type": "company",
+      "id": 175,
+      "created_at": 1610316454,
+      "hex": "D14",
+      "tile": "15-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1610316455,
+      "city": "15-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1610316478,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "B16",
+              "B18"
+            ]
+          ],
+          "hexes": [
+            "B16",
+            "B18"
+          ],
+          "revenue": 60,
+          "revenue_str": "B16-B18"
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "B16"
+          ],
+          "revenue": 80,
+          "revenue_str": "C15-B16"
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "C15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-C15"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1610316479,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1610316484,
+      "train": "4-4",
+      "price": 180,
+      "variant": "4"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1610316496,
+      "hex": "F6",
+      "tile": "9-4",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1610316498,
+      "hex": "E5",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1610316502,
+      "city": "D6-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1610316545,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "I5",
+              "I3",
+              "I1"
+            ]
+          ],
+          "hexes": [
+            "I5",
+            "I1"
+          ],
+          "revenue": 60,
+          "revenue_str": "I5-I1"
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "G7",
+            "G9"
+          ],
+          "revenue": 50,
+          "revenue_str": "G7-G9"
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 70,
+          "revenue_str": "G9-J10"
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G7",
+              "F6",
+              "E5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "G7"
+          ],
+          "revenue": 40,
+          "revenue_str": "D6-G7"
+        }
+      ]
+    },
+    {
+      "id": 184,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610316547
+    },
+    {
+      "id": 185,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610316551
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1610316553,
+      "kind": "payout"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1610316615,
+      "shares": [
+        "NYC_5",
+        "NYC_6"
+      ],
+      "percent": 20,
+      "share_price": 124
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1610316638,
+      "hex": "E7",
+      "tile": "7-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1610316643,
+      "hex": "D8",
+      "tile": "8-7",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1610316646,
+      "city": "295-0-0",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1610316653,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17"
+          ],
+          "revenue": 110,
+          "revenue_str": "C21-D20-E17"
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "E17",
+              "E19",
+              "D20"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "D22",
+            "D20",
+            "E17",
+            "G19"
+          ],
+          "revenue": 150,
+          "revenue_str": "D22-D20-E17-(G19) + Mail Contract"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1610316661,
+      "kind": "payout"
+    },
+    {
+      "id": 193,
+      "type": "buy_train",
+      "price": 450,
+      "train": "5-0",
+      "entity": "NYC",
+      "variant": "4/6",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610316669
+    },
+    {
+      "id": 194,
+      "hex": "E17",
+      "tile": "297-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316751
+    },
+    {
+      "id": 195,
+      "hex": "E15",
+      "tile": "8-8",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316758
+    },
+    {
+      "id": 196,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316768
+    },
+    {
+      "id": 197,
+      "hex": "E15",
+      "tile": "8-8",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316779
+    },
+    {
+      "id": 198,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316786
+    },
+    {
+      "id": 199,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316787
+    },
+    {
+      "id": 200,
+      "type": "sell_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 112,
+      "user": 1491,
+      "created_at": 1610316791
+    },
+    {
+      "id": 201,
+      "city": "H12-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316801
+    },
+    {
+      "id": 202,
+      "hex": "H12",
+      "tile": "292-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316807
+    },
+    {
+      "id": 203,
+      "hex": "I11",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610316811
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 204,
+      "created_at": 1610316950,
+      "message": "i can't travel through G11\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 205,
+      "created_at": 1610316953,
+      "message": "any ideas why?\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 206,
+      "created_at": 1610316957,
+      "message": "Track already there\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 207,
+      "created_at": 1610317003,
+      "message": "Did you lay the yellow tile there this turn?\n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 208,
+      "created_at": 1610317008,
+      "message": "i had to refresh a few  times earlier\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 209,
+      "created_at": 1610317010,
+      "message": "yes\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 210,
+      "created_at": 1610317084,
+      "message": "50 less run\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 211,
+      "created_at": 1610317095,
+      "message": "why can' t i run from cincinatit to cleveland??\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1610317135,
+      "message": "that's weird\n"
+    },
+    {
+      "type": "message",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1610317167,
+      "message": "refresh, go out and reload the game\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 214,
+      "created_at": 1610317171,
+      "message": "G11 looks ghosted out on my map\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 215,
+      "created_at": 1610317180,
+      "message": "so strange\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 216,
+      "created_at": 1610317194,
+      "message": "\nI could try to lay your tiles this turn in master mode\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 217,
+      "created_at": 1610317203,
+      "message": "pls\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 218,
+      "created_at": 1610317208,
+      "message": "no well track is no issue\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 219,
+      "created_at": 1610317217,
+      "message": "can you try do the run in master mode pls?\n"
+    },
+    {
+      "id": 220,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317219
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 221,
+      "created_at": 1610317223,
+      "message": "so from cincinati to cleveland\n"
+    },
+    {
+      "id": 222,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317224
+    },
+    {
+      "id": 223,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317228
+    },
+    {
+      "id": 224,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317247
+    },
+    {
+      "id": 225,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317263
+    },
+    {
+      "id": 226,
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317272
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 227,
+      "created_at": 1610317296,
+      "message": "issued 1 share\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 228,
+      "created_at": 1610317301,
+      "message": "then tokened in cincinati\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1610317307,
+      "message": "then layed 2x track\n"
+    },
+    {
+      "id": 230,
+      "type": "sell_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 112,
+      "user": 2363,
+      "created_at": 1610317317
+    },
+    {
+      "id": 231,
+      "city": "H12-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317320
+    },
+    {
+      "id": 232,
+      "hex": "H12",
+      "tile": "292-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317333
+    },
+    {
+      "id": 233,
+      "hex": "I11",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317335
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 234,
+      "created_at": 1610317342,
+      "message": "ok nvm\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 235,
+      "created_at": 1610317348,
+      "message": "just going to ignore it and run\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 236,
+      "created_at": 1610317356,
+      "message": "that will cost you more if your track isn't already in Cincy wouldn't it?\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 237,
+      "created_at": 1610317385,
+      "message": "what do you mean/\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 238,
+      "created_at": 1610317421,
+      "message": "The token in Cincy is cheaper if you are connected with track or at least if there is track there already\n"
+    },
+    {
+      "id": 239,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317435
+    },
+    {
+      "id": 240,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317437
+    },
+    {
+      "id": 241,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317439
+    },
+    {
+      "id": 242,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317449
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 243,
+      "created_at": 1610317466,
+      "message": "Let me try one more time but I was having trouble getting it to see G11\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 244,
+      "created_at": 1610317479,
+      "message": "ok\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 245,
+      "created_at": 1610317484,
+      "message": "i'll give you 2 mins with it\n"
+    },
+    {
+      "id": 246,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317485
+    },
+    {
+      "id": 247,
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317486
+    },
+    {
+      "id": 248,
+      "type": "sell_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 112,
+      "user": 2363,
+      "created_at": 1610317488
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 249,
+      "created_at": 1610317530,
+      "message": "It won't let me lay track in Cincy even though that is perfectly legal\n"
+    },
+    {
+      "id": 250,
+      "city": "H12-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317568
+    },
+    {
+      "id": 251,
+      "hex": "H12",
+      "tile": "292-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317574
+    },
+    {
+      "id": 252,
+      "hex": "I11",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610317580
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 253,
+      "created_at": 1610317603,
+      "message": "G11 looks ghosted out to me. Looks like a bug\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 254,
+      "created_at": 1610317617,
+      "message": "shall we just go on then?\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 255,
+      "created_at": 1610317649,
+      "message": "does screw me a bitt - buttt we are holding up a live game\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 256,
+      "created_at": 1610317649,
+      "message": "Sure but that could have a big effect the rest of the game\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 257,
+      "created_at": 1610317665,
+      "message": "Sure, maybe it will clear up\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 258,
+      "created_at": 1610317683,
+      "message": "yeah true\n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 259,
+      "created_at": 1610317696,
+      "message": "did you try refreshing?\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 260,
+      "created_at": 1610317701,
+      "message": "\nyeah\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 261,
+      "created_at": 1610317709,
+      "message": "I did even while in master mode\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 262,
+      "created_at": 1610317710,
+      "message": "G11 seems completely ghosted\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 263,
+      "created_at": 1610317736,
+      "message": "I will check when it is my turn to see if NYC can \"see\" it\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 264,
+      "created_at": 1610317786,
+      "message": "ok then I'm not issuing to token obv\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 265,
+      "created_at": 1610317796,
+      "message": "or maybe I am\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 266,
+      "created_at": 1610317797,
+      "message": "You may want to issue another share and token Cleveland because the cheatin game won't let you look thru G11\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 267,
+      "created_at": 1610317802,
+      "message": "taking over again Derrick\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 268,
+      "created_at": 1610317810,
+      "message": "sure\n"
+    },
+    {
+      "id": 269,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317817
+    },
+    {
+      "id": 270,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317819
+    },
+    {
+      "id": 271,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317819
+    },
+    {
+      "id": 272,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317821
+    },
+    {
+      "id": 273,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317822
+    },
+    {
+      "id": 274,
+      "type": "redo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317823
+    },
+    {
+      "id": 275,
+      "city": "295-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317825
+    },
+    {
+      "id": 276,
+      "type": "sell_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 112,
+      "user": 1491,
+      "created_at": 1610317831
+    },
+    {
+      "id": 277,
+      "hex": "G11",
+      "tile": "25-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317865
+    },
+    {
+      "id": 278,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317879
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 279,
+      "created_at": 1610317884,
+      "message": "G11 is completely bugged\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 280,
+      "created_at": 1610317893,
+      "message": "even for laying track to indy\n"
+    },
+    {
+      "id": 281,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317896
+    },
+    {
+      "id": 282,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317899
+    },
+    {
+      "id": 283,
+      "hex": "F12",
+      "tile": "24-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317931
+    },
+    {
+      "id": 284,
+      "hex": "F10",
+      "tile": "8-8",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317935
+    },
+    {
+      "id": 285,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317943
+    },
+    {
+      "id": 286,
+      "type": "sell_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 112,
+      "user": 1491,
+      "created_at": 1610317978
+    },
+    {
+      "id": 287,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317986
+    },
+    {
+      "id": 288,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317987
+    },
+    {
+      "id": 289,
+      "type": "sell_shares",
+      "entity": "B&O",
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 112,
+      "user": 1491,
+      "created_at": 1610317992
+    },
+    {
+      "id": 290,
+      "city": "295-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610317993
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 291,
+      "created_at": 1610317995,
+      "message": "yeah it looks ghosted out on my screen\n"
+    },
+    {
+      "id": 292,
+      "type": "run_routes",
+      "entity": "B&O",
+      "routes": [
+        {
+          "hexes": [
+            "G19",
+            "G21"
+          ],
+          "train": "2-7",
+          "revenue": 100,
+          "connections": [
+            [
+              "G21",
+              "G19"
+            ]
+          ],
+          "revenue_str": "G19-G21 + Port"
+        },
+        {
+          "hexes": [
+            "E17",
+            "D20",
+            "D22"
+          ],
+          "train": "4-0",
+          "revenue": 110,
+          "connections": [
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D22",
+              "D20"
+            ]
+          ],
+          "revenue_str": "E17-D20-D22"
+        },
+        {
+          "hexes": [
+            "D20",
+            "E17",
+            "G19",
+            "H20"
+          ],
+          "train": "4-3",
+          "revenue": 170,
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "G19",
+              "F18",
+              "E17"
+            ],
+            [
+              "H20",
+              "G19"
+            ]
+          ],
+          "revenue_str": "D20-E17-G19-H20 + Port"
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318017
+    },
+    {
+      "id": 293,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318020
+    },
+    {
+      "id": 294,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318025
+    },
+    {
+      "id": 295,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318032
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 296,
+      "created_at": 1610318036,
+      "message": "sorry guys\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 297,
+      "created_at": 1610318043,
+      "message": "that did screwe me big tthough\n"
+    },
+    {
+      "id": 298,
+      "type": "sell_shares",
+      "entity": "GT",
+      "shares": [
+        "GT_4",
+        "GT_5",
+        "GT_6",
+        "GT_7"
+      ],
+      "percent": 40,
+      "entity_type": "corporation",
+      "share_price": 100,
+      "user": 6095,
+      "created_at": 1610318051
+    },
+    {
+      "id": 299,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 6095,
+      "created_at": 1610318062
+    },
+    {
+      "id": 300,
+      "hex": "B14",
+      "tile": "7-1",
+      "type": "lay_tile",
+      "entity": "GT",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 6095,
+      "created_at": 1610318074
+    },
+    {
+      "id": 301,
+      "hex": "C13",
+      "tile": "7-2",
+      "type": "lay_tile",
+      "entity": "GT",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "user": 6095,
+      "created_at": 1610318080
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 302,
+      "created_at": 1610318128,
+      "message": "yeah that is totally unfair to you. I will agree not to token Indy with NYC FWIW even though it is in my interests\n"
+    },
+    {
+      "id": 303,
+      "type": "run_routes",
+      "entity": "GT",
+      "routes": [
+        {
+          "hexes": [
+            "B16",
+            "B18"
+          ],
+          "train": "2-5",
+          "revenue": 60,
+          "connections": [
+            [
+              "B16",
+              "B18"
+            ]
+          ],
+          "revenue_str": "B16-B18"
+        },
+        {
+          "hexes": [
+            "C15",
+            "B16"
+          ],
+          "train": "2-6",
+          "revenue": 80,
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ]
+          ],
+          "revenue_str": "C15-B16"
+        },
+        {
+          "hexes": [
+            "C15",
+            "D14"
+          ],
+          "train": "2-0",
+          "revenue": 80,
+          "connections": [
+            [
+              "C15",
+              "D14"
+            ]
+          ],
+          "revenue_str": "C15-D14"
+        },
+        {
+          "hexes": [
+            "D14",
+            "C15",
+            "B16"
+          ],
+          "train": "4-4",
+          "revenue": 110,
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ],
+            [
+              "B16",
+              "B14",
+              "C15"
+            ]
+          ],
+          "revenue_str": "D14-C15-B16"
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 6095,
+      "created_at": 1610318169
+    },
+    {
+      "id": 304,
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 6095,
+      "created_at": 1610318171
+    },
+    {
+      "id": 305,
+      "hex": "G9",
+      "tile": "619-2",
+      "type": "lay_tile",
+      "entity": "IC",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318210
+    },
+    {
+      "id": 306,
+      "hex": "H6",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "IC",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318225
+    },
+    {
+      "id": 307,
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318234
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 308,
+      "created_at": 1610318244,
+      "message": "wait, in trying to fix B&O somehow my purchase of the first brown train got removed. Did the game do that?\n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 309,
+      "created_at": 1610318262,
+      "message": "maybe? do you want to go back?\n"
+    },
+    {
+      "type": "message",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 310,
+      "created_at": 1610318333,
+      "message": "I was confused by that, I would have a totally different move then.\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 311,
+      "created_at": 1610318343,
+      "message": "Sure. I did buy it. Maybe I went back too far while in master mode\n"
+    },
+    {
+      "type": "message",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 312,
+      "created_at": 1610318359,
+      "message": "go ahead then\n"
+    },
+    {
+      "id": 313,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318363
+    },
+    {
+      "id": 314,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318366
+    },
+    {
+      "id": 315,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318367
+    },
+    {
+      "id": 316,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318370
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 317,
+      "created_at": 1610318373,
+      "message": "Since B&O went right after me, it would have only been an extra undo click\n"
+    },
+    {
+      "id": 318,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318380
+    },
+    {
+      "id": 319,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318381
+    },
+    {
+      "id": 320,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318381
+    },
+    {
+      "id": 321,
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318382
+    },
+    {
+      "id": 322,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318382
+    },
+    {
+      "id": 323,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318383
+    },
+    {
+      "id": 324,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318383
+    },
+    {
+      "id": 325,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318385
+    },
+    {
+      "id": 326,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318386
+    },
+    {
+      "id": 327,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318388
+    },
+    {
+      "id": 328,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318392
+    },
+    {
+      "id": 329,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610318393
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1610318397,
+      "train": "5-0",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1610318425,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "share_price": 112
+    },
+    {
+      "id": 332,
+      "city": "H12-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318427
+    },
+    {
+      "id": 333,
+      "hex": "H12",
+      "tile": "292-0",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318431
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 334,
+      "created_at": 1610318434,
+      "message": "I guess we better put a big asterisk after this one no matter who wins!\n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 335,
+      "created_at": 1610318440,
+      "message": "hahaha\n"
+    },
+    {
+      "id": 336,
+      "hex": "I11",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318440
+    },
+    {
+      "id": 337,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318445
+    },
+    {
+      "id": 338,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318446
+    },
+    {
+      "id": 339,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610318449
+    },
+    {
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 340,
+      "created_at": 1610318474,
+      "city": "H12-0-0",
+      "slot": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 341,
+      "created_at": 1610318484,
+      "hex": "H12",
+      "tile": "292-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1610318487,
+      "hex": "I11",
+      "tile": "9-5",
+      "rotation": 0
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 343,
+      "created_at": 1610318496,
+      "message": "G11 looks normal to me ATM\n"
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 344,
+      "created_at": 1610318507,
+      "message": "this is so messed up - cincinaty still an issue\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 345,
+      "created_at": 1610318510,
+      "message": "nope, just ghosted out\n"
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 346,
+      "created_at": 1610318559,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G21",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "G19",
+            "G21"
+          ],
+          "revenue": 140,
+          "revenue_str": "G19-G21 + Port"
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H12",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "H12"
+          ],
+          "revenue": 110,
+          "revenue_str": "J10-H12"
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "G19",
+              "F18",
+              "E17"
+            ],
+            [
+              "H20",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17",
+            "G19",
+            "H20"
+          ],
+          "revenue": 190,
+          "revenue_str": "D20-E17-G19-H20 + Port"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 347,
+      "created_at": 1610318570,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 348,
+      "created_at": 1610318574
+    },
+    {
+      "type": "sell_shares",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 349,
+      "created_at": 1610318587,
+      "shares": [
+        "GT_4",
+        "GT_5",
+        "GT_6",
+        "GT_7"
+      ],
+      "percent": 40,
+      "share_price": 100
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 350,
+      "created_at": 1610318591,
+      "hex": "C15",
+      "tile": "297-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 351,
+      "created_at": 1610318597,
+      "hex": "B14",
+      "tile": "7-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 352,
+      "created_at": 1610318615,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "B16",
+              "B18"
+            ]
+          ],
+          "hexes": [
+            "B16",
+            "B18"
+          ],
+          "revenue": 80,
+          "revenue_str": "B16-B18"
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "B16"
+          ],
+          "revenue": 90,
+          "revenue_str": "C15-B16"
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14"
+          ],
+          "revenue": 90,
+          "revenue_str": "C15-D14"
+        },
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "B16",
+              "B14",
+              "C15"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "B16"
+          ],
+          "revenue": 150,
+          "revenue_str": "C17-C15-B16"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 353,
+      "created_at": 1610318620,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 354,
+      "created_at": 1610318629,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 355,
+      "created_at": 1610318643,
+      "hex": "D6",
+      "tile": "298-0",
+      "rotation": 0
+    },
+    {
+      "type": "message",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 356,
+      "created_at": 1610318648,
+      "message": "damn, that actually was planned right....\n"
+    },
+    {
+      "id": 357,
+      "type": "sell_shares",
+      "entity": "IC",
+      "shares": [
+        "IC_6",
+        "IC_7",
+        "IC_8"
+      ],
+      "percent": 30,
+      "entity_type": "corporation",
+      "share_price": 70,
+      "user": 833,
+      "created_at": 1610318654
+    },
+    {
+      "id": 358,
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318657
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 359,
+      "created_at": 1610318682,
+      "message": "when i clicked the track between chi and terre, it highlighted G11 as well\n"
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 360,
+      "created_at": 1610318687,
+      "message": "i wonder if there's an indexing issue\n"
+    },
+    {
+      "id": 361,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318721
+    },
+    {
+      "id": 362,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318723
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 363,
+      "created_at": 1610318739,
+      "message": "G11 track is showing as purple now as if it is part of IC's run with its purple 2T\n"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 364,
+      "created_at": 1610318745,
+      "hex": "H6",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "id": 365,
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318751
+    },
+    {
+      "id": 366,
+      "type": "run_routes",
+      "entity": "IC",
+      "routes": [
+        {
+          "hexes": [
+            "C5",
+            "D6"
+          ],
+          "train": "2-2",
+          "revenue": 80,
+          "connections": [
+            [
+              "D6",
+              "C5"
+            ]
+          ],
+          "revenue_str": "C5-D6"
+        },
+        {
+          "hexes": [
+            "G7",
+            "D6"
+          ],
+          "train": "2-3",
+          "revenue": 70,
+          "connections": [
+            [
+              "D6",
+              "E5",
+              "F6",
+              "G7"
+            ]
+          ],
+          "revenue_str": "G7-D6"
+        },
+        {
+          "hexes": [
+            "J10",
+            "G9"
+          ],
+          "train": "2-4",
+          "revenue": 90,
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I9",
+              "J10"
+            ]
+          ],
+          "revenue_str": "J10-G9"
+        },
+        {
+          "hexes": [
+            "I1",
+            "I5"
+          ],
+          "train": "2-1",
+          "revenue": 80,
+          "connections": [
+            [
+              "I5",
+              "I3",
+              "I1"
+            ]
+          ],
+          "revenue_str": "I1-I5"
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318770
+    },
+    {
+      "id": 367,
+      "kind": "half",
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318784
+    },
+    {
+      "id": 368,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318799
+    },
+    {
+      "id": 369,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318802
+    },
+    {
+      "id": 370,
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "user": 833,
+      "created_at": 1610318804
+    },
+    {
+      "type": "sell_shares",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 371,
+      "created_at": 1610318806,
+      "shares": [
+        "IC_6",
+        "IC_7",
+        "IC_8"
+      ],
+      "percent": 30,
+      "share_price": 70
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1610318811
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 373,
+      "created_at": 1610318830,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D6",
+              "C5"
+            ]
+          ],
+          "hexes": [
+            "C5",
+            "D6"
+          ],
+          "revenue": 80,
+          "revenue_str": "C5-D6"
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "D6",
+              "E5",
+              "F6",
+              "G7"
+            ]
+          ],
+          "hexes": [
+            "G7",
+            "D6"
+          ],
+          "revenue": 70,
+          "revenue_str": "G7-D6"
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9"
+          ],
+          "revenue": 90,
+          "revenue_str": "J10-G9"
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "I5",
+              "I3",
+              "I1"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "I5"
+          ],
+          "revenue": 80,
+          "revenue_str": "I1-I5"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1610318833,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 375,
+      "created_at": 1610318836,
+      "train": "5-2",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 376,
+      "created_at": 1610318880
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 377,
+      "created_at": 1610318897,
+      "message": "I think the only reason could token in Cincy was because of its ability. Somehow G11 must have gotten corrupted.. I bet nobody can upgrade in there either...\n"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 378,
+      "created_at": 1610318927,
+      "shares": [
+        "IC_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 379,
+      "created_at": 1610318932,
+      "message": "yeah think so too\n"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 380,
+      "created_at": 1610318940,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 381,
+      "created_at": 1610318969,
+      "message": "thinking\n"
+    },
+    {
+      "type": "par",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 382,
+      "created_at": 1610319133,
+      "corporation": "ERIE",
+      "share_price": "150,0,14"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 383,
+      "created_at": 1610319144,
+      "shares": [
+        "GT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 384,
+      "created_at": 1610319176,
+      "shares": [
+        "NYC_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 385,
+      "created_at": 1610319182,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 386,
+      "created_at": 1610319240,
+      "message": "thinkin\n"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 387,
+      "created_at": 1610319322,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 388,
+      "created_at": 1610319323,
+      "shares": [
+        "ERIE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 389,
+      "created_at": 1610319354,
+      "shares": [
+        "NYC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 390,
+      "created_at": 1610319362
+    },
+    {
+      "type": "pass",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 391,
+      "created_at": 1610319375
+    },
+    {
+      "type": "pass",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 392,
+      "created_at": 1610319379
+    },
+    {
+      "type": "pass",
+      "entity": 6095,
+      "entity_type": "player",
+      "id": 393,
+      "created_at": 1610319383
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 394,
+      "created_at": 1610319396,
+      "message": "now G11 works\n"
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 395,
+      "created_at": 1610319413,
+      "message": "Is G11 ghosted out for you now?\n"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1610319429,
+      "hex": "E17",
+      "tile": "297-1",
+      "rotation": 3
+    },
+    {
+      "id": 397,
+      "hex": "E15",
+      "tile": "8-8",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610319432
+    },
+    {
+      "id": 398,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610319440
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 399,
+      "created_at": 1610319444,
+      "message": "Hopefully it will remain so\n"
+    },
+    {
+      "id": 400,
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610319445
+    },
+    {
+      "type": "message",
+      "entity": 1491,
+      "entity_type": "player",
+      "id": 401,
+      "created_at": 1610319472,
+      "message": "still ghosted\n"
+    },
+    {
+      "id": 402,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610319507
+    },
+    {
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1610319510,
+      "city": "297-1-0",
+      "slot": 2
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 404,
+      "created_at": 1610319517
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 405,
+      "created_at": 1610319536,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D22",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "E17",
+            "D20",
+            "D22"
+          ],
+          "revenue": 150,
+          "revenue_str": "E17-D20-D22"
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "G19",
+              "F18",
+              "E17"
+            ],
+            [
+              "H20",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17",
+            "G19",
+            "H20"
+          ],
+          "revenue": 200,
+          "revenue_str": "D20-E17-G19-H20 + Port"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 406,
+      "created_at": 1610319539,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 407,
+      "created_at": 1610319543
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 408,
+      "created_at": 1610319553,
+      "shares": [
+        "ERIE_2"
+      ],
+      "percent": 10,
+      "share_price": 137
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 409,
+      "created_at": 1610319553,
+      "message": "I wonder if it would have let you upgrade it when it was visable?\n"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 410,
+      "created_at": 1610319571,
+      "hex": "D20",
+      "tile": "611-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 411,
+      "created_at": 1610319580
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 412,
+      "created_at": 1610319606,
+      "train": "5-3",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 413,
+      "created_at": 1610319611
+    },
+    {
+      "id": 414,
+      "type": "sell_shares",
+      "entity": "NYC",
+      "shares": [
+        "NYC_8",
+        "NYC_1"
+      ],
+      "percent": 20,
+      "entity_type": "corporation",
+      "share_price": 124,
+      "user": 2363,
+      "created_at": 1610319623
+    },
+    {
+      "id": 415,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610319635
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 416,
+      "created_at": 1610319668,
+      "hex": "D10",
+      "tile": "9-7",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 417,
+      "created_at": 1610319671,
+      "hex": "D12",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 418,
+      "created_at": 1610319679,
+      "city": "297-0-0",
+      "slot": 1
+    },
+    {
+      "id": 419,
+      "type": "run_routes",
+      "entity": "NYC",
+      "routes": [
+        {
+          "hexes": [
+            "C21",
+            "D20",
+            "E17"
+          ],
+          "train": "4-1",
+          "revenue": 160,
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "revenue_str": "C21-D20-E17"
+        },
+        {
+          "hexes": [
+            "D20",
+            "E17",
+            "G19",
+            "G21"
+          ],
+          "train": "4-2",
+          "revenue": 170,
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "D20"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G19",
+              "G21"
+            ]
+          ],
+          "revenue_str": "D20-E17-(G19)-G21"
+        },
+        {
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "train": "5-0",
+          "revenue": 330,
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "D6",
+              "E7",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "revenue_str": "C17-C15-(D14)-D6-C5 + E/W + Mail Contract"
+        }
+      ],
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610319770
+    },
+    {
+      "id": 420,
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "user": 2363,
+      "created_at": 1610319822
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 421,
+      "created_at": 1610319833,
+      "shares": [
+        "NYC_8",
+        "NYC_1"
+      ],
+      "percent": 20,
+      "share_price": 124
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 422,
+      "created_at": 1610319877,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17"
+          ],
+          "revenue": 160,
+          "revenue_str": "C21-D20-E17"
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "D20"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G19",
+              "G21"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17",
+            "G19",
+            "G21"
+          ],
+          "revenue": 170,
+          "revenue_str": "D20-E17-(G19)-G21"
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "D6",
+              "E7",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 330,
+          "revenue_str": "C17-C15-(D14)-D6-C5 + E/W + Mail Contract"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 423,
+      "created_at": 1610319881,
+      "kind": "withhold"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 424,
+      "created_at": 1610319887,
+      "shares": [
+        "GT_8"
+      ],
+      "percent": 10,
+      "share_price": 112
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 425,
+      "created_at": 1610319897,
+      "hex": "D8",
+      "tile": "24-0",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 426,
+      "created_at": 1610319898,
+      "city": "298-0-2",
+      "slot": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 427,
+      "created_at": 1610319932,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "B16",
+              "C15"
+            ],
+            [
+              "B18",
+              "B16"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "B16",
+            "B18"
+          ],
+          "revenue": 140,
+          "revenue_str": "C15-B16-B18"
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 310,
+          "revenue_str": "C17-C15-D14-D6-C5 + E/W"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 428,
+      "created_at": 1610319949,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 429,
+      "created_at": 1610319955
+    },
+    {
+      "type": "message",
+      "entity": 833,
+      "entity_type": "player",
+      "id": 430,
+      "created_at": 1610320022,
+      "message": "oh shit no money\n"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 431,
+      "created_at": 1610320027
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 432,
+      "created_at": 1610320028,
+      "message": "Should have paid half, that's what I get for trying to watch football while playing....\n"
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 433,
+      "created_at": 1610320060,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "I5",
+              "I3",
+              "I1"
+            ],
+            [
+              "G7",
+              "H6",
+              "I5"
+            ],
+            [
+              "G9",
+              "G7"
+            ],
+            [
+              "J10",
+              "I9",
+              "H10",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "I5",
+            "G7",
+            "G9",
+            "J10"
+          ],
+          "revenue": 190,
+          "revenue_str": "I1-(I5)-G7-G9-J10"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 434,
+      "created_at": 1610320079,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 435,
+      "created_at": 1610320081
+    },
+    {
+      "id": 436,
+      "hex": "G17",
+      "tile": "8-8",
+      "type": "lay_tile",
+      "entity": "B&O",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610320089
+    },
+    {
+      "id": 437,
+      "type": "undo",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "user": 1491,
+      "created_at": 1610320095
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 438,
+      "created_at": 1610320104,
+      "hex": "G17",
+      "tile": "8-8",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 439,
+      "created_at": 1610320133,
+      "hex": "F16",
+      "tile": "25-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 440,
+      "created_at": 1610320142
+    },
+    {
+      "type": "message",
+      "entity": 2363,
+      "entity_type": "player",
+      "id": 441,
+      "created_at": 1610320150,
+      "message": "It looked like I could have upgraded G11 during NYC's turn\n"
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1610320199,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F16",
+              "G17",
+              "G19"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ]
+          ],
+          "hexes": [
+            "G21",
+            "G19",
+            "E17",
+            "D20"
+          ],
+          "revenue": 200,
+          "revenue_str": "G21-G19-E17-(D20) + Port"
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "G19",
+              "F18",
+              "E17"
+            ]
+          ],
+          "hexes": [
+            "D22",
+            "D20",
+            "E17",
+            "G19"
+          ],
+          "revenue": 230,
+          "revenue_str": "D22-D20-E17-G19 + Port"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1610320206,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1610320212
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 445,
+      "created_at": 1610320233,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "B16",
+              "C15"
+            ],
+            [
+              "B18",
+              "B16"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "B16",
+            "B18"
+          ],
+          "revenue": 140,
+          "revenue_str": "C15-B16-B18"
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 310,
+          "revenue_str": "C17-C15-D14-D6-C5 + E/W"
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 446,
+      "created_at": 1610320235,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1610320249
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1610338608,
+      "shares": [
+        "ERIE_3"
+      ],
+      "percent": 10,
+      "share_price": 124
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 449,
+      "created_at": 1610338846,
+      "hex": "G5",
+      "tile": "8-9",
+      "rotation": 2
+    },
+    {
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 450,
+      "created_at": 1610338849
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 451,
+      "created_at": 1610338869,
+      "hex": "G11",
+      "tile": "25-1",
+      "rotation": 3
+    },
+    {
+      "type": "end_game",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 452,
+      "created_at": 1610339059
+    }
+  ],
+  "id": "22071",
+  "players": [
+    {
+      "id": 2363,
+      "name": "Mark Derrick"
+    },
+    {
+      "id": 1491,
+      "name": "DJPieter81"
+    },
+    {
+      "id": 833,
+      "name": "tertel"
+    },
+    {
+      "id": 6095,
+      "name": "herb"
+    }
+  ],
+  "title": "1846",
+  "description": "Cloned from game hs_triipgoo_22071",
+  "max_players": 5,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 202852802,
+    "unlisted": false,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "turn": 3,
+  "round": "Operating Round",
+  "acting": [
+    833
+  ],
+  "result": {
+    "DJPieter81": 1857,
+    "herb": 1423,
+    "tertel": 1105,
+    "Mark Derrick": 904
+  },
+  "loaded": true,
+  "created_at": "2021-01-10",
+  "updated_at": 1610339059,
+  "mode": "hotseat"
+}


### PR DESCRIPTION
* not sure what change broke this, but this spec fails on master and passes with
  the code changes, and seems to fit the description given in #3212

* while in the neighborhood, replace some `any?` calls with `!empty?` in Tile view

[Fixes #3212]