### PR TITLE
18EU - Minor Merge on Par and Minor Exchange for Share

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -133,7 +133,7 @@ module View
       # Allow privates or minors to be exchanged for shares if they have the ability
       def render_exchanges
         children = []
-        source_entities = [*@game.companies, *@game.minors]
+        source_entities = @game.companies + @game.minors
 
         source_entities.each do |entity|
           @game.abilities(entity, :exchange) do |ability|

--- a/lib/engine/config/game/g_18_eu.rb
+++ b/lib/engine/config/game/g_18_eu.rb
@@ -335,7 +335,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"2",
@@ -346,7 +354,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"3",
@@ -358,7 +374,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"4",
@@ -370,7 +394,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"5",
@@ -382,7 +414,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"6",
@@ -394,7 +434,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"7",
@@ -406,7 +454,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"8",
@@ -418,7 +474,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"9",
@@ -430,7 +494,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"10",
@@ -442,7 +514,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"11",
@@ -454,7 +534,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"12",
@@ -466,7 +554,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"13",
@@ -478,7 +574,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"14",
@@ -490,7 +594,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       },
       {
          "sym":"15",
@@ -502,7 +614,15 @@ module Engine
             0
          ],
          "color":"black",
-         "text_color":"white"
+         "text_color":"white",
+         "abilities": [
+            {
+               "type": "exchange",
+               "corporations": ["BNR", "DR", "FS", "RBSR", "RPR", "AIRS", "SNCF", "GSR"],
+               "owner_type": "player",
+               "from": "ipo"
+            }
+         ]
       }
    ],
    "trains":[

--- a/lib/engine/step/g_18_eu/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_18_eu/buy_sell_par_shares.rb
@@ -1,12 +1,50 @@
 # frozen_string_literal: true
 
 require_relative '../buy_sell_par_shares'
+require_relative 'minor_exchange'
 
 module Engine
   module Step
     module G18EU
       class BuySellParShares < BuySellParShares
-        # TODO: Implement Exchange of Minor for Share
+        include MinorExchange
+
+        def actions(entity)
+          actions = super
+
+          actions << 'buy_shares' if entity.minor?
+
+          actions
+        end
+
+        def process_buy_shares(action)
+          entity = action.entity
+          if entity.minor?
+            exchange_minor(entity, action.bundle)
+            entity = entity.owner
+          else
+            buy_shares(entity, action.bundle)
+          end
+
+          @round.last_to_act = entity
+          @current_actions << action
+        end
+
+        def exchange_minor(minor, bundle)
+          corporation = bundle.corporation
+          unless can_gain?(minor.owner, bundle, exchange: true)
+            raise GameError, "#{minor.name} cannot be exchanged for #{corporation.name}"
+          end
+
+          exchange_share(minor, corporation)
+          merge_minor!(minor, bundle.corporation)
+        end
+
+        def can_gain?(entity, bundle, exchange: false)
+          return false if exchange && !bundle.corporation.ipoed
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/step/g_18_eu/home_token.rb
+++ b/lib/engine/step/g_18_eu/home_token.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../home_token'
+require_relative 'minor_exchange'
+
+module Engine
+  module Step
+    module G18EU
+      class HomeToken < HomeToken
+        include MinorExchange
+
+        def process_place_token(action)
+          minor_to_merge = find_minor(action.city, action.entity.owner)
+          exchange_share(minor_to_merge, action.entity) if minor_to_merge
+          merge_minor!(minor_to_merge, action.entity) if minor_to_merge
+
+          super
+        end
+
+        def can_replace_token?(entity, replace_token)
+          @game.home_token_locations(entity).include?(replace_token.city.hex)
+        end
+
+        def find_minor(city, player)
+          @game.minors.find do |minor|
+            next unless minor.owner == player
+            next unless minor.tokens.first.city == city
+
+            minor
+          end
+        end
+
+        def can_buy?(entity, bundle)
+          return unless bundle&.buyable
+
+          can_gain?(entity, bundle)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_18_eu/minor_exchange.rb
+++ b/lib/engine/step/g_18_eu/minor_exchange.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative '../share_buying'
+
+module Engine
+  module Step
+    module G18EU
+      module MinorExchange
+        include ShareBuying
+
+        def merge_minor!(minor, corporation)
+          minor.tokens.first.remove!
+
+          transfer_treasury(minor, corporation)
+          transfer_trains(minor, corporation)
+
+          @game.close_corporation(minor, quiet: false)
+          minor.close!
+        end
+
+        def exchange_share(minor, corporation)
+          @game.log << "#{minor.owner.name} exchanges #{minor.name} for a "\
+            "10% share of #{corporation.name}"
+
+          buy_shares(minor.owner, corporation.ipo_shares.first.to_bundle, exchange: true)
+        end
+
+        def transfer_treasury(source, destination)
+          return unless source.cash.positive?
+
+          @game.log << "#{destination.name} takes #{@game.format_currency(source.cash)}"\
+                       " from #{source.name} remaining cash"
+
+          source.spend(source.cash, destination)
+        end
+
+        def transfer_trains(source, destination)
+          return unless source.trains.any?
+
+          transferred = @game.transfer(:trains, source, destination)
+
+          @game.log << "#{destination.name} takes #{transferred.map(&:name).join(', ')}"\
+                       " train#{transferred.one? ? '' : 's'} from #{source.name}"
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/home_token.rb
+++ b/lib/engine/step/home_token.rb
@@ -64,7 +64,9 @@ module Engine
       def process_place_token(action)
         # the action is faked and doesn't represent the actual token laid
         hex = action.city.hex
-        raise GameError, "Cannot place token on #{hex.name}" unless available_hex(action.entity, hex)
+        unless available_hex(action.entity, hex)
+          raise GameError, "Cannot place token on #{hex.name} as the hex is not available"
+        end
 
         place_token(
           token.corporation,

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -14,7 +14,10 @@ module Engine
                                     swap: swap,
                                     allow_president_change: allow_president_change)
         corporation = shares.corporation
-        @game.place_home_token(corporation) if @game.class::HOME_TOKEN_TIMING == :float && corporation.floated?
+        if (@game.class::HOME_TOKEN_TIMING == :float && corporation.floated?) ||
+            (@game.class::HOME_TOKEN_TIMING == :par && corporation.ipoed)
+          @game.place_home_token(corporation)
+        end
       end
 
       # Returns if a share can be gained by an entity respecting the cert limit

--- a/spec/fixtures/18EU/hs_uflpdrek_1613000790.json
+++ b/spec/fixtures/18EU/hs_uflpdrek_1613000790.json
@@ -2456,6 +2456,442 @@
       "entity_type": "player",
       "id": 235,
       "created_at": 1613404057
+    },
+    {
+      "type": "undo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 236,
+      "created_at": 1613404080
+    },
+    {
+      "type": "par",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 237,
+      "created_at": 1613405008,
+      "corporation": "BNR",
+      "share_price": "70,4,2"
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 238,
+      "created_at": 1613405032
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 239,
+      "created_at": 1613405032
+    },
+    {
+      "type": "undo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 240,
+      "created_at": 1613406962
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 241,
+      "created_at": 1613406963
+    },
+    {
+      "type": "place_token",
+      "entity": "BNR",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1613412176,
+      "city": "202-5-0",
+      "slot": 0
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 243,
+      "created_at": 1613412191
+    },
+    {
+      "type": "place_token",
+      "entity": "BNR",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1613412220,
+      "city": "202-5-0",
+      "slot": 0
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 245,
+      "created_at": 1613412233
+    },
+    {
+      "type": "undo",
+      "entity": "BNR",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1613412370
+    },
+    {
+      "type": "redo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 247,
+      "created_at": 1613412371
+    },
+    {
+      "type": "place_token",
+      "entity": "BNR",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1613413179,
+      "city": "202-5-0",
+      "slot": 0
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 249,
+      "created_at": 1613413207
+    },
+    {
+      "type": "place_token",
+      "entity": "BNR",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1613413215,
+      "city": "K14-0-0",
+      "slot": 0
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 251,
+      "created_at": 1613413223
+    },
+    {
+      "type": "place_token",
+      "entity": "BNR",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1613413509,
+      "city": "202-0-0",
+      "slot": 0
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 253,
+      "created_at": 1613415351
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 254,
+      "created_at": 1613415351
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 255,
+      "created_at": 1613415353,
+      "shares": [
+        "BNR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 256,
+      "created_at": 1613415355
+    },
+    {
+      "type": "undo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 257,
+      "created_at": 1613416598
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 258,
+      "created_at": 1613416599
+    },
+    {
+      "type": "buy_shares",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 259,
+      "created_at": 1613419837,
+      "shares": [
+        "BNR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 260,
+      "created_at": 1613419919,
+      "shares": [
+        "BNR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "undo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 261,
+      "created_at": 1613419925
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 262,
+      "created_at": 1613419932
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 263,
+      "created_at": 1613419933
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 264,
+      "created_at": 1613419933
+    },
+    {
+      "type": "undo",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 265,
+      "created_at": 1613419939
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 266,
+      "created_at": 1613419943,
+      "shares": [
+        "BNR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 267,
+      "created_at": 1613419945
+    },
+    {
+      "type": "pass",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 268,
+      "created_at": 1613419946
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 269,
+      "created_at": 1613419946
+    },
+    {
+      "type": "end_game",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 270,
+      "created_at": 1613420036
+    },
+    {
+      "type": "undo",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 271,
+      "created_at": 1613421555
+    },
+    {
+      "type": "undo",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 272,
+      "created_at": 1613421557
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 273,
+      "created_at": 1613421558
+    },
+    {
+      "type": "undo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 274,
+      "created_at": 1613421559
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 275,
+      "created_at": 1613421561
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 276,
+      "created_at": 1613421567
+    },
+    {
+      "type": "buy_shares",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 277,
+      "created_at": 1613422843,
+      "shares": [
+        "BNR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 278,
+      "created_at": 1613422850
+    },
+    {
+      "type": "undo",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 279,
+      "created_at": 1613423129
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 280,
+      "created_at": 1613423130
+    },
+    {
+      "type": "buy_shares",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 281,
+      "created_at": 1613423134,
+      "shares": [
+        "BNR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 282,
+      "created_at": 1613423140
+    },
+    {
+      "type": "undo",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 283,
+      "created_at": 1613423175
+    },
+    {
+      "type": "redo",
+      "entity": "BNR",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1613423177
+    },
+    {
+      "type": "buy_shares",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 285,
+      "created_at": 1613423181,
+      "shares": [
+        "BNR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "end_game",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 286,
+      "created_at": 1613423326
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 287,
+      "created_at": 1613423363
+    },
+    {
+      "type": "undo",
+      "entity": "Player 3",
+      "entity_type": "player",
+      "id": 288,
+      "created_at": 1613423373
+    },
+    {
+      "type": "pass",
+      "entity": "Player 2",
+      "entity_type": "player",
+      "id": 289,
+      "created_at": 1613423382
+    },
+    {
+      "type": "buy_shares",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 290,
+      "created_at": 1613423385,
+      "shares": [
+        "BNR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "end_game",
+      "entity": "Player 1",
+      "entity_type": "player",
+      "id": 291,
+      "created_at": 1613423408
     }
   ],
   "id": "hs_wmxytzdm_1613000790",
@@ -2484,8 +2920,8 @@
   "created_at": "2021-02-14",
   "loaded": true,
   "result": {
-    "Player 3": 360,
-    "Player 1": 330,
+    "Player 3": 430,
+    "Player 1": 400,
     "Player 2": 290
   },
   "turn": 2,
@@ -2493,5 +2929,5 @@
   "acting": [
     "Player 1"
   ],
-  "updated_at": 1613404057
+  "updated_at": 1613423408
 }


### PR DESCRIPTION
### Background

From: https://github.com/tobymao/18xx/issues/792

If it is before Phase 5, president also needs to trade a minor for one share of the new company and take the minor’s home for the corp home. If it is after phase 5, this is not required (the minors will be gone), but the corp must choose any open city circle on the board.

During the SR a company forms, a player may choose to exchange a _connected_ minor or a 10% share instead of a buy action. It is a straight swap, give assets to corp (_bank if pool share_). _Corp may accept or reject token._

Note: This does not implement the "connected" or "bank if pool share" or "accept or reject tokens" portions of the rules.

### Shared file changes

**buy_sell_shares.rb**

Adds minors to the list of entities that can have the exchange ability. Most of the changes are simply the word company to entity.

**home_token.rb**

A small update to the error text to allow easier finding of the error when it happens.

**share_buying.rb**

Added new home placement timing of **:par**

---

Choosing a Minor to replace with a corporation:

<img width="781" alt="Screen Shot 2021-02-15 at 1 47 42 PM" src="https://user-images.githubusercontent.com/15675400/107992612-4b0f3f00-6f96-11eb-84d7-f5ee414c3ee9.png">

<img width="244" alt="Screen Shot 2021-02-15 at 2 02 43 PM" src="https://user-images.githubusercontent.com/15675400/107992735-8ad62680-6f96-11eb-8376-075105278049.png">


Exchanging Minors for shares:

<img width="330" alt="Screen Shot 2021-02-15 at 2 12 00 PM" src="https://user-images.githubusercontent.com/15675400/107993510-cfae8d00-6f97-11eb-8aec-267dff525a86.png">

<img width="376" alt="Screen Shot 2021-02-15 at 2 10 02 PM" src="https://user-images.githubusercontent.com/15675400/107993439-a988ed00-6f97-11eb-9e50-603bfe8373b1.png">

