### PR TITLE
1817: Various ui and log tweaks

### DIFF
--- a/assets/app/view/game/bid.rb
+++ b/assets/app/view/game/bid.rb
@@ -19,7 +19,7 @@ module View
           price_input = h(:input, style: { marginRight: '1rem' }, props: {
                             value: min_bid,
                             step: min_increment,
-                            min: min_bid + min_increment,
+                            min: min_bid,
                             max: max_bid,
                             type: 'number',
                             size: [@entity.cash.to_s.size, max_bid.to_s.size].max,

--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -35,13 +35,16 @@ module Engine
         true
       end
 
-      def pass_auction(entity)
-        @log << "#{entity.name} passes on #{auctioning.name}"
-
+      def remove_from_auction(entity)
         @bids[auctioning]&.reject! do |bid|
           bid.entity == entity
         end
         resolve_bids
+      end
+
+      def pass_auction(entity)
+        @log << "#{entity.name} passes on #{auctioning.name}"
+        remove_from_auction(entity)
       end
 
       def min_increment


### PR DESCRIPTION
Log in bidding when auto-passed due to cannot afford (fixes #2628)
Make it clear that the user hasn't passed if cannot afford to raise (fixes #2627)
Make min bid actually min bid (fixes #2349)