### PR TITLE
In route selection, display hexes used for hex trains (#3523)

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -136,7 +136,7 @@ module View
 
             td_props = { style: { paddingRight: '0.8rem' } }
 
-            children << h('td.right', td_props, route.distance)
+            children << h('td.right', td_props, route.cost_str)
             if route.halts
               render_halts = true
               children << h('td.right', td_props, halt_actions(route, revenue,
@@ -195,7 +195,7 @@ module View
             h(:thead, [
               h(:tr, [
                 h(:th, 'Train'),
-                h(:th, 'Stops'),
+                h(:th, 'Used'),
                 h(:th, 'Revenue'),
                 h(:th, th_route_props, 'Route'),
               ]),

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -136,7 +136,7 @@ module View
 
             td_props = { style: { paddingRight: '0.8rem' } }
 
-            children << h('td.right', td_props, route.cost_str)
+            children << h('td.right', td_props, route.distance_str)
             if route.halts
               render_halts = true
               children << h('td.right', td_props, halt_actions(route, revenue,

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -963,7 +963,7 @@ module Engine
         "#{entity.percent_to_float}% to float" if entity.corporation?
       end
 
-      def route_cost_str(route)
+      def route_distance_str(route)
         route_distance(route).to_s
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -963,6 +963,10 @@ module Engine
         "#{entity.percent_to_float}% to float" if entity.corporation?
       end
 
+      def route_cost_str(route)
+        route_distance(route).to_s
+      end
+
       def route_distance(route)
         route.visited_stops.sum(&:visit_cost)
       end

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -858,19 +858,18 @@ module Engine
           end
         end
 
-        def route_cost(route)
+        def route_distance(route)
           route.connections.sum { |conn| hex_edge_cost(conn, route.train) }
         end
 
-        def route_cost_str(route)
-          cost = route_cost(route)
-          "#{cost}H"
+        def route_distance_str(route)
+          "#{route_distance(route)}H"
         end
 
         def check_distance(route, _visits)
           limit = route.train.distance
-          cost = route_cost(route)
-          raise GameError, "#{cost} is too many hex edges for #{route.train.name} train" if cost > limit
+          distance = route_distance(route)
+          raise GameError, "#{distance} is too many hex edges for #{route.train.name} train" if distance > limit
         end
 
         def check_other(route)

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -858,9 +858,18 @@ module Engine
           end
         end
 
+        def route_cost(route)
+          route.connections.sum { |conn| hex_edge_cost(conn, route.train) }
+        end
+
+        def route_cost_str(route)
+          cost = route_cost(route)
+          "#{cost}H"
+        end
+
         def check_distance(route, _visits)
           limit = route.train.distance
-          cost = route.connections.sum { |conn| hex_edge_cost(conn, route.train) }
+          cost = route_cost(route)
           raise GameError, "#{cost} is too many hex edges for #{route.train.name} train" if cost > limit
         end
 

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -212,8 +212,8 @@ module Engine
       raise GameError, 'Route cannot pass through terminal' if ordered_paths[1..-2].any?(&:terminal?)
     end
 
-    def cost_str
-      @game.route_cost_str(self)
+    def distance_str
+      @game.route_distance_str(self)
     end
 
     def distance

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -212,6 +212,10 @@ module Engine
       raise GameError, 'Route cannot pass through terminal' if ordered_paths[1..-2].any?(&:terminal?)
     end
 
+    def cost_str
+      @game.route_cost_str(self)
+    end
+
     def distance
       @game.route_distance(self)
     end


### PR DESCRIPTION
Some notes:

- I changed the header "Stops" to "Used" to make it more generic across titles. Some titles (none implemented yet) have both hex trains and number-of-stops trains so I didn't want to assume all trains had the same sort of resource consumption.
- I'm not familiar with all the implemented titles, so I only changed the display for 1849. It seems to be the only game with hex trains. Other games will continue to generically display number of stops, which is not a regression. Games with weird trains (e.g., ones that care about halts) may want to write their own `route_cost_str`.
- Hex distance is displayed with an H suffix (e.g., `3H`) so you can glance at it and be sure that hexes are being counted. This would probably become more important if/when we implement titles with multiple genuses of trains with different sorts of route cost.