### PR TITLE
Reimplement logic to allow holding certs above the limit.

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -54,7 +54,6 @@ module Engine
       @float_percent = opts[:float_percent] || 60
       @floated = false
       @max_ownership_percent = opts[:max_ownership_percent] || 60
-      @can_hold_above_max = opts[:can_hold_above_max] || false
       @min_price = opts[:min_price]
       @always_market_price = opts[:always_market_price] || false
       @needs_token_to_par = opts[:needs_token_to_par] || false
@@ -183,8 +182,6 @@ module Engine
 
     # Is it legal to hold percent shares in this corporation?
     def holding_ok?(share_holder, extra_percent = 0)
-      return true if @can_hold_above_max
-
       percent = share_holder.percent_of(self) + extra_percent
       %i[multiple_buy unlimited].include?(@share_price&.type) || percent <= @max_ownership_percent
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1510,6 +1510,10 @@ module Engine
         @last_game_action_id == @round_history.last
       end
 
+      def can_hold_above_limit?(_entity)
+        false
+      end
+
       private
 
       def init_bank

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -169,8 +169,8 @@ module Engine
         tile_lays
       end
 
-      def corporation_opts
-        { can_hold_above_max: true }
+      def can_hold_above_limit?(_entity)
+        true
       end
 
       def init_round_finished

--- a/lib/engine/game/g_1870.rb
+++ b/lib/engine/game/g_1870.rb
@@ -149,8 +149,8 @@ module Engine
         []
       end
 
-      def corporation_opts
-        { can_hold_above_max: true }
+      def can_hold_above_limit?(_entity)
+        true
       end
 
       def assignment_tokens(assignment)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -86,6 +86,8 @@ module Engine
       end
 
       def must_sell?(entity)
+        return false if @game.can_hold_above_limit?(entity)
+
         @game.num_certs(entity) > @game.cert_limit ||
           !@game.corporations.all? { |corp| corp.holding_ok?(entity) }
       end


### PR DESCRIPTION
 holding_ok? was used by the buy code, so the old way didn't enforce the cert limit when buying.