### PR TITLE
generically capitalize based on number of shares

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1278,7 +1278,7 @@ module Engine
 
         return if corporation.capitalization == :incremental
 
-        @bank.spend(corporation.par_price.price * 10, corporation)
+        @bank.spend(corporation.par_price.price * corporation.total_shares, corporation)
         @log << "#{corporation.name} receives #{format_currency(corporation.cash)}"
       end
 


### PR DESCRIPTION
This covers cases where companies have 4 or 5 shares (etc) without them needing additional logic

Ran the test fixtures, passed