### PR TITLE
[1846] Fix LSL invalid tile lay

### DIFF
--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -57,7 +57,10 @@ module View
         companies.map do |company|
           props = {
             on: {
-              click: -> { store(:selected_company, @selected_company == company ? nil : company) },
+              click: lambda do
+                store(:tile_selector, nil, skip: true)
+                store(:selected_company, @selected_company == company ? nil : company)
+              end,
             },
           }
           props[:class] = { active: true } if @selected_company == company

--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -762,11 +762,7 @@ module Engine
           return unless @players.size.between?(*Engine.player_range(self.class))
 
           remove_from_group!(self.class::ORANGE_GROUP, @companies) do |company|
-            if company == lake_shore_line
-              self.class::LSL_HEXES.each do |hex|
-                hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::LSL_ICON }
-              end
-            end
+            remove_lsl_icons if company == lake_shore_line
             company.close!
             @round.active_step.companies.delete(company)
           end
@@ -1032,7 +1028,7 @@ module Engine
             G1846::Step::Bankrupt,
             G1846::Step::Assign,
             Engine::Step::SpecialToken,
-            Engine::Step::SpecialTrack,
+            G1846::Step::SpecialTrack,
             G1846::Step::BuyCompany,
             G1846::Step::IssueShares,
             G1846::Step::TrackAndToken,
@@ -1053,9 +1049,7 @@ module Engine
 
           @minors.dup.each { |minor| close_corporation(minor) }
 
-          self.class::LSL_HEXES.each do |hex|
-            hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::LSL_ICON }
-          end
+          remove_lsl_icons
         end
 
         def event_remove_tokens!
@@ -1085,6 +1079,12 @@ module Engine
             hex = removal[:hex]
             corp = removal[:corporation]
             @log << "-- Event: #{corp}'s #{company_by_id(company).name} token removed from #{hex} --"
+          end
+        end
+
+        def remove_lsl_icons
+          self.class::LSL_HEXES.each do |hex|
+            hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::LSL_ICON }
           end
         end
 

--- a/lib/engine/game/g_1846/step/special_track.rb
+++ b/lib/engine/game/g_1846/step/special_track.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/special_track'
+
+module Engine
+  module Game
+    module G1846
+      module Step
+        class SpecialTrack < Engine::Step::SpecialTrack
+          def process_lay_tile(action)
+            @game.remove_lsl_icons if action.entity.id == 'LSL'
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/track_and_token.rb
+++ b/lib/engine/step/track_and_token.rb
@@ -65,6 +65,12 @@ module Engine
         lay_tile_action(action)
         pass! if !can_lay_tile?(action.entity) && @tokened
       end
+
+      def available_hex(entity, hex)
+        return super if can_lay_tile?(entity)
+
+        @game.graph.reachable_hexes(entity)[hex]
+      end
     end
   end
 end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -72,6 +72,7 @@ module Engine
         old_tile = hex.tile
 
         @game.companies.each do |company|
+          break if @game.loading
           next if company.closed?
           next unless (ability = @game.abilities(company, :blocks_hexes))
 
@@ -97,11 +98,13 @@ module Engine
         free = false
         discount = 0
         teleport = false
+        ability_found = false
 
         abilities(entity) do |ability|
           next if ability.owner != entity
           next if !ability.hexes.empty? && (!ability.hexes.include?(hex.id) || !ability.tiles.include?(tile.name))
 
+          ability_found = true
           if ability.type == :teleport
             teleport = true
             free = true if ability.free_tile_lay
@@ -120,6 +123,10 @@ module Engine
             discount = ability.discount
             extra_cost += ability.cost
           end
+        end
+
+        if entity.company? && !ability_found
+          raise GameError, "#{entity.name} does not have an ability that allows them to lay this tile"
         end
 
         check_track_restrictions!(entity, old_tile, tile) unless teleport


### PR DESCRIPTION
- Clear the selected tile when toggling an ability
- Verify a matching ability was found when a company lays a tile
- Remove LSL icons after using its ability
- Show available hexes to token after both tiles have been laid
- Minor performance improvement

@Zwergenpunk, this may also fix CZ.

**Please validate against all games before deploying in case their is an edge case I missed where its valid to not have an ability**