### PR TITLE
fix iOS & macOS color inputs

### DIFF
--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -159,7 +159,8 @@ module View
     end
 
     def render_color(label, id, hex_color, attrs: {})
-      render_input(label, id: id, type: :color, attrs: { value: hex_color, **attrs })
+      render_input(label, id: id, type: :color, attrs: { value: hex_color, **attrs },
+                          input_style: { backgroundColor: hex_color })
     end
 
     def render_tile_colors

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -169,6 +169,12 @@ nav#game_menu {
   height: 1.8rem;
   width: 2.7rem;
 }
+::-webkit-color-swatch {
+    background-color: inherit !important; /* fix iOS/macOS black color inputs */
+}
+::-webkit-color-swatch-wrapper {
+    border: 1px solid gainsboro;
+}
 #settings__options .input-container {
   display: block;
 }


### PR DESCRIPTION
finally fixes #2975
Please test on Apple hardware. Browserstack is fine with it:
![image](https://user-images.githubusercontent.com/33390595/108273685-2ffa2600-7174-11eb-88aa-187662fa30de.png)

It’s a bit uglier on Chrome, but I guess that’s a small price to pay if it works on Apple devices.

ante:
![image](https://user-images.githubusercontent.com/33390595/108274148-c9293c80-7174-11eb-86fc-e8af2de390d2.png)
post:
![image](https://user-images.githubusercontent.com/33390595/108274164-cd555a00-7174-11eb-82b7-7e68c69ec121.png)