### PR TITLE
18Mag: implement terrain tokens

### DIFF
--- a/assets/app/view/game/special_buy.rb
+++ b/assets/app/view/game/special_buy.rb
@@ -26,7 +26,12 @@ module View
       end
 
       def render_button(item, &block)
-        h(:button, { on: { click: block } }, "Buy #{item.description} (#{@game.format_currency(item.cost)})")
+        text = if @step.respond_to?(:item_str)
+                 @step.item_str(item)
+               else
+                 "Buy #{item.description} (#{@game.format_currency(item.cost)})"
+               end
+        h(:button, { on: { click: block } }, text)
       end
     end
   end

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -6,7 +6,7 @@ require_relative 'base'
 module Engine
   module Game
     class G18Mag < Base
-      attr_reader :tile_groups, :unused_tiles, :sik, :skev, :ldsteg, :mavag, :raba, :snw, :gc
+      attr_reader :tile_groups, :unused_tiles, :sik, :skev, :ldsteg, :mavag, :raba, :snw, :gc, :terrain_tokens
 
       load_from_json(Config::Game::G18Mag::JSON)
 
@@ -45,6 +45,14 @@ module Engine
       RABA_BONUS = [20, 20, 30, 30].freeze
       SNW_BONUS = [30, 30, 50, 50].freeze
 
+      TERRAIN_TOKENS = {
+        '5' => 3,
+        '6' => 1,
+        '7' => 1,
+        '12' => 2,
+        '13' => 1,
+      }.freeze
+
       def setup
         @sik = @corporations.find { |c| c.name == 'SIK' }
         @skev = @corporations.find { |c| c.name == 'SKEV' }
@@ -53,6 +61,8 @@ module Engine
         @raba = @corporations.find { |c| c.name == 'RABA' }
         @snw = @corporations.find { |c| c.name == 'SNW' }
         @gc = @corporations.find { |c| c.name == 'G&C' }
+
+        @terrain_tokens = TERRAIN_TOKENS.dup
 
         @tile_groups = init_tile_groups
         update_opposites
@@ -415,6 +425,12 @@ module Engine
 
       def routes_subsidy(routes)
         routes.sum(&:subsidy)
+      end
+
+      def status_str(entity)
+        return unless @terrain_tokens[entity.name]
+
+        "Terrain Tokens: #{@terrain_tokens[entity.name]}"
       end
     end
   end

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -22,6 +22,12 @@ module Engine
           }
         end
 
+        def setup
+          super
+
+          @round.terrain_token = nil
+        end
+
         def buyable_items(entity)
           return [] unless @game.terrain_tokens[entity.name]&.positive?
           return [] if @round.terrain_token

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -7,12 +7,39 @@ module Engine
     module G18Mag
       class Track < Track
         K_HEXES = %w[I1 H23 H27].freeze
+        BUY_ACTION = %w[special_buy].freeze
 
         def actions(entity)
           return [] unless entity == current_entity
-          return [] if entity.corporation?
+          return [] if entity.corporation? || entity.company? || !can_lay_tile?(entity)
 
-          super
+          buyable_items(entity).empty? ? ACTIONS : ACTIONS + BUY_ACTION
+        end
+
+        def round_state
+          {
+            terrain_token: nil,
+          }
+        end
+
+        def buyable_items(entity)
+          return [] unless @game.terrain_tokens[entity.name]&.positive?
+          return [] if @round.terrain_token
+
+          [Item.new(description: 'Use Terrain Token', cost: 0)]
+        end
+
+        def item_str(item)
+          item.description
+        end
+
+        def process_special_buy(action)
+          entity = action.entity
+          @round.terrain_token = true
+
+          @game.terrain_tokens[entity.name] -= 1
+
+          @log << "#{entity.name} spends a Terrain Token (#{@game.terrain_tokens[entity.name]} left)"
         end
 
         def log_skip(entity)
@@ -47,15 +74,28 @@ module Engine
           @game.tiles << old_tile.opposite
         end
 
-        def pay_tile_cost(spender, cost, extra_cost)
-          # FIXME: deal with terrain tokens
+        def pay_tile_cost!(entity, tile, rotation, hex, spender, cost, extra_cost)
+          entity_cost = cost
+          entity_cost = extra_cost if (cost - extra_cost).positive? && @round.terrain_token
+          @log << "#{spender.name}"\
+            "#{spender == entity ? '' : " (#{entity.sym})"}"\
+            "#{entity_cost.zero? ? '' : " spends #{@game.format_currency(entity_cost)} and"}"\
+            " lays tile ##{tile.name}"\
+            " with rotation #{rotation} on #{hex.name}"\
+            "#{tile.location_name.to_s.empty? ? '' : " (#{tile.location_name})"}"
+
           if extra_cost.positive?
             spender.spend(extra_cost, @game.skev)
             @log << "#{@game.skev.name} earns #{@game.format_currency(extra_cost)}"
           end
           return unless (cost - extra_cost).positive?
 
-          spender.spend(cost - extra_cost, @game.sik)
+          if @round.terrain_token
+            @round.terrain_token = nil
+            @game.bank.spend(cost - extra_cost, @game.sik)
+          else
+            spender.spend(cost - extra_cost, @game.sik)
+          end
           @log << "#{@game.sik.name} earns #{@game.format_currency(cost - extra_cost)}"
         end
       end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -121,7 +121,7 @@ module Engine
             @game.tile_cost_with_discount(tile, hex, entity, base_cost)
           end
 
-        pay_tile_cost(spender, cost, extra_cost)
+        pay_tile_cost!(entity, tile, rotation, hex, spender, cost, extra_cost)
 
         cities = tile.cities
         if old_tile.paths.empty? &&
@@ -137,13 +137,6 @@ module Engine
 
           token.remove!
         end
-        @log << "#{spender.name}"\
-          "#{spender == entity ? '' : " (#{entity.sym})"}"\
-          "#{cost.zero? ? '' : " spends #{@game.format_currency(cost)} and"}"\
-          " lays tile ##{tile.name}"\
-          " with rotation #{rotation} on #{hex.name}"\
-          "#{tile.location_name.to_s.empty? ? '' : " (#{tile.location_name})"}"
-
         return unless terrain.any?
 
         @game.all_companies_with_ability(:tile_income) do |company, ability|
@@ -164,9 +157,16 @@ module Engine
         @game.tiles << old_tile unless old_tile.preprinted
       end
 
-      def pay_tile_cost(spender, cost, _extra_cost)
+      def pay_tile_cost!(entity, tile, rotation, hex, spender, cost, _extra_cost)
         try_take_loan(spender, cost)
         spender.spend(cost, @game.bank) if cost.positive?
+
+        @log << "#{spender.name}"\
+          "#{spender == entity ? '' : " (#{entity.sym})"}"\
+          "#{cost.zero? ? '' : " spends #{@game.format_currency(cost)} and"}"\
+          " lays tile ##{tile.name}"\
+          " with rotation #{rotation} on #{hex.name}"\
+          "#{tile.location_name.to_s.empty? ? '' : " (#{tile.location_name})"}"
       end
 
       def border_cost(tile, entity)


### PR DESCRIPTION
Use SpecialBuy (again) to implement terrain "tokens"

Common file changes:
- UI::SpecialBuy - allow @step to override default button text
- Step::Tracker - pull tile lay logging message into pay_tile_cost method (to allow redefinition)

![18Mag_Terrain_Tokens](https://user-images.githubusercontent.com/8494213/104794337-2ee46c00-5764-11eb-86ea-12051cc6f120.png)
