### PR TITLE
1860: fix sell in blocks; fix insolvent tile laying

### DIFF
--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -31,6 +31,7 @@ module Engine
       HOME_TOKEN_TIMING = :float
       SELL_AFTER = :any_time
       SELL_BUY_ORDER = :sell_buy
+      MUST_SELL_IN_BLOCKS = true
       MARKET_SHARE_LIMIT = 100
       TRAIN_PRICE_MIN = 10
       TRAIN_PRICE_MULTIPLE = 10

--- a/lib/engine/step/g_1860/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1860/buy_sell_par_shares.rb
@@ -119,7 +119,9 @@ module Engine
         def can_sell?(entity, bundle)
           return unless bundle
 
+          corporation = bundle.corporation
           can_sell_order? &&
+            !(@game.class::MUST_SELL_IN_BLOCKS && @round.players_sold[entity][corporation] == :now) &&
             @game.share_pool.fit_in_bank?(bundle) &&
             can_dump?(entity, bundle)
         end

--- a/lib/engine/step/g_1860/tracker.rb
+++ b/lib/engine/step/g_1860/tracker.rb
@@ -43,6 +43,14 @@ module Engine
           @round.laid_hexes << action.hex
         end
 
+        def pay_tile_cost!(entity, tile, rotation, hex, spender, cost, _extra_cost)
+          if @game.insolvent?(spender) && cost.positive?
+            raise GameError, "#{spender.id} cannot pay for a tile when insolvent"
+          end
+
+          super
+        end
+
         # this must be called before graphs are updated with new tile
         def revenues(tile, entity)
           return [] if @game.loading || tile.color == :white || !entity.operator?


### PR DESCRIPTION
Fixes #3802 
Fixes #3804 

A small number of games may require pinning.