### PR TITLE
Update 1849K2S per starchitect terrain suggestions, add earthquake

### DIFF
--- a/lib/engine/config/game/g_1849_boot.rb
+++ b/lib/engine/config/game/g_1849_boot.rb
@@ -157,7 +157,7 @@ module Engine
       "X1":{
          "count":1,
          "color":"green",
-         "code":"label=A;city=revenue:60,slots:2;path=a:1,b:_0,track:narrow;path=a:4,b:_0;path=a:0,b:_0,track:narrow;path=a:5,b:_0,track:narrow"
+         "code":"label=A;city=revenue:60,slots:2;path=a:1,b:_0,track:dual;path=a:4,b:_0;path=a:0,b:_0,track:narrow;path=a:5,b:_0,track:narrow"
       },
       "X2":{
          "count":1,
@@ -177,7 +177,7 @@ module Engine
       "X5":{
          "count":1,
          "color":"brown",
-         "code":"label=A;city=revenue:90,slots:2;path=a:1,b:_0,track:dual;path=a:4,b:_0;path=a:0,b:_0,track:narrow;path=a:5,b:_0,track:narrow"
+         "code":"label=A;city=revenue:90,slots:2;path=a:1,b:_0,track:dual;path=a:4,b:_0;path=a:0,b:_0,track:dual;path=a:5,b:_0,track:dual"
       },
       "X6":{
          "count":1,
@@ -479,7 +479,7 @@ module Engine
          ]
       },
       "yellow":{
-         "label=A;city=revenue:30;upgrade=cost:80,terrain:mountain;path=a:1,b:_0,track:narrow;path=a:4,b:_0":[
+         "label=A;city=revenue:30;upgrade=cost:80,terrain:mountain;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:5,b:_0,track:narrow;path=a:4,b:_0":[
             "A9"
          ],
          "label=R;city=revenue:10;path=a:3,b:_0,track:narrow;path=a:4,b:_0":[

--- a/lib/engine/config/game/g_1849_boot.rb
+++ b/lib/engine/config/game/g_1849_boot.rb
@@ -341,24 +341,18 @@ module Engine
             "A11",
             "A13",
             "B12",
-            "C13",
             "D6",
             "D8",
             "E7",
-            "E9",
-            "E13",
             "E15",
             "F16",
-            "H10",
             "H14",
             "I17",
             "J8",
             "K19",
             "K15",
-            "M11",
             "M19",
             "M21",
-            "N8",
             "N18",
             "L10",
             "O7"
@@ -367,20 +361,22 @@ module Engine
             "H16"
          ],
          "upgrade=cost:40,terrain:mountain":[
-            "F12",
-            "G11",
+            "E9",
+            "E13",
             "G13",
-            "H12",
+            "H10",
             "I9",
-            "I11"
+            "N8"
          ],
          "upgrade=cost:80,terrain:mountain":[
-            "C9",
+            "C13",
+            "F12",
+            "G11",
             "I15",
             "J14",
             "K17",
-            "O3",
-            "P4"
+            "M11",
+            "O3"
          ],
          "upgrade=cost:160,terrain:mountain":[
             "B8",
@@ -389,7 +385,11 @@ module Engine
             "D12",
             "J12",
             "K11",
-            "N10"
+            "N10",
+            "P4",
+            "H12",
+            "I11",
+            "C9"
          ],
          "city=revenue:0":[
             "L20",
@@ -399,11 +399,8 @@ module Engine
             "L12"
          ],
          "town=revenue:0":[
-            "D14",
             "F8",
             "F10",
-            "F14",
-            "K13",
             "O5",
             "M9"
          ],
@@ -411,12 +408,17 @@ module Engine
             "G17"
          ],
          "town=revenue:0;upgrade=cost:40,terrain:mountain":[
-            "G9",
+            "D14",
+            "F14",
             "J10",
             "J16"
          ],
+         "town=revenue:0;upgrade=cost:80,terrain:mountain":[
+            "K13"
+         ],
          "town=revenue:0;upgrade=cost:160,terrain:mountain":[
-            "D10"
+            "D10",
+            "G9"
          ]
       },
       "blue":{
@@ -909,8 +911,10 @@ module Engine
          "num":1,
          "distance":12,
          "price":800,
-         "events": [
-           {"type": "close_companies"}
+         "events":[
+            {
+               "type":"close_companies"
+            }
          ]
       },
       {

--- a/lib/engine/config/game/g_1849_boot.rb
+++ b/lib/engine/config/game/g_1849_boot.rb
@@ -33,6 +33,7 @@ module Engine
       "A9":"L'Aquila",
       "B14":"Pescara",
       "C5":"Rome",
+      "C7":"Avezzano",
       "D10":"Isernia",
       "D14":"Vasto",
       "E11":"Campobasso",
@@ -440,7 +441,7 @@ module Engine
          "offboard=revenue:white_30|gray_50|black_80;path=a:0,b:_0,track:dual":[
             "N2"
          ],
-         "offboard=revenue:white_60|gray_90|black_120;path=a:5,b:_0,track:dual":[
+         "offboard=revenue:white_60|gray_90|black_120;path=a:5,b:_0,track:dual;path=a:4,b:_0,track:dual":[
             "C5"
          ],
          "path=a:3,b:5,track:dual":[
@@ -448,6 +449,9 @@ module Engine
          ],
          "path=a:0,b:2,track:dual":[
             "N12"
+         ],
+         "town=revenue:30;path=a:1,b:_0,track:narrow;path=a:4,b:_0,track:narrow":[
+            "C7"
          ],
          "town=revenue:20;path=a:3,b:_0,track:dual;path=a:1,b:_0,track:dual":[
             "O11"
@@ -914,6 +918,9 @@ module Engine
          "events":[
             {
                "type":"close_companies"
+            },
+            {
+               "type":"earthquake"
             }
          ]
       },

--- a/lib/engine/game/g_1849_boot.rb
+++ b/lib/engine/game/g_1849_boot.rb
@@ -19,6 +19,17 @@ module Engine
       NEW_PORT_HEXES = %w[B16 G5 J20 L16].freeze
       NEW_SMS_HEXES = %w[B14 G7 H8 J18 L12 L18 L20 N20 O9 P2].freeze
 
+      EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+        'green_par': ['144 Par Available',
+                      'Corporations may now par at 144 (in addition to 67 and 100)'],
+        'brown_par': ['216 Par Available',
+                      'Corporations may now par at 216 (in addition to 67, 100, and 144)'],
+        'earthquake': ['Avezzano Earthquake',
+                       'Avezzano (C7) loses connection to Rome, revenue reduced to 10.']
+      ).freeze
+
+      AVZ_CODE = 'town=revenue:10;path=a:4,b:_0,track:narrow'.freeze
+
       NEW_GRAY_REVENUE_CENTERS =
         {
           'A7':
@@ -126,6 +137,13 @@ module Engine
 
       def gray_revenue(stop)
         NEW_GRAY_REVENUE_CENTERS[stop.hex.id][@phase.name]
+      end
+
+      def event_earthquake!
+        @log << '-- Event: Avezzano Earthquake --'
+        new_tile = Engine::Tile.from_code('C7', :gray, AVZ_CODE)
+        new_tile.location_name = 'Avezzano'
+        hex_by_id('C7').tile = new_tile
       end
 
       def remove_corp; end


### PR DESCRIPTION
Update terrain per starchitect suggestions here (ratchets up terrain costs)
https://boardgamegeek.com/thread/2582803/article/36837090#36837090

There is a new gray hex C7
![image](https://user-images.githubusercontent.com/29106780/105939964-d5abf080-601f-11eb-85d3-2fb22e608109.png)

Upon Phase 12, C7 this downgrades to a 10 value stub.
![image](https://user-images.githubusercontent.com/29106780/105940023-f4aa8280-601f-11eb-8d4f-113ec96f59a7.png)

The A hex/tile sequence is updated to facilitate building to Rome via the Avezzano shortcut and afterwards.

Scott did the terrain, @tysen did the earthquake

I tested the earthquake.