### PR TITLE
1861: Fix various tile rendering issues

### DIFF
--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -7,6 +7,8 @@ module View
     module Part
       # letter label, like "Z", "H", "OO"
       class Label < Base
+        needs :label
+
         # left of center
         SINGLE_CITY_ONE_SLOT = {
           flat: {
@@ -20,15 +22,28 @@ module View
             y: 0,
           },
         }.freeze
+        # right of center
+        SINGLE_CITY_ONE_SLOT_RIGHT = {
+          flat: {
+            region_weights: { (RIGHT_MID + RIGHT_CORNER) => 1, RIGHT_CENTER => 0.5 },
+            x: 55,
+            y: 0,
+          },
+          pointy: {
+            region_weights: { [17, 18] => 1.0, [11, 16] => 0.25 },
+            x: 65,
+            y: 0,
+          },
+        }.freeze
 
         P_LEFT_CORNER = {
           flat: {
-            region_weights: { LEFT_CORNER => 1.0, LEFT_MID => 0.25 },
+            region_weights: { LEFT_CORNER => 1.0 },
             x: -71.25,
             y: 0,
           },
           pointy: {
-            region_weights: { LEFT_CORNER => 1.0, [6] => 0.25 },
+            region_weights: { LEFT_CORNER => 1.0 },
             x: -67,
             y: 0,
           },
@@ -36,12 +51,12 @@ module View
 
         P_RIGHT_CORNER = {
           flat: {
-            region_weights: { RIGHT_CORNER => 1.0, RIGHT_MID => 0.25 },
+            region_weights: { RIGHT_CORNER => 1.0 },
             x: 71.25,
             y: 0,
           },
           pointy: {
-            region_weights: { RIGHT_CORNER => 1.0, [10] => 0.25 },
+            region_weights: { RIGHT_CORNER => 1.0 },
             x: 67,
             y: 0,
           },
@@ -49,12 +64,12 @@ module View
 
         P_BOTTOM_LEFT_CORNER = {
           flat: {
-            region_weights: { BOTTOM_LEFT_CORNER => 1.0, [21] => 0.5 },
+            region_weights: { BOTTOM_LEFT_CORNER => 1.0 },
             x: -30,
             y: 65,
           },
           pointy: {
-            region_weights: { BOTTOM_LEFT_CORNER => 1.0, [21] => 0.5 },
+            region_weights: { BOTTOM_LEFT_CORNER => 1.0 },
             x: -30,
             y: 61,
           },
@@ -81,14 +96,14 @@ module View
           },
           # top left corner
           {
-            region_weights: { UPPER_LEFT_CORNER => 1.0, [2] => 0.5 },
-            x: -30,
+            region_weights: { UPPER_LEFT_CORNER => 1.0 },
+            x: -40,
             y: -65,
           },
           # top right corner
           {
-            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
-            x: 30,
+            region_weights: { UPPER_RIGHT_CORNER => 1.0 },
+            x: 40,
             y: -65,
           },
           P_LEFT_CORNER[:flat],
@@ -96,15 +111,21 @@ module View
           P_BOTTOM_LEFT_CORNER[:flat],
           # bottom right corner
           {
-            region_weights: { BOTTOM_RIGHT_CORNER => 1.0, [21] => 0.5 },
-            x: 30,
+            region_weights: { BOTTOM_RIGHT_CORNER => 1.0 },
+            x: 40,
             y: 65,
           },
           # edge 1
           {
-            region_weights: { [12, 13] => 1.0, [14] => 0.5 },
+            region_weights: { [12, 13] => 1.0 },
             x: -50,
             y: 25,
+          },
+          # bottom center
+          {
+            region_weights: { [21] => 1.0, [20, 22] => 0.5 },
+            x: 0,
+            y: 60,
           },
         ].freeze
 
@@ -160,7 +181,7 @@ module View
             if @tile.cities.one? && (@tile.cities.first.slots > 1)
               [P_LEFT_CORNER[layout]]
             else
-              [SINGLE_CITY_ONE_SLOT[layout]]
+              [SINGLE_CITY_ONE_SLOT[layout], SINGLE_CITY_ONE_SLOT_RIGHT[layout]]
             end
           elsif @tile.city_towns.size > 1 && layout == :flat
             MULTI_CITY_LOCATIONS
@@ -173,13 +194,9 @@ module View
           end
         end
 
-        def load_from_tile
-          @label = @tile.label.to_s
-        end
-
         def render_part
           h(:g, { attrs: { transform: "#{translate} #{rotation_for_layout}" } }, [
-            h('text.tile__text', { attrs: { transform: 'scale(1.5)' } }, @label),
+            h('text.tile__text', { attrs: { transform: 'scale(1.5)' } }, @label.to_s),
           ])
         end
       end

--- a/assets/app/view/game/part/reservation.rb
+++ b/assets/app/view/game/part/reservation.rb
@@ -1,12 +1,198 @@
 # frozen_string_literal: true
 
-require 'view/game/part/label'
+require 'view/game/part/base'
 
 module View
   module Game
     module Part
-      class Reservation < Label
+      class Reservation < Base
         needs :reservation
+
+        # left of center
+        SINGLE_CITY_ONE_SLOT = {
+          flat: {
+            region_weights: { (LEFT_MID + LEFT_CORNER) => 1, LEFT_CENTER => 0.5 },
+            x: -55,
+            y: 0,
+          },
+          pointy: {
+            region_weights: { [5, 6] => 1.0, [7, 12] => 0.25 },
+            x: -65,
+            y: 0,
+          },
+        }.freeze
+        # right of center
+        SINGLE_CITY_ONE_SLOT_RIGHT = {
+          flat: {
+            region_weights: { (RIGHT_MID + RIGHT_CORNER) => 1, RIGHT_CENTER => 0.5 },
+            x: 55,
+            y: 0,
+          },
+          pointy: {
+            region_weights: { [17, 18] => 1.0, [11, 16] => 0.25 },
+            x: 65,
+            y: 0,
+          },
+        }.freeze
+
+        P_LEFT_CORNER = {
+          flat: {
+            region_weights: { LEFT_CORNER => 1.0, LEFT_MID => 0.25 },
+            x: -71.25,
+            y: 0,
+          },
+          pointy: {
+            region_weights: { LEFT_CORNER => 1.0, [6] => 0.25 },
+            x: -67,
+            y: 0,
+          },
+        }.freeze
+
+        P_RIGHT_CORNER = {
+          flat: {
+            region_weights: { RIGHT_CORNER => 1.0, RIGHT_MID => 0.25 },
+            x: 71.25,
+            y: 0,
+          },
+          pointy: {
+            region_weights: { RIGHT_CORNER => 1.0, [10] => 0.25 },
+            x: 67,
+            y: 0,
+          },
+        }.freeze
+
+        P_BOTTOM_LEFT_CORNER = {
+          flat: {
+            region_weights: { BOTTOM_LEFT_CORNER => 1.0, [21] => 0.5 },
+            x: -30,
+            y: 65,
+          },
+          pointy: {
+            region_weights: { BOTTOM_LEFT_CORNER => 1.0, [21] => 0.5 },
+            x: -30,
+            y: 61,
+          },
+        }.freeze
+
+        MULTI_CITY_LOCATIONS = [
+          # top center
+          {
+            region_weights: { [2] => 1.0, [1, 3] => 0.5 },
+            x: 0,
+            y: -60,
+          },
+          # edge 2
+          {
+            region_weights: { [6] => 1.0, [5, 7] => 0.5 },
+            x: -50,
+            y: -31,
+          },
+          # edge 5
+          {
+            region_weights: { [17] => 1.0, [16, 18] => 0.5 },
+            x: 50,
+            y: 37,
+          },
+          # top left corner
+          {
+            region_weights: { UPPER_LEFT_CORNER => 1.0, [2] => 0.5 },
+            x: -30,
+            y: -65,
+          },
+          # top right corner
+          {
+            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
+            x: 30,
+            y: -65,
+          },
+          P_LEFT_CORNER[:flat],
+          P_RIGHT_CORNER[:flat],
+          P_BOTTOM_LEFT_CORNER[:flat],
+          # bottom right corner
+          {
+            region_weights: { BOTTOM_RIGHT_CORNER => 1.0, [21] => 0.5 },
+            x: 30,
+            y: 65,
+          },
+          # edge 1
+          {
+            region_weights: { [12, 13] => 1.0, [14] => 0.5 },
+            x: -50,
+            y: 25,
+          },
+          # bottom center
+          {
+            region_weights: { [21] => 1.0, [20, 22] => 0.5 },
+            x: 0,
+            y: 60,
+          },
+        ].freeze
+
+        POINTY_MULTI_CITY_LOCATIONS = [
+          # top center
+          {
+            region_weights: { [2] => 1.0, [3] => 0.5 },
+            x: 0,
+            y: -60,
+          },
+          # edge 2
+          {
+            region_weights: { [6] => 1.0, [5] => 0.25 },
+            x: -50,
+            y: -31,
+          },
+          # top left corner
+          {
+            region_weights: { UPPER_LEFT_CORNER => 1.0 },
+            x: -30,
+            y: -65,
+          },
+          P_LEFT_CORNER[:pointy],
+          P_BOTTOM_LEFT_CORNER[:pointy],
+          # top right corner
+          {
+            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
+            x: 30,
+            y: -65,
+          },
+          # edge 4
+          {
+            region_weights: { [10] => 1.0, [4, 11] => 0.25 },
+            x: 67,
+            y: 0,
+          },
+          # edge 5
+          {
+            region_weights: { [17] => 1.0, [18, 23] => 0.25 },
+            x: 50,
+            y: 37,
+          },
+          # edge 1
+          {
+            region_weights: { [13, 14] => 1.0 },
+            x: -50,
+            y: 25,
+          },
+        ].freeze
+
+        def preferred_render_locations
+          if @tile.city_towns.one?
+            if @tile.cities.one? && (@tile.cities.first.slots > 1)
+              [P_LEFT_CORNER[layout]]
+            else
+              [SINGLE_CITY_ONE_SLOT[layout], SINGLE_CITY_ONE_SLOT_RIGHT[layout]]
+            end
+          elsif @tile.city_towns.size > 1 && layout == :flat
+            # MULTI_CITY_LOCATIONS
+            [P_BOTTOM_LEFT_CORNER[layout]]
+          elsif @tile.city_towns.size > 1
+            POINTY_MULTI_CITY_LOCATIONS
+          elsif layout == :flat
+            [P_LEFT_CORNER[layout]]
+          else
+            [P_LEFT_CORNER[layout], P_BOTTOM_LEFT_CORNER[layout]]
+          end
+        end
 
         def render_part
           h(:g, { attrs: { transform: "#{translate} #{rotation_for_layout}" } }, [

--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -21,6 +21,12 @@ module View
           y: -60,
         }.freeze
 
+        P_BOTTOM_RIGHT_CORNER = {
+          region_weights: [22, 23],
+          x: 30,
+          y: 60,
+        }.freeze
+
         P_BOTTOM_LEFT_CORNER = {
           region_weights: [19, 20],
           x: -30,
@@ -57,6 +63,7 @@ module View
             P_BOTTOM_LEFT_CORNER,
             P_RIGHT_CORNER,
             P_LEFT_CORNER,
+            P_BOTTOM_RIGHT_CORNER,
           ]
         end
 

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -58,9 +58,8 @@ module View
         borders = render_tile_part(Part::Borders) if @tile.borders.any?(&:type)
         # OO tiles have different rules...
         rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && @tile.cities.size > 1
-
         children << render_tile_part(Part::Revenue) if render_revenue
-        children << render_tile_part(Part::Label) if @tile.label
+        @tile.labels.each { |x| children << render_tile_part(Part::Label, label: x) }
 
         children << render_tile_part(Part::Upgrades) unless @tile.upgrades.empty?
         children << render_tile_part(Part::Blocker)

--- a/lib/engine/config/game/g_1861.rb
+++ b/lib/engine/config/game/g_1861.rb
@@ -1018,7 +1018,7 @@ module Engine
       "city=revenue:0;label=Y": [
         "B4", "D20", "M19", "N10"
       ],
-      "city=revenue:0;label=Kh": [
+      "city=revenue:0;label=Y;label=Kh": [
         "G15"
       ],
       "upgrade=cost:80,terrain:water": [

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -16,7 +16,7 @@ module Engine
 
     attr_accessor :blocks_lay, :hex, :icons, :index, :legal_rotations, :location_name,
                   :name, :opposite, :reservations, :upgrades
-    attr_reader :borders, :cities, :color, :edges, :junction, :nodes, :label,
+    attr_reader :borders, :cities, :color, :edges, :junction, :nodes, :labels,
                 :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
                 :city_towns, :unlimited, :stubs, :partitions, :id, :frame
 
@@ -189,6 +189,7 @@ module Engine
       @blocks_lay = nil
       @reservation_blocks = opts[:reservation_blocks] || false
       @unlimited = opts[:unlimited] || false
+      @labels = []
       @opposite = nil
       @id = "#{@name}-#{@index}"
 
@@ -453,7 +454,12 @@ module Engine
 
     # Used to set label for a recently placed tile
     def label=(label_name)
-      @label = label_name ? Part::Label.new(label_name) : nil
+      @labels.clear
+      @labels << Part::Label.new(label_name) if label_name
+    end
+
+    def label
+      @labels.last
     end
 
     def restore_borders(edges = nil)
@@ -489,7 +495,7 @@ module Engine
           @cities << part
           @city_towns << part
         elsif part.label?
-          @label = part
+          @labels << part
         elsif part.path?
           @paths << part
         elsif part.town?


### PR DESCRIPTION
Add Y in Ottawa/Kharkiv (fixes #2885)
Fix tile 635 overlapping terrain (fixes #3636)

This slightly moves the label allowing it to be contained entirely inside two regions

Because of this i've removed the inheritance of Reservation because the text is bigger