### PR TITLE
or_history rendering empty history

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -116,14 +116,8 @@ module View
       end
 
       def render_history(corporation)
-        hist = corporation.operating_history
-        if hist.empty?
-          # This is a company that hasn't floated yet
-          []
-        else
-          or_history(@game.all_corporations).map do |x|
-            render_or_history_row(hist, corporation, x)
-          end
+        or_history(@game.all_corporations).map do |x|
+          render_or_history_row(corporation.operating_history, corporation, x)
         end
       end
 


### PR DESCRIPTION
Due to `else` (L158) of `if hist[x]` checking `hist.empty?` beforehand seems obsolete. Additionally it looks nicer if all cells of a row have a background-color.

ante
![image](https://user-images.githubusercontent.com/33390595/108768408-e9337400-7557-11eb-832c-ec7c0b234740.png)
post
![image](https://user-images.githubusercontent.com/33390595/108768429-ed5f9180-7557-11eb-8c99-5673429ff30f.png)


