### PR TITLE
Refactor: View - Game Info

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -4,6 +4,7 @@ require 'lib/color'
 require 'lib/settings'
 require 'lib/publisher'
 require 'lib/text'
+require 'view/game/game_meta'
 
 module View
   module Game
@@ -32,7 +33,7 @@ module View
         children.concat(discarded_trains) if @depot.discarded.any?
         children.concat(phases)
         children.concat(timeline) if timeline
-        children.concat(game_info)
+        children << h(GameMeta, game: @game)
       end
 
       def timeline
@@ -42,40 +43,6 @@ module View
 
         @game.timeline.each do |line|
           children << h(:p, line)
-        end
-
-        children
-      end
-
-      def game_info
-        children = [h(:h3, 'Game Info')]
-
-        if (publisher = @game.class::GAME_PUBLISHER)
-          children << h(:p, [
-              'Published by ',
-              *Lib::Publisher.link_list(component: self, publishers: Array(publisher)),
-            ])
-        end
-        children << h(:p, "Designed by #{@game.class::GAME_DESIGNER}") if @game.class::GAME_DESIGNER
-        children << h(:p, "Implemented by #{@game.class::GAME_IMPLEMENTER}") if @game.class::GAME_IMPLEMENTER
-        if @game.class::GAME_RULES_URL.is_a?(Hash)
-          @game.class::GAME_RULES_URL.each do |desc, url|
-            children << h(:p, [h(:a, { attrs: { href: url, target: '_blank' } }, desc)])
-          end
-        else
-          children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_RULES_URL, target: '_blank' } }, 'Rules')])
-        end
-        if @game.optional_rules.any?
-          children << h(:h3, 'Optional Rules Used')
-          @game.class::OPTIONAL_RULES.each do |o_r|
-            next unless @game.optional_rules.include?(o_r[:sym])
-
-            children << h(:p, " * #{o_r[:short_name]}: #{o_r[:desc]}")
-          end
-        end
-
-        if @game.class::GAME_INFO_URL
-          children << h(:p, [h(:a, { attrs: { href: @game.class::GAME_INFO_URL, target: '_blank' } }, 'More info')])
         end
 
         children

--- a/assets/app/view/game/game_meta.rb
+++ b/assets/app/view/game/game_meta.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module View
+  module Game
+    class GameMeta < Snabberb::Component
+      needs :game
+
+      def render
+        children = [h(:h3, 'Game Info')]
+
+        children.concat(render_publisher)
+        children.concat(render_designer)
+        children.concat(render_implementer)
+        children.concat(render_rule_links)
+        children.concat(render_optional_rules)
+        children.concat(render_more_info)
+
+        h(:div, children)
+      end
+
+      def render_publisher
+        return [] unless @game.class::GAME_PUBLISHER
+
+        [h(:p, [
+          'Published by ',
+          *Lib::Publisher.link_list(component: self, publishers: Array(@game.class::GAME_PUBLISHER)),
+        ])]
+      end
+
+      def render_designer
+        return [] unless @game.class::GAME_DESIGNER
+
+        [h(:p, "Designed by #{@game.class::GAME_DESIGNER}")]
+      end
+
+      def render_implementer
+        return [] unless @game.class::GAME_IMPLEMENTER
+
+        [h(:p, "Implemented by #{@game.class::GAME_IMPLEMENTER}")]
+      end
+
+      def render_rule_links
+        unless @game.class::GAME_RULES_URL.is_a?(Hash)
+          return [h(:p, [h(:a, { attrs: { href: @game.class::GAME_RULES_URL, target: '_blank' } }, 'Rules')])]
+        end
+
+        @game.class::GAME_RULES_URL.map do |desc, url|
+          h(:p, [h(:a, { attrs: { href: url, target: '_blank' } }, desc)])
+        end
+      end
+
+      def render_optional_rules
+        return [] if @game.optional_rules.empty?
+
+        used_optional_rules = @game.class::OPTIONAL_RULES.map do |o_r|
+          next unless @game.optional_rules.include?(o_r[:sym])
+
+          h(:p, " * #{o_r[:short_name]}: #{o_r[:desc]}")
+        end
+        return [] if used_optional_rules.empty?
+
+        [h(:h3, 'Optional Rules Used'), *used_optional_rules]
+      end
+
+      def render_more_info
+        return [] unless @game.class::GAME_INFO_URL
+
+        [h(:p, [h(:a, { attrs: { href: @game.class::GAME_INFO_URL, target: '_blank' } }, 'More info')])]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Split from https://github.com/tobymao/18xx/pull/3162

This was a large function of if statements, which I find very difficult to read. This refactor seemed large enough to split out by itself. 

I plan to use this information on the Game Title page, so creating its own module appeared to be a good idea. An argument could be made that not all functions should return arrays, but I liked how clean this made the render function, with no need to run a .compact at the end. Open to debate.

@michaeljb Mentioned the discrepancy between calling this "Game Meta" when the header is "Game Info". There is already a game_info.rb module, so I wasn't sure if it would be more or less confusing to change either.