### PR TITLE
[1822] Track lay privates

### DIFF
--- a/lib/engine/game/g_1822/step/special_choose.rb
+++ b/lib/engine/game/g_1822/step/special_choose.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1822
+      module Step
+        class SpecialChoose < Engine::Step::Base
+          ACTIONS = %w[choose].freeze
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] unless find_company(entity)
+
+            ACTIONS
+          end
+
+          def choice_name
+            return "Choose for #{@company.name}" if @company
+
+            'Choose'
+          end
+
+          def choices
+            return @game.company_choices(@company) if @company
+
+            {}
+          end
+
+          def description
+            'Choose'
+          end
+
+          def process_choose(action)
+            @game.company_made_choice(@company, action.choice)
+            @company = nil
+          end
+
+          def skip!
+            pass!
+          end
+
+          def find_company(entity)
+            # Check all newly acquired companies if they have any choices
+            @company = @round.acquired_companies.find do |c|
+              entity == c.owner && !@game.company_choices(c).empty?
+            end
+            @company
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative 'tracker'
+
+module Engine
+  module Game
+    module G1822
+      module Step
+        class SpecialTrack < Engine::Step::Base
+          include Engine::Game::G1822::Tracker
+
+          ACTIONS = %w[lay_tile].freeze
+
+          def actions(entity)
+            action = abilities(entity)
+            return [] unless action
+
+            ACTIONS
+          end
+
+          def description
+            'Lay Track'
+          end
+
+          def blocks?
+            false
+          end
+
+          def process_lay_tile(action)
+            entity = action.entity
+            ability = abilities(entity)
+            spender = if !entity.owner
+                        nil
+                      elsif entity.owner.corporation?
+                        entity.owner
+                      else
+                        @game.current_entity
+                      end
+            if @game.company_ability_extra_track?(entity)
+              upgraded_extra_track = upgraded_track?(action)
+              raise GameError, 'Cannot lay an extra upgrade' if upgraded_extra_track && @extra_laided_track
+
+              lay_tile(action, spender: spender)
+              if upgraded_extra_track || spender.type == :minor
+                # Use the ability an extra time, upgrade counts as 2 tile lays. Or if its a minor, they ony get one use
+                ability.use!
+              else
+                @extra_laided_track = true
+              end
+            else
+              lay_tile_action(action, spender: spender)
+            end
+            @game.after_lay_tile(action.hex, action.tile)
+            ability.use!
+
+            return if ability.count.positive? || !ability.closed_when_used_up
+
+            @log << "#{ability.owner.name} closes"
+            ability.owner.close!
+          end
+
+          def available_hex(entity, hex)
+            return unless (ability = abilities(entity))
+            return if !ability.hexes&.empty? && !ability.hexes&.include?(hex.id)
+
+            operator = entity.owner.corporation? ? entity.owner : @game.current_entity
+            connected = hex_neighbors(operator, hex)
+            return nil unless connected
+
+            return connected if @game.company_ability_extra_track?(entity)
+
+            tile_lay = get_tile_lay(operator)
+            return nil unless tile_lay
+
+            color = hex.tile.color
+            return nil if color == :white && !tile_lay[:lay]
+            return nil if color != :white && !tile_lay[:upgrade]
+            return nil if color != :white && tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(hex)
+
+            # London yellow tile counts as an upgrade
+            if hex.tile.color == :white && @round.num_laid_track.positive? && hex.name == @game.class::LONDON_HEX
+              return nil
+            end
+
+            # Middleton Railway can only lay track on hexes with one town
+            return nil if entity.id == @game.class::COMPANY_MTONR && (hex.tile.towns.empty? || hex.tile.towns.size > 1)
+
+            # Bristol & Exeter Railway can only lay track on plain hexes or with one town
+            if entity.id == @game.class::COMPANY_BER && @game.class::TRACK_PLAIN.none?(hex.tile.name) &&
+              @game.class::TRACK_TOWN.none?(hex.tile.name)
+              return nil
+            end
+
+            # If player have choosen the tile lay option on the Edinburgh and Glasgow Railway company,
+            # only rough terrain, hill or mountains are valid hexes
+            if entity.id == @game.class::COMPANY_EGR
+              tile_terrain = hex.tile.upgrades.any? do |upgrade|
+                %i[mountain hill swamp].any? { |t| upgrade.terrains.include?(t) }
+              end
+              return nil unless tile_terrain
+            end
+
+            connected
+          end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            return super unless entity.id == @game.class::COMPANY_MTONR
+
+            true
+          end
+
+          def potential_tiles(entity, hex)
+            return [] unless (tile_ability = abilities(entity))
+            return super if tile_ability.tiles.empty?
+
+            tiles = tile_ability.tiles.map { |name| @game.tiles.find { |t| t.name == name } }
+            special = tile_ability.special if tile_ability.type == :tile_lay
+            if entity.id == @game.class::COMPANY_BER
+              return tiles.compact
+                .select { |t| @game.upgrades_to?(hex.tile, t, special) }
+            end
+            tiles
+              .compact
+              .select { |t| @game.phase.tiles.include?(t.color) && @game.upgrades_to?(hex.tile, t, special) }
+          end
+
+          def abilities(entity, **kwargs, &block)
+            return unless entity&.company?
+
+            @game.abilities(
+              entity,
+              :tile_lay,
+              time: %w[special_track %current_step% owning_corp_or_turn],
+              **kwargs,
+              &block
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822/step/track.rb
+++ b/lib/engine/game/g_1822/step/track.rb
@@ -1,15 +1,65 @@
 # frozen_string_literal: true
 
-require_relative '../../../step/track'
+require_relative '../../../step/base'
+require_relative 'tracker'
 
 module Engine
   module Game
     module G1822
       module Step
-        class Track < Engine::Step::Track
+        class Track < Engine::Step::Base
+          include Engine::Game::G1822::Tracker
+
+          ACTIONS = %w[lay_tile pass].freeze
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] if entity.company? || !can_lay_tile?(entity)
+
+            ACTIONS
+          end
+
+          def description
+            tile_lay = get_tile_lay(current_entity)
+            return 'Lay Track' unless tile_lay
+
+            if tile_lay[:lay] && tile_lay[:upgrade]
+              'Lay/Upgrade Track'
+            elsif tile_lay[:lay]
+              'Lay Track'
+            else
+              'Upgrade Track'
+            end
+          end
+
+          def pass_description
+            @acted ? 'Done (Track)' : 'Skip (Track)'
+          end
+
+          def process_lay_tile(action)
+            lay_tile_action(action)
+            pass! unless can_lay_tile?(action.entity)
+
+            @game.after_lay_tile(action.hex, action.tile)
+          end
+
+          def process_pass(action)
+            super
+
+            @game.after_track_pass(action.entity)
+          end
+
           def available_hex(entity, hex)
-            connected = super
+            connected = hex_neighbors(entity, hex)
             return nil unless connected
+
+            tile_lay = get_tile_lay(entity)
+            return nil unless tile_lay
+
+            color = hex.tile.color
+            return nil if color == :white && !tile_lay[:lay]
+            return nil if color != :white && !tile_lay[:upgrade]
+            return nil if color != :white && tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(hex)
 
             # London yellow tile counts as an upgrade
             if hex.tile.color == :white && @round.num_laid_track.positive? && hex.name == @game.class::LONDON_HEX
@@ -17,83 +67,6 @@ module Engine
             end
 
             connected
-          end
-
-          def can_lay_tile?(entity)
-            # Special case for minor 14, the first OR its hometoken placement counts as tile lay
-            return false if entity.corporation? && entity.id == @game.class::MINOR_14_ID && !entity.operated?
-
-            super
-          end
-
-          def check_track_restrictions!(entity, old_tile, new_tile)
-            return if @game.loading || !entity.operator?
-            return if new_tile.hex.name == @game.class::ENGLISH_CHANNEL_HEX
-            return if new_tile.hex.name == @game.class::CARDIFF_HEX
-
-            super
-          end
-
-          def legal_tile_rotation?(entity, hex, tile)
-            # We will remove a town from the white S tile, this meaning we will not follow the normal path upgrade rules
-            if hex.name == @game.class::UPGRADABLE_S_HEX_NAME &&
-              tile.name == @game.class::UPGRADABLE_S_YELLOW_CITY_TILE &&
-              @game.class::UPGRADABLE_S_YELLOW_ROTATIONS.include?(tile.rotation)
-              return true
-            end
-
-            super
-          end
-
-          def process_lay_tile(action)
-            super
-            @game.after_lay_tile(action.hex, action.tile)
-          end
-
-          def potential_tiles(entity, hex)
-            colors = if entity.corporation? && entity.type == :minor &&
-                        @game.phase.status.include?('minors_green_upgrade')
-                       @game.class::MINOR_GREEN_UPGRADE
-                     else
-                       @game.phase.tiles
-                     end
-            @game.tiles
-                 .select { |tile| colors.include?(tile.color) }
-                 .uniq(&:name)
-                 .select { |t| @game.upgrades_to?(hex.tile, t) }
-                 .reject(&:blocks_lay)
-          end
-
-          def remove_border_calculate_cost!(tile, entity)
-            hex = tile.hex
-            types = []
-
-            total_cost = tile.borders.dup.sum do |border|
-              next 0 unless (cost = border.cost)
-
-              edge = border.edge
-              neighbor = hex.neighbors[edge]
-              next 0 unless hex.targeting?(neighbor)
-
-              if neighbor.targeting?(hex)
-                tile.borders.delete(border)
-                neighbor.tile.borders.map! { |nb| nb.edge == hex.invert(edge) ? nil : nb }.compact!
-              end
-
-              types << border.type
-              cost - border_cost_discount(entity, border, hex)
-            end
-            [total_cost, types]
-          end
-
-          def upgraded_track(action)
-            # London yellow tile counts as an upgrade
-            unless action.tile.color != :yellow ||
-              (action.tile.color == :yellow && action.hex.name == @game.class::LONDON_HEX)
-              return
-            end
-
-            @round.upgraded_track = true
           end
         end
       end

--- a/lib/engine/game/g_1822/step/tracker.rb
+++ b/lib/engine/game/g_1822/step/tracker.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/tracker'
+
+module Engine
+  module Game
+    module G1822
+      module Tracker
+        include Engine::Step::Tracker
+
+        def can_lay_tile?(entity)
+          # Special case for minor 14, the first OR its hometoken placement counts as tile lay
+          return false if entity.corporation? && entity.id == @game.class::MINOR_14_ID && !entity.operated?
+
+          super
+        end
+
+        def check_track_restrictions!(entity, old_tile, new_tile)
+          return if @game.loading || !entity.operator?
+          return if new_tile.hex.name == @game.class::ENGLISH_CHANNEL_HEX
+          return if new_tile.hex.name == @game.class::CARDIFF_HEX
+
+          super
+        end
+
+        def legal_tile_rotation?(entity, hex, tile)
+          # We will remove a town from the white S tile, this meaning we will not follow the normal path upgrade rules
+          if hex.name == @game.class::UPGRADABLE_S_HEX_NAME &&
+            tile.name == @game.class::UPGRADABLE_S_YELLOW_CITY_TILE &&
+            @game.class::UPGRADABLE_S_YELLOW_ROTATIONS.include?(tile.rotation)
+            return true
+          end
+
+          operator = entity.company? ? entity.owner : entity
+          super(operator, hex, tile)
+        end
+
+        def potential_tiles(entity, hex)
+          colors = if entity.corporation? && entity.type == :minor &&
+            @game.phase.status.include?('minors_green_upgrade')
+                     @game.class::MINOR_GREEN_UPGRADE
+                   else
+                     @game.phase.tiles
+                   end
+          @game.tiles
+               .select { |tile| colors.include?(tile.color) }
+               .uniq(&:name)
+               .select { |t| @game.upgrades_to?(hex.tile, t) }
+               .reject(&:blocks_lay)
+        end
+
+        def remove_border_calculate_cost!(tile, entity)
+          hex = tile.hex
+          types = []
+          total_cost = tile.borders.dup.sum do |border|
+            next 0 unless (cost = border.cost)
+
+            edge = border.edge
+            neighbor = hex.neighbors[edge]
+            next 0 unless hex.targeting?(neighbor)
+
+            tile.borders.delete(border)
+            types << border.type
+            cost - border_cost_discount(entity, border, hex)
+          end
+
+          # If we use the Glasgow and South-Western Railway private, it removes the border cost of one estuary crossing
+          if entity.id == @game.class::COMPANY_GSWR
+            raise GameError, 'Must lay tile with one path over an estuary crossing' if total_cost.zero?
+
+            total_cost -= @game.class::COMPANY_GSWR_DISCOUNT
+          end
+          [total_cost, types]
+        end
+
+        def upgraded_track(action)
+          @round.upgraded_track = upgraded_track?(action)
+        end
+
+        def upgraded_track?(action)
+          # London yellow tile counts as an upgrade
+          tile_color = action.tile.color
+          tile_color != :yellow || (tile_color == :yellow && action.hex.name == @game.class::LONDON_HEX)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/acquire_company.rb
+++ b/lib/engine/step/acquire_company.rb
@@ -36,10 +36,16 @@ module Engine
         company.owner = entity
         entity.companies << company
 
+        @round.acquired_companies << company
+
         @log << "#{entity.name} acquires #{company.name} from #{owner.name}"
         @game.company_bought(company, entity)
 
         pass! if @game.purchasable_companies(entity).empty?
+      end
+
+      def round_state
+        { acquired_companies: [] }
       end
     end
   end


### PR DESCRIPTION
- I move the override track code into a tracker.rb where i override the gerneric track code. This to make a special_track which uses this as well.
- P2 Remove Small Station. You can lay a plain yellow tile on a white town, or you can upgrade to a plain tile of the next color to remove the town. I had to work around all the track checks here. User have to verify this him/her self to make sure the track lay is correct.
- P8 Mountain/Hill Discount. I had to make a special_choose step. After you acquired this private you have to choose which of the 2 abilities you want to have. Either a one time use of a free track lay on a mountain, hill or swamp. Or you choose to have a passive tile discount of hills and mountains
- P10 River/Estuary Discount. Here the corporation have two uses of a free estuary crossing. As long the corporarion havent used up its charges it gets a tile discount on all swamps.
- P11 Advanced Tile Lay. You can upgrade a yellow, green, brown plain or towntile to the next color. You can even upgrade above current color. If we are in green phase you can upgrade to a brown tile. Here is a visual "feature". You both see the correct upgrade tiles and you also see the same tiles as "Later phase" tiles. I will write this down in my todo, but not a high priotiy to get this to work correcly. Its just when you use this ability.
- P12 Extra Tile Lay. Here you get a extra full tile lay turn. A major company can lay 4 yellow, upgrade 2 tiles and all the combinations with thoose.