### PR TITLE
Fix 3696 - Bank owned companies javascript error (check_consent player.name)

### DIFF
--- a/assets/app/view/game/buy_companies.rb
+++ b/assets/app/view/game/buy_companies.rb
@@ -21,6 +21,12 @@ module View
         ].compact)
       end
 
+      def owned_by_other_player?(player, company)
+        return false unless company&.owner # Bank owned, not a player
+
+        player != company&.owner
+      end
+
       def render_companies
         hidden_companies = false
         props = {
@@ -31,11 +37,11 @@ module View
         }
 
         companies = @game.purchasable_companies.sort_by do |company|
-          [company.owner == @corporation.owner ? 0 : 1, company.value]
+          [!owned_by_other_player?(@corporation.owner, company) ? 0 : 1, company.value]
         end
 
         companies_to_buy = companies.map do |company|
-          if company.owner != @corporation.owner && !@show_other_players
+          if owned_by_other_player?(@corporation.owner, company) && !@show_other_players
             hidden_companies = true
             next
           end

--- a/assets/app/view/game/buy_value_input.rb
+++ b/assets/app/view/game/buy_value_input.rb
@@ -43,7 +43,7 @@ module View
             end
           end
 
-          if @selected_entity.owner == @corporation.owner
+          if @selected_entity.owner == @corporation.owner || !@selected_entity.owner
             buy.call
           else
             check_consent(@selected_entity.owner, buy)


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/3696

Recent changes caused:
1.) Bank owned privates to move under the "Other Player" toggle which
2.) Now requires consent, failing due to the owner not having a name.

Before:

<img width="790" alt="Screen Shot 2021-02-04 at 1 57 01 PM" src="https://user-images.githubusercontent.com/15675400/106975866-93b43600-6714-11eb-90ac-d226fe60590b.png">
