### PR TITLE
18zoo add tickets

### DIFF
--- a/lib/engine/config/game/g_18_zoo.rb
+++ b/lib/engine/config/game/g_18_zoo.rb
@@ -114,26 +114,35 @@ module Engine
       "sym": "HOLIDAY",
       "name": "Holiday (SR)",
       "value": 3,
-      "desc": "Choose a family, its reputation mark goes one tick to the right."
+      "desc": "Choose a family, its reputation mark goes one tick to the right.",
+      "abilities": [{
+        "type": "no_buy",
+        "owner_type": "player"
+      }]
     },
     {
       "sym": "MIDAS",
       "name": "Midas (SR)",
       "value": 2,
-      "desc": "When turn order is appointed, seize the Priority (Squirrel 1)."
+      "desc": "When turn order is appointed, seize the Priority (Squirrel 1).",
+      "abilities": [{
+        "type": "no_buy",
+        "owner_type": "player"
+      }]
     },
     {
       "sym": "TOO_MUCH_RESPONSIBILITY",
       "name": "Too much responsibility (SR)",
       "value": 1,
       "desc": "Get 3$N.",
-      "abilities": [
-          {
-              "type": "description",
-              "description": "Get 3$N",
-              "when": "any"
-          }
-      ]
+      "abilities": [{
+        "type": "no_buy",
+        "owner_type": "player"
+      },{
+        "type": "description",
+        "description": "Get 3$N",
+        "when": "any"
+      }]
     },
     {
       "sym": "LEPRECHAUN_POT_OF_GOLD",
@@ -149,13 +158,21 @@ module Engine
       "sym": "IT_S_ALL_GREEK_TO_ME",
       "name": "It’s all greek to me (SR)",
       "value": 2,
-      "desc": "After your action in a SR, do another one."
+      "desc": "After your action in a SR, do another one.",
+      "abilities": [{
+        "type": "no_buy",
+        "owner_type": "player"
+      }]
     },
     {
       "sym": "WHATSUP",
       "name": "Whatsup (SR)",
       "value": 3,
-      "desc": "During SR, a family can buy the first available squirrel, deactivated. Reputation moves one tick."
+      "desc": "During SR, a family can buy the first available squirrel, deactivated. Reputation moves one tick.",
+      "abilities": [{
+        "type": "no_buy",
+        "owner_type": "player"
+      }]
     },
     {
       "sym": "RABBITS",
@@ -477,7 +494,12 @@ module Engine
       "operating_rounds": 3
     }
   ],
-  "certLimit": {},
+  "certLimit": {
+    "2": { "5": 10, "7": 12 },
+    "3": { "5": 7, "7": 9 },
+    "4": { "5": 5, "7": 7 },
+    "5": { "5": 6, "7": 6 }
+  },
   "startingCash": {},
   "locationNames": {},
   "corporations": [

--- a/lib/engine/game/g_18_zoo.rb
+++ b/lib/engine/game/g_18_zoo.rb
@@ -548,7 +548,7 @@ module Engine
 
       def purchasable_companies(entity = nil)
         entity ||= @round.current_operator
-        return [] unless entity && (entity.corporation? || entity.player?)
+        return [] if !entity || !(entity.corporation? || entity.player?)
 
         if entity.player?
           # player can buy no more than 3 companies

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -101,7 +101,7 @@ module Engine
       end
 
       def pay(entity, owner, price, company)
-        entity.spend(price, owner.nil? ? @game.bank : owner)
+        entity.spend(price, owner || @game.bank)
 
         @game.company_bought(company, entity)
 

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -83,13 +83,8 @@ module Engine
         @round.company_sellers[company] = owner
 
         entity.companies << company
-        entity.spend(price, owner.nil? ? @game.bank : owner)
+        pay(entity, owner, price, company)
 
-        @game.company_bought(company, entity)
-
-        @log << "#{entity.name} buys #{company.name} from "\
-                "#{owner.nil? ? 'the market' : owner.name} for "\
-                "#{@game.format_currency(price)}"
         log_later.each { |l| @log << l }
       end
 
@@ -103,6 +98,16 @@ module Engine
 
       def setup
         @blocks = @opts[:blocks] || false
+      end
+
+      def pay(entity, owner, price, company)
+        entity.spend(price, owner.nil? ? @game.bank : owner)
+
+        @game.company_bought(company, entity)
+
+        @log << "#{entity.name} buys #{company.name} from "\
+                "#{owner.nil? ? 'the market' : owner.name} for "\
+                "#{@game.format_currency(price)}"
       end
     end
   end

--- a/lib/engine/step/g_18_zoo/buy_company.rb
+++ b/lib/engine/step/g_18_zoo/buy_company.rb
@@ -36,7 +36,7 @@ module Engine
         end
 
         def pay(entity, owner, price, company)
-          entity.spend(price, owner.nil? ? @game.bank : owner) if price.positive?
+          entity.spend(price, owner || @game.bank) if price.positive?
           @game.company_bought(company, entity)
 
           @log << "#{owner&.name} earns #{@game.format_currency(price)}"

--- a/lib/engine/step/g_18_zoo/buy_company.rb
+++ b/lib/engine/step/g_18_zoo/buy_company.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../buy_company'
+
+module Engine
+  module Step
+    module G18ZOO
+      class BuyCompany < BuyCompany
+        def description
+          'Buy powers'
+        end
+
+        def pass_description
+          @acted ? 'Done (Buy Powers)' : 'Skip (Buy Powers)'
+        end
+
+        def process_buy_company(action)
+          if action.company.name.start_with?('ZOOTicket')
+            corporation = action.entity
+            company = action.company
+            price = action.price
+            player = company.owner
+
+            @log << "#{corporation.name} sells #{company.name} (owned by #{player.name})"
+
+            @game.bank.spend(price, player) if price.positive?
+            @log << "#{player.name} earns #{@game.format_currency(price)}" if price.positive?
+
+            @game.bank.spend(company.value - price, corporation)
+            @log << "#{corporation.name} earns #{@game.format_currency(company.value - price)}"
+
+            company.close!
+          else
+            super
+          end
+        end
+
+        def pay(entity, owner, price, company)
+          entity.spend(price, owner.nil? ? @game.bank : owner) if price.positive?
+          @game.company_bought(company, entity)
+
+          @log << "#{owner&.name} earns #{@game.format_currency(price)}"
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_zoo/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_zoo/buy_sell_par_shares.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../buy_sell_par_shares'
+
+module Engine
+  module Step
+    module G18ZOO
+      class BuySellParShares < BuySellParShares
+        def actions(entity)
+          return [] unless entity == current_entity
+          return ['sell_shares'] if must_sell?(entity)
+
+          actions = []
+          actions << 'buy_shares' if can_buy_any?(entity)
+          actions << 'par' if can_ipo_any?(entity)
+          actions << 'buy_company' unless purchasable_unsold_companies.empty?
+          actions << 'sell_shares' if can_sell_any?(entity)
+          actions << 'pass' unless actions.empty?
+          actions
+        end
+
+        def can_buy_company?(player, _company)
+          player.companies.count { |c| !c.name.start_with?('ZOOTicket') } < 3
+        end
+
+        def process_buy_company(action)
+          super
+
+          @game.available_companies.delete(action.company)
+        end
+
+        private
+
+        def purchasable_unsold_companies
+          return [] if bought?
+
+          @game.available_companies
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addition to 18ZOO:
- add ZOOTickets on game creation
- companies can be bought from players
- companies (only OR or ZOOTicket from owner player) can be bought by corporation
- ZOOTicket can be sold by corporation (price to player, difference to corporation)
- ZOOTickets value changes every round
- Player orders is higher cash + current order (but not on Draft)