### PR TITLE
1824: Add an interrupt stock exchange step when 4 trains bought

### DIFF
--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -272,6 +272,8 @@ module View
       when Engine::Round::Operating
         if current_entity_actions.include?('merge')
           h(Game::Round::Merger, game: @game)
+        elsif current_entity_actions.include?('buy_shares')
+          h(Game::Round::Stock, game: @game)
         else
           h(Game::Round::Operating, game: @game)
         end

--- a/lib/engine/config/game/g_1824.rb
+++ b/lib/engine/config/game/g_1824.rb
@@ -765,6 +765,10 @@ module Engine
       "num": 4,
       "price": 300,
       "rusts_on": "8",
+      "events": [
+        {"type": "close_mountain_railways"},
+        {"type": "sd_formation"}
+      ],
       "discount": {
         "3": 90
       }
@@ -792,10 +796,6 @@ module Engine
       "price": 360,
       "available_on": "4",
       "rusts_on": "5g",
-      "events": [
-        {"type": "close_mountain_railways"},
-        {"type": "sd_formation"}
-      ],
       "discount": {
         "2g": 120
       }

--- a/lib/engine/game/g_1824.rb
+++ b/lib/engine/game/g_1824.rb
@@ -9,7 +9,7 @@ require_relative '../g_1824/minor'
 module Engine
   module Game
     class G1824 < Base
-      attr_accessor :two_train_bought
+      attr_accessor :two_train_bought, :forced_mountain_railway_exchange
 
       register_colors(
         gray70: '#B3B3B3',
@@ -242,6 +242,7 @@ module Engine
           Step::Bankrupt,
           Step::DiscardTrain,
           Step::HomeToken,
+          Step::G1824::ForcedMountainRailwayExchange,
           Step::Track,
           Step::Token,
           Step::Route,
@@ -315,6 +316,7 @@ module Engine
 
       def setup
         @two_train_bought = false
+        @forced_mountain_railway_exchange = []
 
         @companies.each do |c|
           c.owner = @bank
@@ -499,12 +501,9 @@ module Engine
       end
 
       def event_close_mountain_railways!
-        @log << '-- Exchange any remaining Mountain Railway'
-        @companies.select { |c| mountain_railway?(c).reject(&:closed?) }.each do |mountain_railway|
-          @log << '-- TODO Mountain railway should be exchanged if possible'
-          # TODO: Need interrupt stock exchange step here
-          mountain_railway.close!
-        end
+        @log << '-- Any remaining Mountain Railways are either exchanged or discarded'
+        # If this list contains any companies it will trigger an interrupt exchange/pass step
+        @forced_mountain_railway_exchange = @companies.select { |c| mountain_railway?(c) && !c.closed? }
       end
 
       def event_close_coal_railways!
@@ -512,6 +511,18 @@ module Engine
         @companies.select { |c| coal_railway?(c) }.reject(&:closed?).each do |coal_railway_company|
           exchange_coal_railway(coal_railway_company)
         end
+      end
+
+      def event_sd_formation!
+        @log << 'SD formation not yet implemented'
+      end
+
+      def event_ug_formation!
+        @log << 'UG formation not yet implemented'
+      end
+
+      def event_kk_formation!
+        @log << 'KK formation not yet implemented'
       end
 
       def exchange_coal_railway(company)

--- a/lib/engine/step/g_1824/forced_mountain_railway_exchange.rb
+++ b/lib/engine/step/g_1824/forced_mountain_railway_exchange.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative '../buy_sell_par_shares'
+
+module Engine
+  module Step
+    module G1824
+      class ForcedMountainRailwayExchange < BuySellParShares
+        ACTIONS = %w[buy_shares pass].freeze
+
+        def actions(_entity)
+          return [] if exchangables.empty?
+
+          ACTIONS
+        end
+
+        def active_entities
+          exchangables.take(1).map(&:owner)
+        end
+
+        def override_entities
+          exchangables.map(&:owner)
+        end
+
+        def show_other_players
+          true
+        end
+
+        def active?
+          !exchangables.empty?
+        end
+
+        def blocking?
+          !exchangables.empty?
+        end
+
+        def description
+          'Exchange'
+        end
+
+        def pass_description
+          "Discard Mountain Railway #{mountain_railway.name}"
+        end
+
+        def exchangables
+          @game.forced_mountain_railway_exchange
+        end
+
+        def mountain_railway
+          exchangables.take(1).first
+        end
+
+        def can_buy?(_entity, _bundle)
+          # No buy shares allowed in this step, only exchange
+          false
+        end
+
+        def can_sell?(_entity, _bundle)
+          # No sell shares allowed in this step, only exchange
+          false
+        end
+
+        def can_gain?(entity, bundle, exchange: false)
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_exchange?(entity, bundle = nil)
+          return false unless (ability = @game.abilities(entity, :exchange))
+          return can_gain?(entity.owner, bundle, exchange: true) if bundle
+
+          shares = []
+          @game.exchange_corporations(ability).each do |corporation|
+            shares << corporation.available_share if ability.from.include?(:ipo)
+            shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
+          end
+
+          shares.any? { |s| can_gain?(entity.owner, s&.to_bundle, exchange: true) }
+        end
+
+        def process_buy_shares(action)
+          company = action.entity
+          player = company.owner
+          bundle = action.bundle
+          unless can_exchange?(company, bundle)
+            raise GameError, "Cannot exchange #{company.id} for #{bundle.corporation.id}"
+          end
+
+          bundle.share_price = 0
+          @game.share_pool.buy_shares(player, bundle, exchange: company, exchange_price: 0)
+          company.close!
+          @game.forced_mountain_railway_exchange.shift
+        end
+
+        def process_pass(action)
+          player = action.entity
+          company = mountain_railway
+          company.close!
+          @log << "#{player.name} discards #{company.id} without any compensation"
+          @game.forced_mountain_railway_exchange.shift
+        end
+
+        def redeemable_shares(_entity)
+          # Just to make it compile - redeem is not used in 1824
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_mex/merge.rb
+++ b/lib/engine/step/g_18_mex/merge.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../base'
-# require_relative 'tokener'
 
 module Engine
   module Step


### PR DESCRIPTION
In 1824 when the first 4 train is bought any remaining Mountain
Railways' companies need to be exchanged for shares in one of
the regionals. (Often multiple corporations possible to choose from.)

This is handled by having a stock view with only Exchange possible
during the OR.

This also means that game_page.rb was changed to allow for stock
market rendering during an OR (in case buy_shares is available).

This is the view in the OR when two mountain railways remained. This is shown after Discard Trains step.
![image](https://user-images.githubusercontent.com/2631151/106802622-7c694000-6663-11eb-86fd-d548c8b24fbc.png)
