### PR TITLE
remove unless & compact

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -282,8 +282,6 @@ module View
           .uniq.map { |p| [p, colors[p]] }.to_h
 
           legend_items = types_in_market.map do |type, color|
-            next unless type_text.include?(type)
-
             text = type_text[type]
 
             style = @box_style_2d.merge(backgroundColor: COLOR_MAP[color])
@@ -304,8 +302,6 @@ module View
               h(:div, { style: { maxWidth: '24rem' } }, text),
             ])
           end
-
-          legend_items.compact!
           legend_items.reverse! unless @game.stock_market.one_d?
 
           children << h('div#legend', legend_items)


### PR DESCRIPTION
Thanks for the `compact!`, but because types in `types_in_market` should always be a subset of types in `type_text` we can just get rid of the `unless`. If there’s no text available [=> text = nil] the color box/key and an empty div will be rendered. I’d consider this QA ;-)