### PR TITLE
1867: Previous corp nationalizes causes skip of train buy

### DIFF
--- a/lib/engine/step/g_1867/buy_train.rb
+++ b/lib/engine/step/g_1867/buy_train.rb
@@ -24,7 +24,7 @@ module Engine
 
         def pass!
           super
-          @game.nationalize!(current_entity) if current_entity.trains.none?
+          @game.nationalize!(current_entity) if current_entity.trains.empty?
         end
 
         def discountable_trains_allowed?(_entity)

--- a/lib/engine/step/g_1867/buy_train.rb
+++ b/lib/engine/step/g_1867/buy_train.rb
@@ -23,8 +23,8 @@ module Engine
         end
 
         def pass!
-          @game.nationalize!(current_entity) if current_entity.trains.none?
           super
+          @game.nationalize!(current_entity) if current_entity.trains.none?
         end
 
         def discountable_trains_allowed?(_entity)


### PR DESCRIPTION
In game 23040 NYC was nationalized since it didn't buy a train,
this causes it to skip to the new corps turn GWR but the unpass occurs before
the pass, move the nationalization to after the pass. (fixes #3625)