### PR TITLE
18Mag: Add most of OR steps for minors and majors

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -13,7 +13,7 @@ module View
         @step = @game.active_step
 
         entity = @step.current_entity
-        return render_variable(entity) if @step.respond_to?(:max_amount)
+        return render_variable(entity) if @step.dividend_types.include?(:variable)
 
         options = @step.dividend_options(entity)
 
@@ -133,8 +133,7 @@ module View
       end
 
       def render_variable(entity)
-        max = (@step.max_amount(entity) / entity.total_shares).to_i
-
+        max = (@step.variable_max(entity) / entity.total_shares).to_i
 
         input = h(:input, style: { margin: '1rem 0px', marginRight: '1rem' }, props: {
           value: max,
@@ -155,7 +154,7 @@ module View
 
       def create_dividend(input)
         amount = input.JS['elm'].JS['value'].to_i * @step.current_entity.total_shares
-        process_action(Engine::Action::Dividend.new(@step.current_entity, kind: 'payout', amount: amount))
+        process_action(Engine::Action::Dividend.new(@step.current_entity, kind: 'variable', amount: amount))
       end
     end
   end

--- a/lib/engine/action/dividend.rb
+++ b/lib/engine/action/dividend.rb
@@ -5,19 +5,26 @@ require_relative 'base'
 module Engine
   module Action
     class Dividend < Base
-      attr_reader :kind
+      attr_reader :amount, :kind
 
-      def initialize(entity, kind:)
+      def initialize(entity, kind:, amount: nil)
         super(entity)
         @kind = kind
+        @amount = amount
       end
 
       def self.h_to_args(h, _game)
-        { kind: h['kind'] }
+        {
+          kind: h['kind'],
+          amount: h['amount'],
+        }
       end
 
       def args_to_h
-        { 'kind' => @kind }
+        {
+          'kind' => @kind,
+          'amount' => @amount,
+        }
       end
     end
   end

--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -459,9 +459,9 @@ module Engine
       "color": "green"
     },
     {
-      "sym": "KSB",
+      "sym": "SKEV",
       "name": "Gróf Széchenyi István Konsortium",
-      "logo": "18_mag/KSB",
+      "logo": "18_mag/SKEV",
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -243,9 +243,9 @@ module Engine
         cost = price || train.price
         if price != :free && train.owner == @depot
           corp = %w[2 4].include?(train.name) ? @ldsteg : @mavag
-          operator.spend(cost/2, @bank)
-          operator.spend(cost/2, corp)
-          @log << "#{corp.name} earns #{format_currency(cost/2)}"
+          operator.spend(cost / 2, @bank)
+          operator.spend(cost / 2, corp)
+          @log << "#{corp.name} earns #{format_currency(cost / 2)}"
         elsif price != :free
           operator.spend(cost, train.owner)
         end

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -6,7 +6,7 @@ require_relative 'base'
 module Engine
   module Game
     class G18Mag < Base
-      attr_reader :tile_groups, :unused_tiles
+      attr_reader :tile_groups, :unused_tiles, :sik, :skev, :ldsteg, :mavag, :raba, :snw, :gc
 
       load_from_json(Config::Game::G18Mag::JSON)
 
@@ -25,10 +25,22 @@ module Engine
       SELL_BUY_ORDER = :sell_buy
       MARKET_SHARE_LIMIT = 100
 
+      TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded, cost: 10 }].freeze
+
       START_PRICES = [60, 60, 65, 65, 70, 70, 75, 75, 80, 80].freeze
       MINOR_STARTING_CASH = 50
 
+      TRAIN_PRICE_MIN = 1
+
       def setup
+        @sik = @corporations.find { |c| c.name == 'SIK' }
+        @skev = @corporations.find { |c| c.name == 'SKEV' }
+        @ldsteg = @corporations.find { |c| c.name == 'LdStEG' }
+        @mavag = @corporations.find { |c| c.name == 'MAVAG' }
+        @raba = @corporations.find { |c| c.name == 'RABA' }
+        @snw = @corporations.find { |c| c.name == 'SNW' }
+        @gc = @corporations.find { |c| c.name == 'G&C' }
+
         @tile_groups = init_tile_groups
         update_opposites
         @unused_tiles = []
@@ -165,13 +177,13 @@ module Engine
       def operating_round(round_num)
         Round::Operating.new(self, [
           Step::Exchange,
-          Step::DiscardTrain,
-          Step::G18Mag::Track,
           Step::HomeToken,
-          Step::Token,
-          Step::Route,
+          Step::G18Mag::Track,
+          Step::G18Mag::Token,
+          Step::G18Mag::DiscardTrain,
+          Step::G18Mag::Route,
           Step::G18Mag::Dividend,
-          Step::BuyTrain,
+          Step::G18Mag::BuyTrain,
         ], round_num: round_num)
       end
 
@@ -224,6 +236,24 @@ module Engine
         return false if (from.color == :white) && from.label.to_s == 'OO' && from.cities.size != to.cities.size
 
         true
+      end
+
+      # price is nil, :free, or a positive int
+      def buy_train(operator, train, price = nil)
+        cost = price || train.price
+        if price != :free && train.owner == @depot
+          corp = %w[2 4].include?(train.name) ? @ldsteg : @mavag
+          operator.spend(cost/2, @bank)
+          operator.spend(cost/2, corp)
+          @log << "#{corp.name} earns #{format_currency(cost/2)}"
+        elsif price != :free
+          operator.spend(cost, train.owner)
+        end
+        remove_train(train)
+        train.owner = operator
+        operator.trains << train
+        operator.rusted_self = false
+        @crowded_corps = nil
       end
 
       def place_home_token(_corp); end

--- a/lib/engine/step/g_18_mag/buy_train.rb
+++ b/lib/engine/step/g_18_mag/buy_train.rb
@@ -19,7 +19,7 @@ module Engine
 
         def buyable_trains(entity)
           # All trains start out available
-          depot_trains = @depot.upcoming.group_by(&:name).map { |k,v| v.first }
+          depot_trains = @depot.upcoming.group_by(&:name).map { |_k, v| v.first }
           other_trains = @depot.other_trains(entity)
 
           depot_trains.reject! { |t| entity.cash < t.price }

--- a/lib/engine/step/g_18_mag/buy_train.rb
+++ b/lib/engine/step/g_18_mag/buy_train.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../buy_train'
+
+module Engine
+  module Step
+    module G18Mag
+      class BuyTrain < BuyTrain
+        def actions(entity)
+          return [] if entity != current_entity || entity.corporation? || buyable_trains(entity).empty?
+          return %w[buy_train pass] if can_buy_train?(entity)
+
+          []
+        end
+
+        def log_skip(entity)
+          super unless entity.corporation?
+        end
+
+        def buyable_trains(entity)
+          # All trains start out available
+          depot_trains = @depot.upcoming.group_by(&:name).map { |k,v| v.first }
+          other_trains = @depot.other_trains(entity)
+
+          depot_trains.reject! { |t| entity.cash < t.price }
+          other_trains = [] if entity.cash < @game.class::TRAIN_PRICE_MIN
+
+          depot_trains + other_trains
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mag/discard_train.rb
+++ b/lib/engine/step/g_18_mag/discard_train.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G18Mag
+      class DiscardTrain < Base
+        ACTIONS = %w[discard_train pass].freeze
+
+        def actions(entity)
+          return [] unless entity.minor?
+          return [] if entity.trains.empty?
+
+          ACTIONS
+        end
+
+        def description
+          'Scrap Trains'
+        end
+
+        def crowded_corps
+          return [current_entity] if current_entity.minor?
+
+          []
+        end
+
+        def process_discard_train(action)
+          train = action.train
+          entity = action.entity
+          entity.trains.delete(train)
+          @game.depot.unshift_train(train)
+          @log << "#{entity.name} scraps a #{train.name} train"
+        end
+
+        def trains(corporation)
+          corporation.trains
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mag/dividend.rb
+++ b/lib/engine/step/g_18_mag/dividend.rb
@@ -1,13 +1,153 @@
 # frozen_string_literal: true
 
 require_relative '../dividend'
-require_relative '../minor_half_pay'
 
 module Engine
   module Step
     module G18Mag
       class Dividend < Dividend
-        include MinorHalfPay
+        MIN_CORP_PAYOUT = 10
+
+        def actions(entity)
+          return [] if entity.minor?
+          return [] if !entity.corporation? || entity.receivership? || entity.cash < MIN_CORP_PAYOUT
+
+          ACTIONS
+        end
+
+        def skip!
+          if current_entity.minor?
+            revenue = @game.routes_revenue(routes)
+            process_dividend(Action::Dividend.new(
+              current_entity,
+              kind: revenue.positive? ? 'payout' : 'withhold',
+            ))
+          else
+            amount = (current_entity.cash / MIN_CORP_PAYOUT).to_i * MIN_CORP_PAYOUT
+            process_dividend(Action::Dividend.new(
+              current_entity,
+              kind: 'payout',
+              amount: amount,
+            ))
+          end
+        end
+
+        def process_dividend(action)
+          return super if action.entity.minor?
+
+          entity = action.entity
+          kind = action.kind.to_sym
+          amount = action.amount || 0
+          payout = corp_dividend_options(entity, amount)[kind]
+
+          raise GameError, "Amount must be multiples of #{MIN_CORP_PAYOUT}" if amount % MIN_CORP_PAYOUT != 0
+
+          entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
+            routes,
+            action,
+            amount
+          )
+
+          @round.routes = []
+
+          corp_log_run_payout(entity, kind, amount)
+
+          corp_payout_shares(entity, amount) if amount.positive?
+
+          change_share_price(entity, payout)
+
+          pass!
+        end
+
+        def corp_payout_shares(entity, amount)
+          per_share = payout_per_share(entity, amount)
+
+          payouts = {}
+          @game.players.each do |payee|
+            corp_payout_entity(entity, payee, per_share, payouts)
+          end
+
+          corp_payout_entity(entity, holder_for_corporation(entity), per_share, payouts, @game.bank)
+          receivers = payouts
+            .sort_by { |_r, c| -c }
+            .map { |receiver, cash| "#{@game.format_currency(cash)} to #{receiver.name}" }.join(', ')
+
+          @log << "#{entity.name} pays out #{@game.format_currency(amount)} = "\
+            "#{@game.format_currency(per_share)} (#{receivers})"
+
+        end
+
+        def corp_payout_entity(entity, holder, per_share, payouts, receiver = nil)
+          amount = dividends_for_entity(entity, holder, per_share)
+          return if amount.zero?
+
+          receiver ||= holder
+          payouts[receiver] = amount
+          entity.spend(amount, receiver, check_positive: false)
+        end
+
+
+        def corp_dividend_options(entity, amount)
+          dividend_types.map do |type|
+            payout = send(type, entity, amount)
+            payout[:divs_to_corporation] = 0
+            [type, payout.merge(share_price_change(entity, amount - payout[:corporation]))]
+          end.to_h
+        end
+
+        def withhold(entity, _revenue)
+          return super if entity.minor?
+
+          { corporation: 0, per_share: 0 }
+        end
+
+        def corp_log_run_payout(entity, kind, amount)
+          if amount.positive?
+            @log << "#{entity.name} pays out #{@game.format_currency(amount)}"
+          else
+            @log << "#{entity.name} does not pay out"
+          end
+        end
+
+        def share_price_change(entity, revenue = 0)
+          return {} if entity.minor?
+
+          if revenue.zero?
+            { share_direction: :left, share_times: 1 }
+          elsif revenue <= 20
+            {}
+          elsif revenue <= 50
+            { share_direction: :right, share_times: 1 }
+          elsif revenue <= 100
+            { share_direction: :right, share_times: 2 }
+          elsif revenue <= 200
+            { share_direction: :right, share_times: 3 }
+          else
+            { share_direction: :right, share_times: 4 }
+          end
+        end
+
+        def payout(entity, revenue)
+          return super if entity.corporation?
+
+          amount = revenue / 2
+          { corporation: amount, per_share: amount }
+        end
+
+        def payout_shares(entity, revenue)
+          return super if entity.corporation?
+
+          @log << "#{entity.owner.name} receives #{@game.format_currency(revenue)}"
+          @game.bank.spend(revenue, entity.owner)
+        end
+
+        def min_increment
+          MIN_CORP_PAYOUT
+        end
+
+        def max_amount
+          (current_entity.cash / MIN_CORP_PAYOUT).to_i * MIN_CORP_PAYOUT
+        end
       end
     end
   end

--- a/lib/engine/step/g_18_mag/route.rb
+++ b/lib/engine/step/g_18_mag/route.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G18Mag
+      class Route < Route
+        def log_skip(entity)
+          super unless entity.corporation?
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mag/token.rb
+++ b/lib/engine/step/g_18_mag/token.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../token'
+
+module Engine
+  module Step
+    module G18Mag
+      class Token < Token
+        def actions(entity)
+          return [] unless entity == current_entity
+          return [] if entity.corporation? && entity.receivership?
+
+          super
+        end
+
+        def can_place_token?(entity)
+          current_entity == entity &&
+            (tokens = available_tokens(entity)).any? &&
+            min_token_price(tokens) <= buying_power(entity) &&
+            (entity.corporation? || @game.graph.can_token?(entity))
+        end
+
+        def pay_token_cost(entity, cost)
+          skev_income = (cost / 2).to_i
+          entity.spend(cost - skev_income, @game.bank)
+          entity.spend(skev_income, @game.skev)
+
+          @log << "#{@game.skev.name} earns #{@game.format_currency(skev_income)}"
+        end
+
+        def available_hex(entity, hex)
+          if entity.minor?
+            @game.graph.reachable_hexes(entity)[hex]
+          else
+            hex.tile.cities.any? { |c| c.available_slots.positive? }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -8,6 +8,17 @@ module Engine
       class Track < Track
         K_HEXES = %w[I1 H23 H27].freeze
 
+        def actions(entity)
+          return [] unless entity == current_entity
+          return [] if entity.corporation?
+
+          super
+        end
+
+        def log_skip(entity)
+          super unless entity.corporation?
+        end
+
         def process_lay_tile(action)
           old_tile = action.hex.tile
           super
@@ -34,6 +45,18 @@ module Engine
 
           @game.unused_tiles.delete(old_tile.opposite)
           @game.tiles << old_tile.opposite
+        end
+
+        def pay_tile_cost(spender, cost, extra_cost)
+          # FIXME: deal with terrain tokens
+          if extra_cost.positive?
+            spender.spend(extra_cost, @game.skev)
+            @log << "#{@game.skev.name} earns #{@game.format_currency(extra_cost)}"
+          end
+          return unless (cost - extra_cost).positive?
+
+          spender.spend(cost - extra_cost, @game.sik)
+          @log << "#{@game.sik.name} earns #{@game.format_currency(cost - extra_cost)}"
         end
       end
     end

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -46,7 +46,7 @@ module Engine
         free = !token.price.positive?
         city.place_token(entity, token, free: free, cheater: special_ability&.cheater)
         unless free
-          entity.spend(token.price, @game.bank)
+          pay_token_cost(entity, token.price)
           price_log = " for #{@game.format_currency(token.price)}"
         end
 
@@ -60,6 +60,10 @@ module Engine
         end
 
         @game.graph.clear
+      end
+
+      def pay_token_cost(entity, cost)
+        entity.spend(cost, @game.bank)
       end
 
       def min_token_price(tokens)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -121,8 +121,7 @@ module Engine
             @game.tile_cost_with_discount(tile, hex, entity, base_cost)
           end
 
-        try_take_loan(spender, cost)
-        spender.spend(cost, @game.bank) if cost.positive?
+        pay_tile_cost(spender, cost, extra_cost)
 
         cities = tile.cities
         if old_tile.paths.empty? &&
@@ -163,6 +162,11 @@ module Engine
 
         @game.tiles.delete(tile)
         @game.tiles << old_tile unless old_tile.preprinted
+      end
+
+      def pay_tile_cost(spender, cost, _extra_cost)
+        try_take_loan(spender, cost)
+        spender.spend(cost, @game.bank) if cost.positive?
       end
 
       def border_cost(tile, entity)


### PR DESCRIPTION
- Add optional 2nd tile lay
- Add payment to corps for 2nd tile lay, terrain costs, tokens
- Add "variable" dividend type and UI for corps
- Allow any train from depot.upcoming to be used
- Add "scrap" train step (really just discard trains) with train going back to depot.upcoming
- Switch name and logo for former KSB corp - now SKEV
- Skip tile lay, route, buy_train for corps

Common file changes:
- Add "amount" parameter to Action::dividend
- Add support for "variable" dividend type to UI::dividend
- Break out tile and token payments from vanilla Step::track and Step::token

New "variable" dividend UI:
![18Mag_Dividend](https://user-images.githubusercontent.com/8494213/104377546-e880da00-54e3-11eb-8a2c-a022873c28f4.png)
