### PR TITLE
[1822] Dividend and private companies

### DIFF
--- a/assets/app/view/game/acquire_companies.rb
+++ b/assets/app/view/game/acquire_companies.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+require 'view/game/company'
+
+module View
+  module Game
+    class AcquireCompanies < Snabberb::Component
+      include Actionable
+      needs :show_other_players, default: nil, store: true
+      needs :selected_company, default: nil, store: true
+
+      def render
+        @corporation = @game.current_entity
+
+        h(:div, [
+          *render_companies,
+        ].compact)
+      end
+
+      def owned_by_other_player?(player, company)
+        return false unless company&.owner # Bank owned, not a player
+
+        player != company&.owner
+      end
+
+      def render_companies
+        hidden_companies = false
+        props = {
+          style: {
+            display: 'inline-block',
+            verticalAlign: 'top',
+          },
+        }
+
+        companies = @game.purchasable_companies(@corporation).sort_by do |company|
+          [!owned_by_other_player?(@corporation.owner, company) ? 0 : 1, company.value]
+        end
+
+        companies_to_buy = companies.map do |company|
+          if owned_by_other_player?(@corporation.owner, company) && !@show_other_players
+            hidden_companies = true
+            next
+          end
+          children = [h(Company, company: company)]
+          children << render_acquire_input if @selected_company == company
+          h(:div, props, children)
+        end
+
+        button_props = {
+          style: {
+            margin: '1rem 0 1rem 0',
+            display: 'grid',
+            gridColumn: '1/4',
+            width: 'max-content',
+          },
+        }
+
+        if hidden_companies
+          companies_to_buy << h('button.no_margin',
+                                { on: { click: -> { store(:show_other_players, true) } }, **button_props },
+                                'Show companies from other players')
+        elsif @show_other_players
+          companies_to_buy << h('button.no_margin',
+                                { on: { click: -> { store(:show_other_players, false) } }, **button_props },
+                                'Hide companies from other players')
+        end
+        companies_to_buy.compact
+      end
+
+      def render_acquire_input
+        acquire_click = lambda do
+          acquire = lambda do
+            process_action(Engine::Action::AcquireCompany.new(
+              @corporation,
+              company: @selected_company,
+            ))
+            store(:selected_company, nil, skip: true)
+          end
+
+          if @selected_company.owner == @corporation.owner || !@selected_company.owner
+            acquire.call
+          else
+            check_consent(@selected_company.owner, acquire)
+          end
+        end
+
+        props = {
+          style: {
+            textAlign: 'center',
+          },
+        }
+
+        button_props = {
+          style: {
+            margin: '1rem 0 1rem 0',
+          },
+          on: {
+            click: acquire_click,
+          },
+        }
+
+        h(:div, props, [
+          h(:button, button_props, 'Acquire'),
+        ])
+      end
+    end
+  end
+end

--- a/assets/app/view/game/acquire_companies.rb
+++ b/assets/app/view/game/acquire_companies.rb
@@ -13,9 +13,7 @@ module View
       def render
         @corporation = @game.current_entity
 
-        h(:div, [
-          *render_companies,
-        ].compact)
+        h(:div, render_companies.compact)
       end
 
       def owned_by_other_player?(player, company)

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'view/game/acquire_companies'
 require 'view/game/buy_companies'
 require 'view/game/special_buy'
 require 'view/game/buy_trains'
@@ -82,8 +83,12 @@ module View
               display: 'flex',
             },
           }
-          right = [h(Map, game: @game)]
+
+          aquire_company_action = @current_actions.include?('acquire_company')
+          right = []
+          right << h(Map, game: @game) unless aquire_company_action
           right << h(:div, div_props, [h(BuyCompanies, limit_width: true)]) if @current_actions.include?('buy_company')
+          right << h(:div, div_props, [h(AcquireCompanies)]) if aquire_company_action
 
           left_props = {
             style: {

--- a/lib/engine/action/acquire_company.rb
+++ b/lib/engine/action/acquire_company.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class AcquireCompany < Base
+      attr_reader :entity, :company
+
+      def initialize(entity, company:)
+        super(entity)
+        @company = company
+      end
+
+      def self.h_to_args(h, game)
+        {
+          company: game.company_by_id(h['company']),
+        }
+      end
+
+      def args_to_h
+        {
+          'company' => @company.id,
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/config/game/g_1822.rb
+++ b/lib/engine/config/game/g_1822.rb
@@ -1754,11 +1754,52 @@ module Engine
       "variants": [
         {
           "name": "E",
-          "distance": 99,
-          "num": 20,
-          "price": 1000
+          "distance": [
+            {
+              "nodes": ["city"],
+              "pay": 99,
+              "visit": 99,
+              "multiplier": 2
+            },
+            {
+              "nodes": ["town"],
+              "pay": 0,
+              "visit": 99
+            }
+          ],
+          "price": 1000,
+          "available_on": "7"
         }
       ]
+    },
+    {
+      "name": "2P",
+      "distance": 2,
+      "num": 2,
+      "price": 0
+    },
+    {
+      "name": "5P",
+      "distance": 5,
+      "num": 1,
+      "price": 0
+    },
+    {
+      "name": "P+",
+      "distance": [
+        {
+          "nodes": ["city"],
+          "pay": 99,
+          "visit": 99
+        },
+        {
+          "nodes": ["town"],
+          "pay": 99,
+          "visit": 99
+        }
+      ],
+      "num": 2,
+      "price": 0
     }
   ],
   "hexes": {

--- a/lib/engine/game/g_1822.rb
+++ b/lib/engine/game/g_1822.rb
@@ -101,6 +101,12 @@ module Engine
         'NER' => 3,
       }.freeze
 
+      # Theese trains doesnt count against train limit, they also doesnt count as a train
+      # against the mandatory train ownership. They cant the bought by another corporation.
+      EXTRA_TRAINS = %w[2P P+ LP].freeze
+      EXTRA_TRAIN_PULLMAN = 'P+'
+      EXTRA_TRAIN_PERMANENTS = %w[2P LP].freeze
+
       LIMIT_TOKENS_AFTER_MERGER = 9
 
       MAJOR_TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
@@ -109,10 +115,35 @@ module Engine
       MINOR_BIDBOX_PRICE = 200
       MINOR_GREEN_UPGRADE = %w[yellow green].freeze
 
+      PRIVATE_COMPANIES_ACQUISITION = {
+        'P1' => { acquire: %i[major], phase: 5 },
+        'P2' => { acquire: %i[major minor], phase: 2 },
+        'P3' => { acquire: %i[major], phase: 2 },
+        'P4' => { acquire: %i[major], phase: 2 },
+        'P5' => { acquire: %i[major], phase: 3 },
+        'P6' => { acquire: %i[major], phase: 3 },
+        'P7' => { acquire: %i[major], phase: 3 },
+        'P8' => { acquire: %i[major minor], phase: 3 },
+        'P9' => { acquire: %i[major minor], phase: 3 },
+        'P10' => { acquire: %i[major minor], phase: 3 },
+        'P11' => { acquire: %i[major minor], phase: 2 },
+        'P12' => { acquire: %i[major minor], phase: 3 },
+        'P13' => { acquire: %i[major minor], phase: 5 },
+        'P14' => { acquire: %i[major minor], phase: 5 },
+        'P15' => { acquire: %i[major minor], phase: 2 },
+        'P16' => { acquire: %i[none], phase: 0 },
+        'P17' => { acquire: %i[major], phase: 2 },
+        'P18' => { acquire: %i[major], phase: 5 },
+      }.freeze
+
+      PRIVATE_MAIL_CONTRACTS = %w[P6 P7].freeze
+      PRIVATE_REMOVE_REVENUE = %w[P6 P7].freeze
+      PRIVATE_TRAINS = %w[P1 P3 P4 P13 P14].freeze
+
       TOKEN_PRICE = 100
 
       UPGRADABLE_S_YELLOW_CITY_TILE = '57'
-      UPGRADABLE_S_YELLOW_CITY_TILE_ROTATIONS = [2, 5].freeze
+      UPGRADABLE_S_YELLOW_ROTATIONS = [2, 5].freeze
       UPGRADABLE_S_HEX_NAME = 'D35'
       UPGRADABLE_T_YELLOW_CITY_TILES = %w[5 6].freeze
       UPGRADABLE_T_HEX_NAMES = %w[B43 K42 M42].freeze
@@ -150,16 +181,61 @@ module Engine
       end
 
       def check_overlap(routes)
-        super
+        # Tracks by e-train and normal trains
+        tracks_by_type = Hash.new { |h, k| h[k] = [] }
 
         # Check local train not use the same token more then one time
         local_token_hex = []
+
         routes.each do |route|
           local_token_hex << route.head[:left].hex.id if route.train.local? && !route.connections.empty?
+
+          route.paths.each do |path|
+            a = path.a
+            b = path.b
+
+            tracks = tracks_by_type[train_type(route.train)]
+            tracks << [path.hex, a.num, path.lanes[0][1]] if a.edge?
+            tracks << [path.hex, b.num, path.lanes[1][1]] if b.edge?
+
+            if b.edge? && a.town? && (nedge = a.tile.preferred_city_town_edges[a]) && nedge != b.num
+              tracks << [path.hex, a, path.lanes[0][1]]
+            end
+            if a.edge? && b.town? && (nedge = b.tile.preferred_city_town_edges[b]) && nedge != a.num
+              tracks << [path.hex, b, path.lanes[1][1]]
+            end
+          end
+        end
+
+        tracks_by_type.each do |_type, tracks|
+          tracks.group_by(&:itself).each do |k, v|
+            raise GameError, "Route cannot reuse track on #{k[0].id}" if v.size > 1
+          end
         end
 
         local_token_hex.group_by(&:itself).each do |k, v|
           raise GameError, "Local train can only use the token on #{k[0]} once." if v.size > 1
+        end
+      end
+
+      def company_bought(company, entity)
+        # On acquired abilities
+        # Will add more here when they are implemented
+        on_acquired_train(company, entity) if self.class::PRIVATE_TRAINS.include?(company.id)
+        on_aqcuired_remove_revenue(company) if self.class::PRIVATE_REMOVE_REVENUE.include?(company.id)
+      end
+
+      def compute_other_paths(routes, route)
+        routes
+          .reject { |r| r == route }
+          .select { |r| train_type(route.train) == train_type(r.train) }
+          .flat_map(&:paths)
+      end
+
+      def crowded_corps
+        @crowded_corps ||= corporations.select do |c|
+          trains = c.trains.count { |t| !extra_train?(t) }
+          trains > train_limit(c)
         end
       end
 
@@ -199,13 +275,34 @@ module Engine
       end
 
       def train_help(runnable_trains)
-        return [] if (l_trains = runnable_trains.select { |t| t.name == 'L' }).empty?
+        return [] if runnable_trains.empty?
 
-        corporation = l_trains.first.owner
-        ["L (local) trains run in a city which has a #{corporation.name} token.",
-         'They can additionally run to a single small station, but are not required to do so. '\
-         'They can thus be considered 1 (+1) trains.',
-         'Only one L train may operate on each station token.']
+        entity = runnable_trains.first.owner
+
+        # L - trains
+        l_trains = !runnable_trains.select { |t| t.name == 'L' }.empty?
+
+        # Destination bonues
+        destination_token = nil
+        destination_token = entity.tokens.find { |t| t.used && t.type == :destination } if entity.type == :major
+
+        # Mail contract
+        mail_contracts = entity.companies.any? { |c| self.class::PRIVATE_MAIL_CONTRACTS.include?(c.id) }
+
+        help = []
+        help << "L (local) trains run in a city which has a #{entity.name} token. "\
+                'They can additionally run to a single small station, but are not required to do so. '\
+                'They can thus be considered 1 (+1) trains. '\
+                'Only one L train may operate on each station token.' if l_trains
+
+        help << 'When a train runs between its home station token and its destination station token it doubles the '\
+                'value of its destination station. This only applies to one train per operating '\
+                'turn.' if destination_token
+
+        help << 'Mail contract(s) gives a subsidy equal to one half of the base value of the start and end stations '\
+                'from one of the trains operated. Doubled values (for E trains or destination tokens) '\
+                'do not count.' if mail_contracts
+        help
       end
 
       def init_company_abilities
@@ -223,6 +320,12 @@ module Engine
         stock_round
       end
 
+      def must_buy_train?(entity)
+        !entity.rusted_self &&
+          entity.trains.reject { |t| extra_train?(t) }.empty? &&
+          !depot.depot_trains.empty?
+      end
+
       # TODO: [1822] Make include with 1861, 1867
       def operating_order
         minors, majors = @corporations.select(&:floated?).sort.partition { |c| c.type == :minor }
@@ -233,15 +336,16 @@ module Engine
         Round::Operating.new(self, [
           Step::Bankrupt,
           Step::G1822::FirstTurnHousekeeping,
-          Step::BuyCompany,
+          Step::AcquireCompany,
+          Step::DiscardTrain,
           Step::G1822::Track,
           Step::G1822::DestinationToken,
           Step::G1822::Token,
           Step::Route,
           Step::G1822::Dividend,
-          Step::DiscardTrain,
           Step::G1822::BuyTrain,
           Step::G1822::MinorAcquisition,
+          Step::DiscardTrain,
         ], round_num: round_num)
       end
 
@@ -257,6 +361,51 @@ module Engine
         hex = hex_by_id(self.class::DESTINATIONS[corporation.id])
         token = corporation.find_token_by_type(:destination)
         place_destination_token(corporation, hex, token)
+      end
+
+      def purchasable_companies(entity = nil)
+        return [] unless entity
+
+        @companies.select do |company|
+          company.owner&.player? && entity != company.owner && !company.closed? && !abilities(company, :no_buy) &&
+            acquire_private_company?(entity, company)
+        end
+      end
+
+      def revenue_for(route, stops)
+        revenue = if train_type(route.train) == :normal
+                    super
+                  else
+                    entity = route.train.owner
+                    stops.select(&:city?).sum do |stop|
+                      stop.tokened_by?(entity) ? stop.route_revenue(route.phase, route.train) : 0
+                    end
+                  end
+        destination_bonus = destination_bonus(route.routes)
+        revenue += destination_bonus[:revenue] if destination_bonus && destination_bonus[:route] == route
+        revenue
+      end
+
+      def revenue_str(route)
+        str = super
+
+        destination_bonus = destination_bonus(route.routes)
+        if destination_bonus && destination_bonus[:route] == route
+          str += " (#{format_currency(destination_bonus[:revenue])})"
+        end
+
+        str
+      end
+
+      def routes_subsidy(routes)
+        return 0 if routes.empty?
+
+        mail_bonus = mail_contract_bonus(routes.first.train.owner, routes)
+        return 0 if mail_bonus.empty?
+
+        mail_bonus.sum do |v|
+          v[:subsidy]
+        end
       end
 
       def setup
@@ -318,6 +467,13 @@ module Engine
         super
       end
 
+      def acquire_private_company?(entity, company)
+        company_acquisition = self.class::PRIVATE_COMPANIES_ACQUISITION[company.id]
+        return false unless company_acquisition
+
+        @phase.name.to_i >= company_acquisition[:phase] && company_acquisition[:acquire].include?(entity.type)
+      end
+
       def bidbox_minors
         @companies.select do |c|
           c.id[0] == self.class::COMPANY_MINOR_PREFIX && (!c.owner || c.owner == @bank) && !c.closed?
@@ -336,11 +492,57 @@ module Engine
         end.first(self.class::BIDDING_BOX_PRIVATE_COUNT)
       end
 
+      def can_gain_extra_train?(entity, train)
+        if train.name == self.class::EXTRA_TRAIN_PULLMAN
+          return false if entity.trains.any? { |t| t.name == self.class::EXTRA_TRAIN_PULLMAN }
+        elsif self.class::EXTRA_TRAIN_PERMANENTS.include?(train.name)
+          return false if entity.trains.any? { |t| self.class::EXTRA_TRAIN_PERMANENTS.include?(t.name) }
+        end
+        true
+      end
+
+      def calculate_destination_bonus(route)
+        entity = route.train.owner
+        # Only majors can have a destination token
+        return nil unless entity.type == :major
+
+        # Check if the corporation have placed its destination token
+        destination_token = entity.tokens.find { |t| t.used && t.type == :destination }
+        return nil unless destination_token
+
+        # First token is always the hometoken
+        home_token = entity.tokens.first
+        token_count = 0
+        route.visited_stops.each do |stop|
+          next unless stop.city?
+
+          token_count += 1 if stop.tokens.any? { |t| t == home_token || t == destination_token }
+        end
+
+        # Both hometoken and destination token must be in the route to get the destination bonus
+        return nil unless token_count == 2
+
+        { route: route, revenue: destination_token.city.route_revenue(route.phase, route.train) }
+      end
+
+      def destination_bonus(routes)
+        return nil if routes.empty?
+
+        # If multiple routes gets destination bonus, get the biggest one. If we got E trains
+        # this is bigger then normal train.
+        destination_bonus = routes.map { |r| calculate_destination_bonus(r) }.compact
+        destination_bonus.sort_by { |v| v[:revenue] }.reverse&.first
+      end
+
       def exchange_tokens(entity)
         ability = entity.all_abilities.find { |a| a.type == :exchange_token }
         return 0 unless ability
 
         ability.count
+      end
+
+      def extra_train?(train)
+        self.class::EXTRA_TRAINS.include?(train.name)
       end
 
       def find_corporation(company)
@@ -352,9 +554,43 @@ module Engine
         self.class::BIDDING_TOKENS[@players.size.to_s]
       end
 
+      def mail_contract_bonus(entity, routes)
+        mail_contracts = entity.companies.count { |c| self.class::PRIVATE_MAIL_CONTRACTS.include?(c.id) }
+        return [] unless mail_contracts.positive?
+
+        mail_bonuses = routes.map do |r|
+          stops = r.visited_stops
+          next if stops.size < 2
+
+          first = stops.first.route_base_revenue(r.phase, r.train) / 2
+          last = stops.last.route_base_revenue(r.phase, r.train) / 2
+          { route: r, subsidy: first + last }
+        end.compact
+        mail_bonuses.sort_by { |v| v[:subsidy] }.reverse.take(mail_contracts)
+      end
+
       def move_exchange_token(entity)
         remove_exchange_token(entity)
         entity.tokens << Engine::Token.new(entity, price: self.class::TOKEN_PRICE)
+      end
+
+      def on_aqcuired_remove_revenue(company)
+        company.revenue = 0
+      end
+
+      def on_acquired_train(company, entity)
+        train = @company_trains[company.id]
+
+        unless can_gain_extra_train?(entity, train)
+          raise GameError, "Cannot gain an extra #{train.name}, already have one"
+        end
+
+        buy_train(entity, train, :free)
+        @log << "#{entity.name} gains a #{train.name} train"
+
+        # Company closes after it is flipped into a train
+        company.close!
+        @log << "#{company.name} closes"
       end
 
       def place_destination_token(entity, hex, token)
@@ -391,7 +627,18 @@ module Engine
         ability.description = "Exchange tokens: #{ability.count}"
       end
 
+      def train_type(train)
+        train.name == 'E' ? :etrain : :normal
+      end
+
       private
+
+      def find_and_remove_train_by_id(train_id, buyable: true)
+        train = train_by_id(train_id)
+        @depot.remove_train(train)
+        train.buyable = buyable
+        train
+      end
 
       def setup_companies
         # Randomize from preset seed to get same order
@@ -430,6 +677,14 @@ module Engine
           end
           c.max_price = 10_000
         end
+
+        # Setup company abilities
+        @company_trains = {}
+        @company_trains['P3'] = find_and_remove_train_by_id('2P-0', buyable: false)
+        @company_trains['P4'] = find_and_remove_train_by_id('2P-1', buyable: false)
+        @company_trains['P1'] = find_and_remove_train_by_id('5P-0')
+        @company_trains['P13'] = find_and_remove_train_by_id('P+-0', buyable: false)
+        @company_trains['P14'] = find_and_remove_train_by_id('P+-1', buyable: false)
       end
 
       def setup_destinations

--- a/lib/engine/round/g_1822/stock.rb
+++ b/lib/engine/round/g_1822/stock.rb
@@ -55,7 +55,7 @@ module Engine
           # This will procced the whole game
           remove_l_trains(remove_l_count) if remove_l_count.positive? && @game.depot.upcoming.first.name == 'L'
           remove_minor_and_first_train(remove_minor) if remove_minor
-          remove_first_train if !remove_minor && @game.bidbox_minors.size.zero?
+          remove_first_train if !remove_minor && @game.bidbox_minors.empty?
 
           super
         end

--- a/lib/engine/step/acquire_company.rb
+++ b/lib/engine/step/acquire_company.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Step
+    class AcquireCompany < Base
+      ACTIONS = %w[acquire_company pass].freeze
+
+      def actions(entity)
+        return [] unless entity == current_entity
+        return ACTIONS if can_acquire_company?(entity)
+
+        []
+      end
+
+      def can_acquire_company?(entity)
+        !@game.purchasable_companies(entity).empty?
+      end
+
+      def description
+        'Acquire private companies'
+      end
+
+      def pass_description
+        @acted ? 'Done (Acquire companies)' : 'Skip (Acquire companies)'
+      end
+
+      def process_acquire_company(action)
+        entity = action.entity
+        company = action.company
+
+        owner = company.owner
+        owner&.companies&.delete(company)
+
+        company.owner = entity
+        entity.companies << company
+
+        @log << "#{entity.name} acquires #{company.name} from #{owner.name}"
+        @game.company_bought(company, entity)
+
+        pass! if @game.purchasable_companies(entity).empty?
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1822/buy_train.rb
+++ b/lib/engine/step/g_1822/buy_train.rb
@@ -34,6 +34,10 @@ module Engine
           @game.phase.buying_train!(action.entity, train_check)
         end
 
+        def room?(entity, _shell = nil)
+          entity.trains.reject { |t| @game.extra_train?(t) }.size < @game.train_limit(entity)
+        end
+
         private
 
         def upgrade_train_action(action)

--- a/lib/engine/step/g_1822/dividend.rb
+++ b/lib/engine/step/g_1822/dividend.rb
@@ -12,8 +12,7 @@ module Engine
           return [] if !entity.corporation? || (entity.corporation? && entity.type != :major)
 
           @extra_train_choice ||= ''
-          actions = []
-          actions.concat(super)
+          actions = super.dup
           actions << 'choose' if @extra_train_choice.empty? && find_extra_train(entity) && entity.trains.size > 1
           actions
         end
@@ -28,7 +27,7 @@ module Engine
         end
 
         def choices
-          choices = Hash.new { |h, k| h[k] = [] }
+          choices = {}
           choices['payout'] = 'Pay out'
           choices['half'] = 'Half Pay'
           choices['withhold'] = 'Withhold'

--- a/lib/engine/step/g_1822/dividend.rb
+++ b/lib/engine/step/g_1822/dividend.rb
@@ -1,23 +1,136 @@
 # frozen_string_literal: true
 
 require_relative '../dividend'
-require_relative '../half_pay'
 
 module Engine
   module Step
     module G1822
       class Dividend < Dividend
         DIVIDEND_TYPES = %i[payout half withhold].freeze
-        include HalfPay
 
         def actions(entity)
-          return [] if entity.corporation? && entity.type == :minor
+          return [] if !entity.corporation? || (entity.corporation? && entity.type != :major)
 
-          super
+          @extra_train_choice ||= ''
+          actions = []
+          actions.concat(super)
+          actions << 'choose' if @extra_train_choice.empty? && find_extra_train(entity) && entity.trains.size > 1
+          actions
+        end
+
+        def choice_name
+          train = find_extra_train(current_entity)
+          return '' unless train
+
+          route = routes.find { |r| r.train == train }
+          "Choose #{train.name}'s dividend (#{@game.format_currency(route.revenue)}) if "\
+          'this is to be different from the other trains'
+        end
+
+        def choices
+          choices = Hash.new { |h, k| h[k] = [] }
+          choices['payout'] = 'Pay out'
+          choices['half'] = 'Half Pay'
+          choices['withhold'] = 'Withhold'
+          choices
+        end
+
+        def dividend_options(entity)
+          total_revenue = @game.routes_revenue(routes)
+          extra_train = defined?(@extra_train_choice) && !@extra_train_choice.empty?
+          if extra_train
+            train = find_extra_train(entity)
+            extra_train_revenue = routes.find { |r| r.train == train }.revenue
+            extra_train_payout = send(@extra_train_choice, entity, extra_train_revenue, 0)
+            revenue = total_revenue - extra_train_revenue
+          else
+            revenue = total_revenue
+          end
+          subsidy = @game.routes_subsidy(routes)
+          total_revenue += subsidy
+          dividend_types.map do |type|
+            payout = send(type, entity, revenue, subsidy)
+            if extra_train
+              payout[:corporation] += extra_train_payout[:corporation]
+              payout[:per_share] += extra_train_payout[:per_share]
+            end
+            payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
+            [type, payout.merge(share_price_change(entity, total_revenue - payout[:corporation]))]
+          end.to_h
+        end
+
+        def find_extra_train(entity)
+          train = entity.trains.find { |t| @game.extra_train?(t) }
+          return nil unless train
+
+          route = routes.find { |r| r.train == train }
+          route&.revenue&.positive? ? train : nil
+        end
+
+        def half(entity, revenue, subsidy)
+          withheld = half_pay_withhold_amount(entity, revenue)
+          { corporation: withheld + subsidy, per_share: payout_per_share(entity, revenue - withheld) }
         end
 
         def half_pay_withhold_amount(entity, revenue)
-          entity.type == :minor ? revenue / 2.0 : super
+          entity.type == :minor ? revenue / 2.0 : (revenue / 2 / entity.total_shares).to_i * entity.total_shares
+        end
+
+        def log_run_payout(entity, kind, revenue, subsidy, _action, payout)
+          @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays half" if kind == 'half'
+
+          withhold = payout[:corporation] - subsidy
+          if withhold.positive?
+            @log << "#{entity.name} withholds #{@game.format_currency(withhold)}"
+          elsif payout[:per_share].zero?
+            @log << "#{entity.name} does not run"
+          end
+          @log << "#{entity.name} earns subsidy of #{@game.format_currency(subsidy)}" if subsidy.positive?
+        end
+
+        def payout(entity, revenue, subsidy)
+          { corporation: subsidy, per_share: payout_per_share(entity, revenue) }
+        end
+
+        def process_choose(action)
+          entity = action.entity
+          @extra_train_choice = action.choice
+          text =
+            case @extra_train_choice
+            when 'payout'
+              'pay out'
+            when 'withhold'
+              'withhold'
+            when 'half'
+              'half pay'
+            end
+          @log << "#{current_entity.id} chooses to #{text} with the #{find_extra_train(entity).name} train"
+        end
+
+        def process_dividend(action)
+          entity = action.entity
+          revenue = @game.routes_revenue(routes)
+          subsidy = @game.routes_subsidy(routes)
+          kind = action.kind.to_sym
+          payout = dividend_options(entity)[kind]
+
+          entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
+            routes,
+            action,
+            revenue
+          )
+
+          entity.trains.each { |train| train.operated = true }
+
+          @round.routes = []
+          log_run_payout(entity, kind, revenue, subsidy, action, payout)
+          @game.bank.spend(payout[:corporation], entity) if payout[:corporation].positive?
+          payout_shares(entity, revenue + subsidy - payout[:corporation]) if payout[:per_share].positive?
+          change_share_price(entity, payout)
+
+          pass!
+
+          @extra_train_choice = ''
         end
 
         def skip!
@@ -42,6 +155,10 @@ module Engine
           else
             {}
           end
+        end
+
+        def withhold(_entity, revenue, subsidy)
+          { corporation: revenue + subsidy, per_share: 0 }
         end
       end
     end

--- a/lib/engine/step/g_1822/minor_acquisition.rb
+++ b/lib/engine/step/g_1822/minor_acquisition.rb
@@ -108,7 +108,7 @@ module Engine
           @log << "#{entity.id} acquired #{@selected_minor.id} receiving #{receiving.join(', ')}"
 
           # Remove the proxy company for the minor
-          company = @game.companies.find { |c| c.id == "M#{@selected_minor}" }
+          company = @game.companies.find { |c| c.id == "M#{@selected_minor.id}" }
           @game.companies.delete(company)
 
           # Close the minor, this also removes the minor token if the token choice of 'remove' is selected

--- a/lib/engine/step/g_1822/token.rb
+++ b/lib/engine/step/g_1822/token.rb
@@ -9,6 +9,21 @@ module Engine
         def available_tokens(entity)
           entity.tokens_by_type.reject { |t| t.type == :destination }
         end
+
+        def process_place_token(action)
+          entity = action.entity
+          city = action.city
+
+          if entity.corporation? && entity.type == :major
+            destination_token = entity.find_token_by_type(:destination)
+            if destination_token && city.hex.name == @game.class::DESTINATIONS[entity.id]
+              raise GameError, "Cannot place token on #{city.hex.name}, that hex is reserved for destination token. "\
+                               'Please undo this move and place your destination token'
+            end
+          end
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/step/g_1822/tracker.rb
+++ b/lib/engine/step/g_1822/tracker.rb
@@ -12,7 +12,7 @@ module Engine
           # We will remove a town from the white S tile, this meaning we will not follow the normal path upgrade rules
           if hex.name == @game.class::UPGRADABLE_S_HEX_NAME &&
             tile.name == @game.class::UPGRADABLE_S_YELLOW_CITY_TILE &&
-            @game.class::UPGRADABLE_S_YELLOW_CITY_TILE_ROTATIONS.include?(tile.rotation)
+            @game.class::UPGRADABLE_S_YELLOW_ROTATIONS.include?(tile.rotation)
             return true
           end
 


### PR DESCRIPTION
* Made a new action and a new ui page, Aquire Company. I started with the buy_company view, but i had to modify it with multiple respond_to?, after i while choose to make the new view instead of clutter down the buy company code to much. I assume all other 22 variants need this as well.
* With the private 2P you gain a train in the corporation. They dont count towards the trainlimit or as a train in the mandatory train check. With this train you can also choose a different dividend then the other train, meaning you can ie withhold with the 2P and payout with the others. You can have any combination of the (payout, pay half and withhold)
* Destination bonus, if a train runs a route with both home token and destination token. You get the destination tokens city value one more time. Only one train can have this bonus.
* Mail contracts if the corporation have a mailcontract or both. They take half base value of the start node and half base value of the end node and add it to the corporations treasury. If a corporation have both, they have to have valid routes on 2 different trains to get the bonus from both.
* E-train they can run on the same track as the other trains. They can have no distance restiction, but they only get revenue from cities where corporation have a token. This revenue is doubled, this will also double the destination bonus. One city can give 4x its revenue.
* Some minor bug fixes and clean up