### PR TITLE
fix mobile chat input

### DIFF
--- a/assets/app/view/chat.rb
+++ b/assets/app/view/chat.rb
@@ -46,19 +46,17 @@ module View
           placeholder: 'Send a message (Please keep discussions to 18xx)',
         },
         style: {
-          height: '1.4rem',
           width: '100%',
           margin: '0',
           boxSizing: 'border-box',
           borderRadius: '0',
           background: color_for(:bg2),
           color: color_for(:font2),
-          resize: 'vertical',
         },
         on: { keyup: enter },
       }
 
-      children << h('textarea#chatbar', chatbar_props) if @user
+      children << h('input#chatbar', chatbar_props) if @user
 
       props = {
         key: 'global_chat',

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -48,10 +48,9 @@ module View
                   margin: 'auto 0',
                 },
               }, [@user['name'] + ':']),
-            h(:textarea,
+            h(:input,
               style: {
                 marginLeft: '0.5rem',
-                height: '1.25rem',
                 flex: '1',
               },
               on: { keyup: enter }),


### PR DESCRIPTION
should fix #3247
[kaoskody confirmed](https://18xxgames.slack.com/archives/CV3R3HPUZ/p1610999489181200?thread_ts=1610907937.149900&cid=CV3R3HPUZ) it’s the same issue in the main chat and I could finally reproduce this on browserstack (OnePlus 6T, Chrome), too.
Just weird that nobody stumbled upon this earlier. Main chat input was a textarea [since June](https://github.com/tobymao/18xx/commit/a0290589ef18c354cd8761b1f71d972d40c78e2b) so I didn’t anticipate any problems.

