### PR TITLE
ios macos color inputs (again)

### DIFF
--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -159,7 +159,7 @@ module View
     end
 
     def render_color(label, id, hex_color, attrs: {})
-      render_input(label, id: id, type: :color, attrs: { value: hex_color, **attrs },
+      render_input(label, id: id, type: :color, attrs: { value: hex_color, **attrs }, on: { input: -> { submit } },
                           input_style: { backgroundColor: hex_color })
     end
 

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -170,7 +170,7 @@ nav#game_menu {
   width: 2.7rem;
 }
 ::-webkit-color-swatch {
-    background-color: inherit !important; /* fix iOS/macOS black color inputs */
+    background-color: inherit; /* fix iOS/macOS black color inputs */
 }
 ::-webkit-color-swatch-wrapper {
     border: 1px solid gainsboro;


### PR DESCRIPTION
Without submit color inputs on Safari (iOS/macOS) aren’t updated. After merge changes of main bg and font color will be visible instantly.