### PR TITLE
[1830] fit the NYNH text in the simple logo better

### DIFF
--- a/public/logos/1830/NYNH.alt.svg
+++ b/public/logos/1830/NYNH.alt.svg
@@ -1,1 +1,1 @@
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#d88e39"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#ffffff">NYNH</text></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#d88e39"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="2.75" font-family="Arial" fill="#ffffff">NYNH</text></svg>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1711810/107842499-964c0680-6d78-11eb-9175-d6a779051055.png)


After:
![image](https://user-images.githubusercontent.com/1711810/107842485-6e5ca300-6d78-11eb-862f-560b4f891f86.png)
