### PR TITLE
remove LSL icon appropriately after relevant tiles are upgraded

### DIFF
--- a/lib/engine/step/g_1846/track_and_token.rb
+++ b/lib/engine/step/g_1846/track_and_token.rb
@@ -15,7 +15,7 @@ module Engine
 
         def lay_tile_action(action)
           super
-          return unless @game.lake_shore_line && @game.class::LSL_HEXES.include?(action.hex.id) && @upgraded
+          return unless @game.lake_shore_line && @upgraded && @game.class::LSL_HEXES.include?(action.hex.id)
 
           action.tile.icons.reject! { |icon| icon.name == @game.class::LSL_ICON }
         end

--- a/lib/engine/step/g_1846/track_and_token.rb
+++ b/lib/engine/step/g_1846/track_and_token.rb
@@ -12,6 +12,13 @@ module Engine
         def buying_power(entity)
           @game.track_buying_power(entity)
         end
+
+        def lay_tile_action(action)
+          super
+          return unless @game.lake_shore_line && @game.class::LSL_HEXES.include?(action.hex.id) && @upgraded
+
+          action.tile.icons.reject! { |icon| icon.name == @game.class::LSL_ICON }
+        end
       end
     end
   end

--- a/lib/engine/step/g_1846/track_and_token.rb
+++ b/lib/engine/step/g_1846/track_and_token.rb
@@ -15,7 +15,7 @@ module Engine
 
         def lay_tile_action(action)
           super
-          return unless @game.lake_shore_line && @upgraded && @game.class::LSL_HEXES.include?(action.hex.id)
+          return if !@game.lake_shore_line || !@upgraded || !@game.class::LSL_HEXES.include?(action.hex.id)
 
           action.tile.icons.reject! { |icon| icon.name == @game.class::LSL_ICON }
         end


### PR DESCRIPTION
[Sample game](https://gist.github.com/benjaminxscott/aa25da23db6e496a0d2e99a104f27993)

This clears the `lsl` icon from a given hex after it has been upgraded to green

This is rules-accurate since LSL can be used for a free upgrade (specifically from yellow to green), and LSL goes poof in brown phase (so it can never upgrade from green to brown)

Note that it's safe to clear this icon since LSL doesn't block hexes

Before:
![before](https://user-images.githubusercontent.com/1711810/105612429-03b7d900-5d71-11eb-9d40-5b74a9b42bfe.png)

After:
![after](https://user-images.githubusercontent.com/1711810/105612433-061a3300-5d71-11eb-83e6-b35dd7c54cc9.png)
