### PR TITLE
1860: relocate bankruptcy check

### DIFF
--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -579,10 +579,12 @@ module Engine
         super
       end
 
-      def action_processed(_action)
-        @corporations.each do |corporation|
-          make_bankrupt!(corporation) if corporation.share_price&.type == :close
-        end
+      def action_processed(_action); end
+
+      def check_bankruptcy!(entity)
+        return unless entity.corporation?
+
+        make_bankrupt!(entity) if entity.share_price&.type == :close
       end
 
       def sorted_corporations
@@ -628,6 +630,7 @@ module Engine
         num_shares -= 1 if corporation.share_price.type == :ignore_one_sale
         num_shares.times { @stock_market.move_left(corporation) } if selling_movement?(corporation)
         log_share_price(corporation, price)
+        check_bankruptcy!(corporation)
       end
 
       def close_other_companies!(company)

--- a/lib/engine/step/g_1860/dividend.rb
+++ b/lib/engine/step/g_1860/dividend.rb
@@ -40,6 +40,7 @@ module Engine
           payout_shares(entity, revenue) if payout[:per_share].positive?
           change_share_price(entity, payout)
           @game.check_bank_broken!
+          @game.check_bankruptcy!(entity)
 
           pass!
         end


### PR DESCRIPTION
Move bankrupt corporation check from after_action to after the two places where a stock price can drop: dividends and selling shares.

This makes handling a bankruptcy that is not at the end of an OR more robust.

Fixes #3685 

A very small percentage of games may require pins.