### PR TITLE
Reorder train purchase operations, so that the train is purchased before events are triggered

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -944,8 +944,7 @@ module Engine
       end
 
       def must_buy_train?(entity)
-        !entity.rusted_self &&
-          entity.trains.empty? &&
+        entity.trains.empty? &&
           !depot.depot_trains.empty? &&
           (self.class::MUST_BUY_TRAIN == :always ||
            (self.class::MUST_BUY_TRAIN == :route && @graph.route_info(entity)&.dig(:route_train_purchase)))
@@ -1511,7 +1510,6 @@ module Engine
         remove_train(train)
         train.owner = operator
         operator.trains << train
-        operator.rusted_self = false
         @crowded_corps = nil
 
         close_companies_on_train!(operator)
@@ -1624,7 +1622,7 @@ module Engine
         ability.hexes.include?(hex.id)
       end
 
-      def rust_trains!(train, entity)
+      def rust_trains!(train, _entity)
         obsolete_trains = []
         rusted_trains = []
         owners = Hash.new(0)
@@ -1645,9 +1643,10 @@ module Engine
 
           rusted_trains << t.name
           owners[t.owner.name] += 1
-          entity.rusted_self = true if entity && entity == t.owner
           rust(t)
         end
+
+        @crowded_corps = nil
 
         @log << "-- Event: #{obsolete_trains.uniq.join(', ')} trains are obsolete --" if obsolete_trains.any?
         @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust " \

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2256,9 +2256,8 @@ module Engine
         end
 
         def must_buy_train?(entity)
-          !entity.rusted_self &&
-            entity.trains.none? { |t| !extra_train?(t) } &&
-            !depot.depot_trains.empty?
+          entity.trains.none? { |t| !extra_train?(t) } &&
+          !depot.depot_trains.empty?
         end
 
         # TODO: [1822] Make include with 1861, 1867

--- a/lib/engine/game/g_18_cz.rb
+++ b/lib/engine/game/g_18_cz.rb
@@ -269,7 +269,6 @@ module Engine
       end
 
       def must_buy_train?(entity)
-        !entity.rusted_self &&
         !depot.depot_trains.empty? &&
         (entity.trains.empty? ||
           (entity.type == :medium && entity.trains.none? { |item| train_of_size?(item, :medium) }) ||
@@ -373,7 +372,6 @@ module Engine
 
           rusted_trains << t.name
           owners[t.owner.name] += 1
-          entity.rusted_self = true if entity && entity == t.owner
           rust(t)
         end
         return if rusted_trains.none?

--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -405,7 +405,6 @@ module Engine
           remove_train(train)
           train.owner = operator
           operator.trains << train
-          operator.rusted_self = false
           @crowded_corps = nil
         end
 

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -6,16 +6,13 @@ module Engine
   module Operator
     include Entity
 
-    attr_accessor :rusted_self, :coordinates
+    attr_accessor :coordinates
     attr_reader :color, :city, :loans, :logo, :simple_logo, :operating_history, :text_color, :tokens, :trains
 
     def init_operator(opts)
       @cash = 0
       @trains = []
       @operating_history = {}
-      # phase rusts happen before a train actually buys, so there is a race condition
-      # where buying a train rusts yourself and it looks like you must buy a train
-      @rusted_self = false
       @logo = "/logos/#{opts[:logo]}.svg"
       @simple_logo = opts[:simple_logo] ? "/logos/#{opts[:simple_logo]}.svg" : @logo
       @coordinates = opts[:coordinates]

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -26,7 +26,6 @@ module Engine
         @game.send("event_#{event['type']}!")
       end
       train.events.clear
-
     end
 
     def current

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -19,13 +19,14 @@ module Engine
     def buying_train!(entity, train)
       next! while @next_on.include?(train.sym)
 
+      @game.rust_trains!(train, entity)
+      @depot.depot_trains(clear: true)
+
       train.events.each do |event|
         @game.send("event_#{event['type']}!")
       end
       train.events.clear
 
-      @game.rust_trains!(train, entity)
-      @depot.depot_trains(clear: true)
     end
 
     def current

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -66,7 +66,6 @@ module Engine
         end
 
         try_take_loan(entity, price)
-        @game.queue_log! { @game.phase.buying_train!(entity, train) }
 
         if exchange
           verb = "exchanges a #{exchange.name} for"
@@ -80,9 +79,8 @@ module Engine
         @log << "#{entity.name} #{verb} a #{train.name} train for "\
           "#{@game.format_currency(price)} from #{source}"
 
-        @game.flush_log!
-
         @game.buy_train(entity, train, price)
+        @game.phase.buying_train!(entity, train)
         pass! unless can_buy_train?(entity)
       end
 


### PR DESCRIPTION
Fixes issue when the same corporation that buys the 12H and is closed by the Messina Earthquake.

Ran against the 2/21 db without any failures.