### PR TITLE
[1817] trains s.b. removed, not discarded to the pool

### DIFF
--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -51,6 +51,7 @@ module Engine
       SELL_AFTER = :after_ipo
       DEV_STAGE = :production
       OBSOLETE_TRAINS_COUNT_FOR_LIMIT = true
+      DISCARDED_TRAINS = :remove
 
       ASSIGNMENT_TOKENS = {
         'bridge' => '/icons/1817/bridge_token.svg',


### PR DESCRIPTION
This should also cover the 1817 variants, since they inherit from this class

fixes #3366