### PR TITLE
import 'engine' in spec_helper, 🪓 a bunch of require statements

### DIFF
--- a/spec/game_state_spec.rb
+++ b/spec/game_state_spec.rb
@@ -2,7 +2,6 @@
 
 require 'find'
 
-require 'engine'
 require 'spec_helper'
 
 def game_at_action(game_file, action_id = nil)

--- a/spec/lib/engine/connection_spec.rb
+++ b/spec/lib/engine/connection_spec.rb
@@ -2,8 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine'
-
 module Engine
   describe Connection do
     let(:game) { Engine.game_by_title('1889').new(%w[a b]) }

--- a/spec/lib/engine/corporation_spec.rb
+++ b/spec/lib/engine/corporation_spec.rb
@@ -2,10 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine'
-require 'engine/corporation'
-require 'engine/share_price'
-
 module Engine
   describe Corporation do
     let(:corporation_1) { Engine::Corporation.new(sym: 'a', name: 'a', tokens: []) }

--- a/spec/lib/engine/games/config_spec.rb
+++ b/spec/lib/engine/games/config_spec.rb
@@ -2,7 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine'
 require 'json'
 
 module Engine

--- a/spec/lib/engine/games/g_1828_spec.rb
+++ b/spec/lib/engine/games/g_1828_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
-require 'engine/game/g_1828'
 
 module Engine
   describe Game::G1828::Game do

--- a/spec/lib/engine/games/g_1889_spec.rb
+++ b/spec/lib/engine/games/g_1889_spec.rb
@@ -2,8 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine/game/g_1889'
-require 'engine/part/city'
 require 'json'
 
 module Engine

--- a/spec/lib/engine/games/g_18_zoo_spec.rb
+++ b/spec/lib/engine/games/g_18_zoo_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
-require 'engine/game/g_18_zoo'
 
 module Engine
   describe Game::G18ZOO do

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -2,7 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine'
 require 'find'
 require 'json'
 

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -2,8 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine'
-
 module Engine
   describe Hex do
     let(:game) { Engine.game_by_title('1889').new(%w[a b]) }

--- a/spec/lib/engine/part/city_spec.rb
+++ b/spec/lib/engine/part/city_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
-require 'engine'
-require 'engine/corporation'
-require 'engine/part/city'
-require 'engine/token'
 
 module Engine
   module Part

--- a/spec/lib/engine/part/revenue_center_spec.rb
+++ b/spec/lib/engine/part/revenue_center_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
-require 'engine/part/revenue_center'
 
 module Engine
   module Part

--- a/spec/lib/engine/player_spec.rb
+++ b/spec/lib/engine/player_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
-require 'engine/player'
 
 module Engine
   describe Player do

--- a/spec/lib/engine/round/auction_spec.rb
+++ b/spec/lib/engine/round/auction_spec.rb
@@ -2,14 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine/action/bid'
-require 'engine/game/g_1889'
-require 'engine/player'
-require 'engine/round/auction'
-require 'engine/step/waterfall_auction'
-require 'engine/game/g_1828'
-require 'engine/game/g_1828/step/waterfall_auction'
-
 module Engine
   describe Round::Auction do
     context '#1889' do

--- a/spec/lib/engine/round/operating_spec.rb
+++ b/spec/lib/engine/round/operating_spec.rb
@@ -2,14 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine'
-require 'engine/game/g_1846'
-require 'engine/game/g_1889'
-require 'engine/game/g_18_chesapeake'
-require 'engine/phase'
-require 'engine/round/operating'
-require 'engine/action/place_token'
-
 RSpec::Matchers.define :be_assigned_to do |expected|
   match do |actual|
     expected.assigned?(actual.id)

--- a/spec/lib/engine/round/stock_spec.rb
+++ b/spec/lib/engine/round/stock_spec.rb
@@ -2,13 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine/game/g_1882'
-require 'engine/game/g_1889'
-require 'engine/game/g_18_chesapeake'
-require 'engine/game/g_1828'
-require 'engine/phase'
-require 'engine/round/operating'
-
 module Engine
   describe Round::Stock do
     let(:players) { %w[a b c d e f] }

--- a/spec/lib/engine/share_pool_spec.rb
+++ b/spec/lib/engine/share_pool_spec.rb
@@ -2,13 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine'
-require 'engine/game/g_1846'
-require 'engine/game/g_1889'
-require 'engine/share_pool'
-require 'engine/share_price'
-require 'engine/player'
-
 module Engine
   describe SharePool do
     let(:game) { Game::G1889::Game.new(%w[a b c]) }

--- a/spec/lib/engine/stock_market_spec.rb
+++ b/spec/lib/engine/stock_market_spec.rb
@@ -2,12 +2,6 @@
 
 require './spec/spec_helper'
 
-require 'engine/corporation'
-require 'engine/game/g_1889'
-require 'engine/game/g_1828'
-require 'engine/stock_market'
-require 'engine/game/g_1828/stock_market'
-
 module Engine
   describe StockMarket do
     let(:subject) { StockMarket.new(Game::G1889::Game::MARKET, []) }

--- a/spec/lib/engine/tile_spec.rb
+++ b/spec/lib/engine/tile_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
-require 'engine'
-require 'engine/game/g_1889'
-require 'engine/tile'
 
 module Engine
   include Engine::Part

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'engine'
+require './spec/spec_helper'
 
 describe Engine do
   context 'create games with game_by_title' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require 'snabberb/component'
 
+require 'engine'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
This leads to fewer ~import~ require statements need in spec files, and fixes test behavior when loading a single spec file. For example, on the current master, this fails:

```
docker-compose exec rack rspec spec/lib/engine/stock_market_spec.rb
```

...while this passes:

```
docker-compose exec rack rspec
```

Having `spec_helper` load the whole `engine` allows more tests to pass with fewer `require` LOCs.