### PR TITLE
1856 does destination checks

### DIFF
--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -312,7 +312,7 @@ module Engine
         POST_NATIONALIZATION_CERT_LIMIT[num_corporations][@players.size]
       end
 
-      def destination_check
+      def destination_check!
         @corporations.each do |corp|
           # The capitalization method of unparred corporations is nil
           next unless corp.capitalization == :escrow

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -281,6 +281,7 @@ module Engine
       end
 
       def create_destinations(destinations)
+        @destinations = {}
         destinations.each do |corp, dest|
           dest_arr = Array(dest)
           end_a = dest_arr.first
@@ -294,6 +295,7 @@ module Engine
           dest_arr.each do |d|
             hex_by_id(d).original_tile.icons << Part::Icon.new("../logos/1856/#{corp}")
           end
+          @destinations[corp] = [end_b, end_a].freeze
         end
       end
 
@@ -307,6 +309,16 @@ module Engine
         return PRE_NATIONALIZATION_CERT_LIMIT[@players.size] unless @post_nationalization
 
         POST_NATIONALIZATION_CERT_LIMIT[num_corporations][@players.size]
+      end
+
+      def destination_check
+        @corporations.each do |corp|
+          # The capitalization method of unparred corporations is nil
+          next unless corp.capitalization == :escrow
+
+          reachable_hexes = @graph.ghost_train(corp, [hex_by_id(@destinations[corp.id].first)]).map { |h| h[0].id }
+          @log << "#{corp.name} destination check - hexes: #{reachable_hexes}"
+        end
       end
 
       #

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -316,9 +316,26 @@ module Engine
           # The capitalization method of unparred corporations is nil
           next unless corp.capitalization == :escrow
 
-          reachable_hexes = @graph.ghost_train(corp, [hex_by_id(@destinations[corp.id].first)]).map { |h| h[0].id }
-          @log << "#{corp.name} destination check - hexes: #{reachable_hexes}"
+          destinated!(corp) if hexes_connected?(@destinations[corp.id].first, @destinations[corp.id].last)
         end
+      end
+
+      def hexes_connected?(start_hex_id, goal_hex_ids)
+        tokens = hex_by_id(start_hex_id).tile.cities.map { |city| [city, true] }.to_h
+
+        tokens.keys.each do |node|
+          visited = tokens.reject { |token, _| token == node }
+
+          node.walk(visited: visited, corporation: nil) do |path|
+            return true if goal_hex_ids.include?(path.hex.id)
+          end
+        end
+
+        false
+      end
+
+      def destinated!(corp)
+        @log << "-- #{corp.name} has destinated --"
       end
 
       #

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -98,7 +98,7 @@ module Engine
         'GT' => 'L13',
         'GW' => 'J15',
         'LPS' => 'F15',
-        'TGB' => 'O2', # [['N1', 'O2']] # Canadaian West, but it's a 2 hex offboard
+        'TGB' => [%w[O2 N1]], # Canadian West, but it's a 2 hex offboard
         'THB' => 'H15',
         'WGB' => 'H5',
         'WR' => 'L15',
@@ -277,25 +277,26 @@ module Engine
         @available_bridge_tokens = 2
         @available_tunnel_tokens = 2
 
-        create_destinations(DESTINATIONS)
+        create_destinations(ALTERNATE_DESTINATIONS)
       end
 
       def create_destinations(destinations)
         @destinations = {}
         destinations.each do |corp, dest|
           dest_arr = Array(dest)
-          end_a = dest_arr.first
-          end_b = dest_arr.size > 1 ? dest_arr.last : corporation_by_id(corp).coordinates
+          d_goals = Array(dest_arr.first)
+          d_start = dest_arr.size > 1 ? dest_arr.last : corporation_by_id(corp).coordinates
           ability = Ability::Base.new(
               type: 'destination',
-              description: "Connect #{hex_by_id(end_a).tile.location_name} to"\
-                " #{hex_by_id(end_b).tile.location_name}"
+              description: "Connect #{hex_by_id(d_start).tile.location_name} to"\
+                " #{hex_by_id(d_goals.first).tile.location_name}"
             )
           corporation_by_id(corp).add_ability(ability)
           dest_arr.each do |d|
-            hex_by_id(d).original_tile.icons << Part::Icon.new("../logos/1856/#{corp}")
+            # Array(d).first allows us to treat 'E5' or %[O2 N3] identically
+            hex_by_id(Array(d).first).original_tile.icons << Part::Icon.new("../logos/1856/#{corp}")
           end
-          @destinations[corp] = [end_b, end_a].freeze
+          @destinations[corp] = [d_start, d_goals].freeze
         end
       end
 
@@ -316,7 +317,7 @@ module Engine
           # The capitalization method of unparred corporations is nil
           next unless corp.capitalization == :escrow
 
-          destinated!(corp) if hexes_connected?(@destinations[corp.id].first, @destinations[corp.id].last)
+          destinated!(corp) if hexes_connected?(*@destinations[corp.id])
         end
       end
 

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -11,7 +11,6 @@ module Engine
       @connected_paths = {}
       @reachable_hexes = {}
       @tokenable_cities = {}
-      @ghost_train_reachable_hexes = {}
       @routes = {}
       @tokens = {}
     end
@@ -22,7 +21,6 @@ module Engine
       @connected_paths.clear
       @reachable_hexes.clear
       @tokenable_cities.clear
-      @ghost_train_reachable_hexes = {}
       @tokens.clear
       @routes.delete_if do |_, route|
         !route[:route_train_purchase]
@@ -86,29 +84,19 @@ module Engine
       @connected_paths[corporation]
     end
 
-    def ghost_train(corporation, start_hexes)
-      compute(corporation, start_hexes: start_hexes, ghost_train: true)
-      @ghost_train_reachable_hexes[corporation]
-    end
-
     def reachable_hexes(corporation)
       compute(corporation) unless @reachable_hexes[corporation]
       @reachable_hexes[corporation]
     end
 
-    # ghost_train is for 1856 destination checks
-    # in 1856 destination checks,
-    #  - corporation abilities are unused
-    #  - tokens are ignored
-    #  - the distance to test is unlimited
-    #  - connectivity needs to be hex to hex, typically the corp's home is one of the two
-    def compute(corporation, start_hexes: nil, ghost_train: false, routes_only: false)
+    def compute(corporation, routes_only: false)
       hexes = Hash.new { |h, k| h[k] = {} }
       nodes = {}
       paths = {}
-      (ghost_train ? start_hexes : @game.hexes).each do |hex|
+
+      @game.hexes.each do |hex|
         hex.tile.cities.each do |city|
-          next unless ghost_train || city.tokened_by?(corporation)
+          next unless city.tokened_by?(corporation)
 
           hex.neighbors.each { |e, _| hexes[hex][e] = true }
           nodes[city] = true
@@ -116,28 +104,26 @@ module Engine
       end
 
       tokens = nodes.dup
-      # Corporation specific abilities do not affect the ghost train
-      unless ghost_train
-        @game.abilities(corporation, :token) do |ability, c|
-          next unless c == corporation # Private company token ability uses round/special.rb.
-          next unless ability.teleport_price
 
-          ability.hexes.each do |hex_id|
-            @game.hex_by_id(hex_id).tile.cities.each do |node|
-              nodes[node] = true
-              yield node if block_given?
-            end
+      @game.abilities(corporation, :token) do |ability, c|
+        next unless c == corporation # Private company token ability uses round/special.rb.
+        next unless ability.teleport_price
+
+        ability.hexes.each do |hex_id|
+          @game.hex_by_id(hex_id).tile.cities.each do |node|
+            nodes[node] = true
+            yield node if block_given?
           end
         end
+      end
 
-        @game.abilities(corporation, :teleport) do |ability, _|
-          ability.hexes.each do |hex_id|
-            hex = @game.hex_by_id(hex_id)
-            hex.neighbors.each { |e, _| hexes[hex][e] = true }
-            hex.tile.cities.each do |node|
-              nodes[node] = true
-              yield node if ability.used? && block_given?
-            end
+      @game.abilities(corporation, :teleport) do |ability, _|
+        ability.hexes.each do |hex_id|
+          hex = @game.hex_by_id(hex_id)
+          hex.neighbors.each { |e, _| hexes[hex][e] = true }
+          hex.tile.cities.each do |node|
+            nodes[node] = true
+            yield node if ability.used? && block_given?
           end
         end
       end
@@ -150,7 +136,7 @@ module Engine
         visited = tokens.reject { |token, _| token == node }
         local_nodes = {}
 
-        node.walk(visited: visited, corporation: ghost_train ? nil : corporation) do |path|
+        node.walk(visited: visited, corporation: corporation) do |path|
           paths[path] = true
           path.nodes.each do |p_node|
             nodes[p_node] = true
@@ -190,15 +176,12 @@ module Engine
 
       hexes.default = nil
       hexes.transform_values!(&:keys)
-      if ghost_train
-        @ghost_train_reachable_hexes[corporation] = paths.map { |path, _| [path.hex, true] }.to_h
-      else
-        @routes[corporation] = routes
-        @connected_hexes[corporation] = hexes
-        @connected_nodes[corporation] = nodes
-        @connected_paths[corporation] = paths
-        @reachable_hexes[corporation] = paths.map { |path, _| [path.hex, true] }.to_h
-      end
+
+      @routes[corporation] = routes
+      @connected_hexes[corporation] = hexes
+      @connected_nodes[corporation] = nodes
+      @connected_paths[corporation] = paths
+      @reachable_hexes[corporation] = paths.map { |path, _| [path.hex, true] }.to_h
     end
   end
 end

--- a/lib/engine/step/g_1856/track.rb
+++ b/lib/engine/step/g_1856/track.rb
@@ -39,7 +39,7 @@ module Engine
         def process_lay_tile(action)
           super
           # TODO: Replace 'true' with @loading check & implement auto action usage
-          @game.destination_check # if true
+          @game.destination_check! # if true
         end
       end
     end

--- a/lib/engine/step/g_1856/track.rb
+++ b/lib/engine/step/g_1856/track.rb
@@ -39,7 +39,7 @@ module Engine
         def process_lay_tile(action)
           super
           # TODO: Replace 'true' with @loading check & implement auto action usage
-          @game.destination_check! # if true
+          # @game.destination_check! # if true
         end
       end
     end

--- a/lib/engine/step/g_1856/track.rb
+++ b/lib/engine/step/g_1856/track.rb
@@ -35,6 +35,12 @@ module Engine
 
           old_paths.all? { |path| new_paths.any? { |p| path <= p } }
         end
+
+        def process_lay_tile(action)
+          super
+          # TODO: Replace 'true' with @loading check & implement auto action usage
+          @game.destination_check # if true
+        end
       end
     end
   end


### PR DESCRIPTION
This PR will have 1856 check after every tile lay if any escrow corporations have destinated.
This is used to find which hexes are reachable from the home hex for a corporation. 

Later PRs will:
* Make this process use auto actions and not happen when @loading
* Use the results to determine if a corporation has destinated and if so release escrow