### PR TITLE
spreadsheet usability/cleanup

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -24,22 +24,28 @@ module View
         @hide_not_floated = Lib::Storage['spreadsheet_hide_not_floated']
 
         children = []
+        children << render_table
+        children << render_spreadsheet_controls
 
-        top_line_props = {
+        extra_cards_props = {
+          hook: {
+            insert: lambda { |vnode|
+              last_td = Native(`document.querySelector('#player_details > tr > td:last-child').getBoundingClientRect()`)
+              p_details = Native(`document.getElementById('player_details').getBoundingClientRect()`)
+              controls = Native(`document.getElementById('spreadsheet_controls').getBoundingClientRect()`)
+              Native(vnode)['elm'].style.left = "calc(#{last_td.right.to_i}px + 1rem)"
+              Native(vnode)['elm'].style.top = "-#{controls.bottom.to_i - p_details.top.to_i}px"
+            },
+          },
           style: {
-            display: 'grid',
-            grid: 'auto / repeat(auto-fill, minmax(20rem, 1fr))',
-            gap: '3rem 1.2rem',
+            position: 'relative',
+            maxWidth: 'max-content',
           },
         }
-        top_line = h(:div, top_line_props, [
+        children << h('div#extra_cards', extra_cards_props, [
           h(Bank, game: @game),
           h(GameInfo, game: @game, layout: 'upcoming_trains'),
         ].compact)
-
-        children << top_line
-        children << render_table
-        children << render_spreadsheet_controls
 
         h('div#spreadsheet', {
             style: {
@@ -67,7 +73,7 @@ module View
               h(:td, { attrs: { colspan: @halfpaid ? 6 : 3 } }, "[withheld]#{' ¦half-paid¦' if @halfpaid}"),
             ]),
           ]),
-          h(:tbody, [
+          h('tbody#player_details', [
             render_player_cash,
             render_player_value,
             render_player_liquidity,
@@ -78,7 +84,7 @@ module View
           h(:thead, [
             h(:tr, { style: { height: '1rem' } }, ''),
           ]),
-          h(:tbody, [*render_player_history]),
+          h('tbody#player_history', [*render_player_history]),
         ])
         # TODO: consider adding OR information (could do both corporation OR revenue and player change in value)
         # TODO: consider adding train availability
@@ -286,7 +292,7 @@ module View
       end
 
       def render_spreadsheet_controls
-        h(:div, [
+        h('div#spreadsheet_controls', { style: { maxWidth: 'max-content' } }, [
           h(:button, {
               style: { minWidth: '9.5rem' },
               on: { click: -> { toggle_delta_value } },

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -86,8 +86,6 @@ module View
           ]),
           h('tbody#player_history', [*render_player_history]),
         ])
-        # TODO: consider adding OR information (could do both corporation OR revenue and player change in value)
-        # TODO: consider adding train availability
       end
 
       def or_history(corporations)

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -360,6 +360,8 @@ module View
       end
 
       def render_corporation(corporation, operating_order, current_round)
+        return '' if @hide_not_floated && !corporation.floated?
+
         border_style = "1px solid #{color_for(:font2)}"
 
         name_props =
@@ -373,8 +375,7 @@ module View
         tr_props = tr_default_props
         market_props = { style: { borderRight: border_style } }
         if !corporation.floated?
-          tr_props[:style][:opacity] = '0.6'
-          tr_props[:style][:display] = 'none' if @hide_not_floated
+          tr_props[:style][:opacity] = '0.5'
         elsif corporation.share_price&.highlight? &&
           (color = StockMarket::COLOR_MAP[@game.class::STOCKMARKET_COLORS[corporation.share_price.type]])
           market_props[:style][:backgroundColor] = color

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -77,7 +77,7 @@ module View
           h(:thead, [
             h(:tr, { style: { height: '1rem' } }, ''),
           ]),
-          *render_player_history,
+          h(:tbody, [*render_player_history]),
         ])
         # TODO: consider adding OR information (could do both corporation OR revenue and player change in value)
         # TODO: consider adding train availability
@@ -180,7 +180,7 @@ module View
 
         pd_props = {
           style: {
-            background: 'salmon',
+            backgroundColor: 'salmon',
             color: 'black',
           },
         }
@@ -339,7 +339,7 @@ module View
         name_props =
           {
             style: {
-              background: corporation.color,
+              backgroundColor: corporation.color,
               color: corporation.text_color,
             },
           }

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -137,11 +137,11 @@ module View
           revenue_text, opacity =
             case (hist[x].dividend.is_a?(Engine::Action::Dividend) ? hist[x].dividend.kind : 'withhold')
             when 'withhold'
-              ["[#{hist[x].revenue.abs}]", '0.5']
+              ["[#{hist[x].revenue}]", '0.5']
             when 'half'
-              ["¦#{hist[x].revenue.abs}¦", '0.75']
+              ["¦#{hist[x].revenue}¦", '0.75']
             else
-              [hist[x].revenue.abs.to_s, '1.0']
+              [hist[x].revenue.to_s, '1.0']
             end
 
           props = {

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -23,35 +23,12 @@ module View
         @delta_value = Lib::Storage['spreadsheet_delta_value']
         @hide_not_floated = Lib::Storage['spreadsheet_hide_not_floated']
 
-        children = []
-        children << render_table
-        children << render_spreadsheet_controls
-
-        extra_cards_props = {
-          hook: {
-            insert: lambda { |vnode|
-              last_td = Native(`document.querySelector('#player_details > tr > td:last-child').getBoundingClientRect()`)
-              p_details = Native(`document.getElementById('player_details').getBoundingClientRect()`)
-              controls = Native(`document.getElementById('spreadsheet_controls').getBoundingClientRect()`)
-              Native(vnode)['elm'].style.left = "calc(#{last_td.right.to_i}px + 1rem)"
-              Native(vnode)['elm'].style.top = "-#{controls.bottom.to_i - p_details.top.to_i}px"
-            },
-          },
-          style: {
-            position: 'relative',
-            maxWidth: 'max-content',
-          },
-        }
-        children << h('div#extra_cards', extra_cards_props, [
-          h(Bank, game: @game),
-          h(GameInfo, game: @game, layout: 'upcoming_trains'),
-        ].compact)
-
         h('div#spreadsheet', {
             style: {
               overflow: 'auto',
             },
-          }, children.compact)
+          },
+          [render_table, render_spreadsheet_controls, render_extra_cards])
       end
 
       def render_table
@@ -63,7 +40,7 @@ module View
               whiteSpace: 'nowrap',
             },
           }, [
-          h(:thead, render_title),
+          h(:thead, render_theads),
           h(:tbody, render_corporations),
           h(:thead, [
             h(:tr, { style: { height: '1rem' } }, [
@@ -86,6 +63,29 @@ module View
           ]),
           h('tbody#player_history', [*render_player_history]),
         ])
+      end
+
+      def render_extra_cards
+        props = {
+          hook: {
+            insert: lambda { |vnode|
+              last_td = Native(`document.querySelector('#player_details > tr > td:last-child').getBoundingClientRect()`)
+              p_details = Native(`document.getElementById('player_details').getBoundingClientRect()`)
+              controls = Native(`document.getElementById('spreadsheet_controls').getBoundingClientRect()`)
+              Native(vnode)['elm'].style.left = "calc(#{last_td.right.to_i}px + 1rem)"
+              Native(vnode)['elm'].style.top = "-#{controls.bottom.to_i - p_details.top.to_i}px"
+            },
+          },
+          style: {
+            position: 'relative',
+            maxWidth: 'max-content',
+          },
+        }
+
+        h('div#extra_cards', props, [
+          h(Bank, game: @game),
+          h(GameInfo, game: @game, layout: 'upcoming_trains'),
+        ].compact)
       end
 
       def or_history(corporations)
@@ -168,7 +168,7 @@ module View
         end
       end
 
-      def render_title
+      def render_theads
         th_props = lambda do |cols, border_right = true|
           props = tr_default_props
           props[:attrs] = { colspan: cols }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -111,7 +111,7 @@ th, td {
   background-color: #CCCCCC;
   color: black;
 }
-#spreadsheet tbody > tr:nth-child(2n) > *:not([style*="background"]) { /* zebra-style unless bg-color */
+#spreadsheet tbody > tr:nth-child(2n) {
   background-image: linear-gradient(rgba(255,255,255,0.4),rgba(255,255,255,0.4));
 }
 #spreadsheet tbody > tr:hover {

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -111,6 +111,9 @@ th, td {
   background-color: #CCCCCC;
   color: black;
 }
+#spreadsheet tbody > tr:hover {
+  filter: drop-shadow(1px 0px 2px #555);
+}
 
 @media (prefers-color-scheme: dark) {
   body {

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -111,6 +111,9 @@ th, td {
   background-color: #CCCCCC;
   color: black;
 }
+#spreadsheet tbody > tr:nth-child(2n) > *:not([style*="background"]) { /* zebra-style unless bg-color */
+  background-image: linear-gradient(rgba(255,255,255,0.4),rgba(255,255,255,0.4));
+}
 #spreadsheet tbody > tr:hover {
   filter: drop-shadow(1px 0px 2px #555);
 }

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -339,7 +339,8 @@ text.number {
 }
 
 .name {
-  max-width: 7rem;
+  min-width: 3rem;
+  max-width: 5rem;
 }
 
 .corp div, .player div {


### PR DESCRIPTION
- table split into corporations and player details, to easily render bank & upcoming trains cards next to player details which better utilizes screen space (closes #2804)
- subtle row highlighting
- toggle visibility of not floated corporations
- zebra styling simplified
- slimmer player columns, no wiggling on delta/total toggle

Visibility toggling of not floated corporations also hides merged ones (cf. [18Mex](https://18xx.games/game/20831), [1828](https://18xx.games/game/27831)). I’m not sure if "floated"/"all" is precise (enough). Additionally the link might be better placed above SYM.

ante
![image](https://user-images.githubusercontent.com/33390595/108590819-ca6d8b80-7365-11eb-85f3-f0cc9f8364e7.png)

post
all corps
![image](https://user-images.githubusercontent.com/33390595/108601095-1c7cd400-739b-11eb-875c-2ac93ab21870.png)

not floated hidden, PW row highlighted
![image](https://user-images.githubusercontent.com/33390595/108601358-75993780-739c-11eb-89fc-8533ce052b09.png)