### PR TITLE
Reset tile selector when invalid tile is selected

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -70,20 +70,22 @@ module View
         if current_entity && @tile_selector
           left = (@tile_selector.x + map_x) * @scale
           top = (@tile_selector.y + map_y) * @scale
-          tiles = step.upgradeable_tiles(current_entity, @tile_selector.hex)
           selector =
             if @tile_selector.is_a?(Lib::TokenSelector)
               # 1882
               h(TokenSelector, zoom: map_zoom)
             elsif @tile_selector.role != :map
               # Tile selector not for the map
-            elsif @tile_selector.hex.tile != @tile_selector.tile && !tiles.include?(@tile_selector.tile)
+            elsif @tile_selector.hex.tile != @tile_selector.tile &&
+                                  !step.potential_tiles(current_entity,
+                                                        @tile_selector.hex).include?(@tile_selector.tile)
               # Resets tile_confirmation when the tiles have changed (through abilities etc...)
               store(:tile_selector, nil)
               nil
             elsif @tile_selector.hex.tile != @tile_selector.tile
               h(TileConfirmation)
             else
+              tiles = step.upgradeable_tiles(current_entity, @tile_selector.hex)
               all_upgrades = @game.all_potential_upgrades(@tile_selector.hex.tile)
 
               select_tiles = all_upgrades.map do |tile|

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -70,16 +70,20 @@ module View
         if current_entity && @tile_selector
           left = (@tile_selector.x + map_x) * @scale
           top = (@tile_selector.y + map_y) * @scale
+          tiles = step.upgradeable_tiles(current_entity, @tile_selector.hex)
           selector =
             if @tile_selector.is_a?(Lib::TokenSelector)
               # 1882
               h(TokenSelector, zoom: map_zoom)
             elsif @tile_selector.role != :map
               # Tile selector not for the map
+            elsif @tile_selector.hex.tile != @tile_selector.tile && !tiles.include?(@tile_selector.tile)
+              # Resets tile_confirmation when the tiles have changed (through abilities etc...)
+              store(:tile_selector, nil)
+              nil
             elsif @tile_selector.hex.tile != @tile_selector.tile
               h(TileConfirmation)
             else
-              tiles = step.upgradeable_tiles(current_entity, @tile_selector.hex)
               all_upgrades = @game.all_potential_upgrades(@tile_selector.hex.tile)
 
               select_tiles = all_upgrades.map do |tile|
@@ -120,7 +124,7 @@ module View
             },
           }
           # This needs to be before the map, so that the relative positioning works
-          children.unshift(h(:div, props, [selector]))
+          children.unshift(h(:div, props, [selector])) if selector
         end
 
         props = {

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -80,6 +80,8 @@ module Engine
           end
         end
 
+        raise GameError, "#{tile.name} cannot be placed" unless potential_tiles(entity, hex).include?(tile)
+
         tile.rotate!(rotation)
 
         unless @game.upgrades_to?(old_tile, tile, entity.company?)


### PR DESCRIPTION
When a tile is selected and then the ability is activated, the tile is still selected and can be confirmed and placed.

This change resets the tile confirmation when the upgradable_tiles no longer include the selected tile

Added also validation when tile_lay.

Not sure about the error message, and this could potentially break every game with a tile_lay ability

To reproduce the server error (when commenting the view changes out)
Works with a company in 18CZ or with mitsubishy ferry in 1889

To reproduce:
Be in track Step:
click on tile to build:
activate ability
select purple tile
deacivate ability
place tile
profit