### PR TITLE
1867 & other mergers - Add player info in mergers

### DIFF
--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -71,6 +71,7 @@ module View
           elsif merge_entity
             children << h(:div, props, [h(Corporation, corporation: merge_entity, selectable: false)])
           end
+          children << h(Player, game: @game, player: entity.owner) if entity.owner.player?
 
           if mergeable_entities
             props = {


### PR DESCRIPTION
Add active player information on mergers allowing
for more context of if the player wants to merge/convert
![Screenshot from 2021-01-14 22-23-26](https://user-images.githubusercontent.com/71923/104656995-23d40200-56b8-11eb-889c-caa3b2aeba46.png)

fixes #3301