### PR TITLE
1824: Implement stock round exchange for mountain railway

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -136,7 +136,7 @@ module View
 
         @game.companies.each do |company|
           @game.abilities(company, :exchange) do |ability|
-            next if ability.corporation != @corporation.name && ability.corporation != 'any'
+            next if !ability.corporation.include?(@corporation.name) && ability.corporation != 'any'
             next unless company.owner == @current_entity
 
             if ability.from.include?(:ipo)

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -31,7 +31,7 @@ module View
 
         children = []
         corporations =
-          ability.corporation == 'any' ? @game.corporations : [@game.corporation_by_id(ability.corporation)]
+          ability.corporation == 'any' ? @game.corporations : ability.corporation.map { |c| @game.corporation_by_id(c) }
         corporations.each do |corporation|
           ipo_share = corporation.shares.find { |s| !s.president }
           children << render_exchange(ipo_share, @game.ipo_name(corporation)) if ability.from.include?(:ipo)

--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -107,7 +107,9 @@ Provide a description for an ability that is implemented outside of the ability 
 
 Exchange this company for a share of a corporation.
 
-- `corporation`: The corporation whose share may be exchanged. Use `"any"` to allow for all corporations.
+- `corporation`: A single corporation, an array of corporations, or `"any"`.
+  Specifies which corporation whose share may be exchanged.
+  Use `"any"` to allow for all corporations.
 - `from`: Where the share may be take from, either `"ipo"`,
   `"market"`, or an array containing both.
 

--- a/lib/engine/ability/exchange.rb
+++ b/lib/engine/ability/exchange.rb
@@ -8,7 +8,7 @@ module Engine
       attr_reader :corporation, :from
 
       def setup(corporation:, from:)
-        @corporation = corporation
+        @corporation = Array(corporation)
         @from = Array(from).map(&:to_sym)
       end
     end

--- a/lib/engine/config/game/g_1824.rb
+++ b/lib/engine/config/game/g_1824.rb
@@ -463,7 +463,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporation": "BK",
           "from": "IPO",
           "description": "Phase 3-5: Exchange for BK presidency"
         }
@@ -493,7 +493,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporation": "MS",
           "from": "IPO",
           "description": "Phase 3-5: Exchange for MS presidency"
         }
@@ -523,7 +523,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporation": "CL",
           "from": "IPO",
           "description": "Phase 3-5: Exchange for CL presidency"
         }
@@ -553,7 +553,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporation": "SB",
           "from": "IPO",
           "description": "Phase 3-5: Exchange for SB presidency"
         }

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -131,7 +131,7 @@ module Engine
 
           next unless ability.from.include?(:par)
 
-          corporation = corporation_by_id(ability.corporation)
+          corporation = corporation_by_id(ability.corporation.first)
           corporation.par_via_exchange = company
           @sc_company = company
         end

--- a/lib/engine/step/exchange.rb
+++ b/lib/engine/step/exchange.rb
@@ -43,7 +43,7 @@ module Engine
         return can_gain?(owner, bundle, exchange: true) if bundle
 
         corporations =
-          ability.corporation == 'any' ? @game.corporations : [@game.corporation_by_id(ability.corporation)]
+          ability.corporation == 'any' ? @game.corporations : ability.corporation.map { |c| @game.corporation_by_id(c) }
 
         shares = []
         corporations.each do |corporation|

--- a/lib/engine/step/g_1817/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1817/buy_sell_par_shares.rb
@@ -54,7 +54,7 @@ module Engine
         end
 
         def shorted?
-          @current_actions.any? { |x| x.instance_of?(Action::Short) }
+          @round.player_actions.any? { |x| x.instance_of?(Action::Short) }
         end
 
         def redeemable_shares(entity)
@@ -85,7 +85,7 @@ module Engine
           end
 
           actions = []
-          if @current_actions.none?
+          if @round.player_actions.none?
             actions << 'take_loan' if @game.can_take_loan?(entity) && !@corporate_action.is_a?(Action::BuyShares)
             actions << 'buy_shares' if @game.redeemable_shares(entity).any?
           end
@@ -180,7 +180,7 @@ module Engine
           return par_corporation if @winning_bid
 
           unless @auctioning
-            @current_actions << @corporate_action
+            @round.player_actions << @corporate_action
             return super
           end
 
@@ -197,7 +197,7 @@ module Engine
           @game.short(entity, corporation)
 
           @round.last_to_act = entity
-          @current_actions << action
+          @round.player_actions << action
         end
 
         def process_bid(action)
@@ -233,7 +233,7 @@ module Engine
           else
             @log << "#{entity.name} auctions #{corporation.name} for #{@game.format_currency(price)}"
             @round.last_to_act = action.entity
-            @current_actions.clear
+            @round.player_actions.clear
             @game.place_home_token(action.corporation)
           end
           super(action)

--- a/lib/engine/step/g_1824/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1824/buy_sell_par_shares.rb
@@ -6,13 +6,13 @@ module Engine
   module Step
     module G1824
       class BuySellParShares < BuySellParShares
-        def actions(_entity)
+        def actions(entity)
           result = super
           result << 'buy_company' unless result.empty?
           result
         end
 
-        def can_buy?(_entity, bundle)
+        def can_buy?(entity, bundle)
           super && @game.buyable?(bundle.corporation)
         end
 
@@ -20,7 +20,9 @@ module Engine
           super && @game.buyable?(bundle.corporation)
         end
 
-        def can_gain?(_entity, bundle)
+        def can_gain?(entity, bundle, exchange: false)
+          return false if exchange && !exchange_phase?
+
           super && @game.buyable?(bundle.corporation)
         end
 
@@ -57,10 +59,15 @@ module Engine
 
           par_coal_railway(entity, share_price, coal_railway, regional_railway)
           @round.last_to_act = entity
-          @current_actions << action
+          @round.player_actions << action
         end
 
         private
+
+        def exchange_phase?
+          @game.phase.status.include?('may_exchange_coal_railways') ||
+            @game.phase.status.include?('may_exchange_mountain_railways')
+        end
 
         def par_coal_railway(entity, share_price, coal_railway, regional_railway)
           share = coal_railway.shares.first

--- a/lib/engine/step/g_1824/buy_train.rb
+++ b/lib/engine/step/g_1824/buy_train.rb
@@ -46,6 +46,17 @@ module Engine
 
           trains
         end
+
+        def buy_train_action(action, entity = nil)
+          exchange = action.exchange
+
+          super
+
+          return unless exchange
+
+          # The exchanged train is removed from game
+          @game.remove_train(exchange)
+        end
       end
     end
   end

--- a/lib/engine/step/g_1824/exchange.rb
+++ b/lib/engine/step/g_1824/exchange.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative '../exchange'
+
+module Engine
+  module Step
+    module G1824
+      class Exchange < Exchange
+        def process_buy_shares(action)
+          player = action.entity.owner
+
+          super
+
+          @round.last_to_act = player
+          @round.player_actions << action
+        end
+
+        def can_exchange?(entity, bundle = nil)
+          return false unless exchangable_entity?(entity)
+          return false unless (ability = @game.abilities(entity, :exchange))
+
+          owner = entity.company? ? entity.owner : entity.player
+          return can_gain?(owner, bundle, exchange: true) if bundle
+
+          corporations = ability.corporation.map { |c| @game.corporation_by_id(c) }
+
+          shares = []
+          corporations.each do |corporation|
+            shares << corporation.available_share if ability.from.include?(:ipo)
+            shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
+          end
+
+          shares.any? { |s| can_gain?(entity.owner, s&.to_bundle, exchange: true) }
+        end
+
+        private
+
+        def exchangable_entity?(entity)
+          if entity.corporation?
+            return @game.coal_railway?(entity) && @game.phase.status.include?('may_exchange_coal_railways')
+          end
+
+          return false unless entity.company?
+
+          @game.mountain_railway?(entity) && @game.phase.status.include?('may_exchange_mountain_railways')
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1828/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1828/buy_sell_par_shares.rb
@@ -49,12 +49,12 @@ module Engine
           @round.merge_initiator = corporation
 
           @round.last_to_act = action.entity
-          @current_actions << action
+          @round.player_actions << action
         end
 
         def process_failed_merge(action)
           @log << "#{action.entity.name} failed to merge #{action.corporations.map(&:name).join(' and ')}"
-          @current_actions << action
+          @round.player_actions << action
         end
 
         def can_buy_multiple?(entity, corporation)
@@ -62,7 +62,7 @@ module Engine
         end
 
         def num_shares_bought(corporation)
-          @current_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
+          @round.player_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
         end
 
         def can_merge_any?(entity)
@@ -80,7 +80,7 @@ module Engine
         end
 
         def stock_action(action)
-          @current_actions << action
+          @round.player_actions << action
         end
       end
     end

--- a/lib/engine/step/g_1849/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1849/buy_sell_par_shares.rb
@@ -27,7 +27,7 @@ module Engine
 
         def pass!
           @passed = true
-          if @current_actions.empty?
+          if @round.player_actions.empty?
             @round.pass_order |= [current_entity]
             current_entity.pass!
           else
@@ -52,11 +52,11 @@ module Engine
         end
 
         def just_parred(corporation)
-          @current_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation }
+          @round.player_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation }
         end
 
         def num_shares_bought(corporation)
-          @current_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
+          @round.player_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
         end
       end
     end

--- a/lib/engine/step/g_1856/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1856/buy_sell_par_shares.rb
@@ -48,7 +48,7 @@ module Engine
           buy_shares(entity, share.to_bundle)
           @game.after_par(corporation)
           @round.last_to_act = entity
-          @current_actions << action
+          @round.player_actions << action
         end
       end
     end

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -32,7 +32,7 @@ module Engine
         end
 
         def pass_description
-          if @current_actions.empty?
+          if @round.player_actions.empty?
             'Pass (Certificates)'
           else
             'Done (Certificates)'
@@ -87,7 +87,7 @@ module Engine
 
           player.companies << company
           player.spend(price, owner)
-          @current_actions << action
+          @round.player_actions << action
           @log << "#{player.name} buys #{company.name} from #{owner.name} for #{@game.format_currency(price)}"
 
           @game.close_other_companies!(company) if company.sym == 'FFC'

--- a/lib/engine/step/g_1860/exchange.rb
+++ b/lib/engine/step/g_1860/exchange.rb
@@ -52,7 +52,7 @@ module Engine
           owner = entity.owner
           return can_gain?(owner, bundle, exchange: true) if bundle
 
-          corporation = @game.corporation_by_id(ability.corporation)
+          corporation = @game.corporation_by_id(ability.corporation.first)
           return false unless corporation.ipoed
 
           shares = []

--- a/lib/engine/step/g_1870/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1870/buy_sell_par_shares.rb
@@ -7,11 +7,11 @@ module Engine
     module G1870
       class BuySellParShares < BuySellParShares
         def actions(entity)
-          return [] if @current_actions.last&.entity&.corporation?
+          return [] if @round.player_actions.last&.entity&.corporation?
 
           if entity.corporation? && entity.owned_by?(current_entity)
             actions = []
-            actions << 'buy_shares' if @current_actions.none? &&
+            actions << 'buy_shares' if @round.player_actions.none? &&
                                        entity.operated? &&
                                        entity.num_ipo_shares < 4
 
@@ -74,7 +74,7 @@ module Engine
           end
 
           @round.last_to_act = action.entity.owner
-          @current_actions << action
+          @round.player_actions << action
         end
       end
     end

--- a/lib/engine/step/g_1882/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1882/buy_sell_par_shares.rb
@@ -53,7 +53,7 @@ module Engine
             @game.place_home_token(corporation)
             corporation.par_via_exchange.close!
 
-            @current_actions << action
+            @round.player_actions << action
           else
             super
           end


### PR DESCRIPTION
Make it possible to exchange Mountain Railway private for
share in any regional railway, during phase 3.

Also implement that exchanged trains are removed from game.

To support this, two changes was needed in the general code:

1. Make it possible to specify an array of corporations names
   in ability exchange. Have updated this handling in all
   places this was used. Some titles do only use one value
   and in that cases only the first corporation is used.

2. Made tracker of actions for player round state. This
   round state is reset when a player has completed its
   turn (via unpass!).
   This is needed to make it possible for exchange step
   to handle an exchange as a buy. (This is so in 1824
   while in 1889 you can exchange + buy [but not buy +
   exchange in that order].)
   The effect is that an exchange in 1824 is like a buy,
   except that you get the message that player pass as
   player does not have any valid actions. But at least
   it will not trigger end of stock round.