### PR TITLE
1828 - M&H presidency exchanges

### DIFF
--- a/assets/app/view/game/button/buy_share.rb
+++ b/assets/app/view/game/button/buy_share.rb
@@ -11,6 +11,7 @@ module View
         needs :share
         needs :entity
         needs :swap_share, default: nil
+        needs :partial_percent, default: nil
         needs :percentages_available, default: 1
         needs :prefix, default: 'Buy'
         needs :source, default: 'Market'
@@ -22,6 +23,7 @@ module View
           reduced_price = @game.format_currency(@share.price - @swap_share.price) if @swap_share
 
           text = @prefix.to_s
+          text += " #{@partial_percent}% of" if @partial_percent
           text += " #{@share.percent}%" if show_percentage
           text += " #{@source} Share"
           text += " (#{reduced_price} + #{@swap_share.percent}% Share)" if @swap_share

--- a/assets/app/view/game/corporation_pending_par.rb
+++ b/assets/app/view/game/corporation_pending_par.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+require 'view/game/par'
+require 'view/game/corporation'
+
+module View
+  module Game
+    class CorporationPendingPar < Snabberb::Component
+      include Actionable
+      needs :corporation
+
+      def render
+        h(:div, [h(Corporation, corporation: @corporation), h(Par, corporation: @corporation)])
+      end
+    end
+  end
+end

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -19,8 +19,9 @@ module View
           store(:selected_company, nil, skip: true)
         end
 
-        text =
-          "#{share.president ? "#{100 / share.num_shares}% of " : ''}#{share.corporation.name} #{share_origin} share"
+        text = ''
+        text += "#{@game.exchange_partial_percent(share)}% of " if share.president
+        text += "#{share.corporation.name} #{share_origin} share"
 
         h('button.small', { on: { click: exchange } }, text)
       end

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -19,7 +19,12 @@ module View
           store(:selected_company, nil, skip: true)
         end
 
-        h('button.small', { on: { click: exchange } }, "#{share.corporation.name} #{share_origin} share")
+        text =
+          if share.president
+            text = "#{100 / share.num_shares}% of #{share.corporation.name} Presidency"
+          end
+
+        h('button.small', { on: { click: exchange } }, text || "#{share.corporation.name} #{share_origin} share")
       end
 
       def render
@@ -31,6 +36,10 @@ module View
         corporations.each do |corporation|
           ipo_share = corporation.shares.find { |s| !s.president }
           children << render_exchange(ipo_share, @game.ipo_name(corporation)) if ability.from.include?(:ipo)
+
+          if !corporation.ipoed# && ability.allow_partial_presidency && can_par?
+            children << render_exchange(corporation.shares.find(&:president), 'Presidency')
+          end
 
           pool_share = @game.share_pool.shares_by_corporation[corporation]&.first
           children << render_exchange(pool_share, 'Market') if ability.from.include?(:market)

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -20,11 +20,9 @@ module View
         end
 
         text =
-          if share.president
-            text = "#{100 / share.num_shares}% of #{share.corporation.name} Presidency"
-          end
+          "#{share.president ? "#{100 / share.num_shares}% of " : ''}#{share.corporation.name} #{share_origin} share"
 
-        h('button.small', { on: { click: exchange } }, text || "#{share.corporation.name} #{share_origin} share")
+        h('button.small', { on: { click: exchange } }, text)
       end
 
       def render
@@ -37,8 +35,9 @@ module View
           ipo_share = corporation.shares.find { |s| !s.president }
           children << render_exchange(ipo_share, @game.ipo_name(corporation)) if ability.from.include?(:ipo)
 
-          if !corporation.ipoed# && ability.allow_partial_presidency && can_par?
-            children << render_exchange(corporation.shares.find(&:president), 'Presidency')
+          if ability.from.include?(:ipo) && @game.exchange_for_partial_presidency? &&
+              (presidency_share = corporation.shares.find(&:president))
+            children << render_exchange(presidency_share, 'Presidency')
           end
 
           pool_share = @game.share_pool.shares_by_corporation[corporation]&.first

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -12,6 +12,7 @@ require 'view/game/corporate_buy_shares'
 require 'view/game/map'
 require 'view/game/route_selector'
 require 'view/game/cash_crisis'
+require 'view/game/corporation_pending_par'
 
 module View
   module Game
@@ -26,6 +27,11 @@ module View
           @current_actions = round.actions_for(entity)
 
           entity = entity.owner if entity.company? && !round.active_entities.one?
+
+          if @current_actions.include?('par') &&
+             @step.respond_to?(:corporation_pending_par) && @step.corporation_pending_par
+            return h(CorporationPendingPar, corporation: @step.corporation_pending_par)
+          end
 
           left = []
           left << h(SpecialBuy) if @current_actions.include?('special_buy')

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -12,7 +12,6 @@ require 'view/game/corporate_buy_shares'
 require 'view/game/map'
 require 'view/game/route_selector'
 require 'view/game/cash_crisis'
-require 'view/game/corporation_pending_par'
 
 module View
   module Game
@@ -27,11 +26,6 @@ module View
           @current_actions = round.actions_for(entity)
 
           entity = entity.owner if entity.company? && !round.active_entities.one?
-
-          if @current_actions.include?('par') &&
-             @step.respond_to?(:corporation_pending_par) && @step.corporation_pending_par
-            return h(CorporationPendingPar, corporation: @step.corporation_pending_par)
-          end
 
           left = []
           left << h(SpecialBuy) if @current_actions.include?('special_buy')

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -10,7 +10,6 @@ require 'view/game/players'
 require 'view/game/sell_shares'
 require 'view/game/stock_market'
 require 'view/game/bid'
-require 'view/game/corporation_pending_par'
 
 module View
   module Game
@@ -36,11 +35,6 @@ module View
           if @last_player != @current_entity && !@auctioning_corporation
             store(:selected_corporation, nil, skip: true)
             store(:last_player, @current_entity, skip: true)
-          end
-
-          if @current_actions.include?('par') &&
-             @step.respond_to?(:corporation_pending_par) && @step.corporation_pending_par
-            return h(CorporationPendingPar, corporation: @step.corporation_pending_par)
           end
 
           children = []

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -10,6 +10,7 @@ require 'view/game/players'
 require 'view/game/sell_shares'
 require 'view/game/stock_market'
 require 'view/game/bid'
+require 'view/game/corporation_pending_par'
 
 module View
   module Game
@@ -35,6 +36,11 @@ module View
           if @last_player != @current_entity && !@auctioning_corporation
             store(:selected_corporation, nil, skip: true)
             store(:last_player, @current_entity, skip: true)
+          end
+
+          if @current_actions.include?('par') &&
+             @step.respond_to?(:corporation_pending_par) && @step.corporation_pending_par
+            return h(CorporationPendingPar, corporation: @step.corporation_pending_par)
           end
 
           children = []

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -139,15 +139,22 @@ module View
         end
 
         def render_pre_ipo(corporation)
+          children = []
+
           type = @step.ipo_type(corporation)
           case type
           when :par
-            return h(Par, corporation: corporation) if @current_actions.include?('par')
+            children << h(Par, corporation: corporation) if @current_actions.include?('par')
           when :bid
-            return h(Bid, entity: @current_entity, corporation: corporation) if @current_actions.include?('bid')
+            children << h(Bid, entity: @current_entity, corporation: corporation) if @current_actions.include?('bid')
           when String
-            return h(:div, type)
+            children << h(:div, type)
           end
+          children << h(BuySellShares, corporation: corporation)
+
+          children.compact!
+          return h(:div, children) unless children.empty?
+
           nil
         end
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -254,6 +254,11 @@ module View
 
       return h(Game::DiscardTrains) if current_entity_actions.include?('discard_train')
 
+      if current_entity_actions.include?('par') &&
+          step.respond_to?(:corporation_pending_par) && step.corporation_pending_par
+        return h(Game::CorporationPendingPar, corporation: step.corporation_pending_par)
+      end
+
       case @round
       when Engine::Round::Stock
         if !(%w[place_token lay_tile remove_token] & current_entity_actions).empty?
@@ -293,6 +298,10 @@ module View
 
     def current_entity_actions
       @current_entity_actions ||= @game.round.actions_for(@game.round.active_step&.current_entity) || []
+    end
+
+    def step
+      @game.round.active_step
     end
   end
 end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1495,6 +1495,10 @@ module Engine
         false
       end
 
+      def exchange_partial_percent(_share)
+        nil
+      end
+
       def round_start?
         @last_game_action_id == @round_history.last
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1495,6 +1495,10 @@ module Engine
         false
       end
 
+      def round_start?
+        @last_game_action_id == @round_history.last
+      end
+
       private
 
       def init_bank

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -631,7 +631,7 @@ module Engine
 
             # Finalize round setup (for things that need round correctly set like place_home_token)
             @round.setup
-            @round_history << @actions.size
+            @round_history << current_action_id
           end
         end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1491,6 +1491,10 @@ module Engine
         transferred
       end
 
+      def exchange_for_partial_presidency?
+        false
+      end
+
       private
 
       def init_bank

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -89,7 +89,7 @@ module Engine
       def operating_round(round_num)
         Round::Operating.new(self, [
           Step::Bankrupt,
-          Step::Exchange,
+          Step::G1828::Exchange,
           Step::G1828::DiscardTrain,
           Step::HomeToken,
           Step::G1828::SpecialTrack,

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -387,6 +387,10 @@ module Engine
         hex.tile.cities[city_index].place_token(@blocking_corporation, token, check_tokenable: false)
       end
 
+      def exchange_for_partial_presidency?
+        true
+      end
+
       private
 
       def setup_minors

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -391,6 +391,12 @@ module Engine
         true
       end
 
+      def exchange_partial_percent(share)
+        return nil unless share.president
+
+        100 / share.num_shares
+      end
+
       private
 
       def setup_minors

--- a/lib/engine/step/g_1828/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1828/buy_sell_par_shares.rb
@@ -14,10 +14,19 @@ module Engine
 
           unless bought?
             actions << 'choose' if can_merge_any?(entity)
-            actions << 'pass' if actions.any? && !actions.include?('pass')
+            actions << 'buy_shares' if player_can_exchange?(entity)
+            actions << 'pass' if !actions.empty? && !actions.include?('pass')
           end
 
           actions
+        end
+
+        def player_can_exchange?(entity)
+          return false unless entity.player?
+
+          company = entity.companies.find { |c| c.id == 'M&H' }
+          step = @round.steps.find { |r| r.is_a?(Engine::Step::G1828::Exchange) }
+          company && step&.can_exchange?(company)
         end
 
         def choice_available?(_entity)

--- a/lib/engine/step/g_1828/exchange.rb
+++ b/lib/engine/step/g_1828/exchange.rb
@@ -8,9 +8,98 @@ module Engine
   module Step
     module G1828
       class Exchange < Exchange
+        def actions(entity)
+          return super unless @entity
+
+          entity == @entity ? %w[par] : []
+        end
+
+        def description
+          @entity ? 'Choose Corporation Par Value' : super
+        end
+
+        def active_entities
+          @entity ? [@entity] : super
+        end
+
+        def blocking?
+          @entity || super
+        end
+
         def process_buy_shares(action)
-          super
-          @round.steps.find { |s| s.is_a?(Engine::Step::G1828::BuySellParShares) }.stock_action(action)
+          company = action.entity
+          bundle = action.bundle
+
+          if @round.stock?
+            unless @round.current_entity == company.owner
+              raise GameError, "Must use #{company.name} on your turn when in a stock round"
+            end
+            raise GameError, 'Cannot exchange and buy on the same turn' if buy_sell_step&.bought?(company.owner)
+          end
+
+          if !bundle.presidents_share
+            corporation = bundle.shares.first.corporation
+            already_floated = corporation.floated?
+
+            super
+
+            # Exchange counts as a stock action
+            buy_sell_step&.stock_action(action)
+
+            # Corporation operates at the start of the operating round where it floated
+            if @round.operating? && @game.last_game_action_id == @game.round_history.last &&
+               !already_floated && corporation.floated?
+              @round.entities.replace(@round.select_entities)
+            end
+          else
+            @corporation = bundle.presidents_share.corporation
+            @entity = company.owner
+
+            unless @game.can_par?(@corporation, @entity)
+              raise GameError, "#{@entity.name} cannot par #{@corporation.name}"
+            end
+            unless cash_to_par?(@entity)
+              raise GameError, "#{@entity.name} does not have enough cash to par #{@corporation.name}"
+            end
+
+            company.close!
+          end
+        end
+
+        def process_par(action)
+          raise GameError, "Must par #{@corporation.name}" unless action.corporation == @corporation
+          raise GameError, "Only #{@entity.name} can par" unless action.entity == @entity
+
+          share_price = action.share_price
+
+          @game.stock_market.set_par(@corporation, share_price)
+          bundle = @corporation.presidents_share.to_bundle
+          @game.share_pool.buy_shares(@entity,
+                                      bundle,
+                                      exchange: true,
+                                      exchange_price: bundle.price_per_share)
+
+          # Exchange counts as a stock action
+          buy_sell_step&.stock_action(action)
+
+          @entity = nil
+          @corporation = nil
+        end
+
+        def corporation_pending_par
+          @corporation
+        end
+
+        def get_par_prices(_entity, _corporation)
+          @game.stock_market.par_prices.select { |p| p.price <= @entity.cash }
+        end
+
+        def cash_to_par?(entity, corporation)
+          !get_par_prices(entity, corporation).empty?
+        end
+
+        def buy_sell_step
+          @round.steps.find { |s| s.is_a?(Engine::Step::G1828::BuySellParShares) }
         end
       end
     end

--- a/lib/engine/step/g_1828/exchange.rb
+++ b/lib/engine/step/g_1828/exchange.rb
@@ -31,7 +31,7 @@ module Engine
           bundle = action.bundle
 
           if @round.stock?
-            unless @round.current_entity == company.owner
+            if @round.current_entity != company.owner
               raise GameError, "Must use #{company.name} on your turn when in a stock round"
             end
             raise GameError, 'Cannot exchange and buy on the same turn' if buy_sell_step&.bought?(company.owner)
@@ -47,8 +47,7 @@ module Engine
             buy_sell_step&.stock_action(action)
 
             # Corporation operates at the start of the operating round where it floated
-            if @round.operating? && @game.last_game_action_id == @game.round_history.last &&
-               !already_floated && corporation.floated?
+            if @round.operating? && @game.round_start? && !already_floated && corporation.floated?
               @round.entities.replace(@round.select_entities)
             end
           else


### PR DESCRIPTION
- Exchange for one share of the presidency (cash for the other after parring)
- Add logic to trigger parring of the corporation after the exchange
- If exchange causes corporation to float, it operates in the next operating in which no corporations have yet operated (could be the current OR)