### PR TITLE
1860: ui improvements

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -44,7 +44,7 @@ module View
               moves.map do |times, dir|
                 times.times { new_share = @game.stock_market.find_relative_share_price(new_share, dir) }
 
-                "#{times} #{dir}"
+                @step.respond_to?(:movement_str) ? @step.movement_str(times, dir) : "#{times} #{dir}"
               end.join(', ')
             else
               'None'

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -678,6 +678,7 @@ module Engine
         if trains.select { |t| t.owner == @depot }.any? && !option_original_insolvency?
           help << 'Leased trains ignore town/halt allowance.'
           help << "Revenue = #{format_currency(40)} + number_of_stops * #{format_currency(20)}"
+          help << "Max revenue possible: #{format_currency(40 + @depot.min_depot_train.distance[0]['pay'] * 20)}"
         end
         if trains.select { |t| t.owner == @depot }.any? && option_original_insolvency?
           help << 'Leased trains run for half revenue (but full subsidies).'
@@ -1130,6 +1131,14 @@ module Engine
 
       def routes_subsidy(routes)
         routes.sum(&:subsidy)
+      end
+
+      def player_sort(entities)
+        entities.sort_by(&:name).sort_by { |e| corp_layer(e) }.group_by(&:owner)
+      end
+
+      def bank_sort(entities)
+        entities.sort_by(&:name).sort_by { |e| corp_layer(e) }
       end
     end
   end

--- a/lib/engine/step/g_1860/dividend.rb
+++ b/lib/engine/step/g_1860/dividend.rb
@@ -99,6 +99,10 @@ module Engine
           @log << "#{entity.name} pays out #{@game.format_currency(revenue)} = "\
             "#{@game.format_currency(per_share)} (#{receivers})"
         end
+
+        def movement_str(times, dir)
+          "#{times / 2} #{dir}"
+        end
       end
     end
   end


### PR DESCRIPTION
- Fix share movement description on dividend step to match expectations (despite zig-zag market). I.e. "move 2 right" becomes "move 1 right"
- Add hint to leased trains showing maximum possible revenue
- Sort companies in entities tab by layer

Common file change:
- UI::DIvidend - use step method (if implemented) to generate text for share price movement in table

Fixes #3214 
Fixes #3215 
Fixes #3205

**Old**
![1860_move_before](https://user-images.githubusercontent.com/8494213/105803412-a7b0a880-5f5a-11eb-8d13-58bbcbb2e8a1.png)

**New**
![1860_move_after](https://user-images.githubusercontent.com/8494213/105803423-ad0df300-5f5a-11eb-9c33-09451348c359.png)
