### PR TITLE
18CO - Show bank-owned companies (for later purchase)

### DIFF
--- a/lib/engine/game/g_18_co.rb
+++ b/lib/engine/game/g_18_co.rb
@@ -622,6 +622,10 @@ module Engine
         end
       end
 
+      def unowned_purchasable_companies(_entity)
+        @companies.select { |company| !company.closed? && company.owner.nil? }
+      end
+
       def entity_can_use_company?(entity, company)
         entity.corporation? && entity == company.owner
       end


### PR DESCRIPTION
Taking advantage of the work done in https://github.com/tobymao/18xx/pull/3445

In 18CO, a private does not need to be purchased in the initial auction. It remains in the bank and can be purchased at a later time by a corporation. Prior, there was no way to see which privates had not been purchased except for the log.

<img width="913" alt="Screen Shot 2021-01-27 at 7 43 37 AM" src="https://user-images.githubusercontent.com/15675400/106007353-7081ea80-6073-11eb-94fa-9150618aba49.png">
