### PR TITLE
Initial programmed actions framework which progresses buys until floats

### DIFF
--- a/lib/engine/action/program_buy_shares.rb
+++ b/lib/engine/action/program_buy_shares.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'program_enable'
+
+module Engine
+  module Action
+    class ProgramBuyShares < ProgramEnable
+      attr_reader :corporation, :until_condition
+
+      def initialize(entity, corporation:, until_condition:)
+        super(entity)
+        @corporation = corporation
+        @until_condition = until_condition
+      end
+
+      def self.h_to_args(h, game)
+        { corporation: game.corporation_by_id(h['corporation']), until_condition: h['until_condition'] }
+      end
+
+      def args_to_h
+        { 'corporation' => @corporation.id, 'until_condition' => @until_condition }
+      end
+
+      def self.description
+        'Buy shares until condition is met'
+      end
+
+      def self.print_name
+        'Buy Shares'
+      end
+    end
+  end
+end

--- a/lib/engine/action/program_disable.rb
+++ b/lib/engine/action/program_disable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class ProgramDisable < Base
+      attr_reader :reason
+
+      def initialize(entity, reason:)
+        super(entity)
+        @reason = reason
+      end
+
+      def self.h_to_args(h, _game)
+        { reason: h['reason'] }
+      end
+
+      def args_to_h
+        { 'reason' => @reason }
+      end
+    end
+  end
+end

--- a/lib/engine/action/program_enable.rb
+++ b/lib/engine/action/program_enable.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class ProgramEnable < Base
+    end
+  end
+end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -78,7 +78,7 @@ module Engine
                   :phase, :players, :operating_rounds, :round, :share_pool, :stock_market, :tile_groups,
                   :tiles, :turn, :total_loans, :undo_possible, :redo_possible, :round_history, :all_tiles,
                   :optional_rules, :exception, :last_processed_action, :broken_action,
-                  :turn_start_action_id, :last_turn_start_action_id
+                  :turn_start_action_id, :last_turn_start_action_id, :programmed_actions
 
       DEV_STAGES = %i[production beta alpha prealpha].freeze
       DEV_STAGE = :prealpha
@@ -430,7 +430,6 @@ module Engine
         @raw_actions = []
         @turn_start_action_id = 0
         @last_turn_start_action_id = 0
-
         @exception = nil
         @names = if names.is_a?(Hash)
                    names.freeze
@@ -439,6 +438,7 @@ module Engine
                  end
 
         @players = @names.map { |player_id, name| Player.new(player_id, name) }
+        @programmed_actions = {}
 
         @optional_rules = init_optional_rules(optional_rules)
 

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -16,6 +16,7 @@ module Engine
       DEFAULT_STEPS = [
         Step::EndGame,
         Step::Message,
+        Step::Program,
       ].freeze
 
       def initialize(game, steps, **opts)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -2,6 +2,7 @@
 
 require_relative 'base'
 require_relative 'share_buying'
+require_relative 'programmer'
 require_relative '../action/buy_company'
 require_relative '../action/buy_shares'
 require_relative '../action/par'
@@ -10,6 +11,7 @@ module Engine
   module Step
     class BuySellParShares < Base
       include ShareBuying
+      include Programmer
 
       PURCHASE_ACTIONS = [Action::BuyCompany, Action::BuyShares, Action::Par].freeze
 
@@ -263,6 +265,26 @@ module Engine
         @current_actions << action
         @log << "#{owner ? '-- ' : ''}#{entity.name} buys #{company.name} from "\
                 "#{owner ? owner.name : 'the market'} for #{@game.format_currency(price)}"
+      end
+
+      def auto_actions(entity)
+        programmed_auto_actions(entity)
+      end
+
+      def activate_program_buy_shares(entity, program)
+        # TODO: non-ipo? non-10% shares
+        corporation = program.corporation
+        # check if end condition met
+        if program.until_condition == 'float'
+          return [Action::ProgramDisable.new(entity, reason: "#{corporation.name} is floated")] if corporation.floated?
+          # TODO: until n shares
+        end
+        share = corporation.ipo_shares.first
+        if can_buy?(entity, share.to_bundle)
+          [Action::BuyShares.new(entity, shares: share)]
+        else
+          [Action::ProgramDisable.new(entity, reason: "Cannot buy #{corporation.name}")]
+        end
       end
     end
   end

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Step
+    class Program < Base
+      ACTIONS = %w[program_buy_shares program_disable].freeze
+
+      def actions(entity)
+        return [] unless entity.player?
+
+        ACTIONS
+      end
+
+      def process_program_buy_shares(action)
+        process_program_enable(action)
+      end
+
+      def process_program_enable(action)
+        @log << "#{action.entity.name} enabling programmed action #{action.class.print_name}"
+        @game.programmed_actions[action.entity] = action
+      end
+
+      def process_program_disable(action)
+        # @todo: This should only log to the player
+        @log << "#{action.entity.name} programming disabled due to '#{action.reason}'" if action.reason
+        @game.programmed_actions.delete(action.entity)
+      end
+
+      def skip!; end
+
+      def blocks?
+        false
+      end
+    end
+  end
+end

--- a/lib/engine/step/programmer.rb
+++ b/lib/engine/step/programmer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Step
+    module Programmer
+      def programmed_auto_actions(entity)
+        return unless (program = @game.programmed_actions[entity.player])
+
+        method = "activate_#{program.type}"
+        return unless respond_to?(method)
+
+        send(method, entity, program)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relates to #209

This is the initial version.
Next steps would be:
* Separate the logging to be per player
* Deactivate programmed moves at end of round (in a way that also works for 1817)
* Add the UI