### PR TITLE
18Mag: fix L37 revenue

### DIFF
--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -186,7 +186,7 @@ module Engine
     "L37": {
       "count": 1,
       "color": "gray",
-      "code": "city=revenue:60,slots:4;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=B"
+      "code": "city=revenue:80,slots:4;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=B"
     }
   },
   "market": [


### PR DESCRIPTION
Budapest's revenue should be 80 in gray phase. Fixes #3426.