### PR TITLE
18SJ: Correct E train token handling (fixes #3173)

### DIFF
--- a/lib/engine/round/g_18_sj/operating.rb
+++ b/lib/engine/round/g_18_sj/operating.rb
@@ -7,11 +7,6 @@ module Engine
   module Round
     module G18SJ
       class Operating < Operating
-        def next_entity!
-          @game.clean_up_after_entity
-          super
-        end
-
         def cash_crisis_player
           @game.cash_crisis_player
         end

--- a/lib/engine/step/g_18_sj/buy_train_action.rb
+++ b/lib/engine/step/g_18_sj/buy_train_action.rb
@@ -8,6 +8,8 @@ module BuyTrainAction
 
     @game.perform_nationalization if @game.pending_nationalization?
 
+    @game.buy_electric_train if action.train.name == 'E'
+
     return if !(exchange = action.exchange) || exchange.name == '4'
 
     @log << "The exchanged #{exchange.name} is removed from game"

--- a/lib/engine/step/g_18_sj/dividend.rb
+++ b/lib/engine/step/g_18_sj/dividend.rb
@@ -30,6 +30,13 @@ module Engine
 
           super
         end
+
+        def process_dividend(action)
+          super
+
+          # Do some clean up for the entity in the OR
+          @game.clean_up_after_dividend
+        end
       end
     end
   end


### PR DESCRIPTION
The SJ tokens is now made passable (neutral) when
route step is setup (if current entity owns E train)
and made impassible when dividend has been paid.

This might break some existing games that has broken
the rules of the game.
As this happens late in the games I think they can be
pinned if not completed, and archived if completed.