### PR TITLE
18Mag: remove 6 train from 2P green phase

### DIFF
--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -1598,7 +1598,7 @@ module Engine
             },
             {
               name: 'Green',
-              on: %w[3 4 6],
+              on: %w[3 4],
               train_limit: 2,
               tiles: %i[
                 yellow


### PR DESCRIPTION
Simple change to Green phase definition for the 2P game