### PR TITLE
Programmed actions: Automatically disable and log when used

### DIFF
--- a/lib/engine/action/program_buy_shares.rb
+++ b/lib/engine/action/program_buy_shares.rb
@@ -29,6 +29,10 @@ module Engine
       def self.print_name
         'Buy Shares'
       end
+
+      def disable?(game)
+        !game.round.stock?
+      end
     end
   end
 end

--- a/lib/engine/action/program_enable.rb
+++ b/lib/engine/action/program_enable.rb
@@ -5,6 +5,10 @@ require_relative 'base'
 module Engine
   module Action
     class ProgramEnable < Base
+      # Is the game state such that the program should be disabled
+      def disable?(_game)
+        true
+      end
     end
   end
 end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -556,6 +556,10 @@ module Engine
         active_players.map(&:id)
       end
 
+      def player_log(_entity, msg)
+        @log << "-- #{msg}"
+      end
+
       def self.filtered_actions(actions)
         active_undos = []
         filtered_actions = Array.new(actions.size)
@@ -642,7 +646,11 @@ module Engine
 
       def process_single_action(action)
         if action.user
-          @log << "• Action(#{action.type}) via Master Mode by: #{player_by_id(action.user)&.name || 'Owner'}"
+          @log << if action.user == 'programmed'
+                    "• Action(#{action.type}) via #{action.entity.player.name} programmed action"
+                  else
+                    "• Action(#{action.type}) via Master Mode by: #{player_by_id(action.user)&.name || 'Owner'}"
+                  end
         end
 
         preprocess_action(action)
@@ -1957,6 +1965,16 @@ module Engine
             reorder_players
             new_stock_round
           end
+        check_programmed_actions
+      end
+
+      def check_programmed_actions
+        @programmed_actions.reject! do |entity, action|
+          if action&.disable?(self)
+            player_log(entity, 'Programmed action removed due to round change')
+            true
+          end
+        end
       end
 
       def game_end_check_values

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -646,11 +646,7 @@ module Engine
 
       def process_single_action(action)
         if action.user
-          @log << if action.user == 'programmed'
-                    "• Action(#{action.type}) via #{action.entity.player.name} programmed action"
-                  else
-                    "• Action(#{action.type}) via Master Mode by: #{player_by_id(action.user)&.name || 'Owner'}"
-                  end
+          @log << "• Action(#{action.type}) via Master Mode by: #{player_by_id(action.user)&.name || 'Owner'}"
         end
 
         preprocess_action(action)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -281,9 +281,7 @@ module Engine
         end
         share = corporation.ipo_shares.first
         if can_buy?(entity, share.to_bundle)
-          action = Action::BuyShares.new(entity, shares: share)
-          action.user = 'programmed'
-          [action]
+          [Action::BuyShares.new(entity, shares: share)]
         else
           [Action::ProgramDisable.new(entity, reason: "Cannot buy #{corporation.name}")]
         end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -281,7 +281,9 @@ module Engine
         end
         share = corporation.ipo_shares.first
         if can_buy?(entity, share.to_bundle)
-          [Action::BuyShares.new(entity, shares: share)]
+          action = Action::BuyShares.new(entity, shares: share)
+          action.user = 'programmed'
+          [action]
         else
           [Action::ProgramDisable.new(entity, reason: "Cannot buy #{corporation.name}")]
         end

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -18,13 +18,13 @@ module Engine
       end
 
       def process_program_enable(action)
-        @log << "#{action.entity.name} enabling programmed action #{action.class.print_name}"
+        @game.player_log(action.entity, "Enabled programmed action #{action.class.print_name}")
         @game.programmed_actions[action.entity] = action
       end
 
       def process_program_disable(action)
         # @todo: This should only log to the player
-        @log << "#{action.entity.name} programming disabled due to '#{action.reason}'" if action.reason
+        @game.player_log(action.entity, "Disabled programmed action due to '#{action.reason}'") if action.reason
         @game.programmed_actions.delete(action.entity)
       end
 


### PR DESCRIPTION
* Move to a player_log for things that should only be seen by a player (not yet filtered to the player)
* Automatically remove programmed actions on round change