### PR TITLE
18SJ: Correct GKB revenue (fixes #3822)

### DIFF
--- a/lib/engine/game/g_18_sj.rb
+++ b/lib/engine/game/g_18_sj.rb
@@ -657,7 +657,15 @@ module Engine
 
         bonuses = route.stops.count { |s| ability.hexes.include?(s.hex.name) }
         if bonuses.positive?
-          bonus[:revenue] = ability.amount * bonuses
+          amount = case ability.count
+                   when 3
+                     50
+                   when 2
+                     30
+                   else
+                     20
+                   end
+          bonus[:revenue] = amount * bonuses
           bonus[:description] = 'GKB'
           bonus[:description] += "x#{bonuses}" if bonuses > 1
         end


### PR DESCRIPTION
GKB gave 50 bonus every time it was used, instead of decreasing.
So too much money was received.

If games are broken by this, it cannot be fixed. So delete, pin or
archive them.