### PR TITLE
Ability timing fix for companies with two tile_lay abilities.

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2083,7 +2083,7 @@ module Engine
         current_step = ability_blocking_step
         current_step_name = current_step&.type
 
-        if (ability.type == :tile_lay) && current_step&.is_a?(Step::SpecialTrack)
+        if ability.type == :tile_lay && ability.must_lay_all && current_step&.is_a?(Step::SpecialTrack)
           return current_step.company == ability.owner
         end
 


### PR DESCRIPTION
The check was implemented for18Chesapeake's B&S company, where both tiles are required to be laid at the same time. It was not intended for all tile_lay abilities. Update the logic to only trigger for tile_lay abilities that also use 'must_lay_all'. Implemented in conjunction with @michaeljb. 

This is a required fix before 1828 goes to alpha.

I ran it against my db snapshot and all looked good. Please run against the latest DB also before deploying. @michaeljb may be able to do some additional validation tonight if need be.