### PR TITLE
Developing on Fedora

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,6 +97,15 @@ Compose documentation:
 - https://docs.docker.com/compose/
 - https://docs.docker.com/compose/compose-file/
 
+#### Can I use [Podman](https://podman.io/) instead of Docker?
+
+Yes.
+
+```
+make CONTAINER_ENGINE=podman …
+```
+
+
 #### Before filing a pull request
 
 Run `docker-compose exec rack rake` while a docker instance is running to run rubocop (to ensure your changes meet the project's code style guidelines) as well as the test suite.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 .DEFAULT_GOAL := dev_up_b
+CONTAINER_COMPOSE ?= $(CONTAINER_ENGINE)-compose
+CONTAINER_ENGINE ?= docker
 
 clean:
 	sudo rm -rfv build/ public/assets/app.js public/assets/deps.js public/assets/engine.js public/assets/main.js public/assets/main.js.gz public/assets/opal.js
@@ -8,7 +10,7 @@ cleandeps:
 
 # ensure ./db/data exists and is not owned by root
 data_dir:
-	./scripts/data_dir.sh
+	./scripts/data_dir.sh $(CONTAINER_ENGINE)
 
 # ensure the required environment variables exist when running with prod config
 ensure_prod_env:
@@ -24,30 +26,30 @@ prod_link : clean_link
 
 # dev config, run locally
 dev_build : dev_link data_dir
-	docker-compose build
+	$(CONTAINER_COMPOSE) build
 dev_up : dev_link data_dir
-	docker-compose up
+	$(CONTAINER_COMPOSE) up
 dev_up_b : dev_link data_dir
-	docker-compose up --build
+	$(CONTAINER_COMPOSE) up --build
 
 # prod config, run locally
 prod_build : prod_link data_dir ensure_prod_env
-	docker-compose build
+	$(CONTAINER_COMPOSE) build
 prod_up : prod_link data_dir ensure_prod_env
-	docker-compose up
+	$(CONTAINER_COMPOSE) up
 prod_up_b : prod_link data_dir ensure_prod_env
-	docker-compose up --build
+	$(CONTAINER_COMPOSE) up --build
 prod_up_b_d : prod_link data_dir ensure_prod_env
-	docker-compose up --build --detach
+	$(CONTAINER_COMPOSE) up --build --detach
 prod_rack_up_b_d : prod_link data_dir ensure_prod_env
-	docker-compose up --build --no-deps --detach rack && \
-		docker-compose up --build --no-deps --detach queue && \
+	$(CONTAINER_COMPOSE) up --build --no-deps --detach rack && \
+		$(CONTAINER_COMPOSE) up --build --no-deps --detach queue && \
 		sleep 20 && \
-		docker-compose up --build --no-deps --detach rack_backup
+		$(CONTAINER_COMPOSE) up --build --no-deps --detach rack_backup
 
 # remotely deploy latest master in prod
 prod_deploy :
-	docker-compose run rack rake precompile && \
+	$(CONTAINER_COMPOSE) run rack rake precompile && \
 		scp public/assets/main.js \
 		public/assets/main.js.gz \
 		public/assets/version.json \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ x-rack: &rack
     RACK_ENV: development
     RUBYOPTS: --jit
   volumes:
-    - .:/18xx
+    - .:/18xx:z
     - /18xx/vendor
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   db:
     build: ./db/
     volumes:
-      - ./db/data:/var/lib/postgresql/data
+      - ./db/data:/var/lib/postgresql/data:Z
     ports:
       - 127.0.0.1:5433:5432
     logging:

--- a/scripts/data_dir.sh
+++ b/scripts/data_dir.sh
@@ -12,6 +12,17 @@
 #   like ./db/data/.keep is checked into the repo, it will error out instead of
 #   initializing properly
 
+umask 0077
 mkdir -p db/data
 
-[ $(ls -l db/ | grep data | awk '{print $3}' | head -1) = 'root' ] && sudo chown -R $USER:$USER db/data || true
+if [[ $1 == 'podman' ]]; then
+  db_uid=1000
+  mapped_db_uid=$(($(grep "^$USER:" /etc/subuid | cut -d: -f2) - 1 + db_uid))
+  if [[ $(stat --format=%u db/data) -ne $mapped_db_uid ]]; then
+    sudo chown -R $mapped_db_uid:$mapped_db_uid db/data
+  fi
+else
+  if [[ $(stat --format=%U db/data) == 'root' ]]; then
+    sudo chown -R "$USER":"$USER" db/data
+  fi
+fi


### PR DESCRIPTION
This pull request makes some changes to allow the development environment to run on Fedora.

- Docker doesn’t yet support Control Group v2 so doesn’t run out of the box on Fedora.  Allow Podman to be used instead.
- By default, Podman runs as the user rather than as root, and maps UIDs within the container to different UIDs outside the container.  Apply this mapping when creating the db/data/ directory.
- Fedora use SELinux by default, which means we need to relabel some volumes to allow them to be accessed from within the containers.

This was sufficient for me to be able to run `make` and access http://localhost:9292/.  I haven’t tried running any of this on a non-Fedora system, so it’s probably worth doing that before merging.