### PR TITLE
Show track restrictions on the UI for games which cannot upgrade

### DIFF
--- a/lib/engine/step/g_1817/special_track.rb
+++ b/lib/engine/step/g_1817/special_track.rb
@@ -30,7 +30,7 @@ module Engine
           step.laid_track = step.laid_track + 1
         end
 
-        def available_hex(entity, hex)
+        def hex_neighbors(entity, hex)
           return super if entity.company? && entity.id == @game.class::PITTSBURGH_PRIVATE_NAME
 
           hexes = tile_lay_abilities(entity)&.hexes

--- a/lib/engine/step/g_1856/track.rb
+++ b/lib/engine/step/g_1856/track.rb
@@ -16,7 +16,7 @@ module Engine
           extra_cities = [0, new_ctedges.size - old_ctedges.size].max
 
           new_exits.all? { |edge| hex.neighbors[edge] } &&
-            (new_exits & available_hex(entity, hex)).any? &&
+            (new_exits & hex_neighbors(entity, hex)).any? &&
             old_paths_are_preserved(old_paths, new_paths) &&
             # Count how many cities on the new tile that aren't included by any of the old tile.
             # Make sure this isn't more than the number of new cities added.

--- a/lib/engine/step/g_1860/home_track.rb
+++ b/lib/engine/step/g_1860/home_track.rb
@@ -75,10 +75,6 @@ module Engine
         def available_hex(_entity, hex)
           pending_track[:hexes].include?(hex)
         end
-
-        def hex_neighbors(entity, hex)
-          @game.graph.connected_hexes(entity)[hex]
-        end
       end
     end
   end

--- a/lib/engine/step/g_1860/track.rb
+++ b/lib/engine/step/g_1860/track.rb
@@ -136,10 +136,6 @@ module Engine
 
           false
         end
-
-        def hex_neighbors(entity, hex)
-          @game.graph.connected_hexes(entity)[hex]
-        end
       end
     end
   end

--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -213,26 +213,6 @@ module Engine
           end
           false
         end
-
-        def legal_tile_rotation?(entity, hex, tile)
-          return false unless @game.legal_tile_rotation?(entity, hex, tile)
-
-          old_paths = hex.tile.paths
-          old_ctedges = hex.tile.city_town_edges
-
-          new_paths = tile.paths
-          new_exits = tile.exits
-          new_ctedges = tile.city_town_edges
-          extra_cities = [0, new_ctedges.size - old_ctedges.size].max
-
-          new_exits.all? { |edge| hex.neighbors[edge] } &&
-            (new_exits & hex_neighbors(entity, hex)).any? &&
-            old_paths.all? { |path| new_paths.any? { |p| path <= p } } &&
-            # Count how many cities on the new tile that aren't included by any of the old tile.
-            # Make sure this isn't more than the number of new cities added.
-            # 1836jr30 D6 -> 54 adds more cities
-            extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } }
-        end
       end
     end
   end

--- a/lib/engine/step/g_18_cz/home_track.rb
+++ b/lib/engine/step/g_18_cz/home_track.rb
@@ -67,8 +67,12 @@ module Engine
           )
         end
 
-        def available_hex(_entity, hex)
+        def hex_neighbors(_entity, hex)
           pending_track[:hexes].include?(hex)
+        end
+
+        def available_hex(entity, hex)
+          hex_neighbors(entity, hex)
         end
 
         def potential_tiles(entity, _hex)

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -58,6 +58,10 @@ module Engine
       end
 
       def available_hex(entity, hex)
+        hex_neighbors(entity, hex)
+      end
+
+      def hex_neighbors(entity, hex)
         return unless (ability = tile_lay_abilities(entity))
         return if ability.hexes&.any? && !ability.hexes&.include?(hex.id)
         return if ability.reachable && !@game.graph.connected_hexes(entity.owner)[hex]

--- a/lib/engine/step/track.rb
+++ b/lib/engine/step/track.rb
@@ -39,7 +39,18 @@ module Engine
       end
 
       def available_hex(entity, hex)
-        @game.graph.connected_hexes(entity)[hex]
+        connected = hex_neighbors(entity, hex)
+        return nil unless connected
+
+        tile_lay = get_tile_lay(entity)
+        return nil unless tile_lay
+
+        color = hex.tile.color
+        return nil if color == :white && !tile_lay[:lay]
+        return nil if color != :white && !tile_lay[:upgrade]
+        return nil if color != :white && !tile_lay[:upgrade_same_hex] && @previous_laid_hexes.include?(hex)
+
+        connected
       end
     end
   end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -276,7 +276,7 @@ module Engine
         multi_city_upgrade = new_ctedges.size > 1 && old_ctedges.size > 1
 
         new_exits.all? { |edge| hex.neighbors[edge] } &&
-          !(new_exits & available_hex(entity, hex)).empty? &&
+          !(new_exits & hex_neighbors(entity, hex)).empty? &&
           old_paths.all? { |path| new_paths.any? { |p| path <= p } } &&
           # Count how many cities on the new tile that aren't included by any of the old tile.
           # Make sure this isn't more than the number of new cities added.
@@ -291,6 +291,10 @@ module Engine
           tile.rotate!(rotation)
           legal_tile_rotation?(entity, hex, tile)
         end
+      end
+
+      def hex_neighbors(entity, hex)
+        @game.graph.connected_hexes(entity)[hex]
       end
     end
   end


### PR DESCRIPTION
as a second action

fixes #3256
also tidies up some 1860 code since it was fixing a similar bug