### PR TITLE
[1822] English channel and Minor 14

### DIFF
--- a/assets/app/view/game/part/track_offboard.rb
+++ b/assets/app/view/game/part/track_offboard.rb
@@ -6,8 +6,6 @@ module View
   module Game
     module Part
       class TrackOffboard < Base
-        PARALLEL_SPACING = [8, 6, 4].freeze
-
         needs :path
         needs :offboard
         needs :color, default: 'black'
@@ -22,10 +20,6 @@ module View
           4 => [10],
           5 => [17],
         }.freeze
-
-        def calculate_shift(lane)
-          (lane[1] * 2 - lane[0] + 1) * (@width.to_i + PARALLEL_SPACING[lane[0] - 2]) / 2.0
-        end
 
         def edge
           @edge ||= @path.exits[0]
@@ -45,21 +39,11 @@ module View
           rotate = 60 * edge
 
           d_width = @width.to_i / 2
-          offboard_start_x = d_width
-          offboard_end_x = -d_width
-          begin_lane, = @path.lanes
-          if begin_lane[0] > 1
-            begin_shift = calculate_shift(begin_lane)
-            offboard_start_x += begin_shift
-            offboard_end_x += begin_shift
-          end
-          point_x = (offboard_start_x + offboard_end_x) / 2
 
           props = {
             attrs: {
               transform: "rotate(#{rotate})",
-              d: "M #{offboard_start_x} 75 L #{offboard_start_x} 87 L #{offboard_end_x} 87 "\
-                 "L #{offboard_end_x} 75 L #{point_x} 48 Z",
+              d: "M #{d_width} 75 L #{d_width} 87 L -#{d_width} 87 L -#{d_width} 75 L 0 48 Z",
               fill: @color,
               stroke: 'none',
               'stroke-linecap': 'butt',

--- a/assets/app/view/game/part/track_offboard.rb
+++ b/assets/app/view/game/part/track_offboard.rb
@@ -6,6 +6,8 @@ module View
   module Game
     module Part
       class TrackOffboard < Base
+        PARALLEL_SPACING = [8, 6, 4].freeze
+
         needs :path
         needs :offboard
         needs :color, default: 'black'
@@ -20,6 +22,10 @@ module View
           4 => [10],
           5 => [17],
         }.freeze
+
+        def calculate_shift(lane)
+          (lane[1] * 2 - lane[0] + 1) * (@width.to_i + PARALLEL_SPACING[lane[0] - 2]) / 2.0
+        end
 
         def edge
           @edge ||= @path.exits[0]
@@ -39,11 +45,21 @@ module View
           rotate = 60 * edge
 
           d_width = @width.to_i / 2
+          offboard_start_x = d_width
+          offboard_end_x = -d_width
+          begin_lane, = @path.lanes
+          if begin_lane[0] > 1
+            begin_shift = calculate_shift(begin_lane)
+            offboard_start_x += begin_shift
+            offboard_end_x += begin_shift
+          end
+          point_x = (offboard_start_x + offboard_end_x) / 2
 
           props = {
             attrs: {
               transform: "rotate(#{rotate})",
-              d: "M #{d_width} 75 L #{d_width} 87 L -#{d_width} 87 L -#{d_width} 75 L 0 48 Z",
+              d: "M #{offboard_start_x} 75 L #{offboard_start_x} 87 L #{offboard_end_x} 87 "\
+                 "L #{offboard_end_x} 75 L #{point_x} 48 Z",
               fill: @color,
               stroke: 'none',
               'stroke-linecap': 'butt',

--- a/lib/engine/config/game/g_1822.rb
+++ b/lib/engine/config/game/g_1822.rb
@@ -98,6 +98,7 @@ module Engine
     "M26": "Lincoln",
     "M30": "Peterborough",
     "M36": "Hertford",
+    "M38": "London",
     "M42": "Brighton",
     "N21": "Hull",
     "N23": "Grimsby",
@@ -150,7 +151,7 @@ module Engine
     "X20": {
       "count": 1,
       "color": "yellow",
-      "code": "city=revenue:40;city=revenue:40;city=revenue:40;city=revenue:40;city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=London"
+      "code": "city=revenue:40;city=revenue:40;city=revenue:40;city=revenue:40;city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=L"
     },
     "405": {
       "count": 3,
@@ -180,7 +181,7 @@ module Engine
     "X21": {
       "count": 1,
       "color": "green",
-      "code": "city=revenue:60;city=revenue:60;city=revenue:60;city=revenue:60;city=revenue:60;city=revenue:60;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=London"
+      "code": "city=revenue:60;city=revenue:60;city=revenue:60;city=revenue:60;city=revenue:60;city=revenue:60;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=L"
     },
     "145": {
       "count": 4,
@@ -230,7 +231,7 @@ module Engine
     "X22": {
       "count": 1,
       "color": "brown",
-      "code": "city=revenue:80;city=revenue:80;city=revenue:80;city=revenue:80;city=revenue:80;city=revenue:80;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=London"
+      "code": "city=revenue:80;city=revenue:80;city=revenue:80;city=revenue:80;city=revenue:80;city=revenue:80;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=L"
     },
     "169": {
       "count": 2,
@@ -285,7 +286,7 @@ module Engine
     "X23": {
       "count": 1,
       "color": "gray",
-      "code": "city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;label=London"
+      "code": "city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;label=L"
     }
   },
   "market": [
@@ -1365,7 +1366,6 @@ module Engine
       "hide_shares": true,
       "shares": [100],
       "max_ownership_percent": 100,
-      "coordinates": "R38",
       "color": "white",
       "text_color": "black"
     },
@@ -1756,7 +1756,7 @@ module Engine
           "name": "E",
           "distance": [
             {
-              "nodes": ["city"],
+              "nodes": ["city", "offboard"],
               "pay": 99,
               "visit": 99,
               "multiplier": 2
@@ -2036,8 +2036,7 @@ module Engine
         "L33",
         "M30",
         "P35",
-        "P41",
-        "R38"
+        "P41"
       ],
       "city=revenue:0;border=edge:1,type:impassable": [
         "I42"
@@ -2054,7 +2053,7 @@ module Engine
       "city=revenue:20,loc:center;town=revenue:10,loc:1;path=a:_0,b:_1;border=edge:0,type:impassable;label=S":[
         "D35"
       ],
-      "city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=London": [
+      "city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;label=L": [
         "M38"
       ],
       "city=revenue:0;label=T": [
@@ -2151,7 +2150,7 @@ module Engine
       "city=revenue:yellow_30|green_40|brown_50|gray_60,slots:2;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1": [
         "H1"
       ],
-      "offboard=revenue:yellow_0|green_60|brown_90|gray_120;path=a:2,b:_0": [
+      "offboard=revenue:yellow_0|green_60|brown_90|gray_120,visit_cost:0;path=a:2,b:_0": [
         "Q44"
       ]
     },

--- a/lib/engine/game/g_1822.rb
+++ b/lib/engine/game/g_1822.rb
@@ -542,7 +542,7 @@ module Engine
       end
 
       def after_lay_tile(hex, tile)
-        # If we upgraded lodon, check if we need to add the extra slot from minor 14
+        # If we upgraded london, check if we need to add the extra slot from minor 14
         upgrade_london(hex) if hex.name == self.class::LONDON_HEX
 
         # If we upgraded the english channel to brown, upgrade france as well since we got 2 lanes to france.

--- a/lib/engine/step/g_1822/minor_acquisition.rb
+++ b/lib/engine/step/g_1822/minor_acquisition.rb
@@ -204,15 +204,9 @@ module Engine
               # in london. This means you cant just acquire to get an exchange token if you dont have a valid
               # path to another node in london.
               # Try all 6 cities in london to see if there is atleast one connection
-              found_connected_city = false
               connected_nodes = @game.graph.connected_nodes(entity)
-              @game.hex_by_id(@game.class::LONDON_HEX).tile.cities.each do |c|
-                found_connected_city = connected_nodes[c]
-                if found_connected_city && c.tokened_by?(entity)
-                  found_connected_city = false
-                elsif found_connected_city
-                  break
-                end
+              found_connected_city = @game.hex_by_id(@game.class::LONDON_HEX).tile.cities.any? do |c|
+                connected_nodes[c] && !c.tokened_by?(entity)
               end
             else
               minor_city = if !minor.owner || minor.owner == @bank

--- a/lib/engine/step/g_1822/pending_token.rb
+++ b/lib/engine/step/g_1822/pending_token.rb
@@ -16,7 +16,7 @@ module Engine
           if action.city.tokened_by?(entity)
             hex = city.hex
             city_string = city.hex.tile.cities.size > 1 ? " city #{city.index}" : ''
-            raise GameError, "Cannot place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
+            raise GameError, "Can't place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
                              'tokens in the same city'
           end
 

--- a/lib/engine/step/g_1822/pending_token.rb
+++ b/lib/engine/step/g_1822/pending_token.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../home_token'
+
+module Engine
+  module Step
+    module G1822
+      class PendingToken < HomeToken
+        def can_replace_token?(_entity, _token)
+          true
+        end
+
+        def process_place_token(action)
+          entity = action.entity
+          city = action.city
+          if action.city.tokened_by?(entity)
+            hex = city.hex
+            city_string = city.hex.tile.cities.size > 1 ? " city #{city.index}" : ''
+            raise GameError, "Cannot place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
+                             'tokens in the same city'
+          end
+
+          connected = action.entity.id != @game.class::MINOR_14_ID
+          place_token(token.corporation, city, token, connected: connected, extra: true, check_tokenable: false)
+          @round.pending_tokens.shift
+          @game.after_place_pending_token(action.city)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/g_1822/token.rb
+++ b/lib/engine/step/g_1822/token.rb
@@ -17,14 +17,14 @@ module Engine
           if entity.corporation? && entity.type == :major
             destination_token = entity.find_token_by_type(:destination)
             if destination_token && city.hex.name == @game.class::DESTINATIONS[entity.id]
-              raise GameError, "Cannot place token on #{city.hex.name}, that hex is reserved for destination token. "\
+              raise GameError, "Can't place token on #{city.hex.name}, that hex is reserved for destination token. "\
                                'Please undo this move and place your destination token'
             end
 
             if city.tokened_by?(entity)
               hex = city.hex
               city_string = city.hex.tile.cities.size > 1 ? " city #{city.index}" : ''
-              raise GameError, "Cannot place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
+              raise GameError, "Can't place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
                              'tokens in the same city'
             end
           end

--- a/lib/engine/step/g_1822/token.rb
+++ b/lib/engine/step/g_1822/token.rb
@@ -20,9 +20,18 @@ module Engine
               raise GameError, "Cannot place token on #{city.hex.name}, that hex is reserved for destination token. "\
                                'Please undo this move and place your destination token'
             end
+
+            if city.tokened_by?(entity)
+              hex = city.hex
+              city_string = city.hex.tile.cities.size > 1 ? " city #{city.index}" : ''
+              raise GameError, "Cannot place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
+                             'tokens in the same city'
+            end
           end
 
-          super
+          check_tokenable = city.hex.name != @game.class::LONDON_HEX
+          place_token(entity, action.city, action.token, check_tokenable: check_tokenable)
+          pass!
         end
       end
     end

--- a/lib/engine/step/g_1822/track.rb
+++ b/lib/engine/step/g_1822/track.rb
@@ -8,6 +8,30 @@ module Engine
     module G1822
       class Track < Engine::Step::Track
         include Tracker
+
+        def available_hex(entity, hex)
+          connected = super
+          return nil unless connected
+
+          # London yellow tile counts as an upgrade
+          if hex.tile.color == :white && @round.num_laid_track.positive? && hex.name == @game.class::LONDON_HEX
+            return nil
+          end
+
+          connected
+        end
+
+        def check_track_restrictions!(entity, old_tile, new_tile)
+          return if @game.loading || !entity.operator?
+          return if new_tile.hex.name == @game.class::ENGLISH_CHANNEL_HEX
+
+          super
+        end
+
+        def process_lay_tile(action)
+          super
+          @game.after_lay_tile(action.hex, action.tile)
+        end
       end
     end
   end

--- a/lib/engine/step/g_1822/tracker.rb
+++ b/lib/engine/step/g_1822/tracker.rb
@@ -8,6 +8,13 @@ module Engine
       module Tracker
         include Step::Tracker
 
+        def can_lay_tile?(entity)
+          # Special case for minor 14, the first OR its hometoken placement counts as tile lay
+          return false if entity.corporation? && entity.id == @game.class::MINOR_14_ID && !entity.operated?
+
+          super
+        end
+
         def legal_tile_rotation?(entity, hex, tile)
           # We will remove a town from the white S tile, this meaning we will not follow the normal path upgrade rules
           if hex.name == @game.class::UPGRADABLE_S_HEX_NAME &&
@@ -53,6 +60,16 @@ module Engine
             cost - border_cost_discount(entity, border, hex)
           end
           [total_cost, types]
+        end
+
+        def upgraded_track(action)
+          # London yellow tile counts as an upgrade
+          unless action.tile.color != :yellow ||
+            (action.tile.color == :yellow && action.hex.name == @game.class::LONDON_HEX)
+            return
+          end
+
+          @round.upgraded_track = true
         end
       end
     end

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -33,7 +33,7 @@ module Engine
         false
       end
 
-      def place_token(entity, city, token, connected: true, extra: false, special_ability: nil)
+      def place_token(entity, city, token, connected: true, extra: false, special_ability: nil, check_tokenable: true)
         hex = city.hex
         extra ||= special_ability.extra if special_ability&.type == :token
 
@@ -70,7 +70,8 @@ module Engine
           cheater = ability.cheater
           extra_slot = ability.extra_slot
         end
-        city.place_token(entity, token, free: free, cheater: cheater, extra_slot: extra_slot)
+        city.place_token(entity, token, free: free, check_tokenable: check_tokenable,
+                                        cheater: cheater, extra_slot: extra_slot)
         unless free
           pay_token_cost(entity, token.price)
           price_log = " for #{@game.format_currency(token.price)}"


### PR DESCRIPTION
- Only one of the 2 tracks connecting Merthyr Tydfil and Pontypool can be used each OR.
- Lay a yellow tile on London counts as an upgrade. In the real game, this is a wooden token you flip.
- A corporation now can have more than one token in London.
- English channel, must have connection to France to be able to run train to english channel. France doesnt count as a stop.
- When upgrading english channel to brown, there are 2 lanes to france. Upgrade the france tile to a tile with 2 lanes as well.
- Fixed off board graphics to handle lanes.
- Exposed the parameter from city.place_token "check_tokenable: true" in the tokener.place_token method. I need to bypass the check if a corporation already have a token on a tile. In London you can have multiple tokens.
- Minor 14, this minor shares a city in london with another corporation. When placing home token you have the choise of any of the 6 cities in london and spot in that city will open up. When a major acquires minor 14 they have the option of replace its token or remove it. If they remove the token the newly opened slot will become permantent so other corporations can token there. If a major i phase 5+ choose to acquire minor 14 from the bidbox they have the option of placing a token in any of the cities in london they have connection to. This also opens up a new slot in the selected city.
- There a alot of special cases in the code just for minor 14. I tried to make it as clean as possible.
- London is a real mess in the gui, 6 cities, city revenue, upgrade cost, a label and location name. If minor 14 starts one of the cities also gets 2 slots. What i can test everything works, but there are lot of hit boxes to press and you need some precision to press the right one. Mobile user will have to zoom quite a bit :)

After this PR i will try to migrate to the new structure.