### PR TITLE
allow rake dev_down to specific version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,14 +27,14 @@ task :dev_up do
   migrate.call('development', nil)
 end
 
-desc 'Migrate development database to all the way down'
-task :dev_down do
-  migrate.call('development', 0, true)
+desc 'Migrate development database to version x (0 if no arg given)'
+task :dev_down, [:version] do |_t, args|
+  migrate.call('development', args[:version].to_i, true)
 end
 
-desc 'Migrate development database all the way down and then back up'
-task :dev_bounce do
-  migrate.call('development', 0, true)
+desc 'Migrate development database down to version x (0 if no arg given) and then back up'
+task :dev_bounce, [:version] do |_t, args|
+  migrate.call('development', args[:version].to_i, true)
   Sequel::Migrator.apply(DB, 'migrate')
 end
 


### PR DESCRIPTION
Migrating down to 0 is quite annoying due to wiping the DB in the process. This allows migrating down to any previous version to test migration scripts e.g.
[no or bogus argument => version = 0 == previous behavior]