### PR TITLE
Only require ssl encryption of cookies on production

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -120,12 +120,3 @@ Once a game has been made available on the website, bugs may be found where the 
 4. Execute `migrate_json('your_json_file.json')`
 
 This will apply the migrations to the game file you specified, allowing you to verify it worked as expected.
-
-#### Logging in Locally
-
-You may run into a security problem when trying to log in. As a workaround, one may change the cookie security level.
-
-In routes/user.rb, ~line 110 change
-`secure: true,` to `secure: false,`
-
-Do not try to push this change!

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -107,7 +107,7 @@ class Api
       expires: Date.today + Session::EXPIRE_TIME,
       domain: nil,
       httponly: true,
-      secure: true,
+      secure: PRODUCTION,
       path: '/',
     )
 


### PR DESCRIPTION
This enables logging while in development, but keeps the secure cookie flag on production 