### PR TITLE
18SJ: Fix Motala Verkstad (fixes #3267)

### DIFF
--- a/lib/engine/config/game/g_18_sj.rb
+++ b/lib/engine/config/game/g_18_sj.rb
@@ -407,14 +407,13 @@ module Engine
       "name": "Motala Verkstad",
       "value": 90,
       "revenue": 15,
-      "desc": "Owning corporation may buy trains at any one time during operating rounds. For 18xx.games this means that owning corporation can buy trains before Run Routes.",
+      "desc": "Owning corporation may do a premature buy of one or more trains, just before Run Routes. These trains can be run even if they have run earlier in the OR. If ability is used the owning corporation cannot buy any trains later in the same OR.",
       "sym": "MV",
       "abilities": [
         {
            "type": "train_buy",
-           "description": "Buy train any time during its OR",
-           "owner_type": "corporation",
-           "count": 1
+           "description": "Buy trains before instead of after Run Routes",
+           "owner_type": "corporation"
         }
       ]
     },

--- a/lib/engine/step/g_18_sj/buy_train.rb
+++ b/lib/engine/step/g_18_sj/buy_train.rb
@@ -11,11 +11,13 @@ module Engine
         include BuyTrainAction
 
         def actions(entity)
-          # If this entity has used Motala Verkstad to buy train(s) do not allow any more train buys
-          return [] if @round.respond_to?(:premature_trains_bought) && @round.premature_trains_bought == entity
+          # If this entity has used Motala Verkstad to buy train(s) do not allow any normal train buys
+          return [] if @round.respond_to?(:premature_trains_bought) && @round.premature_trains_bought.include?(entity)
 
           super
         end
+
+        def do_after_buy_train_action(_action, _entity); end
       end
     end
   end

--- a/lib/engine/step/g_18_sj/buy_train_action.rb
+++ b/lib/engine/step/g_18_sj/buy_train_action.rb
@@ -4,6 +4,8 @@ module BuyTrainAction
   def buy_train_action(action, entity = nil)
     super
 
+    do_after_buy_train_action(action, entity)
+
     @game.perform_nationalization if @game.pending_nationalization?
 
     return if !(exchange = action.exchange) || exchange.name == '4'


### PR DESCRIPTION
Fixed Motala Verkstad:
- Using ability does not close the private
- Can buy any number of trains before running route
  (But still, cannot buy after route if used)
- Prematurely bought trains can operate (cmf KHJ buy-in)
- Updated description

This might break some 18SJ games as the blocking premature
buy now will appear in each OR as long as Motala Verkstad
owned by the corporation operating.
It should be possible to migrate these games and add a
pass action if needed. Alternative is to just delete the games.