### PR TITLE
Fix 1849-K2S RSA (#3903)

### DIFF
--- a/lib/engine/config/game/g_1849_boot.rb
+++ b/lib/engine/config/game/g_1849_boot.rb
@@ -662,7 +662,7 @@ module Engine
          "abilities":[
             {
                "type":"shares",
-               "shares":"random_president"
+               "shares":"first_president"
             },
             {
                "type":"no_buy"

--- a/lib/engine/game/g_1849_boot.rb
+++ b/lib/engine/game/g_1849_boot.rb
@@ -19,6 +19,8 @@ module Engine
       NEW_PORT_HEXES = %w[B16 G5 J20 L16].freeze
       NEW_SMS_HEXES = %w[B14 G7 H8 J18 L12 L18 L20 N20 O9 P2].freeze
 
+      OPTIONAL_RULES = [].freeze
+
       EVENTS_TEXT = Base::EVENTS_TEXT.merge(
         'green_par': ['144 Par Available',
                       'Corporations may now par at 144 (in addition to 67 and 100)'],


### PR DESCRIPTION
Also removes the "delay IFT" option from 1849-K2S.