### PR TITLE
For Buy Company, set Max to max company price or treasury, whichever is lower.

### DIFF
--- a/assets/app/view/game/buy_companies.rb
+++ b/assets/app/view/game/buy_companies.rb
@@ -64,11 +64,12 @@ module View
       end
 
       def render_input
+        max_price = max_purchase_price(@corporation, @selected_company)
         input = h(:input, style: { marginRight: '1rem' }, props: {
-                    value: @selected_company.max_price,
+                    value: max_price,
                     type: 'number',
                     min: @selected_company.min_price,
-                    max: @selected_company.max_price,
+                    max: max_price,
                     size: @corporation.cash.to_s.size,
                   })
 
@@ -101,6 +102,10 @@ module View
           input,
           h(:button, { on: { click: buy_click } }, 'Buy'),
         ])
+      end
+
+      def max_purchase_price(corporation, company)
+        [company.max_price, corporation.cash].min
       end
     end
   end


### PR DESCRIPTION
Limit the max price to corporation cash if it is less than the company max price.

This prevents a player from submitting too high a price and getting back an error.

I started to worry about buying power, but that is irrelevant - one still would have to actually issue the share, and thus get the money in the treasury, to pay more for the company.

From: https://github.com/tobymao/18xx/issues/2671 but useful for all games.

Showing max price when corporation has more than max
<img width="709" alt="Screen Shot 2021-01-19 at 7 03 43 PM" src="https://user-images.githubusercontent.com/15675400/105117528-dfff4500-5a89-11eb-9c65-d263686f60bc.png">

Showing treasury amount when corporation cannot afford max
<img width="701" alt="Screen Shot 2021-01-19 at 7 03 56 PM" src="https://user-images.githubusercontent.com/15675400/105117532-e1307200-5a89-11eb-81ce-c3f06775bdaa.png">
