### PR TITLE
18MEX remove P2's ability if Copper Canyon is laid [Fixes #2855]

### DIFF
--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -1090,6 +1090,17 @@ module Engine
           super + Array(abilities(entity, :train_limit)).sum(&:increase)
         end
 
+        def action_processed(action)
+          case action
+          when Action::LayTile
+            return unless action.hex.id == 'F5'
+            return if p2_company.closed? || action.entity == p2_company
+
+            p2_company.remove_ability(p2_company.all_abilities.first)
+            @log << "#{p2_company.name} loses the ability to lay F5"
+          end
+        end
+
         private
 
         def handle_no_mail(entity, trainless: true)

--- a/lib/engine/game/g_18_mex/step/special_track.rb
+++ b/lib/engine/game/g_18_mex/step/special_track.rb
@@ -14,8 +14,7 @@ module Engine
 
             ability if ability &&
               entity.owner == @game.round.current_entity &&
-              @game.round.active_step.respond_to?(:process_lay_tile) &&
-              copper_canyon_hex_empty?(ability)
+              @game.round.active_step.respond_to?(:process_lay_tile)
           end
 
           def process_lay_tile(action)
@@ -25,13 +24,6 @@ module Engine
             action.tile.label = nil
             @game.log << "#{@game.p2_company.name} closes"
             @game.p2_company.close!
-          end
-
-          private
-
-          def copper_canyon_hex_empty?(ability)
-            @copper_canyon_hex ||= @game.hex_by_id(ability.hexes.first)
-            @copper_canyon_hex.tile.color == :white
           end
         end
       end


### PR DESCRIPTION
I have a local migration for this that fixes 55/60 of the broken cases. The last 5 can't be fixed by that migration and are all finished anyway; they'll need more fixing anyway for the changes I have in progress for the [rest of the issues I'm working on](https://github.com/tobymao/18xx/issues?q=is%3Aopen+is%3Aissue+assignee%3Amichaeljb+label%3A%22ability+timing%22).