### PR TITLE
18Mag: phase changes

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -112,7 +112,7 @@ module View
 
           h(:tr, [
             h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
-            h(:td, Array(phase[:on]).first),
+            h(:td, @game.info_on_trains(phase)),
             h(:td, phase[:operating_rounds]),
             h(:td, train_limit),
             h(:td, phase_props, phase_color.capitalize),

--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -412,7 +412,6 @@ module Engine
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [
-        0,
         40,
         80
       ],
@@ -425,7 +424,6 @@ module Engine
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [
-        0,
         40,
         80
       ],
@@ -439,7 +437,6 @@ module Engine
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [
-        0,
         40,
         80
       ],
@@ -452,7 +449,6 @@ module Engine
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [
-        0,
         40,
         80
       ],
@@ -465,7 +461,6 @@ module Engine
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [
-        0,
         40,
         80
       ],
@@ -479,7 +474,6 @@ module Engine
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [
-        0,
         40,
         80
       ],
@@ -492,7 +486,6 @@ module Engine
       "float_percent": 0,
       "max_ownership_percent": 60,
       "tokens": [
-        0,
         40,
         80
       ],
@@ -510,19 +503,28 @@ module Engine
       "name": "3",
       "distance": 3,
       "price": 120,
-      "num": 25
+      "num": 25,
+      "events": [
+        {"type": "first_three"}
+      ]
     },
     {
       "name": "4",
       "distance": 4,
       "price": 200,
-      "num": 25
+      "num": 25,
+      "events": [
+        {"type": "first_four"}
+      ]
     },
     {
       "name": "6",
       "distance": 6,
       "price": 320,
-      "num": 25
+      "num": 25,
+      "events": [
+        {"type": "first_six"}
+      ]
     }
   ],
   "hexes": {
@@ -707,7 +709,7 @@ module Engine
   },
   "phases": [
     {
-      "name": "yellow",
+      "name": "Yellow",
       "train_limit": 2,
       "tiles": [
         "yellow"
@@ -715,8 +717,8 @@ module Engine
       "operating_rounds": 1
     },
     {
-      "name": "green",
-      "on": "3",
+      "name": "Green",
+      "on": ["3", "4", "6"],
       "train_limit": 2,
       "tiles": [
         "yellow",
@@ -725,8 +727,7 @@ module Engine
       "operating_rounds": 2
     },
     {
-      "name": "brown",
-      "on": "4",
+      "name": "Brown",
       "train_limit": 2,
       "tiles": [
         "yellow",
@@ -736,8 +737,7 @@ module Engine
       "operating_rounds": 2
     },
     {
-      "name": "gray",
-      "on": "6",
+      "name": "Gray",
       "train_limit": 2,
       "tiles": [
         "yellow",
@@ -745,7 +745,10 @@ module Engine
         "brown",
         "gray"
       ],
-      "operating_rounds": 3
+      "operating_rounds": 3,
+      "status":[
+        "end_game_triggered"
+      ]
     }
   ]
 }

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2042,6 +2042,10 @@ module Engine
         corporations.sort_by(&:name)
       end
 
+      def info_on_trains(phase)
+        Array(phase[:on]).first
+      end
+
       def ability_right_type?(ability, type)
         !type || (ability.type == type)
       end

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -32,6 +32,16 @@ module Engine
 
       TRAIN_PRICE_MIN = 1
 
+      EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+        'first_three' => ['First 3', 'Advance phase'],
+        'first_four' => ['First 4', 'Advance phase'],
+        'first_six' => ['First 6', 'Advance phase'],
+      ).freeze
+
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        'end_game_triggered' => ['End Game', 'After next SR, final three ORs are played'],
+      ).freeze
+
       def setup
         @sik = @corporations.find { |c| c.name == 'SIK' }
         @skev = @corporations.find { |c| c.name == 'SKEV' }
@@ -81,6 +91,8 @@ module Engine
           end
           corp.owner = @share_pool
         end
+
+        @trains_left = %w[3 4 6]
       end
 
       def init_tile_groups
@@ -257,6 +269,31 @@ module Engine
       end
 
       def place_home_token(_corp); end
+
+      def event_first_three!
+        @trains_left.delete('3')
+        @phase.current[:on] = nil
+        @phase.upcoming[:on] = @trains_left if @phase.upcoming
+        @phase.next_on = @trains_left
+      end
+
+      def event_first_four!
+        @trains_left.delete('4')
+        @phase.current[:on] = nil
+        @phase.upcoming[:on] = @trains_left if @phase.upcoming
+        @phase.next_on = @trains_left
+      end
+
+      def event_first_six!
+        @trains_left.delete('6')
+        @phase.current[:on] = nil
+        @phase.upcoming[:on] = @trains_left if @phase.upcoming
+        @phase.next_on = @trains_left
+      end
+
+      def info_on_trains(phase)
+        Array(phase[:on]).join(', ')
+      end
     end
   end
 end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -4,6 +4,7 @@ require_relative 'action/buy_train'
 
 module Engine
   class Phase
+    attr_accessor :next_on
     attr_reader :name, :operating_rounds, :tiles, :phases, :status, :corporation_sizes
 
     def initialize(phases, game)
@@ -30,6 +31,10 @@ module Engine
 
     def current
       @phases[@index]
+    end
+
+    def upcoming
+      @phases[@index + 1]
     end
 
     def train_limit(entity)


### PR DESCRIPTION
18Mag changes phases on the purchase of a new train type - independent of which type that is.

Common file changes:
- Engine::Phase - make @next_on accessible, add method to get next phase
- UI::GameInfo - game-specific formatting of phase triggering trains
- Game::Base - game-specific formatting of phase triggering trains

Game Info:
![18Mag_game_info](https://user-images.githubusercontent.com/8494213/104540586-fd8d6400-55dc-11eb-81a8-b427fbdf208c.png)
