### PR TITLE
[1828] various fixes

### DIFF
--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -49,6 +49,8 @@ module Engine
 
       NEXT_SR_PLAYER_ORDER = :first_to_pass
 
+      TRACK_RESTRICTION = :permissive
+
       MARKET_TEXT = Base::MARKET_TEXT.merge(par: 'Yellow Phase Par',
                                             par_1: 'Green Phase Par',
                                             par_2: 'Blue Phase Par',

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -51,6 +51,8 @@ module Engine
 
       TRACK_RESTRICTION = :permissive
 
+      DISCARDED_TRAINS = :remove
+
       MARKET_TEXT = Base::MARKET_TEXT.merge(par: 'Yellow Phase Par',
                                             par_1: 'Green Phase Par',
                                             par_2: 'Blue Phase Par',


### PR DESCRIPTION
This should also cover the 1817 variants, since they inherit from this class

fixes #3366

fixes #3369 

Checked the verbiage on the permissive track lays, for confirmation

```
After placing or upgrading a track tile the placing share
company must be able to trace a continuous line of track
from one of its station markers to a line of track on the
placed track tile without:
– Passing through a city with all of station-marker
spaces filled with other companies’ station or blocking station markers.
– Passing through the Virginia Coalfields (K11) if the
public company doesn’t already own a coal token.
– Crossing any hexagon-edge twice.
```