### PR TITLE
Add push notifications on the browser with service workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'tilt'
 gem 'uglifier'
 gem 'unicorn'
 gem 'unicorn-worker-killer'
+gem 'webpush'
 
 group :development do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,10 @@ GEM
       rake
     get_process_mem (0.2.7)
       ffi (~> 1.0)
+    hkdf (0.3.0)
+    jwt (2.2.2)
     kgio (2.11.3)
+    libv8 (8.4.255.0)
     libv8 (8.4.255.0-x86_64-linux)
     listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -100,6 +103,9 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
+    webpush (1.1.0)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
 
 PLATFORMS
   ruby
@@ -129,6 +135,7 @@ DEPENDENCIES
   uglifier
   unicorn
   unicorn-worker-killer
+  webpush
 
 BUNDLED WITH
    2.2.3

--- a/api.rb
+++ b/api.rb
@@ -114,6 +114,7 @@ class Api < Roda
 
   def render(**needs)
     needs[:user] = user&.to_h(for_user: true)
+    needs[:vapid_public_key] = ENV['VAPID_PUBLIC_KEY']
 
     return render_pin(**needs) if needs[:pin]
 

--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -24,6 +24,7 @@ class App < Snabberb::Component
   include GameManager
   include UserManager
   needs :pin, default: nil
+  needs :vapid_public_key, default: nil, store: true
 
   def render
     props = {

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -14,6 +14,10 @@ module View
     include UserManager
 
     needs :type
+    needs :vapid_public_key, default: nil, store: true
+    needs :notification_permission, default: nil, store: true
+    needs :serviceworker, default: nil, store: true
+    needs :webpush_subscription, default: nil, store: true
 
     TILE_COLORS = Lib::Hex::COLOR.freeze
     ROUTE_COLORS = Lib::Settings::ROUTE_COLORS.freeze
@@ -79,6 +83,7 @@ module View
         .sort_by { |game| -game['updated_at'] }
 
       [render_form(title, inputs),
+       render_webpush,
        h(GameRow,
          header: 'Your Finished Games',
          game_row_games: finished_games,
@@ -279,6 +284,131 @@ module View
       when :profile
         edit_user(params)
       end
+    end
+
+    def render_webpush
+      %x{
+        if("navigator" in window) {
+          if (navigator.serviceWorker && #{@serviceworker.nil?}) {
+            navigator.serviceWorker.register('/serviceworker.js')
+            .then(function(reg) {
+              self['$store']('serviceworker', true)
+            });
+          }
+
+          navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
+            serviceWorkerRegistration.pushManager
+            .getSubscription()
+            .then((subscription) => {
+              if(subscription && subscription.endpoint != #{@webpush_subscription}) {
+                self['$store']('webpush_subscription', subscription.endpoint);
+              }
+            });
+          });
+        }
+
+        if ("Notification" in window && Notification.permission != #{@notification_permission}) {
+          self['$store']('notification_permission', Notification.permission);
+        }
+      }
+
+      webpush_subscriptions = @user&.dig(:settings, :webpush_subscriptions) || []
+
+      subscribed = false
+      rows = webpush_subscriptions.map do |l|
+        current_device = l[:subscription][:endpoint] == @webpush_subscription
+        subscribed = true if current_device
+
+        h(:li, [
+          l[:device] + (current_device ? ' (This device) ' : ' '),
+          render_button('Remove') { webpush_unsubscribe(l[:device], current_device) },
+        ])
+      end
+
+      h(:div, [
+        h(:H2, 'Background notifications'),
+        h(:ul, rows),
+        render_webpush_subscribe(subscribed),
+      ])
+    end
+
+    def render_webpush_subscribe(subscribed)
+      return h(:div, 'This device doesn\'t support background notifications') unless @serviceworker
+
+      return h(:div, 'You have denied permission to show notifications') if @notification_permission == 'denied'
+
+      unless @notification_permission == 'granted'
+        return render_button('Allow browser notifications') { ask_notifications_permission }
+      end
+
+      return h(:div, 'Push notifications are enabled for this device') if subscribed
+
+      device_input = h(:input, { attrs: { type: :text } })
+
+      h(:div, [
+        'Device name:',
+        device_input,
+        render_button('Add device') { webpush_subscribe(Native(device_input).elm.value) },
+      ])
+    end
+
+    def ask_notifications_permission
+      %x{
+        if ("Notification" in window) {
+          if (Notification.permission === "default") {
+            Notification.requestPermission().then(function(permission) {
+              self['$store']('notification_permission', permission);
+            })
+          }
+        }
+      }
+    end
+
+    # rubocop:disable Lint/UnusedMethodArgument
+    def webpush_subscribe(device)
+      %x{
+        if("navigator" in window) {
+          navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
+            console.log(vapid_public_key);
+            serviceWorkerRegistration.pushManager
+            .subscribe({
+              userVisibleOnly: true,
+              applicationServerKey: #{@vapid_public_key}
+            })
+            .then((subscription) => {
+              self['$webpush_subscribe_save'](device, subscription.toJSON())
+            });
+          });
+        }
+      }
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+
+    def webpush_subscribe_save(device, subscription)
+      webpush_subscriptions = @user[:settings][:webpush_subscriptions] || []
+      webpush_subscriptions << { device: device, subscription: subscription }
+
+      edit_user({ webpush_subscriptions: webpush_subscriptions })
+    end
+
+    def webpush_unsubscribe(device, current_device)
+      subscriptions = @user[:settings][:webpush_subscriptions]
+      edit_user({ webpush_subscriptions: subscriptions.reject { |s| s[:device] == device } })
+      return unless current_device
+
+      %x{
+        if("navigator" in window) {
+          navigator.serviceWorker.ready.then((serviceWorkerRegistration) => {
+            serviceWorkerRegistration.pushManager
+            .getSubscription()
+            .then((subscription) => {
+              if(subscription) {
+                subscription.unsubscribe();
+              }
+            });
+          });
+        }
+      }
     end
   end
 end

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,8 @@ x-rack: &rack
   image: 18xx_rack:dev
   environment:
     DATABASE_URL: postgres://root:password@db:5432/18xx_development
+    VAPID_PUBLIC_KEY: BLHSKjvJ5hKgizomDjxqOLoAGXVXxwZrzhoqEch2Py7m4VcbsRo6t8hhfdTJzQgefyj-nhMtULffPbE2-UZ-xho
+    VAPID_PRIVATE_KEY: 8uG0SY8pNq5V2bxOmjy2cbIJlqYPcWGLIYd_ZNFZYLk
     RACK_ENV: development
     RUBYOPTS: --jit
   volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,9 @@ services:
 
   queue:
     <<: *rack
+    environment:
+      VAPID_PUBLIC_KEY: $VAPID_PUBLIC_KEY
+      VAPID_PRIVATE_KEY: $VAPID_PRIVATE_KEY
     command: bundle exec ruby queue.rb
 
   db:

--- a/models/user.rb
+++ b/models/user.rb
@@ -16,7 +16,7 @@ class User < Base
       "r#{index}_#{prop}"
     end
   end + %w[
-    consent notifications simple_logos red_logo bg font bg2 font2 your_turn hotseat_game
+    consent notifications simple_logos red_logo bg font bg2 font2 your_turn hotseat_game webpush_subscriptions
     white yellow green brown gray red blue
   ]).freeze
 

--- a/public/serviceworker.js
+++ b/public/serviceworker.js
@@ -1,0 +1,37 @@
+'use strict';
+
+self.addEventListener('push', function(event) {
+  var data = event.data.json()
+  var icon = '/images/logo_polygon_yellow.svg';
+
+  event.waitUntil(
+    self.registration.showNotification(data['title'], {
+      body: data['body'],
+      icon: icon,
+      data: data
+    })
+  );
+});
+
+self.addEventListener('notificationclick', function(event) {
+  console.log('On notification click: ', event.notification.tag);
+  // Android doesn’t close the notification when you click on it
+  // See: http://crbug.com/463146
+  event.notification.close();
+
+  // This looks to see if the current is already open and
+  // focuses if it is
+  event.waitUntil(clients.matchAll({
+    type: 'window'
+  }).then(function(clientList) {
+    for (var i = 0; i < clientList.length; i++) {
+      var client = clientList[i];
+      if (client.url === event.notification.data['url'] && 'focus' in client) {
+        return client.focus();
+      }
+    }
+    if (clients.openWindow) {
+      return clients.openWindow( event.notification.data['url']);
+    }
+  }));
+});

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -211,6 +211,7 @@ class Api
       user_ids: user_ids,
       game_id: game_id,
       game_url: "#{url}/game/#{game_id}",
+      relative_url: "/game/#{game_id}",
       type: type,
       force: force,
     )

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -107,7 +107,7 @@ class Api
       expires: Date.today + Session::EXPIRE_TIME,
       domain: nil,
       httponly: true,
-      secure: true,
+      secure: PRODUCTION,
       path: '/',
     )
 


### PR DESCRIPTION
You will need to add the VAPID keys to the server environment config.

To generate VAPID keys in Ruby, you just need to run:
```
require 'webpush'
Webpush.generate_key()
```

I've put some default keys for the dev environment, because it seemed harmless and more pratical.

Each browser uses their own push service and informs us with a unique endpoint URL, which is stored in user settings. Push notifications are sent more or less anytime an email notification is sent (if they're both enabled).

This is how the settings look like:
![image](https://user-images.githubusercontent.com/3337865/106051942-fbe59500-60e0-11eb-9c15-c50b967534bb.png)

![image](https://user-images.githubusercontent.com/3337865/106051855-e40e1100-60e0-11eb-86da-65f4cb5d202b.png)

![image](https://user-images.githubusercontent.com/3337865/106051838-d9ec1280-60e0-11eb-906b-4b1be3aa34e0.png)


We don't have much control over the notifications themselves and the look changes wildly across OSs and browsers.