### PR TITLE
1828: Augmented the corporation card for systems

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -124,7 +124,7 @@ module View
       def render_title
         title_row_props = {
           style: {
-            grid: '1fr / auto auto',
+            grid: '1fr / auto auto auto',
             padding: '0.2rem 0.4rem',
             background: @corporation.color,
             color: @corporation.text_color,
@@ -147,14 +147,23 @@ module View
           style: {
             color: 'currentColor',
             display: 'inline-block',
-            justifySelf: 'start',
+            justifySelf: 'center',
           },
         }
+        children = [h(:img, logo_props),
+                    h('div.title', name_props, @corporation.full_name)]
 
-        h('div.corp__title', title_row_props, [
-          h(:img, logo_props),
-          h('div.title', name_props, @corporation.full_name),
-        ])
+        if @corporation.system?
+          logo_props[:attrs][:src] = logo_for_user(@corporation.corporations.last)
+        else
+          logo_props[:attrs][:src] = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+          logo_props[:style][:border] = nil
+          logo_props[:style][:borderRadius] = nil
+        end
+        logo_props[:style][:justifySelf] = 'end'
+        children << h(:img, logo_props)
+
+        h('div.corp__title', title_row_props, children)
       end
 
       def render_holdings
@@ -207,17 +216,23 @@ module View
       end
 
       def render_trains
-        trains = @corporation.trains.map do |train|
-          train.obsolete ? "(#{train.name})" : train.name
+        trains = (@corporation.system? ? @corporation.shells : [@corporation]).map do |c|
+          if c.trains.empty?
+            'None'
+          else
+            c.trains.map { |t| t.obsolete ? "(#{t.name})" : t.name }.join(' ')
+          end
         end
 
-        render_header_segment(trains.empty? ? 'None' : trains.join(' '), 'Trains')
+        render_header_segment(trains, 'Trains')
       end
 
-      def render_header_segment(value, key)
+      def render_header_segment(values, key)
+        values = [values] unless values.is_a?(Array)
+
         segment_props = {
           style: {
-            grid: '25px auto / 1fr',
+            grid: @corporation.system? ? '45px auto / 1fr' : '25px auto / 1fr',
           },
         }
 
@@ -228,8 +243,9 @@ module View
           },
         }
 
-        value_props[:style].merge!(fontSize: 'small') if value.size > 6
-        value_props[:style].merge!(fontSize: 'x-small') if value.size > 10
+        max_size = values.max_by(&:size).size
+        value_props[:style].merge!(fontSize: 'small') if max_size > 6
+        value_props[:style].merge!(fontSize: 'x-small') if max_size > 10
 
         key_props = {
           style: {
@@ -237,7 +253,7 @@ module View
           },
         }
         h(:div, segment_props, [
-          h('div.right.nowrap', value_props, value),
+          h('div.right.nowrap', values.map { |v| h(:div, value_props, v) }),
           h(:div, key_props, key),
         ])
       end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -124,7 +124,8 @@ module View
       def render_title
         title_row_props = {
           style: {
-            grid: '1fr / auto auto auto',
+            grid: '1fr / repeat(auto-fit, auto)',
+            gridAutoFlow: 'column',
             padding: '0.2rem 0.4rem',
             background: @corporation.color,
             color: @corporation.text_color,
@@ -147,21 +148,17 @@ module View
           style: {
             color: 'currentColor',
             display: 'inline-block',
-            justifySelf: 'center',
           },
         }
+        name_props[:style][:justifySelf] = 'start' unless @corporation.system?
         children = [h(:img, logo_props),
                     h('div.title', name_props, @corporation.full_name)]
 
         if @corporation.system?
           logo_props[:attrs][:src] = logo_for_user(@corporation.corporations.last)
-        else
-          logo_props[:attrs][:src] = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-          logo_props[:style][:border] = nil
-          logo_props[:style][:borderRadius] = nil
+          logo_props[:style][:justifySelf] = 'end'
+          children << h(:img, logo_props)
         end
-        logo_props[:style][:justifySelf] = 'end'
-        children << h(:img, logo_props)
 
         h('div.corp__title', title_row_props, children)
       end
@@ -232,7 +229,7 @@ module View
 
         segment_props = {
           style: {
-            grid: @corporation.system? ? '45px auto / 1fr' : '25px auto / 1fr',
+            grid: @corporation.system? ? '40px auto / 1fr' : '25px auto / 1fr',
           },
         }
 

--- a/lib/engine/g_1828/system.rb
+++ b/lib/engine/g_1828/system.rb
@@ -13,7 +13,9 @@ module Engine
         opts[:float_percent] = 50
         super(sym: sym, name: name, **opts)
 
-        @corporations = []
+        @corporations = opts[:corporations]
+        @name = @corporations.first.name
+
         @shells = []
       end
 

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -296,13 +296,13 @@ module Engine
         system_data[:sym] = corporations.map(&:name).join('-')
         system_data[:tokens] = []
         system_data[:abilities] = []
+        system_data[:corporations] = corporations
         system = init_system(@stock_market, system_data)
 
         @corporations << system
         @_corporations[system.id] = system
         system.shares.each { |share| @_shares[share.id] = share }
 
-        system.corporations.replace(corporations)
         corporations.each { |corporation| transfer_assets_to_system(corporation, system) }
 
         # Order tokens for better visual


### PR DESCRIPTION
Augmented the corporation card by including the logo for each shell and a separate line for the trains in each shell. Below are a few examples. @yzemaze, can you please review?

### Desktop
![image](https://user-images.githubusercontent.com/67359577/105661666-fea37880-5e9b-11eb-8b79-5b8da7aef913.png)
![image](https://user-images.githubusercontent.com/67359577/105661702-111db200-5e9c-11eb-87d2-0b0701426e77.png)
![image](https://user-images.githubusercontent.com/67359577/105661817-56da7a80-5e9c-11eb-97f8-f5240ec36d4c.png)

### Mobile
Portrait orientation
![image](https://user-images.githubusercontent.com/67359577/105662081-e41dcf00-5e9c-11eb-807c-d69b14b98428.png)

Landscape orientation
![image](https://user-images.githubusercontent.com/67359577/105662640-36abbb00-5e9e-11eb-9953-faced4643d49.png)

