### PR TITLE
Fix Hex.lay to map cities more robustly

### DIFF
--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -128,15 +128,8 @@ module Engine
       @tile.cities.each_with_index do |old_city, index|
         next if city_map[old_city]
 
-        new_city = if !new_cities.include?(tile.cities[index])
-                     tile.cities[index]
-                   elsif !new_cities.include?(tile.cities[0])
-                     tile.cities[0]
-                   else
-                     tile.cities.find { |city| !new_cities.include?(city) }
-                   end
-        # failsafe
-        new_city ||= tile.cities[index] || tile.cities[0]
+        new_city = tile.cities[index]
+        new_city = tile.cities.find { |city| !new_cities.include?(city) } if new_cities.include?(new_city)
 
         city_map[old_city] = new_city
         new_cities << new_city

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -110,7 +110,7 @@ module Engine
           @tile.cities.zip(tile.cities).to_h
         # if @tile is not blank, ensure connectivity is maintained
         else
-          @tile.cities.map.with_index do |old_city, _index|
+          @tile.cities.map do |old_city|
             new_city = tile.cities.find do |city|
               # we want old_edges to be subset of new_edges
               # without the any? check, first city will always match

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -114,7 +114,7 @@ module Engine
             new_city = tile.cities.find do |city|
               # we want old_edges to be subset of new_edges
               # without the any? check, first city will always match
-              old_city.exits.any? && (old_city.exits - city.exits).empty?
+              !old_city.exits.empty? && (old_city.exits - city.exits).empty?
             end
 
             [old_city, new_city]


### PR DESCRIPTION
Modify the logic in Hex.lay(tile) to map cities without exits more robustly.

Fixes: #3550 

The current logic fails when mapping a two-city tile with one city having track and the other not, to an upgraded tile:

![18mag_OO_upgrade](https://user-images.githubusercontent.com/8494213/105947470-64237080-6026-11eb-93ea-977873434244.png)
