### PR TITLE
1893: Add more functionality related to shares, and 2nd stock round

### DIFF
--- a/lib/engine/config/game/g_1893.rb
+++ b/lib/engine/config/game/g_1893.rb
@@ -438,6 +438,8 @@ module Engine
   "corporations": [
     {
       "float_percent": 50,
+      "float_excludes_market": true,
+      "always_market_price": true,
       "name": "Dürener Eisenbahn",
       "sym": "DE",
       "tokens": [
@@ -459,6 +461,8 @@ module Engine
       "name": "Rhein-Sieg Eisenbahn",
       "sym": "RSE",
       "float_percent": 50,
+      "float_excludes_market": true,
+      "always_market_price": true,
       "tokens": [
         0,
         40,
@@ -479,6 +483,8 @@ module Engine
       "name": "Rheinbahn AG",
       "sym": "RAG",
       "float_percent": 50,
+      "float_excludes_market": true,
+      "always_market_price": true,
       "tokens": [
         0,
         40,
@@ -496,9 +502,32 @@ module Engine
       ]
     },
     {
+      "name": "Anleihen der Stadt Köln",
+      "sym": "AdSK",
+      "float_percent": 101,
+      "always_market_price": true,
+      "max_ownership_percent": 100,
+      "floatable": false,
+      "tokens": [
+      ],
+      "shares":[0, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+      "logo": "1893/AdSK",
+      "color": "gray",
+      "text_color": "white",
+      "abilities": [
+        {
+            "type": "no_buy",
+            "description": "Unbuyable until all but one privates sold"
+        }
+      ]
+    },
+    {
       "name": "AG für Verkehrswesen",
       "sym": "AGV",
       "float_percent": 50,
+      "float_excludes_market": true,
+      "always_market_price": true,
+      "floatable": false,
       "tokens": [
         100,
         100
@@ -518,6 +547,9 @@ module Engine
       "name": "Häfen und Güterverkehr Köln AG",
       "sym": "HGK",
       "float_percent": 50,
+      "float_excludes_market": true,
+      "always_market_price": true,
+      "floatable": false,
       "tokens": [
         100,
         100

--- a/lib/engine/g_18_chesapeake/share_pool.rb
+++ b/lib/engine/g_18_chesapeake/share_pool.rb
@@ -6,7 +6,7 @@ require_relative '../share_pool'
 module Engine
   module G18Chesapeake
     class SharePool < SharePool
-      def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil)
+      def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil, allow_president_change: true)
         return super unless shares
         return super unless @game.two_player?
 

--- a/lib/engine/g_18_tn/share_pool.rb
+++ b/lib/engine/g_18_tn/share_pool.rb
@@ -5,7 +5,7 @@ require_relative '../share_pool'
 module Engine
   module G18TN
     class SharePool < SharePool
-      def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil)
+      def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil, allow_president_change: true)
         super
 
         return if shares.corporation.id != 'L&N' || !@game.lnr.owner

--- a/lib/engine/game/g_1893.rb
+++ b/lib/engine/game/g_1893.rb
@@ -2,6 +2,7 @@
 
 require_relative 'base'
 require_relative '../config/game/g_1893'
+require_relative '../round/g_1893/stock'
 
 module Engine
   module Game
@@ -127,6 +128,13 @@ module Engine
         ])
       end
 
+      def stock_round
+        Round::G1893::Stock.new(self, [
+          Step::DiscardTrain,
+          Step::G1893::BuySellParSharesFollowingSR,
+        ])
+      end
+
       def operating_round(round_num)
         Round::Operating.new(self, [
           Step::Bankrupt,
@@ -141,6 +149,7 @@ module Engine
       end
 
       def float_str(entity)
+        return 'Each pay 10M per OR' if entity.name == 'AdSK'
         return super if !entity.corporation || entity.floatable
         return super unless merged_corporation?(entity)
 
@@ -150,16 +159,13 @@ module Engine
       def status_str(entity)
         return 'Minor' if entity.minor?
         return 'Exchangable corporation' if !entity.floated? && merged_corporation?(entity)
+        return 'Bond - Buy/Sell as share for set price' if entity == adsk
 
         'Corproation'
       end
 
-      def ipo_name(_entity = nil)
-        'Stock Market'
-      end
-
-      def ipo_reserved_name(_entity = nil)
-        'Reserved'
+      def adsk
+        @adsk_corporation ||= corporation_by_id('AdSK')
       end
 
       def agv
@@ -172,32 +178,32 @@ module Engine
 
       def hdsk_reserved_share
         # 10% certificate in HGK
-        @hdsk_reserved_share ||= hgk.shares[1]
+        { share: hgk.shares[1], private: company_by_id('HdSK'), minor: nil }
       end
 
       def ekb_reserved_share
         # President's certificate in AGV
-        @ekb_reserved_share ||= agv.shares[0]
+        { share: agv.shares[0], private: nil, minor: minor_by_id('EKB') }
       end
 
       def kfbe_reserved_share
         # 20% certificate in HGK
-        @kfbe_reserved_share ||= hgk.shares[2]
+        { share: hgk.shares[2], private: nil, minor: minor_by_id('KFBE') }
       end
 
       def ksz_reserved_share
         # 10% certificate in AGV
-        @ksz_reserved_share ||= agv.shares[1]
+        { share: agv.shares[1], private: nil, minor: minor_by_id('KSZ') }
       end
 
       def kbe_reserved_share
         # President's certificate in HGK
-        @kbe_reserved_share ||= hgk.shares[0]
+        { share: hgk.shares[0], private: nil, minor: minor_by_id('KBE') }
       end
 
       def bkb_reserved_share
         # 20% certificate in AGV
-        @bkb_reserved_share ||= agv.shares[2]
+        { share: agv.shares[2], private: nil, minor: minor_by_id('BKB') }
       end
 
       def merged_corporation?(corporation)
@@ -205,10 +211,17 @@ module Engine
       end
 
       def setup
-        agv.floatable = false
-        hgk.floatable = false
+        # Set up bonds to have a presidency share owned by the bank
+        # and have a set price of 100
+        adsk.shares[0].buyable = false
+        @share_pool.transfer_shares(adsk.shares[0].to_bundle, @bank)
+        bond_price = @stock_market.par_prices.find { |p| p.price == 100 }
+        @stock_market.set_par(adsk, bond_price)
+        adsk.ipoed = true
+        move_buyable_shares_to_market(adsk)
+
         [hdsk_reserved_share, ekb_reserved_share, kfbe_reserved_share, ksz_reserved_share,
-         kbe_reserved_share, bkb_reserved_share].each { |s| s.buyable = false }
+         kbe_reserved_share, bkb_reserved_share].each { |info| info[:share].buyable = false }
 
         @companies.each do |c|
           c.owner = @bank
@@ -240,10 +253,46 @@ module Engine
         raise GameError, "Cannot place a tile in #{from.hex.name} until green phase"
       end
 
-      def event_remove_tile_block
+      def event_remove_tile_block!
         @hexes
           .select { |hex| TILE_BLOCK.include?(hex.name) }
           .each { |hex| hex.tile.icons = [] }
+      end
+
+      def event_agv_buyable!
+        @log << "Unreserved #{agv.name} shares are now available to buy"
+        bond_price = @stock_market.par_prices.find { |p| p.price == 120 }
+        @stock_market.set_par(agv, bond_price)
+        move_buyable_shares_to_market(agv)
+      end
+
+      def event_agv_founded!
+        found_agv unless agv.presidents_share.buyable
+      end
+
+      def found_agv
+        @log << "#{agv.name} founded"
+        form_mergable(agv, [ekb_reserved_share, ksz_reserved_share, bkb_reserved_share])
+      end
+
+      def event_hgk_buyable!
+        @log << "Unreserved #{hgk.name} shares are now available to buy"
+        bond_price = @stock_market.par_prices.reverse.find { |p| p.price == 120 }
+        @stock_market.set_par(hgk, bond_price)
+        move_buyable_shares_to_market(hgk)
+      end
+
+      def event_hgk_founded!
+        found_hgk unless hgk.presidents_share.buyable
+      end
+
+      def found_hgk
+        @log << "#{hgk.name} founded"
+        form_mergable(hgk, [kbe_reserved_share, hdsk_reserved_share, kfbe_reserved_share])
+      end
+
+      def form_mergable(_mergable, _exchange_info)
+        @log << 'NOT YET IMPLEMENTED'
       end
 
       def buyable?(entity)
@@ -264,7 +313,28 @@ module Engine
         super
       end
 
+      def payout_companies
+        super
+
+        @players.each do |player|
+          bonds = player.num_shares_of(adsk)
+          next unless bonds.positive?
+
+          revenue = bonds * 10
+          @log << "#{player.name} collects #{format_currency(revenue)} from #{adsk.name}"
+          @bank.spend(revenue, player)
+        end
+      end
+
       private
+
+      def move_buyable_shares_to_market(corporation)
+        corporation.shares.each do |s|
+          next unless s.buyable
+
+          @share_pool.transfer_shares(s.to_bundle, @share_pool, price: 0, allow_president_change: false)
+        end
+      end
 
       def base_map
         simple_city = %w[I2 I8 L3 O2 O4 R7 T3]

--- a/lib/engine/round/g_1893/stock.rb
+++ b/lib/engine/round/g_1893/stock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../stock'
+
+module Engine
+  module Round
+    module G1893
+      class Stock < Stock
+        def sold_out?(corporation)
+          return false if corporation == @game.adsk
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -29,7 +29,7 @@ module Engine
       nil
     end
 
-    def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil)
+    def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil, allow_president_change: true)
       bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
       if @allow_president_sale && bundle.presidents_share && bundle.owner == self
         bundle = ShareBundle.new(bundle.shares, bundle.corporation.share_percent)
@@ -103,11 +103,12 @@ module Engine
           receiver: receiver,
           price: price,
           swap: swap,
-          swap_to_entity: swap ? self : nil
+          swap_to_entity: swap ? self : nil,
+          allow_president_change: allow_president_change
         )
       end
 
-      @game.float_corporation(corporation) unless floated == corporation.floated?
+      @game.float_corporation(corporation) if corporation.floatable && floated != corporation.floated?
     end
 
     def sell_shares(bundle, allow_president_change: true, swap: nil)

--- a/lib/engine/step/g_1893/buy_sell_par_shares_first_sr.rb
+++ b/lib/engine/step/g_1893/buy_sell_par_shares_first_sr.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../buy_sell_par_shares'
+require_relative 'par_and_buy_actions'
 
 module Engine
   module Step
@@ -60,6 +61,8 @@ module Engine
 
           buy_minor(minor, entity, price)
         end
+
+        include ParAndBuy
 
         private
 

--- a/lib/engine/step/g_1893/buy_sell_par_shares_following_sr.rb
+++ b/lib/engine/step/g_1893/buy_sell_par_shares_following_sr.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../buy_sell_par_shares'
+require_relative 'par_and_buy_actions'
+
+module Engine
+  module Step
+    module G1893
+      class BuySellParSharesFollowingSR < BuySellParShares
+        def can_buy?(_entity, bundle)
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_sell?(_entity, bundle)
+          return !bought? if bundle.corporation == @game.adsk
+
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_gain?(_entity, bundle, exchange: false)
+          return false if exchange
+
+          super && @game.buyable?(bundle.corporation)
+        end
+
+        def can_exchange?(_entity)
+          false
+        end
+
+        include ParAndBuy
+
+        def process_sell_shares(action)
+          if action.bundle.corporation == @game.adsk
+            sell_adsk(action.bundle)
+          else
+            # In case president's share is reserved, do not change presidency
+            allow_president_change = action.bundle.corporation.presidents_share.buyable
+            sell_shares(action.entity, action.bundle, swap: action.swap, allow_president_change: allow_president_change)
+          end
+
+          @round.last_to_act = action.entity
+          @current_actions << action
+        end
+
+        private
+
+        def sell_adsk(bundle)
+          entity = bundle.owner
+          price = bundle.price
+          @log << "#{entity.name} sell #{bundle.percent}% " \
+            "of #{bundle.corporation.name} and receives #{@game.format_currency(price)}"
+          @game.share_pool.transfer_shares(bundle,
+                                           @game.share_pool,
+                                           spender: @bank,
+                                           receiver: entity,
+                                           price: price,
+                                           allow_president_change: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1893/par_and_buy_actions.rb
+++ b/lib/engine/step/g_1893/par_and_buy_actions.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This module is used by the buy and par steps of 1893
+
+module ParAndBuy
+  def process_par(action)
+    corporation = action.corporation
+
+    super
+
+    @log << "Remaining 80% of #{corporation.name} are moved to market"
+    @game.move_buyable_shares_to_market(corporation)
+  end
+
+  def process_buy_shares(action)
+    # In case president's share is reserved, do not change presidency
+    allow_president_change = action.bundle.corporation.presidents_share.buyable
+    buy_shares(action.entity, action.bundle, swap: action.swap, allow_president_change: allow_president_change)
+    @round.last_to_act = action.entity
+    @current_actions << action
+  end
+end

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -5,10 +5,14 @@ require_relative 'base'
 module Engine
   module Step
     module ShareBuying
-      def buy_shares(entity, shares, exchange: nil, swap: nil)
+      def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true)
         raise GameError, "Cannot buy a share of #{shares&.corporation&.name}" if !can_buy?(entity, shares) && !swap
 
-        @game.share_pool.buy_shares(entity, shares, exchange: exchange, swap: swap)
+        @game.share_pool.buy_shares(entity,
+                                    shares,
+                                    exchange: exchange,
+                                    swap: swap,
+                                    allow_president_change: allow_president_change)
         corporation = shares.corporation
         @game.place_home_token(corporation) if @game.class::HOME_TOKEN_TIMING == :float && corporation.floated?
       end

--- a/public/logos/1893/AdSK.svg
+++ b/public/logos/1893/AdSK.svg
@@ -1,0 +1,4 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="50%" cy="50%" r="49%" fill="#666"/>
+ <text x="50%" y="62%" fill="#ffffff" font-family="Arial" font-size="10.667px" font-weight="700" text-anchor="middle" style="line-height:0">AdSK</text>
+</svg>


### PR DESCRIPTION
Handle bonds (AdSK) as a president less corporation that does not
change price if sold (out). Gives 10M per 10% each OR.

Parring a normal corporation moves non-reserved shares to share pool.
AdSK starts with 100% in share pool.

AGV and HGK moves 50% to share pool when they can be bought.

AdSK, and corporations with reserved presidency share, does not change
presidency if bought/sold.

Two changes in general code, both in share_pool.rb:
- Added allow_president_change parameter to buy_shares, default true
- Do not call float_corporation when share bought, in case corporation
  is not floatable (default wise all corporations are floatable)
These two changes are needed by 1824 and 1893 but should not affect
any other title as default behavior is as before.