### PR TITLE
18CO Beta and Denver Tile Tweak

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -18,10 +18,9 @@ module View
     def render_notification
       message = <<~MESSAGE
 
-        <p>18Mag and 1828.Games are now in alpha.<p>
+        <p>18Mag, 1828.Games and 1849 are now in alpha.<p>
+        <p>18CO: Rock & Stock, 1860 and 1867 are now in beta. 18Chesapeake: Off The Rails is now in beta with a new stock market.</p>
         <p>The authentication system is now more efficient. You need to log back in and all pins have been deleted.</p>
-        <p>1849 is now in alpha.</p>
-        <p>1860 and 1867 are now in beta. 18Chesapeake: Off The Rails is now in beta with a new stock market.</p>
 
         <p>Please file <a href='https://github.com/tobymao/18xx/issues'>issues and ideas</a> on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>.<br>

--- a/lib/engine/config/game/g_18_co.rb
+++ b/lib/engine/config/game/g_18_co.rb
@@ -140,7 +140,7 @@ module Engine
 		"co2": {
 			"count": 1,
 			"color": "green",
-			"code": "city=revenue:50,slots:3;city=revenue:50,hide:1;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;label=D;"
+			"code": "city=revenue:50,slots:3,loc:16.5;city=revenue:50;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;label=D;"
 		},
 		"co6": {
 			"count": 1,

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -25,7 +25,7 @@ module Engine
       load_from_json(Config::Game::G18CO::JSON)
       AXES = { x: :number, y: :letter }.freeze
 
-      DEV_STAGE = :alpha
+      DEV_STAGE = :beta
 
       GAME_LOCATION = 'Colorado, USA'
       GAME_RULES_URL = 'https://drive.google.com/open?id=0B3lRHMrbLMG_eEp4elBZZ0toYnM'


### PR DESCRIPTION
Move 18CO to beta as there haven't been any bug reports for 5 days and no breaking changes are expected to be introduced.

Fix https://github.com/tobymao/18xx/issues/2814
Fix https://github.com/tobymao/18xx/issues/2986

It is still a teeny bit difficult to see the two exits, but the revenue now shows and the circles are actually within the tile.

<img width="124" alt="Screen Shot 2021-01-21 at 11 48 20 AM" src="https://user-images.githubusercontent.com/15675400/105423553-f7ae0900-5c02-11eb-8d94-229fc5852091.png">

Before
<img width="197" alt="Screen Shot 2021-01-21 at 4 14 21 PM" src="https://user-images.githubusercontent.com/15675400/105424222-3a241580-5c04-11eb-99c3-109684bb161f.png">

After
<img width="224" alt="Screen Shot 2021-01-21 at 4 17 24 PM" src="https://user-images.githubusercontent.com/15675400/105424224-3abcac00-5c04-11eb-8e89-770d20dbd8df.png">
