### PR TITLE
1860: add share price movement chart to route_selector

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -171,7 +171,7 @@ module View
 
         props = {
           style: {
-            border: '1px solid black',
+            border: '1px solid',
           },
         }
 
@@ -186,7 +186,8 @@ module View
           style: {
             margin: '0.5rem 0 0.5rem 0',
             textAlign: 'left',
-            border: '1px solid black',
+            border: '1px solid',
+            borderColor: color_for(:font),
             borderCollapse: 'collapse',
           },
         }
@@ -194,7 +195,7 @@ module View
         header_props = {
           style: {
             backgroundColor: color_for(:bg2),
-            border: '1px solid black',
+            border: '1px solid',
           },
         }
 

--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+require 'lib/color'
+require 'lib/settings'
 require 'view/game/actionable'
 
 module View
   module Game
     class Dividend < Snabberb::Component
       include Actionable
+      include Lib::Color
+      include Lib::Settings
 
       needs :routes, store: true, default: []
 
@@ -180,18 +184,25 @@ module View
 
         table_props = {
           style: {
-            margin: '0.5rem 0 0 0',
+            margin: '0.5rem 0 0.5rem 0',
             textAlign: 'left',
             border: '1px solid black',
             borderCollapse: 'collapse',
           },
         }
 
+        header_props = {
+          style: {
+            backgroundColor: color_for(:bg2),
+            border: '1px solid black',
+          },
+        }
+
         h(:table, table_props, [
           h(:thead, [
             h(:tr, props, [
-              h('th.no_padding', props, header[0]),
-              h(:th, props, header[1]),
+              h('th.no_padding', header_props, header[0]),
+              h(:th, header_props, header[1]),
             ]),
           ]),
           h(:tbody, rows),

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -280,7 +280,7 @@ module View
 
         props = {
           style: {
-            border: '1px solid black',
+            border: '1px solid',
           },
         }
 
@@ -295,7 +295,8 @@ module View
           style: {
             margin: '0.5rem 0 0 0',
             textAlign: 'left',
-            border: '1px solid black',
+            border: '1px solid',
+            borderColor: color_for(:font),
             borderCollapse: 'collapse',
           },
         }
@@ -303,7 +304,7 @@ module View
         header_props = {
           style: {
             backgroundColor: color_for(:bg2),
-            border: '1px solid black',
+            border: '1px solid',
           },
         }
 

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -186,6 +186,7 @@ module View
         instructions += ' Click button under Revenue to pick number of halts.' if render_halts
 
         h(:div, div_props, [
+          dividend_chart,
           h(:h3, { style: { margin: '0.5rem 0 0.2rem' } }, 'Select Routes'),
           h('div.small_font', description),
           h('div.small_font', instructions),
@@ -268,6 +269,52 @@ module View
             h('button.small', { on: { click: reset_all } }, 'Reset'),
           ]),
           h(:button, { style: submit_style, on: { click: submit } }, 'Submit ' + revenue + subsidy),
+        ])
+      end
+
+      def dividend_chart
+        step = @game.active_step
+        return nil unless step.respond_to?(:chart)
+
+        header, *chart = step.chart(@game.round.current_entity)
+
+        props = {
+          style: {
+            border: '1px solid black',
+          },
+        }
+
+        rows = chart.map do |r|
+          h(:tr, props, [
+            h('td.right', props, r[0]),
+            h(:td, props, r[1]),
+          ])
+        end
+
+        table_props = {
+          style: {
+            margin: '0.5rem 0 0 0',
+            textAlign: 'left',
+            border: '1px solid black',
+            borderCollapse: 'collapse',
+          },
+        }
+
+        header_props = {
+          style: {
+            backgroundColor: color_for(:bg2),
+            border: '1px solid black',
+          },
+        }
+
+        h(:table, table_props, [
+          h(:thead, [
+            h(:tr, props, [
+              h('th.right', header_props, header[0]),
+              h(:th, header_props, header[1]),
+            ]),
+          ]),
+          h(:tbody, rows),
         ])
       end
     end

--- a/lib/engine/step/g_1860/route.rb
+++ b/lib/engine/step/g_1860/route.rb
@@ -96,6 +96,21 @@ module Engine
             routes: [],
           }
         end
+
+        def chart(entity)
+          curr_price = entity.share_price.price
+          [
+            ['Revenue', 'Price Change'],
+            [@game.format_currency(0), '1 to the left'],
+            ["#{@game.format_currency(1)} - #{@game.format_currency(curr_price - 1)}", 'none'],
+            ["#{@game.format_currency(curr_price)} - #{@game.format_currency(2 * curr_price - 1)}", '1 to the right'],
+            ["#{@game.format_currency(2 * curr_price)} - #{@game.format_currency(3 * curr_price - 1)}",
+             '2 to the right'],
+            ["#{@game.format_currency(3 * curr_price)} - #{@game.format_currency(4 * curr_price - 1)}",
+             '3 to the right'],
+            ["#{@game.format_currency(4 * curr_price)} or more", '4 to the right'],
+          ]
+        end
       end
     end
   end


### PR DESCRIPTION
Add a chart to UI::route_selector to give a player the same info they'd see playing a F2F game by looking at the game board:

![1860_chart](https://user-images.githubusercontent.com/8494213/106310850-70275200-6221-11eb-9a5e-b29e65db94a7.png)

Also, tweaked dividend table for 18Mag in UI::dividend.

Fixes #3213 