### PR TITLE
1861: Changes colors of MK and MKV companies 

### DIFF
--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -534,7 +534,7 @@ module Engine
             always_market_price: true,
             tokens: [0, 20, 40],
             type: 'major',
-            color: '#3c7b5c',
+            color: '#7b352a',
             reservation_color: nil,
           },
           {
@@ -567,7 +567,7 @@ module Engine
             always_market_price: true,
             tokens: [0, 20, 40],
             type: 'major',
-            color: '#7b352a',
+            color: '#3c7b5c',
             reservation_color: nil,
           },
           {

--- a/public/logos/1861/MK.svg
+++ b/public/logos/1861/MK.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#3c7b5c"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" font-family="Lato" fill="#fff">MK</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#7b352a"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" font-family="Lato" fill="#fff">MK</text></svg>

--- a/public/logos/1861/MKV.svg
+++ b/public/logos/1861/MKV.svg
@@ -1,1 +1,1 @@
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#7b352a"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#ffffff">MKV</text></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#3c7b5c"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#ffffff">MKV</text></svg>


### PR DESCRIPTION
matches the colors of MK and MKV in published editions of the game.

https://github.com/tobymao/18xx/issues/4169

original edition: https://boardgamegeek.com/image/167006/1861-railways-russian-empire
1861/1867 edition: https://boardgamegeek.com/image/5033873/18611867