### PR TITLE
1861: Allow 'Green' phase minors token reservations to be green,

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -47,7 +47,7 @@ module View
 
         def render_part
           children = []
-          color = 'white'
+          color = @reservation&.corporation? && @reservation&.reservation_color || 'white'
           radius = @radius
           if (owner = @token&.corporation&.owner) && Lib::Storage['show_player_colors'] &&
               @game.players.include?(owner)

--- a/lib/engine/config/game/g_1861.rb
+++ b/lib/engine/config/game/g_1861.rb
@@ -577,7 +577,7 @@ module Engine
     {
       "sym": "MB",
       "name": "Moscow-Brest Railway",
-      "logo": "1861/KP",
+      "logo": "1861/MB",
       "float_percent": 100,
       "always_market_price": true,
       "tokens": [
@@ -587,7 +587,8 @@ module Engine
       "max_ownership_percent": 100,
       "type": "minor",
       "coordinates": "E9",
-      "color": "blue"
+      "color": "blue",
+      "reservation_color": "lightGreen"
     },
     {
       "sym": "KR",
@@ -633,7 +634,8 @@ module Engine
       "max_ownership_percent": 100,
       "type": "minor",
       "coordinates": "H18",
-      "color": "red"
+      "color": "red",
+      "reservation_color": "lightGreen"
     },
     {
       "sym": "M-K",
@@ -695,7 +697,8 @@ module Engine
       "max_ownership_percent": 100,
       "type": "minor",
       "coordinates": "I19",
-      "color": "gray"
+      "color": "gray",
+      "reservation_color": "lightGreen"
     },
     {
       "sym": "TR",
@@ -710,7 +713,8 @@ module Engine
       "max_ownership_percent": 100,
       "type": "minor",
       "coordinates": "K17",
-      "color": "gray"
+      "color": "gray",
+      "reservation_color": "lightGreen"
     },
     {
       "sym": "SV",
@@ -725,7 +729,8 @@ module Engine
       "max_ownership_percent": 100,
       "type": "minor",
       "coordinates": "N10",
-      "color": "gray"
+      "color": "gray",
+      "reservation_color": "lightGreen"
     },
     {
       "sym": "E",
@@ -740,7 +745,8 @@ module Engine
       "max_ownership_percent": 100,
       "type": "minor",
       "coordinates": "Q3",
-      "color": "gray"
+      "color": "gray",
+      "reservation_color": "lightGreen"
     },
     {
       "sym": "RSR",

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -24,7 +24,7 @@ module Engine
 
     attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent, :capitalization, :second_share
     attr_reader :companies, :min_price, :name, :full_name, :fraction_shares, :type, :id, :needs_token_to_par,
-                :presidents_share
+                :presidents_share, :reservation_color
     attr_writer :par_price, :share_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze
@@ -60,6 +60,7 @@ module Engine
       @par_via_exchange = nil
       @type = opts[:type]&.to_sym
       @hide_shares = opts[:hide_shares] || false
+      @reservation_color = opts[:reservation_color]
 
       init_abilities(opts[:abilities])
       init_operator(opts)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -388,6 +388,8 @@ module Engine
           corporation.transform_keys!(&:to_sym)
           corporation[:abilities]&.each { |ability| ability.transform_keys!(&:to_sym) }
           corporation[:color] = const_get(:COLORS)[corporation[:color]&.to_sym] if const_defined?(:COLORS)
+          corporation[:reservation_color] =
+            const_get(:COLORS)[corporation[:reservation_color]&.to_sym] if const_defined?(:COLORS)
           corporation
         end
 

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -17,6 +17,7 @@ module Engine
                       gray: '#7c7b8c',
                       green: '#3c7b5c',
                       olive: '#808000',
+                      lightGreen: '#009a54ff',
                       lightBlue: '#4cb5d2',
                       lightishBlue: '#0097df',
                       teal: '#009595',

--- a/public/logos/1861/KP.svg
+++ b/public/logos/1861/KP.svg
@@ -1,1 +1,0 @@
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#0189d1"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" font-family="Lato" fill="#ffffff">MB</text></svg>

--- a/public/logos/1861/MB.svg
+++ b/public/logos/1861/MB.svg
@@ -1,0 +1,1 @@
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#0189d1"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#ffffff">MB</text></svg>


### PR DESCRIPTION
making it obvious which minors are which

fixes #3645
Also correct the name of MB's logo