### PR TITLE
spreadsheet tokens cleanup, opacity if operated, title added

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -504,14 +504,14 @@ module View
       def render_operating_order
         round = @game.round
         order =
-          if @game.round.operating?
-            @game.round.entities.index(@corporation)
+          if round.operating?
+            round.entities.index(@corporation)
           else
             @game.operating_order.index(@corporation)
           end
 
         if order
-          m = round.entities.index(round.current_entity) if @game.round.operating?
+          m = round.entities.index(round.current_entity) if round.operating?
           span_class = '.bold' if order && m && order >= m
           [h(:div, { style: { display: 'inline' } }, [
             'Order: ',

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -140,6 +140,7 @@ module View
           props[:attrs][:title] = "#{corporation.name} has operated"
           props[:style][:opacity] = '0.4'
         end
+
         props
       end
 

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -119,7 +119,7 @@ module View
         order < idx if order && idx
       end
 
-      def token_props(corporation)
+      def token_props(corporation, index = nil, num = nil, spacing = nil)
         props = {
           attrs: {
             src: logo_for_user(corporation),
@@ -128,6 +128,14 @@ module View
           },
           style: { marginTop: "#{VERTICAL_TOKEN_PAD}px" },
         }
+        if index
+          props[:attrs][:width] = "#{TOKEN_SIZE}px"
+          props[:style] = {
+            position: 'absolute',
+            left: num > 1 ? "#{LEFT_TOKEN_POS + ((num - index - 1) * spacing)}px" : "#{MID_TOKEN_POS}px",
+            zIndex: num - index,
+          }
+        end
         if operated?(corporation)
           props[:attrs][:title] = "#{corporation.name} has operated"
           props[:style][:opacity] = '0.4'
@@ -199,27 +207,7 @@ module View
               corporations = price.corporations
               num = corporations.size
               spacing = num > 1 ? (RIGHT_TOKEN_POS - LEFT_TOKEN_POS) / (num - 1) : 0
-
-              tokens = corporations.map.with_index do |corporation, index|
-                props = {
-                  attrs: {
-                    src: logo_for_user(corporation),
-                    title: corporation.name,
-                    width: "#{TOKEN_SIZE}px",
-                  },
-                  style: {
-                    position: 'absolute',
-                    left: num > 1 ? "#{LEFT_TOKEN_POS + ((num - index - 1) * spacing)}px" : "#{MID_TOKEN_POS}px",
-                    zIndex: num - index,
-                  },
-                }
-                if operated?(corporation)
-                  props[:attrs][:title] = "#{corporation.name} has operated"
-                  props[:style][:opacity] = '0.4'
-                end
-
-                h(:img, props)
-              end
+              tokens = corporations.map.with_index { |corp, index| h(:img, token_props(corp, index, num, spacing)) }
 
               h(:div, { style: cell_style(@box_style_2d, price.types) }, [
                 h(:div, { style: { fontSize: '80%' } }, price.price),


### PR DESCRIPTION
cleanup
+ opacity 0.4 if operated
+ title for all tokens (order could be included if !operated, but I didn’t see much value)

closes #3958
also helps in some cases of #1122 (which is still not solved perfectly)

![image](https://user-images.githubusercontent.com/33390595/108205425-58a6ff00-7125-11eb-81e9-9f6ab15c72aa.png)
![image](https://user-images.githubusercontent.com/33390595/108205434-5b095900-7125-11eb-86f5-8f5d791265cc.png)