### PR TITLE
Add possibility to specify a selection of corporations for exchange

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -136,7 +136,7 @@ module View
 
         @game.companies.each do |company|
           @game.abilities(company, :exchange) do |ability|
-            next if ability.corporation != @corporation.name && ability.corporation != 'any'
+            next unless ability.corporations(@game).include?(@corporation)
             next unless company.owner == @current_entity
 
             if ability.from.include?(:ipo)

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -136,7 +136,7 @@ module View
 
         @game.companies.each do |company|
           @game.abilities(company, :exchange) do |ability|
-            next unless ability.corporations(@game).include?(@corporation)
+            next unless @game.exchange_corporations(ability).include?(@corporation)
             next unless company.owner == @current_entity
 
             if ability.from.include?(:ipo)

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -30,7 +30,7 @@ module View
         return h(:span) unless (ability = @game.abilities(@selected_company, :exchange))
 
         children = []
-        ability.corporations(@game).each do |corporation|
+        @game.exchange_corporations(ability).each do |corporation|
           ipo_share = corporation.shares.find { |s| !s.president }
           children << render_exchange(ipo_share, @game.ipo_name(corporation)) if ability.from.include?(:ipo)
 

--- a/assets/app/view/game/exchange.rb
+++ b/assets/app/view/game/exchange.rb
@@ -30,9 +30,7 @@ module View
         return h(:span) unless (ability = @game.abilities(@selected_company, :exchange))
 
         children = []
-        corporations =
-          ability.corporation == 'any' ? @game.corporations : [@game.corporation_by_id(ability.corporation)]
-        corporations.each do |corporation|
+        ability.corporations(@game).each do |corporation|
           ipo_share = corporation.shares.find { |s| !s.president }
           children << render_exchange(ipo_share, @game.ipo_name(corporation)) if ability.from.include?(:ipo)
 

--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -105,9 +105,11 @@ Provide a description for an ability that is implemented outside of the ability 
 
 ## exchange
 
-Exchange this company for a share of a corporation.
+This company may be exchanged for a single share of a specified corporation during a step
+that allows exchange.
 
-- `corporation`: The corporation whose share may be exchanged. Use `"any"` to allow for all corporations.
+- `corporations`: An array with corporation names, whose share may be exchanged.
+  Use a simple `"any"` (no array) to allow for any corporation.
 - `from`: Where the share may be take from, either `"ipo"`,
   `"market"`, or an array containing both.
 

--- a/lib/engine/ability/exchange.rb
+++ b/lib/engine/ability/exchange.rb
@@ -5,20 +5,11 @@ require_relative 'base'
 module Engine
   module Ability
     class Exchange < Base
-      attr_reader :from
+      attr_reader :from, :corporations
 
       def setup(corporations:, from:)
         @corporations = corporations
         @from = Array(from).map(&:to_sym)
-      end
-
-      def corporations(game)
-        candidates = if @corporations == 'any'
-                       game.corporations
-                     else
-                       @corporations.map { |c| game.corporation_by_id(c) }
-                     end
-        candidates.reject(&:closed?)
       end
     end
   end

--- a/lib/engine/ability/exchange.rb
+++ b/lib/engine/ability/exchange.rb
@@ -5,11 +5,20 @@ require_relative 'base'
 module Engine
   module Ability
     class Exchange < Base
-      attr_reader :corporation, :from
+      attr_reader :from
 
-      def setup(corporation:, from:)
-        @corporation = corporation
+      def setup(corporations:, from:)
+        @corporations = corporations
         @from = Array(from).map(&:to_sym)
+      end
+
+      def corporations(game)
+        candidates = if @corporations == 'any'
+                       game.corporations
+                     else
+                       @corporations.map { |c| game.corporation_by_id(c) }
+                     end
+        candidates.reject(&:closed?)
       end
     end
   end

--- a/lib/engine/config/game/g_1824.rb
+++ b/lib/engine/config/game/g_1824.rb
@@ -463,7 +463,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporations": ["BK"],
           "from": "IPO",
           "description": "Phase 3-5: Exchange for BK presidency"
         }
@@ -493,7 +493,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporations": ["MS"],
           "from": "IPO",
           "description": "Phase 3-5: Exchange for MS presidency"
         }
@@ -523,7 +523,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporations": ["CL"],
           "from": "IPO",
           "description": "Phase 3-5: Exchange for CL presidency"
         }
@@ -553,7 +553,7 @@ module Engine
         {
           "type": "exchange",
           "owner_type": "corporation",
-          "corporation": "",
+          "corporations": ["SB"],
           "from": "IPO",
           "description": "Phase 3-5: Exchange for SB presidency"
         }

--- a/lib/engine/config/game/g_1828.rb
+++ b/lib/engine/config/game/g_1828.rb
@@ -516,7 +516,7 @@ module Engine
                 },
                 {
                     "type": "exchange",
-                    "corporation": "any",
+                    "corporations": "any",
                     "owner_type": "player",
                     "from": [
                         "ipo",

--- a/lib/engine/config/game/g_1835.rb
+++ b/lib/engine/config/game/g_1835.rb
@@ -230,7 +230,7 @@ module Engine
       "abilities": [
         {
           "type": "exchange",
-          "corporation": "PR",
+          "corporations": ["PR"],
           "owner_type": "player",
           "when": [
             "Phase 2.3",
@@ -279,7 +279,7 @@ module Engine
       "abilities": [
         {
           "type": "exchange",
-          "corporation": "PR",
+          "corporations": ["PR"],
           "owner_type": "player",
           "when": [
             "Phase 2.3",

--- a/lib/engine/config/game/g_1836_jr30.rb
+++ b/lib/engine/config/game/g_1836_jr30.rb
@@ -334,7 +334,7 @@ module Engine
          "abilities":[
             {
                "type":"exchange",
-               "corporation":"B",
+               "corporations":["B"],
                "owner_type":"player",
                "from":["ipo","market"]
             },

--- a/lib/engine/config/game/g_1860.rb
+++ b/lib/engine/config/game/g_1860.rb
@@ -399,7 +399,7 @@ module Engine
       "abilities": [
         {
           "type": "exchange",
-          "corporation": "BHI&R",
+          "corporations": ["BHI&R"],
           "owner_type": "player",
           "from": "ipo"
         }
@@ -414,7 +414,7 @@ module Engine
       "abilities": [
         {
           "type": "exchange",
-          "corporation": "FYN",
+          "corporations": ["FYN"],
           "owner_type": "player",
           "from": "ipo"
         }
@@ -429,7 +429,7 @@ module Engine
       "abilities": [
         {
           "type": "exchange",
-          "corporation": "C&N",
+          "corporations": ["C&N"],
           "owner_type": "player",
           "from": "ipo"
         }
@@ -444,7 +444,7 @@ module Engine
       "abilities": [
         {
           "type": "exchange",
-          "corporation": "IOW",
+          "corporations": ["IOW"],
           "owner_type": "player",
           "from": "ipo"
         }

--- a/lib/engine/config/game/g_1882.rb
+++ b/lib/engine/config/game/g_1882.rb
@@ -266,7 +266,7 @@ module Engine
         },
         {
           "type": "exchange",
-          "corporation": "SC",
+          "corporations": ["SC"],
           "owner_type": "player",
           "from": "par"
         }

--- a/lib/engine/config/game/g_1889.rb
+++ b/lib/engine/config/game/g_1889.rb
@@ -312,7 +312,7 @@ module Engine
       "abilities": [
         {
           "type": "exchange",
-          "corporation": "IR",
+          "corporations": ["IR"],
           "owner_type": "player",
           "when": "any",
           "from": "ipo"

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1518,6 +1518,15 @@ module Engine
         nil
       end
 
+      def exchange_corporations(exchange_ability)
+        candidates = if exchange_ability.corporations == 'any'
+                       corporations
+                     else
+                       exchange_ability.corporations.map { |c| corporation_by_id(c) }
+                     end
+        candidates.reject(&:closed?)
+      end
+
       def round_start?
         @last_game_action_id == @round_history.last
       end

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -131,7 +131,7 @@ module Engine
 
           next unless ability.from.include?(:par)
 
-          ability.corporations(self).first.par_via_exchange = company
+          exchange_corporations(ability).first.par_via_exchange = company
           @sc_company = company
         end
         super

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -131,8 +131,7 @@ module Engine
 
           next unless ability.from.include?(:par)
 
-          corporation = corporation_by_id(ability.corporation)
-          corporation.par_via_exchange = company
+          ability.corporations(self).first.par_via_exchange = company
           @sc_company = company
         end
         super

--- a/lib/engine/step/exchange.rb
+++ b/lib/engine/step/exchange.rb
@@ -42,11 +42,8 @@ module Engine
         owner = entity.owner
         return can_gain?(owner, bundle, exchange: true) if bundle
 
-        corporations =
-          ability.corporation == 'any' ? @game.corporations : [@game.corporation_by_id(ability.corporation)]
-
         shares = []
-        corporations.each do |corporation|
+        ability.corporations(@game).each do |corporation|
           shares << corporation.available_share if ability.from.include?(:ipo)
           shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
         end

--- a/lib/engine/step/exchange.rb
+++ b/lib/engine/step/exchange.rb
@@ -43,7 +43,7 @@ module Engine
         return can_gain?(owner, bundle, exchange: true) if bundle
 
         shares = []
-        ability.corporations(@game).each do |corporation|
+        @game.exchange_corporations(ability).each do |corporation|
           shares << corporation.available_share if ability.from.include?(:ipo)
           shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
         end

--- a/lib/engine/step/g_1860/exchange.rb
+++ b/lib/engine/step/g_1860/exchange.rb
@@ -52,7 +52,7 @@ module Engine
           owner = entity.owner
           return can_gain?(owner, bundle, exchange: true) if bundle
 
-          corporation = ability.corporations(@game).first
+          corporation = @game.exchange_corporations(ability).first
           return false unless corporation.ipoed
 
           shares = []

--- a/lib/engine/step/g_1860/exchange.rb
+++ b/lib/engine/step/g_1860/exchange.rb
@@ -52,7 +52,7 @@ module Engine
           owner = entity.owner
           return can_gain?(owner, bundle, exchange: true) if bundle
 
-          corporation = @game.corporation_by_id(ability.corporation)
+          corporation = ability.corporations(@game).first
           return false unless corporation.ipoed
 
           shares = []


### PR DESCRIPTION
Added an attribute 'corporations' that takes an array of corporation names.

If 'corporation' attribute is not specified, the 'corporations' is used instead.

This is a replacement for part of #3393.