### PR TITLE
Bold the most recent stock action

### DIFF
--- a/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
@@ -190,8 +190,7 @@ module Engine
             @round.players_sold[entity][corporation] = :short
             @game.short(entity, corporation)
 
-            @round.last_to_act = entity
-            @current_actions << action
+            track_action(action, corporation)
           end
 
           def process_bid(action)
@@ -248,7 +247,7 @@ module Engine
               @game.unshort(entity, bundle.shares[0]) if unshort
             else
               buy_shares(entity, bundle)
-              @round.last_to_act = action.entity.player
+              track_action(action, corporation, false)
               @corporate_action = action
             end
           end
@@ -322,7 +321,7 @@ module Engine
             end
 
             @corporate_action = action
-            @round.last_to_act = action.entity.player
+            track_action(action, action.entity, false)
             @game.take_loan(action.entity, action.loan)
             try_buy_tokens(action.entity)
           end

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -171,8 +171,7 @@ module Engine
               corporation.par_via_exchange.close!
 
               @game.after_par(corporation)
-              @round.last_to_act = entity
-              @current_actions << action
+              track_action(action, corporation)
             else
               super
             end

--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -1289,6 +1289,7 @@ module Engine
           end
 
           float_corporation(regional) if regional.floated?
+          regional
         end
 
         def float_corporation(corporation)

--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -59,7 +59,7 @@ module Engine
             company.close!
 
             # Exchange is treated as a Buy, and no more actions allowed as Sell-Buy
-            @current_actions << action
+            track_action(action, bundle.corporation)
           end
 
           def buyable_items(entity)
@@ -77,10 +77,11 @@ module Engine
           end
 
           def process_special_buy(action)
-            @game.exchange_coal_railway(@game.company_by_id(action.item.description))
+            company = @game.company_by_id(action.item.description)
+            regional = @game.exchange_coal_railway(company)
 
             # Exchange is treated as a Buy, and no more actions allowed as Sell-Buy
-            @current_actions << action
+            track_action(action, regional)
           end
 
           private

--- a/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
@@ -49,8 +49,7 @@ module Engine
             @round.acting_player = action.entity
             @round.merge_initiator = corporation
 
-            @round.last_to_act = action.entity
-            @current_actions << action
+            track_action(action, corporation)
           end
 
           def process_failed_merge(action)

--- a/lib/engine/game/g_1856/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1856/step/buy_sell_par_shares.rb
@@ -48,8 +48,7 @@ module Engine
             share = corporation.shares.first
             buy_shares(entity, share.to_bundle)
             @game.after_par(corporation)
-            @round.last_to_act = entity
-            @current_actions << action
+            track_action(action, corporation)
           end
         end
       end

--- a/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
@@ -78,8 +78,7 @@ module Engine
               s.buyable = true
             end
 
-            @round.last_to_act = action.entity.owner
-            @current_actions << action
+            track_action(action, action.entity)
           end
         end
       end

--- a/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
@@ -81,8 +81,7 @@ module Engine
             corporation = action.bundle.corporation
             buy_shares(action.entity, action.bundle, swap: action.swap,
                                                      allow_president_change: @game.pres_change_ok?(corporation))
-            @round.last_to_act = action.entity
-            @current_actions << action
+            track_action(action, corporation)
           end
 
           def process_par(action)
@@ -97,8 +96,7 @@ module Engine
 
             form_public_mine(entity, corporation)
 
-            @round.last_to_act = entity
-            @current_actions << action
+            track_action(action, corporation)
           end
 
           def form_public_mine(entity, corporation)

--- a/lib/engine/game/g_1877/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1877/step/buy_sell_par_shares.rb
@@ -108,9 +108,9 @@ module Engine
             end
 
             @corporate_action = action
-            @round.last_to_act = action.entity.player
 
             entity ||= action.entity
+            track_action(action, entity, false)
             train = action.train
             price = action.price
 

--- a/lib/engine/game/g_1882/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1882/step/buy_sell_par_shares.rb
@@ -54,7 +54,7 @@ module Engine
               @game.place_home_token(corporation)
               corporation.par_via_exchange.close!
 
-              @current_actions << action
+              track_action(action, corporation)
             else
               super
             end

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares_following_sr.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares_following_sr.rb
@@ -40,8 +40,7 @@ module Engine
                                                         allow_president_change: allow_president_change)
             end
 
-            @round.last_to_act = action.entity
-            @current_actions << action
+            track_action(action, action.bundle.corporation)
           end
 
           private

--- a/lib/engine/game/g_18_eu/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_eu/step/buy_sell_par_shares.rb
@@ -22,13 +22,11 @@ module Engine
             entity = action.entity
             if entity.minor?
               exchange_minor(entity, action.bundle)
-              entity = entity.owner
             else
               buy_shares(entity, action.bundle)
             end
 
-            @round.last_to_act = entity
-            @current_actions << action
+            track_action(action, action.bundle.corporation)
           end
 
           def exchange_minor(minor, bundle)

--- a/lib/engine/step/base.rb
+++ b/lib/engine/step/base.rb
@@ -40,6 +40,10 @@ module Engine
         false
       end
 
+      def last_acted_upon?(_corporation, _entity)
+        false
+      end
+
       def log_pass(entity)
         @log << "#{entity.name} passes #{description.downcase}"
       end

--- a/lib/engine/step/exchange.rb
+++ b/lib/engine/step/exchange.rb
@@ -28,6 +28,7 @@ module Engine
         end
 
         buy_shares(company.owner, bundle, exchange: company)
+        @round.players_history[company.owner][bundle.corporation] << action if @round.respond_to?(:players_history)
         company.close!
       end
 


### PR DESCRIPTION
fixes #1399

This is mostly so I can implement the auto-pass functionality which needs to track if other players have sold.

There's a slight issue to tidy up in a subsequent PR in that it doesn't show what you did last turn, but I think that's best done separately.