### PR TITLE
Link to BoardGameGeek in the Game Info section of the Info tab

### DIFF
--- a/assets/app/view/game/game_meta.rb
+++ b/assets/app/view/game/game_meta.rb
@@ -63,9 +63,33 @@ module View
       end
 
       def render_more_info
-        return [] unless @game.class::GAME_INFO_URL
+        return [] unless @game.class::GAME_WIKI_URL || @game.class::GAME_BGG_ID
 
-        [h(:p, [h(:a, { attrs: { href: @game.class::GAME_INFO_URL, target: '_blank' } }, 'More info')])]
+        p_inner = ['More info ']
+        p_inner.push(
+          'in the ',
+          h(:a, {
+              attrs: {
+                href: @game.class::GAME_WIKI_URL,
+                target: '_blank',
+              },
+            }, '18xx.Games wiki'),
+        ) if @game.class::GAME_WIKI_URL
+        p_inner.push(' and ') \
+          if @game.class::GAME_WIKI_URL && @game.class::GAME_BGG_ID
+        p_inner.push(
+          'at ',
+          h(:a, {
+              attrs: {
+                href: 'https://boardgamegeek.com/boardgame/' +
+                  `encodeURIComponent(#{@game.class::GAME_BGG_ID})`,
+                target: '_blank',
+              },
+            }, 'BoardGameGeek'),
+        ) if @game.class::GAME_BGG_ID
+        p_inner.push('.')
+
+        [h(:p, p_inner)]
       end
     end
   end

--- a/lib/engine/game/g_1817.rb
+++ b/lib/engine/game/g_1817.rb
@@ -35,7 +35,8 @@ module Engine
       GAME_RULES_URL = 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view'
       GAME_DESIGNER = 'Craig Bartell, Tim Flowers'
       GAME_PUBLISHER = :all_aboard_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1817'
+      GAME_BGG_ID = 63_170
       TRAIN_STATION_PRIVATE_NAME = 'TS'
       PITTSBURGH_PRIVATE_NAME = 'PSM'
       PITTSBURGH_PRIVATE_HEX = 'F13'

--- a/lib/engine/game/g_1817_na.rb
+++ b/lib/engine/game/g_1817_na.rb
@@ -15,7 +15,7 @@ module Engine
 
       GAME_LOCATION = 'North America'
       SEED_MONEY = 150
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817NA'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1817NA'
       GAME_RULES_URL = {
         '1817NA' => 'https://docs.google.com/document/d/1b1qmHoyLnzBo8SRV8Ff17iDWnB7UWNbIsOyDADT0-zY/view',
         '1817 Rules' => 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view',

--- a/lib/engine/game/g_1817_wo.rb
+++ b/lib/engine/game/g_1817_wo.rb
@@ -17,7 +17,7 @@ module Engine
 
       GAME_LOCATION = 'Earth.'
       SEED_MONEY = 100
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817WO'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1817WO'
       GAME_RULES_URL = {
         '1817WO' => 'https://docs.google.com/document/d/1g9QnttpJa8yOCOTnfPaU9hfAZFFzg-rAs_WGy9T38J0/',
         '1817 Rules' => 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view',

--- a/lib/engine/game/g_1822.rb
+++ b/lib/engine/game/g_1822.rb
@@ -30,7 +30,8 @@ module Engine
       GAME_RULES_URL = 'http://google.com'
       GAME_DESIGNER = 'Simon Cutforth'
       GAME_PUBLISHER = :all_aboard_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1822'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1822'
+      GAME_BGG_ID = 193_867
 
       HOME_TOKEN_TIMING = :operate
       MUST_BUY_TRAIN = :always

--- a/lib/engine/game/g_1824.rb
+++ b/lib/engine/game/g_1824.rb
@@ -23,7 +23,8 @@ module Engine
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/188242/1824-english-rules'
       GAME_DESIGNER = 'Leonhard Orgler & Helmut Ohley'
       GAME_PUBLISHER = :lonny_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1824'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1824'
+      GAME_BGG_ID = 277_030
 
       GAME_END_CHECK = { bank: :full_or }.freeze
 

--- a/lib/engine/game/g_1828.rb
+++ b/lib/engine/game/g_1828.rb
@@ -34,7 +34,8 @@ module Engine
       GAME_LOCATION = 'North East, USA'
       GAME_RULES_URL = 'https://kanga.nu/~claw/1828/1828-Rules.pdf'
       GAME_IMPLEMENTER = 'Chris Rericha based on 1828 by J C Lawrence'
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1828.Games'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1828.Games'
+      GAME_BGG_ID = 272_538
 
       MULTIPLE_BUY_TYPES = %i[unlimited].freeze
 

--- a/lib/engine/game/g_1835.rb
+++ b/lib/engine/game/g_1835.rb
@@ -30,7 +30,8 @@ module Engine
       GAME_LOCATION = 'Germany'
       GAME_RULES_URL = 'http://google.com'
       GAME_DESIGNER = 'Michael Meier-Bachl, Francis Tresham'
-      GAME_INFO_URL = 'https://google.com'
+      GAME_WIKI_URL = nil
+      GAME_BGG_ID = 422
 
       HOME_TOKEN_TIMING = :operating_round
 

--- a/lib/engine/game/g_1836_jr30.rb
+++ b/lib/engine/game/g_1836_jr30.rb
@@ -12,7 +12,8 @@ module Engine
       GAME_LOCATION = 'Netherlands'
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/114572/1836jr-30-rules'
       GAME_DESIGNER = 'David G. D. Hecht'
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1836Jr-30'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1836Jr-30'
+      GAME_BGG_ID = 173_574
 
       SELL_BUY_ORDER = :sell_buy_sell
       TRACK_RESTRICTION = :permissive

--- a/lib/engine/game/g_1846/meta.rb
+++ b/lib/engine/game/g_1846/meta.rb
@@ -11,10 +11,11 @@ module Engine
         DEV_STAGE = :production
 
         GAME_DESIGNER = 'Thomas Lehmann'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1846'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1846'
         GAME_LOCATION = 'Midwest, USA'
         GAME_PUBLISHER = %i[gmt_games golden_spike].freeze
         GAME_RULES_URL = 'https://s3-us-west-2.amazonaws.com/gmtwebsiteassets/1846/1846-RULES-GMT.pdf'
+        GAME_BGG_ID = 17_405
 
         PLAYER_RANGE = [3, 5].freeze
       end

--- a/lib/engine/game/g_1846_two_player_variant/meta.rb
+++ b/lib/engine/game/g_1846_two_player_variant/meta.rb
@@ -12,7 +12,7 @@ module Engine
         DEPENDS_ON = '1846'
 
         GAME_DESIGNER = 'Thomas Lehmann'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1846'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1846'
         GAME_LOCATION = 'Midwest, USA'
         GAME_PUBLISHER = %i[gmt_games golden_spike].freeze
         GAME_RULES_URL = {

--- a/lib/engine/game/g_1848.rb
+++ b/lib/engine/game/g_1848.rb
@@ -13,7 +13,8 @@ module Engine
       GAME_RULES_URL = 'http://ohley.de/english/1848/1848-rules.pdf'
       GAME_DESIGNER = 'Leonhard Orgler and Helmut Ohley'
       GAME_PUBLISHER = :oo_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1848'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1848'
+      GAME_BGG_ID = 32_424
 
       # Two tiles can be laid at a time, with max one upgrade
       TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded }].freeze

--- a/lib/engine/game/g_1849.rb
+++ b/lib/engine/game/g_1849.rb
@@ -27,7 +27,8 @@ module Engine
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/206628/1849-rules'
       GAME_DESIGNER = 'Federico Vellani'
       GAME_PUBLISHER = :all_aboard_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1849'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1849'
+      GAME_BGG_ID = 3097
 
       CAPITALIZATION = :incremental
 

--- a/lib/engine/game/g_1849_boot.rb
+++ b/lib/engine/game/g_1849_boot.rb
@@ -13,7 +13,7 @@ module Engine
       GAME_LOCATION = 'Southern Italy'
       GAME_RULES_URL = 'https://docs.google.com/document/d/1gNn2RmtcPWh0KpNduv3p0Lraa3iWIAV3cWcHpCu8X-E/edit'
       GAME_DESIGNER = 'Scott Petersen (Based on 1849 by Federico Vellani)'
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1849#variants-and-optional-rules'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1849#variants-and-optional-rules'
 
       NEW_AFG_HEXES = %w[E11 H8 I13 I17 J18 K19 L12 L20 O9].freeze
       NEW_PORT_HEXES = %w[B16 G5 J20 L16].freeze

--- a/lib/engine/game/g_1856.rb
+++ b/lib/engine/game/g_1856.rb
@@ -55,7 +55,8 @@ module Engine
       GAME_LOCATION = 'Ontario, Canada'
       GAME_RULES_URL = 'http://google.com'
       GAME_DESIGNER = 'Bill Dixon'
-      GAME_INFO_URL = 'https://google.com'
+      GAME_WIKI_URL = nil
+      GAME_BGG_ID = 423
 
       HOME_TOKEN_TIMING = :operating_round
 

--- a/lib/engine/game/g_1860.rb
+++ b/lib/engine/game/g_1860.rb
@@ -22,7 +22,8 @@ module Engine
       GAME_RULES_URL = 'https://www.dropbox.com/s/usfbqtdjzx6ug8f/1860-rules.pdf'
       GAME_DESIGNER = 'Mike Hutton'
       GAME_PUBLISHER = :all_aboard_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1860'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1860'
+      GAME_BGG_ID = 12_750
 
       DEV_STAGE = :production
 

--- a/lib/engine/game/g_1867.rb
+++ b/lib/engine/game/g_1867.rb
@@ -38,7 +38,8 @@ module Engine
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/212807/18611867-rulebook'
       GAME_DESIGNER = 'Ian D. Wilson'
       GAME_PUBLISHER = :grand_trunk_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1867'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1867'
+      GAME_BGG_ID = 292_187
 
       HOME_TOKEN_TIMING = :float
       MUST_BID_INCREMENT_MULTIPLE = true

--- a/lib/engine/game/g_1870.rb
+++ b/lib/engine/game/g_1870.rb
@@ -21,7 +21,8 @@ module Engine
       GAME_LOCATION = 'Mississippi, USA'
       GAME_RULES_URL = 'http://www.hexagonia.com/rules/MFG_1870.pdf'
       GAME_DESIGNER = 'Bill Dixon'
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1870'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1870'
+      GAME_BGG_ID = 424
 
       EBUY_PRES_SWAP = false
       EBUY_OTHER_VALUE = false

--- a/lib/engine/game/g_1873.rb
+++ b/lib/engine/game/g_1873.rb
@@ -33,7 +33,8 @@ module Engine
       GAME_RULES_URL = 'https://docs.google.com/viewer?a=v&pid=sites&srcid=YWxsLWFib2FyZGdhbWVzLmNvbXxhYWdsbGN8Z3g6MThhODUwM2Q3MWUyMmI2Nw'
       GAME_DESIGNER = 'Klaus Kiermeier'
       GAME_PUBLISHER = :all_aboard_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/Harzbahn-1873'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/Harzbahn-1873'
+      GAME_BGG_ID = 28_944
 
       # DEV_STAGE = :alpha
 

--- a/lib/engine/game/g_1877.rb
+++ b/lib/engine/game/g_1877.rb
@@ -10,7 +10,7 @@ module Engine
 
       GAME_DESIGNER = 'Scott Petersen & Toby Mao'
       GAME_RULES_URL = 'https://github.com/tobymao/18xx/wiki/1877'
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1877'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1877'
       GAME_PUBLISHER = :all_aboard_games
       GAME_LOCATION = 'Venezuela'
 

--- a/lib/engine/game/g_1882.rb
+++ b/lib/engine/game/g_1882.rb
@@ -24,7 +24,8 @@ module Engine
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/206629/1882-rules'
       GAME_DESIGNER = 'Marc Voyer'
       GAME_PUBLISHER = :all_aboard_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1882'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1882'
+      GAME_BGG_ID = 282_435
 
       MUST_BID_INCREMENT_MULTIPLE = true
       SELL_BUY_ORDER = :sell_buy_sell

--- a/lib/engine/game/g_1889/meta.rb
+++ b/lib/engine/game/g_1889/meta.rb
@@ -11,10 +11,11 @@ module Engine
         DEV_STAGE = :production
 
         GAME_DESIGNER = 'Yasutaka Ikeda (池田 康隆)'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1889'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1889'
         GAME_LOCATION = 'Shikoku, Japan'
         GAME_PUBLISHER = :grand_trunk_games
         GAME_RULES_URL = 'http://dl.deepthoughtgames.com/1889-Rules.pdf'
+        GAME_BGG_ID = 23_540
 
         PLAYER_RANGE = [2, 6].freeze
       end

--- a/lib/engine/game/g_1893.rb
+++ b/lib/engine/game/g_1893.rb
@@ -19,7 +19,8 @@ module Engine
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/188718/1893-cologne-rule-summary-version-10'
       GAME_DESIGNER = 'Edwin Eckert'
       GAME_PUBLISHER = :marflow_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1893'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/1893'
+      GAME_BGG_ID = 162_677
 
       GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
 

--- a/lib/engine/game/g_18_al.rb
+++ b/lib/engine/game/g_18_al.rb
@@ -15,7 +15,8 @@ module Engine
       GAME_LOCATION = 'Alabama, USA'
       GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
       GAME_DESIGNER = 'Mark Derrick'
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18AL'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18AL'
+      GAME_BGG_ID = 2612
 
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 

--- a/lib/engine/game/g_18_chesapeake/meta.rb
+++ b/lib/engine/game/g_18_chesapeake/meta.rb
@@ -11,9 +11,10 @@ module Engine
         DEV_STAGE = :production
 
         GAME_DESIGNER = 'Scott Petersen'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://www.dropbox.com/s/x0dsehrxqr1tl6w/18Chesapeake_Rules.pdf'
+        GAME_BGG_ID = 253_608
 
         PLAYER_RANGE = [2, 6].freeze
       end

--- a/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
+++ b/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
@@ -12,10 +12,11 @@ module Engine
         DEPENDS_ON = '18Chesapeake'
 
         GAME_DESIGNER = 'Scott Petersen'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://www.dropbox.com/s/ivm4jsopnzabhru/18ChesOTR_Rules.png?dl=0'
         GAME_TITLE = '18Chesapeake: Off the Rails'
+        GAME_BGG_ID = 328_829
 
         PLAYER_RANGE = [2, 6].freeze
       end

--- a/lib/engine/game/g_18_co/meta.rb
+++ b/lib/engine/game/g_18_co/meta.rb
@@ -11,9 +11,10 @@ module Engine
         DEV_STAGE = :beta
 
         GAME_DESIGNER = 'R. Ryan Driskel'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18CO:-Rock-&-Stock'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18CO:-Rock-&-Stock'
         GAME_LOCATION = 'Colorado, USA'
         GAME_RULES_URL = 'https://drive.google.com/open?id=0B3lRHMrbLMG_eEp4elBZZ0toYnM'
+        GAME_BGG_ID = 327_295
 
         PLAYER_RANGE = [3, 6].freeze
         OPTIONAL_RULES = [

--- a/lib/engine/game/g_18_cz.rb
+++ b/lib/engine/game/g_18_cz.rb
@@ -22,7 +22,8 @@ module Engine
       GAME_RULES_URL = 'https://www.lonny.at/app/download/9940504884/rules_English.pdf'
       GAME_DESIGNER = 'Leonhard Orgler'
       GAME_PUBLISHER = :lonny_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18CZ'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18CZ'
+      GAME_BGG_ID = 163_841
 
       SELL_BUY_ORDER = :sell_buy
       SELL_MOVEMENT = :left_block

--- a/lib/engine/game/g_18_fl.rb
+++ b/lib/engine/game/g_18_fl.rb
@@ -22,7 +22,8 @@ module Engine
       GAME_RULES_URL = 'http://google.com'
       GAME_DESIGNER = 'David Hecht'
       GAME_PUBLISHER = nil
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18FL'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18FL'
+      GAME_BGG_ID = 21_436
 
       HOME_TOKEN_TIMING = :operating_round
       SELL_BUY_ORDER = :sell_buy

--- a/lib/engine/game/g_18_ga.rb
+++ b/lib/engine/game/g_18_ga.rb
@@ -14,7 +14,8 @@ module Engine
       GAME_LOCATION = 'Georgia, USA'
       GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18GA_Rules_v3_26.pdf'
       GAME_DESIGNER = 'Mark Derrick'
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18GA'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18GA'
+      GAME_BGG_ID = 2583
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
 
       STATUS_TEXT = Base::STATUS_TEXT.merge(

--- a/lib/engine/game/g_18_los_angeles/meta.rb
+++ b/lib/engine/game/g_18_los_angeles/meta.rb
@@ -12,7 +12,7 @@ module Engine
         DEPENDS_ON = '1846'
 
         GAME_DESIGNER = 'Anthony Fryer'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18LosAngeles'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18LosAngeles'
         GAME_PUBLISHER = %i[traxx sea_horse].freeze
         GAME_RULES_URL = {
           '18 Los Angeles Rules' =>
@@ -20,6 +20,7 @@ module Engine
           '1846 Rules' =>
                 'https://s3-us-west-2.amazonaws.com/gmtwebsiteassets/1846/1846-RULES-GMT.pdf',
         }.freeze
+        GAME_BGG_ID = 306_257
         GAME_TITLE = '18 Los Angeles'
 
         PLAYER_RANGE = [2, 5].freeze

--- a/lib/engine/game/g_18_mag.rb
+++ b/lib/engine/game/g_18_mag.rb
@@ -32,7 +32,8 @@ module Engine
       GAME_RULES_URL = 'https://www.lonny.at/games/18magyarorsz%C3%A1g/'
       GAME_DESIGNER = 'Leonhard "Lonny" Orgler'
       GAME_PUBLISHER = :lonny_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Mag'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18Mag'
+      GAME_BGG_ID = 325_191
 
       DEV_STAGE = :beta
 

--- a/lib/engine/game/g_18_mex/meta.rb
+++ b/lib/engine/game/g_18_mex/meta.rb
@@ -11,10 +11,11 @@ module Engine
         DEV_STAGE = :production
 
         GAME_DESIGNER = 'Mark Derrick'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18MEX'
+        GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18MEX'
         GAME_LOCATION = 'Mexico'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://secure.deepthoughtgames.com/games/18MEX/rules.pdf'
+        GAME_BGG_ID = 18_485
 
         PLAYER_RANGE = [3, 5].freeze
         OPTIONAL_RULES = [

--- a/lib/engine/game/g_18_ms.rb
+++ b/lib/engine/game/g_18_ms.rb
@@ -17,7 +17,8 @@ module Engine
       GAME_RULES_URL = 'https://boardgamegeek.com/filepage/209791'
       GAME_DESIGNER = 'Mark Derrick'
       GAME_PUBLISHER = :all_aboard_games
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18MS'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18MS'
+      GAME_BGG_ID = 313_129
 
       # Game will end after 10 ORs (or 11 in case of optional rule) - checked in end_now? below
       GAME_END_CHECK = {}.freeze

--- a/lib/engine/game/g_18_sj.rb
+++ b/lib/engine/game/g_18_sj.rb
@@ -28,7 +28,8 @@ module Engine
       GAME_RULES_URL = 'https://drive.google.com/file/d/1WgvqSp5HWhrnCAhAlLiTIe5oXfYtnVt9/view?usp=drivesdk'
       GAME_DESIGNER = 'Örjan Wennman'
       GAME_PUBLISHER = :self_published
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18SJ'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18SJ'
+      GAME_BGG_ID = 328_237
 
       # Stock market 350 triggers end of game in same OR, but bank full OR set
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :full_or }.freeze

--- a/lib/engine/game/g_18_tn.rb
+++ b/lib/engine/game/g_18_tn.rb
@@ -17,7 +17,8 @@ module Engine
       GAME_DESIGNER = 'Mark Derrick'
       GAME_PUBLISHER = :golden_spike
       GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_or, bank: :current_or }.freeze
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18TN'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18TN'
+      GAME_BGG_ID = 25_344
 
       STATUS_TEXT = Base::STATUS_TEXT.merge(
         'can_buy_companies_operation_round_one' =>

--- a/lib/engine/game/g_18_usa.rb
+++ b/lib/engine/game/g_18_usa.rb
@@ -15,13 +15,14 @@ module Engine
 
       GAME_LOCATION = 'United States'
       SEED_MONEY = 200
-      GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18USA'
+      GAME_WIKI_URL = 'https://github.com/tobymao/18xx/wiki/18USA'
       GAME_RULES_URL = {
         '18USA' => 'https://boardgamegeek.com/filepage/145024/18usa-rules',
         '1817 Rules' => 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view',
       }.freeze
       # Alphabetized. Not sure what official ordering is
       GAME_DESIGNER = 'Edward Reece, Mark Hendrickson, and Shawn Fox'
+      GAME_BGG_ID = 219_717
 
       OFFBOARD_VALUES = [[20, 30, 40, 50], [20, 30, 40, 60], [20, 30, 50, 60], [20, 30, 50, 60], [20, 30, 60, 90],
                          [20, 40, 50, 80], [30, 40, 40, 50], [30, 40, 50, 60], [30, 50, 60, 80], [30, 50, 60, 80],

--- a/lib/engine/game/meta.rb
+++ b/lib/engine/game/meta.rb
@@ -11,11 +11,12 @@ module Engine
       # real game metadata
       GAME_DESIGNER = nil
       GAME_IMPLEMENTER = nil
-      GAME_INFO_URL = nil
+      GAME_WIKI_URL = nil
       GAME_LOCATION = nil
       GAME_PUBLISHER = nil
       GAME_RULES_URL = nil
       GAME_TITLE = nil
+      GAME_BGG_ID = nil
 
       # rules data that needs to be known to the engine without loading in the
       # full game class

--- a/scripts/move_game.rb
+++ b/scripts/move_game.rb
@@ -17,11 +17,12 @@ class Mover
   METADATA_CONSTANTS = %i[
     GAME_DESIGNER
     GAME_IMPLEMENTER
-    GAME_INFO_URL
+    GAME_WIKI_URL
     GAME_LOCATION
     GAME_PUBLISHER
     GAME_RULES_URL
     GAME_TITLE
+    GAME_BGG_ID
   ].freeze
 
   attr_reader :name, :module_name, :old_game_file, :game_class, :game_config_json


### PR DESCRIPTION
Put the BoardGameGeek link next to the existing “more info” link to the wiki.

If we don’t have a link to the wiki, linking to the Google front page seems unhelpful, so let’s not show the link in that case.

Since GAME_INFO_URL will always point to the wiki, make that clearer by renaming it to GAME_WIKI_URL.

### Motivation

Iʼd like to include these and future games in my online boardgame directory at <https://www.mavit.org.uk/boardgames-online/>.  If thereʼs metadata to scrape, I can set things up so that happens automatically.