### PR TITLE
Revert "login: not an email address => error msg"

### DIFF
--- a/routes/user.rb
+++ b/routes/user.rb
@@ -8,7 +8,6 @@ class Api
       r.post do
         # POST '/api/user/login'
         r.is 'login' do
-          halt(400, 'Invalid email address') unless /^[^@\s]+@[^@\s]+\.[^@\s]+$/.match?(r['email'])
           halt(400, 'Could not find user') unless (user = User.by_email(r['email']))
           halt(401, 'Incorrect password') unless Argon2::Password.verify_password(r['password'], user.password)
 


### PR DESCRIPTION
Reverts tobymao/18xx#3359
Some users don’t have a valid e-mail-address in the DB. The (reverted) change would prevent them from logging in.