### PR TITLE
add round_no to AR and MR

### DIFF
--- a/lib/engine/player_info.rb
+++ b/lib/engine/player_info.rb
@@ -13,7 +13,7 @@ module Engine
     end
 
     def round
-      if round_name.include?('OR')
+      if %w[AR MR OR].include?(round_name)
         "#{round_name} #{turn}.#{round_no}"
       else
         "#{round_name} #{turn}"


### PR DESCRIPTION
fixes #4059
Due to https://github.com/tobymao/18xx/blob/87568900957bc4e4cda677be11629d53e58f3f1d/assets/app/view/game/spreadsheet.rb#L104 rounds are only rendered if values changed from last round. Therefore some rounds are gone in the 2nd screenshot each.
Caveat: I don’t know if any other games are affected as well.

[1817NA](https://18xx.games/game/22282)
ante
![image](https://user-images.githubusercontent.com/33390595/108607116-b99d3400-73be-11eb-86fd-f644bc96408e.png)
post
![image](https://user-images.githubusercontent.com/33390595/108607119-bc982480-73be-11eb-9246-04ec7fbb70c9.png)

[1867](https://18xx.games/game/23010#spreadsheet)
ante
![image](https://user-images.githubusercontent.com/33390595/108607125-c883e680-73be-11eb-982b-4307efbdb248.png)
post
![image](https://user-images.githubusercontent.com/33390595/108607411-996e7480-73c0-11eb-8e18-683ff8c1fecd.png)
