### PR TITLE
1861: Implement operating round for the national corp

### DIFF
--- a/lib/engine/round/g_1861/operating.rb
+++ b/lib/engine/round/g_1861/operating.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../g_1867/operating'
+
+module Engine
+  module Round
+    module G1861
+      class Operating < G1867::Operating
+        NATIONAL_START_PHASE = 4
+        NATIONAL_END_PHASE = 8
+        def skip_entity?(entity)
+          return super if entity.type != :national
+
+          @game.phase.name.to_i < NATIONAL_START_PHASE || @game.phase.name.to_i >= NATIONAL_END_PHASE
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1861/buy_company.rb
+++ b/lib/engine/step/g_1861/buy_company.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../buy_company'
+require_relative 'skip_for_national'
+
+module Engine
+  module Step
+    module G1861
+      class BuyCompany < BuyCompany
+        include SkipForNational
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1861/buy_train.rb
+++ b/lib/engine/step/g_1861/buy_train.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../g_1867/buy_train'
+
+module Engine
+  module Step
+    module G1861
+      class BuyTrain < G1867::BuyTrain
+        include SkipForNational
+
+        def buy_cheapest(entity)
+          train = @depot.min_depot_train
+          action = Engine::Action::BuyTrain.new(
+            entity,
+            train: train,
+            price: train.price,
+          )
+          process_buy_train(action)
+        end
+
+        def skip!
+          entity = current_entity
+          return super if entity.type != :national
+
+          buy_cheapest(entity) while must_buy_train?(entity) || entity.cash > @depot.min_depot_train.price
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1861/dividend.rb
+++ b/lib/engine/step/g_1861/dividend.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../g_1867/dividend'
+
+module Engine
+  module Step
+    module G1861
+      class Dividend < G1867::Dividend
+        include SkipForNational
+
+        def payout(entity, revenue)
+          return super if entity.type != :national
+
+          { corporation: revenue, per_share: 0 }
+        end
+
+        def share_price_change(entity, revenue = 0)
+          return {} if entity.type == :national
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1861/skip_for_national.rb
+++ b/lib/engine/step/g_1861/skip_for_national.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Engine
+  module Step
+    module G1861
+      module SkipForNational
+        def actions(entity)
+          return [] if entity.corporation? && entity.type == :national
+
+          super
+        end
+
+        def log_skip(entity)
+          super if entity.type != :national
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1861/token.rb
+++ b/lib/engine/step/g_1861/token.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../g_1867/token'
+require_relative 'skip_for_national'
+
+module Engine
+  module Step
+    module G1861
+      class Token < G1867::Token
+        include SkipForNational
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1861/track.rb
+++ b/lib/engine/step/g_1861/track.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../g_1867/track'
+require_relative 'skip_for_national'
+
+module Engine
+  module Step
+    module G1861
+      class Track < G1867::Track
+        include SkipForNational
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1867/track.rb
+++ b/lib/engine/step/g_1867/track.rb
@@ -14,7 +14,7 @@ module Engine
 
         def lay_tile(action, extra_cost: 0, entity: nil)
           super
-          @game.place_cn_montreal_token(action.hex.tile) if action.tile.name == '639'
+          @game.place_639_token(action.hex.tile) if action.tile.name == '639'
         end
 
         def connects_to?(hex, tile, to)


### PR DESCRIPTION
Also rename CN in 1867 generally as 'national' as 1861 refers to it as 'Russian State'