### PR TITLE
1873: tile laying rules

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -83,10 +83,7 @@ module View
           merge = lambda do
             if @selected_corporation
               do_merge = lambda do
-                process_action(Engine::Action::Merge.new(
-                  @mergeable_entity,
-                  corporation: @selected_corporation,
-                ))
+                merge_action(@mergeable_entity, @selected_corporation)
               end
 
               if @mergeable_entity.owner == @selected_corporation.owner
@@ -100,6 +97,20 @@ module View
           end
 
           [h(:button, { on: { click: merge } }, @step.merge_action)]
+        end
+
+        def merge_action(merge_entity, selected)
+          if selected.corporation?
+            process_action(Engine::Action::Merge.new(
+              merge_entity,
+              corporation: selected,
+            ))
+          else
+            process_action(Engine::Action::Merge.new(
+              merge_entity,
+              minor: selected,
+            ))
+          end
         end
 
         def render_payoff_player_debt_button

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -83,7 +83,15 @@ module View
           merge = lambda do
             if @selected_corporation
               do_merge = lambda do
-                merge_action(@mergeable_entity, @selected_corporation)
+                to_merge = if @selected_corporation.corporation?
+                             { corporation: @selected_corporation }
+                           else
+                             { minor: @selected_corporation }
+                           end
+                process_action(Engine::Action::Merge.new(
+                  @mergeable_entity,
+                  **to_merge
+                ))
               end
 
               if @mergeable_entity.owner == @selected_corporation.owner
@@ -97,20 +105,6 @@ module View
           end
 
           [h(:button, { on: { click: merge } }, @step.merge_action)]
-        end
-
-        def merge_action(merge_entity, selected)
-          if selected.corporation?
-            process_action(Engine::Action::Merge.new(
-              merge_entity,
-              corporation: selected,
-            ))
-          else
-            process_action(Engine::Action::Merge.new(
-              merge_entity,
-              minor: selected,
-            ))
-          end
         end
 
         def render_payoff_player_debt_button

--- a/lib/engine/action/destination_connection.rb
+++ b/lib/engine/action/destination_connection.rb
@@ -5,19 +5,26 @@ require_relative 'base'
 module Engine
   module Action
     class DestinationConnection < Base
-      attr_reader :corporations
+      attr_reader :corporations, :minors
 
-      def initialize(entity, corporations:)
+      def initialize(entity, corporations: nil, minors: nil)
         super(entity)
         @corporations = corporations
+        @minors = minors
       end
 
       def self.h_to_args(h, game)
-        { corporations: h['corporations'].map { |c| game.corporation_by_id(c) } }
+        {
+          corporations: h['corporations']&.map { |c| game.corporation_by_id(c) },
+          minors: h['minors']&.map { |m| game.minor_by_id(m) },
+        }
       end
 
       def args_to_h
-        { 'corporations' => @corporations.map(&:id) }
+        {
+          'corporations' => @corporations&.map(&:id),
+          'minors' => @minors&.map(&:id),
+        }
       end
     end
   end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -468,7 +468,7 @@ module Engine
         init_starting_cash(@players, @bank)
         @share_pool = init_share_pool
         @hexes = init_hexes(@companies, @corporations)
-        @graph = Graph.new(self)
+        @graph = init_graph
 
         # call here to set up ids for all cities before any tiles from @tiles
         # can be placed onto the map
@@ -1214,6 +1214,10 @@ module Engine
         city.place_token(corporation, token)
       end
 
+      def graph_for_entity(_entity)
+        @graph
+      end
+
       def upgrade_cost(tile, hex, entity)
         ability = entity.all_abilities.find do |a|
           a.type == :tile_discount &&
@@ -1655,6 +1659,10 @@ module Engine
       end
 
       private
+
+      def init_graph
+        Graph.new(self)
+      end
 
       def init_bank
         cash = self.class::BANK_CASH

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -3,6 +3,9 @@
 require_relative 'meta'
 require_relative '../base'
 require_relative 'step/buy_sell_par_shares'
+require_relative 'step/draft'
+require_relative 'step/track'
+require_relative 'step/destinate'
 
 module Engine
   module Game
@@ -10,7 +13,7 @@ module Engine
       class Game < Game::Base
         include_meta(G1873::Meta)
 
-        attr_reader :mine_12, :corporation_info, :minor_info, :mhe
+        attr_reader :mine_12, :corporation_info, :minor_info, :mhe, :mine_graph, :reserved_tiles
         attr_accessor :premium, :premium_order
 
         register_colors(tan: '#d6a06c')
@@ -45,7 +48,9 @@ module Engine
 
         SELL_MOVEMENT = :down_share
 
-        TILE_LAYS = [{ lay: true, upgrade: true }, { lay: true, upgrade: :not_if_upgraded, cost: 10 }].freeze
+        # there are special rules for mines, and RRs that need to complete their concession route
+        TILE_LAYS = [{ lay: true, upgrade: true, cost: 0 },
+                     { lay: :double_lay, upgrade: :double_lay, cost: 0 }].freeze
 
         # FIXME
         # EVENTS_TEXT = Base::EVENTS_TEXT.merge(
@@ -65,6 +70,56 @@ module Engine
         RAILWAY_MIN_BID = 100
         MIN_BID_INCREMENT = 10
         MHE_START_PRICE = 120
+
+        CONCESSION_TILES = {
+          # HBE
+          'B17' => { entity: 'HBE', tile: '78', exits: [0, 4], cost: 0 },
+          # NWE
+          'C8' => { entity: 'NWE', tile: '79', exits: [0, 3], cost: 150 },
+          'D7' => { entity: 'NWE', tile: '956', exits: [0, 3], cost: 50 },
+          'E6' => { entity: 'NWE', tile: '956', exits: [0, 3], cost: 50 },
+          'H7' => { entity: 'NWE', tile: '78', exits: [2, 4], cost: 100 },
+          'I8' => { entity: 'NWE', tile: '956', exits: [0, 3], cost: 150 },
+          # WBE
+          'C10' => { entity: 'WBE', tile: '78', exits: [2, 4], cost: 0 },
+          'C12' => { entity: 'WBE', tile: '956', exits: [1, 4], cost: 0 },
+          'C14' => { entity: 'WBE', tile: '76', exits: [1, 5], cost: 0 },
+          'D15' => { entity: 'WBE', tile: '974', exits: [1, 2, 3, 5], cost: 0 },
+          # SHE
+          'F3' => { entity: 'SHE', tile: '956', exits: [0, 3], cost: 150 },
+          'G2' => { entity: 'SHE', tile: '956', exits: [0, 3], cost: 150 },
+          # KEZ
+          'H3' => { entity: 'KEZ', tile: '78', exits: [3, 5], cost: 100 },
+          # GHE
+          'H19' => { entity: 'GHE', tile: '78', exits: [1, 3], cost: 150 },
+        }.freeze
+
+        STATE_NETWORK = %w[
+         B9
+         E20
+         I2
+        ].freeze
+
+        DOUBLE_LAY_TILES = %w[
+          77
+          78
+          79
+          75
+          76
+          956
+          957
+          958
+          959
+          960
+          961
+          964
+          965
+          966
+          967
+          968
+          969
+          970
+        ].freeze
 
         def location_name(coord)
           @location_names ||= game_location_names
@@ -97,6 +152,21 @@ module Engine
             )
           end
           @mhe.owner = @share_pool
+          @mine_graph = Graph.new(self, home_as_token: true, no_blocking: true)
+          @reserved_tiles = Hash.new { |h, k| h[k] = {} }
+          @state_network_hexes = STATE_NETWORK.map { |h| hex_by_id(h) }
+        end
+
+        def init_graph
+          Graph.new(self, skip_track: :broad)
+        end
+
+        def graph_for_entity(entity)
+          if entity.minor?
+            @mine_graph
+          else
+            @graph
+          end
         end
 
         def load_minor_extended
@@ -232,7 +302,7 @@ module Engine
             @turn > 1
           else
             num_vh = @minors.count { |m| m.owner == player && @minor_info[m][:vor_harzer] }
-            num_vh > 1 && (@turn > 1 || @mine_12.owner == player)
+            num_vh >= 1 && (@turn > 1 || @mine_12.owner == player)
           end
         end
 
@@ -309,6 +379,36 @@ module Engine
           entity.corporation? && @corporation_info[entity][:type] == :railway
         end
 
+        def concession_pending?(entity)
+          entity.corporation? &&
+            @corporation_info[entity][:type] == :railway &&
+            @corporation_info[entity][:concession_pending]
+        end
+
+        def concession_route_done?(entity)
+          return true unless concession_pending?(entity)
+
+          concession_hexes(entity).all? do |h|
+            info = CONCESSION_TILES[h]
+            (hex_by_id(h).tile.exits & info[:exits]).size == info[:exits].size
+          end
+        end
+
+        def concession_hexes(entity)
+          CONCESSION_TILES.keys.select { |h| CONCESSION_TILES[h][:entity] == entity.name }
+        end
+
+        def concession_complete!(entity)
+          return unless concession_pending?(entity)
+
+          @corporation_info[entity][:concession_pending] = false
+          @log << "#{entity.name} has a complete concession route"
+        end
+
+        def connected_mine?(entity)
+          entity.minor? && @minor_info[entity][:connected]
+        end
+
         def init_round
           new_premium_round
         end
@@ -356,7 +456,8 @@ module Engine
         # FIXME
         def operating_round(round_num)
           Engine::Round::Operating.new(self, [
-            Engine::Step::Track,
+            G1873::Step::Track,
+            G1873::Step::Destinate,
             # Engine::Step::Token,
             # Engine::Step::Route,
             # Engine::Step::Dividend,
@@ -409,10 +510,81 @@ module Engine
           end
         end
 
-        # FIXME
+        def operating_order
+          open_private_mines + @corporations.select(&:floated?).sort
+        end
+
+        def concession_hex(hex)
+          CONCESSION_TILES[hex.id]
+        end
+
+        # concession route in this hex
+        def reserve_tile!(hex, tile)
+          return false unless (ch = concession_hex(hex))
+
+          # look for an upgrade to the tile being laid that has the exits
+          # needed by the concession route
+          res_tile = @tiles.find do |t|
+            exits_match?(t.exits, tile.exits, ch[:exits]) &&
+              upgrades_to?(tile, t) &&
+              t.cities.size == tile.cities.size
+          end
+
+          return false unless res_tile
+
+          add_tile_reservation!(hex, res_tile)
+          res_tile
+        end
+
+        # see if exits_a contain exits_b and exits_c under some rotation
+        def exits_match?(exits_a, exits_b, exits_c)
+          6.times do |rot|
+            rot_exits = rotate_exits(exits_a, rot)
+            return true if (rot_exits & exits_b).size == exits_b.size && (rot_exits & exits_c).size == exits_c.size
+          end
+          false
+        end
+
+        def rotate_exits(exits, rot)
+          exits.map { |e| (e + rot) % 6 }
+        end
+
+        def add_tile_reservation!(hex, tile)
+          ch = concession_hex(hex)
+
+          @log << "Reserving tile ##{tile.name} for #{ch[:entity]} concession route"
+
+          # if there already is a reserved tile for this hex, make the old one available again
+          @tiles << @reserved_tiles[hex.id][:tile] unless @reserved_tiles[hex.id].empty?
+
+          @reserved_tiles[hex.id] = { tile: tile, entity: ch[:entity] }
+          @tiles.delete(tile)
+        end
+
+        # If tile is in reservation hex and it completes the route there,
+        # free the reservation
+        # If it was a different tile that was reserved, put the reserved
+        # tile back into the tile list
+        def free_tile_reservation!(hex, tile)
+          return unless @reserved_tiles[hex]
+
+          ch = concession_hex(hex)
+          return unless (ch[:exits] & tile.exits).size != ch[:exits].size
+
+          @tiles << @reserved_tiles[hex.id][:tile] if @reserved_tiles[hex.id][:tile] != tile
+          @reserved_tiles.delete(hex.id)
+        end
+
+        def double_lay?(tile)
+          DOUBLE_LAY_TILES.include?(tile.name)
+        end
+
         def upgrades_to?(from, to, special = false)
           # correct color progression?
-          return false unless Engine::Tile::COLORS.index(to.color) == (Engine::Tile::COLORS.index(from.color) + 1)
+          if !(reserved_tiles[from.hex.id] && reserved_tiles[from.hex.id][:tile] == to) &&
+            (Engine::Tile::COLORS.index(to.color) != (Engine::Tile::COLORS.index(from.color) + 1))
+            return false
+          end
 
           # honors pre-existing track?
           return false unless from.paths_are_subset_of?(to.paths)
@@ -421,19 +593,38 @@ module Engine
           return true if special
 
           # correct label?
-          return false if from.label != to.label && !(from.label.to_s == 'K' && to.color == :yellow)
+          return false if from.label != to.label
+
+          # old tile doesn't have a lock icon and it's not yet phase 3
+          return false if !@phase.tiles.include?(:green) && from.icons.any? { |i| i.name == 'lock' }
 
           # honors existing town/city counts?
-          # - allow labelled cities to upgrade regardless of count; they're probably
-          #   fine (e.g., 18Chesapeake's OO cities merge to one city in brown)
-          # - TODO: account for games that allow double dits to upgrade to one town
-          return false if from.towns.size != to.towns.size
-          return false if (!from.label || from.label.to_s == 'K') && from.cities.size != to.cities.size
-
-          # handle case where we are laying a yellow OO tile and want to exclude single-city tiles
-          return false if (from.color == :white) && from.label.to_s == 'OO' && from.cities.size != to.cities.size
+          # 1873: towns always upgrade to cities
+          # 1873: single yellow cities can upgrate to single city or OO,
+          #       except B-label tile is one city to one city
+          # 1873: framed tiles can only upgrade to framed tiles
+          return false if from.city_towns.empty? && !to.city_towns.empty?
+          return false if !from.towns.empty? && from.towns.size != to.cities.size
+          return false if !from.cities.empty? && to.cities.empty?
+          return false if from.label.to_s == 'B' && from.cities.size != to.cities.size
+          return false if (from.frame && !to.frame) || (!from.frame && to.frame)
 
           true
+        end
+
+        def check_mine_connected?(entity)
+          return false unless entity.minor?
+          return true if @minor_info[entity][:connected]
+
+          @state_network_hexes.any? { |h| @mine_graph.reachable_hexes(entity)[h] }
+        end
+
+        def connect_mine!(entity)
+          return unless entity.minor?
+
+          old = @minor_info[entity][:connected]
+          @minor_info[entity][:connected] = true
+          @log << "Mine #{entity.name} is now connected to state railway network" unless old
         end
 
         # FIXME: take care of compulsory train
@@ -602,11 +793,11 @@ module Engine
         def game_tiles
           {
             '77' => 2,
-            '78' => 10,
-            '79' => 4,
+            '78' => 'unlimited',
+            '79' => 'unlimited',
             '75' => 4,
-            '76' => 7,
-            '956' => 10,
+            '76' => 'unlimited',
+            '956' => 'unlimited',
             '957' => 2,
             '958' => 2,
             '959' => 1,

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -162,11 +162,7 @@ module Engine
         end
 
         def graph_for_entity(entity)
-          if entity.minor?
-            @mine_graph
-          else
-            @graph
-          end
+          entity.minor? ? @mine_graph : @graph
         end
 
         def load_minor_extended

--- a/lib/engine/game/g_1873/step/destinate.rb
+++ b/lib/engine/game/g_1873/step/destinate.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class Destinate < Engine::Step::Base
+          ACTIONS = %w[destination_connection].freeze
+          def auto_actions(entity)
+            return [] unless @round.num_laid_track.positive?
+
+            [
+              Engine::Action::DestinationConnection.new(
+                entity,
+                minors: @game.minors.select { |m| @game.check_mine_connected?(m) }
+              ),
+            ]
+          end
+
+          def skip!
+            pass!
+          end
+
+          def actions(_entity)
+            return [] unless @round.num_laid_track.positive?
+
+            ACTIONS
+          end
+
+          def process_destination_connection(action)
+            action.minors.each { |m| @game.connect_mine!(m) }
+            pass!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/step/form.rb
+++ b/lib/engine/game/g_1873/step/form.rb
@@ -10,7 +10,7 @@ module Engine
           MERGE_ACTION = %w[merge].freeze
 
           def actions(entity)
-            return [] unless entity == owner || entity == buyer
+            return [] if entity != owner && entity != buyer
 
             MERGE_ACTION
           end

--- a/lib/engine/game/g_1873/step/form.rb
+++ b/lib/engine/game/g_1873/step/form.rb
@@ -10,7 +10,7 @@ module Engine
           MERGE_ACTION = %w[merge].freeze
 
           def actions(entity)
-            return [] unless entity == owner
+            return [] unless entity == owner || entity == buyer
 
             MERGE_ACTION
           end
@@ -23,8 +23,8 @@ module Engine
             'Select Private Mines'
           end
 
-          def blocks
-            true
+          def blocks?
+            !@round.pending_forms.empty?
           end
 
           def round_state
@@ -37,6 +37,10 @@ module Engine
 
           def active?
             !@round.pending_forms.empty?
+          end
+
+          def merge_action
+            'Merge'
           end
 
           def buyer
@@ -55,16 +59,40 @@ module Engine
             false
           end
 
+          def mergeable_entity
+            buyer
+          end
+
+          def merge_in_progress?
+            buyer
+          end
+
+          def ipo_type(_corp)
+            ''
+          end
+
+          def mergeable_type(corporation)
+            "Mines that can be formed into Public Mining Company #{corporation.name}:"
+          end
+
+          # first mine must be owned by player doing the formation
+          #
           # if turn 1: first mine must be mine 12
           # else if HW corp, mines must be open private von-harzer mines
           # else all open private mines
-          def mergeable
+          def mergeable_entities
+            available_mines = if target_mines.empty?
+                                @game.open_private_mines.select { |m| m.owner == owner }
+                              else
+                                @game.open_private_mines - [target_mines.first]
+                              end
+
             if @game.turn == 1 && target_mines.empty?
               [@game.mine_12]
             elsif @game.corporation_info[buyer][:vor_harzer]
-              @game.open_private_mines.select { |pm| @game.minor_info[pm][:vor_harzer] } - [target_mines.first]
+              available_mines.select { |pm| @game.minor_info[pm][:vor_harzer] }
             else
-              @game.open_private_mines - [target_mines.first]
+              available_mines
             end
           end
 
@@ -72,6 +100,11 @@ module Engine
             mine = action.minor
             @log << "#{buyer.id} acquires #{mine.full_name} "\
               "(face value #{@game.format_currency(@game.minor_info[mine][:value])})"
+
+            # new corp gets formerly independent mines and their cash
+            # machines and switchers stay with mines
+            mine.owner = buyer
+            mine.spend(mine.cash, buyer) if mine.cash.positive?
 
             target_mines << mine
             finalize_formation unless target_mines.one?
@@ -96,13 +129,6 @@ module Engine
             price = @game.stock_market.market.first.select { |p| p.price <= average }.max_by(&:price)
             @game.stock_market.set_par(buyer, price)
             @log << "#{buyer.id} share price is set to #{@game.format_currency(price.price)}"
-
-            # new corp gets formerly independent mines and their cash
-            # machines and switchers stay with mines
-            target_mines.each do |m|
-              m.owner = buyer
-              m.spend(m.cash, buyer) if m.cash.positive?
-            end
 
             buyer.ipoed = true
 

--- a/lib/engine/game/g_1873/step/track.rb
+++ b/lib/engine/game/g_1873/step/track.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class Track < Engine::Step::Track
+          def round_state
+            {
+              non_double_tile: false,
+              num_laid_track: 0,
+            }
+          end
+
+          def setup
+            @round.num_laid_track = 0
+            @round.non_double_tile = false
+          end
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] if @game.public_mine?(entity) || @game.connected_mine?(entity) || entity == @game.mhe
+            return [] if entity.company? || !can_lay_tile?(entity)
+
+            ACTIONS
+          end
+
+          def process_pass(action)
+            # deal with case where concession route happened to be completed
+            # before railroad even got to it's first OR
+            entity = action.entity
+            if @game.concession_pending?(entity) && @game.concession_route_done?(entity)
+              @game.concession_complete!(entity)
+              pay_full_concession_cost!(entity)
+            end
+
+            super
+          end
+
+          def process_lay_tile(action)
+            entity = action.entity
+
+            # deal with case where concession route happened to be completed
+            # before railroad even got to it's first OR
+            if @game.concession_pending?(entity) && @game.concession_route_done?(entity)
+              @game.concession_complete!(entity)
+              pay_full_concession_cost!(entity)
+            end
+
+            lay_tile_action(action)
+
+            # force recalculation of mine connections
+            @game.mine_graph.clear if entity.corporation?
+
+            # check to see if concession is complete
+            if @game.concession_pending?(entity) && @game.concession_route_done?(entity)
+              @game.concession_complete!(entity)
+              @round.num_laid_track = 2 # prevent any more tiles this turn
+            end
+
+            @game.free_tile_reservation!(action.hex, action.tile)
+
+            pass! unless can_lay_tile?(action.entity)
+          end
+
+          def skip!
+            if !@acted && current_entity && !@game.public_mine?(current_entity) && current_entity != @game.mhe
+              log_skip(current_entity)
+            end
+            pass!
+          end
+
+          def can_lay_tile?(entity)
+            return true if abilities(entity, time: type, passive_ok: false)
+            return false if entity.minor? && @round.num_laid_track.positive?
+            return false if !@game.concession_pending?(entity) && @round.non_double_tile
+
+            action = get_tile_lay(entity)
+            return false unless action
+
+            (entity.minor? || !entity.tokens.empty?) && (buying_power(entity) >= action[:cost]) &&
+              (action[:lay] || action[:upgrade])
+          end
+
+          def get_tile_lay(entity)
+            return @game.tile_lays(entity)[0]&.clone if @game.concession_pending?(entity)
+
+            action = @game.tile_lays(entity)[@round.num_laid_track]&.clone
+            return unless action
+
+            action[:lay] = !@round.non_double_tile if action[:lay] == :double_lay
+            action[:upgrade] = !@round.non_double_tile if action[:upgrade] == :double_lay
+            action[:cost] = action[:cost] || 0
+            action
+          end
+
+          def lay_tile_action(action, entity: nil, spender: nil)
+            tile = action.tile
+            tile_lay = get_tile_lay(action.entity)
+
+            if !@game.double_lay?(tile) && @round.num_laid_track.positive?
+              raise GameError, 'Must lay yellow or green with 2 unconnected track sections'
+            end
+
+            lay_tile(action, extra_cost: tile_lay[:cost], entity: entity, spender: spender)
+            @round.num_laid_track += 1
+            @round.non_double_tile = true unless @game.double_lay?(tile)
+          end
+
+          def potential_tiles(entity, hex)
+            return super unless (pending = @game.concession_pending?(entity))
+
+            if !@game.concession_hex(hex)
+              # can only lay in concession hexes
+              []
+            elsif @game.reserved_tiles[hex.id][:entity] == entity.name
+              # can only lay reserved tile for this hex
+              [@game.reserved_tiles[hex.id][:tile]]
+            else
+              # can only lay concession tile of this hex
+              [@game.tiles.find { |t| t.name == @game.concession_hex(hex)[:tile] }]
+            end
+          end
+
+          def check_track_restrictions!(entity, old_tile, new_tile)
+            return if @game.loading || !entity.operator?
+
+            graph = @game.graph_for_entity(entity)
+            old_paths = old_tile.paths
+
+            # tile is illegal if there exists a path on the new tile that is:
+            # A. Not reachable, AND
+            # B. Not on the old tile, AND
+            # C. Not state RR track
+            new_tile.paths.each do |np|
+              if !graph.connected_paths(entity)[np] && np.track != :broad && !old_paths.find { |path| np <= path }
+                raise GameError, 'Must use all new track'
+              end
+            end
+          end
+
+          def pay_tile_cost!(entity, tile, rotation, hex, spender, cost, _extra_cost)
+            reimburse = false
+            ch = @game.concession_hex(tile.hex)
+            if ch && entity.name != ch[:entity] && (tile.exits & ch[:exits]).size == ch[:exits].size
+              @log << "Laying tile finishes concession track in #{hex.id}"
+              reimburse = true
+            elsif ch && entity.name != ch[:entity] && (tile.exits & ch[:exits]).size != ch[:exits].size
+              res_tile = @game.reserve_tile!(hex, tile)
+              raise GameError, 'Tile prevents concession from being completed' unless res_tile
+
+              reimburse = true
+            elsif ch && (tile.exits & ch[:exits]).size != ch[:exits].size
+              raise GameError, 'Tile must complete concession route'
+            elsif ch && cost != ch[:cost]
+              cost += ch[:cost]
+              @log << "#{entity.owner} must pay for previously reimbused tile cost"\
+                "of #{@game.format_cureency(ch[:cost])}"
+            end
+
+            super
+
+            return unless reimburse && cost.positive?
+
+            @game.bank.spend(cost, entity.owner)
+            @log << "#{entity.owner.name} is reimbursed for building the tile"
+          end
+
+          def pay_full_concession_cost!(entity)
+            total_cost = @game.concession_hexes(entity).sum { |h| @game.concession_hex(h)[:cost] }
+            return unless total_cost.positive?
+
+            @log << "#{entity.name} had entire concession route previously built"
+            @log << "#{entity.name} pays entire concession cost of #{@game.format_currency(total_cost)}"
+            entity.spend(total_cost, @game.bank)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -70,6 +70,7 @@ module Engine
         hex = action.hex
         rotation = action.rotation
         old_tile = hex.tile
+        graph = @game.graph_for_entity(entity)
 
         @game.companies.each do |company|
           break if @game.loading
@@ -94,7 +95,7 @@ module Engine
 
         hex.lay(tile)
 
-        @game.graph.clear
+        graph.clear
         free = false
         discount = 0
         teleport = false
@@ -117,7 +118,7 @@ module Engine
             raise GameError, "Track laid must be connected to one of #{spender.id}'s stations" if ability.reachable &&
               hex.name != spender.coordinates &&
               !@game.loading &&
-              !@game.graph.reachable_hexes(spender)[hex]
+              !graph.reachable_hexes(spender)[hex]
 
             free = ability.free
             discount = ability.discount
@@ -237,12 +238,14 @@ module Engine
       def check_track_restrictions!(entity, old_tile, new_tile)
         return if @game.loading || !entity.operator?
 
+        graph = @game.graph_for_entity(entity)
+
         old_paths = old_tile.paths
         changed_city = false
         used_new_track = old_paths.empty?
 
         new_tile.paths.each do |np|
-          next unless @game.graph.connected_paths(entity)[np]
+          next unless graph.connected_paths(entity)[np]
 
           op = old_paths.find { |path| np <= path }
           used_new_track = true unless op
@@ -316,7 +319,7 @@ module Engine
       end
 
       def hex_neighbors(entity, hex)
-        @game.graph.connected_hexes(entity)[hex]
+        @game.graph_for_entity(entity).connected_hexes(entity)[hex]
       end
     end
   end


### PR DESCRIPTION
Common file changes:
* UI::Round::Stock - allow minors as parameter to Action::Merge
* Action::DestinationConnection - allow minors as parameters
* Step::Tracker - call game method for graph to check and clear
* Game::Base - use init_graph method instead of calling Graph.new directly; implement method for above

1873 implementation:
* fix public mine formation via SR view
* independent mines can lay one tile if not connected
* check for independent mine connection after every tile lay (mine or RR)
* concession route tile lays for concession company
* reserving tiles when other company lays on concession route
* reimburse owner when laying on other company's concession route (and back charge concession company when they complete the concession route)
* limit concession route tile lays to required tiles only (possibly from reserved list)
* concession route tile lay of reserved tile can be any color
* free tile reservations when needed
* prohibit laying on "locked" hexes until phase 3
* RR can lay 2 tiles (after concession route is done) if both are either yellow or green with 2 unconnected sections of track
* towns upgrade to cities
* bordered tiles can only upgrade to bordered tiles