### PR TITLE
1828: Fixes for major bugs found in pre-alpha multiplayer playthrough of full game

### DIFF
--- a/lib/engine/g_1828/system.rb
+++ b/lib/engine/g_1828/system.rb
@@ -29,7 +29,7 @@ module Engine
           transfer_trains(corporation, shell)
         end
 
-        max_price = tokens.max(&:price).price + 1
+        max_price = tokens.max_by(&:price).price + 1
         tokens.sort_by! { |t| (t.used ? -max_price : max_price) + t.price }
       end
 
@@ -38,7 +38,6 @@ module Engine
       end
 
       def remove_train(train)
-        super
         @shells.each { |shell| shell.trains.delete(train) }
       end
 

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -155,15 +155,13 @@ module Engine
         tiles
       end
 
-      SYSTEM_EXTRA_TILE_LAY = { lay: true, upgrade: :not_if_upgraded }.freeze
-      CORP_EXTRA_TILE_LAY = { lay: :not_if_upgraded, upgrade: false, cost: 40 }.freeze
       EXTRA_TILE_LAY_CORPS = %w[B&M NYH].freeze
 
       def tile_lays(entity)
         tile_lays = super
-        tile_lays += [SYSTEM_EXTRA_TILE_LAY] if entity.system?
+        tile_lays += [{ lay: true, upgrade: :not_if_upgraded }] if entity.system?
         (entity.system? ? entity.corporations.map(&:name) : [entity.name]).each do |corp_name|
-          tile_lays += [CORP_EXTRA_TILE_LAY] if EXTRA_TILE_LAY_CORPS.include?(corp_name)
+          tile_lays += [{ lay: :not_if_upgraded, upgrade: false, cost: 40 }] if EXTRA_TILE_LAY_CORPS.include?(corp_name)
         end
 
         tile_lays
@@ -216,7 +214,7 @@ module Engine
 
       def event_remove_corporations!
         @log << "-- Event: #{EVENTS_TEXT['remove_corporations'][1]}. --"
-        @corporations.reject(&:ipoed).each do |corporation|
+        @corporations.reject(&:ipoed).reject(&:closed?).each do |corporation|
           place_home_blocking_token(corporation)
           place_second_home_blocking_token(corporation) if corporation.name == 'ERIE'
           @log << "Removing #{corporation.name}"
@@ -278,11 +276,11 @@ module Engine
       def create_system(corporations)
         return nil unless corporations.size == 2
 
-        system_data = CORPORATIONS.find { |c| c['sym'] == corporations.first.id }.dup
-        system_data['sym'] = corporations.map(&:name).join('-')
-        system_data['tokens'] = []
-        system_data['game'] = self
-        system_data['corporations'] = corporations
+        system_data = CORPORATIONS.find { |c| c[:sym] == corporations.first.id }.dup
+        system_data[:sym] = corporations.map(&:name).join('-')
+        system_data[:tokens] = []
+        system_data[:game] = self
+        system_data[:corporations] = corporations
         system = init_system(@stock_market, system_data)
 
         @corporations << system
@@ -418,6 +416,12 @@ module Engine
 
       def system_by_id(id)
         corporation_by_id(id)
+      end
+
+      def remove_train(train)
+        super
+
+        train.owner.remove_train(train) if train.owner&.system?
       end
 
       private

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -118,12 +118,9 @@ module Engine
 
         payouts = {}
         (@game.players + @game.corporations).each do |payee|
-          next if entity == payee
-
           payout_entity(entity, payee, per_share, payouts)
         end
 
-        payout_entity(entity, holder_for_corporation(entity), per_share, payouts, entity)
         receivers = payouts
                       .sort_by { |_r, c| -c }
                       .map { |receiver, cash| "#{@game.format_currency(cash)} to #{receiver.name}" }.join(', ')
@@ -132,8 +129,13 @@ module Engine
                         "#{@game.format_currency(per_share)} (#{receivers})"
       end
 
-      def payout_entity(entity, holder, per_share, payouts, receiver = nil)
-        amount = dividends_for_entity(entity, holder, per_share)
+      def payout_entity(entity, holder, per_share, payouts)
+        amount =
+          if entity == holder
+            corporation_dividends(entity, per_share)
+          else
+            dividends_for_entity(entity, holder, per_share)
+          end
         return if amount.zero?
 
         receiver ||= holder

--- a/lib/engine/step/g_1828/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1828/buy_sell_par_shares.rb
@@ -6,7 +6,7 @@ module Engine
   module Step
     module G1828
       class BuySellParShares < BuySellParShares
-        PURCHASE_ACTIONS = Engine::Step::BuySellParShares::PURCHASE_ACTIONS + [Action::FailedMerge]
+        PURCHASE_ACTIONS = Engine::Step::BuySellParShares::PURCHASE_ACTIONS + [Action::Choose, Action::FailedMerge]
 
         def actions(entity)
           actions = super
@@ -71,6 +71,12 @@ module Engine
 
         def can_merge?(entity, corporation)
           @game.merge_candidates(entity, corporation).any?
+        end
+
+        def can_gain?(entity, bundle, exchange: false)
+          return true if exchange
+
+          super
         end
 
         def stock_action(action)

--- a/lib/engine/step/g_1828/buy_train.rb
+++ b/lib/engine/step/g_1828/buy_train.rb
@@ -8,7 +8,14 @@ module Engine
       class BuyTrain < BuyTrain
         def actions(entity)
           actions = super
-          actions.delete('pass') if entity.corporation? && must_buy_train?(entity)
+
+          # Actions in base class don't align with system behavior. Fix here.
+          if entity.corporation? && must_buy_train?(entity)
+            actions.delete('pass')
+          elsif actions.include?('buy_train')
+            actions << 'pass'
+          end
+
           actions
         end
 

--- a/lib/engine/step/g_1828/dividend.rb
+++ b/lib/engine/step/g_1828/dividend.rb
@@ -9,9 +9,9 @@ module Engine
       class Dividend < Dividend
         include MinorHalfPay
 
-        def dividends_for_entity(entity, holder, per_share)
-          # Include payout for treasury share
-          entity.system? ? ((holder.num_shares_of(entity) + 1) * per_share).ceil : super
+        # Systems also get paid for their treasury share
+        def corporation_dividends(entity, per_share)
+          super + (entity.system? ? per_share : 0)
         end
       end
     end

--- a/lib/engine/step/g_1828/exchange.rb
+++ b/lib/engine/step/g_1828/exchange.rb
@@ -100,6 +100,12 @@ module Engine
         def buy_sell_step
           @round.steps.find { |s| s.is_a?(Engine::Step::G1828::BuySellParShares) }
         end
+
+        def can_gain?(entity, bundle, exchange: false)
+          return true if exchange
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/step/g_1828/merger.rb
+++ b/lib/engine/step/g_1828/merger.rb
@@ -278,11 +278,11 @@ module Engine
                     "#{shares_needed} system share#{'s' if shares_needed > 1}"
           else
             # Execute trade to get share(s) needed for the exchange
-            shares_to_trade = [merger_pshare, target_pshare, entity.shares_of(@target).first].compact
+            shares_to_trade = [merger_pshare || target_pshare || entity.shares_of(@target).first]
             from_merger_shares = from.shares_of(@merger).reject(&:president)
             shares_to_receive = [from_merger_shares.first,
                                  from.shares_of(@target).reject(&:president).first,
-                                 from_merger_shares[2]].take(shares_needed)
+                                 from_merger_shares[1]].compact.take(shares_needed)
             trade_share(entity, shares_to_trade, from, shares_to_receive)
 
             # Exchange the shares
@@ -332,6 +332,7 @@ module Engine
 
         def restore_odd_share(entity)
           @odd_share&.transfer(entity)
+          @odd_share = nil
         end
 
         def exchange_singles(entity)
@@ -401,7 +402,7 @@ module Engine
               merger_shares = src.shares_of(@merger).reject(&:president)
               target_shares = src.shares_of(@target).reject(&:president)
 
-              merger_shares.size.positive? && [merger_shares + target_shares].size >= num_needed
+              merger_shares.size.positive? && (merger_shares.size + target_shares.size) >= num_needed
             end
 
             # If exchanging with another player, check to see if there are options to choose from


### PR DESCRIPTION
Bugs fixed:
- Discard train did not remove the train from the shell
- Merger did not work on server (Ruby vs JS)
- System owner could not contribute cash if one of the shells were empty
- Game required a train in both shells
- Systems paid a one share dividend to *every* entity
- Couldn't exchange for a share when at the share limit