### PR TITLE
[18CZ] Limit private buy-ins by corp size

### DIFF
--- a/lib/engine/game/g_18_cz.rb
+++ b/lib/engine/game/g_18_cz.rb
@@ -126,7 +126,7 @@ module Engine
           Step::G18CZ::SellCompany,
           Step::HomeToken,
           Step::SpecialTrack,
-          Step::BuyCompany,
+          Step::G18CZ::BuyCompany,
           Step::Track,
           Step::G18CZ::Token,
           Step::Route,

--- a/lib/engine/step/g_18_cz/buy_company.rb
+++ b/lib/engine/step/g_18_cz/buy_company.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module Engine
+  module Step
+    module G18CZ
+      class BuyCompany < Base
+        def process_buy_company(action)
+          entity = action.entity
+          company = action.company
+          owner = company.owner
+
+          case entity.type
+          when :medium
+            raise GameError,
+                  "Cannot buy #{company.name} from #{owner.name}" unless company.sym.include?('M') || company.sym.include?('S')
+          when :small
+            raise GameError, "Cannot buy #{company.name} from #{owner.name}" unless company.sym.include?('S')
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_cz/buy_company.rb
+++ b/lib/engine/step/g_18_cz/buy_company.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require_relative '../base'
+require_relative '../buy_company'
 
 module Engine
   module Step
     module G18CZ
-      class BuyCompany < Base
+      class BuyCompany < BuyCompany
         def process_buy_company(action)
           entity = action.entity
           company = action.company
-          owner = company.owner
 
           case entity.type
           when :medium
-            raise GameError,
-                  "Cannot buy #{company.name} from #{owner.name}" unless company.sym.include?('M') || company.sym.include?('S')
+            unless company.sym.include?('M') || company.sym.include?('S')
+              raise GameError, "#{entity.name} can only buy #{entity.type} companies or smaller"
+            end
           when :small
-            raise GameError, "Cannot buy #{company.name} from #{owner.name}" unless company.sym.include?('S')
+            raise GameError, "#{entity.name} can only buy #{entity.type} companies" unless company.sym.include?('S')
           end
 
           super


### PR DESCRIPTION
Small corps can only buy in small privates
Med corps can buy in small/medium
Large corps can buy in any size

[Test case](https://gist.github.com/benjaminxscott/cebe98b021cf8d3c9f70ac2f31626581)

Size is denoted by `sym`, which I don't love but I also didn't want to add something like `type` to the generic private definition since this is just for CZ