### PR TITLE
1893: First part of Start package

### DIFF
--- a/lib/engine/config/game/g_1893.rb
+++ b/lib/engine/config/game/g_1893.rb
@@ -377,6 +377,7 @@ module Engine
     {
       "sym": "EKB",
       "name": "1 Euskirchener Kreisbahn",
+      "type": "minor",
       "tokens": [
         0
       ],
@@ -388,6 +389,7 @@ module Engine
     {
       "sym": "KFBE",
       "name": "2 Köln-Frechen-Benzelrather E",
+      "type": "minor",
       "tokens": [
         0
       ],
@@ -399,6 +401,7 @@ module Engine
     {
       "sym": "KSZ",
       "name": "3 Kleinbagn Siegburg-Zündprf",
+      "type": "minor",
       "tokens": [
         0
       ],
@@ -410,6 +413,7 @@ module Engine
     {
       "sym": "KBE",
       "name": "4 Köln-Bonner Eisenbahn",
+      "type": "minor",
       "tokens": [
         0
       ],
@@ -421,6 +425,7 @@ module Engine
     {
        "sym": "BKB",
        "name": "5 Bergerheimer Kreisbahn",
+       "type": "minor",
        "tokens": [
          0
        ],

--- a/lib/engine/minor.rb
+++ b/lib/engine/minor.rb
@@ -18,13 +18,14 @@ module Engine
     include Passer
     include Spender
 
-    attr_reader :name, :full_name
+    attr_reader :name, :full_name, :type
 
     def initialize(sym:, name:, abilities: [], **opts)
       @name = sym
       @full_name = name
       @floated = false
       @closed = false
+      @type = opts[:type]&.to_sym
       init_operator(opts)
       init_abilities(abilities)
     end

--- a/lib/engine/step/g_1893/buy_sell_par_shares_first_sr.rb
+++ b/lib/engine/step/g_1893/buy_sell_par_shares_first_sr.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative '../buy_sell_par_shares'
+
+module Engine
+  module Step
+    module G1893
+      FIRST_SR_ACTIONS = %w[buy_company pass].freeze
+
+      class BuySellParSharesFirstSR < BuySellParShares
+        def actions(entity)
+          return [] unless entity&.player?
+
+          result = super
+          result.concat(FIRST_SR_ACTIONS) if can_buy_company?(entity)
+          result
+        end
+
+        def can_buy_company?(_player, _company)
+          bank_companies.any? && !sold? && !bought?
+        end
+
+        def can_buy?(_entity, bundle)
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_sell?(_entity, _bundle)
+          false
+        end
+
+        def can_gain?(_entity, bundle, exchange: false)
+          return false if exchange
+
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_exchange?(_entity)
+          false
+        end
+
+        def process_buy_company(action)
+          entity = action.entity
+          company = action.company
+          price = action.price
+
+          super
+
+          if bank_companies.one?
+            @game.corporations.each do |c|
+              next if @game.merged_corporation?(c)
+
+              @game.remove_ability(c, :no_buy)
+            end
+          end
+
+          @round.last_to_act = entity
+
+          minor = @game.minor_by_id(company.id)
+          return unless (minor = @game.minor_by_id(company.id))
+
+          buy_minor(minor, entity, price)
+        end
+
+        private
+
+        def buy_minor(minor, buyer, treasury)
+          @game.log << "Minor #{minor.full_name} floats and receives "\
+            "#{@game.format_currency(treasury)} in treasury"
+          minor.owner = buyer
+          minor.float!
+          @game.bank.spend(treasury, minor)
+        end
+
+        def bank_companies
+          @game.companies.select { |c| c.owner == @game.bank }
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1893/buy_train.rb
+++ b/lib/engine/step/g_1893/buy_train.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../buy_train'
+
+module Engine
+  module Step
+    module G1893
+      class BuyTrain < BuyTrain
+        def actions(entity)
+          return [] if entity != current_entity
+          # TODO: Not sure this is right
+          return %w[sell_shares buy_train] if president_may_contribute?(entity)
+
+          return %w[buy_train pass] if can_buy_train?(entity)
+
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1893/dividend.rb
+++ b/lib/engine/step/g_1893/dividend.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../dividend'
+require_relative '../minor_half_pay'
+
+module Engine
+  module Step
+    module G1893
+      class Dividend < Dividend
+        include MinorHalfPay
+        def actions(entity)
+          return [] if routeless_minor?(entity)
+
+          super
+        end
+
+        def skip!
+          return [] if routeless_minor?(current_entity)
+
+          super
+        end
+
+        private
+
+        def routeless_minor?(entity)
+          entity.minor? && routes.empty?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
General change: Added optional type attribute on minor class.
Needed to allow for train limit for minors.
Used in 1824 and 1893.

Can buy privates during SR1. When all but one private is sold
shares in non-mergable corporations can be bought as normal.

Minors can operate, pay dividend, buy trains.

Remains:
- Special handling of SR 2 in case any of the privates
remain unsold. (Need to be sold first in SR 2.) Special
handling if everyone passes before all is sold. (Price decrease
plus forced buy at certain price.)
- Bank should not receive revenue for unsold privates
if everyone passes.
- Bonds (10 in total, cost 100M to buy, get 100M when sold,
give 10M revenue each OR, can be bought/sold during SR
according to share rules