### PR TITLE
1867 bug fixes:

### DIFF
--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -219,6 +219,8 @@ module Engine
       end
 
       def nationalize!(corporation)
+        return if !corporation.floated? || !@corporations.include?(corporation)
+
         @log << "#{corporation.name} is nationalized"
 
         while corporation.cash > @loan_value && !corporation.loans.empty?
@@ -289,6 +291,7 @@ module Engine
           close_corporation(corporation)
         else
           reset_corporation(corporation)
+          @round.force_next_entity! if @round.current_entity == corporation
         end
       end
 

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -72,6 +72,7 @@ module Engine
           @log << "#{player.name} contributes #{@game.format_currency(remaining)}"
         end
 
+        try_take_loan(entity, price)
         @game.queue_log! { @game.phase.buying_train!(entity, train) }
 
         if exchange
@@ -88,7 +89,6 @@ module Engine
 
         @game.flush_log!
 
-        try_take_loan(entity, price)
         @game.buy_train(entity, train, price)
         pass! unless can_buy_train?(entity)
       end


### PR DESCRIPTION
Correct nationalization of corp to skip to next entity (fixes #3372)
Take loans before trains have rusted (fixes #3380)