### PR TITLE
1860: move bankruptcy check out of dividend step

### DIFF
--- a/lib/engine/game/g_1860/round/operating.rb
+++ b/lib/engine/game/g_1860/round/operating.rb
@@ -22,6 +22,7 @@ module Engine
               end
             end
 
+            @game.check_bankruptcy!(entity)
             super
           end
 

--- a/lib/engine/game/g_1860/round/operating.rb
+++ b/lib/engine/game/g_1860/round/operating.rb
@@ -22,7 +22,6 @@ module Engine
               end
             end
 
-            @game.check_bankruptcy!(entity)
             super
           end
 
@@ -33,6 +32,8 @@ module Engine
 
           def after_operating(entity)
             return unless entity.corporation?
+
+            @game.check_bankruptcy!(entity)
             return if @game.bankrupt?(entity)
 
             if entity.trains.empty? && @game.legal_route?(entity)

--- a/lib/engine/game/g_1860/step/dividend.rb
+++ b/lib/engine/game/g_1860/step/dividend.rb
@@ -41,7 +41,6 @@ module Engine
             payout_shares(entity, revenue) if payout[:per_share].positive?
             change_share_price(entity, payout)
             @game.check_bank_broken!
-            @game.check_bankruptcy!(entity)
 
             pass!
           end


### PR DESCRIPTION
Move bankruptcy check out of the process_dividend method and into the Round::after_operating method.
This avoids issues with "auto" dividends that causes bankruptcies.

Fixes #4136 