### PR TITLE
1860: update route.halts even if no halts are desired

### DIFF
--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -1095,7 +1095,7 @@ module Engine
         end
 
         # update route halts
-        route.halts = num_halts if (num_halts.positive? || route.halts) && !loaner_new_rules?(route)
+        route.halts = num_halts if (halts.any? || route.halts) && !loaner_new_rules?(route) && !ignore_halts?
 
         stops
       end


### PR DESCRIPTION
Previous change to halts meant that selecting a route that had enough towns to fill the train allowance prevented ever selecting non-zero halts.

With this change, route.halts will always be written if there are halts are visited on the route, except for loaner trains and when the southern forms (after sr).

Fixes #3581

No pins should be required because it just affects route selection via UI.