### PR TITLE
full text search & games menu

### DIFF
--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -27,10 +27,17 @@ class App < Snabberb::Component
   include Lib::Settings
 
   needs :pin, default: nil
-  needs :title, default: nil
   needs :production, default: nil
+  needs :show_games_submenu, default: false, store: true
+  needs :show_main_submenu, default: false, store: true
+  needs :title, default: nil
 
   def render
+    close_submenus = lambda do
+      store(:show_games_submenu, false, skip: true)
+      store(:show_main_submenu, false)
+    end
+
     props = {
       props: { id: 'app' },
       style: {
@@ -40,6 +47,7 @@ class App < Snabberb::Component
         padding: '0 2vmin 2vmin 2vmin',
         transition: 'background-color 1s ease',
       },
+      on: { click: close_submenus },
     }
 
     h(:div, props, [

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -61,7 +61,7 @@ module GameManager
   def get_game(id)
     @connection.safe_get("/game/#{id}") do |data|
       data[:loaded] = @game_data[:loaded] if @game_data
-      update_game(data)
+      update_games(data)
     end
   end
 
@@ -79,25 +79,25 @@ module GameManager
     end
 
     @connection.safe_post(url(game, '/delete'), game) do |data|
-      update_game(data)
+      update_games(data)
     end
   end
 
   def join_game(game)
     @connection.safe_post(url(game, '/join')) do |data|
-      update_game(data)
+      update_games(data)
     end
   end
 
   def leave_game(game)
     @connection.safe_post(url(game, '/leave')) do |data|
-      update_game(data)
+      update_games(data)
     end
   end
 
   def start_game(game)
     @connection.safe_post(url(game, '/start')) do |data|
-      update_game(data)
+      update_games(data)
     end
   end
 
@@ -146,7 +146,7 @@ module GameManager
 
   def kick(game, player)
     @connection.safe_post(url(game, '/kick'), player) do |data|
-      update_game(data)
+      update_games(data, false)
     end
   end
 
@@ -182,11 +182,11 @@ module GameManager
     end
   end
 
-  def update_game(game)
+  def update_games(game, remove = true)
     @games += [game] if @games.none? { |g| g['id'] == game['id'] }
-    @games.reject! { |g| g['id'] == game['id'] } if game['deleted']
+    @games.reject! { |g| g['id'] == game['id'] } if remove
     @games.map! { |g| g['id'] == game['id'] ? game : g }
     store(:game_data, game, skip: true) if @game_data&.dig('id') == game['id']
-    store(:games, @games.sort_by { |g| g['id'] }.reverse)
+    store(:games, @games)
   end
 end

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -133,7 +133,7 @@ module GameManager
 
     game_url = url(game)
     store(:game_data, game.merge(loading: true), skip: true)
-    route = game_url + `window.location.search`
+    route = game_url + `window.location.search.replace(/games=[a-z]+\&status=[a-z]+/, '')`
     store(:app_route, route, skip: @app_route == route)
 
     @connection.safe_get(game_url) do |data|

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -54,7 +54,7 @@ module GameManager
     params ||= `window.location.search`
 
     @connection.get("/game#{params}") do |data|
-      store(:games, data[:games]) unless data[:error]
+      (error = data[:error]) ? store(:flash_opts, error) : store(:games, data[:games])
     end
   end
 

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -66,9 +66,9 @@ module GameManager
   end
 
   def create_game(params)
-    @connection.safe_post('/game', params) do |data|
-      store(:games, [data] + @games)
-      store(:app_route, '/', skip: true)
+    @connection.safe_post('/game', params) do
+      get_games('?games=personal&status=new')
+      store(:app_route, '/?games=personal&status=new')
     end
   end
 

--- a/assets/app/user_manager.rb
+++ b/assets/app/user_manager.rb
@@ -32,13 +32,11 @@ module UserManager
   def logout
     @connection.safe_post('/user/logout')
     invalidate_user
-    store(:app_route, '/')
   end
 
   def delete_user
     @connection.safe_post('/user/delete')
     invalidate_user
-    store(:app_route, '/')
   end
 
   def forgot(params)
@@ -67,5 +65,7 @@ module UserManager
 
   def invalidate_user
     store(:user, nil, skip: true)
+    store(:games, [], skip: true)
+    store(:app_route, '/')
   end
 end

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -178,7 +178,7 @@ module View
 
       invite_url = url(@gdata)
       flash = lambda do
-        `navigator.clipboard.writeText((window.location + invite_url).replace('//game', '/game'))`
+        `navigator.clipboard.writeText(window.location.origin + invite_url)`
         store(:flash_opts, { message: msg, color: 'lightgreen' }, skip: false)
       end
       render_link(invite_url, flash, 'Invite')

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -342,15 +342,8 @@ module View
         style: { textDecoration: route_anchor == anchor[1..-1] ? 'underline' : 'none' },
         on: { click: ->(_event) { change_anchor(anchor) } },
       }
-      li_props = {
-        style: {
-          float: 'left',
-          margin: '0 0.5rem',
-          listStyle: 'none',
-        },
-      }
 
-      h(:li, li_props, [h(:a, a_props, name)])
+      h(:li, [h(:a, a_props, name)])
     end
 
     def route_anchor

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -300,7 +300,7 @@ module View
           backgroundColor: bg_color,
           color: active_player ? contrast_on(bg_color) : color_for(:font2),
           fontSize: 'large',
-          zIndex: '9999',
+          zIndex: '999',
         },
       }
 

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -9,13 +9,14 @@ module View
 
     needs :header
     needs :game_row_games
-    needs :user
+    needs :status, default: 'active'
     needs :type
+    needs :user
 
     LIMIT = 12
 
     def render
-      @limit = @type == :personal ? 1000 : LIMIT
+      @limit = @type == :personal ? 8 : LIMIT
       h("div##{@type}.game_row", { key: @header }, [
         render_header(@header),
         *render_row,
@@ -25,9 +26,10 @@ module View
     def render_header(header)
       children = [h(:h2, header)]
       p = page.to_i
+      params = "games=#{@type}#{@type != :hotseat ? "&status=#{@status}" : ''}"
       @offset = @type == :hotseat ? (p * @limit) : 0
-      children << render_more('Prev', "?#{@type}=#{p - 1}") if p.positive?
-      children << render_more('Next', "?#{@type}=#{p + 1}") if @game_row_games.size > @offset + @limit
+      children << render_more('Prev', "?#{params}&p=#{p - 1}") if p.positive?
+      children << render_more('Next', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + @limit
 
       props = {
         style: {
@@ -72,7 +74,7 @@ module View
     def page
       return 0 if `typeof URLSearchParams === 'undefined'` # rubocop:disable Lint/LiteralAsCondition
 
-      `(new URLSearchParams(window.location.search)).get(#{@type})` || 0
+      `(new URLSearchParams(window.location.search)).get('p')` || 0
     end
   end
 end

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -19,7 +19,7 @@ module View
 
     def render
       @limit = @type == :personal ? 12 : LIMIT
-      h('div#games_list', { key: @header }, [
+      h('div#games_list', { key: @header, style: { minHeight: '70rem' } }, [
         render_header(@header),
         *render_row,
       ])

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -18,7 +18,6 @@ module View
     LIMIT = 12
 
     def render
-      @limit = @type == :personal ? 12 : LIMIT
       h('div#games_list', { key: @header, style: { minHeight: '70rem' } }, [
         render_header(@header),
         *render_row,
@@ -31,10 +30,10 @@ module View
       params = "games=#{@type}#{@type != :hs ? "&status=#{@status}" : ''}"
       params += "&s=#{`encodeURIComponent(#{@search_string})`}" if @search_string
 
-      @offset = @type == :hs ? (p * @limit) : 0
+      @offset = @type == :hs ? (p * LIMIT) : 0
       pagination = []
       pagination << render_more('<', "?#{params}&p=#{p - 1}") if p.positive?
-      pagination << render_more('>', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + @limit
+      pagination << render_more('>', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + LIMIT
 
       props = {
         style: {
@@ -158,7 +157,7 @@ D = round/turn/rules',
 
     def render_row
       if @game_row_games.any?
-        @game_row_games.slice(@offset, @limit).map { |game| h(GameCard, gdata: game, user: @user) }
+        @game_row_games.slice(@offset, LIMIT).map { |game| h(GameCard, gdata: game, user: @user) }
       else
         [h(:div, 'No games to display')]
       end

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -26,15 +26,15 @@ module View
     end
 
     def render_header(header)
-      children = [h(:h2, header)]
       p = Lib::Params['p']&.to_i || 0
       @search_string = Lib::Params['s']
       params = "games=#{@type}#{@type != :hs ? "&status=#{@status}" : ''}"
       params += "&s=#{`encodeURIComponent(#{@search_string})`}" if @search_string
 
       @offset = @type == :hs ? (p * @limit) : 0
-      children << render_more('<', "?#{params}&p=#{p - 1}") if p.positive?
-      children << render_more('>', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + @limit
+      pagination = []
+      pagination << render_more('<', "?#{params}&p=#{p - 1}") if p.positive?
+      pagination << render_more('>', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + @limit
 
       props = {
         style: {
@@ -46,7 +46,10 @@ module View
           marginRight: '0.5rem',
         },
       }
-      h(:div, [h('div#header', props, children), render_search])
+      children = [h('div#header', props, [h(:h2, header), *pagination])]
+      children << render_search unless @type == 'hs'
+
+      h(:div, children)
     end
 
     def render_more(text, params)

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -120,14 +120,37 @@ module View
       @inputs = {}
       h(:div, props, [
         @inputs['search'] = h('input.no_margin', input_props),
-        h('button.small', { style: { width: '2.5rem', margin: '0' }, on: { click: search_games } }, '🔍'),
-        h('a.button_link.small',
-          {
+        h('button.small', {
             attrs: {
-              href: 'https://github.com/tobymao/18xx/wiki',
-              title: 'ts_vector explanation', # TODO: short overview + wiki page
+              title: 'Search',
             },
-            style: { width: '2.5rem', textAlign: 'center', margin: '0' },
+            style: {
+              width: '2.5rem',
+              margin: '0',
+            },
+            on: { click: search_games },
+          },
+          '🔍'),
+        h('a.button_link.small', {
+            attrs: {
+              href: 'https://github.com/tobymao/18xx/wiki/FAQ#search',
+              title: 'Click to open help!
+
+text:* = trailing wildcard
+& = and
+| = or
+! = not
+() = group
+text:ABCD = limit to …
+A = game title
+B = users
+C = description
+D = round/turn/rules',
+            },
+            style: {
+              width: '2.5rem',
+              margin: '0',
+            },
           },
           '?'),
       ])

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -19,7 +19,7 @@ module View
 
     def render
       @limit = @type == :personal ? 12 : LIMIT
-      h("div##{@type}.game_row", { key: @header }, [
+      h('div#games_list', { key: @header }, [
         render_header(@header),
         *render_row,
       ])

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -46,7 +46,7 @@ module View
           marginRight: '0.5rem',
         },
       }
-      children = [h('div#header', props, [h(:h2, header), *pagination])]
+      children = [h(:div, props, [h(:h2, header), *pagination])]
       children << render_search unless @type == 'hs'
 
       h(:div, children)

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -27,7 +27,7 @@ module View
     def render_header(header)
       p = Lib::Params['p']&.to_i || 0
       @search_string = Lib::Params['s']
-      params = "games=#{@type}#{@type != :hs ? "&status=#{@status}" : ''}"
+      params = "games=#{@type}&status=#{@status}"
       params += "&s=#{`encodeURIComponent(#{@search_string})`}" if @search_string
 
       @offset = @type == :hs ? (p * LIMIT) : 0

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -83,6 +83,11 @@ module View
       search_games = lambda do |event|
         if event.JS['type'] == 'click' || event.JS['keyCode'] == 13
           val = Native(@inputs['search']).elm.value
+          if val.match(/^[^&|:*!]+$/)
+            # no tsquery => attach :* to all terms and put & in-between
+            val = val.gsub(/(.+)\b$/, '\1:*').gsub(/\b\s+\b/, ':* & ')
+            Native(@inputs['search']).elm.value = val
+          end
           @search_param = val.empty? ? '' : "&s=#{`encodeURIComponent(#{val})`}"
           params = "/?games=#{@type}&status=#{@status}#{@search_param}"
           get_games(params)

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -132,7 +132,7 @@ module View
           '🔍'),
         h('a.button_link.small', {
             attrs: {
-              href: 'https://github.com/tobymao/18xx/wiki/FAQ#search',
+              href: 'https://github.com/tobymao/18xx/wiki/Power-User-Features#search',
               title: 'Click to open help!
 
 text:* = trailing wildcard

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -80,11 +80,19 @@ module View
 
       search_games = lambda do |event|
         if event.JS['type'] == 'click' || event.JS['keyCode'] == 13
-          val = Native(@inputs[search_id]).elm.value
-          val == '' ? Lib::Storage.delete(search_id) : Lib::Storage[search_id] = val
-          params = "/?games=#{@type}&status=#{@status}#{"&s=#{Native(`encodeURI(#{val})`)}" if val != ''}"
-          get_games(params)
-          store(:app_route, params)
+          elm_val = Native(@inputs[search_id]).elm.value
+          val = elm_val.empty? ? nil : elm_val
+          if val != Lib::Storage[search_id]
+            if val
+              Lib::Storage[search_id] = val
+              search_param = "&s=#{`encodeURIComponent(#{val})`}"
+            else
+              Lib::Storage.delete(search_id)
+            end
+            params = "/?games=#{@type}&status=#{@status}#{search_param}"
+            get_games(params)
+            store(:app_route, params)
+          end
         end
       end
 

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -66,7 +66,11 @@ module View
     end
 
     def render_row
-      @game_row_games.slice(@offset, @limit).map { |game| h(GameCard, gdata: game, user: @user) }
+      if @game_row_games.any?
+        @game_row_games.slice(@offset, @limit).map { |game| h(GameCard, gdata: game, user: @user) }
+      else
+        [h(:div, 'No games to display')]
+      end
     end
 
     private

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -49,7 +49,7 @@ module View
     end
 
     def render_more(text, params)
-      params += "&s=#{@search_string}" if @search_string
+      params += "&s=#{Native(`encodeURI(#{@search_string})`)}" if @search_string
 
       change_page = lambda do
         get_games(params)
@@ -82,7 +82,7 @@ module View
         if event.JS['type'] == 'click' || event.JS['keyCode'] == 13
           val = Native(@inputs[search_id]).elm.value
           val == '' ? Lib::Storage.delete(search_id) : Lib::Storage[search_id] = val
-          params = "/?games=#{@type}&status=#{@status}#{"&s=#{val}" if val != ''}"
+          params = "/?games=#{@type}&status=#{@status}#{"&s=#{Native(`encodeURI(#{val})`)}" if val != ''}"
           get_games(params)
           store(:app_route, params)
         end

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -18,7 +18,7 @@ module View
     LIMIT = 12
 
     def render
-      @limit = @type == :personal ? 8 : LIMIT
+      @limit = @type == :personal ? 12 : LIMIT
       h("div##{@type}.game_row", { key: @header }, [
         render_header(@header),
         *render_row,

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -32,18 +32,18 @@ module View
       @offset = @type == :hs ? (p * @limit) : 0
       children << render_more('<', "?#{params}&p=#{p - 1}") if p.positive?
       children << render_more('>', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + @limit
-      children << render_search
 
       props = {
         style: {
-          display: 'grid',
-          grid: '1fr / 11.5rem 3rem 3rem 1fr',
-          gap: '1rem',
+          display: 'inline-grid',
+          grid: '1fr / 13rem 2.5rem 2.5rem',
+          gap: '0 0.5rem',
           alignItems: 'center',
+          width: '20rem',
+          marginRight: '0.5rem',
         },
       }
-
-      h(:div, props, children)
+      h(:div, [h('div#header', props, children), render_search])
     end
 
     def render_more(text, params)
@@ -62,11 +62,12 @@ module View
         style: {
           justifySelf: 'center',
           gridColumnStart: text == '>' ? '3' : '2',
+          width: '2.5rem',
           margin: '0',
         },
       }
 
-      h('a.button_link', props, text)
+      h('a.button_link.small.no_margin', props, text)
     end
 
     def render_search
@@ -88,14 +89,33 @@ module View
           value: Lib::Storage[search_id] || '',
           placeholder: 'game, description, players, …',
         },
-        style: { width: '13.5rem' },
+        style: { width: '13rem' },
         on: { keyup: search_games },
       }
-      @inputs = {}
 
-      h(:div, { style: { gridColumnStart: 4 } }, [
-        @inputs[search_id] = h(:input, input_props),
-        h(:button, { on: { click: search_games } }, 'Search'),
+      props = {
+        style: {
+          display: 'inline-grid',
+          grid: '1fr / 13rem 2.5rem 2.5rem',
+          gap: '0 0.5rem',
+          width: '20rem',
+          alignItems: 'center',
+          marginBottom: '1rem',
+        },
+      }
+      @inputs = {}
+      h(:div, props, [
+        @inputs[search_id] = h('input.no_margin', input_props),
+        h('button.small', { style: { width: '2.5rem', margin: '0' }, on: { click: search_games } }, '🔍'),
+        h('a.button_link.small',
+          {
+            attrs: {
+              href: 'https://github.com/tobymao/18xx/wiki',
+              title: 'ts_vector explanation', # TODO: short overview + wiki page
+            },
+            style: { width: '2.5rem', textAlign: 'center', margin: '0' },
+          },
+          '?'),
       ])
     end
 

--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -28,10 +28,10 @@ module View
     def render_header(header)
       children = [h(:h2, header)]
       p = page.to_i
-      params = "games=#{@type}#{@type != :hotseat ? "&status=#{@status}" : ''}"
-      @offset = @type == :hotseat ? (p * @limit) : 0
-      children << render_more('Prev', "?#{params}&p=#{p - 1}") if p.positive?
-      children << render_more('Next', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + @limit
+      params = "games=#{@type}#{@type != :hs ? "&status=#{@status}" : ''}"
+      @offset = @type == :hs ? (p * @limit) : 0
+      children << render_more('<', "?#{params}&p=#{p - 1}") if p.positive?
+      children << render_more('>', "?#{params}&p=#{p + 1}") if @game_row_games.size > @offset + @limit
       children << render_search
 
       props = {
@@ -61,11 +61,12 @@ module View
         },
         style: {
           justifySelf: 'center',
-          gridColumnStart: text == 'Next' ? '3' : '2',
+          gridColumnStart: text == '>' ? '3' : '2',
+          margin: '0',
         },
       }
 
-      h("a.#{text.downcase}", props, text)
+      h('a.button_link', props, text)
     end
 
     def render_search

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -44,7 +44,7 @@ module View
           .sort_by { |gd| gd[:id] }
           .reverse
 
-        render_row(children, 'Hotseat Games', hs_games, :hs)
+        render_row(children, 'Hotseat Games', hs_games, :hs, 'all')
       else
         render_row(children, "#{status.capitalize} Games", @games, :all, status)
       end

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -13,8 +13,9 @@ module View
     include GameManager
     include Lib::Settings
 
-    needs :user
+    needs :autoscroll, default: true, store: true
     needs :refreshing, default: nil, store: true
+    needs :user
 
     def render
       type = Lib::Params['games'] || (@user ? 'personal' : 'all')
@@ -48,11 +49,18 @@ module View
         render_row(children, "#{status.capitalize} Games", @games, :all, status)
       end
 
+      # without timeout element might not exist
+      `setTimeout(function(){
+        document.getElementById('games_list').scrollIntoView();
+        window.scrollBy(0, -55);
+      }, 100);` if @autoscroll == true && @app_route != '/'
+      store(:autoscroll, false, skip: true)
+
+      game_refresh
+
       `document.title = #{(acting ? '* ' : '') + '18xx.Games'}`
       change_favicon(acting)
       change_tab_color(acting)
-
-      game_refresh
 
       destroy = lambda do
         `clearTimeout(#{@refreshing})`

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -18,11 +18,11 @@ module View
 
     def render
       type = Lib::Params['games'] || (@user ? 'personal' : 'all')
-      status = Lib::Params['status'] || (@user ? 'active' : 'new')
+      status = Lib::Params['status'] || 'active'
 
       children = [
         render_header,
-        h(Welcome, show_intro: false), # personal_games.size < 2), # TODO: change condition
+        h(Welcome, show_intro: !@user),
         h(Chat, user: @user, connection: @connection),
       ]
 

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -45,7 +45,7 @@ module View
 
         render_row(children, 'Hotseat Games', hs_games, :hs)
       else
-        render_row(children, "#{status&.capitalize} Games", @games, :all, status)
+        render_row(children, "#{status.capitalize} Games", @games, :all, status)
       end
 
       `document.title = #{(acting ? '* ' : '') + '18xx.Games'}`

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -26,8 +26,6 @@ module View
         h(Chat, user: @user, connection: @connection),
       ]
 
-      children << render_games_links
-
       acting = false
 
       case type
@@ -100,58 +98,6 @@ module View
       h('div#greeting', [
         h(:h2, "Welcome#{@user ? ' ' + @user['name'] : ''}!"),
       ])
-    end
-
-    def render_games_links
-      links =
-        if @user
-          [
-            h(:label, { style: { margin: '0 0.3rem 0 0' } }, 'Your Games:'),
-            item('Active', 'personal', 'active'),
-            item('New', 'personal', 'new'),
-            item('Finished', 'personal', 'finished'),
-            item('Archived', 'personal', 'archived'),
-            item('Hotseat', 'hs'),
-            h(:label, { style: { margin: '0 0.3rem 0 1rem' } }, 'Other Games:'),
-          ]
-        else
-          [
-            h(:label, { style: { margin: '0 0.3rem 0 0' } }, 'Games:'),
-          ]
-        end
-      links.concat [
-        item('Active', 'all', 'active'),
-        item('New', 'all', 'new'),
-        item('Finished', 'all', 'finished'),
-        item('Archived', 'all', 'archived'),
-      ]
-      links << item('Hotseat', 'hs') unless @user
-
-      h('nav', links)
-    end
-
-    def item(name, type, status)
-      params = "?games=#{type}"
-      params += "&status=#{status}" if status
-
-      store_route = lambda do
-        get_games(params)
-        store(:app_route, params)
-      end
-
-      props = {
-        attrs: {
-          href: params,
-          onclick: 'return false',
-        },
-        on: {
-          click: store_route,
-        },
-        style: {
-          margin: '0 0.3rem',
-        },
-      }
-      h(:a, props, name)
     end
   end
 end

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'game_manager'
+require 'lib/params'
 require 'lib/settings'
 require 'lib/storage'
 require 'view/chat'
@@ -16,8 +17,8 @@ module View
     needs :refreshing, default: nil, store: true
 
     def render
-      type = get_url_param('games') || (@user ? 'personal' : 'all')
-      status = get_url_param('status') || (@user ? 'active' : 'new')
+      type = Lib::Params['games'] || (@user ? 'personal' : 'all')
+      status = Lib::Params['status'] || (@user ? 'active' : 'new')
 
       children = [
         render_header,
@@ -130,10 +131,8 @@ module View
     end
 
     def item(name, type, status)
-      search_string = Lib::Storage["search_#{type}_#{status}"]
       params = "?games=#{type}"
       params += "&status=#{status}" if status
-      params += "&s=#{Native(`encodeURI(#{search_string})`)}" if search_string
 
       store_route = lambda do
         get_games(params)
@@ -153,12 +152,6 @@ module View
         },
       }
       h(:a, props, name)
-    end
-
-    def get_url_param(param)
-      return if `typeof URLSearchParams === 'undefined'` # rubocop:disable Lint/LiteralAsCondition
-
-      `(new URLSearchParams(window.location.search)).get(#{param})`
     end
   end
 end

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -124,6 +124,7 @@ module View
         item('Finished', 'all', 'finished'),
         item('Archived', 'all', 'archived'),
       ]
+      links << item('Hotseat', 'hs') unless @user
 
       h('nav', links)
     end

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -132,7 +132,7 @@ module View
       search_string = Lib::Storage["search_#{type}_#{status}"]
       params = "?games=#{type}"
       params += "&status=#{status}" if status
-      params += "&s=#{search_string}" if search_string
+      params += "&s=#{Native(`encodeURI(#{search_string})`)}" if search_string
 
       store_route = lambda do
         get_games(params)

--- a/assets/app/view/logo.rb
+++ b/assets/app/view/logo.rb
@@ -7,8 +7,14 @@ module View
     include Lib::Settings
 
     needs :user, default: nil, store: true
+    needs :app_route, default: nil, store: true
 
     def render
+      show_home = lambda do
+        store(:app_route, '/')
+        `document.getElementById('app').scrollIntoView();`
+      end
+
       h1_props = {
         style: {
           margin: '0',
@@ -17,11 +23,18 @@ module View
         },
       }
       a_props = {
-        attrs: { href: '/', title: '18xx.Games' },
+        attrs: {
+          href: '/',
+          title: '18xx.Games - Main Line',
+          onclick: 'return false',
+        },
         style: {
           color: 'currentColor',
           fontWeight: 'bold',
           textDecoration: 'none',
+        },
+        on: {
+          click: show_home,
         },
       }
       logo_color = setting_for(:red_logo) ? 'red' : 'yellow'

--- a/assets/app/view/logo.rb
+++ b/assets/app/view/logo.rb
@@ -11,7 +11,7 @@ module View
     def render
       h1_props = {
         style: {
-          margin: '0 1rem 0 0',
+          margin: '0',
           fontSize: '1rem',
           whiteSpace: 'nowrap',
         },

--- a/assets/app/view/logo.rb
+++ b/assets/app/view/logo.rb
@@ -12,7 +12,7 @@ module View
     def render
       show_home = lambda do
         store(:app_route, '/')
-        `document.getElementById('app').scrollIntoView();`
+        `document.getElementById('app').scrollIntoView()`
       end
 
       h1_props = {

--- a/assets/app/view/logo.rb
+++ b/assets/app/view/logo.rb
@@ -11,7 +11,7 @@ module View
     def render
       h1_props = {
         style: {
-          margin: '0',
+          margin: '0 1rem 0 0',
           fontSize: '1rem',
           whiteSpace: 'nowrap',
         },

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -2,11 +2,13 @@
 
 require 'game_manager'
 require 'lib/connection'
+require 'lib/settings'
 require 'view/create_game'
 require 'view/logo'
 
 module View
   class Navigation < Snabberb::Component
+    include Lib::Settings
     needs :app_route, default: nil, store: true
     needs :user, default: nil, store: true
 
@@ -25,8 +27,10 @@ module View
         style: {
           display: 'grid',
           grid: '1fr / auto 1fr',
-          marginBottom: '1rem',
-          paddingBottom: '1vmin',
+          position: 'sticky',
+          top: '0',
+          padding: '0.5vmin 0',
+          backgroundColor: color_for(:bg),
           boxShadow: '0 2px 0 0 gainsboro',
         },
       }

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -8,70 +8,108 @@ require 'view/logo'
 
 module View
   class Navigation < Snabberb::Component
+    include GameManager
     include Lib::Settings
     needs :app_route, default: nil, store: true
     needs :user, default: nil, store: true
-
-    include GameManager
+    needs :show_games_sub, default: false, store: true
+    needs :show_main_sub, default: false, store: true
 
     def render
       store(:connection, Lib::Connection.new(root), skip: true) unless @connection
-      links = if @user
-                [item("Profile (#{@user['name']})", '/profile')]
-              else
-                [item('Signup', '/signup'), item('Login', '/login')]
-              end
-      links << item('About', '/about')
 
-      props = {
+      head_props = {
         style: {
           display: 'grid',
           grid: '1fr / auto 1fr',
           position: 'sticky',
           top: '0',
-          padding: '0.5vmin 0',
+          margin: '0 -2vmin',
+          padding: '0.5vmin 2vmin',
           backgroundColor: color_for(:bg),
           boxShadow: '0 2px 0 0 gainsboro',
         },
       }
+      nav_props = {
+        style: {
+          display: 'grid',
+          grid: '1fr / 1fr auto',
+          alignItems: 'center',
+          justifyItems: 'center',
+        },
+      }
 
-      h('div#header', props, [
+      h('div#header', head_props, [
         h(Logo),
-        h(:div, [
-          h('nav#games', [render_games_links]),
-          h('nav#main', [h('ul.no_margin.no_padding', links)]),
+        h(:div, nav_props, [
+          render_games_menu,
+          render_main_menu,
         ]),
       ])
     end
 
-    def item(name, anchor)
-      h('li.nav', [h(:a, { attrs: { href: anchor } }, name)])
+    def render_games_menu
+      toggle_menu = lambda do
+        store(:show_games_sub, !@show_games_sub)
+        # change z-index to overlap any sticky elements (game-page nav)
+        `document.getElementById('header').style.zIndex = #{@show_games_sub ? 1000 : 0}`
+      end
+
+      li_props = {
+        style: {
+          position: 'relative',
+        },
+      }
+      submenu_props = {
+        style: {
+          display: 'none',
+        },
+      }
+      submenu_props = {
+        style: {
+          display: 'block',
+          position: 'absolute',
+          left: '0',
+          backgroundColor: color_for(:bg),
+        },
+      } if @show_games_sub
+      toggle_props = {
+        attrs: {
+          href: '#',
+          onclick: 'return false',
+          title: 'All Games',
+        },
+        on: {
+          click: toggle_menu,
+        },
+      }
+
+      sub_links = if @user
+                    [
+                      games_link('New', 'Your New Games', 'personal', 'new'),
+                      games_link('Finished', 'Your Finished Games', 'personal', 'finished'),
+                      games_link('Hotseat', 'Your Hotseat Games', 'hs', '',
+                                 { style: { borderBottom: '1px solid' } }),
+                    ]
+                  else
+                    []
+                  end
+      sub_links << games_link("#{'All ' if @user}Active", "#{"Others' " if @user}Active Games", 'all', 'active')
+      sub_links << games_link('All New', "Others' New Games", 'all', 'new') if @user
+      sub_links << games_link("#{'All ' if @user}Finished", "#{"Others' " if @user}Finished Games", 'all', 'finished')
+      sub_links << games_link('Hotseat', 'Your Hotseat Games', 'hs') unless @user
+      games_submenu = h('ul.submenu', submenu_props, sub_links)
+      links = if @user
+                [games_link('Your Games', 'Your Active Games', 'personal', 'active'),
+                 h(:li, li_props, [h(:a, toggle_props, 'more'), games_submenu])]
+              else
+                [h(:li, li_props, [h(:a, toggle_props, 'View Games'), games_submenu])]
+              end
+
+      h('nav#games_nav', [h('ul.menu', links)])
     end
 
-    def render_games_links
-      links =
-        if @user
-          [
-            h('li.nav', [h(:label, 'Your Games:')]),
-            games_link('Active', 'personal', 'active'),
-            games_link('New', 'personal', 'new'),
-            games_link('Finished', 'personal', 'finished'),
-            games_link('Hotseat', 'hs'),
-            h('li.nav', [h(:label, 'Other Games:')]),
-          ]
-        else
-          [h('li.nav', [h(:label, 'Games:')])]
-        end
-      links.concat [
-        games_link('Active', 'all', 'active'),
-        games_link('New', 'all', 'new'),
-        games_link('Finished', 'all', 'finished'),
-      ]
-      links << games_link('Hotseat', 'hs') unless @user
-      h('ul.no_margin.no_padding', links)
-    end
-
-    def games_link(name, type, status)
+    def games_link(label, title, type, status, attrs = {})
       params = "?games=#{type}"
       params += "&status=#{status}" if status
 
@@ -80,16 +118,68 @@ module View
         store(:app_route, "/#{params}")
       end
 
-      props = {
+      a_props = {
         attrs: {
           href: "/#{params}",
           onclick: 'return false',
+          title: title,
         },
         on: {
           click: store_route,
         },
       }
-      h('li.nav', [h(:a, props, name)])
+      h(:li, attrs, [h(:a, a_props, label)])
+    end
+
+    def render_main_menu
+      toggle_menu = lambda do
+        store(:show_main_sub, !@show_main_sub)
+        # change z-index to overlap any sticky elements (game-page nav)
+        `document.getElementById('header').style.zIndex = #{@show_main_sub ? 1000 : 0}`
+      end
+
+      menu_props = {
+        style: {
+          display: 'block',
+          position: 'absolute',
+          right: '0',
+          minWidth: '5rem',
+          backgroundColor: color_for(:bg),
+        },
+        class: {
+          submenu: true,
+        },
+      } if @show_main_sub
+
+      toggle_props = {
+        attrs: {
+          href: '#',
+          onclick: 'return false',
+          title: 'Menu',
+        },
+        style: {
+          position: 'relative',
+          fontSize: '1.5rem',
+        },
+        on: {
+          click: toggle_menu,
+        },
+      }
+      toggle_props[:style][:color] = 'red' unless @user
+
+      links = if @user
+                [menu_item("Profile (#{@user['name']})", '/profile')]
+              else
+                [menu_item('Signup', '/signup'),
+                 menu_item('Login', '/login')]
+              end
+      links << menu_item('About', '/about')
+
+      h('nav#main_nav', [h('a.toggle', toggle_props, '☰'), h('ul.menu', *menu_props, links)])
+    end
+
+    def menu_item(name, anchor)
+      h(:li, [h(:a, { attrs: { href: anchor } }, name)])
     end
   end
 end

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -9,27 +9,37 @@ module View
     needs :user, default: nil, store: true
 
     def render
-      other_links = [item('About', '/about')]
-
       if @user
-        other_links << item("Profile (#{@user['name']})", '/profile')
+        games_links = [item('Your Games', '/?games=personal&status=active')]
+        games_links << item('New Games', '/?games=all&status=new')
+        other_links = [item("Profile (#{@user['name']})", '/profile')]
       else
-        other_links << item('Signup', '/signup')
-        other_links << item('Login', '/login')
+        games_links = [item('All Games', '/?games=all&status=new')]
+        other_links = [item('Signup', '/signup'), item('Login', '/login')]
       end
+      other_links << item('About', '/about')
 
       props = {
         style: {
-          display: 'flex',
-          padding: '0.75vmin 0',
+          display: 'grid',
+          grid: '1fr / auto 1fr',
+          marginBottom: '1rem',
+          paddingBottom: '1vmin',
           boxShadow: '0 2px 0 0 gainsboro',
-          justifyContent: 'space-between',
+        },
+      }
+      nav_props = {
+        style: {
+          margin: 'auto 0',
         },
       }
 
       h('div#header', props, [
         h(Logo),
-        render_other_links(other_links),
+        h(:div, [
+          h('nav#games_nav', nav_props, games_links),
+          h('nav#main_nav', nav_props, other_links),
+        ]),
       ])
     end
 
@@ -39,23 +49,10 @@ module View
           href: href,
         },
         style: {
-          margin: '0 0.5rem',
+          margin: '0 1rem',
         },
       }
       h(:a, props, name)
-    end
-
-    def render_other_links(other_links)
-      children = other_links.map do |link|
-        link
-      end
-
-      nav_props = {
-        style: {
-          margin: 'auto 0',
-        },
-      }
-      h('div#nav', nav_props, children)
     end
   end
 end

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -28,31 +28,22 @@ module View
           boxShadow: '0 2px 0 0 gainsboro',
         },
       }
-      nav_props = {
-        style: {
-          margin: 'auto 0',
-        },
-      }
 
       h('div#header', props, [
         h(Logo),
         h(:div, [
-          h('nav#games_nav', nav_props, games_links),
-          h('nav#main_nav', nav_props, other_links),
+          h('nav#games_nav', [
+            h('ul.no_margin.no_padding', games_links),
+          ]),
+          h('nav#main_nav', [
+            h('ul.no_margin.no_padding', other_links),
+          ]),
         ]),
       ])
     end
 
-    def item(name, href)
-      props = {
-        attrs: {
-          href: href,
-        },
-        style: {
-          margin: '0 1rem',
-        },
-      }
-      h(:a, props, name)
+    def item(name, anchor)
+      h('li.nav', [h(:a, { attrs: { href: anchor } }, name)])
     end
   end
 end

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -96,7 +96,7 @@ module View
                     [
                       games_link('New', 'Your New Games', 'personal', 'new'),
                       games_link('Finished', 'Your Finished Games', 'personal', 'finished'),
-                      games_link('Hotseat', 'Your Hotseat Games', 'hs', '',
+                      games_link('Hotseat', 'Your Hotseat Games', 'hs', 'all',
                                  { style: { borderBottom: '1px solid' } }),
                     ]
                   else
@@ -105,7 +105,7 @@ module View
       sub_links << games_link("#{'All ' if @user}Active", "#{"Others' " if @user}Active Games", 'all', 'active')
       sub_links << games_link('All New', "Others' New Games", 'all', 'new') if @user
       sub_links << games_link("#{'All ' if @user}Finished", "#{"Others' " if @user}Finished Games", 'all', 'finished')
-      sub_links << games_link('Hotseat', 'Your Hotseat Games', 'hs') unless @user
+      sub_links << games_link('Hotseat', 'Your Hotseat Games', 'hs', 'all') unless @user
       games_submenu = h('ul.submenu', submenu_props, sub_links)
       links = if @user
                 [games_link('Your Games', 'Your Active Games', 'personal', 'active'),
@@ -125,8 +125,7 @@ module View
     end
 
     def games_link(label, title, type, status, attrs = {})
-      params = "?games=#{type}"
-      params += "&status=#{status}" if status
+      params = "?games=#{type}&status=#{status}"
 
       a_props = {
         attrs: {

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -115,14 +115,15 @@ module View
       h('nav#games_nav', [h('ul.menu', links)])
     end
 
+    def store_route(event, params = nil)
+      event.JS.stopPropagation
+      get_games(params) if params
+      store(:app_route, "/#{params}")
+    end
+
     def games_link(label, title, type, status, attrs = {})
       params = "?games=#{type}"
       params += "&status=#{status}" if status
-
-      store_route = lambda do
-        get_games(params)
-        store(:app_route, "/#{params}")
-      end
 
       a_props = {
         attrs: {
@@ -131,7 +132,7 @@ module View
           title: title,
         },
         on: {
-          click: store_route,
+          click: ->(event) { store_route(event, params) },
         },
       }
       h(:li, attrs, [h(:a, a_props, label)])

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -11,9 +11,10 @@ module View
     include GameManager
     include Lib::Settings
     needs :app_route, default: nil, store: true
-    needs :user, default: nil, store: true
+    needs :autoscroll, default: false, store: true
     needs :show_games_submenu, default: false, store: true
     needs :show_main_submenu, default: false, store: true
+    needs :user, default: nil, store: true
 
     def render
       store(:connection, Lib::Connection.new(root), skip: true) unless @connection
@@ -118,6 +119,7 @@ module View
     def store_route(event, params = nil)
       event.JS.stopPropagation
       get_games(params) if params
+      store(:autoscroll, true, skip: true)
       store(:app_route, "/#{params}")
     end
 

--- a/assets/app/view/navigation.rb
+++ b/assets/app/view/navigation.rb
@@ -4,6 +4,7 @@ require 'game_manager'
 require 'lib/connection'
 require 'lib/settings'
 require 'view/create_game'
+require 'view/link'
 require 'view/logo'
 
 module View
@@ -137,6 +138,7 @@ module View
           click: ->(event) { store_route(event, params) },
         },
       }
+
       h(:li, attrs, [h(:a, a_props, label)])
     end
 
@@ -181,8 +183,26 @@ module View
       h('nav#main_nav', [h('a.toggle', toggle_props, '☰'), h('ul.menu', menu_props, links)])
     end
 
-    def menu_item(name, anchor)
-      h(:li, [h(:a, { attrs: { href: anchor } }, name)])
+    def menu_item(text, page)
+      show_page = lambda do
+        store(:app_route, page)
+        # without timeout element might not exist
+        `setTimeout(function(){
+          document.getElementById('app').scrollIntoView();
+        }, 100);`
+      end
+
+      props = {
+        attrs: {
+          href: "/#{page}",
+          onclick: 'return false',
+        },
+        on: {
+          click: show_page,
+        },
+      }
+
+      h(:li, [h(:a, props, text)])
     end
   end
 end

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -65,16 +65,7 @@ module View
         ]),
       ]
 
-      finished_games = @games
-        .select { |game| user_in_game?(@user, game) && %w[finished archived].include?(game['status']) }
-        .sort_by { |game| -game['updated_at'] }
-
-      [render_form(title, inputs),
-       h(GameRow,
-         header: 'Your Finished Games',
-         game_row_games: finished_games,
-         type: :personal,
-         user: @user)]
+      [render_form(title, inputs)]
     end
 
     def render_signup

--- a/migrate/0006_add_tsvector_to_games.rb
+++ b/migrate/0006_add_tsvector_to_games.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table :games do
+      add_column :tsv, :tsvector # , null: false, default: ''
+      add_index :tsv, type: :gin
+    end
+
+    run "
+      UPDATE games g
+      SET tsv = setweight(to_tsvector(g.title), 'A') ||
+          setweight(to_tsvector(SUBSTRING(g.title, 3, 99)), 'A') ||
+          setweight(to_tsvector(g.round), 'D') ||
+          setweight(to_tsvector(CAST(g.turn AS text)), 'D') ||
+          setweight(to_tsvector(COALESCE(g.settings->>'optional_rules', '')), 'D') ||
+          setweight(to_tsvector(COALESCE(g.description, '')), 'C') ||
+          setweight(to_tsvector(
+            (SELECT STRING_AGG(u.name, ' ')
+              FROM users u
+              INNER JOIN game_users gu ON u.id = gu.user_id
+              INNER JOIN games g2 ON g2.id = gu.game_id
+              WHERE g.id = g2.id)
+          ), 'B');
+    "
+
+    run "
+      DROP FUNCTION IF EXISTS games_trigger() CASCADE;
+
+      CREATE OR REPLACE FUNCTION games_trigger() RETURNS trigger AS $$
+      BEGIN
+        UPDATE games g
+        SET tsv = (setweight(to_tsvector(g.title), 'A') ||
+            setweight(to_tsvector(g.round), 'D') ||
+            setweight(to_tsvector(CAST(g.turn AS text)), 'D') ||
+            setweight(to_tsvector(COALESCE(g.settings->>'optional_rules', '')), 'D') ||
+            setweight(to_tsvector(COALESCE(g.description, '')), 'C') ||
+            setweight(to_tsvector(
+              (SELECT STRING_AGG(u.name, ' ')
+                FROM users u
+                INNER JOIN game_users gu ON u.id = gu.user_id
+                INNER JOIN games g2 ON g2.id = gu.game_id
+                WHERE g.id = g2.id)
+            ), 'B'));
+        RETURN NEW;
+      END
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER tsv_update
+      AFTER UPDATE OF round, turn ON games
+      FOR EACH ROW EXECUTE FUNCTION games_trigger();
+
+      CREATE TRIGGER tsv_insert
+      AFTER INSERT ON games
+      FOR EACH ROW EXECUTE FUNCTION games_trigger();
+    "
+  end
+
+  down do
+    alter_table :games do
+      drop_column :tsv
+      drop_index :tsv
+    end
+    run 'DROP FUNCTION IF EXISTS games_trigger() CASCADE;'
+    run 'DROP TRIGGER IF EXISTS tsv_update ON games;'
+    run 'DROP TRIGGER IF EXISTS tsv_insert ON games;'
+  end
+end

--- a/models/game.rb
+++ b/models/game.rb
@@ -99,7 +99,7 @@ class Game < Base
     opts = {
       games: opts['games'] || (user ? 'personal' : 'all'),
       page: opts['p']&.to_i || 0,
-      status: opts['status'] || (user ? 'active' : 'new'),
+      status: opts['status'] || 'active',
       search_string: opts['s'] || nil,
     }
     opts[:user_id] = user.id if user

--- a/models/game.rb
+++ b/models/game.rb
@@ -59,9 +59,9 @@ class Game < Base
 
   def self.home_games(user, **opts)
     opts = {
-      type: opts['games'] || user ? 'personal' : 'all',
+      type: opts['games'] || (user ? 'personal' : 'all'),
       page: opts['p']&.to_i || 0,
-      status: opts['status'] || user ? 'active' : 'new',
+      status: opts['status'] || (user ? 'active' : 'new'),
     }
     opts[:user_id] = user.id if user
 

--- a/models/game.rb
+++ b/models/game.rb
@@ -92,7 +92,7 @@ class Game < Base
       type: opts['games'] || (user ? 'personal' : 'all'),
       page: opts['p']&.to_i || 0,
       status: opts['status'] || (user ? 'active' : 'new'),
-      search_string: opts['s'] || '18:*',
+      search_string: opts['s'] || '1:*',
     }
     opts[:user_id] = user.id if user
 

--- a/models/game.rb
+++ b/models/game.rb
@@ -72,9 +72,9 @@ class Game < Base
          JOIN game_users gu ON g.id = gu.game_id
          JOIN users u ON u.id = gu.user_id
          GROUP BY g.id) g_search
-      WHERE g_search.ts_vector @@ to_tsquery('Ches')
+      WHERE g_search.ts_vector @@ to_tsquery(:search_string)
+      ORDER BY ts_rank(g_search.ts_vector, to_tsquery(:search_string)) DESC, updated_at DESC
       /* WHERE g_search.ts_vector @@ to_tsquery('(183:* & (test | local2)) | !Auction') */
-      ORDER BY ts_rank(g_search.ts_vector, to_tsquery('(183:* & (test | local2)) | !Auction')) DESC, updated_at DESC
     )
 
     SELECT g.*
@@ -92,10 +92,9 @@ class Game < Base
       type: opts['games'] || (user ? 'personal' : 'all'),
       page: opts['p']&.to_i || 0,
       status: opts['status'] || (user ? 'active' : 'new'),
-      search_string: opts['search_string'] || '',
+      search_string: opts['s'] || '18:*',
     }
     opts[:user_id] = user.id if user
-    # opts[:search_string] = Lib::Storage["search_#{opts[:type]}_#{opts[:status]}"]
 
     query =
       if user && opts[:type] == 'personal'

--- a/models/game.rb
+++ b/models/game.rb
@@ -106,7 +106,7 @@ class Game < Base
 
   def self.home_games(user, **opts)
     opts = {
-      type: opts['games'] || (user ? 'personal' : 'all'),
+      games: opts['games'] || (user ? 'personal' : 'all'),
       page: opts['p']&.to_i || 0,
       status: opts['status'] || (user ? 'active' : 'new'),
       search_string: opts['s'] || nil,
@@ -114,7 +114,7 @@ class Game < Base
     opts[:user_id] = user.id if user
 
     query =
-      if user && opts[:type] == 'personal'
+      if user && opts[:games] == 'personal'
         opts[:search_string] ? PERSONAL_GAMES_SEARCH_QUERY : PERSONAL_GAMES_QUERY
       elsif user
         opts[:search_string] ? OTHER_GAMES_SEARCH_QUERY : OTHER_GAMES_QUERY

--- a/models/game.rb
+++ b/models/game.rb
@@ -11,75 +11,92 @@ class Game < Base
   QUERY_LIMIT = 13
   PERSONAL_QUERY_LIMIT = 9
 
-  FILTER_QUERY = <<~SQL
+  USER_GAMES_IDS = <<~SQL
+    SELECT game_id AS id
+    FROM game_users
+    WHERE user_id = :user_id
+  SQL
+
+  FILTERED_GAMES = <<~SQL
     SELECT *
     FROM (SELECT g.*,
         setweight(to_tsvector(g.title), 'A') ||
         setweight(to_tsvector(g.round), 'D') ||
-        setweight(to_tsvector(g.description), 'C') ||
+        setweight(to_tsvector(COALESCE(g.description, '')), 'C') ||
         setweight(to_tsvector(coalesce(string_agg(u.name, ' '))), 'B') as ts_vector
        FROM games g
-       JOIN game_users gu ON g.id = gu.game_id
-       JOIN users u ON u.id = gu.user_id
+       INNER JOIN game_users gu ON g.id = gu.game_id
+       INNER JOIN users u ON u.id = gu.user_id
+       WHERE g.status = :status
        GROUP BY g.id) g_search
-    WHERE g_search.ts_vector @@ to_tsquery('(183:* & (test | local2)) | !Auction')
-    ORDER BY ts_rank(g_search.ts_vector, to_tsquery('(183:* & (test | local2)) | !Auction')) DESC, updated_at DESC;
+    WHERE g_search.ts_vector @@ to_tsquery(:search_string)
+    /* ORDER BY ts_rank(g_search.ts_vector, to_tsquery(:search_string)) DESC, updated_at DESC */
+  SQL
+
+  ALL_GAMES_SEARCH_QUERY = <<~SQL
+    SELECT *
+    FROM (#{FILTERED_GAMES}) filtered_games
+    WHERE NOT COALESCE((settings->>'unlisted')::boolean, false)
+    ORDER BY updated_at DESC
+    LIMIT #{QUERY_LIMIT}
+    OFFSET :page * #{QUERY_LIMIT - 1}
   SQL
 
   ALL_GAMES_QUERY = <<~SQL
     SELECT *
     FROM games
     WHERE status = :status
-      AND (settings->>'unlisted')::boolean = false
+    AND NOT COALESCE((settings->>'unlisted')::boolean, false)
     ORDER BY updated_at DESC
     LIMIT #{QUERY_LIMIT}
     OFFSET :page * #{QUERY_LIMIT - 1}
   SQL
 
-  NON_PERSONAL_GAMES_QUERY = <<~SQL
-    WITH user_games AS (
-      SELECT game_id AS id
-      FROM game_users
-      WHERE user_id = :user_id
-    )
-
+  OTHER_GAMES_SEARCH_QUERY = <<~SQL
+    WITH user_games AS (#{USER_GAMES_IDS})
+    , filtered_games AS (#{FILTERED_GAMES})
     SELECT g.*
-    FROM games g
+    FROM filtered_games g
     LEFT JOIN user_games ug
       ON g.id = ug.id
-    WHERE g.status = :status
-      AND ug.id IS NULL
-      AND (settings->>'unlisted')::boolean = false
-    ORDER BY g.updated_at DESC
+    WHERE ug.id IS NULL
+      AND NOT COALESCE((settings->>'unlisted')::boolean, false)
+    ORDER BY updated_at DESC
     LIMIT #{QUERY_LIMIT}
     OFFSET :page * #{QUERY_LIMIT - 1}
   SQL
 
-  PERSONAL_GAMES_QUERY = <<~SQL
-    WITH user_games AS (
-      SELECT game_id AS id
-      FROM game_users
-      WHERE user_id = :user_id
-    )
-    , filtered_games AS (
-      SELECT id, user_id, description, title, max_players, settings, status, turn, round, acting, result, created_at, updated_at
-      FROM (SELECT g.*,
-          setweight(to_tsvector(g.title), 'A') ||
-          setweight(to_tsvector(g.round), 'D') ||
-          setweight(to_tsvector(g.description), 'C') ||
-          setweight(to_tsvector(coalesce(string_agg(u.name, ' '))), 'B') as ts_vector
-         FROM games g
-         JOIN game_users gu ON g.id = gu.game_id
-         JOIN users u ON u.id = gu.user_id
-         GROUP BY g.id) g_search
-      WHERE g_search.ts_vector @@ to_tsquery(:search_string)
-      ORDER BY ts_rank(g_search.ts_vector, to_tsquery(:search_string)) DESC, updated_at DESC
-      /* WHERE g_search.ts_vector @@ to_tsquery('(183:* & (test | local2)) | !Auction') */
-    )
+  OTHER_GAMES_QUERY = <<~SQL
+    WITH user_games AS (#{USER_GAMES_IDS})
+    SELECT g.*
+    FROM games g
+    LEFT JOIN user_games ug
+      ON g.id = ug.id
+    WHERE ug.id IS NULL
+      AND g.status = :status
+      AND NOT COALESCE((settings->>'unlisted')::boolean, false)
+    ORDER BY updated_at DESC
+    LIMIT #{QUERY_LIMIT}
+    OFFSET :page * #{QUERY_LIMIT - 1}
+  SQL
 
+  PERSONAL_GAMES_SEARCH_QUERY = <<~SQL
+    WITH user_games AS (#{USER_GAMES_IDS})
+    , filtered_games AS (#{FILTERED_GAMES})
     SELECT g.*
     FROM filtered_games g
-    JOIN user_games ug
+    INNER JOIN user_games ug
+      ON g.id = ug.id
+    ORDER BY g.acting && '{:user_id}' DESC, g.updated_at DESC
+    LIMIT #{PERSONAL_QUERY_LIMIT}
+    OFFSET :page * #{PERSONAL_QUERY_LIMIT - 1}
+  SQL
+
+  PERSONAL_GAMES_QUERY = <<~SQL
+    WITH user_games AS (#{USER_GAMES_IDS})
+    SELECT g.*
+    FROM games g
+    INNER JOIN user_games ug
       ON g.id = ug.id
     WHERE g.status = :status
     ORDER BY g.acting && '{:user_id}' DESC, g.updated_at DESC
@@ -92,17 +109,17 @@ class Game < Base
       type: opts['games'] || (user ? 'personal' : 'all'),
       page: opts['p']&.to_i || 0,
       status: opts['status'] || (user ? 'active' : 'new'),
-      search_string: opts['s'] || '1:*',
+      search_string: opts['s'] || nil,
     }
     opts[:user_id] = user.id if user
 
     query =
       if user && opts[:type] == 'personal'
-        PERSONAL_GAMES_QUERY
+        opts[:search_string] ? PERSONAL_GAMES_SEARCH_QUERY : PERSONAL_GAMES_QUERY
       elsif user
-        NON_PERSONAL_GAMES_QUERY
+        opts[:search_string] ? OTHER_GAMES_SEARCH_QUERY : OTHER_GAMES_QUERY
       else
-        ALL_GAMES_QUERY
+        opts[:search_string] ? ALL_GAMES_SEARCH_QUERY : ALL_GAMES_QUERY
       end
 
     fetch(query, **opts,).all

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -31,7 +31,7 @@ button, .button_link {
   box-sizing: border-box;
   text-align: center;
 }
-button.small {
+button.small, .button_link.small {
   padding: 0.2rem 0.5rem;
   margin-right: 0.5rem;
 }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -13,11 +13,6 @@ a {
 nav a {
   text-decoration: none;
 }
-nav li {
-  float: left;
-  margin: 0 0.5rem;
-  list-style: none;
-}
 
 button, .button_link {
   font-size: 14px;
@@ -113,7 +108,13 @@ input + label, select + label {
   margin-right: 1rem;
 }
 
+nav ul {
+  margin: 0;
+  padding: 0;
+}
 nav li {
+  float: left;
+  padding: 0 0.5rem;
   list-style: none;
 }
 
@@ -199,13 +200,31 @@ nav#game_menu {
   font-weight: bold;
 }
 
-#header div {
-  display: grid;
-  grid: 1fr / 1fr auto;
+nav .submenu {
+  padding: 0.3rem 0.5rem;
 }
-nav#games, nav#main {
-  justify-self: center;
-  margin: auto 0;
+nav .submenu li {
+  float: none;
+}
+nav .submenu a {
+  display: block;
+  min-width: 5.5rem;
+}
+@media only screen and (max-width: 600px) {
+  #main_nav .menu {
+    display: none;
+  }
+  nav .submenu li {
+    padding: 0.4rem 0;
+  }
+}
+@media only screen and (min-width: 601px) {
+  #main_nav a.toggle {
+    display: none;
+  }
+  nav .submenu li {
+    padding: 0.2rem 0;
+  }
 }
 
 #profile-settings > div {

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -194,18 +194,9 @@ nav#game_menu {
   display: grid;
   grid: 1fr / 1fr auto;
 }
-#games_nav {
+nav#games, nav#main {
   justify-self: center;
-}
-
-@media only screen and (max-width: 479px) {
-  #header div {
-    grid: 2fr / auto;
-  }
-  #games_nav {
-    grid-row-start: 2;
-    justify-self: start;
-  }
+  margin: auto 0;
 }
 
 #profile-settings > div {

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -242,15 +242,6 @@ nav#game_menu {
   margin: 3px;
 }
 
-.card_header {
-  font-size: 1.2rem;
-  font-weight: bold;
-  margin: 1rem 0;
-}
-.card_header h2, #left h2 {
-  margin: 0;
-}
-
 .back {
   font-size: 1.2rem;
   font-weight: bold;

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -13,6 +13,11 @@ a {
 nav a {
   text-decoration: none;
 }
+nav li {
+  float: left;
+  margin: 0 0.5rem;
+  list-style: none;
+}
 
 button, .button_link {
   font-size: 14px;
@@ -156,7 +161,7 @@ svg {
 }
 
 nav#game_menu {
-  padding: 1rem 2vmin 1rem 2vmin;
+  padding: 1rem 2vmin calc(0.9rem + 0.5vmin) 2vmin;
 }
 /* Safari 10.1+ hack, affects most browsers on iOS => more space for scroll bar */
 @media not all and (min-resolution:.001dpcm) { @media {

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -227,9 +227,6 @@ nav .submenu a {
   }
 }
 
-#profile-settings > div {
-  margin: 0.2rem 0;
-}
 #profile-settings > div * {
   vertical-align: middle;
 }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -10,6 +10,9 @@ a {
   color: currentColor;
   text-underline-offset: 0.2em;
 }
+nav a {
+  text-decoration: none;
+}
 
 button, .button_link {
   font-size: 14px;
@@ -187,6 +190,27 @@ nav#game_menu {
   font-weight: bold;
 }
 
+#header div {
+  display: grid;
+  grid: 1fr / 1fr auto;
+}
+#games_nav {
+  justify-self: center;
+}
+
+@media only screen and (max-width: 479px) {
+  #header div {
+    grid: 2fr / auto;
+  }
+  #games_nav {
+    grid-row-start: 2;
+    justify-self: start;
+  }
+}
+
+#profile-settings > div {
+  margin: 0.2rem 0;
+}
 #profile-settings > div * {
   vertical-align: middle;
 }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -108,6 +108,10 @@ input + label, select + label {
   margin-right: 1rem;
 }
 
+nav li {
+  list-style: none;
+}
+
 p {
   margin: 0.7rem 0;
 }

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -145,7 +145,11 @@ class Api
       end
 
       r.get do
-        { games: Game.home_games(user, **r.params).map(&:to_h) }
+        games_h = Game.home_games(user, **r.params).map(&:to_h)
+      rescue Sequel::DatabaseError => e
+        e.message.match(/^PG::SyntaxError/) ? halt(400, 'Syntax error in your search query') : halt(500, e.message)
+      else
+        { games: games_h }
       end
 
       # POST '/api/game[/*]'


### PR DESCRIPTION
finally resolves #782 and #4778, fixes #3595, fixes #762

Some things that are possible with full text search are listed in the Wiki: https://github.com/tobymao/18xx/wiki/FAQ#search If this turns out to be too limited it’ll get its own page. If you have questions, please ask.

For this too work easily games are split into sections (your: active, new, archive, hotseat – all/others’: active, new, archive) and only one of these is shown. Switching is easy and possible without page reloads …
![image](https://user-images.githubusercontent.com/33390595/107808663-3cdcdb00-6d6a-11eb-81d4-2627a780d362.png)
… and from everywhere, because the top menu is sticky. (Game Menu is still able to scroll over it.) Hotkeys/Shortcuts would be possible of course. (I think) I managed to kill all other page reloads (login, profile, home etc.), too. (Snappier site!)
Search in finished games for 60 in titles only =>
![image](https://user-images.githubusercontent.com/33390595/107810117-77477780-6d6c-11eb-8336-69538176b1c6.png)

There’s for sure some optimization to be done on DB-queries, triggers and the DB-migration script.
Limit is set to 12 for testing purposes only. In regards to performance upping this to 50-ish should be no problem at all, but this would result in more scrolling especially on mobile devices. => I’d just let users decide (in a range from 12 to 48), likely by storing the limit in localStorage to allow different values per device.

No search for hotseat games as of now – and I wouldn’t prioritize implementing it.

I used `scrollIntoView()` a lot, because `#anchors` turned out to be problematic. They just don’t work (well) with a sticky menu and caused problems with url-params, too.

Fire away!