### PR TITLE
[1822] Minor acquisition

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -94,6 +94,7 @@ module View
           if selected?
             props[:style][:backgroundColor] = 'lightblue'
             props[:style][:color] = 'black'
+            props[:style][:border] = '1px solid'
           end
           props[:style][:display] = @display
 

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -54,6 +54,7 @@ module View
         if selected?
           card_style[:backgroundColor] = 'lightblue'
           card_style[:color] = 'black'
+          card_style[:border] = '1px solid'
         end
 
         children = [render_title, render_holdings]

--- a/lib/engine/config/game/g_1822.rb
+++ b/lib/engine/config/game/g_1822.rb
@@ -1735,7 +1735,10 @@ module Engine
       "name": "5",
       "distance": 5,
       "num": 5,
-      "price": 500
+      "price": 500,
+      "events":[
+        {"type": "close_concessions"}
+      ]
     },
     {
       "name": "6",
@@ -2203,7 +2206,10 @@ module Engine
         "brown"
       ],
       "status": [
-        "can_buy_trains"
+        "can_buy_trains",
+        "can_acquire_minor_bidbox",
+        "can_par",
+        "minors_green_upgrade"
       ],
       "operating_rounds": 2
     },
@@ -2220,7 +2226,11 @@ module Engine
         "brown"
       ],
       "status": [
-        "can_buy_trains"
+        "can_buy_trains",
+        "can_acquire_minor_bidbox",
+        "can_par",
+        "full_capitalisation",
+        "minors_green_upgrade"
       ],
       "operating_rounds": 2
     },
@@ -2238,7 +2248,11 @@ module Engine
         "gray"
       ],
       "status": [
-        "can_buy_trains"
+        "can_buy_trains",
+        "can_acquire_minor_bidbox",
+        "can_par",
+        "full_capitalisation",
+        "minors_green_upgrade"
       ],
       "operating_rounds": 2
     }

--- a/lib/engine/step/g_1822/minor_acquisition.rb
+++ b/lib/engine/step/g_1822/minor_acquisition.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative '../token_merger'
+
+module Engine
+  module Step
+    module G1822
+      class MinorAcquisition < Base
+        include TokenMerger
+
+        ACQUIRE_ACTIONS = %w[merge pass].freeze
+        CHOOSE_ACTIONS = %w[choose].freeze
+        CHOOSE_PAY_SHARES = { 'money' => 0, 'one_share' => 1, 'two_shares' => 2 }.freeze
+
+        def actions(entity)
+          return [] unless entity == current_entity
+
+          # Init the state to :select_minor if this is the first time here
+          @acquire_state ||= :select_minor
+
+          # We either on the choose pay or choose token step
+          return CHOOSE_ACTIONS if @acquire_state == :choose_pay || @acquire_state == :choose_token
+
+          # Do we have any minors to acquire
+          return [] unless can_acquire?(entity)
+
+          ACQUIRE_ACTIONS
+        end
+
+        def can_acquire?(entity)
+          return false if !entity.corporation? || (entity.corporation? && entity.type != :major)
+          return false unless entity.operating_history.size > 1
+
+          !mergeable(entity).empty?
+        end
+
+        def choice_name
+          return 'How to pay' if @acquire_state == :choose_pay
+
+          'What to do with the token'
+        end
+
+        def choices
+          return @pay_choices if @acquire_state == :choose_pay
+
+          @token_choices
+        end
+
+        def description
+          'Acquire a minor'
+        end
+
+        def merge_name
+          'Acquire a minor'
+        end
+
+        def mergeable(entity)
+          corporations = @game.corporations.select do |minor|
+            minor.type == :minor && minor.floated? && minor.operating_history.size > 1 &&
+              !pay_choices(entity, minor).empty?
+          end
+          if @game.phase.status.include?('can_acquire_minor_bidbox')
+            bidbox_minors = @game.bidbox_minors.map { |c| @game.find_corporation(c) }.reject do |minor|
+              pay_choices(entity, minor).empty?
+            end
+            corporations.concat(bidbox_minors) if bidbox_minors
+          end
+
+          corporations
+        end
+
+        def mergeable_type(corporation)
+          "Minors that can merge with #{corporation.name}"
+        end
+
+        def pass_description
+          'Skip (Minor acquisition)'
+        end
+
+        def acquire_bank_minor(entity, token_choice)
+          # Transfer money from corporation to the bank
+          entity.spend(@game.class::MINOR_BIDBOX_PRICE, @game.bank)
+
+          receiving = []
+          if token_choice == 'replace'
+            minor_city = @game.hex_by_id(@selected_minor.coordinates).tile.cities[@selected_minor.city || 0]
+            minor_city.reservations.delete(@selected_minor)
+
+            if minor_city.tokened_by?(entity)
+              @game.move_exchange_token(entity)
+              receiving << "one token from exchange to available since #{entity.id} cant have 2 tokens "\
+                           'in the same city'
+            else
+              @game.remove_exchange_token(entity)
+              token = Engine::Token.new(entity)
+              entity.tokens << token
+              minor_city.place_token(entity, token, check_tokenable: false)
+              @game.graph.clear
+              receiving << "a token on hex #{@selected_minor.coordinates}"
+            end
+          elsif token_choice == 'exchange'
+            @game.move_exchange_token(entity)
+            receiving << 'one token from exchange to available'
+          end
+
+          @log << pay_choice_str(entity, @selected_minor, @selected_share_num, show_owner_name: true)
+          @log << "#{entity.id} acquired #{@selected_minor.id} receiving #{receiving.join(', ')}"
+
+          # Remove the proxy company for the minor
+          company = @game.companies.find { |c| c.id == "M#{@selected_minor}" }
+          @game.companies.delete(company)
+
+          # Close the minor, this also removes the minor token if the token choice of 'remove' is selected
+          @game.close_corporation(@selected_minor)
+        end
+
+        def acquire_entity_minor(entity, token_choice)
+          share_difference = pay_choice_difference(entity, @selected_minor, @selected_share_num)
+
+          # Transfer money from/to corporation and minor owner
+          @selected_minor.owner.spend(share_difference.abs, entity) if share_difference.negative?
+          entity.spend(share_difference, @selected_minor.owner) if share_difference.positive?
+
+          # Transfer IPO shares from corporation to minor owner
+          @selected_share_num.times.each do |_i|
+            entity.ipo_shares.first.transfer(@selected_minor.owner)
+          end
+
+          # Transfer assets from minor to major
+          receiving = []
+          if @selected_minor.cash.positive?
+            receiving << @game.format_currency(@selected_minor.cash)
+            @selected_minor.spend(@selected_minor.cash, entity)
+          end
+
+          companies = @game.transfer(:companies, @selected_minor, entity).map(&:name)
+          receiving << "companies (#{companies.join(', ')})" if companies.any?
+
+          trains = @game.transfer(:trains, @selected_minor, entity).map(&:name)
+          receiving << "trains (#{trains})" if trains.any?
+
+          if token_choice == 'replace'
+            minor_city = @selected_minor.tokens.first.city
+            if minor_city.tokened_by?(entity)
+              @game.move_exchange_token(entity)
+              receiving << "one token from exchange to available since #{entity.id} cant have 2 tokens "\
+                           'in the same city'
+            else
+              @game.remove_exchange_token(entity)
+              tokens = move_tokens_to_surviving(entity, @selected_minor, check_tokenable: false)
+              receiving << "a token on hex #{tokens.compact}"
+            end
+          elsif token_choice == 'exchange'
+            @game.move_exchange_token(entity)
+            receiving << 'one token from exchange to available'
+          end
+
+          @log << pay_choice_str(entity, @selected_minor, @selected_share_num, show_owner_name: true)
+          @log << "#{entity.id} acquired #{@selected_minor.id} receiving #{receiving.join(', ')}"
+
+          # Close the minor, this also removes the minor token if the token choice of 'remove' is selected
+          @game.close_corporation(@selected_minor)
+        end
+
+        def process_choose(action)
+          if @acquire_state == :choose_pay
+            @selected_share_num = CHOOSE_PAY_SHARES[action.choice]
+            @acquire_state = :choose_token
+          else
+            if !@selected_minor.owner || @selected_minor.owner == @bank
+              acquire_bank_minor(action.entity, action.choice)
+            else
+              acquire_entity_minor(action.entity, action.choice)
+            end
+            @acquire_state = :select_minor
+            pass!
+          end
+        end
+
+        def process_merge(action)
+          entity = action.entity
+          minor = action.corporation
+
+          unless @game.loading
+            if !minor.owner || minor.owner == @bank
+              # Trying to acquire a bidbox minor. Trace route to its hometokenplace
+              minor_city = @game.hex_by_id(minor.coordinates).tile.cities[minor.city || 0]
+              found_connected_city = @game.graph.connected_nodes(entity)[minor_city]
+            else
+              # Minors only have one token, check if its connected
+              found_connected_city = @game.graph.connected_nodes(entity)[minor.tokens.first.city]
+            end
+            raise GameError, "Cannot acquire minor #{minor.id} "\
+                             "because it is not connected to #{entity.id}" unless found_connected_city
+          end
+
+          @selected_minor = minor
+          @pay_choices = pay_choices(entity, minor)
+          @token_choices = token_choices(entity)
+          @acquire_state = :choose_pay
+        end
+
+        def pay_choices(entity, minor)
+          choices = Hash.new { |h, k| h[k] = [] }
+
+          # Minor is a bidbox minor
+          if !minor.owner || minor.owner == @bank
+            if entity.cash >= @game.class::MINOR_BIDBOX_PRICE
+              choice = pay_choice_str(entity, minor, 0)
+              choices['money'] = choice if choice
+            end
+            return choices
+          end
+
+          # Pay only with corporation money
+          if entity.cash >= (minor.share_price.price * 2)
+            choice = pay_choice_str(entity, minor, 0)
+            choices['money'] = choice if choice
+          end
+
+          # The corporation have atleast one share, calculate if corp or player should receive/pay difference
+          ipo_shares = entity.num_ipo_shares
+          if ipo_shares.positive?
+            choice = pay_choice_str(entity, minor, 1)
+            choices['one_share'] = choice if choice
+          end
+
+          # The corporation have atleast two share, calculate if corp or player should receive/pay difference
+          if ipo_shares > 1 && @game.num_certs(minor.owner) < @game.cert_limit
+            choice = pay_choice_str(entity, minor, 2)
+            choices['two_shares'] = choice if choice
+          end
+          choices
+        end
+
+        def pay_choice_difference(entity, minor, share_num)
+          (minor.share_price.price * 2) - (entity.share_price.price * share_num)
+        end
+
+        def pay_choice_str(entity, minor, share_num, show_owner_name: false)
+          if !minor.owner || minor.owner == @bank
+            return "#{entity.id} pays #{@game.format_currency(@game.class::MINOR_BIDBOX_PRICE)} to the bank"
+          end
+
+          owner_name = show_owner_name ? "#{minor.owner.name} receives" : 'Receive'
+          if share_num.zero?
+            return "#{owner_name} #{@game.format_currency(minor.share_price.price * 2)} from #{entity.id}"
+          end
+
+          share_difference = pay_choice_difference(entity, minor, share_num)
+          share_str = share_num == 1 ? '1 share' : '2 shares'
+          if share_difference.negative? && share_difference.abs <= minor.owner.cash
+            "#{owner_name} #{share_str} and pay #{@game.format_currency(share_difference.abs)} to #{entity.id}"
+          elsif share_difference.zero?
+            "#{owner_name} #{share_str} from #{entity.id}"
+          elsif share_difference.positive? && share_difference <= entity.cash
+            "#{owner_name} #{share_str} and #{@game.format_currency(share_difference)} from #{entity.id}"
+          end
+        end
+
+        def token_choices(entity)
+          choices = Hash.new { |h, k| h[k] = [] }
+
+          if @game.exchange_tokens(entity).positive?
+            choices['replace'] = 'Replace token on the map with an exchange token'
+            choices['exchange'] = 'Move an exchange token to available token area on the corporation chart'
+          else
+            choices['remove'] = 'Remove the minors token since no exchange tokens is available'
+          end
+          choices
+        end
+
+        def show_other_players
+          false
+        end
+
+        def skip!
+          if !@acted && current_entity && current_entity.corporation? && current_entity.type == :major
+            log_skip(current_entity)
+          end
+          pass!
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1822/tracker.rb
+++ b/lib/engine/step/g_1822/tracker.rb
@@ -8,6 +8,31 @@ module Engine
       module Tracker
         include Step::Tracker
 
+        def legal_tile_rotation?(entity, hex, tile)
+          # We will remove a town from the white S tile, this meaning we will not follow the normal path upgrade rules
+          if hex.name == @game.class::UPGRADABLE_S_HEX_NAME &&
+            tile.name == @game.class::UPGRADABLE_S_YELLOW_CITY_TILE &&
+            @game.class::UPGRADABLE_S_YELLOW_CITY_TILE_ROTATIONS.include?(tile.rotation)
+            return true
+          end
+
+          super
+        end
+
+        def potential_tiles(entity, hex)
+          colors = if entity.corporation? && entity.type == :minor &&
+                      @game.phase.status.include?('minors_green_upgrade')
+                     @game.class::MINOR_GREEN_UPGRADE
+                   else
+                     @game.phase.tiles
+                   end
+          @game.tiles
+               .select { |tile| colors.include?(tile.color) }
+               .uniq(&:name)
+               .select { |t| @game.upgrades_to?(hex.tile, t) }
+               .reject(&:blocks_lay)
+        end
+
         def remove_border_calculate_cost!(tile, entity)
           hex = tile.hex
           types = []
@@ -28,17 +53,6 @@ module Engine
             cost - border_cost_discount(entity, border, hex)
           end
           [total_cost, types]
-        end
-
-        def legal_tile_rotation?(entity, hex, tile)
-          # We will remove a town from the white S tile, this meaning we will not follow the normal path upgrade rules
-          if hex.name == @game.class::UPGRADABLE_S_HEX_NAME &&
-            tile.name == @game.class::UPGRADABLE_S_YELLOW_CITY_TILE &&
-            @game.class::UPGRADABLE_S_YELLOW_CITY_TILE_ROTATIONS.include?(tile.rotation)
-            return true
-          end
-
-          super
         end
       end
     end


### PR DESCRIPTION
* Major can now acquire minors as a step. Phase 2-7 majors can acquire player owned minors. Phase 5-7 they can also acquire one of the minors from the bidboxes. They still need to have a legal route to both options.
* Majors now have exchange tokens, did this as an ability wich already had a count on it. Did some logic for moving and removing them.
* Minors can only upgrade to green tiles even in brown and gray phase. In the green phase they still gets the option of upgrade to brown with text "Later phase". Might fix this later, it doesnt affect gameplay, since minors cant choose a brown tile when game have progressed into it.
* Phase change to phase 5 closes all concessions and changes float percent to 50. Now all majors can par as normal incremental companies.
* Did a very small change in the gui when you select a corporation or company, added a 1 px solid border. This to see if a minor is selected since i hade the hide_shares option on. This change is verified and approved by Toby.
