### PR TITLE
Fixed purchasable share count

### DIFF
--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -33,8 +33,9 @@ module View
             },
             on: { click: par },
           }
+
           purchasable_shares = [(entity.cash / share_price.price).to_i,
-                                @corporation.max_ownership_percent / @corporation.total_shares].min
+                                (@corporation.max_ownership_percent / 100) * @corporation.total_shares].min
           at_limit = purchasable_shares * @corporation.total_shares >= @corporation.max_ownership_percent
           flags = at_limit ? ' L' : ''
 


### PR DESCRIPTION
The previous soultion did not work as expected

With 10 Shares and 60% max_ownership:
60/10 = 6 - > works
with 4 shares and 75% max ownership:
75/4 => 18,75 -> meeh

the new soultion should work for all values
With 10 Shares and 60% max_ownership:
(60/100) * 10 = 6
with 4 shares and 75% max ownership:
(75/100) * 4 = 3

