### PR TITLE
full size tile manifest & tile selector improvements

### DIFF
--- a/assets/app/lib/radial_selector.rb
+++ b/assets/app/lib/radial_selector.rb
@@ -26,7 +26,7 @@ module Lib
         bottom: "#{bottom}px",
         width: "#{size}px",
         height: "#{size}px",
-        filter: "drop-shadow(#{DROP_SHADOW_SIZE}px #{DROP_SHADOW_SIZE}px 2px #888)",
+        filter: "drop-shadow(#{DROP_SHADOW_SIZE}px #{DROP_SHADOW_SIZE}px 2px #555)",
         pointerEvents: 'auto',
       }
     end

--- a/assets/app/lib/radial_selector.rb
+++ b/assets/app/lib/radial_selector.rb
@@ -5,13 +5,16 @@ module Lib
     DROP_SHADOW_SIZE = 5
 
     # item -> [item,x,y]
-    def list_coordinates(list, distance, offset)
-      theta = 360.0 / list.size * Math::PI / 180
-      list.map.with_index do |x, index|
+    # angle = opening angle for tile fan
+    # rotate counterclockwise by rotation degrees
+    def list_coordinates(list, distance, offset, angle = 360, rotation = 0)
+      angle = angle * list.size / (list.size - 1) if angle < 360 && list.size > 1
+      theta = angle / list.size * Math::PI / 180
+      list.map.with_index do |item, index|
         [
-          x,
-          distance * Math.cos(index * theta) - offset,
-          distance * Math.sin(index * theta) - offset,
+          item,
+          distance * Math.cos(index * theta + rotation / 180 * Math::PI) - offset,
+          distance * Math.sin(index * theta + rotation / 180 * Math::PI) - offset,
         ]
       end
     end

--- a/assets/app/lib/radial_selector.rb
+++ b/assets/app/lib/radial_selector.rb
@@ -2,7 +2,9 @@
 
 module Lib
   module RadialSelector
-    # item -> [x,y,item]
+    DROP_SHADOW_SIZE = 5
+
+    # item -> [item,x,y]
     def list_coordinates(list, distance, offset)
       theta = 360.0 / list.size * Math::PI / 180
       list.map.with_index do |x, index|
@@ -21,11 +23,9 @@ module Lib
         bottom: "#{bottom}px",
         width: "#{size}px",
         height: "#{size}px",
-        filter: 'drop-shadow(5px 5px 2px #888)',
+        filter: "drop-shadow(#{DROP_SHADOW_SIZE}px #{DROP_SHADOW_SIZE}px 2px #888)",
         pointerEvents: 'auto',
       }
     end
-
-    DROP_SHADOW_SIZE = 5
   end
 end

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -99,7 +99,7 @@ module View
 
               return h(:div) if select_tiles.empty?
 
-              distance = (TileSelector::DISTANCE + (TileSelector::TILE_SIZE / 2)) * map_zoom
+              distance = TileSelector::DISTANCE * map_zoom
               width, height = map_size
               ts_ds = [TileSelector::DROP_SHADOW_SIZE - 5, 0].max # ignore up to 5px of ds (< 2vmin padding of #app)
               left_col = left < distance

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -79,20 +79,6 @@ module View
             elsif @tile_selector.hex.tile != @tile_selector.tile
               h(TileConfirmation)
             else
-              # Selecting column A can cause tiles to go off the edge of the map
-              distance = (TileSelector::DISTANCE + (TileSelector::TILE_SIZE / 2)) * map_zoom
-
-              width, height = map_size
-              left = distance if (left - distance).negative?
-              if (left + distance + TileSelector::DROP_SHADOW_SIZE) >= width
-                left = width - TileSelector::DROP_SHADOW_SIZE - distance
-              end
-
-              top = distance if (top - distance).negative?
-              if (top + distance + TileSelector::DROP_SHADOW_SIZE) >= height
-                top = height - TileSelector::DROP_SHADOW_SIZE - distance
-              end
-
               tiles = step.upgradeable_tiles(current_entity, @tile_selector.hex)
               all_upgrades = @game.all_potential_upgrades(@tile_selector.hex.tile)
 
@@ -111,7 +97,18 @@ module View
               # Add tiles that aren't part of all_upgrades (Mitsubishi ferry)
               select_tiles.append(*tiles.map { |t| [t, nil] })
 
-              h(TileSelector, layout: @layout, tiles: select_tiles, actions: actions, zoom: map_zoom)
+              return h(:div) if select_tiles.empty?
+
+              distance = (TileSelector::DISTANCE + (TileSelector::TILE_SIZE / 2)) * map_zoom
+              width, height = map_size
+              ts_ds = [TileSelector::DROP_SHADOW_SIZE - 5, 0].max # ignore up to 5px of ds (< 2vmin padding of #app)
+              left_col = left < distance
+              right_col = width - left < distance + ts_ds
+              top_row = top < distance
+              bottom_row = height - top < distance + ts_ds
+
+              h(TileSelector, layout: @layout, tiles: select_tiles, actions: actions, zoom: map_zoom, top_row: top_row,
+                              left_col: left_col, right_col: right_col, bottom_row: bottom_row)
             end
 
           # Move the position to the middle of the hex

--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -13,6 +13,11 @@ module View
         return [] if @tile_selector.role != :tile_page || @tile_selector.hex&.tile&.name != tile.name
 
         upgrade_tiles = @game.all_potential_upgrades(@tile_selector.hex.tile, tile_manifest: true).map do |t|
+          Engine::Tile::ALL_EDGES.select do |r|
+            break if @tile_selector.hex.tile.paths.all? { |path| t.paths.any? { |p| path <= p } }
+
+            t.rotate!(r)
+          end
           [t, remaining[t.name]&.any? ? nil : 'None Left']
         end
 

--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -16,21 +16,28 @@ module View
           [t, remaining[t.name]&.any? ? nil : 'None Left']
         end
 
+        return [] if upgrade_tiles.empty?
+
+        m = Native(`document.getElementById('tile_manifest').getBoundingClientRect()`)
+        c = Native(`document.getElementById('tile_' + #{tile.name}).getBoundingClientRect()`)
+        ts_ds = [TileSelector::DROP_SHADOW_SIZE - 5, 0].max # ignore up to 5px of drop-shadow (< 2vmin padding of #app)
+        left_col = c.left - m.left < WIDTH
+        right_col = m.right - c.right < WIDTH + ts_ds
+        bottom_row = m.bottom - c.bottom < WIDTH + ts_ds
+        top_row = c.top - m.top < WIDTH
+
         # Move the position to the middle of the hex
         props = {
           style: {
             position: 'absolute',
             left: "#{WIDTH * shift + WIDTH / 2}px",
-            top: "#{(WIDTH / 2) - 1}px",
+            top: "#{WIDTH / 2 - 1}px",
           },
         }
 
-        selector = h(TileSelector,
-                     layout: @game.layout,
-                     tiles: upgrade_tiles,
-                     actions: [],
-                     unavailable_clickable: true,
-                     role: :tile_page)
+        selector = h(TileSelector, layout: @game.layout, tiles: upgrade_tiles, unavailable_clickable: true,
+                                   role: :tile_page, left_col: left_col, right_col: right_col,
+                                   bottom_row: bottom_row, top_row: top_row)
 
         parent_props = {
           style: {

--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -102,7 +102,7 @@ module View
 
         props = {
           style: {
-            'margin': '70px',
+            'margin': '3vmin 1vmin',
           },
         }
         h('div#tile_manifest', props, children)

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -16,6 +16,10 @@ module View
       needs :role, default: :tile_selector
       needs :unavailable_clickable, default: false
       needs :zoom, default: 1
+      needs :left_col, default: false
+      needs :right_col, default: false
+      needs :top_row, default: false
+      needs :bottom_row, default: false
 
       SCALE = 0.3
       TILE_SIZE = 60
@@ -26,10 +30,16 @@ module View
       MIN_ANGLE = FULL_CIRCLE / MAX_TILES_PER_CIRCLE
       IDEAL_TILES_PER_CIRCLE = 6
       MAX_ANGLE = FULL_CIRCLE / IDEAL_TILES_PER_CIRCLE
+      ADDITIONAL_ANGLE = 20 # extend opening angle by x degrees
 
       def render
         @distance ||= DISTANCE
-        hexes = @tiles.map do |tile, unavailable|
+        @angle, @rotation = calc_angle_rotation(@left_col, @right_col, @top_row, @bottom_row)
+        if @angle < FULL_CIRCLE
+          @angle += ADDITIONAL_ANGLE # fan out tiles A_A degrees more
+          @rotation -= ADDITIONAL_ANGLE / 2
+        end
+        tiles = @tiles.map do |tile, unavailable|
           hex = Engine::Hex.new('A1', layout: @layout, tile: tile)
           h(Hex,
             hex: hex,

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -49,13 +49,38 @@ module View
             unavailable: unavailable)
         end
 
-        hexes = list_coordinates(hexes, @distance, SIZE).map do |hex, left, bottom|
+        hexes = coordinates_for(tiles).map do |hex, left, bottom|
           h(:svg,
             { style: style(left * @zoom, bottom * @zoom, TILE_SIZE * @zoom) },
             [h(:g, { attrs: { transform: "scale(#{SCALE * @zoom})" } }, [hex])])
         end
 
         h(:div, hexes)
+      end
+
+      def calc_angle_rotation(left, right, top, bottom)
+        # calculate angle of tile fan(s)
+        angle = case [left, right, top, bottom].count(true)
+                when 0 # center
+                  rotation = 0
+                  FULL_CIRCLE
+                when 1 # side
+                  180
+                else # corner
+                  90
+                end
+        # rotate tile fan(s) in corners and on sides to center of viewport
+        rotation ||= if left && !bottom
+                       -90
+                     elsif !left && top
+                       -180
+                     elsif right && !top
+                       -270
+                     else
+                       0
+                     end
+
+        [angle, rotation]
       end
     end
   end

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -21,6 +21,11 @@ module View
       TILE_SIZE = 60
       SIZE = Hex::SIZE * SCALE
       DISTANCE = Hex::SIZE
+      FULL_CIRCLE = 360
+      MAX_TILES_PER_CIRCLE = 12
+      MIN_ANGLE = FULL_CIRCLE / MAX_TILES_PER_CIRCLE
+      IDEAL_TILES_PER_CIRCLE = 6
+      MAX_ANGLE = FULL_CIRCLE / IDEAL_TILES_PER_CIRCLE
 
       def render
         @distance ||= DISTANCE

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -24,14 +24,15 @@ module View
       SCALE = 0.3
       TILE_SIZE = 60
       SIZE = Hex::SIZE * SCALE
-      DISTANCE = Hex::SIZE * 0.95
+      DISTANCE = Hex::SIZE
+      DISTANCE_SCALE = 0.85
       FULL_CIRCLE = 360
       MAX_TILES_PER_CIRCLE = 12
       MIN_ANGLE = FULL_CIRCLE / MAX_TILES_PER_CIRCLE
       IDEAL_TILES_PER_CIRCLE = 6
       MAX_ANGLE = FULL_CIRCLE / IDEAL_TILES_PER_CIRCLE
-      ADDITIONAL_ANGLE = 20 # extend opening angle by x degrees
-      DISTANCE_SCALE = 1.6
+      ADDITIONAL_ANGLE = 20
+      DISTANCE_SCALE_OUTER_FAN = 1.6
 
       def render
         @distance ||= DISTANCE
@@ -92,21 +93,16 @@ module View
           cutoff = [@angle / MIN_ANGLE, (n_hexes + 1) / 3].max
           hexes1 = hexes[0..cutoff]
           hexes2 = hexes[cutoff + 1..-1]
-          angle = (hexes2.size * MIN_ANGLE) / 2 + ADDITIONAL_ANGLE / DISTANCE_SCALE
+          angle = [(hexes2.size * MIN_ANGLE) / 2 + ADDITIONAL_ANGLE / DISTANCE_SCALE_OUTER_FAN, 105].min
           rotation = @rotation + (@angle - angle) / 2
 
           list_coordinates(hexes1, @distance, SIZE, @angle, @rotation).concat(
-            list_coordinates(hexes2, @distance * DISTANCE_SCALE, SIZE, angle, rotation)
+            list_coordinates(hexes2, @distance * DISTANCE_SCALE_OUTER_FAN, SIZE, angle, rotation)
           )
         else
-          if @angle == FULL_CIRCLE && n_hexes < IDEAL_TILES_PER_CIRCLE
-            angle = (n_hexes - 1) * MAX_ANGLE
-          elsif @angle < FULL_CIRCLE # center tile fan + orient to viewport center
-            angle = [(n_hexes - 1) * MAX_ANGLE, @angle].min
-            @rotation += (@angle - angle) / 2
-          else
-            angle = @angle
-          end
+          angle = [(n_hexes - 1) * MAX_ANGLE, @angle].min
+          @rotation += (@angle - angle) / 2 if @angle < FULL_CIRCLE # center tile fan + orient to viewport center
+          @distance *= DISTANCE_SCALE if n_hexes <= 8
 
           list_coordinates(hexes, @distance, SIZE, angle, @rotation)
         end

--- a/assets/app/view/game/tile_selector.rb
+++ b/assets/app/view/game/tile_selector.rb
@@ -100,9 +100,11 @@ module View
             list_coordinates(hexes2, @distance * DISTANCE_SCALE_OUTER_FAN, SIZE, angle, rotation)
           )
         else
+          @distance *= DISTANCE_SCALE if n_hexes <= 8
           angle = [(n_hexes - 1) * MAX_ANGLE, @angle].min
           @rotation += (@angle - angle) / 2 if @angle < FULL_CIRCLE # center tile fan + orient to viewport center
-          @distance *= DISTANCE_SCALE if n_hexes <= 8
+          # rotate tile fan to cover seams between adjacent hexes instead of hexes themselves
+          @rotation += 30 if @layout == :pointy && @angle == FULL_CIRCLE && @role != :tile_page
 
           list_coordinates(hexes, @distance, SIZE, angle, @rotation)
         end

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -51,7 +51,7 @@ module View
         hex.x = 0
         hex.y = 0
 
-        h('div.tile__block', props, [
+        h("div#tile_#{name}.tile__block", props, [
             *extra_children,
             h(:div, { style: { textAlign: 'center', fontSize: '12px' } }, text),
             h(:svg, { style: { width: '100%', height: '100%' } }, [
@@ -125,7 +125,7 @@ module View
         hex_b.x = 0
         hex_b.y = 0
 
-        h('div.tile__block', props, [
+        h("div#tile_#{name}.tile__block", props, [
             *extra_children_a,
             *extra_children_b,
             h(:div, { style: { textAlign: 'center', fontSize: '12px' } }, text),

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -262,7 +262,7 @@ text.number {
 .tile__block {
   display: inline-block;
   padding: 0.1em;
-  margin: 10px 1px 10px 0;
+  margin: 0 1px 0 0;
   outline-style: solid;
   outline-width: thin;
 }


### PR DESCRIPTION
- tile manifest with reduced margins => mobile and 2nd window friendly
- edges/corners of maps/tile manifest: arcs/fans of tiles instead of full circles moved towards center
- tiles are rendered with less distance to clicked hex
- map: tiles cover seams instead of hexes (in most cases)
- darker drop-shadow => better differentiation from background

Mobile edge cases (360px, 320px) …

![image](https://user-images.githubusercontent.com/33390595/107631899-09188d00-6c66-11eb-8b99-c62f4e3a6b21.png).![image](https://user-images.githubusercontent.com/33390595/107631907-0c137d80-6c66-11eb-8b2b-daf3c4375c63.png)

![image](https://user-images.githubusercontent.com/33390595/107632795-43cef500-6c67-11eb-99c6-177a0d109d61.png).![image](https://user-images.githubusercontent.com/33390595/107632805-46314f00-6c67-11eb-96fa-738ad91b2558.png)

… and map examples:

![image](https://user-images.githubusercontent.com/33390595/107633253-ff902480-6c67-11eb-810d-7d907f7abf87.png).![image](https://user-images.githubusercontent.com/33390595/107633272-03bc4200-6c68-11eb-92a9-cc62249bcd6c.png)

![image](https://user-images.githubusercontent.com/33390595/107633300-0f0f6d80-6c68-11eb-80f2-3c71e2b76064.png).![image](https://user-images.githubusercontent.com/33390595/107633306-12a2f480-6c68-11eb-80f9-2a3d962760f1.png)

![image](https://user-images.githubusercontent.com/33390595/107633550-7fb68a00-6c68-11eb-8a47-caa86d7ce6b7.png).![image](https://user-images.githubusercontent.com/33390595/107633559-834a1100-6c68-11eb-9de8-ec32806eaabe.png)
