### PR TITLE
Fix check_distance for base and 18Mag to handle N+M trains correctly

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1023,14 +1023,19 @@ module Engine
 
         grouped = visits.group_by(&:type)
 
-        grouped.each do |type, group|
+        grouped.sort_by { |t, _| type_info[t].size }.each do |type, group|
           num = group.sum(&:visit_cost)
 
-          type_info[type].sort_by(&:size).each do |info|
+          type_info[type].each do |info|
             next unless info[:visit].positive?
 
-            info[:visit] -= num
-            num = info[:visit] * -1
+            if num <= info[:visit]
+              info[:visit] -= num
+              num = 0
+            else
+              num -= info[:visit]
+              info[:visit] = 0
+            end
             break unless num.positive?
           end
 

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -459,7 +459,7 @@ module Engine
         distance = if gc_train?(route) && !other_gc_train?(route)
                      [
                        {
-                         nodes: %w[city offboard],
+                         nodes: %w[city offboard town],
                          pay: route.train.distance,
                          visit: route.train.distance,
                        },
@@ -481,6 +481,8 @@ module Engine
           return
         end
 
+        puts "distance = #{distance}"
+
         type_info = Hash.new { |h, k| h[k] = [] }
 
         distance.each do |h|
@@ -492,14 +494,19 @@ module Engine
 
         grouped = visits.group_by(&:type)
 
-        grouped.each do |type, group|
+        grouped.sort_by { |t, _| type_info[t].size }.each do |type, group|
           num = group.sum(&:visit_cost)
 
-          type_info[type].sort_by(&:size).each do |info|
+          type_info[type].each do |info|
             next unless info[:visit].positive?
 
-            info[:visit] -= num
-            num = info[:visit] * -1
+            if num <= info[:visit]
+              info[:visit] -= num
+              num = 0
+            else
+              num -= info[:visit]
+              info[:visit] = 0
+            end
             break unless num.positive?
           end
 

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -481,8 +481,6 @@ module Engine
           return
         end
 
-        puts "distance = #{distance}"
-
         type_info = Hash.new { |h, k| h[k] = [] }
 
         distance.each do |h|


### PR DESCRIPTION
Fixes #3531 

Changes Game::Base::check_distance as well.

**Old behavior:**
![18mag_2+2_bad](https://user-images.githubusercontent.com/8494213/105794989-52b86680-5f49-11eb-87ac-2bc25ba45126.png)


**New behavior:**
![18mag_2+2_good](https://user-images.githubusercontent.com/8494213/105795003-5946de00-5f49-11eb-89e0-054c1a4e0aad.png)
