### PR TITLE
Fix 18CO Prior Connected Paths Timing

### DIFF
--- a/lib/engine/step/g_18_co/tracker.rb
+++ b/lib/engine/step/g_18_co/tracker.rb
@@ -35,6 +35,7 @@ module Engine
         end
 
         def check_track_restrictions!(entity, old_tile, new_tile)
+          return if @game.loading || !entity.operator?
           return true if pending_token(entity)
 
           super(entity, old_tile, new_tile)
@@ -67,6 +68,8 @@ module Engine
         end
 
         def prior_connected_paths(entity, old_tile)
+          return [] if @game.loading
+
           @game.graph.connected_paths(entity).map do |connected_path, _b|
             next unless connected_path.hex == old_tile.hex
 


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/3297

In lay_tile, before check_track_restrictions! is called, the new tile is laid and the graph updated. This meant the original timing for calling prior_connected_paths was after the graph was updated, and thus we were examining newly connected paths as well. If the corporation could trace a loop back to the old segment of track, it would be returned as connected.

The new logic sets the prior_connected_paths before the graph is updated, so we are working with the true set of prior_connected_paths.

**Example**

Here CS should NOT have been able to upgrade the tile to connect between Pueblo and Trinidad (as happened in https://18xx.games/game/22553?action=451 ). The old logic failed because of the loop between Colorado Springs and Pueblo.

<img width="254" alt="Screen Shot 2021-01-14 at 5 54 31 PM" src="https://user-images.githubusercontent.com/15675400/104787712-82978b00-574d-11eb-9ad3-2711f0869a4e.png">
