### PR TITLE
18Mag: K-tile bug fix; end-game bug fix

### DIFF
--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -353,40 +353,48 @@ module Engine
         @phase.next!
         @phase.current[:on] = nil
         @phase_change = true
-        return unless @phase.upcoming
-
-        @phase.upcoming[:on] = @trains_left
-        @phase.next_on = @trains_left
+        if @phase.upcoming
+          @phase.upcoming[:on] = @trains_left
+          @phase.next_on = @trains_left
+        else
+          @depot.trains.each { |t| t.events.clear }
+        end
       end
 
       def event_first_three!
+        @phase_change = true
         @trains_left.delete('3')
         @phase.current[:on] = nil
-        return unless @phase.upcoming
-
-        @phase.upcoming[:on] = @trains_left
-        @phase.next_on = @trains_left
-        @phase_change = true
+        if @phase.upcoming
+          @phase.upcoming[:on] = @trains_left
+          @phase.next_on = @trains_left
+        else
+          @depot.trains.each { |t| t.events.clear }
+        end
       end
 
       def event_first_four!
+        @phase_change = true
         @trains_left.delete('4')
         @phase.current[:on] = nil
-        return unless @phase.upcoming
-
-        @phase.upcoming[:on] = @trains_left
-        @phase.next_on = @trains_left
-        @phase_change = true
+        if @phase.upcoming
+          @phase.upcoming[:on] = @trains_left
+          @phase.next_on = @trains_left
+        else
+          @depot.trains.each { |t| t.events.clear }
+        end
       end
 
       def event_first_six!
+        @phase_change = true
         @trains_left.delete('6')
         @phase.current[:on] = nil
-        return unless @phase.upcoming
-
-        @phase.upcoming[:on] = @trains_left
-        @phase.next_on = @trains_left
-        @phase_change = true
+        if @phase.upcoming
+          @phase.upcoming[:on] = @trains_left
+          @phase.next_on = @trains_left
+        else
+          @depot.trains.each { |t| t.events.clear }
+        end
       end
 
       def info_on_trains(phase)

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -55,11 +55,11 @@ module Engine
         def process_lay_tile(action)
           old_tile = action.hex.tile
           super
+          old_tile.clear_label! if old_tile.color == :yellow && old_tile.label.to_s == 'K'
           return unless K_HEXES.include?(action.hex.coordinates)
 
           # Handle special upgrade rules from K hexes
           action.tile.label = 'K' if action.tile.color == :yellow
-          old_tile.label = nil if old_tile.color == :yellow
         end
 
         def update_tile_lists(tile, old_tile)

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -55,7 +55,7 @@ module Engine
         def process_lay_tile(action)
           old_tile = action.hex.tile
           super
-          old_tile.clear_label! if old_tile.color == :yellow && old_tile.label.to_s == 'K'
+          old_tile.label = nil if old_tile.color == :yellow && old_tile.label.to_s == 'K'
           return unless K_HEXES.include?(action.hex.coordinates)
 
           # Handle special upgrade rules from K hexes

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -456,6 +456,10 @@ module Engine
       @label = Part::Label.new(label_name)
     end
 
+    def clear_label!
+      @label = nil
+    end
+
     def restore_borders(edges = nil)
       edges ||= ALL_EDGES
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -453,11 +453,7 @@ module Engine
 
     # Used to set label for a recently placed tile
     def label=(label_name)
-      @label = Part::Label.new(label_name)
-    end
-
-    def clear_label!
-      @label = nil
+      @label = label_name ? Part::Label.new(label_name) : nil
     end
 
     def restore_borders(edges = nil)


### PR DESCRIPTION
- Clearing 'K' label on outgoing yellow tile required new method in Engine::Tile
- Fixed error introduced with new end-game rule where triggering OR wasn't followed by an SR correctly

Common file changes: Engine::Tile add clear_label! method

Fixes #3462 
Fixes #3482 

This is likely to require pins.