### PR TITLE
tile-manifest: full view

### DIFF
--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -100,12 +100,7 @@ module View
           end
         end
 
-        props = {
-          style: {
-            'margin': '70px',
-          },
-        }
-        h('div#tile_manifest', props, children)
+        h('div#tile_manifest', children)
       end
     end
   end


### PR DESCRIPTION
The margins are plain annoying when viewing tiles in a second window.

Alternative:
`@media only screen and (min-width: 900px) {
  #tile_manifest {
    margin: 2vw;
  }
}
`