### PR TITLE
bank / upcoming trains / game info cleanup

### DIFF
--- a/assets/app/view/game/bank.rb
+++ b/assets/app/view/game/bank.rb
@@ -16,6 +16,7 @@ module View
             padding: '0.4rem',
             backgroundColor: color_for(:bg2),
             color: color_for(:font2),
+            fontStyle: 'italic',
           },
         }
         body_props = {
@@ -59,11 +60,11 @@ module View
 
             props = {
               attrs: { title: "#{@show_loan_table ? 'Hide' : 'Show'} loan table" },
-              style: { width: '7.3rem', margin: '0 0 0 0.5rem' },
+              style: { width: '4rem', margin: '0' },
               on: { click: toggle_loan_table },
             }
             trs << h(:tr, [
-              h(:td, 'Loan Table'),
+              h('td.middle', 'Loan Table'),
               h('td.right', [h(:button, props, (@show_loan_table ? 'Hide' : 'Show').to_s)]),
             ])
 
@@ -106,7 +107,7 @@ module View
         return if trs.empty?
 
         h('div#bank.card', [
-          h('div.title', title_props, [h(:em, 'The Bank')]),
+          h('div.title', title_props, 'The Bank'),
           h(:div, body_props, [
             h(:table, trs),
             h(GameInfo, game: @game, layout: 'discarded_trains'),

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -156,47 +156,36 @@ module View
             padding: '0.4rem',
             backgroundColor: color_for(:bg2),
             color: color_for(:font2),
+            fontStyle: 'italic',
           },
         }
         body_props = {
           style: {
-            margin: '0.3rem 0.5rem 0.4rem',
+            margin: '0.3rem 0 0.4rem',
             display: 'grid',
-            grid: 'auto / 1fr',
-            gap: '0.5rem',
             justifyItems: 'center',
-          },
-        }
-        table_props = {
-          style: {
-            borderSpacing: '0.4rem 0.8rem',
           },
         }
 
         rust_schedule, obsolete_schedule = rust_obsolete_schedule
         trs = @game.depot.upcoming.group_by(&:name).map do |name, trains|
-          train = trains.first
-          names_to_prices = train.names_to_prices
-          availability = [h(:div,
-                            "#{trains.size} at " +
-                            names_to_prices.values.map { |p| @game.format_currency(p) }.join(', '))]
+          names_to_prices = trains.first.names_to_prices
           events = []
-          events << h(:div, 'rusts ' + rust_schedule[name].join(',')) if rust_schedule[name]
-          events << h(:div, 'obsoletes ' + obsolete_schedule[name].join(',')) if obsolete_schedule[name]
+          events << h('div.left', "rusts #{rust_schedule[name].join(', ')}") if rust_schedule[name]
+          events << h('div.left', "obsoletes #{obsolete_schedule[name].join(', ')}") if obsolete_schedule[name]
+          tds = [h(:td, names_to_prices.keys.join(', ')),
+                 h(:td, names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
+                 h('td.right', "×#{trains.size}")]
+          tds << h('td.right', events) if events.size.positive?
 
-          h(:tr, [
-            h(:td, names_to_prices.keys.join(', ')),
-            h('td.right', availability),
-            h('td.right', events),
-])
+          h(:tr, tds)
         end
-
-        return unless trs.any?
+        trs ||= 'None'
 
         h('div#upcoming_trains.card', [
-          h('div.title', title_props, [h(:em, 'Upcoming Trains')]),
+          h('div.title', title_props, 'Upcoming Trains'),
           h(:div, body_props, [
-            h(:table, table_props, trs),
+            h(:table, [h(:tbody, trs)]),
           ]),
         ])
       end
@@ -237,7 +226,7 @@ module View
           upcoming_train_content = [
             h(:td, names_to_prices.keys.join(', ')),
             h('td.right', names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
-            h(:td, trains.size),
+            h('td.center', trains.size),
           ]
 
           show_rusts_inline = true
@@ -315,7 +304,7 @@ module View
               h(:thead, [
                 h(:tr, upcoming_train_header),
               ]),
-              h('tbody.zebra', rows),
+              h(:tbody, rows),
             ]),
           ]),
           *event_text,

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -174,7 +174,7 @@ module View
           events << h('div.left', "rusts #{rust_schedule[name].join(', ')}") if rust_schedule[name]
           events << h('div.left', "obsoletes #{obsolete_schedule[name].join(', ')}") if obsolete_schedule[name]
           tds = [h(:td, names_to_prices.keys.join(', ')),
-                 h(:td, names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
+                 h("td#{price_str_class}", names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
                  h('td.right', "×#{trains.size}")]
           tds << h('td.right', events) if events.size.positive?
 
@@ -225,7 +225,7 @@ module View
 
           upcoming_train_content = [
             h(:td, names_to_prices.keys.join(', ')),
-            h('td.right', names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
+            h("td#{price_str_class}", names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
             h('td.center', trains.size),
           ]
 
@@ -309,6 +309,13 @@ module View
           ]),
           *event_text,
         ]
+      end
+
+      def price_str_class
+        max_size = @game.depot.upcoming.group_by(&:name).map do |_name, trains|
+          trains.first.names_to_prices.keys.size
+        end.max
+        max_size == 1 ? '.right' : ''
       end
 
       def discarded_trains

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -93,7 +93,7 @@ module View
         end
 
         if status_text.any?
-          status_text = [h(:table, [
+          status_text = [h(:table, { style: { marginTop: '0.3rem' } }, [
             h(:thead, [
               h(:tr, [
                 h(:th, 'Status'),
@@ -247,14 +247,14 @@ module View
             show_rusts_inline = false
           end
 
-          upcoming_train_content << h(:td, obsolete_schedule[name]&.join(', ') || 'None') if show_obsolete_schedule
+          upcoming_train_content << h(:td, obsolete_schedule[name]&.join(', ') || '') if show_obsolete_schedule
           upcoming_train_content << if show_rusts_inline
-                                      h(:td, rusts&.join(', ') || 'None')
+                                      h(:td, rusts&.join(', ') || '')
                                     else
                                       h(:td,
                                         rusts&.map do |value|
                                           h(:div, { style: { paddingBottom: '0.1rem' } }, value)
-                                        end || 'None')
+                                        end || '')
                                     end
 
           upcoming_train_content << h(:td, discounts&.join(' ')) if show_upgrade
@@ -270,7 +270,7 @@ module View
           end
 
         if event_text.any?
-          event_text = [h(:table, [
+          event_text = [h(:table, { style: { marginTop: '0.3rem' } }, [
             h(:thead, [
               h(:tr, [
                 h(:th, 'Event'),

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -64,7 +64,7 @@ module View
             h(:thead, [
               h(:th, { style: { minWidth: '5rem' } }, ''),
               *@game.players.map do |p|
-                h('th.name.nowrap.right', p == @game.priority_deal_player ? pd_props : '', p.name)
+                h('th.name.nowrap', p == @game.priority_deal_player ? pd_props : '', p.name)
               end,
             ]),
             h('tbody#player_or_history', [*render_player_or_history]),
@@ -74,7 +74,7 @@ module View
       end
 
       def render_extra_cards
-        h('div#extra_cards', [
+        h('div#extra_cards', { style: { marginBottom: '1rem' } }, [
           h(Bank, game: @game),
           h(GameInfo, game: @game, layout: 'upcoming_trains'),
         ].compact)
@@ -194,7 +194,7 @@ module View
           h(:tr, [
             h(:th, { style: { paddingBottom: '0.3rem' } }, render_sort_link('SYM', :id)),
             *@game.players.map do |p|
-              h('th.name.nowrap.right', p == @game.priority_deal_player ? pd_props : '', render_sort_link(p.name, p.id))
+              h('th.name.nowrap', p == @game.priority_deal_player ? pd_props : '', render_sort_link(p.name, p.id))
             end,
             h(:th, render_sort_link(@game.ipo_name, :ipo_shares)),
             h(:th, render_sort_link('Market', :market_shares)),
@@ -275,7 +275,7 @@ module View
       end
 
       def render_spreadsheet_controls
-        h('div#spreadsheet_controls', [
+        h('div#spreadsheet_controls', { style: { marginBottom: '1rem' } }, [
           h(:button, {
               style: { minWidth: '9.5rem' },
               on: { click: -> { toggle_delta_value } },

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -33,15 +33,17 @@ module View
       end
 
       def render_corporation_table
-        h('table#corporation_table', table_props, [
-          h(:thead, render_titles),
-          h(:tbody, render_corporations),
-          h(:thead, [
-            h(:tr, { style: { height: '1rem' } }, [
-              h(:td, { attrs: { colspan: @game.players.size + 8 } }, ''),
-              h(:td, { attrs: { colspan: 2 } }, @game.respond_to?(:token_note) ? @game.token_note : ''),
-              h(:td, { attrs: { colspan: 1 + @extra_size } }, ''),
-              h(:td, { attrs: { colspan: @halfpaid ? 6 : 3 } }, "[withheld]#{' ¦half-paid¦' if @halfpaid}"),
+        h('div#corporation_table', [
+          h(:table, table_props, [
+            h(:thead, render_titles),
+            h(:tbody, render_corporations),
+            h(:tfoot, [
+              h(:tr, { style: { height: '1rem' } }, [
+                h(:td, { attrs: { colspan: @game.players.size + 8 } }, ''),
+                h(:td, { attrs: { colspan: 2 } }, @game.respond_to?(:token_note) ? @game.token_note : ''),
+                h(:td, { attrs: { colspan: 1 + @extra_size } }, ''),
+                h(:td, { attrs: { colspan: @halfpaid ? 6 : 3 } }, "[withheld]#{' ¦half-paid¦' if @halfpaid}"),
+              ]),
             ]),
           ]),
         ])

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -113,7 +113,7 @@ th, td {
   background-color: #CCCCCC;
   color: black;
 }
-#spreadsheet tbody > tr:nth-child(2n) {
+#spreadsheet > div:not(#extra_cards) tbody > tr:nth-child(2n) {
   background-image: linear-gradient(rgba(255,255,255,0.4),rgba(255,255,255,0.4));
 }
 #spreadsheet tbody > tr:hover {
@@ -158,6 +158,9 @@ nav#game_menu {
 }
 .top {
   vertical-align: top;
+}
+.middle {
+  vertical-align: middle;
 }
 
 .italic {

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -109,14 +109,14 @@ th, td {
   vertical-align: top;
 }
 
-#game_info tbody > tr:hover {
-  background-color: #CCCCCC;
+#game_info tbody > tr:hover, #bank.card tr:hover, #upcoming_trains.card tr:hover {
+  background-color: gainsboro;
   color: black;
 }
 #spreadsheet > div:not(#extra_cards) tbody > tr:nth-child(2n) {
   background-image: linear-gradient(rgba(255,255,255,0.4),rgba(255,255,255,0.4));
 }
-#spreadsheet tbody > tr:hover {
+#spreadsheet > div:not(#extra_cards) tbody > tr:hover {
   filter: drop-shadow(1px 0px 2px #555);
 }
 
@@ -319,7 +319,7 @@ text.number {
   margin: 0 0.5rem 0.5rem 0;
 }
 #entities .card {
-  margin: 0 0 0.5rem 0;
+  margin: 0.5rem 0 0 0;
   width: 100%;
   max-width: 20rem;
 }


### PR DESCRIPTION
Triggered by [18CZ’s upcoming trains card](https://github.com/tobymao/18xx/commit/ef4ea392f8778ab2b04947637783a993c068476d#r47411082) (incl. discussion with dfannius about these changes).

The usual: margins, alignments, some vestiges removed, some minor code changes etc.

[1817NA](https://18xx.games/game/26939)
ante
![image](https://user-images.githubusercontent.com/33390595/108734463-c9885580-752f-11eb-94b8-26bcc9a9f3a2.png)
post
![image](https://user-images.githubusercontent.com/33390595/108734520-d86f0800-752f-11eb-9f87-d2585d1c3e30.png)

[18CZ](https://18xx.games/game/29230)
ante
![image](https://user-images.githubusercontent.com/33390595/108734328-a8276980-752f-11eb-945c-ec9d75fed30d.png)
post
![image](https://user-images.githubusercontent.com/33390595/108734277-9ba31100-752f-11eb-8fcc-09a196cb653c.png)

I also added row highlighting on hover to these cards which might be useful in some cases:
![image](https://user-images.githubusercontent.com/33390595/108734684-ff2d3e80-752f-11eb-9f18-05eccb35015c.png)

game info
ante
![image](https://user-images.githubusercontent.com/33390595/108735162-7b278680-7530-11eb-838b-37704f05a779.png)
post
![image](https://user-images.githubusercontent.com/33390595/108735172-7f53a400-7530-11eb-8813-271a0dfa8679.png)