### PR TITLE
18Mag: Auto-lay token on yellow OO tiles

### DIFF
--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -303,8 +303,6 @@ module Engine
 
       def operating_round(round_num)
         Round::Operating.new(self, [
-          Step::Exchange,
-          Step::HomeToken,
           Step::G18Mag::Track,
           Step::G18Mag::Token,
           Step::G18Mag::DiscardTrain,

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -104,6 +104,21 @@ module Engine
           end
           @log << "#{@game.sik.name} earns #{@game.format_currency(cost - extra_cost)}"
         end
+
+        # handle yellow OO tile
+        def update_token!(_action, _entity, tile, old_tile)
+          cities = tile.cities
+          if old_tile.paths.empty? &&
+              !tile.paths.empty? &&
+              cities.size > 1 &&
+              cities.flat_map(&:tokens).any?
+            token = cities.flat_map(&:tokens).find(&:itself)
+
+            # always move token to city with index 0
+            token.move!(cities[0])
+            @game.graph.clear
+          end
+        end
       end
     end
   end

--- a/lib/engine/step/g_18_mag/track.rb
+++ b/lib/engine/step/g_18_mag/track.rb
@@ -111,8 +111,7 @@ module Engine
           if old_tile.paths.empty? &&
               !tile.paths.empty? &&
               cities.size > 1 &&
-              cities.flat_map(&:tokens).any?
-            token = cities.flat_map(&:tokens).find(&:itself)
+              (token = cities.flat_map(&:tokens).find(&:itself))
 
             # always move token to city with index 0
             token.move!(cities[0])

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -131,21 +131,8 @@ module Engine
 
         pay_tile_cost!(entity, tile, rotation, hex, spender, cost, extra_cost)
 
-        cities = tile.cities
-        if old_tile.paths.empty? &&
-            !tile.paths.empty? &&
-            cities.size > 1 &&
-            cities.flat_map(&:tokens).any?
-          token = cities.flat_map(&:tokens).find(&:itself)
-          @round.pending_tokens << {
-            entity: entity,
-            hexes: [action.hex],
-            token: token,
-          }
-          @log << "#{entity.name} must choose city for token"
+        update_token!(action, entity, tile, old_tile)
 
-          token.remove!
-        end
         return if terrain.empty?
 
         @game.all_companies_with_ability(:tile_income) do |company, ability|
@@ -176,6 +163,24 @@ module Engine
           " lays tile ##{tile.name}"\
           " with rotation #{rotation} on #{hex.name}"\
           "#{tile.location_name.to_s.empty? ? '' : " (#{tile.location_name})"}"
+      end
+
+      def update_token!(action, entity, tile, old_tile)
+        cities = tile.cities
+        if old_tile.paths.empty? &&
+            !tile.paths.empty? &&
+            cities.size > 1 &&
+            cities.flat_map(&:tokens).any?
+          token = cities.flat_map(&:tokens).find(&:itself)
+          @round.pending_tokens << {
+            entity: entity,
+            hexes: [action.hex],
+            token: token,
+          }
+          @log << "#{entity.name} must choose city for token"
+
+          token.remove!
+        end
       end
 
       def border_cost(tile, entity)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -170,8 +170,7 @@ module Engine
         if old_tile.paths.empty? &&
             !tile.paths.empty? &&
             cities.size > 1 &&
-            cities.flat_map(&:tokens).any?
-          token = cities.flat_map(&:tokens).find(&:itself)
+            (token = cities.flat_map(&:tokens).find(&:itself))
           @round.pending_tokens << {
             entity: entity,
             hexes: [action.hex],


### PR DESCRIPTION
Minor tokens should always be placed on city index 0 when laying a yellow OO according to Lonny.
Before this change, the player had to select a city via HomeToken.

This change will require pinning most 18Mag games due to now superfluous place_token actions at the start of games.

Fixes #3650 