### PR TITLE
1870: Fix share selling when above 60%

### DIFF
--- a/lib/engine/step/g_1870/buy_sell_par_shares.rb
+++ b/lib/engine/step/g_1870/buy_sell_par_shares.rb
@@ -55,6 +55,10 @@ module Engine
           entity.cash >= bundle.price && redeemable_shares(entity).include?(bundle)
         end
 
+        def can_sell?(entity, bundle)
+          super && bundle.corporation.holding_ok?(entity, -bundle.percent)
+        end
+
         def process_buy_shares(action)
           super
           return unless action.entity.corporation?


### PR DESCRIPTION
If a player owns more than 60% of a corp and they want to sell shares, they need to sell enough to comply with the 60% limit