### PR TITLE
login: not an email address => error msg

### DIFF
--- a/routes/user.rb
+++ b/routes/user.rb
@@ -8,6 +8,7 @@ class Api
       r.post do
         # POST '/api/user/login'
         r.is 'login' do
+          halt(400, 'Invalid email address') unless /^[^@\s]+@[^@\s]+\.[^@\s]+$/.match?(r['email'])
           halt(400, 'Could not find user') unless (user = User.by_email(r['email']))
           halt(401, 'Incorrect password') unless Argon2::Password.verify_password(r['password'], user.password)
 


### PR DESCRIPTION
not a valid mail address => 'Invalid email address'
valid mail address, but unknown => 'Could not find user'

triggered by #3319