### PR TITLE
18CO optional rules

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1952,8 +1952,12 @@ module Engine
         player_order.reject(&:bankrupt).index(entity)
       end
 
+      def next_sr_player_order
+        self.class::NEXT_SR_PLAYER_ORDER
+      end
+
       def reorder_players(order = nil)
-        order ||= self.class::NEXT_SR_PLAYER_ORDER
+        order ||= next_sr_player_order
         case order
         when :after_last_to_act
           player = @players.reject(&:bankrupt)[@round.entity_index]

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -126,7 +126,12 @@ module Engine
         {
           sym: :priority_order_pass,
           short_name: 'Priority Oder Pass',
-          desc: 'Priority is awarded in pass order in both Auction and Stock Rounds.',
+          desc: '(alpha) Priority is awarded in pass order in both Auction and Stock Rounds.',
+        },
+        {
+          sym: :major_investors,
+          short_name: 'Major Investors',
+          desc: '(alpha) The Presidency cannot be transferred to another player during Corporate Share Buying.',
         },
       ].freeze
 
@@ -237,7 +242,7 @@ module Engine
         Step::G18CO::ReturnToken,
         Step::BuyCompany,
         Step::G18CO::RedeemShares,
-        Step::CorporateBuyShares,
+        Step::G18CO::CorporateBuyShares,
         Step::G18CO::SpecialTrack,
         Step::G18CO::Track,
         Step::Token,

--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -122,6 +122,14 @@ module Engine
         ]
       ).freeze
 
+      OPTIONAL_RULES = [
+        {
+          sym: :priority_order_pass,
+          short_name: 'Priority Oder Pass',
+          desc: 'Priority is awarded in pass order in both Auction and Stock Rounds.',
+        },
+      ].freeze
+
       include CompanyPrice50To150Percent
 
       def ipo_name(_entity = nil)
@@ -144,6 +152,12 @@ module Engine
         setup_company_price_50_to_150_percent
         setup_corporations
         @presidents_choice = nil
+      end
+
+      def next_sr_player_order
+        return :first_to_pass if @optional_rules&.include?(:priority_order_pass)
+
+        super
       end
 
       def setup_corporations

--- a/lib/engine/step/g_18_co/corporate_buy_shares.rb
+++ b/lib/engine/step/g_18_co/corporate_buy_shares.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../corporate_buy_shares'
+
+module Engine
+  module Step
+    module G18CO
+      class CorporateBuyShares < CorporateBuyShares
+        def can_buy?(entity, bundle)
+          default_can_buy = super
+          return default_can_buy unless @game.optional_rules&.include?(:major_investors)
+          return false unless default_can_buy
+
+          president = entity.owner
+          target = bundle.corporation
+          president_percent = president.percent_of(target)
+          bundle_percent = bundle.percent
+
+          # Triggers an immediate Takeover without giving another player the presidency
+          return true if entity.percent_of(target) + bundle_percent > president_percent
+
+          # Our least concern is the current president
+          # We care about players with the highest percentage
+          major_share_holder, major_share_percent =
+            target.player_share_holders
+              .max_by { |holder, percent| [president != holder ? 1 : 0, percent] }
+
+          # This is the case when there are no other player share holders
+          return true if major_share_holder == president
+
+          # The can be bought as long as the president wont change
+          president_percent >= major_share_percent + bundle_percent
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_co/moving_bid_auction.rb
+++ b/lib/engine/step/g_18_co/moving_bid_auction.rb
@@ -48,6 +48,7 @@ module Engine
           entity = action.entity
           @log << "#{entity.name} passes bidding"
           entity.pass!
+          @round.pass_order |= [current_entity]
           end_auction! if all_passed?
           @round.next_entity_index!
         end
@@ -55,12 +56,14 @@ module Engine
         def process_bid(action)
           add_bid(action)
           action.entity.unpass!
+          @round.pass_order.delete(current_entity)
           @round.next_entity_index!
         end
 
         def process_move_bid(action)
           move_bid(action)
           action.entity.unpass!
+          @round.pass_order.delete(current_entity)
           @round.next_entity_index!
         end
 


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/3461

Pass Order Priority: Priority order is determined by the order in which players pass. ( see 1828 )
 Pay-Per-Trash: Selling multiple shares before a corporation's first OR returns the amount from each movement down on the market, starting at the initial price
 Major Investors: Corporate share purchase cannot trigger Presidency exchange to another player.

 Pay-Per-Trash
<img width="316" alt="Screen Shot 2021-01-23 at 2 48 35 PM" src="https://user-images.githubusercontent.com/15675400/105616874-18a76300-5d97-11eb-96a2-220e3c2c34e4.png">
