### PR TITLE
[1822] Buying power and loans

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2188,6 +2188,10 @@ module Engine
           corporations.reject { |c| c.type == :minor }.sort_by(&:name)
         end
 
+        def buying_power(entity, **)
+          entity.cash
+        end
+
         def can_hold_above_limit?(_entity)
           true
         end
@@ -3220,7 +3224,7 @@ module Engine
           player.cash += loan
 
           # Add interest to the loan, must atleast pay 150% of the loaned value
-          @player_debts[player] += player_loan_interest(loan)
+          @player_debts[player] += loan + player_loan_interest(loan)
         end
 
         def train_type(train)

--- a/lib/engine/game/g_1822/step/issue_shares.rb
+++ b/lib/engine/game/g_1822/step/issue_shares.rb
@@ -37,6 +37,13 @@ module Engine
             @game.sell_shares_and_change_price(action.bundle)
             pass!
           end
+
+          def skip!
+            if !@acted && current_entity && current_entity.corporation? && current_entity.type == :major
+              log_skip(current_entity)
+            end
+            pass!
+          end
         end
       end
     end


### PR DESCRIPTION
- Do not include issuable shares in the corporations buying power. You cant isse shares during an emergency train buy
- Fix a bug when taking a loan during emergency train buy
- Dont log skipped issue shares step on minor corporations