### PR TITLE
Add sort for trains, tokens, and companies columns in Spreadsheet tab

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -201,10 +201,10 @@ module View
             h(:th, render_sort_link('Market', :share_price)),
             h(:th, render_sort_link('Cash', :cash)),
             h(:th, render_sort_link('Order', :order)),
-            h(:th, 'Trains'),
-            h(:th, 'Tokens'),
+            h(:th, render_sort_link('Trains', :trains)),
+            h(:th, render_sort_link('Tokens', :tokens)),
             *extra,
-            h(:th, 'Companies'),
+            h(:th, render_sort_link('Companies', :companies)),
             h(:th, ''),
             *or_history_titles,
           ]),
@@ -293,6 +293,12 @@ module View
             @game.buying_power(corporation, full: true)
           when :interest
             @game.interest_owed(corporation)
+          when :trains
+            corporation.floated? ? corporation.trains.size : -1
+          when :tokens
+            @game.count_available_tokens(corporation)
+          when :companies
+            corporation.companies.size
           else
             @game.player_by_id(@spreadsheet_sort_by)&.num_shares_of(corporation)
           end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2200,8 +2200,12 @@ module Engine
         []
       end
 
+      def count_available_tokens(corporation)
+        corporation.tokens.map { |t| t.used ? 0 : 1 }.sum
+      end
+
       def token_string(corporation)
-        "#{corporation.tokens.map { |t| t.used ? 0 : 1 }.sum}/#{corporation.tokens.size}"
+        "#{count_available_tokens(corporation)}/#{corporation.tokens.size}"
       end
 
       # minors to show on player cards

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -205,9 +205,13 @@ module Engine
         @sc_company = nil
       end
 
+      def count_available_tokens(corporation)
+        corporation.tokens.map { |t| t.used || t.corporation != corporation ? 0 : 1 }.sum
+      end
+
       def token_string(corporation)
         # All neutral tokens belong to CN, so it will count them normally.
-        "#{corporation.tokens.map { |t| t.used || t.corporation != corporation ? 0 : 1 }.sum}"\
+        "#{count_available_tokens(corporation)}"\
         "/#{corporation.tokens.map { |t| t.corporation != corporation ? 0 : 1 }.sum}"\
         "#{', N' if corporation.tokens.any? { |t| t.corporation != corporation }}"
       end


### PR DESCRIPTION
For part of [issue #2506](https://github.com/tobymao/18xx/issues/2506). After this change, all columns in the Corporation section of the spreadsheet should be sortable (the loans column mentioned in the issue is already sortable). Worked on with @erperreault 🌈 🚋 

## Sorting Companies:
![Screen Shot 2021-01-31 at 7 55 58 PM](https://user-images.githubusercontent.com/4404805/106411205-e84c6e00-6401-11eb-9f60-24576cf6c242.png)

## Sorting Tokens:
#### Neutral token case
![Screen Shot 2021-01-31 at 7 41 51 PM](https://user-images.githubusercontent.com/4404805/106411208-e97d9b00-6401-11eb-9963-0647b3135f90.png)
#### Non-neutral token case
![Screen Shot 2021-01-31 at 8 23 51 PM](https://user-images.githubusercontent.com/4404805/106411329-45e0ba80-6402-11eb-8b31-157cef89ff03.png)


## Sorting Trains:
![Screen Shot 2021-01-31 at 8 26 09 PM](https://user-images.githubusercontent.com/4404805/106411449-96581800-6402-11eb-905e-48f57bf5d7b5.png)
![Screen Shot 2021-01-31 at 8 24 59 PM](https://user-images.githubusercontent.com/4404805/106411451-96f0ae80-6402-11eb-8c60-db24e7b28a19.png)

