### PR TITLE
Fix so lanes shows correctly on offboards

### DIFF
--- a/assets/app/view/game/part/track_offboard.rb
+++ b/assets/app/view/game/part/track_offboard.rb
@@ -6,6 +6,8 @@ module View
   module Game
     module Part
       class TrackOffboard < Base
+        PARALLEL_SPACING = [8, 6, 4].freeze
+
         needs :path
         needs :offboard
         needs :color, default: 'black'
@@ -20,6 +22,10 @@ module View
           4 => [10],
           5 => [17],
         }.freeze
+
+        def calculate_shift(lane)
+          (lane[1] * 2 - lane[0] + 1) * (@width.to_i + PARALLEL_SPACING[lane[0] - 2]) / 2.0
+        end
 
         def edge
           @edge ||= @path.exits[0]
@@ -39,11 +45,21 @@ module View
           rotate = 60 * edge
 
           d_width = @width.to_i / 2
+          offboard_start_x = d_width
+          offboard_end_x = -d_width
+          begin_lane, = @path.lanes
+          if begin_lane[0] > 1
+            begin_shift = calculate_shift(begin_lane)
+            offboard_start_x += begin_shift
+            offboard_end_x += begin_shift
+          end
+          point_x = (offboard_start_x + offboard_end_x) / 2
 
           props = {
             attrs: {
               transform: "rotate(#{rotate})",
-              d: "M #{d_width} 75 L #{d_width} 87 L -#{d_width} 87 L -#{d_width} 75 L 0 48 Z",
+              d: "M #{offboard_start_x} 75 L #{offboard_start_x} 87 L #{offboard_end_x} 87 "\
+                 "L #{offboard_end_x} 75 L #{point_x} 48 Z",
               fill: @color,
               stroke: 'none',
               'stroke-linecap': 'butt',


### PR DESCRIPTION
If you have lanes in an offboard the all clumped together in center of the edge. This fix changes them to allign with the rest of the lane code.