### PR TITLE
add descriptions of exporting

### DIFF
--- a/lib/engine/config/game/g_1867.rb
+++ b/lib/engine/config/game/g_1867.rb
@@ -1065,7 +1065,8 @@ module Engine
         "green"
       ],
       "status":[
-        "can_buy_companies"
+        "can_buy_companies",
+        "export_train"
       ],
       "on": "4",
       "operating_rounds": 2
@@ -1082,7 +1083,8 @@ module Engine
         "brown"
       ],
       "status":[
-        "can_buy_companies"
+        "can_buy_companies",
+        "export_train"
       ],
       "on": "5",
       "operating_rounds": 2
@@ -1099,7 +1101,8 @@ module Engine
         "brown"
       ],
       "on": "6",
-      "operating_rounds": 2
+      "operating_rounds": 2,
+      "status":["export_train"]
     },
     {
       "name": "7",
@@ -1114,7 +1117,8 @@ module Engine
         "gray"
       ],
       "on": "7",
-      "operating_rounds": 2
+      "operating_rounds": 2,
+      "status":["export_train"]
     },
     {
       "name": "8",

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -101,6 +101,13 @@ module Engine
       include InterestOnLoans
       attr_reader :loan_value, :owner_when_liquidated, :stock_prices_start_merger
 
+      def timeline
+        @timeline = [
+          'At the end of each OR the next available train will be exported
+           (removed, triggering phase change as if purchased)',
+        ]
+      end
+
       def init_cert_limit
         @log << '1817 has not been tested thoroughly with more than seven players.' if @players.size > 7
 

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -49,6 +49,12 @@ module Engine
 
       CERT_LIMIT_CHANGE_ON_BANKRUPTCY = true
 
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        'export_train' => ['Train Export to CN',
+                           'At the end of each OR the next available train will be exported
+                            (given to the CN, triggering phase change as if purchased)'],
+      ).freeze
+
       # Two lays with one being an upgrade, second tile costs 20
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded, cost: 20 }].freeze
 

--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -95,6 +95,13 @@ module Engine
         end
       end
 
+      def timeline
+        @timeline = [
+          'At the end of each set of ORs the next available non-permanent (2,3 or 4) train will be exported
+           (removed, triggering phase change as if purchased)',
+        ]
+      end
+
       def check_special_tile_lay(action, company)
         abilities(company, :tile_lay, time: 'any') do |ability|
           hexes = ability.hexes

--- a/lib/engine/game/g_18_cz.rb
+++ b/lib/engine/game/g_18_cz.rb
@@ -153,8 +153,10 @@ module Engine
 
       def timeline
         @timeline = [
-          "Game ends after OR #{@last_or}",
+          'At the end of each set of ORs the next available train will be exported
+           (removed, triggering phase change as if purchased)',
         ]
+        @timeline.append("Game ends after OR #{@last_or}")
         @timeline.append("Current value of each private company is #{COMPANY_VALUES[[0, @or - 1].max]}")
         @timeline.append("Next set of Operating Rounds will have #{OR_SETS[@turn - 1]} ORs")
       end


### PR DESCRIPTION
Adds a `timeline` to 18Ches (also covers 18ChesOTR), 1817, 18CZ (since exports happen through the entire game)

Adds a `status` for 1867 (since exports only happen in specific phases)

Someone may want to double-check this, since I haven't played 1817 or 1867 (wrote it up based on a quick rules read-through)

closes #2863 