### PR TITLE
1867 bug fixes

### DIFF
--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -566,11 +566,12 @@ module Engine
 
       def event_minors_nationalized!
         # Given minors have a train limit of 1, this shouldn't cause the order to be disrupted.
-        @corporations, removed = @corporations.partition do |corporation|
+        corporations, removed = @corporations.partition do |corporation|
           corporation.type != :minor
         end
         @log << 'Minors nationalized' if removed.any?
         removed.each { |c| nationalize!(c) }
+        @corporations = corporations
       end
 
       def event_signal_end_game!

--- a/lib/engine/step/g_1867/post_merger_shares.rb
+++ b/lib/engine/step/g_1867/post_merger_shares.rb
@@ -45,7 +45,7 @@ module Engine
         end
 
         def check_merge
-          return unless active_entities.none?
+          return unless eligible_players.empty?
 
           if corporation.shares.first&.president
             @broken_merge = true
@@ -101,12 +101,21 @@ module Engine
           corporation
         end
 
+        def eligible_players
+          @round.share_dealing_players
+          .select { |p| p.active? && can_buy_any?(p) }
+        end
+
         def active_entities
           return [] unless corporation
           return @game.players if @broken_merge
 
-          [@round.share_dealing_players
-          .select { |p| p.active? && can_buy_any?(p) }.first].compact
+          players = eligible_players
+          if players.empty?
+            check_merge
+            players = eligible_players
+          end
+          [players.first].compact
         end
       end
     end


### PR DESCRIPTION
Allow players to buy shares if none of the merge corps could afford shares (fixes #3483)
Fix nationalization on phase 8 (fixes #3459)