### PR TITLE
[1822] End of stock round

### DIFF
--- a/lib/engine/config/game/g_1822.rb
+++ b/lib/engine/config/game/g_1822.rb
@@ -1671,14 +1671,15 @@ module Engine
       "name": "7",
       "distance": 7,
       "num": 20,
-      "price": 750
-    },
-    {
-      "name": "E",
-      "distance": 99,
-      "num": 20,
-      "price": 1000,
-      "available_on": "7"
+      "price": 750,
+      "variants": [
+        {
+          "name": "E",
+          "distance": 99,
+          "num": 20,
+          "price": 1000
+        }
+      ]
     }
   ],
   "hexes": {

--- a/lib/engine/round/g_1822/stock.rb
+++ b/lib/engine/round/g_1822/stock.rb
@@ -131,7 +131,7 @@ module Engine
         def remove_l_trains(count)
           @game.log << "#{count} minors with no bids. If available up to #{count} L trains will be removed"
           while (train = @game.depot.upcoming.first).name == 'L' && count.positive?
-            @game.depot.remove_train(train)
+            @game.remove_train(train)
             count -= 1
           end
         end
@@ -140,7 +140,7 @@ module Engine
           # Remove the next train
           train = @game.depot.upcoming.first
           @game.log << "No bids on minor #{company.id}, it will close and a #{train.name} train is removed"
-          @game.depot.remove_train(train)
+          @game.remove_train(train)
           @game.phase.buying_train!(nil, train)
 
           ## Find the correct minor in the corporations and close it

--- a/lib/engine/round/g_1822/stock.rb
+++ b/lib/engine/round/g_1822/stock.rb
@@ -14,12 +14,19 @@ module Engine
         end
 
         def finish_round
-          @game.bidbox_minors.each do |minor|
+          float_minors = []
+          minor_count = 0
+          remove_l_count = 0
+          remove_minor = nil
+          @game.bidbox_minors.each_with_index do |minor, index|
             if (bid = highest_bid(minor))
-              float_minor(bid)
+              float_minors << [bid, index]
             else
               minor.owner = nil
+              remove_l_count += 1
+              remove_minor = minor if index.zero?
             end
+            minor_count += 1
           end
 
           @game.bidbox_concessions.each do |concessions|
@@ -38,6 +45,17 @@ module Engine
             end
           end
 
+          # Sort the minors first according to bid price, highest first. If a tie, lowest index first
+          float_minors.sort_by { |m| [m[0].price, minor_count - m[1]] }.reverse.each do |arr|
+            float_minor(arr[0])
+          end
+
+          # Every minor with no bids will export a L/2 train. If no bid on first minors bidbidbox an additional
+          # train will be exported, additionally the minor is also removed from the game.
+          # This will procced the whole game
+          remove_l_trains(remove_l_count) if remove_l_count.positive? && @game.depot.upcoming.first.name == 'L'
+          remove_minor_and_train(remove_minor) if remove_minor
+
           super
         end
 
@@ -52,18 +70,27 @@ module Engine
           @log << "#{player.name} wins the bid #{company.name} for #{@game.format_currency(price)}"
         end
 
+        def find_minor(company)
+          minor_id = company.id[1..-1]
+          @game.corporations.find { |m| m.id == minor_id }
+        end
+
         def float_minor(bid)
           player = bid.entity
           company = bid.company
           price = bid.price
 
-          ## Find the correct minor in the corporations
-          minor_id = company.id[1..-1]
-          minor = @game.corporations.find { |m| m.id == minor_id }
+          # Find the correct minor in the corporations
+          minor = find_minor(company)
 
-          # TODO: Get the correct par price according to phase
-          par_price = 50
-          share_price = @game.stock_market.par_prices.find { |pp| pp.price == par_price }
+          # Get the correct par price according to phase
+          current_phase = @game.phase.name.to_i
+          max_par_price = @game.stock_market.par_prices.map(&:price).max
+          par_price_to_find = current_phase == 1 ? @game.class::MINOR_START_PAR_PRICE : price / 2
+          par_price_to_find = max_par_price if par_price_to_find > max_par_price
+
+          share_price = @game.stock_market.par_prices.find { |pp| pp.price <= par_price_to_find }
+          par_price = share_price.price
 
           # Temporarily give the player cash to buy the minors PAR shares
           @game.bank.spend(share_price.price * 2, player)
@@ -77,8 +104,12 @@ module Engine
           # Clear the corporation of par cash
           minor.spend(minor.cash, @game.bank)
 
-          # TODO: Move the correct amount to money to the minor. This is according to phase of the game
-          treasury = par_price * 2
+          # Move the correct amount to money to the minor. This is according to phase of the game
+          treasury = if current_phase < 3
+                       par_price * 2
+                     else
+                       price
+                     end
           @game.bank.spend(treasury, minor)
 
           # Spend the whole amount the player have bid
@@ -95,6 +126,29 @@ module Engine
 
         def highest_bid(company)
           @bids[company]&.max_by(&:price)
+        end
+
+        def remove_l_trains(count)
+          @game.log << "#{count} minors with no bids. If available up to #{count} L trains will be removed"
+          while (train = @game.depot.upcoming.first).name == 'L' && count.positive?
+            @game.depot.remove_train(train)
+            count -= 1
+          end
+        end
+
+        def remove_minor_and_train(company)
+          # Remove the next train
+          train = @game.depot.upcoming.first
+          @game.log << "No bids on minor #{company.id}, it will close and a #{train.name} train is removed"
+          @game.depot.remove_train(train)
+          @game.phase.buying_train!(nil, train)
+
+          ## Find the correct minor in the corporations and close it
+          minor = find_minor(company)
+          @game.close_corporation(minor)
+
+          # Remove the proxy company for the minor
+          @game.companies.delete(company)
         end
 
         def sold_out?(corporation)

--- a/lib/engine/step/g_1822/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1822/buy_sell_par_shares.rb
@@ -12,6 +12,8 @@ module Engine
         attr_accessor :bidders, :bid_actions
 
         def actions(entity)
+          return super if entity != current_entity
+
           actions = super
           actions << 'bid'
           actions

--- a/lib/engine/step/g_1822/buy_train.rb
+++ b/lib/engine/step/g_1822/buy_train.rb
@@ -30,7 +30,7 @@ module Engine
           # base train's sym and not the variant's sym. Cant change in buying_train! since other games relay on
           # the base sym to change phase or rust trains
           train = action.train
-          train_check = Engine::Train.new(name: train.name, distance: train.name, price: train.price)
+          train_check = Engine::Train.new(name: train.name, distance: train.distance, price: train.price)
           @game.phase.buying_train!(action.entity, train_check)
         end
 

--- a/lib/engine/step/g_1822/first_turn_housekeeping.rb
+++ b/lib/engine/step/g_1822/first_turn_housekeeping.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../buy_train'
+
+module Engine
+  module Step
+    module G1822
+      class FirstTurnHousekeeping < BuyTrain
+        def actions(entity)
+          if entity.corporation? && entity.type == :minor && !entity.operated? &&
+            @game.depot.upcoming.first.name == 'L' && can_buy_train?(entity)
+            return %w[buy_train pass]
+          end
+
+          []
+        end
+
+        def buyable_trains(_entity)
+          # Clone the first available L train, this to remove the 2 train variant from it. Since a L train is the
+          # only train you are allowed to buy during the housekeeping
+          train = @game.depot.upcoming.first
+          l_train = Engine::Train.new(name: train.name, distance: train.distance, price: train.price)
+          l_train.owner = @game.depot
+          [l_train]
+        end
+
+        def process_buy_train(action)
+          # Make sure the corp buy the correct train with a 2 variant
+          new_action = Action::BuyTrain.new(
+            action.entity,
+            train: @game.depot.upcoming.first,
+            price: action.price,
+            variant: action.variant,
+          )
+
+          super(new_action)
+          pass!
+        end
+
+        def must_buy_train?(_entity)
+          false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* End of stock round, remove trains if no bids on minors.
* Minors bidding par price, startorder and treasury.
* First turn housekeeping, minors can buy a L train if one still in the depot as first action in its first operation round it floated.
* Some minor code cleanup.