### PR TITLE
Restore stockview in OR (for 1824) but corrected

### DIFF
--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -278,6 +278,8 @@ module View
       when Engine::Round::Operating
         if current_entity_actions.include?('merge')
           h(Game::Round::Merger, game: @game)
+        elsif current_entity_actions.include?('buy_shares') && @game.current_entity&.player?
+          h(Game::Round::Stock, game: @game)
         else
           h(Game::Round::Operating, game: @game)
         end


### PR DESCRIPTION
The Stock view appeared by mistake in titles that had a redeem
possibility for a corporation. By restricting the view to
active players only it should just get the player options.