### PR TITLE
[18CZ] Add original par price to corporation model, use when floating companies

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -23,7 +23,7 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent, :capitalization, :second_share,
-                  :type, :floatable
+                  :type, :floatable, :original_par_price
     attr_reader :companies, :min_price, :name, :full_name, :fraction_shares, :id, :needs_token_to_par,
                 :presidents_share, :reservation_color
     attr_writer :par_price, :share_price
@@ -46,6 +46,7 @@ module Engine
 
       @share_price = nil
       @par_price = nil
+      @original_par_price = nil
       @ipoed = false
       @companies = []
 

--- a/lib/engine/game/g_18_cz.rb
+++ b/lib/engine/game/g_18_cz.rb
@@ -203,7 +203,13 @@ module Engine
 
       def float_corporation(corporation)
         @recently_floated << corporation
-        super
+
+        @log << "#{corporation.name} floats"
+
+        return if corporation.capitalization == :incremental
+
+        @bank.spend(corporation.original_par_price.price * corporation.total_shares, corporation)
+        @log << "#{corporation.name} receives #{format_currency(corporation.cash)}"
       end
 
       def or_set_finished

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -40,6 +40,7 @@ module Engine
       share_price.corporations << corporation
       corporation.share_price = share_price
       corporation.par_price = share_price
+      corporation.original_par_price = share_price
     end
 
     def move_right(corporation)


### PR DESCRIPTION
Adds the original par value to the corporation (Maybe some other games need the property as well)

closes #4073

