### PR TITLE
history: fixed button positions, button style

### DIFF
--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -147,13 +147,11 @@ module View
           title: title,
           children: text,
           style: {
-            textAlign: 'center',
-            textDecoration: 'none',
-            width: '2.4rem',
+            margin: '0',
             **style_extra,
           },
         }
-        props['class'] = '.button_link' if as_button
+        props[:class] = '.button_link' if as_button
 
         h(Link, props)
       end

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -147,7 +147,9 @@ module View
           title: title,
           children: text,
           style: {
+            textAlign: 'center',
             textDecoration: 'none',
+            width: '2.4rem',
             **style_extra,
           },
         }

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -15,12 +15,11 @@ module View
       def render
         return h(:div) if @num_actions.zero?
 
-        divs = [h('b.margined', 'History')]
+        divs = [h(:h3, { style: { margin: '0' } }, 'History')]
         cursor = Lib::Params['action']&.to_i
-        style_extra = { padding: '0 1rem' }
 
         unless cursor&.zero?
-          divs << history_link('|<', 'Start', 0, style_extra)
+          divs << history_link('|<', 'Start', 0)
 
           last_round =
             if cursor == @game.raw_actions.size
@@ -28,7 +27,7 @@ module View
             else
               @game.round_history[-1]
             end
-          divs << history_link('<<', 'Previous Round', last_round, style_extra) if last_round
+          divs << history_link('<<', 'Previous Round', last_round, { gridColumnStart: '3' }) if last_round
 
           prev_action =
             if @game.exception
@@ -38,18 +37,27 @@ module View
             else
               @num_actions - 1
             end
-          divs << history_link('<', 'Previous Action', prev_action, style_extra)
+          divs << history_link('<', 'Previous Action', prev_action, { gridColumnStart: '4' })
         end
 
         if cursor && !@game.exception
-          divs << history_link('>', 'Next Action', cursor + 1 < @num_actions ? cursor + 1 : nil, style_extra)
+          divs << history_link('>', 'Next Action', cursor + 1 < @num_actions ? cursor + 1 : nil,
+                               { gridColumnStart: '5' })
           store(:round_history, @game.round_history, skip: true) unless @round_history
           next_round = @round_history[@game.round_history.size]
-          divs << history_link('>>', 'Next Round', next_round, style_extra) if next_round
-          divs << history_link('>|', 'Current', nil, style_extra)
+          divs << history_link('>>', 'Next Round', next_round, { gridColumnStart: '6' }) if next_round
+          divs << history_link('>|', 'Current', nil, { gridColumnStart: '7' })
         end
 
-        h(:div, divs)
+        props = {
+          style: {
+            display: 'grid',
+            grid: '1fr / 4rem repeat(6, 2.5rem)',
+            justifyItems: 'center',
+          },
+        }
+
+        h(:div, props, divs)
       end
     end
   end

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -17,7 +17,7 @@ module View
 
         divs = [h(:h3, { style: { margin: '0', justifySelf: 'left' } }, 'History')]
         cursor = Lib::Params['action']&.to_i
-        style_extra = { padding: '0 0.5rem', width: '100%' }
+        style_extra = { padding: '0.2rem 0.5rem', width: '100%' }
 
         unless cursor&.zero?
           divs << history_link('|<', 'Start', 0, style_extra, true)

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -17,7 +17,7 @@ module View
 
         divs = [h(:h3, { style: { margin: '0', justifySelf: 'left' } }, 'History')]
         cursor = Lib::Params['action']&.to_i
-        style_extra = { padding: '0 0.5rem', width: '2rem' }
+        style_extra = { padding: '0 0.5rem', width: '100%' }
 
         unless cursor&.zero?
           divs << history_link('|<', 'Start', 0, style_extra, true)
@@ -55,8 +55,9 @@ module View
         props = {
           style: {
             display: 'grid',
-            grid: '1fr / 4.2rem repeat(6, 2.5rem)',
+            grid: '1fr / 4.2rem repeat(6, minmax(2rem, 2.5rem))',
             justifyItems: 'center',
+            gap: '0 0.5rem',
           },
         }
 

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -15,11 +15,12 @@ module View
       def render
         return h(:div) if @num_actions.zero?
 
-        divs = [h(:h3, { style: { margin: '0' } }, 'History')]
+        divs = [h(:h3, { style: { margin: '0', justifySelf: 'left' } }, 'History')]
         cursor = Lib::Params['action']&.to_i
+        style_extra = { padding: '0 0.5rem', width: '2rem' }
 
         unless cursor&.zero?
-          divs << history_link('|<', 'Start', 0)
+          divs << history_link('|<', 'Start', 0, style_extra, true)
 
           last_round =
             if cursor == @game.raw_actions.size
@@ -27,7 +28,8 @@ module View
             else
               @game.round_history[-1]
             end
-          divs << history_link('<<', 'Previous Round', last_round, { gridColumnStart: '3' }) if last_round
+          divs << history_link('<<', 'Previous Round', last_round,
+                               { gridColumnStart: '3', **style_extra }, true) if last_round
 
           prev_action =
             if @game.exception
@@ -37,22 +39,23 @@ module View
             else
               @num_actions - 1
             end
-          divs << history_link('<', 'Previous Action', prev_action, { gridColumnStart: '4' })
+          divs << history_link('<', 'Previous Action', prev_action, { gridColumnStart: '4', **style_extra }, true)
         end
 
         if cursor && !@game.exception
           divs << history_link('>', 'Next Action', cursor + 1 < @num_actions ? cursor + 1 : nil,
-                               { gridColumnStart: '5' })
+                               { gridColumnStart: '5', **style_extra }, true)
           store(:round_history, @game.round_history, skip: true) unless @round_history
           next_round = @round_history[@game.round_history.size]
-          divs << history_link('>>', 'Next Round', next_round, { gridColumnStart: '6' }) if next_round
-          divs << history_link('>|', 'Current', nil, { gridColumnStart: '7' })
+          divs << history_link('>>', 'Next Round', next_round,
+                               { gridColumnStart: '6', **style_extra }, true) if next_round
+          divs << history_link('>|', 'Current', nil, { gridColumnStart: '7', **style_extra }, true)
         end
 
         props = {
           style: {
             display: 'grid',
-            grid: '1fr / 4rem repeat(6, 2.5rem)',
+            grid: '1fr / 4.2rem repeat(6, 2.5rem)',
             justifyItems: 'center',
           },
         }

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -21,7 +21,6 @@ module View
     BUTTON_STYLE = {
       margin: '0',
       padding: '0.2rem 0',
-      textAlign: 'center',
       width: '3.5rem',
     }.freeze
 

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -26,6 +26,7 @@ button, .button_link {
 .button_link {
   display: inline-block; /* else padding doesn’t work => different height than button */
   box-sizing: border-box;
+  text-align: center;
 }
 button.small {
   padding: 0.2rem 0.5rem;


### PR DESCRIPTION
No more jumping buttons when clicking through history.
Screenshots at 320px / 20 rem width.

ante:
![image](https://user-images.githubusercontent.com/33390595/106439929-867b1b00-6478-11eb-8e1f-58312a636ff3.png)

post:
![image](https://user-images.githubusercontent.com/33390595/106445099-e70d5680-647e-11eb-8583-7e50a273beac.png)

… and crap like this shouldn’t happen anymore:
![image](https://user-images.githubusercontent.com/33390595/106440188-d6f27880-6478-11eb-8bae-91f528eed68c.png)

Buttons extend a bit on bigger screens.
As a nice side effect we get a rudimentary loading indicator due to buttons being :active until the triggered action completes:
![image](https://user-images.githubusercontent.com/33390595/106445121-ec6aa100-647e-11eb-9e17-79bd18f79134.png)
(ymmv, browsers …)