### PR TITLE
Outgoing pres swap option fix

### DIFF
--- a/lib/engine/g_1849/share_pool.rb
+++ b/lib/engine/g_1849/share_pool.rb
@@ -5,7 +5,7 @@ require_relative 'share_pool'
 module Engine
   module G1849
     class SharePool < SharePool
-      def change_president(presidents_share, swap_to, president)
+      def change_president(presidents_share, swap_to, president, previous_president)
         corporation = presidents_share.corporation
 
         incoming_pres_shares = president.shares_of(corporation)
@@ -13,8 +13,9 @@ module Engine
         double = incoming_pres_shares.find(&:last_cert)
         shares =
           if double
-            if !swap_to.share_pool? && incoming_pres_shares.sum(&:percent) >= 40
-              @game.swap_choice_player = swap_to
+            if incoming_pres_shares.sum(&:percent) >= 40
+              @game.swap_choice_player = previous_president
+              @game.swap_location = swap_to
               @game.swap_other_player = president
               @game.swap_corporation = corporation
               @game.log << "Presidency swapped for last cert by default.

--- a/lib/engine/g_1860/share_pool.rb
+++ b/lib/engine/g_1860/share_pool.rb
@@ -98,7 +98,7 @@ module Engine
         # if the owner only sold half of their president's share, take one away
         swap_to = previous_president.percent_of(corporation) >= presidents_share.percent ? previous_president : self
 
-        change_president(presidents_share, swap_to, president)
+        change_president(presidents_share, swap_to, president, previous_president)
 
         return unless bundle.partial?
 

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -394,7 +394,7 @@ module Engine
           president_share = previous_president.shares_of(corporation).find(&:president)
           corporation.owner = president
           @log << "#{president.name} becomes the president of #{corporation.name}"
-          @share_pool.change_president(president_share, previous_president, president)
+          @share_pool.change_president(president_share, previous_president, president, previous_president)
         end
 
         # Consolidate shorts with their share pair (including share pool shares)

--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -115,7 +115,7 @@ module Engine
       PORT_HEXES = %w[a12 A5 L14 N8].freeze
       SMS_HEXES = %w[B14 C1 C5 H12 J6 M9 M13].freeze
 
-      attr_accessor :swap_choice_player, :swap_other_player, :swap_corporation,
+      attr_accessor :swap_choice_player, :swap_location, :swap_other_player, :swap_corporation,
                     :loan_choice_player, :player_debts,
                     :max_value_reached,
                     :old_operating_order, :moved_this_turn

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -215,7 +215,7 @@ module Engine
       # if the owner only sold half of their president's share, take one away
       swap_to = previous_president.percent_of(corporation) >= presidents_share.percent ? previous_president : self
 
-      change_president(presidents_share, swap_to, president)
+      change_president(presidents_share, swap_to, president, previous_president)
 
       return unless bundle.partial?
 
@@ -224,7 +224,7 @@ module Engine
       num_shares.times { move_share(shares_of(corporation).first, owner) }
     end
 
-    def change_president(presidents_share, swap_to, president)
+    def change_president(presidents_share, swap_to, president, _previous_president)
       corporation = presidents_share.corporation
 
       num_shares = presidents_share.percent / corporation.share_percent

--- a/lib/engine/step/g_1849/swap_choice.rb
+++ b/lib/engine/step/g_1849/swap_choice.rb
@@ -54,11 +54,12 @@ module Engine
 
           if choice == 'Two 10% certs'
             @log << "#{entity.name} chooses two 10% certificates"
-            @game.share_pool.swap_double_cert(@game.swap_choice_player, @game.swap_other_player, @game.swap_corporation)
+            @game.share_pool.swap_double_cert(@game.swap_location, @game.swap_other_player, @game.swap_corporation)
           else
             @log << "#{entity.name} chooses the 20% last certificate"
           end
           @game.swap_choice_player = nil
+          @game.swap_location = nil
           @game.swap_other_player = nil
           @game.swap_corporation = nil
         end


### PR DESCRIPTION
Fixes #3502

The outgoing president can choose to let the incoming president retain
the double cert (if that player has two single certs). This is probably
a bad idea.