### PR TITLE
Convert 1828.Games and 1849 to use par groups for phased par values

### DIFF
--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -965,7 +965,7 @@ module Engine
 
         def new_auction_round
           Engine::Round::Auction.new(self, [
-            Engine::Step::CompanyPendingPar,
+            G1828::Step::CompanyPendingPar,
             G1828::Step::WaterfallAuction,
           ])
         end
@@ -1004,6 +1004,8 @@ module Engine
           setup_minors
           setup_company_min_price
 
+          @available_par_groups = %i[par]
+
           @log << "-- Setting game up for #{@players.size} players --"
           remove_extra_private_companies
           remove_extra_trains
@@ -1016,13 +1018,8 @@ module Engine
         end
 
         def init_stock_market
-          sm = G1828::StockMarket.new(self.class::MARKET, [],
-                                      multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
-          sm.enable_par_price(67)
-          sm.enable_par_price(71)
-          sm.enable_par_price(79)
-
-          sm
+          G1828::StockMarket.new(self.class::MARKET, [],
+                                 multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
         end
 
         def init_tiles
@@ -1076,20 +1073,19 @@ module Engine
 
         def event_green_par!
           @log << "-- Event: #{EVENTS_TEXT['green_par'][1]} --"
-          stock_market.enable_par_price(86)
-          stock_market.enable_par_price(94)
+          @available_par_groups << :par_1
           update_cache(:share_prices)
         end
 
         def event_blue_par!
           @log << "-- Event: #{EVENTS_TEXT['blue_par'][1]} --"
-          stock_market.enable_par_price(105)
+          @available_par_groups << :par_2
           update_cache(:share_prices)
         end
 
         def event_brown_par!
           @log << "-- Event: #{EVENTS_TEXT['brown_par'][1]} --"
-          stock_market.enable_par_price(120)
+          @available_par_groups << :par_3
           update_cache(:share_prices)
         end
 
@@ -1140,6 +1136,10 @@ module Engine
           return false if from.hex.id == VA_TUNNEL_HEX && to.name != '4'
 
           super
+        end
+
+        def par_prices
+          @stock_market.share_prices_with_types(@available_par_groups)
         end
 
         def merge_candidates(player, corporation)

--- a/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
@@ -85,6 +85,10 @@ module Engine
             super
           end
 
+          def get_par_prices(entity, _corp)
+            @game.par_prices.select { |p| p.price * 2 <= entity.cash }
+          end
+
           def stock_action(action)
             @current_actions << action
           end

--- a/lib/engine/game/g_1828/step/company_pending_par.rb
+++ b/lib/engine/game/g_1828/step/company_pending_par.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/company_pending_par'
+
+module Engine
+  module Game
+    module G1828
+      module Step
+        class CompanyPendingPar < Engine::Step::CompanyPendingPar
+          def get_par_prices(entity, _corp)
+            @game.par_prices.select { |p| p.price * 2 <= entity.cash }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1828/step/exchange.rb
+++ b/lib/engine/game/g_1828/step/exchange.rb
@@ -90,8 +90,8 @@ module Engine
             @corporation
           end
 
-          def get_par_prices(_entity, _corporation)
-            @game.stock_market.par_prices.select { |p| p.price <= @entity.cash }
+          def get_par_prices(entity, _corporation)
+            @game.par_prices.select { |p| p.price <= entity.cash }
           end
 
           def cash_to_par?(entity, corporation)

--- a/lib/engine/game/g_1828/stock_market.rb
+++ b/lib/engine/game/g_1828/stock_market.rb
@@ -6,19 +6,6 @@ module Engine
   module Game
     module G1828
       class StockMarket < Engine::StockMarket
-        def initialize(market, unlimited_types, multiple_buy_types: [])
-          super
-          @disabled_par_prices = @par_prices
-          @par_prices = []
-        end
-
-        def enable_par_price(price)
-          return unless (par = @disabled_par_prices.find { |p| p.price == price })
-
-          @par_prices << par
-          @disabled_par_prices.delete(par)
-        end
-
         def move_up(corporation)
           return move_right(corporation) if top_row?(corporation)
 

--- a/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
@@ -40,6 +40,10 @@ module Engine
             @moved_any = false
           end
 
+          def get_par_prices(entity, _corp)
+            @game.par_prices.select { |p| p.price * 2 <= entity.cash }
+          end
+
           def can_buy?(entity, bundle)
             super && @game.last_cert_last?(bundle)
           end

--- a/lib/engine/game/g_1849/step/company_pending_par.rb
+++ b/lib/engine/game/g_1849/step/company_pending_par.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/company_pending_par'
+
+module Engine
+  module Game
+    module G1849
+      module Step
+        class CompanyPendingPar < Engine::Step::CompanyPendingPar
+          def get_par_prices(entity, _corp)
+            @game.par_prices.select { |p| p.price * 2 <= entity.cash }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -11,19 +11,6 @@ module Engine
         BLOCKED_RIGHT_PRICES = [218, 240, 276].freeze
         BLOCKED_UP_PRICES = [230].freeze
 
-        def initialize(market, unlimited_types, multiple_buy_types: [])
-          super
-          @disabled_par_prices = @par_prices
-          @par_prices = []
-        end
-
-        def enable_par_price(price)
-          return unless (par = @disabled_par_prices.find { |p| p.price == price })
-
-          @par_prices << par
-          @disabled_par_prices.delete(par)
-        end
-
         def move(corp, row, column, force: false)
           super
           return if corp.reached_max_value || !corp.share_price.end_game_trigger?

--- a/spec/lib/engine/games/g_1828_spec.rb
+++ b/spec/lib/engine/games/g_1828_spec.rb
@@ -30,25 +30,25 @@ module Engine
 
     describe 'events' do
       it 'should be unlocked by game phase' do
-        expect(stock_market.par_prices.size).to eq(3)
-        expect(stock_market.par_prices.map(&:price)).to include(67, 71, 79)
+        expect(game.par_prices.size).to eq(3)
+        expect(game.par_prices.map(&:price)).to include(67, 71, 79)
 
         phase.buying_train!(corporation, game.trains.find { |t| t.name == '3' })
-        expect(stock_market.par_prices.size).to eq(5)
-        expect(stock_market.par_prices.map(&:price)).to include(67, 71, 79, 86, 94)
+        expect(game.par_prices.size).to eq(5)
+        expect(game.par_prices.map(&:price)).to include(67, 71, 79, 86, 94)
 
         phase.buying_train!(corporation, game.trains.find { |t| t.name == '5' })
-        expect(stock_market.par_prices.size).to eq(6)
-        expect(stock_market.par_prices.map(&:price)).to include(67, 71, 79, 86, 94, 105)
+        expect(game.par_prices.size).to eq(6)
+        expect(game.par_prices.map(&:price)).to include(67, 71, 79, 86, 94, 105)
 
         phase.buying_train!(corporation, game.trains.find { |t| t.name == '3+D' })
-        expect(stock_market.par_prices.size).to eq(7)
-        expect(stock_market.par_prices.map(&:price)).to include(67, 71, 79, 86, 94, 105, 120)
+        expect(game.par_prices.size).to eq(7)
+        expect(game.par_prices.map(&:price)).to include(67, 71, 79, 86, 94, 105, 120)
       end
 
       it 'should remove unparred corporations at purple phase' do
         player_1.cash = 10_000
-        stock_market.set_par(corporation, stock_market.par_prices.first)
+        stock_market.set_par(corporation, game.par_prices.first)
         5.times { game.share_pool.buy_shares(player_1, corporation.shares.first) }
 
         erie = game.corporations.find { |c| c.name == 'ERIE' }
@@ -69,7 +69,7 @@ module Engine
 
       it 'should trigger end game at purple phase' do
         player_1.cash = 10_000
-        stock_market.set_par(corporation, stock_market.par_prices.first)
+        stock_market.set_par(corporation, game.par_prices.first)
         5.times { game.share_pool.buy_shares(player_1, corporation.shares.first) }
 
         next_or!
@@ -87,7 +87,7 @@ module Engine
 
       it 'should block unless coal marker purchased' do
         player_1.cash = 10_000
-        stock_market.set_par(ic, stock_market.par_prices.first)
+        stock_market.set_par(ic, game.par_prices.first)
         5.times { game.share_pool.buy_shares(player_1, ic.shares.first) }
 
         next_or!
@@ -127,7 +127,7 @@ module Engine
 
       it 'should acquire coal marker when laying VA tunnel' do
         player_1.cash = 10_000
-        stock_market.set_par(co, stock_market.par_prices.first)
+        stock_market.set_par(co, game.par_prices.first)
         5.times { game.share_pool.buy_shares(player_1, co.shares.first) }
 
         next_or!


### PR DESCRIPTION
This PR refactors the phased par value logic shared by 1828.Games and 1849, to instead use par groups. Par groups functionality was added after these games were implemented, but has has recently been added to both to display the phased par prices as different colors in the stock market.

Additional rationale for the refactoring is 1) data classes (stock_market) shouldn't contain logic and 2) unifies par price behavior with how other games handle variable par prices.

Tested 1828.Games and 1849 in hot seat games, up through the green phase, to verify the par price logic.