### PR TITLE
1882: Fix neutral token simple_logo when using NWR ability

### DIFF
--- a/lib/engine/step/g_1882/special_nwr.rb
+++ b/lib/engine/step/g_1882/special_nwr.rb
@@ -77,7 +77,8 @@ module Engine
 
             # Add a new neutral/CN token
             cn_corp = @game.corporation_by_id('CN')
-            token = Engine::Token.new(cn_corp, price: 0, logo: '/logos/1882/neutral.svg', type: :neutral)
+            logo = '/logos/1882/neutral.svg'
+            token = Engine::Token.new(cn_corp, price: 0, logo: logo, simple_logo: logo, type: :neutral)
             cn_corp.tokens << token
 
             action.city.reservations.delete(owner)


### PR DESCRIPTION
Addressing Issue https://github.com/tobymao/18xx/issues/3592. The neutral token generated by this ability was just missing the simple_logo attribute :)