### PR TITLE
Fit reservation text into OO tiles

### DIFF
--- a/assets/app/view/game/part/reservation.rb
+++ b/assets/app/view/game/part/reservation.rb
@@ -163,7 +163,7 @@ module View
           },
           # edge 5
           {
-            region_weights: { [17] => 1.0, [18, 23] => 0.25 },
+            region_weights: { [23] => 1.0, [17] => 0.25 },
             x: 50,
             y: 37,
           },

--- a/assets/app/view/game/part/reservation.rb
+++ b/assets/app/view/game/part/reservation.rb
@@ -183,8 +183,7 @@ module View
               [SINGLE_CITY_ONE_SLOT[layout], SINGLE_CITY_ONE_SLOT_RIGHT[layout]]
             end
           elsif @tile.city_towns.size > 1 && layout == :flat
-            # MULTI_CITY_LOCATIONS
-            [P_BOTTOM_LEFT_CORNER[layout]]
+            MULTI_CITY_LOCATIONS
           elsif @tile.city_towns.size > 1
             POINTY_MULTI_CITY_LOCATIONS
           elsif layout == :flat


### PR DESCRIPTION
closes #4152 

CZ: ATE in E9 before
![Screenshot 2021-02-24 at 12 18 52 PM](https://user-images.githubusercontent.com/1711810/109100544-02642e00-76da-11eb-874f-0c38b5cbf244.png)

after
![Screenshot 2021-02-24 at 7 53 15 PM](https://user-images.githubusercontent.com/1711810/109100541-01cb9780-76da-11eb-8fc2-3d7ed811cef0.png)

--
1882: QLL in J10 before
![Screenshot 2021-02-24 at 8 25 43 PM](https://user-images.githubusercontent.com/1711810/109102850-90daae80-76de-11eb-8c9e-ed03cd47da81.png)


after
![qll_after](https://user-images.githubusercontent.com/1711810/109102779-70aaef80-76de-11eb-9adb-7b8701338770.png)


1830's erie still looks fine
![Screenshot 2021-02-24 at 7 55 18 PM](https://user-images.githubusercontent.com/1711810/109100736-4a835080-76da-11eb-9719-c4e54897d47d.png)

