### PR TITLE
status_array: option to highlight specific status strings (1860: insolvent, bankrupt etc.)

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -128,7 +128,7 @@ module View
         if @corporation.trains.any? && !@corporation.floated?
           children << h(:div, status_props, @game.float_str(@corporation))
         end
-        children << h('div.xsmall_font', status_props, @game.status_str(@corporation)) if @game.status_str(@corporation)
+        children << h(:div, status_props, @game.status_str(@corporation)) if @game.status_str(@corporation)
         if @game.status_array(@corporation)
           children << h(:div, status_array_props,
                         @game.status_array(@corporation).map { |text, klass| h("div.#{klass}", item_props, text) })

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -109,12 +109,29 @@ module View
             color: color_for(:font2),
           },
         }
+        status_array_props = {
+          style: {
+            display: 'inline-block',
+            width: '100%',
+            textAlign: 'center',
+            backgroundColor: color_for(:bg2),
+            color: color_for(:font2),
+          },
+        }
+        item_props = {
+          style: {
+            display: 'inline-block',
+            padding: '0 0.5rem',
+          },
+        }
 
         if @corporation.trains.any? && !@corporation.floated?
           children << h(:div, status_props, @game.float_str(@corporation))
         end
-        if @game.status_str(@corporation)
-          children << h('div.bold.xsmall_font', status_props, @game.status_str(@corporation))
+        children << h('div.xsmall_font', status_props, @game.status_str(@corporation)) if @game.status_str(@corporation)
+        if @game.status_array(@corporation)
+          children << h(:div, status_array_props,
+                        @game.status_array(@corporation).map { |text, klass| h("div.#{klass}", item_props, text) })
         end
 
         h('div.corp.card', { style: card_style, on: { click: select_corporation } }, children)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2222,6 +2222,8 @@ module Engine
 
       def status_str(_corporation); end
 
+      def status_array(_corporation); end
+
       # Override this, and add elements (paragraphs of text) here to display it on Info page.
       def timeline
         []

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -530,8 +530,8 @@ module Engine
                     "Par #{prices.join(', ')}"
                   end
 
-        status = [[layer_str, 'xsmall_font']]
-        status << [par_str, 'xsmall_font'] if par_str
+        status = [[layer_str]]
+        status << [par_str] if par_str
         status << %w[Insolvent bold] if insolvent?(corp)
         status << %w[Receivership bold] if corp.receivership?
         status << %w[Bankrupt bold] if bankrupt?(corp)

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -519,24 +519,25 @@ module Engine
         @nationalized_corps << corp
       end
 
-      def status_str(corp)
+      def status_array(corp)
         layer_str = "Layer #{corp_layer(corp)}"
         layer_str += ' (N/A)' unless can_ipo?(corp)
 
         prices = par_prices(corp).map(&:price).sort
         par_str = if !corp.ipoed && bankrupt?(corp)
-                    " | Par #{prices[0]}-#{prices[-1]}"
+                    "Par #{prices[0]}-#{prices[-1]}"
                   elsif !corp.ipoed
-                    " | Par #{prices.join(', ')}"
-                  else
-                    ''
+                    "Par #{prices.join(', ')}"
                   end
 
-        status = ' | Inslvt' if insolvent?(corp)
-        status = status ? status + ',Rcv' : ' | Rcv' if corp.receivership?
-        status = status ? status + ',Bkrpt' : ' | Bkrpt' if bankrupt?(corp)
-        status = status ? status + ',Nat' : ' | Nat' if nationalized?(corp)
-        layer_str + par_str + (status || '')
+        status = [[layer_str, 'xsmall_font']]
+        status << [par_str, 'xsmall_font'] if par_str
+        status << %w[Insolvent bold] if insolvent?(corp)
+        status << %w[Receivership bold] if corp.receivership?
+        status << %w[Bankrupt bold] if bankrupt?(corp)
+        status << %w[Nationalized bold] if nationalized?(corp)
+
+        status
       end
 
       def corp_hi_par(corp)


### PR DESCRIPTION
fixes #3805
This adds possibility to tag specific status strings with css-class(es) for rendering. In case of 1860 insolvent, bankrupt etc. are bold. Font size of layer + par were chosen by @roseundy.
I got rid of bold and xsmall_font on other status_strs for better legibility (and a cleaner look) as well. Afaik these changes were implemented solely because of the longer 1860 strings anyway. 18Mag and 18Chessie (2p) look fine this way and 1824 etc. should be ok, too. Status strings needing more than 1 line would wrap nicely.

I wouldn’t mind merging status_str into status_array – if that’s desirable. (=> a few lines less, but more `[ ]` of course.)

ante
![image](https://user-images.githubusercontent.com/33390595/107832159-fc905380-6d8f-11eb-9b38-490e8df63768.png)

![image](https://user-images.githubusercontent.com/33390595/107847438-dc8e7d80-6deb-11eb-9594-4efe7357b284.png).![image](https://user-images.githubusercontent.com/33390595/107847442-e1ebc800-6deb-11eb-87b3-fdbf826ba8bf.png)



post
![image](https://user-images.githubusercontent.com/33390595/107847218-f6c75c00-6de9-11eb-9691-c5e70412c86d.png)

![image](https://user-images.githubusercontent.com/33390595/107847383-5b36eb00-6deb-11eb-8cf4-8a495da0afd0.png).![image](https://user-images.githubusercontent.com/33390595/107847386-5d994500-6deb-11eb-9873-d52b1146c2b5.png)
