### PR TITLE
18Mag - Skip logging scrap train for majors

### DIFF
--- a/lib/engine/step/g_18_mag/discard_train.rb
+++ b/lib/engine/step/g_18_mag/discard_train.rb
@@ -19,6 +19,10 @@ module Engine
           'Scrap Trains'
         end
 
+        def log_skip(entity)
+          super unless entity.corporation?
+        end
+
         def crowded_corps
           return [current_entity] if current_entity.minor?
 


### PR DESCRIPTION
[20:09]Vanish operates LdStEG
[20:10]LdStEG passes place a token
**[20:10]LdStEG skips scrap trains**
[20:11]LdStEG pays out 110 Ft
[20:11]LdStEG pays out 110 Ft = 11 Ft (55 Ft to Vanish, 44 Ft to NightFlyer, 11 Ft to DelmarSon)
[20:11]LdStEG's share price changes from 75 Ft to 90 Ft


Majors can never scrap, so no point in logging it.