### PR TITLE
18 fl misc

### DIFF
--- a/lib/engine/game/g_18_fl.rb
+++ b/lib/engine/game/g_18_fl.rb
@@ -29,6 +29,7 @@ module Engine
       HOME_TOKEN_TIMING = :operating_round
       SELL_BUY_ORDER = :sell_buy
       SELL_MOVEMENT = :left_block
+      SELL_AFTER = :operate
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(

--- a/lib/engine/game/g_18_fl.rb
+++ b/lib/engine/game/g_18_fl.rb
@@ -29,6 +29,7 @@ module Engine
       SELL_BUY_ORDER = :sell_buy
       SELL_MOVEMENT = :left_block
       SELL_AFTER = :operate
+      EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(

--- a/lib/engine/game/g_18_fl.rb
+++ b/lib/engine/game/g_18_fl.rb
@@ -24,7 +24,6 @@ module Engine
       GAME_PUBLISHER = nil
       GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18FL'
 
-      EBUY_PRES_SWAP = false # allow presidential swaps of other corps when ebuying
       EBUY_OTHER_VALUE = false # allow ebuying other corp trains for up to face
       HOME_TOKEN_TIMING = :operating_round
       SELL_BUY_ORDER = :sell_buy

--- a/lib/engine/step/g_18_fl/convert.rb
+++ b/lib/engine/step/g_18_fl/convert.rb
@@ -21,7 +21,10 @@ module Engine
         end
 
         def can_convert?(entity)
-          entity.corporation? && @game.phase.status.include?('may_convert') && entity.total_shares == 5
+          entity.corporation? &&
+            entity.operated? &&
+            @game.phase.status.include?('may_convert') &&
+            entity.total_shares == 5
         end
 
         def process_convert(action)


### PR DESCRIPTION
This knocks off 4 of the 11 remaining rules for 18FL

A corporation must have operated before to voluntarily convert to a 10 share
Any pool / depot trains can be emergency bought
Presidencies of other corporations may be changed during emergency train buying
Cannot sell shares in corporations that have not operated yet


This one needs a separate PR
Trainless corps may force buy trains from other companies up to face value - IF they have 0 cash, but shares may not be sold