### PR TITLE
1824 mainly: Make Coal Railways minors

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -305,6 +305,7 @@ module View
         def render_buy_input(company)
           return [] unless @current_actions.include?('buy_company')
           return [] unless @step.can_buy_company?(@current_entity, company)
+          return render_buy_input_interval(company) if company.interval
 
           buy = lambda do
             process_action(Engine::Action::BuyCompany.new(
@@ -314,10 +315,39 @@ module View
             ))
             store(:selected_company, nil, skip: true)
           end
-
           [h(:button,
              { on: { click: buy } },
              "Buy #{@selected_company.sym} from Bank for #{@game.format_currency(company.value)}")]
+        end
+
+        def render_buy_input_interval(company)
+          prices = company.interval.sort
+
+          buy_buttons = prices.map do |price|
+            buy = lambda do
+              process_action(Engine::Action::BuyCompany.new(
+                @current_entity,
+                company: company,
+                price: price,
+              ))
+            end
+
+            props = {
+              style: {
+                width: 'calc(17.5rem/6)',
+                padding: '0.2rem',
+              },
+              on: { click: buy },
+            }
+
+            h('button.small.buy_company', props, @game.format_currency(price).to_s)
+          end
+
+          div_class = buy_buttons.size < 5 ? '.inline' : ''
+          [h(:div, [
+            h("div#{div_class}", { style: { marginTop: '0.5rem' } }, "Buy #{@selected_company.sym}: "),
+            *buy_buttons,
+          ])]
         end
       end
     end

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -11,7 +11,7 @@ module Engine
     include Ownable
 
     attr_accessor :desc, :max_price, :min_price, :revenue, :discount, :value
-    attr_reader :name, :sym, :min_auction_price, :treasury
+    attr_reader :name, :sym, :min_auction_price, :treasury, :interval
 
     def initialize(sym:, name:, value:, revenue: 0, desc: '', abilities: [], **opts)
       @sym = sym
@@ -25,6 +25,7 @@ module Engine
       @closed = false
       @min_price = @value / 2
       @max_price = @value * 2
+      @interval = opts[:interval] # Array of prices or nil
 
       init_abilities(abilities)
     end

--- a/lib/engine/config/game/g_1824.rb
+++ b/lib/engine/config/game/g_1824.rb
@@ -264,6 +264,90 @@ module Engine
   ],
   "companies": [
     {
+      "sym":"EPP",
+      "name":"Eisenbahn Pilsen - Priesen (C1)",
+      "value":200,
+      "interval": [120, 140, 160, 180, 200],
+      "revenue":0,
+      "desc":"Buyer take control of minor Coal Railway EPP (C1), which can be exchanged for the Director's certificate of Regional Railway MS during SRs in phase 3 or 4, or automatically when phase 5 starts. BK floats after exchange as soon as 50% or more are owned by players. This private cannot be sold.",
+      "abilities": [
+        {
+          "type": "no_buy",
+          "owner_type": "player"
+        },
+        {
+          "type": "exchange",
+          "owner_type": "player",
+          "corporations": ["BK"],
+          "from": "IPO",
+          "description": "SR phase 3-5: Exchange for BK presidency"
+        }
+      ]
+    },
+    {
+      "sym":"EOD",
+      "name":"Eisenbahn Oderberg - Dombran (C2)",
+      "value":200,
+      "interval": [120, 140, 160, 180, 200],
+      "revenue":0,
+      "desc":"Buyer take control of minor Coal Railway EOD (C2), which can be exchanged for the Director's certificate of Regional Railway MS during SRs in phase 3 or 4, or automatically when phase 5 starts. MS floats after exchange as soon as 50% or more are owned by players. This private cannot be sold.",
+      "abilities": [
+        {
+          "type": "no_buy",
+          "owner_type": "player"
+        },
+        {
+          "type": "exchange",
+          "owner_type": "player",
+          "corporations": ["BK"],
+          "from": "IPO",
+          "description": "SR phase 3-5: Exchange for MS presidency"
+        }
+      ]
+    },
+    {
+      "sym":"MLB",
+      "name":"Mosty - Lemberg Bahn (C3)",
+      "value":200,
+      "interval": [120, 140, 160, 180, 200],
+      "revenue":0,
+      "desc":"Buyer take control of minor Coal Railway MLB (C3), which can be exchanged for the Director's certificate of Regional Railway CL during SRs in phase 3 or 4, or automatically when phase 5 starts. CL floats after exchange as soon as 50% or more are owned by players. This private cannot be sold.",
+      "abilities": [
+        {
+          "type": "no_buy",
+          "owner_type": "player"
+        },
+        {
+          "type": "exchange",
+          "owner_type": "player",
+          "corporations": ["CL"],
+          "from": "IPO",
+          "description": "SR phase 3-5: Exchange for CL presidency"
+        }
+      ]
+    },
+    {
+      "sym":"SPB",
+      "name":"Simeria-Petrosani Bahn (C4)",
+      "value":200,
+      "interval": [120, 140, 160, 180, 200],
+      "revenue":0,
+      "desc":"Buyer take control of minor Coal Railway SPB (C4), which can be exchanged for the Director's certificate of Regional Railway SB during SRs in phase 3 or 4, or automatically when phase 5 starts. SB floats after exchange as soon as 50% or more are owned by players. This private cannot be sold.",
+      "abilities": [
+        {
+          "type": "no_buy",
+          "owner_type": "player"
+        },
+        {
+          "type": "exchange",
+          "owner_type": "player",
+          "corporations": ["SB"],
+          "from": "IPO",
+          "description": "SR phase 3-5: Exchange for SB presidency"
+        }
+      ]
+    },
+    {
       "sym":"S1",
       "name":"Wien-Gloggnitzer Eisenbahngesellschaft (S1)",
       "value":240,
@@ -357,6 +441,55 @@ module Engine
   ],
   "minors":[
     {
+      "sym": "EPP",
+      "name": "Eisenbahn Pilsen - Priesen (C1)",
+      "type": "Coal",
+      "tokens": [
+        0
+      ],
+      "logo": "1824/C1",
+      "coordinates": "C6",
+      "city": 0,
+      "color": "gray50"
+    },
+    {
+      "sym": "EOD",
+      "name": "Eisenbahn Oderberg - Dombran (C2)",
+      "type": "Coal",
+      "tokens": [
+        0
+      ],
+      "logo": "1824/C2",
+      "coordinates": "A12",
+      "city": 0,
+      "color": "gray50"
+    },
+    {
+      "float_percent": 100,
+      "sym": "MLB",
+      "name": "Mosty - Lemberg Bahn (C3)",
+      "type": "Coal",
+      "tokens": [
+        0
+      ],
+      "logo": "1824/C3",
+      "coordinates": "A22",
+      "city": 0,
+      "color": "gray50"
+    },
+    {
+      "sym": "SPB",
+      "name": "Simeria-Petrosani Bahn (C4)",
+      "type": "Coal",
+      "tokens": [
+        0
+      ],
+      "logo": "1824/C4",
+      "coordinates": "H25",
+      "city": 0,
+      "color": "gray50"
+    },
+    {
        "sym": "S1",
        "name": "Wien-Gloggnitzer Eisenbahngesellschaft",
        "type": "PreStaatsbahn",
@@ -443,106 +576,6 @@ module Engine
   ],
   "corporations": [
     {
-      "sym": "EPP",
-      "name": "Eisenbahn Pilsen - Priesen",
-      "type": "Coal",
-      "float_percent": 100,
-      "capitalization": "incremental",
-      "shares": [100],
-      "max_ownership_percent": 100,
-      "tokens": [
-        0
-      ],
-      "always_market_price": true,
-      "abilities": [
-        {
-          "type": "exchange",
-          "owner_type": "corporation",
-          "corporations": ["BK"],
-          "from": "IPO",
-          "description": "Phase 3-5: Exchange for BK presidency"
-        }
-      ],
-      "logo": "1824/C1",
-      "coordinates": "C6",
-      "color": "gray50"
-    },
-    {
-      "sym": "EOD",
-      "name": "Eisenbahn Oderberg - Dombran",
-      "type": "Coal",
-      "float_percent": 100,
-      "capitalization": "incremental",
-      "shares": [100],
-      "max_ownership_percent": 100,
-      "tokens": [
-        0
-      ],
-      "always_market_price": true,
-      "abilities": [
-        {
-          "type": "exchange",
-          "owner_type": "corporation",
-          "corporations": ["MS"],
-          "from": "IPO",
-          "description": "Phase 3-5: Exchange for MS presidency"
-        }
-      ],
-      "logo": "1824/C2",
-      "coordinates": "A12",
-      "color": "gray50"
-  },
-    {
-      "float_percent": 100,
-      "sym": "MLB",
-      "name": "Mosty - Lemberg Bahn",
-      "type": "Coal",
-      "capitalization": "incremental",
-      "shares": [100],
-      "max_ownership_percent": 100,
-      "tokens": [
-        0
-      ],
-      "always_market_price": true,
-      "abilities": [
-        {
-          "type": "exchange",
-          "owner_type": "corporation",
-          "corporations": ["CL"],
-          "from": "IPO",
-          "description": "Phase 3-5: Exchange for CL presidency"
-        }
-      ],
-      "logo": "1824/C3",
-      "coordinates": "A22",
-      "color": "gray50"
-    },
-    {
-      "float_percent": 100,
-      "sym": "SPB",
-      "name": "Simeria-Petrosani Bahn",
-      "type": "Coal",
-      "capitalization": "incremental",
-      "shares": [100],
-      "max_ownership_percent": 100,
-      "tokens": [
-        0
-      ],
-      "always_market_price": true,
-      "abilities": [
-        {
-          "type": "exchange",
-          "owner_type": "corporation",
-          "corporations": ["SB"],
-          "from": "IPO",
-          "description": "Phase 3-5: Exchange for SB presidency"
-        }
-      ],
-      "logo": "1824/C4",
-      "coordinates": "H25",
-      "color": "gray50"
-    },
-    {
       "float_percent": 50,
       "name": "Böhmische Kommerzbahn",
       "sym": "BK",
@@ -624,6 +657,26 @@ module Engine
       "coordinates": "J13"
     },
     {
+      "name": "Südbahn",
+      "sym": "SD",
+      "type": "Staatsbahn",
+      "float_percent": 10,
+      "tokens": [
+        100,
+        100
+      ],
+      "abilities": [
+        {
+            "type": "no_buy",
+            "description": "Unavailable in SR before phase 4"
+        }
+      ],
+      "logo": "1824/SD",
+      "simple_logo": "1824/SD.alt",
+      "color": "orange",
+      "text_color": "black"
+    },
+    {
       "name": "Ungarische Staatsbahn",
       "sym": "UG",
       "type": "Staatsbahn",
@@ -663,26 +716,6 @@ module Engine
       "logo": "1824/KK",
       "simple_logo": "1824/KK.alt",
       "color": "brown"
-    },
-    {
-      "name": "Südbahn",
-      "sym": "SD",
-      "type": "Staatsbahn",
-      "float_percent": 10,
-      "tokens": [
-        100,
-        100
-      ],
-      "abilities": [
-        {
-            "type": "no_buy",
-            "description": "Unavailable in SR before phase 4"
-        }
-      ],
-      "logo": "1824/SD",
-      "simple_logo": "1824/SD.alt",
-      "color": "orange",
-      "text_color": "black"
     }
   ],
   "trains": [

--- a/lib/engine/round/g_1824/stock.rb
+++ b/lib/engine/round/g_1824/stock.rb
@@ -7,7 +7,7 @@ module Engine
     module G1824
       class Stock < Stock
         def finish_round
-          @game.corporations.reject { |c| @game.coal_railway?(c) }.select(&:floated?).sort.each do |corp|
+          @game.corporations.select(&:floated?).sort.each do |corp|
             prev = corp.share_price.price
             sold_out_stock_movement(corp) if sold_out?(corp)
             @game.log_share_price(corp, prev)

--- a/lib/engine/step/g_1824/buy_sell_par_shares_first_sr.rb
+++ b/lib/engine/step/g_1824/buy_sell_par_shares_first_sr.rb
@@ -34,61 +34,41 @@ module Engine
 
           super
 
-          return unless (pre_staatsbahn = @game.minor_by_id(company.id))
+          minor = @game.minor_by_id(company.id)
+          return unless (minor = @game.minor_by_id(company.id))
+          return buy_pre_staatsbahn(minor, entity, action) if @game.pre_staatsbahn?(minor)
 
-          treasury = action.price
-          @game.log << "Pre-Staatsbahn #{pre_staatsbahn.full_name} floats and receives "\
-            "#{@game.format_currency(treasury)} in treasury"
-          pre_staatsbahn.owner = entity
-          pre_staatsbahn.float!
-          @game.bank.spend(treasury, pre_staatsbahn)
-        end
-
-        def process_par(action)
-          corporation = action.corporation
-          return super unless @game.coal_railway?(corporation)
-
-          share_price = action.share_price
-          coal_railway = corporation
-          regional_railway = @game.associated_regional_railway(coal_railway)
-
-          entity = action.entity
-          raise GameError, "#{coal_railway.name} cannot be parred" unless @game.can_par?(corporation, entity)
-
-          par_coal_railway(entity, share_price, coal_railway, regional_railway)
-          @round.last_to_act = entity
-          @current_actions << action
+          buy_coal_railway(minor, entity, action.price)
         end
 
         private
 
-        def par_coal_railway(entity, share_price, coal_railway, regional_railway)
-          share = coal_railway.shares.first
-          bundle = share.to_bundle
+        def buy_pre_staatsbahn(pre_staatsbahn, buyer, action)
+          treasury = action.price
+          @game.log << "Pre-Staatsbahn #{pre_staatsbahn.full_name} floats and receives "\
+            "#{@game.format_currency(treasury)} in treasury"
+          pre_staatsbahn.owner = buyer
+          pre_staatsbahn.float!
+          @game.bank.spend(treasury, pre_staatsbahn)
+        end
 
-          regional_railway.ipoed = true
-          price = share_price.price
-          @game.stock_market.set_par(regional_railway, share_price)
-          coal_railway.par_price = share_price
-          treasury = 2 * price
+        def buy_coal_railway(coal_railway, buyer, price)
+          regional_railway = @game.associated_regional_railway(coal_railway)
 
-          @game.log << "#{entity.name} buys the presidency share of #{coal_railway.name} "\
-            "for #{@game.format_currency(treasury)}"
-          @game.log << "#{entity.name} pars #{regional_railway.name} at #{@game.format_currency(share_price.price)}"
-
-          @game.share_pool.transfer_shares(
-            bundle,
-            entity,
-            spender: entity,
-            receiver: coal_railway,
-            price: price
-          )
-
-          entity.spend(treasury - price, coal_railway)
+          coal_railway.owner = buyer
+          coal_railway.float!
+          @game.bank.spend(price, coal_railway)
           g_train = @game.depot.upcoming.select { |t| @game.g_train?(t) }.shift
+          treasury = price - g_train.price
           @game.log << "#{coal_railway.name} floats and buys a #{g_train.name} train from the depot "\
-          "for #{@game.format_currency(g_train.price)}"
+          "for #{@game.format_currency(g_train.price)} and remaining #{@game.format_currency(treasury)} "\
+          'is put in treasury'
           @game.buy_train(coal_railway, g_train, g_train.price)
+
+          share_price = @game.stock_market.par_prices.find { |s| s.price == price / 2 }
+          regional_railway.ipoed = true
+          @game.stock_market.set_par(regional_railway, share_price)
+          @game.log << "#{buyer.name} pars #{regional_railway.name} at #{@game.format_currency(share_price.price)}"
         end
       end
     end

--- a/lib/engine/step/g_1824/dividend.rb
+++ b/lib/engine/step/g_1824/dividend.rb
@@ -7,7 +7,7 @@ module Engine
     module G1824
       class Dividend < Dividend
         def actions(entity)
-          return [] if minor_style_dividend?(entity)
+          return [] if entity.minor?
 
           super
         end
@@ -51,7 +51,7 @@ module Engine
         end
 
         def skip!
-          return super unless minor_style_dividend?(current_entity)
+          return super unless current_entity.minor?
 
           revenue = @game.routes_revenue(routes)
 
@@ -62,7 +62,7 @@ module Engine
         end
 
         def share_price_change(entity, revenue = 0)
-          return super unless minor_style_dividend?(entity)
+          return super unless entity.minor?
 
           {}
         end
@@ -72,17 +72,16 @@ module Engine
         end
 
         def payout(entity, revenue, mine_revenue)
-          if minor_style_dividend?(entity)
+          if entity.minor?
             fifty_percent = revenue / 2
-            per_share = @game.coal_railway?(entity) ? fifty_percent / 2 : fifty_percent
-            { corporation: fifty_percent + mine_revenue, per_share: per_share }
+            { corporation: fifty_percent + mine_revenue, per_share: fifty_percent }
           else
             { corporation: mine_revenue, per_share: payout_per_share(entity, revenue) }
           end
         end
 
         def payout_shares(entity, revenue)
-          return super unless minor_style_dividend?(entity)
+          return super unless entity.minor?
 
           owner_revenue = revenue / 2
           @log << "#{entity.owner.name} receives #{@game.format_currency(owner_revenue)}"
@@ -90,10 +89,6 @@ module Engine
         end
 
         private
-
-        def minor_style_dividend?(entity)
-          @game.pre_staatsbahn?(entity) || @game.coal_railway?(entity)
-        end
 
         def log_run_payout(entity, kind, revenue, mine_revenue, action, payout)
           unless Dividend::DIVIDEND_TYPES.include?(kind)


### PR DESCRIPTION
The first attempt was to make Coal Railways corporations but they function
in all ways as a minor so this commits makes them minors.

The main reason for having them as corporations was that these had
5 different purchase prices (120G - 200G) so using the parring worked.

But it turned out to cause problems down the line so I now go back
to having them as minors.

Now, it still needs to support buying for different prices. And I have
now added support for having multiple prices by adding an interval
attribute to companies. In case this is set (default nil) the stock
view will render buy buttons similar to par buttons, when buying
private from bank.
In case interval is not specified as attribute this change has no
effect.

This is how the Stock view looks like in interval attribute specified for the selected company:
![image](https://user-images.githubusercontent.com/2631151/105786488-74cbdc00-5f7d-11eb-910c-b1a3fd72c2ca.png)
