### PR TITLE
1828 visual updates

### DIFF
--- a/assets/app/view/game/bank.rb
+++ b/assets/app/view/game/bank.rb
@@ -75,7 +75,7 @@ module View
           ])
         end
 
-        return unless trs.any?
+        return h(:div) if trs.empty?
 
         h('div.bank.card', [
           h('div.title.nowrap', title_props, [h(:em, 'The Bank')]),

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -102,6 +102,17 @@ module View
 
           @selected_company = @step.auctioning if @step.auctioning
 
+          companies = @step.available.select(&:company?)
+          if @step.respond_to?(:tiered_auction?) && @step.tiered_auction?
+            companies.group_by(&:value).values.map do |tier|
+              h(:div, { style: { display: 'table' } }, tier.map { |company| render_company(company) })
+            end
+          else
+            companies.map { |company| render_company(company) }
+          end
+        end
+
+        def render_company(company)
           props = {
             style: {
               display: 'inline-block',
@@ -109,11 +120,9 @@ module View
             },
           }
 
-          @step.available.select(&:company?).map do |company|
-            children = [h(Company, company: company, bids: @step.bids[company])]
-            children << render_input(company) if @selected_company == company
-            h(:div, props, children)
-          end
+          children = [h(Company, company: company, bids: @step.bids[company])]
+          children << render_input(company) if @selected_company == company
+          h(:div, props, children)
         end
 
         def render_input(company)

--- a/lib/engine/config/game/g_1828.rb
+++ b/lib/engine/config/game/g_1828.rb
@@ -522,7 +522,7 @@ module Engine
             "name": "Erie & Kalamazoo Railroad",
             "value": 120,
             "revenue": 20,
-            "desc": "Blocks Adrian & Ann Arbor (E7) while owned by a player. A yellow track tile is placed at E7 when purchased by a company. Owning company may (once) place an additional yellow track tile at $20 as part of its normal track build.",
+            "desc": "Blocks Adrian & Ann Arbor (E7) while owned by a player. A yellow track tile is placed at E7 when purchased by a company. Owning company may (once) place a second yellow track tile at $20 as part of its normal track build.",
             "sym": "E&K",
             "abilities": [
                 {
@@ -818,7 +818,7 @@ module Engine
             "abilities": [
                 {
                     "type": "description",
-                    "description": "Place an additional yellow tile for $40"
+                    "description": "Place a second yellow tile for $40"
                 }
             ]
         },
@@ -961,7 +961,7 @@ module Engine
             "abilities": [
                 {
                     "type": "description",
-                    "description": "Place an additional yellow tile for $40"
+                    "description": "Place a second yellow tile for $40"
                 }
             ]
         },

--- a/lib/engine/config/game/g_1828.rb
+++ b/lib/engine/config/game/g_1828.rb
@@ -535,7 +535,7 @@ module Engine
                 {
                     "type": "tile_lay",
                     "owner_type": "corporation",
-                    "time": "sold",
+                    "when": "sold",
                     "blocks": true,
                     "count": 1,
                     "hexes": [

--- a/lib/engine/config/game/g_1828.rb
+++ b/lib/engine/config/game/g_1828.rb
@@ -160,7 +160,7 @@ module Engine
         ],
         [
             "112",
-            "120p",
+            "120w",
             "127",
             "136",
             "145",
@@ -195,7 +195,7 @@ module Engine
         [
             "95",
             "100",
-            "105p",
+            "105z",
             "111",
             "117",
             "124",
@@ -230,7 +230,7 @@ module Engine
             "81",
             "86",
             "90",
-            "94p",
+            "94x",
             "99",
             "104",
             "109",
@@ -262,7 +262,7 @@ module Engine
             "75",
             "78",
             "82",
-            "86p",
+            "86x",
             "91",
             "95",
             "101",
@@ -535,7 +535,7 @@ module Engine
                 {
                     "type": "tile_lay",
                     "owner_type": "corporation",
-                    "when": "sold",
+                    "time": "sold",
                     "blocks": true,
                     "count": 1,
                     "hexes": [

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -49,6 +49,20 @@ module Engine
 
       NEXT_SR_PLAYER_ORDER = :first_to_pass
 
+      MARKET_TEXT = Base::MARKET_TEXT.merge(par: 'Yellow Phase Par',
+                                            par_1: 'Green Phase Par',
+                                            par_2: 'Blue Phase Par',
+                                            par_3: 'Brown Phase Par',
+                                            unlimited: 'Corporation shares can be held above 60%, ' \
+                                                       'President may buy two shares at a time')
+
+      STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(par: :yellow,
+                                                          par_1: :green,
+                                                          par_2: :blue,
+                                                          par_3: :brown,
+                                                          unlimited: :gray,
+                                                          endgame: :red)
+
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(
         'green_par' => ['Green phase pars',
                         '$86 and $94 par prices are now available'],

--- a/lib/engine/share_price.rb
+++ b/lib/engine/share_price.rb
@@ -18,13 +18,14 @@ module Engine
       's' => :safe_par,
       'x' => :par_1,
       'z' => :par_2,
+      'w' => :par_3,
       'C' => :convert_range,
       'm' => :max_price,
       'u' => :phase_limited,
     }.freeze
 
     # Types which are info only and shouldn't
-    NON_HIGHLIGHT_TYPES = %i[par safe_par par_1 par_2 safe_par convert_range max_price repar].freeze
+    NON_HIGHLIGHT_TYPES = %i[par safe_par par_1 par_2 par_3 safe_par convert_range max_price repar].freeze
 
     def self.from_code(code, row, column, unlimited_types, multiple_buy_types: [])
       return nil if !code || code == ''
@@ -80,7 +81,7 @@ module Engine
     end
 
     def can_par?
-      %i[par par_1 par_2].include?(@type)
+      %i[par par_1 par_2 par_3].include?(@type)
     end
 
     def end_game_trigger?

--- a/lib/engine/step/g_1828/buy_company.rb
+++ b/lib/engine/step/g_1828/buy_company.rb
@@ -22,8 +22,7 @@ module Engine
                                                          hexes: [minor.coordinates],
                                                          price: 0,
                                                          teleport_price: 0,
-                                                         from_owner: true,
-                                                         when: 'sold'))
+                                                         from_owner: true))
 
           @game.remove_minor!(minor)
         end

--- a/lib/engine/step/g_1828/exchange.rb
+++ b/lib/engine/step/g_1828/exchange.rb
@@ -34,7 +34,7 @@ module Engine
             if @round.current_entity != company.owner
               raise GameError, "Must use #{company.name} on your turn when in a stock round"
             end
-            raise GameError, 'Cannot exchange and buy on the same turn' if buy_sell_step&.bought?(company.owner)
+            raise GameError, 'Cannot exchange and buy on the same turn' if buy_sell_step&.bought?
           end
 
           if !bundle.presidents_share

--- a/lib/engine/step/g_1828/waterfall_auction.rb
+++ b/lib/engine/step/g_1828/waterfall_auction.rb
@@ -18,6 +18,10 @@ module Engine
           super
         end
 
+        def tiered_auction?
+          true
+        end
+
         protected
 
         def resolve_bids


### PR DESCRIPTION
- Resolve "undefined" in view when bank in nil by returning an empty div
- Implement tiered auction in the view. This is an auction when the first private cannot be bought unless other privates on its row have been bid on. The engine code was already there. This was only to add the view side.
- Use par groups for the stock market and misc stock mark visual cleanup
- Resolve an ability timing bug