### PR TITLE
18CO QoL upgrades

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -354,7 +354,7 @@ module View
           .map do |other_corp, president, num_shares, did_sell, at_limit|
             flags = (president ? '*' : '') + (at_limit ? 'L' : '')
             h('tr.corp', [
-              h("td.left.name.nowrap.#{president ? 'president' : ''}", other_corp.name),
+              h("td.left.name.nowrap.#{president ? 'president' : ''}", "© #{other_corp.name}"),
               h('td.right', shares_props, "#{flags.empty? ? '' : flags + ' '}#{share_number_str(num_shares)}"),
               did_sell ? h('td.italic', 'Sold') : '',
             ])

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -397,7 +397,7 @@ module Engine
       end
 
       def revenue_str(route)
-        str = super
+        str = route.stops.map { |s| s.hex.name }.join('-')
 
         bonus = east_west_bonus(route.stops)[:description]
         str += " + #{bonus}" if bonus


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/2671

Make corporate shares more distinguishable on the card ( show a symbol next to corps )
In revenue string, don't show the ignored towns.

<img width="217" alt="Screen Shot 2021-01-18 at 10 04 46 AM" src="https://user-images.githubusercontent.com/15675400/104952080-0c7b6a00-5981-11eb-9501-e73ca8dd0cb3.png">
