### PR TITLE
18Mag: Partition, End game and Server-mod fixes

### DIFF
--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -263,7 +263,7 @@ module Engine
     },
     {
       "sym":"4",
-      "name":"Tisza Vidéki Vasút",
+      "name":"TiszaVidéki Vasút",
       "logo":"18_mag/4",
        "tokens":[
          0,
@@ -313,7 +313,7 @@ module Engine
     },
     {
       "sym":"8",
-      "name":"Hrvatske željeznice",
+      "name":"Hrvatske Željeznice",
       "logo":"18_mag/8",
        "tokens":[
          0,
@@ -325,7 +325,7 @@ module Engine
     },
     {
       "sym":"9",
-      "name":"Szeged-Petrovaradin-Zemun Vasútvonal",
+      "name":"Szabadka-Újvidék Vasút",
       "logo":"18_mag/9",
        "tokens":[
          0,
@@ -351,7 +351,7 @@ module Engine
     },
     {
       "sym":"11",
-      "name":"Győr-Sopron-Ebenfurti Vasút Zrt.",
+      "name":"Győr-Sopron-Ebenfurti Vasút",
       "logo":"18_mag/11",
        "tokens":[
          0,
@@ -363,7 +363,7 @@ module Engine
     },
     {
       "sym":"12",
-      "name":"Calea ferată îngustă Sibiu-Agnita",
+      "name":"Segesvár–Szentágotai Vasút",
       "logo":"18_mag/12",
        "tokens":[
          0,
@@ -401,13 +401,19 @@ module Engine
          "E26",
          "I20"
         ],
-       "color":"white"
-    }
+       "color":"white",
+       "abilities":[
+         {
+           "type": "blocks_partition",
+            "partition_type": "water"
+         }
+       ]
+     }
   ],
   "corporations": [
     {
       "sym": "RABA",
-      "name": "RÁBA Company",
+      "name": "Magyar Waggon-és Gépgyár Rt.",
       "logo": "18_mag/RABA",
       "float_percent": 0,
       "max_ownership_percent": 60,
@@ -432,7 +438,7 @@ module Engine
     },
     {
       "sym": "SNW",
-      "name": "Schlick-Nicholsonsche Waggon-Fabrik A.-G.",
+      "name": "Schlick-Nicholson Gép-, Waggon és Hajógyár Rt.",
       "logo": "18_mag/SNW",
       "float_percent": 0,
       "max_ownership_percent": 60,
@@ -440,11 +446,11 @@ module Engine
         40,
         80
       ],
-      "color": "black"
+      "color": "dimgray"
     },
     {
       "sym": "SIK",
-      "name": "Károly Széchy Tunnelbau",
+      "name": "Gróf Széchenyi István Konsorcium",
       "logo": "18_mag/SIK",
       "float_percent": 0,
       "max_ownership_percent": 60,
@@ -456,7 +462,7 @@ module Engine
     },
     {
       "sym": "SKEV",
-      "name": "Gróf Széchenyi István Konsortium",
+      "name": "Széchy Károly Építőipari Vállalat",
       "logo": "18_mag/SKEV",
       "float_percent": 0,
       "max_ownership_percent": 60,
@@ -469,7 +475,7 @@ module Engine
     },
     {
       "sym": "LdStEG",
-      "name": "Lokomotivfabrik der StEG",
+      "name": "Lokomotivfabrik der Staatseisenbahn-Gesellschaft",
       "logo": "18_mag/LdStEG",
       "float_percent": 0,
       "max_ownership_percent": 60,
@@ -496,7 +502,7 @@ module Engine
     {
       "name": "2",
       "distance": 2,
-      "price": 80,
+      "price": 480,
       "num": 25
     },
     {

--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -405,7 +405,7 @@ module Engine
        "abilities":[
          {
            "type": "blocks_partition",
-            "partition_type": "water"
+           "partition_type": "water"
          }
        ]
      }

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -375,6 +375,7 @@ module Engine
         data['minors'].map! do |minor|
           minor.transform_keys!(&:to_sym)
           minor[:color] = const_get(:COLORS)[minor[:color]] if const_defined?(:COLORS)
+          minor[:abilities]&.each { |ability| ability.transform_keys!(&:to_sym) }
           minor
         end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -96,7 +96,7 @@ module Engine
       #   after: When game should end if check triggered
       # Leave out a reason if game does not support that.
       # Allowed reasons:
-      #  bankrupt, stock_market, bank, final_train
+      #  bankrupt, stock_market, bank, final_train, final_phase, custom
       # Allowed after:
       #  immediate - ends in current turn
       #  current_round - ends at the end of the current round
@@ -1629,7 +1629,7 @@ module Engine
         end
 
         partition_blockers = {}
-        companies.each do |company|
+        partition_companies.each do |company|
           abilities(company, :blocks_partition) do |ability|
             partition_blockers[ability.partition_type] = company
           end
@@ -1688,6 +1688,10 @@ module Engine
             end
           end
         end.flatten.compact
+      end
+
+      def partition_companies
+        companies
       end
 
       def init_tiles
@@ -1824,6 +1828,7 @@ module Engine
           bank: @bank.broken?,
           stock_market: @stock_market.max_reached?,
           final_train: @depot.empty?,
+          final_phase: @phase.phases.last == @phase.current,
           custom: custom_end_game_reached?,
         }.select { |_, t| t }
 
@@ -1892,6 +1897,7 @@ module Engine
           bankrupt: 'Bankruptcy',
           stock_market: 'Company hit max stock value',
           final_train: 'Final train was purchased',
+          final_phase: 'Final phase was reached',
         }
         "#{reason_map[reason]}#{after_text}"
       end

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -285,7 +285,7 @@ module Engine
         return true if special
 
         # correct label?
-        return false if from.label != to.label && !(from.label.to_s == 'K' && to.color == 'yellow')
+        return false if from.label != to.label && !(from.label.to_s == 'K' && to.color == :yellow)
 
         # honors existing town/city counts?
         # - allow labelled cities to upgrade regardless of count; they're probably

--- a/lib/engine/minor.rb
+++ b/lib/engine/minor.rb
@@ -20,13 +20,13 @@ module Engine
 
     attr_reader :name, :full_name
 
-    def initialize(sym:, name:, **opts)
+    def initialize(sym:, name:, abilities: [], **opts)
       @name = sym
       @full_name = name
       @floated = false
       @closed = false
       init_operator(opts)
-      init_abilities(opts[:abilities])
+      init_abilities(abilities)
     end
 
     def companies

--- a/lib/engine/step/g_18_mag/route.rb
+++ b/lib/engine/step/g_18_mag/route.rb
@@ -12,9 +12,11 @@ module Engine
         def actions(entity)
           return [] if !entity.operator? || entity.runnable_trains.empty? || !@game.can_run_route?(entity)
 
-          route_actions = ACTIONS
-          route_actions.concat(BUY_ACTION) unless buyable_items(entity).empty?
-          route_actions
+          if buyable_items(entity).empty?
+            ACTIONS
+          else
+            ACTIONS + BUY_ACTION
+          end
         end
 
         def setup

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -58,8 +58,8 @@ module Engine
           return unless K_HEXES.include?(action.hex.coordinates)
 
           # Handle special upgrade rules from K hexes
-          action.tile.label = 'K' if action.tile.color == 'yellow'
-          old_tile.label = nil if old_tile.color == 'yellow'
+          action.tile.label = 'K' if action.tile.color == :yellow
+          old_tile.label = nil if old_tile.color == :yellow
         end
 
         def update_tile_lists(tile, old_tile)

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -6,7 +6,7 @@ module Engine
   module Step
     module G18Mag
       class Track < Track
-        K_HEXES = %w[I1 H23 H27].freeze
+        K_HEXES = %w[I2 H23 H27].freeze
         BUY_ACTION = %w[special_buy].freeze
 
         def actions(entity)


### PR DESCRIPTION
- Use 1870-pioneered river partition for F9
- Implement end game
- Add descriptions of corporate powers to corp cards
- Fix references to tile color (need to by symbols, not strings)
- Fix attaching abilities to minors

Common file edits:
- Game::Base - convert ability strings to symbols for minors, add support for new end condition: final phase
- Engine::Minor - deal with abilities converted to symbols

Fixes #3381