### PR TITLE
Maintain relative order when sorting players by most cash

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2107,7 +2107,7 @@ module Engine
         when :first_to_pass
           @players = @round.pass_order if @round.pass_order.any?
         when :most_cash
-          current_order = @players.dup
+          current_order = @players.dup.reverse
           @players.sort_by! { |p| [p.cash, current_order.index(p)] }.reverse!
         when :least_cash
           current_order = @players.dup


### PR DESCRIPTION
fixes #3883

Game boxes affected:
(ones using `:most_cash` sorting)

18CZ: This change reflects the correct implementation 
```
Resolve any ties so that the player who was earlier in the old order is also earlier in the new order.
```

1822: This change reflects the correct implementation

```
If two players have equal cash, their stock turn order relative to each other stays unchanged from the previous stock round. 
```