### PR TITLE
Add options to graph and node for 1873

### DIFF
--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -107,7 +107,7 @@ module Engine
       end
 
       if @home_as_token
-        home_hexes =  Array(corporation.coordinates).map { |h| @game.hex_by_id(h) }
+        home_hexes = Array(corporation.coordinates).map { |h| @game.hex_by_id(h) }
         home_hexes.each do |hex|
           hex.tile.city_towns.each do |ct|
             hex.neighbors.each { |e, _| hexes[hex][e] = true }

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -107,9 +107,8 @@ module Engine
       end
 
       if @home_as_token
-        @game.hexes.each do |hex|
-          next unless Array(corporation.coordinates).include?(hex.id)
-
+        home_hexes =  Array(corporation.coordinates).map { |h| @game.hex_by_id(h) }
+        home_hexes.each do |hex|
           hex.tile.city_towns.each do |ct|
             hex.neighbors.each { |e, _| hexes[hex][e] = true }
             nodes[ct] = true

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -99,10 +99,21 @@ module Engine
 
       @game.hexes.each do |hex|
         hex.tile.cities.each do |city|
-          next unless city.tokened_by?(corporation) || @home_as_token && corporation.coordinates == hex.id
+          next unless city.tokened_by?(corporation)
 
           hex.neighbors.each { |e, _| hexes[hex][e] = true }
           nodes[city] = true
+        end
+      end
+
+      if @home_as_token
+        @game.hexes.each do |hex|
+          next unless Array(corporation.coordinates).include?(hex.id)
+
+          hex.tile.city_towns.each do |ct|
+            hex.neighbors.each { |e, _| hexes[hex][e] = true }
+            nodes[ct] = true
+          end
         end
       end
 

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -36,13 +36,15 @@ module Engine
         on.keys.select { |p| on[p] == 1 }
       end
 
-      def walk(visited: nil, on: nil, corporation: nil, visited_paths: {})
+      def walk(visited: nil, on: nil, corporation: nil, visited_paths: {}, skip_track: nil)
         return if visited&.[](self)
 
         visited = visited&.dup || {}
         visited[self] = true
 
         paths.each do |node_path|
+          next if node_path.track == skip_track
+
           node_path.walk(visited: visited_paths, on: on) do |path, vp|
             yield path
             path.nodes.each do |next_node|
@@ -55,6 +57,7 @@ module Engine
                 on: on,
                 corporation: corporation,
                 visited_paths: visited_paths.merge(vp),
+                skip_track: skip_track,
               ) { |p| yield p }
             end
           end


### PR DESCRIPTION
1873 has special requirements for the Graph:
* RR corps have to ignore normal-gauge track when laying tiles and tokens
* private mines need to ignore tokens when laying lines and calculating connectivity to the state railroad track (normal-gauge)
* private mines need to trace track starting from their home hex even though they have no tokens

Engine::Graph now supports three new options: home_as_token, no_blocking, and skip_track to support this
Engine::Part::Node now has a skip_track option to support this