### PR TITLE
Move map controls above the map instead of below

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -133,8 +133,7 @@ module View
             position: 'relative',
           },
         }
-
-        h(:div, [h(:div, props, children), render_controls])
+        h(:div, [render_controls, h(:div, props, children)])
       end
 
       def map_x


### PR DESCRIPTION
Why? If the controls are below the map, if you try to zoom in or out multiple times in a row
 the map will resize and will move the buttons with it. If the buttons are above instead,
 when the map resizes the buttons stay in place
 
 There are still some cases where the controls will move but this is more stable than what is currently live and it doesn't trample much in the code