### PR TITLE
1849 option to delay IFT

### DIFF
--- a/lib/engine/config/game/g_1849.rb
+++ b/lib/engine/config/game/g_1849.rb
@@ -639,7 +639,7 @@ module Engine
       "abilities": [
         {
           "type": "shares",
-          "shares": "random_president"
+          "shares": "first_president"
         },
         {
           "type": "no_buy"

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1887,8 +1887,9 @@ module Engine
           real_shares = []
           ability.shares.each do |share|
             case share
-            when 'random_president'
-              corporation = @corporations[rand % @corporations.size]
+            when 'random_president', 'first_president'
+              idx = share == 'first_president' ? 0 : rand % @corporations.size
+              corporation = @corporations[idx]
               share = corporation.shares[0]
               real_shares << share
               company.desc = "Purchasing player takes a president's share (20%) of #{corporation.name} \

--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -115,10 +115,24 @@ module Engine
       PORT_HEXES = %w[a12 A5 L14 N8].freeze
       SMS_HEXES = %w[B14 C1 C5 H12 J6 M9 M13].freeze
 
+      OPTIONAL_RULES = [
+        {
+          sym: :delay_ift,
+          short_name: 'Delay IFT',
+          desc: 'IFT may not be one of the first three corporations (recommended for newer players)',
+        },
+      ].freeze
+
+      IFT_BUFFER = 3
+
       attr_accessor :swap_choice_player, :swap_location, :swap_other_player, :swap_corporation,
                     :loan_choice_player, :player_debts,
                     :max_value_reached,
                     :old_operating_order, :moved_this_turn
+
+      def option_delay_ift?
+        @optional_rules&.include?(:delay_ift)
+      end
 
       def ipo_name(_entity = nil)
         'Treasury'
@@ -154,7 +168,6 @@ module Engine
       end
 
       def setup
-        @corporations.sort_by! { rand }
         setup_companies
         afg # init afg helper
         remove_corp if @players.size == 3
@@ -165,20 +178,16 @@ module Engine
       end
 
       def setup_companies
-        # RSA to close on train buy
         rsa = company_by_id('RSA')
         rsa_share = rsa.all_abilities[0].shares.first
+
+        # RSA closes on train buy
         rsa.add_ability(Ability::Close.new(
           type: :close,
           when: 'bought_train',
           corporation: rsa_share.corporation.name,
         ))
 
-        # RSA corp to be first
-        index = @corporations.index { |corp| corp.id == rsa_share.corporation.id }
-        @corporations[0], @corporations[index] = @corporations[index], @corporations[0]
-
-        # min_price == 1
         companies.each { |c| c.min_price = 1 }
       end
 
@@ -238,13 +247,24 @@ module Engine
       def init_corporations(stock_market)
         min_price = stock_market.par_prices.map(&:price).min
 
-        self.class::CORPORATIONS.map do |corporation|
+        corporations = self.class::CORPORATIONS.map do |corporation|
           Engine::G1849::Corporation.new(
             min_price: min_price,
             capitalization: self.class::CAPITALIZATION,
             **corporation.merge(corporation_opts),
           )
         end
+
+        corporations.sort_by! { rand }
+        if option_delay_ift?
+          ift_idx = corporations.index { |corp| corp.id == 'IFT' }
+          if ift_idx && ift_idx < IFT_BUFFER
+            # Not the algorithm in the rules but it produces the same distribution
+            corporations[ift_idx], corporations[IFT_BUFFER] = corporations[IFT_BUFFER], corporations[ift_idx]
+          end
+        end
+
+        corporations
       end
 
       def init_share_pool


### PR DESCRIPTION
Unfortunately this requires pinning of active 1849 games because of the change in randomization. It would be possible to avoid this at the cost of much uglier code; read on if interested.

Previously, the order of operations was
- `init_corporations` (title-specific) just created `@corporations`.
- `init_company_abilities` (generic) associated RSA with a random corp because it has `random_president` ability.
- `setup` (title-specific) shuffled the corps and then called `setup_companies`, which moved RSA's corp to the front of the list.

The new order is
- `init_corporations` shuffles the corps, and moves IFT out of the first three if the option is selected.
- `init_company_abilities` associates RSA with the first corp because it has the (new) `first_president` abilitiy.
- `setup` doesn't need to do anything.

This is cleaner for both cases (option on or off), but inconsistent with the old order of random number generation.

Here's how one could avoid pinning:
- RSA starts with the `random_president` ability.
- `init_corporations`: if the option is selected, shuffle the corps (burying IFT if necessary) and switch RSA's ability to be `first_president`. Otherwise do nothing.
- `init_company_abilities`: assigns RSA to the first corp or a random corp depending on its ability.
- `setup`: if the option is not selected, shuffle the corps now and move RSA's corp to the front of the list.

I think this is too ugly to outweigh the benefit of not having to pin games, but that's my opinion.
