### PR TITLE
18MS: Fix phase change problem for upcoming trains (fixes #3192)

### DIFF
--- a/lib/engine/step/g_18_ms/buy_train.rb
+++ b/lib/engine/step/g_18_ms/buy_train.rb
@@ -50,6 +50,8 @@ module Engine
           # Phase change triggered here to avoid problems that 2D is cheaper than 6 train (see issue #1553)
           @game.phase.next! if train.name == '6' && !@game.phase.available?('6')
           @game.phase.next! if train.name.include?('D') && !@game.phase.available?('D')
+          # Make D trains available in case 6 train is bought (see issue #3192)
+          @depot.depot_trains(clear: true) if train.name == '6'
 
           return unless emergency_buy_with_loan
 


### PR DESCRIPTION
18MS handles train buys in its own way due to an earlier problem
(#1553) so a refresh of depot trains is needed.