### PR TITLE
[1822] Convert concession into a major company.

### DIFF
--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -13,9 +13,8 @@ module View
         entity = @game.current_entity
         return h(:div, 'Cannot Par') unless @game.can_par?(@corporation, entity)
 
-        prices = @game.round.active_step
-          .get_par_prices(entity, @corporation)
-          .sort_by(&:price)
+        step = @game.round.active_step
+        prices = step.get_par_prices(entity, @corporation).sort_by(&:price)
 
         par_buttons = prices.map do |share_price|
           par = lambda do
@@ -34,7 +33,9 @@ module View
             on: { click: par },
           }
 
-          purchasable_shares = [(entity.cash / share_price.price).to_i,
+          available_cash = entity.cash
+          available_cash = step.available_par_cash(entity, @corporation) if step.respond_to?(:available_par_cash)
+          purchasable_shares = [(available_cash / share_price.price).to_i,
                                 (@corporation.max_ownership_percent / 100) * @corporation.total_shares].min
           at_limit = purchasable_shares * @corporation.total_shares >= @corporation.max_ownership_percent
           flags = at_limit ? ' L' : ''

--- a/lib/engine/config/game/g_1822.rb
+++ b/lib/engine/config/game/g_1822.rb
@@ -381,7 +381,7 @@ module Engine
       "70",
       "80",
       "90",
-      "100p",
+      "100px",
       "110",
       "120",
       "135",
@@ -404,7 +404,7 @@ module Engine
       "60",
       "70",
       "80",
-      "90p",
+      "90px",
       "100",
       "110",
       "120",
@@ -424,7 +424,7 @@ module Engine
       "50",
       "60",
       "70",
-      "80p",
+      "80px",
       "90",
       "100",
       "110",
@@ -442,7 +442,7 @@ module Engine
       "45y",
       "50",
       "60",
-      "70p",
+      "70px",
       "80",
       "90",
       "100",
@@ -458,7 +458,7 @@ module Engine
       "40y",
       "45y",
       "50",
-      "60p",
+      "60px",
       "70",
       "80",
       "90",
@@ -695,6 +695,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and converts into the LNWR's 10% director certificate. LNWR may also put it's destination token into Manchester when converted.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["LNWR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "lnwrBlack",
       "text_color": "white"
@@ -706,6 +712,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the GWR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["GWR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "gwrGreen",
       "text_color": "white"
@@ -717,6 +729,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the LBSCR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["LBSCR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "lbscrYellow",
       "text_color": "white"
@@ -728,6 +746,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the SECR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["SECR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "secrOrange",
       "text_color": "white"
@@ -739,6 +763,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the CR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["CR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "crBlue",
       "text_color": "white"
@@ -750,6 +780,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the MR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["MR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "mrRed",
       "text_color": "white"
@@ -761,6 +797,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the L&YR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["L&YR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "lyrPurple",
       "text_color": "white"
@@ -772,6 +814,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the NBR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["NBR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "nbrBrown",
       "text_color": "white"
@@ -783,6 +831,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the SWR director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["SWR"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "swrGray",
       "text_color": "white"
@@ -794,6 +848,12 @@ module Engine
       "revenue": 10,
       "desc": "Have a face value £100 and contribute £100 to the conversion into the NER director’s certificate.",
       "abilities": [
+        {
+          "type": "exchange",
+          "corporations": ["NER"],
+          "owner_type": "player",
+          "from": "par"
+        }
       ],
       "color": "nerGreen",
       "text_color": "white"
@@ -1481,10 +1541,12 @@ module Engine
       "name": "London and North West Railway",
       "logo": "1822/LNWR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
-      "float_percent": 20,
+      "float_percent": 10,
+      "shares": [10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
       "always_market_price": true,
       "coordinates": "M38",
       "city": 3,
@@ -1495,7 +1557,8 @@ module Engine
       "name": "Great Western Railway",
       "logo": "1822/GWR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1509,7 +1572,8 @@ module Engine
       "name": "London, Brighton and South Coast Railway",
       "logo": "1822/LBSCR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1524,7 +1588,8 @@ module Engine
       "name": "South Eastern & Chatham Railway",
       "logo": "1822/SECR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1538,7 +1603,8 @@ module Engine
       "name": "Caledonian Railway",
       "logo": "1822/CR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1551,7 +1617,8 @@ module Engine
       "name": "Midland Railway",
       "logo": "1822/MR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1564,7 +1631,8 @@ module Engine
       "name": "Lancashire & Yorkshire",
       "logo": "1822/LYR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1577,7 +1645,8 @@ module Engine
       "name": "North British Railway",
       "logo": "1822/NBR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1590,7 +1659,8 @@ module Engine
       "name": "South Wales Railway",
       "logo": "1822/SWR",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -1604,7 +1674,8 @@ module Engine
       "name": "North Eastern Railway",
       "logo": "1822/NER",
       "tokens": [
-        0
+        0,
+        100
       ],
       "type": "major",
       "float_percent": 20,
@@ -2068,13 +2139,16 @@ module Engine
     },
     {
       "name": "2",
-      "on": "2",
+      "on": ["2", "3"],
       "train_limit": {
         "minor": 2,
         "major": 4
       },
       "tiles": [
         "yellow"
+      ],
+      "status": [
+        "can_convert_concessions"
       ],
       "operating_rounds": 2
     },
@@ -2090,7 +2164,8 @@ module Engine
         "green"
       ],
       "status": [
-        "can_buy_trains"
+        "can_buy_trains",
+        "can_convert_concessions"
       ],
       "operating_rounds": 2
     },
@@ -2106,7 +2181,8 @@ module Engine
         "green"
       ],
       "status": [
-        "can_buy_trains"
+        "can_buy_trains",
+        "can_convert_concessions"
       ],
       "operating_rounds": 2
     },

--- a/lib/engine/step/g_1822/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1822/buy_sell_par_shares.rb
@@ -14,13 +14,64 @@ module Engine
         def actions(entity)
           return super if entity != current_entity
 
-          actions = super
-          actions << 'bid'
+          # You can either sell/buy shares or you can use your bidding tokens
+          actions = (@current_actions.empty? || @bid_actions.zero? ? super : [])
+          actions << 'bid' if @current_actions.empty? || @bid_actions.positive?
+          actions << 'pass' unless actions.include?('pass')
           actions
+        end
+
+        def available_cash(entity)
+          entity.cash - committed_cash(entity)
+        end
+
+        def available_par_cash(entity, corporation)
+          available = available_cash(entity)
+          available += corporation.par_via_exchange.value if corporation.par_via_exchange
+          available
+        end
+
+        def can_buy?(entity, bundle, available_cash: nil)
+          return unless bundle&.buyable
+
+          corporation = bundle.corporation
+          return unless corporation.type == :major
+
+          cash = available_cash || available_cash(entity)
+          cash >= bundle.price &&
+            !@round.players_sold[entity][corporation] &&
+            (can_buy_multiple?(entity, corporation) || !bought?) &&
+            can_gain?(entity, bundle)
+        end
+
+        def can_buy_any_from_ipo?(entity)
+          @game.corporations.select { |c| c.type == :major }.each do |corporation|
+            next unless corporation.ipoed
+            return true if can_buy_shares?(entity, corporation.shares)
+          end
+
+          false
+        end
+
+        def can_ipo_any?(entity)
+          !bought? && @game.corporations.select { |c| c.type == :major }.any? do |corporation|
+            @game.can_par?(corporation, entity) &&
+              can_buy?(entity, corporation.shares.first&.to_bundle,
+                       available_cash: available_par_cash(entity, corporation))
+          end
         end
 
         def description
           'Bid, convert concession or buy/sell shares'
+        end
+
+        def get_par_prices(entity, corporation)
+          share_multiplier = corporation.shares.first.percent / 10
+          available_cash = available_par_cash(entity, corporation)
+
+          # Only get the par price for the majors
+          @game.stock_market.share_prices_with_types(%i[par_1])
+            .select { |p| p.price * share_multiplier <= available_cash }
         end
 
         def log_pass(entity)
@@ -33,9 +84,64 @@ module Engine
           super
         end
 
+        def pass_description
+          return 'Pass (Bids)' if @bid_actions.positive?
+          return 'Pass (Share)' unless @current_actions.empty?
+
+          'Pass'
+        end
+
         def process_bid(action)
           action.entity.unpass!
           add_bid(action)
+        end
+
+        def process_buy_shares(action)
+          super
+          log_pass(action.entity)
+          pass!
+        end
+
+        def process_par(action)
+          share_price = action.share_price
+          corporation = action.corporation
+          entity = action.entity
+          raise GameError, "#{corporation} cannot be parred" unless @game.can_par?(corporation, entity)
+
+          if corporation.par_via_exchange
+            share = corporation.shares.first
+            bundle = share.to_bundle
+            unless can_buy?(entity, bundle, available_cash: available_par_cash(entity, corporation))
+              raise GameError, "Cannot buy a share of #{bundle&.corporation&.name}"
+            end
+
+            # Calculate the correct price of the exchange
+            share_multiplier = bundle.percent / 10
+            exchange_price = (share_price.price * share_multiplier) - corporation.par_via_exchange.value
+            exchange_price = nil if exchange_price.negative?
+
+            @game.stock_market.set_par(corporation, share_price)
+            @game.share_pool.buy_shares(action.entity,
+                                        bundle,
+                                        exchange: corporation.par_via_exchange,
+                                        exchange_price: exchange_price)
+
+            # Add the missing money for the concession into the corporation from the bank
+            concession_money = (exchange_price ? corporation.par_via_exchange.value : share_price.price)
+            @game.bank.spend(concession_money, corporation)
+
+            # Close the concession company
+            corporation.par_via_exchange.close!
+
+            @game.after_par(corporation)
+            @round.last_to_act = entity
+            @current_actions << action
+          else
+            super
+          end
+
+          log_pass(action.entity)
+          pass!
         end
 
         def setup

--- a/lib/engine/step/g_1822/dividend.rb
+++ b/lib/engine/step/g_1822/dividend.rb
@@ -11,7 +11,7 @@ module Engine
         include HalfPay
 
         def actions(entity)
-          return [] if entity.type == :minor
+          return [] if entity.corporation? && entity.type == :minor
 
           super
         end
@@ -33,8 +33,12 @@ module Engine
         def share_price_change(entity, revenue = 0)
           return { share_direction: :left, share_times: 1 } unless revenue.positive?
 
-          if revenue >= entity.share_price.price || entity.type == :minor
-            { share_direction: :right, share_times: 1 }
+          price = entity.share_price.price
+          times = 0
+          times = 1 if revenue >= price || entity.type == :minor
+          times = 2 if revenue >= price * 2 && entity.type == :major
+          if times.positive?
+            { share_direction: :right, share_times: times }
           else
             {}
           end

--- a/lib/engine/step/g_1822/first_turn_housekeeping.rb
+++ b/lib/engine/step/g_1822/first_turn_housekeeping.rb
@@ -41,6 +41,10 @@ module Engine
         def must_buy_train?(_entity)
           false
         end
+
+        def skip!
+          pass!
+        end
       end
     end
   end


### PR DESCRIPTION
* In phase 2 in the stockround you can convert a concession into the president of the major company.
* After trying quite a few solutions i settle with the 1882 solution of showing the par values and automatic convert the concession.
* Did a very small modification to the base files, the par view. Checked after a method "available_par_cash", this is for the number of shares are correct on the buttons.
* Some minor bug fixes