### PR TITLE
Fix 18CO private share buyable before being parred

### DIFF
--- a/lib/engine/step/corporate_buy_shares.rb
+++ b/lib/engine/step/corporate_buy_shares.rb
@@ -62,6 +62,7 @@ module Engine
       def can_buy?(entity, bundle)
         return unless bundle
         return unless bundle.buyable
+        return unless bundle.corporation.ipoed
         return if bundle.presidents_share
         return if entity == bundle.corporation
 


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/3262

A corporation should not be able to buy the free share provided by one of the privates unless that share has had its par price set.