### PR TITLE
Share movement fix

### DIFF
--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -118,7 +118,7 @@ module Engine
       attr_accessor :swap_choice_player, :swap_other_player, :swap_corporation,
                     :loan_choice_player, :player_debts,
                     :max_value_reached,
-                    :old_operating_order, :sold_this_turn
+                    :old_operating_order, :moved_this_turn
 
       def sms_hexes
         SMS_HEXES
@@ -157,7 +157,7 @@ module Engine
         @corporations[0].next_to_par = true
 
         @player_debts = Hash.new { |h, k| h[k] = 0 }
-        @sold_this_turn = []
+        @moved_this_turn = []
       end
 
       def setup_companies
@@ -382,8 +382,8 @@ module Engine
       end
 
       def reorder_corps
-        just_sold = @sold_this_turn.uniq
-        @sold_this_turn = []
+        just_moved = @moved_this_turn.uniq
+        @moved_this_turn = []
         same_spot =
           @corporations
             .select(&:floated?)
@@ -393,12 +393,12 @@ module Engine
 
         same_spot.each do |sp, corps|
           current_order = corps.sort
-          sold, unsold = current_order.partition { |c| just_sold.include?(c) }
-          sold_ordered = sold.sort_by { |c| old_operating_order.index(c) }
-          new_order = unsold + sold_ordered
+          moved, unmoved = current_order.partition { |c| just_moved.include?(c) }
+          moved_ordered = moved.sort_by { |c| old_operating_order.index(c) }
+          new_order = unmoved + moved_ordered
           next if current_order == new_order
 
-          @log << 'Updating operating order for sold corporations
+          @log << 'Updating operating order for sold (and moved) corporations now
                     on same share value space to maintain relative order before sales.'
           @log << "#{current_order.map(&:name)} --> #{new_order.map(&:name)}"
           sp.corporations.clear

--- a/lib/engine/step/g_1849/bankrupt.rb
+++ b/lib/engine/step/g_1849/bankrupt.rb
@@ -26,8 +26,9 @@ module Engine
           player.shares_by_corporation.each do |c, _|
             next unless (bundle = @game.sellable_bundles(player, c).max_by(&:price))
 
+            price_before = bundle.shares.first.price
             @game.sell_shares_and_change_price(bundle)
-            @game.sold_this_turn << bundle.corporation
+            @game.moved_this_turn << bundle.corporation if price_before != bundle.shares.first.price
           end
 
           # player cash given to corp, corp closed

--- a/lib/engine/step/g_1849/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1849/buy_sell_par_shares.rb
@@ -17,9 +17,12 @@ module Engine
         end
 
         def process_sell_shares(action)
+          price_before = action.bundle.shares.first.price
           super
-          @game.sold_this_turn << action.bundle.corporation
-          @sold_any = true
+          return unless price_before != action.bundle.shares.first.price
+
+          @game.moved_this_turn << action.bundle.corporation
+          @moved_any = true
         end
 
         def pass!
@@ -28,12 +31,12 @@ module Engine
             @round.pass_order |= [current_entity]
             current_entity.pass!
           else
-            @game.reorder_corps if @sold_any
+            @game.reorder_corps if @moved_any
             @round.pass_order.delete(current_entity)
             current_entity.unpass!
           end
           @game.old_operating_order = @game.corporations.sort
-          @sold_any = false
+          @moved_any = false
         end
 
         def can_buy?(entity, bundle)

--- a/lib/engine/step/g_1849/buy_train.rb
+++ b/lib/engine/step/g_1849/buy_train.rb
@@ -12,14 +12,17 @@ module Engine
 
         def pass!
           super
-          @game.reorder_corps if @sold_any
-          @sold_any = false
+          @game.reorder_corps if @moved_any
+          @moved_any = false
         end
 
         def process_sell_shares(action)
+          price_before = action.bundle.shares.first.price
           super
-          @sold_any = true
-          @game.sold_this_turn << action.bundle.corporation
+          return unless price_before != action.bundle.shares.first.price
+
+          @game.moved_this_turn << action.bundle.corporation
+          @moved_any = true
         end
       end
     end


### PR DESCRIPTION
If two corps are sold and one is ledged, the unledged one should remain
in front on that space.