### PR TITLE
Fix AFG quake again

### DIFF
--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -568,7 +568,7 @@ module Engine
         # If Garibaldi's only token removed, close Garibaldi
         if afg && city.tokened_by?(afg) && afg.placed_tokens.one?
           @log << '-- AFG loses only token, closing. --'
-          @round.entities.delete(afg)
+          @round.force_next_entity! if @round.current_entity == afg
           close_corporation(afg)
         end
 


### PR DESCRIPTION
Fixes #3337 

Removing the corp from the operating order messes with `entity_index`.