### PR TITLE
store log position only when scrolled up at least one line

### DIFF
--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -218,7 +218,8 @@ module View
       change_anchor = lambda do
         unless route_anchor
           elm = Native(`document.getElementById('chatlog')`)
-          store(:scroll_pos, elm.scrollTop < elm.scrollHeight - 220 ? elm.scrollTop : nil, skip: true)
+          # only store when scrolled up at least one line (20px)
+          store(:scroll_pos, elm.scrollTop < elm.scrollHeight - elm.offsetHeight - 20 ? elm.scrollTop : nil, skip: true)
         end
         store(:tile_selector, nil, skip: true)
         store(:app_route, "#{@app_route.split('#').first}#{anchor}")

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -216,7 +216,10 @@ module View
 
     def item(name, anchor = '')
       change_anchor = lambda do
-        store(:scroll_pos, `document.getElementById('chatlog').scrollTop`, skip: true) unless route_anchor
+        unless route_anchor
+          elm = Native(`document.getElementById('chatlog')`)
+          store(:scroll_pos, elm.scrollTop < elm.scrollHeight - 220 ? elm.scrollTop : nil, skip: true)
+        end
         store(:tile_selector, nil, skip: true)
         store(:app_route, "#{@app_route.split('#').first}#{anchor}")
       end


### PR DESCRIPTION
Difference between scrollHeight and scrollTop is offsetHeight. Exact match would lead to problems, adding 20 (line-height) seems to work fine.

Log still does not scroll to the bottom when taking an action (== pre #3719 behavior).