### PR TITLE
show non-standard president share percentage when relevant

### DIFF
--- a/lib/engine/game/g_18_chesapeake.rb
+++ b/lib/engine/game/g_18_chesapeake.rb
@@ -95,6 +95,12 @@ module Engine
         end
       end
 
+      def status_str(corp)
+        return unless two_player?
+
+        "#{corp.presidents_percent}% President's Share"
+      end
+
       def timeline
         @timeline = [
           'At the end of each set of ORs the next available non-permanent (2,3 or 4) train will be exported

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -56,6 +56,12 @@ module Engine
         @green_nashville_tile ||= @tiles.find { |t| t.name == 'TN2' }
       end
 
+      def status_str(corp)
+        return unless corp.id == 'IC'
+
+        "#{corp.presidents_percent}% President's Share"
+      end
+
       def operating_round(round_num)
         # For OR 1, set company buy price to face value only
         @companies.each do |company|


### PR DESCRIPTION
For 18TN:
![Screenshot 2021-02-01 at 1 42 58 PM](https://user-images.githubusercontent.com/1711810/106521836-b4218d80-6493-11eb-86a8-b56cfa0975a9.png)

--
For 18Ches two-player:

Note that C&A is the "Cornelius" company in this test game, so its presidency is 20%

![Screenshot 2021-02-01 at 1 43 18 PM](https://user-images.githubusercontent.com/1711810/106521833-b388f700-6493-11eb-91f3-00e67760bcef.png)



closes #3600