### PR TITLE
Fix null ring for corps not owned by a player

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -49,7 +49,8 @@ module View
           children = []
           color = 'white'
           radius = @radius
-          if (owner = @token&.corporation&.owner) && Lib::Storage['show_player_colors']
+          if (owner = @token&.corporation&.owner) && Lib::Storage['show_player_colors'] &&
+              @game.players.include?(owner)
             color = player_colors(@game.players)[owner]
             radius -= 4
           end


### PR DESCRIPTION
Fixes #3642 

Before:
![Ring_before](https://user-images.githubusercontent.com/8494213/106639144-e4c00080-6541-11eb-8795-22c0035b464d.png)


After:
![Ring_after](https://user-images.githubusercontent.com/8494213/106639159-e984b480-6541-11eb-9de8-298aa95153b6.png)
