### PR TITLE
hotkeys / keyboard shortcuts

### DIFF
--- a/assets/app/view/chat.rb
+++ b/assets/app/view/chat.rb
@@ -29,9 +29,8 @@ module View
 
       enter = lambda do |event|
         event = Native(event)
-        code = event['keyCode']
 
-        if code && code == 13
+        if event['key'] == 'Enter'
           message = event['target']['value']
           if message.strip != ''
             add_line(user: @user, created_at: Time.now.to_i, message: message)

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -27,13 +27,8 @@ module View
     end
 
     def render_form(name, inputs, description = nil)
-      enter = lambda do |event|
-        code = event.JS['keyCode']
-        submit if code && code == 13
-      end
-
       props = {
-        on: { keyup: enter },
+        on: { keyup: ->(event) { submit if Native(event)['key'] == 'Enter' } },
       }
       h2_props = { style: { margin: '1rem 0 0.5rem 0' } }
 

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -131,7 +131,7 @@ module View
         store(:selected_action_id, nil, skip: true)
       end
 
-      def history_link(text, title, action_id = nil, style_extra = {}, as_button = false)
+      def history_link(text, title, hotkey, action_id = nil, style_extra = {}, as_button = false)
         route = Lib::Params.add(@app_route, 'action', action_id)
 
         click = lambda do
@@ -144,14 +144,15 @@ module View
         props = {
           href: route,
           click: click,
-          title: title,
+          title: "#{title}, shortcut: #{hotkey}",
           children: text,
           style: {
             margin: '0',
             **style_extra,
           },
+          class: "#hist_#{hotkey}",
         }
-        props[:class] = '.button_link' if as_button
+        props[:class] += '.button_link' if as_button
 
         h(Link, props)
       end

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -144,7 +144,7 @@ module View
         props = {
           href: route,
           click: click,
-          title: "#{title}, shortcut: #{hotkey}",
+          title: "#{title} – hotkey: #{hotkey}",
           children: text,
           style: {
             margin: '0',

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -33,6 +33,7 @@ module View
               process_action(Engine::Action::Message.new(sender, message: message))
             end
           end
+          `document.getElementById('game').focus()` if code && code == 27
         end
 
         if participant?
@@ -49,7 +50,10 @@ module View
                   margin: 'auto 0',
                 },
               }, [@user['name'] + ':']),
-            h(:input,
+            h('input#chatbar',
+              attrs: {
+                title: 'Shortcut: c | esc to leave',
+              },
               style: {
                 marginLeft: '0.5rem',
                 flex: '1',

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -21,19 +21,20 @@ module View
 
         @player = @game.player_by_id(@user['id']) if @user
 
-        enter = lambda do |event|
+        key_event = lambda do |event|
           event = Native(event)
-          code = event['keyCode']
+          key = event['key']
 
-          if code && code == 13
+          if key == 'Enter'
             message = event['target']['value']
             if message.strip != ''
               event['target']['value'] = ''
               sender = @player || Engine::Player.new(@game_data['user']['id'], @game_data['user']['name'])
               process_action(Engine::Action::Message.new(sender, message: message))
             end
+          elsif key == 'Escape'
+            `document.getElementById('game').focus()`
           end
-          `document.getElementById('game').focus()` if code && code == 27
         end
 
         if participant?
@@ -58,7 +59,7 @@ module View
                 marginLeft: '0.5rem',
                 flex: '1',
               },
-              on: { keyup: enter }),
+              on: { keyup: key_event }),
             ])
         end
 

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -53,7 +53,7 @@ module View
               }, [@user['name'] + ':']),
             h('input#chatbar',
               attrs: {
-                title: 'Shortcut: c | esc to leave',
+                title: 'hotkey: c – esc to leave',
               },
               style: {
                 marginLeft: '0.5rem',

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -20,7 +20,7 @@ module View
         style_extra = { padding: '0.2rem 0.5rem', width: '100%' }
 
         unless cursor&.zero?
-          divs << history_link('|<', 'Start', 0, style_extra, true)
+          divs << history_link('|<', 'Start', 'Home', 0, style_extra, true)
 
           last_round =
             if cursor == @game.raw_actions.size
@@ -28,7 +28,7 @@ module View
             else
               @game.round_history[-1]
             end
-          divs << history_link('<<', 'Previous Round', last_round,
+          divs << history_link('<<', 'Previous Round', 'PageUp', last_round,
                                { gridColumnStart: '3', **style_extra }, true) if last_round
 
           prev_action =
@@ -39,17 +39,18 @@ module View
             else
               @num_actions - 1
             end
-          divs << history_link('<', 'Previous Action', prev_action, { gridColumnStart: '4', **style_extra }, true)
+          divs << history_link('<', 'Previous Action', 'ArrowLeft', prev_action,
+                               { gridColumnStart: '4', **style_extra }, true)
         end
 
         if cursor && !@game.exception
-          divs << history_link('>', 'Next Action', cursor + 1 < @num_actions ? cursor + 1 : nil,
+          divs << history_link('>', 'Next Action', 'ArrowRight', cursor + 1 < @num_actions ? cursor + 1 : nil,
                                { gridColumnStart: '5', **style_extra }, true)
           store(:round_history, @game.round_history, skip: true) unless @round_history
           next_round = @round_history[@game.round_history.size]
-          divs << history_link('>>', 'Next Round', next_round,
+          divs << history_link('>>', 'Next Round', 'PageDown', next_round,
                                { gridColumnStart: '6', **style_extra }, true) if next_round
-          divs << history_link('>|', 'Current', nil, { gridColumnStart: '7', **style_extra }, true)
+          divs << history_link('>|', 'Current Action', 'End', nil, { gridColumnStart: '7', **style_extra }, true)
         end
 
         props = {

--- a/assets/app/view/game/map_zoom.rb
+++ b/assets/app/view/game/map_zoom.rb
@@ -30,9 +30,9 @@ module View
         }
 
         h('div#map_zoom.inline-block', props, [
-          render_button('-', "Zoom to #{(@map_zoom / 0.011).round} %", on_click.call(@map_zoom / 1.1)),
-          render_button('0', 'Reset zoom to 100 %', on_click.call(1)),
-          render_button('+', "Zoom to #{(@map_zoom * 110).round} %", on_click.call(@map_zoom * 1.1)),
+          render_button('-', "Zoom to #{(@map_zoom / 0.011).round} %, shortcut -", on_click.call(@map_zoom / 1.1)),
+          render_button('0', 'Reset zoom to 100 %, shortcut 0', on_click.call(1)),
+          render_button('+', "Zoom to #{(@map_zoom * 110).round} %, shortcut +", on_click.call(@map_zoom * 1.1)),
         ])
       end
 
@@ -52,7 +52,7 @@ module View
           },
         }
 
-        h('button.small', props, text)
+        h("button#zoom#{text}.small", props, text)
       end
     end
   end

--- a/assets/app/view/game/map_zoom.rb
+++ b/assets/app/view/game/map_zoom.rb
@@ -30,9 +30,9 @@ module View
         }
 
         h('div#map_zoom.inline-block', props, [
-          render_button('-', "Zoom to #{(@map_zoom / 0.011).round} %, shortcut -", on_click.call(@map_zoom / 1.1)),
-          render_button('0', 'Reset zoom to 100 %, shortcut 0', on_click.call(1)),
-          render_button('+', "Zoom to #{(@map_zoom * 110).round} %, shortcut +", on_click.call(@map_zoom * 1.1)),
+          render_button('-', "Zoom to #{(@map_zoom / 0.011).round} % – hotkey -", on_click.call(@map_zoom / 1.1)),
+          render_button('0', 'Reset zoom to 100 % – hotkey 0', on_click.call(1)),
+          render_button('+', "Zoom to #{(@map_zoom * 110).round} % – hotkey +", on_click.call(@map_zoom * 1.1)),
         ])
       end
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -168,10 +168,15 @@ module View
     end
 
     def hotkey_check(event)
+      # 'search for text when you start typing' feature of browser prevents execution
+      # only execute when no modifier is pressed to not interfere with OS shortcuts
+      event = Native(event)
+      return if event.getModifierState('Alt') || event.getModifierState('AltGraph') || event.getModifierState('Meta') ||
+        event.getModifierState('Control') || event.getModifierState('OS') || event.getModifierState('Shift')
+
       active = Native(`document.activeElement`)
       return unless active.id == 'game' || active.localName == 'body'
 
-      event = Native(event)
       case event['keyCode']
       when 71 # g
         change_anchor('')

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -197,6 +197,7 @@ module View
         change_anchor('#tools')
       when 'c'
         `document.getElementById('chatbar').focus()`
+        event.preventDefault
       when '-', '0', '+'
         map = `document.getElementById('map')`
         `document.getElementById('zoom'+#{key}).click()` if map

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -241,14 +241,14 @@ module View
       }
 
       menu_items = [
-        item('Game'),
-        item('Entities', '#entities'),
-        item('Map', '#map'),
-        item('Market', '#market'),
-        item('Info', '#info'),
-        item('Tiles', '#tiles'),
-        item('Spreadsheet', '#spreadsheet'),
-        item('Tools', '#tools'),
+        item('Game', '', 'g'),
+        item('Entities', '#entities', 'e'),
+        item('Map', '#map', 'm'),
+        item('Market', '#market', 'a or k'),
+        item('Info', '#info', 'i'),
+        item('Tiles', '#tiles', 't'),
+        item('Spreadsheet', '#spreadsheet', 's'),
+        item('Tools', '#tools', 'o'),
       ]
 
       h('nav#game_menu', nav_props, [
@@ -256,7 +256,7 @@ module View
       ])
     end
 
-    def item(name, anchor = '')
+    def item(name, anchor, shortcut)
       change_anchor = lambda do
         unless route_anchor
           elm = Native(`document.getElementById('chatlog')`)
@@ -271,6 +271,7 @@ module View
         attrs: {
           href: anchor,
           onclick: 'return false',
+          title: "Shortcut: #{shortcut}",
         },
         style: { textDecoration: route_anchor == anchor[1..-1] ? 'underline' : 'none' },
         on: { click: change_anchor },

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -271,12 +271,12 @@ module View
       ])
     end
 
-    def item(name, anchor, shortcut)
+    def item(name, anchor, hotkey)
       a_props = {
         attrs: {
           href: anchor,
           onclick: 'return false',
-          title: "Shortcut: #{shortcut}",
+          title: "hotkey: #{hotkey}",
         },
         style: { textDecoration: route_anchor == anchor[1..-1] ? 'underline' : 'none' },
         on: { click: ->(_event) { change_anchor(anchor) } },

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -259,16 +259,6 @@ module View
     end
 
     def item(name, anchor, shortcut)
-      change_anchor = lambda do
-        unless route_anchor
-          elm = Native(`document.getElementById('chatlog')`)
-          # only store when scrolled up at least one line (20px)
-          store(:scroll_pos, elm.scrollTop < elm.scrollHeight - elm.offsetHeight - 20 ? elm.scrollTop : nil, skip: true)
-        end
-        store(:tile_selector, nil, skip: true)
-        store(:app_route, "#{@app_route.split('#').first}#{anchor}")
-      end
-
       a_props = {
         attrs: {
           href: anchor,
@@ -276,7 +266,7 @@ module View
           title: "Shortcut: #{shortcut}",
         },
         style: { textDecoration: route_anchor == anchor[1..-1] ? 'underline' : 'none' },
-        on: { click: change_anchor },
+        on: { click: ->(_event) { change_anchor(anchor) } },
       }
       li_props = {
         style: {

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -202,8 +202,7 @@ module View
         map = `document.getElementById('map')`
         `document.getElementById('zoom'+#{key}).click()` if map
       when 'Home', 'End', 'PageUp', 'PageDown', 'ArrowLeft', 'ArrowRight'
-        history = `document.getElementById('history')`
-        `document.getElementById('hist_'+#{key}).click()` if history
+        Native(`document.getElementById('hist_'+#{key})`)&.click()
         event.preventDefault
       end
     end

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -179,7 +179,7 @@ module View
         change_anchor('#entities')
       when 77 # m
         change_anchor('#map')
-      when 75 # k
+      when 65, 75 # a, k
         change_anchor('#market')
       when 73 # i
         change_anchor('#info')
@@ -189,6 +189,8 @@ module View
         change_anchor('#spreadsheet')
       when 79 # o
         change_anchor('#tools')
+      when 67 # c
+        `document.getElementById('chatbar').focus()`
       end
     end
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -144,7 +144,7 @@ module View
           destroy: destroy,
         },
         on: {
-          keyup: ->(event) { hotkey_check(event) },
+          keydown: ->(event) { hotkey_check(event) },
         },
       }
 
@@ -200,6 +200,10 @@ module View
       when '-', '0', '+'
         map = `document.getElementById('map')`
         `document.getElementById('zoom'+#{key}).click()` if map
+      when 'Home', 'End', 'PageUp', 'PageDown', 'ArrowLeft', 'ArrowRight'
+        history = `document.getElementById('history')`
+        `document.getElementById('hist_'+#{key}).click()` if history
+        event.preventDefault
       end
     end
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -135,9 +135,16 @@ module View
       render_title
 
       props = {
+        attrs: {
+          autofocus: true, # does not work on all browsers
+          tabindex: -1, # necessary to be focusable so keyup works; -1 == not accessible by tabbing
+        },
         key: 'game_page',
         hook: {
           destroy: destroy,
+        },
+        on: {
+          keyup: ->(event) { hotkey_check(event) },
         },
       }
 
@@ -147,7 +154,42 @@ module View
       ]
       children.unshift(render_broken_game(@game.exception)) if @game.exception
 
-      h(:div, props, children)
+      h('div#game', props, children)
+    end
+
+    def change_anchor(anchor)
+      unless route_anchor
+        elm = Native(`document.getElementById('chatlog')`)
+        # only store when scrolled up at least one line (20px)
+        store(:scroll_pos, elm.scrollTop < elm.scrollHeight - elm.offsetHeight - 20 ? elm.scrollTop : nil, skip: true)
+      end
+      store(:tile_selector, nil, skip: true)
+      store(:app_route, "#{@app_route.split('#').first}#{anchor}")
+    end
+
+    def hotkey_check(event)
+      active = Native(`document.activeElement`)
+      return unless active.id == 'game' || active.localName == 'body'
+
+      event = Native(event)
+      case event['keyCode']
+      when 71 # g
+        change_anchor('')
+      when 69 # e
+        change_anchor('#entities')
+      when 77 # m
+        change_anchor('#map')
+      when 75 # k
+        change_anchor('#market')
+      when 73 # i
+        change_anchor('#info')
+      when 84 # t
+        change_anchor('#tiles')
+      when 83 # s
+        change_anchor('#spreadsheet')
+      when 79 # o
+        change_anchor('#tools')
+      end
     end
 
     def game_path

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -177,25 +177,29 @@ module View
       active = Native(`document.activeElement`)
       return unless active.id == 'game' || active.localName == 'body'
 
-      case event['keyCode']
-      when 71 # g
+      key = event['key']
+      case key
+      when 'g'
         change_anchor('')
-      when 69 # e
+      when 'e'
         change_anchor('#entities')
-      when 77 # m
+      when 'm'
         change_anchor('#map')
-      when 65, 75 # a, k
+      when 'a', 'k'
         change_anchor('#market')
-      when 73 # i
+      when 'i'
         change_anchor('#info')
-      when 84 # t
+      when 't'
         change_anchor('#tiles')
-      when 83 # s
+      when 's'
         change_anchor('#spreadsheet')
-      when 79 # o
+      when 'o'
         change_anchor('#tools')
-      when 67 # c
+      when 'c'
         `document.getElementById('chatbar').focus()`
+      when '-', '0', '+'
+        map = `document.getElementById('map')`
+        `document.getElementById('zoom'+#{key}).click()` if map
       end
     end
 

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -362,6 +362,10 @@ div.game.card em {
   text-decoration: underline;
 }
 
+div#game:focus {
+  outline: none; /* prevent default outline of some browsers */
+}
+
 #history {
   float: left;
 }


### PR DESCRIPTION
resolves #495

- Implemented on game_page for tab change, chat-activation/-leave and map zoom only – for now. If this turns out ok, more shortcuts/hotkeys and even systemwide ones (h = home, p = profile, n = next game to act …) shouldn’t be a big deal.
- Shortcuts function only if `div#game` or `body` is focussed. There should be no interference with the chat/input. Downside: on some browsers one click is necessary to focus (almost? anywhere but button, inputs, chat and top menu bar) before shortcuts work as intended. `div#game` is set to `autofocus`, but this is a hack and doesn’t work reliably on all browsers. (While testing Chrome did fine, FF didn’t. ymmv)
- Titles of anchors and buttons do work as tooltips, although a dedicated tooltip-lib might be better suited for this in the long-run.
- Shortcuts aren’t underlined on game menu anchors (like in most programs), because it would look pretty ugly there. [If people insist on them, I don’t mind changing this.]
- Modifiers are catched, so there shouldn’t be any interference on OS-/browser shortcuts.
- If `search for text when you start typing` feature of browser is activated, hotkeys won’t work.
- I chose both a + k for Market, because k feels more natural to me (and it’s the only k as of now), but a was proposed by Scott in the linked issue.

In addition I refactored use of keyCode to key, because keyCode is deprecated. Added benefits: source code with key is way easier to grasp and problems on international keyboard locales are prevented [`-` => `slash` on a German layout e.g.].
I’m not sure why `code &&` in `if code && code == 13` e.g. might have been necessary previously, but my tests didn’t suggest any regressions.

keycode test just for the curious ones: https://keycode.info/