### PR TITLE
1860: fix available_hex for upgrades

### DIFF
--- a/lib/engine/game/g_1860/step/track.rb
+++ b/lib/engine/game/g_1860/step/track.rb
@@ -117,9 +117,8 @@ module Engine
             return true if reachable_hex?(entity, hex, max_distance)
 
             path_distances = @game.path_distances(entity)
-            return false if hex.tile.paths.any? { |p| path_distances[p] }
 
-            # tile is currently not on network (it should be a neighbor to one that is)
+            # tile is currently not on the reachable network (it should be a neighbor to one that is)
             # We err on the side of caution, final determination needs to be based on actual tile placed
             neighbors.each do |edge|
               nhex = hex.neighbors[edge]


### PR DESCRIPTION
Fixes #4029 

I was too conservative in calculating what hexes could be upgraded.
This should a very safe change, since it only affects the UI. If anything, more hexes than needed will be un-greyed for the lay tile action. The validation of the tile being laid, however, has not been changed at all.

**Examples (BHI&R has a 3+2 train)**

Before (Ryde is greyed out)
![1860_reachable_before](https://user-images.githubusercontent.com/8494213/108574073-92b60380-72d3-11eb-9e0c-d850a26b98ab.png)

After (Ryde is available for an upgrade)
![1860_rechable_fix](https://user-images.githubusercontent.com/8494213/108574108-a497a680-72d3-11eb-93de-d1050683b9a1.png)

Showing that an upgrade is now possible:
![1860_reachable_after](https://user-images.githubusercontent.com/8494213/108574152-ce50cd80-72d3-11eb-8ac2-59473a51cb06.png)


