### PR TITLE
Fix invite page var name and auto refresh

### DIFF
--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -54,6 +54,13 @@ module GameManager
     end
   end
 
+  def get_game(id)
+    @connection.safe_get("/game/#{id}") do |data|
+      data[:loaded] = @game_data[:loaded] if @game_data
+      update_game(data)
+    end
+  end
+
   def create_game(params)
     @connection.safe_post('/game', params) do |data|
       store(:games, [data] + @games)
@@ -166,7 +173,7 @@ module GameManager
     @games += [game] if @games.none? { |g| g['id'] == game['id'] }
     @games.reject! { |g| g['id'] == game['id'] } if game['deleted']
     @games.map! { |g| g['id'] == game['id'] ? game : g }
-    store(:game, game, skip: true) if @game&.[]('id') == game['id']
+    store(:game_data, game, skip: true) if @game_data&.dig('id') == game['id']
     store(:games, @games.sort_by { |g| g['id'] }.reverse)
   end
 end

--- a/assets/app/view/invite_game.rb
+++ b/assets/app/view/invite_game.rb
@@ -8,17 +8,45 @@ module View
     include GameManager
 
     needs :user
+    needs :refreshing, default: false, store: true
 
     def render
+      game_refresh
+
       children = [h(:h2, 'This game has not started yet')]
       if @user
-        children << h(:div, [h(GameCard, gdata: @game, user: @user)])
+        children << h(:div, [h(GameCard, gdata: @game_data, user: @user)])
       else
         children << h(:h3, 'You need to login before joining a game:')
         children << h(View::User, type: :login)
       end
 
-      h('div', children)
+      destroy = lambda do
+        `clearTimeout(#{@refreshing})`
+        store(:refreshing, nil, skip: true)
+      end
+
+      props = {
+        key: 'invite_page',
+        hook: {
+          destroy: destroy,
+        },
+      }
+
+      h('div', props, children)
+    end
+
+    def game_refresh
+      return if @refreshing
+
+      timeout = %x{
+        setTimeout(function(){
+          self['$get_game'](#{@game_data['id']})
+          self['$store']('refreshing', nil, Opal.hash({skip: true}))
+        }, 10000)
+      }
+
+      store(:refreshing, timeout, skip: true)
     end
   end
 end


### PR DESCRIPTION
Previously the invitation page did not refresh automatically, which was confusing to a lot of users. I took the chance and created a channel to listen to general game metadata changes to make the home page update automatically and avoid the need to refresh.

I've increased the refresh timeout, since it's less important now. It is still there because the new channel does not publish when an action is submitted. I think that would require a more targeted approach to avoid flooding all the online users.

PS: I'm sorry for lashing out the other day. My life has been rough, but that's no excuse for my reaction. I really appreciate Toby's selfless work (as everyone else's)