### PR TITLE
18EU - Ports, Status Text, Event Typo Fix, Optional Trains Verified

### DIFF
--- a/lib/engine/config/game/g_18_eu.rb
+++ b/lib/engine/config/game/g_18_eu.rb
@@ -520,6 +520,12 @@ module Engine
             },
             {
                "nodes":[
+                  "offboard"
+               ],
+               "pay":2
+            },
+            {
+               "nodes":[
                   "town"
                ],
                "pay":99,
@@ -540,6 +546,12 @@ module Engine
                ],
                "pay":3,
                "visit":3
+            },
+            {
+               "nodes":[
+                  "offboard"
+               ],
+               "pay":2
             },
             {
                "nodes":[
@@ -572,6 +584,12 @@ module Engine
             },
             {
                "nodes":[
+                  "offboard"
+               ],
+               "pay":2
+            },
+            {
+               "nodes":[
                   "town"
                ],
                "pay":99,
@@ -591,6 +609,12 @@ module Engine
                ],
                "pay":5,
                "visit":5
+            },
+            {
+               "nodes":[
+                  "offboard"
+               ],
+               "pay":2
             },
             {
                "nodes":[
@@ -621,6 +645,12 @@ module Engine
             },
             {
                "nodes":[
+                  "offboard"
+               ],
+               "pay":2
+            },
+            {
+               "nodes":[
                   "town"
                ],
                "pay":99,
@@ -640,6 +670,12 @@ module Engine
                ],
                "pay":8,
                "visit":8
+            },
+            {
+               "nodes":[
+                  "offboard"
+               ],
+               "pay":2
             },
             {
                "nodes":[
@@ -672,10 +708,10 @@ module Engine
          ]
       },
       "blue":{
-         "offboard=revenue:10;path=a:0,b:_0;icon=image:port;":[
+         "offboard=revenue:10,visit_cost:0,route:optional;path=a:0,b:_0;icon=image:port;":[
             "D1"
          ],
-         "offboard=revenue:10;path=a:3,b:_0;icon=image:port;":[
+         "offboard=revenue:10,visit_cost:0,route:optional;path=a:3,b:_0;icon=image:port;":[
             "B21",
             "E22",
             "I20"

--- a/lib/engine/config/game/g_18_eu.rb
+++ b/lib/engine/config/game/g_18_eu.rb
@@ -861,7 +861,7 @@ module Engine
             "yellow"
          ],
          "status": [
-
+            "minor_limit_two"
 			],
 			"operating_rounds": 2
       },
@@ -874,7 +874,7 @@ module Engine
             "green"
          ],
          "status": [
-
+            "minor_limit_two"
 			],
 			"operating_rounds": 2
       },
@@ -887,7 +887,7 @@ module Engine
             "green"
          ],
          "status": [
-
+            "minor_limit_one"
 			],
 			"operating_rounds": 2
       },
@@ -901,7 +901,8 @@ module Engine
             "brown"
          ],
          "status": [
-
+            "minor_limit_one",
+            "normal_formation"
 			],
 			"operating_rounds": 2
       },
@@ -915,7 +916,7 @@ module Engine
             "brown"
          ],
          "status": [
-
+            "normal_formation"
 			],
 			"operating_rounds": 2
       },
@@ -930,7 +931,7 @@ module Engine
             "gray"
          ],
          "status": [
-
+            "normal_formation"
 			],
 			"operating_rounds": 2
       }

--- a/lib/engine/game/g_18_eu.rb
+++ b/lib/engine/game/g_18_eu.rb
@@ -28,11 +28,28 @@ module Engine
       TILE_LAYS = [{ lay: true, upgrade: true }].freeze
 
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(
-          'minor_exchane' => [
+          'minor_exchange' => [
             'Minor Exchange',
             'Conduct the Minor Company Final Exchange Round immediately prior to the next Stock Round.',
           ],
         ).freeze
+
+      STATUS_TEXT = Base::STATUS_TEXT.merge(
+        'minor_limit_two' => [
+          'Minor Train Limit: 2',
+          'Minor companies are limited to owning 2 trains.',
+        ],
+        'minor_limit_one' => [
+          'Minor Train Limit: 1',
+          'Minor companies are limited to owning 1 train.',
+        ],
+        'normal_formation' => [
+          'Full Capitalization',
+          'Corporations may be formed without exchanging a minor, selecting any open city. '\
+          'The five remaining shares are placed in the bank pool, with the par price paid '\
+          'to the corporation.',
+        ]
+      ).freeze
 
       OPTIONAL_RULES = [
         {

--- a/lib/engine/game/g_18_eu.rb
+++ b/lib/engine/game/g_18_eu.rb
@@ -91,7 +91,7 @@ module Engine
       def add_optional_train(type)
         modified_trains = @depot.trains.select { |t| t.name == type }
         new_train = modified_trains.first.clone
-        new_train.index = copy_this_train.length
+        new_train.index = modified_trains.length
         @depot.add_train(new_train)
       end
 

--- a/spec/fixtures/18EU/hs_uflpdrek_1613000790.json
+++ b/spec/fixtures/18EU/hs_uflpdrek_1613000790.json
@@ -1,5 +1,5 @@
 {
-  "status": "active",
+  "status": "finished",
   "actions": [
     {
       "type": "bid",
@@ -2449,6 +2449,13 @@
       "entity_type": "player",
       "id": 234,
       "created_at": 1613403227
+    },
+    {
+      "type": "end_game",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 235,
+      "created_at": 1613404057
     }
   ],
   "id": "hs_wmxytzdm_1613000790",
@@ -2476,11 +2483,15 @@
   },
   "created_at": "2021-02-14",
   "loaded": true,
-  "result": {},
+  "result": {
+    "Player 3": 360,
+    "Player 1": 330,
+    "Player 2": 290
+  },
   "turn": 2,
   "round": "Stock Round",
   "acting": [
     "Player 1"
   ],
-  "updated_at": 1613403227
+  "updated_at": 1613404057
 }

--- a/spec/fixtures/18EU/hs_uflpdrek_1613000790.json
+++ b/spec/fixtures/18EU/hs_uflpdrek_1613000790.json
@@ -1,5 +1,5 @@
 {
-  "status": "finished",
+  "status": "active",
   "actions": [
     {
       "type": "bid",
@@ -888,9 +888,1570 @@
       "entity_type": "minor",
       "id": 120,
       "created_at": 1613065995
+    },
+    {
+      "type": "undo",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 121,
+      "created_at": 1613086138
+    },
+    {
+      "type": "lay_tile",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 122,
+      "created_at": 1613086145,
+      "hex": "B9",
+      "tile": "8-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 123,
+      "created_at": 1613086149,
+      "hex": "B7",
+      "tile": "58-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 124,
+      "created_at": 1613087571,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "B7",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "A6",
+            "B7",
+            "A10"
+          ],
+          "revenue": 80,
+          "revenue_str": "A6-B7-A10"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 125,
+      "created_at": 1613323880
+    },
+    {
+      "type": "lay_tile",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 126,
+      "created_at": 1613323889,
+      "hex": "C8",
+      "tile": "201-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 127,
+      "created_at": 1613323892,
+      "hex": "D7",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 128,
+      "created_at": 1613323899,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "C8",
+              "D7"
+            ]
+          ],
+          "hexes": [
+            "D7",
+            "C8"
+          ],
+          "revenue": 50,
+          "revenue_str": "D7-C8"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 129,
+      "created_at": 1613323988
+    },
+    {
+      "type": "lay_tile",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 130,
+      "created_at": 1613323994,
+      "hex": "B11",
+      "tile": "8-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 131,
+      "created_at": 1613324001,
+      "hex": "B13",
+      "tile": "3-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 132,
+      "created_at": 1613324017,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "A10",
+              "B11",
+              "B13"
+            ]
+          ],
+          "hexes": [
+            "B13",
+            "A10"
+          ],
+          "revenue": 50,
+          "revenue_str": "B13-A10"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 133,
+      "created_at": 1613324095
+    },
+    {
+      "type": "lay_tile",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 134,
+      "created_at": 1613324112,
+      "hex": "J7",
+      "tile": "202-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 135,
+      "created_at": 1613324115,
+      "hex": "I8",
+      "tile": "58-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 136,
+      "created_at": 1613324119,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "J7",
+              "I8"
+            ]
+          ],
+          "hexes": [
+            "I8",
+            "J7"
+          ],
+          "revenue": 40,
+          "revenue_str": "I8-J7"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 137,
+      "created_at": 1613324121
+    },
+    {
+      "type": "lay_tile",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 138,
+      "created_at": 1613324132,
+      "hex": "H19",
+      "tile": "201-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 139,
+      "created_at": 1613324135,
+      "hex": "H21",
+      "tile": "8-2",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 140,
+      "created_at": 1613324140,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H19",
+              "H21",
+              "G22"
+            ]
+          ],
+          "hexes": [
+            "G22",
+            "H19"
+          ],
+          "revenue": 60,
+          "revenue_str": "G22-H19"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 141,
+      "created_at": 1613324149
+    },
+    {
+      "type": "lay_tile",
+      "entity": "6",
+      "entity_type": "minor",
+      "id": 142,
+      "created_at": 1613324156,
+      "hex": "J17",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "6",
+      "entity_type": "minor",
+      "id": 143,
+      "created_at": 1613324160,
+      "hex": "I18",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "6",
+      "entity_type": "minor",
+      "id": 144,
+      "created_at": 1613324250,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "K14",
+              "K16",
+              "J17",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "K14"
+          ],
+          "revenue": 50,
+          "revenue_str": "I18-K14"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "6",
+      "entity_type": "minor",
+      "id": 145,
+      "created_at": 1613340489
+    },
+    {
+      "type": "lay_tile",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 146,
+      "created_at": 1613340494,
+      "hex": "K4",
+      "tile": "58-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 147,
+      "created_at": 1613340496,
+      "hex": "L5",
+      "tile": "4-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 148,
+      "created_at": 1613340500,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "J5",
+              "K4"
+            ]
+          ],
+          "hexes": [
+            "L5",
+            "K4",
+            "J5"
+          ],
+          "revenue": 50,
+          "revenue_str": "L5-K4-J5"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 149,
+      "created_at": 1613340545
+    },
+    {
+      "type": "lay_tile",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 150,
+      "created_at": 1613340556,
+      "hex": "M16",
+      "tile": "202-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 151,
+      "created_at": 1613340560,
+      "hex": "M14",
+      "tile": "8-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 152,
+      "created_at": 1613340570,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "M16",
+              "N17"
+            ]
+          ],
+          "hexes": [
+            "N17",
+            "M16"
+          ],
+          "revenue": 60,
+          "revenue_str": "N17-M16"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 153,
+      "created_at": 1613340571
+    },
+    {
+      "type": "lay_tile",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 154,
+      "created_at": 1613340582,
+      "hex": "I6",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 155,
+      "created_at": 1613340585,
+      "hex": "H7",
+      "tile": "3-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 156,
+      "created_at": 1613340591,
+      "routes": [
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "I8",
+              "J7"
+            ],
+            [
+              "H7",
+              "I8"
+            ],
+            [
+              "J5",
+              "I6",
+              "H7"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I8",
+            "H7",
+            "J5"
+          ],
+          "revenue": 80,
+          "revenue_str": "J7-I8-H7-J5"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 157,
+      "created_at": 1613340607
+    },
+    {
+      "type": "lay_tile",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 158,
+      "created_at": 1613340614,
+      "hex": "E18",
+      "tile": "202-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 159,
+      "created_at": 1613340619,
+      "hex": "E20",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 160,
+      "created_at": 1613340627,
+      "routes": [
+        {
+          "train": "2-9",
+          "connections": [
+            [
+              "E18",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "E18"
+          ],
+          "revenue": 50,
+          "revenue_str": "E20-E18"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 161,
+      "created_at": 1613340628
+    },
+    {
+      "type": "lay_tile",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 162,
+      "created_at": 1613340633,
+      "hex": "K12",
+      "tile": "58-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 163,
+      "created_at": 1613340636,
+      "hex": "J11",
+      "tile": "57-3",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 164,
+      "created_at": 1613340640,
+      "routes": [
+        {
+          "train": "2-10",
+          "connections": [
+            [
+              "K12",
+              "J11"
+            ],
+            [
+              "K14",
+              "K12"
+            ]
+          ],
+          "hexes": [
+            "J11",
+            "K12",
+            "K14"
+          ],
+          "revenue": 60,
+          "revenue_str": "J11-K12-K14"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 165,
+      "created_at": 1613340642
+    },
+    {
+      "type": "lay_tile",
+      "entity": "12",
+      "entity_type": "minor",
+      "id": 166,
+      "created_at": 1613340646,
+      "hex": "D3",
+      "tile": "202-3",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "12",
+      "entity_type": "minor",
+      "id": 167,
+      "created_at": 1613340649,
+      "hex": "C4",
+      "tile": "3-2",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "12",
+      "entity_type": "minor",
+      "id": 168,
+      "created_at": 1613340654,
+      "routes": [
+        {
+          "train": "2-11",
+          "connections": [
+            [
+              "D3",
+              "C4"
+            ]
+          ],
+          "hexes": [
+            "C4",
+            "D3"
+          ],
+          "revenue": 40,
+          "revenue_str": "C4-D3"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "12",
+      "entity_type": "minor",
+      "id": 169,
+      "created_at": 1613340655
+    },
+    {
+      "type": "lay_tile",
+      "entity": "13",
+      "entity_type": "minor",
+      "id": 170,
+      "created_at": 1613340668,
+      "hex": "G12",
+      "tile": "202-4",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "13",
+      "entity_type": "minor",
+      "id": 171,
+      "created_at": 1613340673,
+      "hex": "G10",
+      "tile": "58-4",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "13",
+      "entity_type": "minor",
+      "id": 172,
+      "created_at": 1613340682,
+      "routes": [
+        {
+          "train": "2-12",
+          "connections": [
+            [
+              "G12",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "G12"
+          ],
+          "revenue": 40,
+          "revenue_str": "G10-G12"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "13",
+      "entity_type": "minor",
+      "id": 173,
+      "created_at": 1613340684
+    },
+    {
+      "type": "lay_tile",
+      "entity": "14",
+      "entity_type": "minor",
+      "id": 174,
+      "created_at": 1613340698,
+      "hex": "D13",
+      "tile": "202-5",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "14",
+      "entity_type": "minor",
+      "id": 175,
+      "created_at": 1613340701,
+      "hex": "E12",
+      "tile": "4-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "14",
+      "entity_type": "minor",
+      "id": 176,
+      "created_at": 1613340707,
+      "routes": [
+        {
+          "train": "2-13",
+          "connections": [
+            [
+              "D13",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "D13"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-D13"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "14",
+      "entity_type": "minor",
+      "id": 177,
+      "created_at": 1613340715
+    },
+    {
+      "type": "lay_tile",
+      "entity": "15",
+      "entity_type": "minor",
+      "id": 178,
+      "created_at": 1613340722,
+      "hex": "B17",
+      "tile": "202-6",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "15",
+      "entity_type": "minor",
+      "id": 179,
+      "created_at": 1613340725,
+      "hex": "B19",
+      "tile": "57-4",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "15",
+      "entity_type": "minor",
+      "id": 180,
+      "created_at": 1613340730,
+      "routes": [
+        {
+          "train": "2-14",
+          "connections": [
+            [
+              "B17",
+              "B19"
+            ]
+          ],
+          "hexes": [
+            "B19",
+            "B17"
+          ],
+          "revenue": 50,
+          "revenue_str": "B19-B17"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "15",
+      "entity_type": "minor",
+      "id": 181,
+      "created_at": 1613340790
+    },
+    {
+      "type": "pass",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 182,
+      "created_at": 1613340809
+    },
+    {
+      "type": "run_routes",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 183,
+      "created_at": 1613340811,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "B7",
+              "A6"
+            ],
+            [
+              "A10",
+              "B9",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "A6",
+            "B7",
+            "A10"
+          ],
+          "revenue": 90,
+          "revenue_str": "A6-B7-A10"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 184,
+      "created_at": 1613340860
+    },
+    {
+      "type": "pass",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 185,
+      "created_at": 1613340860
+    },
+    {
+      "type": "run_routes",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 186,
+      "created_at": 1613340862,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "C8",
+              "D7"
+            ]
+          ],
+          "hexes": [
+            "C8",
+            "D7"
+          ],
+          "revenue": 50,
+          "revenue_str": "C8-D7"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 187,
+      "created_at": 1613340863
+    },
+    {
+      "type": "pass",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 188,
+      "created_at": 1613340864
+    },
+    {
+      "type": "undo",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 189,
+      "created_at": 1613340868
+    },
+    {
+      "type": "lay_tile",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 190,
+      "created_at": 1613340874,
+      "hex": "C12",
+      "tile": "8-4",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 191,
+      "created_at": 1613340877,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "A10",
+              "B11",
+              "B13"
+            ],
+            [
+              "B13",
+              "C12",
+              "D13"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "B13",
+            "D13"
+          ],
+          "revenue": 80,
+          "revenue_str": "A10-B13-D13"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 192,
+      "created_at": 1613340878
+    },
+    {
+      "type": "pass",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 193,
+      "created_at": 1613341172
+    },
+    {
+      "type": "run_routes",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 194,
+      "created_at": 1613341177,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "J7",
+              "I8"
+            ],
+            [
+              "I8",
+              "H7"
+            ],
+            [
+              "H7",
+              "I6",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I8",
+            "H7",
+            "J5"
+          ],
+          "revenue": 80,
+          "revenue_str": "J7-I8-H7-J5"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 195,
+      "created_at": 1613341178
+    },
+    {
+      "type": "lay_tile",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 196,
+      "created_at": 1613341189,
+      "hex": "G20",
+      "tile": "4-2",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 197,
+      "created_at": 1613341195,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H19",
+              "G20"
+            ],
+            [
+              "H19",
+              "H21",
+              "G22"
+            ]
+          ],
+          "hexes": [
+            "G20",
+            "H19",
+            "G22"
+          ],
+          "revenue": 70,
+          "revenue_str": "G20-H19-G22"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 198,
+      "created_at": 1613341196
+    },
+    {
+      "type": "pass",
+      "entity": "6",
+      "entity_type": "minor",
+      "id": 199,
+      "created_at": 1613341201
+    },
+    {
+      "type": "run_routes",
+      "entity": "6",
+      "entity_type": "minor",
+      "id": 200,
+      "created_at": 1613341205,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "K14",
+              "K16",
+              "J17",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "K14",
+            "I18"
+          ],
+          "revenue": 50,
+          "revenue_str": "K14-I18"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "6",
+      "entity_type": "minor",
+      "id": 201,
+      "created_at": 1613341217
+    },
+    {
+      "type": "lay_tile",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 202,
+      "created_at": 1613341224,
+      "hex": "M6",
+      "tile": "8-5",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 203,
+      "created_at": 1613341226,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "L5",
+              "M6",
+              "N5"
+            ],
+            [
+              "K4",
+              "L5"
+            ],
+            [
+              "J5",
+              "K4"
+            ]
+          ],
+          "hexes": [
+            "N5",
+            "L5",
+            "K4",
+            "J5"
+          ],
+          "revenue": 70,
+          "revenue_str": "N5-L5-K4-J5"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 204,
+      "created_at": 1613341307
+    },
+    {
+      "type": "lay_tile",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 205,
+      "created_at": 1613341324,
+      "hex": "L13",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 206,
+      "created_at": 1613341329,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "M16",
+              "N17"
+            ]
+          ],
+          "hexes": [
+            "M16",
+            "N17"
+          ],
+          "revenue": 60,
+          "revenue_str": "M16-N17"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 207,
+      "created_at": 1613341332
+    },
+    {
+      "type": "pass",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 208,
+      "created_at": 1613341336
+    },
+    {
+      "type": "run_routes",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 209,
+      "created_at": 1613341338,
+      "routes": [
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "I8",
+              "J7"
+            ],
+            [
+              "H7",
+              "I8"
+            ],
+            [
+              "J5",
+              "I6",
+              "H7"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I8",
+            "H7",
+            "J5"
+          ],
+          "revenue": 80,
+          "revenue_str": "J7-I8-H7-J5"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 210,
+      "created_at": 1613341341
+    },
+    {
+      "type": "pass",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 211,
+      "created_at": 1613341346
+    },
+    {
+      "type": "run_routes",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 212,
+      "created_at": 1613344252,
+      "routes": [
+        {
+          "train": "2-9",
+          "connections": [
+            [
+              "E20",
+              "E18"
+            ],
+            [
+              "E20",
+              "E22"
+            ]
+          ],
+          "hexes": [
+            "E18",
+            "E20",
+            "E22"
+          ],
+          "revenue": 60,
+          "revenue_str": "E18-E20-E22"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 213,
+      "created_at": 1613344255
+    },
+    {
+      "type": "pass",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 214,
+      "created_at": 1613344259
+    },
+    {
+      "type": "run_routes",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 215,
+      "created_at": 1613344262,
+      "routes": [
+        {
+          "train": "2-10",
+          "connections": [
+            [
+              "K12",
+              "J11"
+            ],
+            [
+              "K14",
+              "K12"
+            ]
+          ],
+          "hexes": [
+            "J11",
+            "K12",
+            "K14"
+          ],
+          "revenue": 60,
+          "revenue_str": "J11-K12-K14"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 216,
+      "created_at": 1613345655
+    },
+    {
+      "type": "lay_tile",
+      "entity": "12",
+      "entity_type": "minor",
+      "id": 217,
+      "created_at": 1613345660,
+      "hex": "D5",
+      "tile": "3-3",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "12",
+      "entity_type": "minor",
+      "id": 218,
+      "created_at": 1613345666,
+      "routes": [
+        {
+          "train": "2-11",
+          "connections": [
+            [
+              "D3",
+              "D1"
+            ],
+            [
+              "D3",
+              "C4"
+            ],
+            [
+              "C4",
+              "D5"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "C4",
+            "D5"
+          ],
+          "revenue": 60,
+          "revenue_str": "D1-D3-C4-D5"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "12",
+      "entity_type": "minor",
+      "id": 219,
+      "created_at": 1613345669
+    },
+    {
+      "type": "lay_tile",
+      "entity": "13",
+      "entity_type": "minor",
+      "id": 220,
+      "created_at": 1613345686,
+      "hex": "F9",
+      "tile": "57-5",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "13",
+      "entity_type": "minor",
+      "id": 221,
+      "created_at": 1613345689,
+      "routes": [
+        {
+          "train": "2-12",
+          "connections": [
+            [
+              "G12",
+              "G10"
+            ],
+            [
+              "G10",
+              "F9"
+            ]
+          ],
+          "hexes": [
+            "G12",
+            "G10",
+            "F9"
+          ],
+          "revenue": 60,
+          "revenue_str": "G12-G10-F9"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "13",
+      "entity_type": "minor",
+      "id": 222,
+      "created_at": 1613345690
+    },
+    {
+      "type": "lay_tile",
+      "entity": "14",
+      "entity_type": "minor",
+      "id": 223,
+      "created_at": 1613345700,
+      "hex": "F11",
+      "tile": "3-4",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "14",
+      "entity_type": "minor",
+      "id": 224,
+      "created_at": 1613345706,
+      "routes": [
+        {
+          "train": "2-13",
+          "connections": [
+            [
+              "B13",
+              "B11",
+              "A10"
+            ],
+            [
+              "D13",
+              "C12",
+              "B13"
+            ],
+            [
+              "D13",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "B13",
+            "D13",
+            "E12",
+            "F11"
+          ],
+          "revenue": 100,
+          "revenue_str": "A10-B13-D13-E12-F11"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "14",
+      "entity_type": "minor",
+      "id": 225,
+      "created_at": 1613401575
+    },
+    {
+      "type": "lay_tile",
+      "entity": "15",
+      "entity_type": "minor",
+      "id": 226,
+      "created_at": 1613401584,
+      "hex": "C16",
+      "tile": "4-3",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "15",
+      "entity_type": "minor",
+      "id": 227,
+      "created_at": 1613401591,
+      "routes": [
+        {
+          "train": "2-14",
+          "connections": [
+            [
+              "B17",
+              "C16"
+            ],
+            [
+              "B19",
+              "B17"
+            ],
+            [
+              "B21",
+              "B19"
+            ]
+          ],
+          "hexes": [
+            "C16",
+            "B17",
+            "B19",
+            "B21"
+          ],
+          "revenue": 70,
+          "revenue_str": "C16-B17-B19-B21"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "15",
+      "entity_type": "minor",
+      "id": 228,
+      "created_at": 1613401601
+    },
+    {
+      "type": "par",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1613403216,
+      "corporation": "BNR",
+      "share_price": "70,4,2"
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 230,
+      "created_at": 1613403219
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 231,
+      "created_at": 1613403219
+    },
+    {
+      "type": "undo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 232,
+      "created_at": 1613403223
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 233,
+      "created_at": 1613403225
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 234,
+      "created_at": 1613403227
     }
   ],
-  "id": "hs_uflpdrek_1613000790",
+  "id": "hs_wmxytzdm_1613000790",
   "players": [
     {
       "name": "Player 1"
@@ -903,7 +2464,7 @@
     }
   ],
   "title": "18EU",
-  "description": "18EU Auction Test Fixture - Update as progress is made.",
+  "description": "Cloned from game hs_uflpdrek_1613000790",
   "max_players": "3",
   "settings": {
     "optional_rules": []
@@ -913,17 +2474,13 @@
     "id": 0,
     "name": "You"
   },
-  "created_at": "2021-02-10",
+  "created_at": "2021-02-14",
   "loaded": true,
-  "result": {
-    "Player 3": 60,
-    "Player 2": 0,
-    "Player 1": 0
-  },
-  "turn": 1,
-  "round": "Operating Round",
+  "result": {},
+  "turn": 2,
+  "round": "Stock Round",
   "acting": [
     "Player 1"
   ],
-  "updated_at": 1613065995
+  "updated_at": 1613403227
 }


### PR DESCRIPTION
By adding the additional "pay" to the trains and "visit_cost": 0 to the hexes we can tack on the ports for free as endpoints.