### PR TITLE
Back out of stock round merger change

### DIFF
--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -376,8 +376,6 @@ module View
       when Engine::Round::Stock
         if !(%w[place_token lay_tile remove_token] & current_entity_actions).empty?
           h(Game::Map, game: @game)
-        elsif current_entity_actions.include?('merge')
-          h(Game::Round::Merger, game: @game)
         else
           h(Game::Round::Stock, game: @game)
         end


### PR DESCRIPTION
I modified game_page for 1873 to display Round::Merger if there is a "merge" action during a SR. This breaks 1828. Reverting this change.

Fixes #4119 