### PR TITLE
18Mag: functionality additions

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -233,6 +233,7 @@ module View
 
         clear = lambda do
           @selected_route&.reset!
+          @game.reset_route!(@selected_route)
           store(:selected_route, @selected_route)
         end
 
@@ -240,12 +241,14 @@ module View
           @selected_route = nil
           store(:selected_route, @selected_route)
           @routes.clear
-          store(:routes, @routes)
           @game.round.routes = @routes
+          @game.reset_all_routes!
+          store(:routes, @routes)
         end
 
         clear_all = lambda do
           @routes.each(&:reset!)
+          @game.reset_all_routes!
           store(:routes, @routes)
         end
 

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -86,7 +86,6 @@ module View
           @selected_route = @routes.first
           store(:routes, @routes, skip: true)
           store(:selected_route, @selected_route, skip: true)
-          @game.round.routes = @routes
         end
 
         if !@selected_route && (first_train = trains[0])
@@ -94,8 +93,9 @@ module View
           @routes << route
           store(:routes, @routes, skip: true)
           store(:selected_route, route, skip: true)
-          @game.round.routes = @routes
         end
+
+        @routes.each(&:clear_cache!)
 
         render_halts = false
         trains = trains.flat_map do |train|
@@ -106,7 +106,6 @@ module View
               store(:routes, @routes)
             end
             store(:selected_route, route)
-            @game.round.routes = @routes
           end
 
           selected = @selected_route&.train == train
@@ -233,7 +232,6 @@ module View
 
         clear = lambda do
           @selected_route&.reset!
-          @game.reset_route!(@selected_route)
           store(:selected_route, @selected_route)
         end
 
@@ -241,14 +239,11 @@ module View
           @selected_route = nil
           store(:selected_route, @selected_route)
           @routes.clear
-          @game.round.routes = @routes
-          @game.reset_all_routes!
           store(:routes, @routes)
         end
 
         clear_all = lambda do
           @routes.each(&:reset!)
-          @game.reset_all_routes!
           store(:routes, @routes)
         end
 

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -86,6 +86,7 @@ module View
           @selected_route = @routes.first
           store(:routes, @routes, skip: true)
           store(:selected_route, @selected_route, skip: true)
+          @game.round.routes = @routes
         end
 
         if !@selected_route && (first_train = trains[0])
@@ -93,6 +94,7 @@ module View
           @routes << route
           store(:routes, @routes, skip: true)
           store(:selected_route, route, skip: true)
+          @game.round.routes = @routes
         end
 
         render_halts = false
@@ -104,6 +106,7 @@ module View
               store(:routes, @routes)
             end
             store(:selected_route, route)
+            @game.round.routes = @routes
           end
 
           selected = @selected_route&.train == train
@@ -238,6 +241,7 @@ module View
           store(:selected_route, @selected_route)
           @routes.clear
           store(:routes, @routes)
+          @game.round.routes = @routes
         end
 
         clear_all = lambda do

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -724,6 +724,10 @@ module Engine
         entity.runnable_trains
       end
 
+      def reset_route!(_route); end
+
+      def reset_all_routes!; end
+
       # Before rusting, check if this train individual should rust.
       def rust?(_train)
         true

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -724,10 +724,6 @@ module Engine
         entity.runnable_trains
       end
 
-      def reset_route!(_route); end
-
-      def reset_all_routes!; end
-
       # Before rusting, check if this train individual should rust.
       def rust?(_train)
         true

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -890,6 +890,10 @@ module Engine
           percent = bundle.percent
           percent -= swap.percent if swap
           (percent / 10).to_i.times { @stock_market.move_down(corporation) }
+        when :down_block
+          @stock_market.move_down(corporation)
+        when :left_block
+          @stock_market.move_left(corporation)
         when :left_block_pres
           stock_market.move_left(corporation) if was_president
         when :none

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -385,7 +385,7 @@ module Engine
         raise GameError, 'Must visit minimum of two non-mine stops' if visits.sum(&:visit_cost) < 2
 
         return unless @round.rail_cars.include?('G&C')
-        return unless visits.sum(&:visit_cost) <= route.train.distance
+        return unless visits.sum(&:visit_cost) > route.train.distance
 
         @round.gc_train = route.train
       end
@@ -452,6 +452,18 @@ module Engine
 
       def routes_subsidy(routes)
         routes.sum(&:subsidy)
+      end
+
+      def reset_route!(route)
+        @round.snw_train = nil if route.train == @round.snw_train
+        @round.gc_train = nil if route.train == @round.gc_train
+        @round.raba_trains.delete(route.train)
+      end
+
+      def reset_all_routes!
+        @round.snw_train = nil
+        @round.gc_train = nil
+        @round.raba_trains.clear
       end
 
       def status_str(entity)

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -27,6 +27,7 @@ module Engine
     end
 
     def clear_cache!
+      connection_data
       @connection_hexes = nil
       @hexes = nil
       @revenue = nil

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -26,9 +26,8 @@ module Engine
       @stops = nil
     end
 
-    def clear_cache!
-      connection_data
-      @connection_hexes = nil
+    def clear_cache!(all: false)
+      @connection_hexes = nil if all
       @hexes = nil
       @revenue = nil
       @revenue_str = nil
@@ -37,7 +36,7 @@ module Engine
     end
 
     def reset!
-      clear_cache!
+      clear_cache!(all: true)
 
       @halts = nil
       @connection_data = nil
@@ -136,7 +135,7 @@ module Engine
         @last_node = node
       end
 
-      @routes.each(&:clear_cache!)
+      @routes.each { |r| r.clear_cache!(all: true) }
     end
 
     def paths

--- a/lib/engine/step/g_18_mag/route.rb
+++ b/lib/engine/step/g_18_mag/route.rb
@@ -38,7 +38,7 @@ module Engine
           items = []
 
           unless @round.rail_cars.include?('G&C')
-            items << Item.new(description: 'Plus-train Upgrade from G&C', cost: item_cost)
+            items << Item.new(description: 'Train Upgrade from G&C', cost: item_cost)
           end
 
           unless @round.rail_cars.include?('RABA')
@@ -75,6 +75,8 @@ module Engine
 
           action.entity.spend(item.cost, corp)
           @log << "#{action.entity.name} buys #{desc} for #{@game.format_currency(item.cost)}"
+
+          @round.routes.each(&:clear_cache!)
         end
       end
     end

--- a/lib/engine/step/g_18_mag/route.rb
+++ b/lib/engine/step/g_18_mag/route.rb
@@ -21,9 +21,6 @@ module Engine
           super
 
           @round.rail_cars = []
-          @round.raba_trains = []
-          @round.snw_train = nil
-          @round.gc_train = nil
         end
 
         def log_skip(entity)
@@ -60,9 +57,6 @@ module Engine
           {
             routes: [],
             rail_cars: [],
-            raba_trains: [],
-            snw_train: nil,
-            gc_train: nil,
           }
         end
 
@@ -75,8 +69,6 @@ module Engine
 
           action.entity.spend(item.cost, corp)
           @log << "#{action.entity.name} buys #{desc} for #{@game.format_currency(item.cost)}"
-
-          @round.routes.each(&:clear_cache!)
         end
       end
     end

--- a/lib/engine/step/g_18_mag/token.rb
+++ b/lib/engine/step/g_18_mag/token.rb
@@ -21,11 +21,20 @@ module Engine
         end
 
         def pay_token_cost(entity, cost)
+          return super unless entity.minor?
+
           skev_income = (cost / 2).to_i
           entity.spend(cost - skev_income, @game.bank)
           entity.spend(skev_income, @game.skev)
 
           @log << "#{@game.skev.name} earns #{@game.format_currency(skev_income)}"
+        end
+
+        def process_place_token(action)
+          entity = action.entity
+
+          place_token(entity, action.city, action.token, teleport: entity.corporation?)
+          pass!
         end
 
         def available_hex(entity, hex)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -134,6 +134,7 @@ module Engine
             hexes: [action.hex],
             token: token,
           }
+          @log << "#{entity.name} must choose city for token"
 
           token.remove!
         end


### PR DESCRIPTION
Most minor changes:
- Fixed orientation for BudaPest
- Move left by one on block sales
- Set must_buy_train false
- Permissive tile lays
- Corp token placement and bonus

Common file changes:
- UI::route_select - clear route caches when refreshing
- Game::base - support for :down_block and :left_block
- Step::tracker - add log message when home token needs to be placed on upgrade
- Engine::route - calculate connection_data before clearing cache