### PR TITLE
stock market: scroll grid only, horizontal and ordered legend

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -266,7 +266,13 @@ module View
         }
 
         children << h(:div, props, [h(Bank, game: @game)].compact)
-        children.concat(grid)
+        grid_props = {
+          style: {
+            width: '100%',
+            overflow: 'auto',
+          },
+        }
+        children << h(:div, grid_props, grid)
 
         if @explain_colors
           type_text = @game.class::MARKET_TEXT
@@ -344,14 +350,7 @@ module View
           ])
         end
 
-        props = {
-          style: {
-            width: '100%',
-            overflow: 'auto',
-          },
-        }
-
-        h(:div, props, children)
+        h(:div, children)
       end
     end
   end

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -281,10 +281,10 @@ module View
           types_in_market = @game.stock_market.market.flatten.compact.flat_map(&:types)
           .uniq.map { |p| [p, colors[p]] }.to_h
 
-          type_text.each do |type, text|
-            next unless types_in_market.include?(type)
+          legend_items = types_in_market.map do |type, color|
+            next unless type_text.include?(type)
 
-            color = types_in_market[type]
+            text = type_text[type]
 
             style = @box_style_2d.merge(backgroundColor: COLOR_MAP[color])
             style[:borderColor] = color_for(:font) if color == :black
@@ -299,11 +299,13 @@ module View
               },
             }
 
-            children << h(:div, line_props, [
+            h(:div, line_props, [
               h(:div, { style: cell_style(@box_style_2d, [type]) }, []),
               h(:div, { style: { maxWidth: '30rem' } }, text),
             ])
           end
+
+          children << h('div#legend', legend_items)
         end
 
         if @game.respond_to?(:price_movement_chart)

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -301,7 +301,7 @@ module View
 
             children << h(:div, line_props, [
               h(:div, { style: cell_style(@box_style_2d, [type]) }, []),
-              h(:div, text),
+              h(:div, { style: { maxWidth: '30rem' } }, text),
             ])
           end
         end

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -291,19 +291,20 @@ module View
 
             line_props = {
               style: {
-                display: 'grid',
+                display: 'inline-grid',
                 grid: '1fr / auto 1fr',
                 gap: '0.5rem',
                 alignItems: 'center',
-                marginTop: '1rem',
+                margin: '1rem 1rem 0 0',
               },
             }
 
             h(:div, line_props, [
               h(:div, { style: cell_style(@box_style_2d, [type]) }, []),
-              h(:div, { style: { maxWidth: '30rem' } }, text),
+              h(:div, { style: { maxWidth: '24rem' } }, text),
             ])
           end
+          legend_items.reverse! unless @game.stock_market.one_d?
 
           children << h('div#legend', legend_items)
         end


### PR DESCRIPTION
Bank and legend stay in place while grid is scrollable horizontally:
![image](https://user-images.githubusercontent.com/33390595/108989864-5ea55e80-7696-11eb-8582-aa5c76aab092.png)

Legend inline and ordered by appearance in market (left to right & top to bottom, reversed if not 1d). This should work better than before for most titles.

ante
![image](https://user-images.githubusercontent.com/33390595/108990039-9f04dc80-7696-11eb-9f4a-d52e566e2083.png)

post
![image](https://user-images.githubusercontent.com/33390595/108990053-a4622700-7696-11eb-9b38-d20ec4c1218c.png)
![image](https://user-images.githubusercontent.com/33390595/108990086-adeb8f00-7696-11eb-85d9-7b1ce3c45472.png)
