### PR TITLE
18Mag: UI improvements

### DIFF
--- a/assets/app/view/game/discard_trains.rb
+++ b/assets/app/view/game/discard_trains.rb
@@ -36,6 +36,8 @@ module View
           ])
         end
 
+        overflow << h(Map, game: @game) if @game.round.is_a?(Engine::Round::Operating)
+
         h(:div, [
           h(:div, { style: { marginBottom: '1rem', fontWeight: 'bold' } }, 'Discard Trains'),
           *overflow,

--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -150,8 +150,8 @@ module View
 
         h(:div,
           [
-            "Select per share amount to distribute to shareholders, between #{@game.format_currency(0)}",
-            " and #{@game.format_currency(max)}",
+            dividend_chart,
+            @step.help_str(max),
             input,
             h(:button, { on: { click: -> { create_dividend(input) } } }, 'Pay Dividend'),
         ])
@@ -160,6 +160,42 @@ module View
       def create_dividend(input)
         amount = input.JS['elm'].JS['value'].to_i * @step.current_entity.total_shares
         process_action(Engine::Action::Dividend.new(@step.current_entity, kind: 'variable', amount: amount))
+      end
+
+      def dividend_chart
+        header, *chart = @step.chart
+
+        props = {
+          style: {
+            border: '1px solid black',
+          },
+        }
+
+        rows = chart.map do |r|
+          h(:tr, props, [
+            h('td.right', props, r[0]),
+            h(:td, props, r[1]),
+          ])
+        end
+
+        table_props = {
+          style: {
+            margin: '0.5rem 0 0 0',
+            textAlign: 'left',
+            border: '1px solid black',
+            borderCollapse: 'collapse',
+          },
+        }
+
+        h(:table, table_props, [
+          h(:thead, [
+            h(:tr, props, [
+              h('th.no_padding', props, header[0]),
+              h(:th, props, header[1]),
+            ]),
+          ]),
+          h(:tbody, rows),
+        ])
       end
     end
   end

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -42,6 +42,7 @@ module View
               *render_minors,
               *render_corporations,
               render_players,
+              render_map,
             ].compact)
           end
         end
@@ -330,6 +331,13 @@ module View
             from_price: from_price,
           ))
           store(:selected_company, nil, skip: true)
+        end
+
+        # show the map if there are minors to pick from
+        def render_map
+          return nil unless @step.available.any?(&:minor?)
+
+          h(Game::Map, game: @game)
         end
       end
     end

--- a/lib/engine/config/game/g_18_mag.rb
+++ b/lib/engine/config/game/g_18_mag.rb
@@ -13,7 +13,7 @@ module Engine
   "filename": "18_mag",
   "modulename": "18Mag",
   "currencyFormatStr": "%d Ft",
-  "bankCash": 12000,
+  "bankCash": 100000,
   "certLimit": {
     "3": 18,
     "4": 14,

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -225,6 +225,10 @@ module Engine
         end
       end
 
+      def all_corporations
+        minors + corporations
+      end
+
       def new_auction_round
         Round::Draft.new(self, [Step::G18Mag::SimpleDraft], rotating_order: true)
       end

--- a/lib/engine/step/g_18_mag/dividend.rb
+++ b/lib/engine/step/g_18_mag/dividend.rb
@@ -164,6 +164,23 @@ module Engine
         def variable_max
           (current_entity.cash / MIN_CORP_PAYOUT).to_i * MIN_CORP_PAYOUT
         end
+
+        def help_str(max)
+          "Select per share amount to distribute to shareholders, between #{@game.format_currency(0)}"\
+          " and #{@game.format_currency(max)}"
+        end
+
+        def chart
+          [
+            ['Per Share Dividend', 'Share Price Change'],
+            ['0 Ft', '1 space to the left'],
+            ['1 - 2 Ft', 'none'],
+            ['3 - 5 Ft', '1 space to the left'],
+            ['6 - 10 Ft', '2 spaces to the left'],
+            ['11 - 20 Ft', '3 spaces to the left'],
+            ['more than 20 Ft', '4 spaces to the left'],
+          ]
+        end
       end
     end
   end

--- a/lib/engine/step/g_18_mag/route.rb
+++ b/lib/engine/step/g_18_mag/route.rb
@@ -37,16 +37,15 @@ module Engine
           items = []
 
           unless @round.rail_cars.include?('G&C')
-            items << Item.new(description: 'Train Upgrade from G&C', cost: item_cost)
+            items << Item.new(description: 'Plus Train Upgrade [G&C]', cost: item_cost)
           end
 
           unless @round.rail_cars.include?('RABA')
-            items << Item.new(description: 'Off Board Bonus from RABA', cost: item_cost)
+            items << Item.new(description: "+#{@game.raba_delta(@game.phase)} Offboard Bonus [RABA]",
+                              cost: item_cost)
           end
 
-          unless @round.rail_cars.include?('SNW')
-            items << Item.new(description: 'Mine Access from SNW', cost: item_cost)
-          end
+          items << Item.new(description: 'Mine Access [SNW]', cost: item_cost) unless @round.rail_cars.include?('SNW')
 
           items
         end


### PR DESCRIPTION
- Add map display to draft rounds with minors on offer (generic)
- Add map display to discard_train steps during operating rounds (generic)
- Add price movement chart for 18Mag dividends
- Add specific RABA benefit to special_buy button
- Make bank large enough to avoid bank breaking
- Add minors to spreadsheet view

Common file edits:
- UI::DiscardTrains - show map if in OR
- UI::Dividend - show movement chart for variable dividends
- UI::Round::Auction - show map if minors are available

Fixes #3419 
Fixes #3450 
Fixes #3481 

![18Mag_new_bonus_text](https://user-images.githubusercontent.com/8494213/105616938-c3b81c80-5d97-11eb-9906-95ac6ce9d69a.png)
![18Mag_dividend_chart](https://user-images.githubusercontent.com/8494213/105616940-c74ba380-5d97-11eb-9624-0c860ae55c53.png)
![18Mag_new_spreadsheet](https://user-images.githubusercontent.com/8494213/105616941-cb77c100-5d97-11eb-90b5-5a87db50ed77.png)
