### PR TITLE
Nicer layout of trains-remaining table

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -157,9 +157,9 @@ module View
             justifyItems: 'center',
           },
         }
-        info_props = {
+        table_props = {
           style: {
-            verticalAlign: 'top',
+            borderSpacing: '0.4rem 0.8rem',
           },
         }
 
@@ -167,14 +167,17 @@ module View
         trs = @game.depot.upcoming.group_by(&:name).map do |name, trains|
           train = trains.first
           names_to_prices = train.names_to_prices
-          summary = [h(:div,
-                       "#{trains.size} at " + names_to_prices.values.map { |p| @game.format_currency(p) }.join(', '))]
-          summary << h(:div, ' rusts ' + rust_schedule[name].join(',')) if rust_schedule[name]
-          summary << h(:div, ' obsoletes ' + obsolete_schedule[name].join(',')) if obsolete_schedule[name]
+          availability = [h(:div,
+                            "#{trains.size} at " +
+                            names_to_prices.values.map { |p| @game.format_currency(p) }.join(', '))]
+          events = []
+          events << h(:div, 'rusts ' + rust_schedule[name].join(',')) if rust_schedule[name]
+          events << h(:div, 'obsoletes ' + obsolete_schedule[name].join(',')) if obsolete_schedule[name]
 
           h(:tr, [
-            h(:td, info_props, names_to_prices.keys.join(', ')),
-            h('td.right', summary),
+            h(:td, names_to_prices.keys.join(', ')),
+            h('td.right', availability),
+            h('td.right', events),
 ])
         end
 
@@ -183,7 +186,7 @@ module View
         h('div#upcoming_trains.card', [
           h('div.title', title_props, [h(:em, 'Upcoming Trains')]),
           h(:div, body_props, [
-            h(:table, trs),
+            h(:table, table_props, trs),
           ]),
         ])
       end


### PR DESCRIPTION
Before: 
<img width="258" alt="Screen Shot 2021-02-20 at 5 35 08 PM" src="https://user-images.githubusercontent.com/1295244/108610376-3e7a5480-73a3-11eb-8871-7936d9b7ce28.png">

After:
<img width="259" alt="Screen Shot 2021-02-20 at 5 37 13 PM" src="https://user-images.githubusercontent.com/1295244/108610380-420ddb80-73a3-11eb-8d16-4bde7442366f.png">

