### PR TITLE
18SJ: Fix bug that caused nationalization to be dealyed (fixes #3437)

### DIFF
--- a/lib/engine/game/g_18_sj.rb
+++ b/lib/engine/game/g_18_sj.rb
@@ -271,7 +271,7 @@ module Engine
           Step::G18SJ::BuyTrainBeforeRunRoute,
           Step::G18SJ::Route,
           Step::G18SJ::Dividend,
-          Step::SpecialBuyTrain,
+          Step::G18SJ::SpecialBuyTrain,
           Step::G18SJ::BuyTrain,
           [Step::BuyCompany, blocks: true],
         ], round_num: round_num)

--- a/lib/engine/step/g_18_sj/special_buy_train.rb
+++ b/lib/engine/step/g_18_sj/special_buy_train.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../special_buy_train'
+require_relative 'buy_train_action'
+
+module Engine
+  module Step
+    module G18SJ
+      class SpecialBuyTrain < SpecialBuyTrain
+        include BuyTrainAction
+
+        def actions(entity)
+          # If this entity has used Motala Verkstad to buy train(s) do not allow any normal train buys
+          return [] if @round.respond_to?(:premature_trains_bought) && @round.premature_trains_bought.include?(entity)
+
+          super
+        end
+
+        def do_after_buy_train_action(_action, _entity); end
+      end
+    end
+  end
+end


### PR DESCRIPTION
18SJ needed its own special train buy to add the needed checks.

If this break any game delete, pin or archive as usual. Cannot fix via migration as the bug means a corporation might gets to act even though it should have been closed.

Fixes #3437 