### PR TITLE
1824: Support exchange Mountain and Coal Railways

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -56,6 +56,7 @@ module View
           end
 
           children.concat(render_buttons)
+          children << h(SpecialBuy) if @current_actions.include?('special_buy')
           children.concat(render_failed_merge) if @current_actions.include?('failed_merge')
           children.concat(render_corporations)
           children.concat(render_mergeable_entities) if @current_actions.include?('merge')

--- a/lib/engine/config/game/g_1824.rb
+++ b/lib/engine/config/game/g_1824.rb
@@ -265,28 +265,21 @@ module Engine
   "companies": [
     {
       "sym":"EPP",
-      "name":"Eisenbahn Pilsen - Priesen (C1)",
+      "name":"C1 Eisenbahn Pilsen - Priesen",
       "value":200,
       "interval": [120, 140, 160, 180, 200],
       "revenue":0,
-      "desc":"Buyer take control of minor Coal Railway EPP (C1), which can be exchanged for the Director's certificate of Regional Railway MS during SRs in phase 3 or 4, or automatically when phase 5 starts. BK floats after exchange as soon as 50% or more are owned by players. This private cannot be sold.",
+      "desc":"Buyer take control of minor Coal Railway EPP (C1), which can be exchanged for the Director's certificate of Regional Railway BK during SRs in phase 3 or 4, or automatically when phase 5 starts. BK floats after exchange as soon as 50% or more are owned by players. This private cannot be sold.",
       "abilities": [
         {
           "type": "no_buy",
           "owner_type": "player"
-        },
-        {
-          "type": "exchange",
-          "owner_type": "player",
-          "corporations": ["BK"],
-          "from": "IPO",
-          "description": "SR phase 3-5: Exchange for BK presidency"
         }
       ]
     },
     {
       "sym":"EOD",
-      "name":"Eisenbahn Oderberg - Dombran (C2)",
+      "name":"C2 Eisenbahn Oderberg - Dombran",
       "value":200,
       "interval": [120, 140, 160, 180, 200],
       "revenue":0,
@@ -295,19 +288,12 @@ module Engine
         {
           "type": "no_buy",
           "owner_type": "player"
-        },
-        {
-          "type": "exchange",
-          "owner_type": "player",
-          "corporations": ["BK"],
-          "from": "IPO",
-          "description": "SR phase 3-5: Exchange for MS presidency"
         }
       ]
     },
     {
       "sym":"MLB",
-      "name":"Mosty - Lemberg Bahn (C3)",
+      "name":"C3 Mosty - Lemberg Bahn",
       "value":200,
       "interval": [120, 140, 160, 180, 200],
       "revenue":0,
@@ -316,19 +302,12 @@ module Engine
         {
           "type": "no_buy",
           "owner_type": "player"
-        },
-        {
-          "type": "exchange",
-          "owner_type": "player",
-          "corporations": ["CL"],
-          "from": "IPO",
-          "description": "SR phase 3-5: Exchange for CL presidency"
         }
       ]
     },
     {
       "sym":"SPB",
-      "name":"Simeria-Petrosani Bahn (C4)",
+      "name":"C4 Simeria-Petrosani Bahn",
       "value":200,
       "interval": [120, 140, 160, 180, 200],
       "revenue":0,
@@ -337,19 +316,12 @@ module Engine
         {
           "type": "no_buy",
           "owner_type": "player"
-        },
-        {
-          "type": "exchange",
-          "owner_type": "player",
-          "corporations": ["SB"],
-          "from": "IPO",
-          "description": "SR phase 3-5: Exchange for SB presidency"
         }
       ]
     },
     {
       "sym":"S1",
-      "name":"Wien-Gloggnitzer Eisenbahngesellschaft (S1)",
+      "name":"S1 Wien-Gloggnitzer Eisenbahngesellschaft",
       "value":240,
       "revenue":0,
       "desc":"Buyer take control of pre-staatsbahn S1, which will be exchanged for the Director's certificate of SD when the first 4 train is sold. Pre-Staatsbahnen starts in Wien (E12). Cannot be sold.",
@@ -362,7 +334,7 @@ module Engine
     },
     {
       "sym":"S2",
-      "name":"Kärntner Bahn (S2)",
+      "name":"S2 Kärntner Bahn",
       "value":120,
       "revenue":0,
       "desc":"Buyer take control of pre-staatsbahn S2, which will be exchanged for a 10% share of SD when the first 4 train is sold. Pre-Staatsbahnen starts in Graz (G10). Cannot be sold.",
@@ -375,7 +347,7 @@ module Engine
     },
     {
       "sym":"S3",
-      "name":"Nordtiroler Staatsbahn (S3)",
+      "name":"S3 Nordtiroler Staatsbahn",
       "value":120,
       "revenue":0,
       "desc":"Buyer take control of pre-staatsbahn S3, which will be exchanged for a 10% share of SD when the first 4 train is sold. Pre-Staatsbahnen starts in Innsbruck (G4). Cannot be sold.",
@@ -388,7 +360,7 @@ module Engine
     },
     {
       "sym":"U1",
-      "name":"Eisenbahn Pest - Waitzen (U1)",
+      "name":"U1 Eisenbahn Pest - Waitzen",
       "value":240,
       "revenue":0,
       "desc":"Buyer take control of pre-staatsbahn U1, which will be exchanged for the Director's certificate of UG when the first 5 train is sold. Pre-Staatsbahnen starts in Pest (F17) in base 1824 and in Budapest (G12) for 3 players on the Cislethania map. Cannot be sold.",
@@ -401,7 +373,7 @@ module Engine
     },
     {
       "sym":"U2",
-      "name":"Mohacs-Fünfkirchner Bahn (U2)",
+      "name":"U2 Mohacs-Fünfkirchner Bahn",
       "value":120,
       "revenue":0,
       "desc":"Buyer take control of pre-staatsbahn U2, which will be exchanged for a 10% share of UG when the first 5 train is sold. Pre-Staatsbahnen starts in Fünfkirchen (H15). Cannot be sold.",
@@ -414,7 +386,7 @@ module Engine
     },
     {
       "sym":"K1",
-      "name":"Kaiserin Elisabeth-Bahn (K1)",
+      "name":"K1 Kaiserin Elisabeth-Bahn",
       "value":240,
       "revenue":0,
       "desc":"Buyer take control of pre-staatsbahn K1, which will be exchanged for the Director's certificate of KK when the first 6 train is sold. Pre-Staatsbahnen starts in Wien (E12). Cannot be sold.",
@@ -427,7 +399,7 @@ module Engine
     },
     {
       "sym":"K2",
-      "name":"Kaiser Franz Joseph-Bahn (K2)",
+      "name":"K2 Kaiser Franz Joseph-Bahn",
       "value":120,
       "revenue":0,
       "desc":"Buyer take control of pre-staatsbahn K2, which will be exchanged for a 10% share of KK when the first 6 train is sold. Pre-Staatsbahnen starts in Wien (E12). Cannot be sold.",
@@ -442,7 +414,7 @@ module Engine
   "minors":[
     {
       "sym": "EPP",
-      "name": "Eisenbahn Pilsen - Priesen (C1)",
+      "name": "C1 Eisenbahn Pilsen - Priesen",
       "type": "Coal",
       "tokens": [
         0
@@ -454,7 +426,7 @@ module Engine
     },
     {
       "sym": "EOD",
-      "name": "Eisenbahn Oderberg - Dombran (C2)",
+      "name": "C2 Eisenbahn Oderberg - Dombran",
       "type": "Coal",
       "tokens": [
         0
@@ -467,7 +439,7 @@ module Engine
     {
       "float_percent": 100,
       "sym": "MLB",
-      "name": "Mosty - Lemberg Bahn (C3)",
+      "name": "C3 Mosty - Lemberg Bahn",
       "type": "Coal",
       "tokens": [
         0
@@ -479,7 +451,7 @@ module Engine
     },
     {
       "sym": "SPB",
-      "name": "Simeria-Petrosani Bahn (C4)",
+      "name": "C4 Simeria-Petrosani Bahn",
       "type": "Coal",
       "tokens": [
         0
@@ -491,7 +463,7 @@ module Engine
     },
     {
        "sym": "S1",
-       "name": "Wien-Gloggnitzer Eisenbahngesellschaft",
+       "name": "S1 Wien-Gloggnitzer Eisenbahngesellschaft",
        "type": "PreStaatsbahn",
        "tokens": [
          0
@@ -503,7 +475,7 @@ module Engine
     },
     {
       "sym": "S2",
-      "name": "Kärntner Bahn",
+      "name": "S2 Kärntner Bahn",
       "type": "PreStaatsbahn",
       "tokens": [
         0
@@ -515,7 +487,7 @@ module Engine
     },
     {
       "sym": "S3",
-      "name": "Nordtiroler Staatsbahn",
+      "name": "S3 Nordtiroler Staatsbahn",
       "type": "PreStaatsbahn",
       "tokens": [
         0
@@ -527,7 +499,7 @@ module Engine
     },
     {
       "sym": "U1",
-      "name": "Eisenbahn Pest - Waitzen",
+      "name": "U1 Eisenbahn Pest - Waitzen",
       "type": "PreStaatsbahn",
       "tokens": [
         0
@@ -539,7 +511,7 @@ module Engine
     },
     {
       "sym": "U2",
-      "name": "Mohacs-Fünfkirchner Bahn",
+      "name": "U2 Mohacs-Fünfkirchner Bahn",
       "type": "PreStaatsbahn",
       "tokens": [
         0
@@ -551,7 +523,7 @@ module Engine
     },
     {
       "sym": "K1",
-      "name": "Kaiserin Elisabeth-Bahn",
+      "name": "K1 Kaiserin Elisabeth-Bahn",
       "type": "PreStaatsbahn",
       "tokens": [
           0
@@ -563,7 +535,7 @@ module Engine
     },
     {
       "sym": "K2",
-      "name": "Kaiser Franz Joseph-Bahn",
+      "name": "K2 Kaiser Franz Joseph-Bahn",
       "type": "PreStaatsbahn",
       "tokens": [
         0

--- a/lib/engine/game/g_1824.rb
+++ b/lib/engine/game/g_1824.rb
@@ -133,7 +133,7 @@ module Engine
           # So set them as closed and removed so that they do not appear
           # Affected: Coal Railway C4 (SPB), Regional Railway BH and SB, and possibly UG
           corporations.each do |c|
-            if (%w[SB BH].include?(c.name) || (two_player? && c.name == 'UG'))
+            if %w[SB BH].include?(c.name) || (two_player? && c.name == 'UG')
               c.close!
               c.removed = true
             end

--- a/lib/engine/game/g_1824.rb
+++ b/lib/engine/game/g_1824.rb
@@ -120,13 +120,6 @@ module Engine
       def init_corporations(stock_market)
         corporations = CORPORATIONS.dup
 
-        if option_cisleithania
-          # Remove Coal Railway C4 (SPB), Regional Railway BH and SB, and possibly UG
-          corporations.reject! do |c|
-            (%w[SB BH].include?(c[:sym]) || (two_player? && c[:sym] == 'UG'))
-          end
-        end
-
         corporations.map! do |corporation|
           Engine::G1824::Corporation.new(
             min_price: stock_market.par_prices.map(&:price).min,
@@ -135,16 +128,16 @@ module Engine
           )
         end
 
-        return corporations unless option_cisleithania
-
-        # Some corporations need to be removed, but they need to exists (for implementation reasons)
-        # So set them as closed and removed so that they do not appear
-        # Affected: Coal Railway C4 (SPB), Regional Railway BH and SB, and possibly UG
-        corporations.reject! do |c|
-          next unless %w[SPB SB BH].include?(c.id) || (two_player? && c.id == 'UG')
-
-          c.close!
-          c.removed = true
+        if option_cisleithania
+          # Some corporations need to be removed, but they need to exists (for implementation reasons)
+          # So set them as closed and removed so that they do not appear
+          # Affected: Coal Railway C4 (SPB), Regional Railway BH and SB, and possibly UG
+          corporations.each do |c|
+            if (%w[SB BH].include?(c.name) || (two_player? && c.name == 'UG'))
+              c.close!
+              c.removed = true
+            end
+          end
         end
 
         corporations

--- a/lib/engine/game/g_1824.rb
+++ b/lib/engine/game/g_1824.rb
@@ -127,13 +127,27 @@ module Engine
           end
         end
 
-        corporations.map do |corporation|
+        corporations.map! do |corporation|
           Engine::G1824::Corporation.new(
             min_price: stock_market.par_prices.map(&:price).min,
             capitalization: self.class::CAPITALIZATION,
             **corporation.merge(corporation_opts),
           )
         end
+
+        return corporations unless option_cisleithania
+
+        # Some corporations need to be removed, but they need to exists (for implementation reasons)
+        # So set them as closed and removed so that they do not appear
+        # Affected: Coal Railway C4 (SPB), Regional Railway BH and SB, and possibly UG
+        corporations.reject! do |c|
+          next unless %w[SPB SB BH].include?(c.id) || (two_player? && c.id == 'UG')
+
+          c.close!
+          c.removed = true
+        end
+
+        corporations
       end
 
       def init_minors
@@ -234,15 +248,12 @@ module Engine
         Round::Operating.new(self, [
           Step::Bankrupt,
           Step::DiscardTrain,
-          Step::BuyCompany,
           Step::HomeToken,
-          Step::SpecialTrack,
           Step::Track,
           Step::Token,
           Step::Route,
           Step::G1824::Dividend,
           Step::G1824::BuyTrain,
-          [Step::BuyCompany, blocks: true],
         ], round_num: round_num)
       end
 
@@ -251,6 +262,13 @@ module Engine
         @log << 'Player order is reversed the first turn'
         Round::G1824::FirstStock.new(self, [
           Step::G1824::BuySellParSharesFirstSR,
+        ])
+      end
+
+      def stock_round
+        Round::Stock.new(self, [
+          Step::DiscardTrain,
+          Step::G1824::BuySellParExchangeShares,
         ])
       end
 
@@ -346,7 +364,7 @@ module Engine
       end
 
       def can_par?(corporation, parrer)
-        super && buyable?(corporation)
+        super && buyable?(corporation) && !reserved_regional(corporation)
       end
 
       def g_train?(train)
@@ -357,8 +375,18 @@ module Engine
         entity.company? && entity.sym.start_with?('B')
       end
 
+      def mountain_railway_exchangable?
+        @phase.status.include?('may_exchange_mountain_railways')
+      end
+
       def coal_railway?(entity)
-        entity.minor? && entity.type == :Coal
+        return entity.type == :Coal if entity.minor?
+
+        entity.company? && associated_regional_railway(entity)
+      end
+
+      def coal_railway_exchangable?
+        @phase.status.include?('may_exchange_coal_railways')
       end
 
       def pre_staatsbahn?(entity)
@@ -383,11 +411,16 @@ module Engine
       def buyable?(entity)
         return true unless entity.corporation?
 
-        entity.all_abilities.none? { |a| a.type == :no_buy } && !reserved_regional(entity)
+        entity.all_abilities.none? { |a| a.type == :no_buy }
       end
 
       def corporation_available?(entity)
         buyable?(entity)
+      end
+
+      def entity_can_use_company?(_entity, _company)
+        # Return false here so that Exchange abilities does not appear in GUI
+        false
       end
 
       def sorted_corporations
@@ -399,7 +432,8 @@ module Engine
       end
 
       def associated_regional_railway(coal_railway)
-        case coal_railway.name
+        key = coal_railway.minor? ? coal_railway.name : coal_railway.id
+        case key
         when 'EPP'
           regional_bk
         when 'EOD'
@@ -471,6 +505,85 @@ module Engine
         @corporations.reject(&:removed)
       end
 
+      def event_close_mountain_railways!
+        @log << '-- Exchange any remaining Mountain Railway'
+        @companies.select { |c| mountain_railway?(c).reject(&:closed?) }.each do |mountain_railway|
+          @log << '-- TODO Mountain railway should be exchanged if possible'
+          # TODO: Need interrupt stock exchange step here
+          mountain_railway.close!
+        end
+      end
+
+      def event_close_coal_railways!
+        @log << '-- Exchange any remaining Coal Railway'
+        @companies.select { |c| coal_railway?(c) }.reject(&:closed?).each do |coal_railway_company|
+          exchange_coal_railway(coal_railway_company)
+        end
+      end
+
+      def exchange_coal_railway(company)
+        player = company.owner
+        minor = minor_by_id(company.id)
+        regional = associated_regional_railway(company)
+
+        @log << "#{player.name} receives presidency of #{regional.name} in exchange for #{minor.name}"
+        company.close!
+
+        # Transfer Coal Railway cash and trains to Regional. Remove CR token.
+        if minor.cash.positive?
+          @log << "#{regional.name} recieves the #{minor.name} treasury of #{format_currency(minor.cash)}"
+          minor.spend(minor.cash, regional)
+        end
+        unless minor.trains.empty?
+          transferred = transfer(:trains, minor, regional)
+          @log << "#{regional.name} receives the trains: #{transferred.map(&:name).join(', ')}"
+        end
+        minor.tokens.first.remove!
+        minor.close!
+
+        # Handle Regional presidency, possibly transfering to another player in case they own more in the regional
+        presidency_share = regional.shares.find(&:president)
+        presidency_share.buyable = true
+        regional.floatable = true
+        @share_pool.transfer_shares(
+          presidency_share.to_bundle,
+          player,
+          allow_president_change: false,
+          price: 0
+        )
+
+        # Give presidency to majority owner (with minor owner priority if that player is one of them)
+        max_shares = @share_pool.presidency_check_shares(regional).values.max
+        majority_share_holders = @share_pool.presidency_check_shares(regional).select { |_, p| p == max_shares }.keys
+        if !majority_share_holders.find { |owner| owner == player }
+          # FIXME: Handle the case where multiple share the presidency criteria
+          new_president = majority_share_holders.first
+          @share_pool.change_president(presidency_share, player, new_president, player)
+          regional.owner = new_president
+          @log << "#{new_president.name} becomes president of #{regional.name} as majority owner"
+        else
+          regional.owner = player
+        end
+
+        float_corporation(regional) if regional.floated?
+      end
+
+      def float_corporation(corporation)
+        @log << "#{corporation.name} floats"
+
+        return if corporation.capitalization == :incremental
+
+        case corporation.name
+        when 'BK', 'MS', 'CL', 'SB'
+          floating_capital = corporation.par_price.price * 8
+        else
+          floating_capital = corporation.par_price.price * corporation.total_shares
+        end
+
+        @bank.spend(floating_capital, corporation)
+        @log << "#{corporation.name} receives floating capital of #{format_currency(floating_capital)}"
+      end
+
       private
 
       def mine_hex?(hex)
@@ -479,7 +592,7 @@ module Engine
 
       MOUNTAIN_RAILWAY_DEFINITION = {
         sym: 'B%1$d',
-        name: '%2$s (B%1$d)',
+        name: 'B%1$d %2$s',
         value: 120,
         revenue: 25,
         desc: 'Moutain railway (B%1$d). Cannot be sold but can be exchanged for a 10 percent share in a '\
@@ -489,6 +602,12 @@ module Engine
           {
             type: 'no_buy',
             owner_type: 'player',
+          },
+          {
+            'type': 'exchange',
+            'corporations': %w[BK MS CL SB BH],
+            'owner_type': 'player',
+            'from': %w[ipo market],
           },
         ],
       }.freeze

--- a/lib/engine/round/g_1824/first_stock.rb
+++ b/lib/engine/round/g_1824/first_stock.rb
@@ -93,7 +93,6 @@ module Engine
         end
 
         def remove_reservation(minor)
-          puts("Coordinates for #{minor.name} is #{minor.coordinates}")
           hex = @game.hex_by_id(minor.coordinates)
           tile = hex.tile
           cities = tile.cities

--- a/lib/engine/step/g_1824/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/step/g_1824/buy_sell_par_exchange_shares.rb
@@ -10,9 +10,7 @@ module Engine
         BUY_ACTION = %w[special_buy].freeze
 
         def actions(entity)
-          if entity.company?
-            return can_exchange?(entity) ? EXCHANGE_ACTIONS : []
-          end
+          return can_exchange?(entity) ? EXCHANGE_ACTIONS : [] if entity.company?
 
           actions = super
           actions << 'special_buy' if !actions.empty? && buyable_items(entity)

--- a/lib/engine/step/g_1824/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/step/g_1824/buy_sell_par_exchange_shares.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require_relative '../buy_sell_par_shares'
+
+module Engine
+  module Step
+    module G1824
+      class BuySellParExchangeShares < BuySellParShares
+        EXCHANGE_ACTIONS = %w[buy_shares].freeze
+        BUY_ACTION = %w[special_buy].freeze
+
+        def actions(entity)
+          if entity.company?
+            return can_exchange?(entity) ? EXCHANGE_ACTIONS : []
+          end
+
+          actions = super
+          actions << 'special_buy' if !actions.empty? && buyable_items(entity)
+          actions
+        end
+
+        def can_buy?(entity, bundle)
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_sell?(_entity, bundle)
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_gain?(entity, bundle, exchange: false)
+          return false if exchange && !@game.mountain_railway_exchangable? && !@game.coal_railway_exchangable?
+
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_exchange?(entity, bundle = nil)
+          return false unless (ability = exchangable_ability(entity))
+          return can_gain?(entity.owner, bundle, exchange: true) if bundle
+
+          shares = []
+          @game.exchange_corporations(ability).each do |corporation|
+            shares << corporation.available_share if ability.from.include?(:ipo)
+            shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
+          end
+
+          shares.any? { |s| can_gain?(entity.owner, s&.to_bundle, exchange: true) }
+        end
+
+        def process_buy_shares(action)
+          return super unless action.entity.company?
+
+          company = action.entity
+          bundle = action.bundle
+          unless can_exchange?(company, bundle)
+            raise GameError, "Cannot exchange #{action.entity.id} for #{bundle.corporation.id}"
+          end
+
+          bundle.share_price = 0
+          buy_shares(company.owner, bundle, exchange: company)
+          company.close!
+
+          # Exchange is treated as a Buy, and no more actions allowed as Sell-Buy
+          @current_actions << action
+        end
+
+        def buyable_items(entity)
+          return [] unless @game.coal_railway_exchangable?
+
+          @game.companies.select { |c| @game.coal_railway?(c) && c.owner == entity }.map do |c|
+            Item.new(description: c.id, cost: 0)
+          end
+        end
+
+        def item_str(item)
+          company = @game.company_by_id(item.description)
+          regional = @game.associated_regional_railway(@game.company_by_id(item.description))
+          "Exchange #{company.name} for #{regional.name} presidency"
+        end
+
+        def process_special_buy(action)
+          @game.exchange_coal_railway(@game.company_by_id(action.item.description))
+
+          # Exchange is treated as a Buy, and no more actions allowed as Sell-Buy
+          @current_actions << action
+        end
+
+        private
+
+        def exchangable_ability(entity)
+          return if !entity.company? || !@game.mountain_railway?(entity) || !@game.mountain_railway_exchangable?
+
+          @game.abilities(entity, :exchange)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1824/buy_sell_par_shares_first_sr.rb
+++ b/lib/engine/step/g_1824/buy_sell_par_shares_first_sr.rb
@@ -24,13 +24,21 @@ module Engine
           super && @game.buyable?(bundle.corporation)
         end
 
-        def can_gain?(_entity, bundle)
+        def can_gain?(_entity, bundle, exchange: false)
+          return false if exchange
+
           super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_exchange?(_entity)
+          false
         end
 
         def process_buy_company(action)
           entity = action.entity
           company = action.company
+          price = action.price
+          company.value = price
 
           super
 
@@ -38,7 +46,7 @@ module Engine
           return unless (minor = @game.minor_by_id(company.id))
           return buy_pre_staatsbahn(minor, entity, action) if @game.pre_staatsbahn?(minor)
 
-          buy_coal_railway(minor, entity, action.price)
+          buy_coal_railway(minor, entity, price)
         end
 
         private


### PR DESCRIPTION
Mountain Railways is exchanged during SR in phase 3 by selecting
a regional, and click on Exchange. This exchange is for a 10% share.

Coal Railway is done as a Special Buy during SR in phase 3 or 4.
This exchange is for a 20% presidency share.
(The reason for separate ways is that the presidency share is set
to No Buy, and implementing support for doing normal exchange is
complicated. Think this way is good enough.)

When phase 5 is started the exchange of any remaining Coal Railways
is triggered.

Only change in general code is to show Special Buy during stock
round if any step responds to special_buy action.

Some minor changes of details (e.g. names) discovered during
play testing.