### PR TITLE
18Mag: add RABA, G&C and SNW power purchase

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -257,7 +257,8 @@ module View
                     '(Invalid Route)'
                   end
 
-        subsidy = render_halts ? ' + ' + @game.format_currency(@game.routes_subsidy(active_routes)) : ''
+        render_halts ||= @game.respond_to?(:routes_subsidy) && @game.routes_subsidy(active_routes).positive?
+        subsidy = render_halts ? " + #{@game.format_currency(@game.routes_subsidy(active_routes))} (subsidy)" : ''
         h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
           h(:div, [
             h('button.small', { on: { click: clear } }, 'Clear Train'),

--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -693,16 +693,16 @@ module Engine
       ]
     },
     "gray": {
-      "city=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0": [
+      "city=revenue:yellow_30|brown_50,visit_cost:0;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0": [
         "A10"
       ],
-      "city=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0": [
+      "city=revenue:yellow_30|brown_50,visit_cost:0;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0": [
         "A18"
       ],
-      "city=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0": [
+      "city=revenue:yellow_30|brown_50,visit_cost:0;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0": [
         "E26"
       ],
-      "city=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0": [
+      "city=revenue:yellow_30|brown_50,visit_cost:0;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0": [
         "I20"
       ]
     }

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -42,6 +42,9 @@ module Engine
         'end_game_triggered' => ['End Game', 'After next SR, final three ORs are played'],
       ).freeze
 
+      RABA_BONUS = [20, 20, 30, 30].freeze
+      SNW_BONUS = [30, 30, 50, 50].freeze
+
       def setup
         @sik = @corporations.find { |c| c.name == 'SIK' }
         @skev = @corporations.find { |c| c.name == 'SKEV' }
@@ -293,6 +296,125 @@ module Engine
 
       def info_on_trains(phase)
         Array(phase[:on]).join(', ')
+      end
+
+      def check_distance(route, visits)
+        distance = if @round.rail_cars.include?('G&C') && (!@round.gc_train || @round.gc_train == route.train)
+                     [
+                       {
+                         nodes: %w[city offboard],
+                         pay: route.train.distance,
+                         visit: route.train.distance,
+                       },
+                       {
+                         nodes: %w[town],
+                         pay: route.train.distance,
+                         visit: route.train.distance,
+                       },
+                     ]
+                   else
+                     route.train.distance
+                   end
+
+        if distance.is_a?(Numeric)
+          route_distance = visits.sum(&:visit_cost)
+          raise GameError, "#{route_distance} is too many stops for #{distance} train" if distance < route_distance
+          raise GameError, 'Must visit minimum of two non-mine stops' if route_distance < 2
+
+          return
+        end
+
+        type_info = Hash.new { |h, k| h[k] = [] }
+
+        distance.each do |h|
+          pay = h['pay']
+          visit = h['visit'] || pay
+          info = { pay: pay, visit: visit }
+          h['nodes'].each { |type| type_info[type] << info }
+        end
+
+        grouped = visits.group_by(&:type)
+
+        grouped.each do |type, group|
+          num = group.sum(&:visit_cost)
+
+          type_info[type].sort_by(&:size).each do |info|
+            next unless info[:visit].positive?
+
+            info[:visit] -= num
+            num = info[:visit] * -1
+            break unless num.positive?
+          end
+
+          raise GameError, 'Route has too many stops' if num.positive?
+        end
+        raise GameError, 'Must visit minimum of two non-mine stops' if visits.sum(&:visit_cost) < 2
+
+        return unless @round.rail_cars.include?('G&C')
+        return unless visits.sum(&:visit_cost) <= route.train.distance
+
+        @round.gc_train = route.train
+      end
+
+      # Change "Stop" displayed if G&C power is used
+      def route_distance(route)
+        return super if @round.gc_train != route.train
+
+        n_cities = route.stops.count { |n| n.city? || n.offboard? }
+        n_towns = route.stops.count(&:town?)
+        "#{n_cities}+#{n_towns}"
+      end
+
+      # See if RABA power is used
+      # Check to see if it's OK to visit a mine (SNW power)
+      def check_other(route)
+        if @round.rail_cars.include?('RABA')
+          if route.stops.select(&:offboard?).empty?
+            @round.raba_trains.delete(route.train)
+          elsif !@round.raba_trains.include?(route.train)
+            @round.raba_trains << route.train
+          end
+        end
+
+        visited = route.visited_stops
+        mines = visited.select { |n| n.city? && n.tokens.any? { |t| t&.type == :neutral } }
+        if @round.rail_cars.include?('SNW') && (!@round.snw_train || @round.snw_train == route.train)
+          route.clear_cache! if !@round.snw_train || @round.snw_train && mines.empty?
+          @round.snw_train = mines.empty? ? nil : route.train
+        elsif !mines.empty?
+          raise GameError, 'Cannot visit mine'
+        end
+
+        raise GameError, 'Cannot visit multiple mines' if mines.size > 1
+      end
+
+      # Modify revenue of offboard if RABA is used
+      def revenue_for(route, stops)
+        raba_add = @round.raba_trains.first == route.train ? raba_delta(@phase) : 0
+        stops.select { |s| s.visit_cost.positive? }.sum { |stop| stop.route_revenue(route.phase, route.train) } +
+          raba_add
+      end
+
+      def raba_delta(phase)
+        RABA_BONUS[phase.current[:tiles].size - 1]
+      end
+
+      # Modify revenue string if RABA is used
+      def revenue_str(route)
+        raba_add = @round.raba_trains.first == route.train ? ' (RABA)' : ''
+        route.hexes.map(&:name).join('-') + raba_add
+      end
+
+      def subsidy_for(route, _stops)
+        @round.snw_train == route.train ? snw_delta : 0
+      end
+
+      def snw_delta
+        SNW_BONUS[phase.current[:tiles].size - 1]
+      end
+
+      def routes_subsidy(routes)
+        routes.sum(&:subsidy)
       end
     end
   end

--- a/lib/engine/step/g_18_mag/dividend.rb
+++ b/lib/engine/step/g_18_mag/dividend.rb
@@ -34,7 +34,14 @@ module Engine
         end
 
         def process_dividend(action)
-          return super if action.entity.minor?
+          if action.entity.minor?
+            subsidy = @game.routes_subsidy(routes)
+            if subsidy.positive?
+              @game.bank.spend(subsidy, action.entity)
+              @log << "#{action.entity.name} retains a subsidy of #{@game.format_currency(subsidy)}"
+            end
+            return super
+          end
 
           entity = action.entity
           kind = action.kind.to_sym

--- a/lib/engine/step/g_18_mag/route.rb
+++ b/lib/engine/step/g_18_mag/route.rb
@@ -6,8 +6,74 @@ module Engine
   module Step
     module G18Mag
       class Route < Route
+        BUY_ACTION = %w[special_buy].freeze
+
+        def actions(entity)
+          return [] if !entity.operator? || entity.runnable_trains.empty? || !@game.can_run_route?(entity)
+
+          route_actions = ACTIONS
+          route_actions.concat(BUY_ACTION) unless buyable_items(entity).empty?
+          route_actions
+        end
+
+        def setup
+          super
+
+          @round.rail_cars = []
+          @round.raba_trains = []
+          @round.snw_train = nil
+          @round.gc_train = nil
+        end
+
         def log_skip(entity)
           super unless entity.corporation?
+        end
+
+        def buyable_items(entity)
+          return [] unless entity.minor?
+          return [] unless entity.minor?
+          return [] unless entity.cash >= item_cost
+
+          items = []
+
+          unless @round.rail_cars.include?('G&C')
+            items << Item.new(description: 'Plus-train Upgrade from G&C', cost: item_cost)
+          end
+
+          unless @round.rail_cars.include?('RABA')
+            items << Item.new(description: 'Off Board Bonus from RABA', cost: item_cost)
+          end
+
+          unless @round.rail_cars.include?('SNW')
+            items << Item.new(description: 'Mine Access from SNW', cost: item_cost)
+          end
+
+          items
+        end
+
+        def item_cost
+          10 * (@round.rail_cars.size + 1)
+        end
+
+        def round_state
+          {
+            routes: [],
+            rail_cars: [],
+            raba_trains: [],
+            snw_train: nil,
+            gc_train: nil,
+          }
+        end
+
+        def process_special_buy(action)
+          item = action.item
+          desc = item.description
+          corp_str = desc[desc.index('from ') + 5..-1]
+          corp = @game.corporation_by_id(corp_str)
+          @round.rail_cars << corp_str
+
+          action.entity.spend(item.cost, corp)
+          @log << "#{action.entity.name} buys #{desc} for #{@game.format_currency(item.cost)}"
         end
       end
     end

--- a/lib/engine/step/g_18_mag/route.rb
+++ b/lib/engine/step/g_18_mag/route.rb
@@ -7,6 +7,7 @@ module Engine
     module G18Mag
       class Route < Route
         BUY_ACTION = %w[special_buy].freeze
+        RAILCAR_BASE = [10, 10, 20, 20].freeze
 
         def actions(entity)
           return [] if !entity.operator? || entity.runnable_trains.empty? || !@game.can_run_route?(entity)
@@ -52,7 +53,7 @@ module Engine
         end
 
         def item_cost
-          10 * (@round.rail_cars.size + 1)
+          RAILCAR_BASE[@game.phase.current[:tiles].size - 1] + 10 * @round.rail_cars.size
         end
 
         def round_state


### PR DESCRIPTION
Use SpecialBuy to allow minor to pay for RABA, G&C and SNW "railcar" powers

G&C, RABA, and SNW powers are available via button above route selector:
![18Mag_buys](https://user-images.githubusercontent.com/8494213/104761666-7b0dbd00-5720-11eb-883a-9290cbad167f.png)

Common file change:
- UI::route_selector - generalize case of showing subsidies (since mines generate those)

G&C power - convert to N+N train:
![18Mag_Plus](https://user-images.githubusercontent.com/8494213/104761443-25d1ab80-5720-11eb-8ef8-021114c499db.png)

RABA power - offboard bonus:
![18Mag_RABA](https://user-images.githubusercontent.com/8494213/104761487-34b85e00-5720-11eb-83d7-8950cc6edc67.png)

SNW power - allow use of mines:
![18Mag_Mine](https://user-images.githubusercontent.com/8494213/104761523-43067a00-5720-11eb-961c-3c6c6ad30228.png)
