### PR TITLE
[1882] add separate count for neutral tokens in spreadsheet

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -363,7 +363,16 @@ module View
           h('td.padded_number', @game.format_currency(corporation.cash)),
           h('td.left', order_props, operating_order_text),
           h(:td, corporation.trains.map(&:name).join(', ')),
-          h(:td, "#{corporation.tokens.map { |t| t.used ? 0 : 1 }.sum}/#{corporation.tokens.size}"),
+          if corporation.name == 'CN'
+            h(:td,
+              "#{corporation.tokens.map { |t| t.used ? 0 : 1 }.sum}"\
+              "/#{corporation.tokens.map { |t| t.type == :neutral ? 1 : 0 }.sum}")
+          else
+            h(:td,
+              "#{corporation.tokens.map { |t| t.used || t.type == :neutral ? 0 : 1 }.sum}"\
+              "/#{corporation.tokens.map { |t| t.type == :neutral ? 0 : 1 }.sum}"\
+              "#{corporation.tokens.map { |t| t.type == :neutral ? '+N' : '' }.join('')}")
+          end,
           *extra,
           render_companies(corporation),
           h(:th, name_props, corporation.name),


### PR DESCRIPTION
Small addition to spreadsheet.rb to count and display neutral tokens. Added special case for CN to count neutral tokens as its own. Other companies show neutral token as "+N".

Issue https://github.com/tobymao/18xx/issues/1332

## Current behavior (can be misleading, CPR vs others for example):
![before](https://user-images.githubusercontent.com/69309175/105653084-e2e2a700-5e88-11eb-9a28-75ece1cd4f1e.png)

## New behavior:
![after](https://user-images.githubusercontent.com/69309175/105653011-ae6eeb00-5e88-11eb-8e7b-6b7f143567c7.png)

## CN counts neutral tokens as its own:
![CNafter](https://user-images.githubusercontent.com/69309175/105653014-b038ae80-5e88-11eb-9fc3-7e950d1ce958.png)
