### PR TITLE
[1849] Shares are in "Treasury" , not "IPO"

### DIFF
--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -120,6 +120,10 @@ module Engine
                     :max_value_reached,
                     :old_operating_order, :moved_this_turn
 
+      def ipo_name(_entity = nil)
+        'Treasury'
+      end
+
       def sms_hexes
         SMS_HEXES
       end


### PR DESCRIPTION


![Screenshot 2021-01-30 at 4 18 43 PM](https://user-images.githubusercontent.com/1711810/106371249-0be6ba00-6317-11eb-929f-bcfe99833b1a.png)


closes https://github.com/tobymao/18xx/issues/3603