### PR TITLE
1860: updated flotation rules

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -52,6 +52,7 @@ module Engine
       @capitalization = opts[:capitalization] || :full
       @closed = false
       @float_percent = opts[:float_percent] || 60
+      @float_excludes_market = opts[:float_excludes_market] || false
       @floated = false
       @max_ownership_percent = opts[:max_ownership_percent] || 60
       @min_price = opts[:min_price]
@@ -163,11 +164,17 @@ module Engine
     end
 
     def floated?
-      @floated ||= percent_of(self) <= 100 - @float_percent
+      @floated ||= percent_of(self) <= 100 - @float_percent - (@float_excludes_market ? percent_in_market : 0)
     end
 
     def percent_to_float
-      @floated ? 0 : percent_of(self) - (100 - @float_percent)
+      return 0 if @floated
+
+      percent_of(self) - (100 - @float_percent - (@float_excludes_market ? percent_in_market : 0))
+    end
+
+    def percent_in_market
+      num_market_shares * share_percent
     end
 
     def unfloat!

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -204,6 +204,10 @@ module Engine
         @nationalization = false
       end
 
+      def corporation_opts
+        { float_excludes_market: true }
+      end
+
       def share_prices
         repar_prices
       end


### PR DESCRIPTION
Corps now require 50% of shares to be owned by players in order to float (instead of 50% of IPO sold).

Added new option to Engine::Corporation - "float_excludes_market" for use in calculating when flotation occurs.

Fixes #3705 

There is a very small chance, but not zero, that this will requires pins