### PR TITLE
[18CZ] remove unused yellow value from large offboards

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -162,7 +162,7 @@ module Engine
             'count' => 1,
             'color' => 'red',
             'code' =>
-            'city=revenue:yellow_20|green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
+            'city=revenue:green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
                   'icon=image:18_cz/50;label=Ug',
           },
           '8895' =>
@@ -170,7 +170,7 @@ module Engine
             'count' => 1,
             'color' => 'red',
             'code' =>
-            'city=revenue:yellow_20|green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
+            'city=revenue:green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
                   'icon=image:18_cz/50;label=kk',
           },
           '8896' =>
@@ -178,7 +178,7 @@ module Engine
             'count' => 1,
             'color' => 'red',
             'code' =>
-            'city=revenue:yellow_20|green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
+            'city=revenue:green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
                   'icon=image:18_cz/50;label=SX',
           },
           '8897' =>
@@ -186,7 +186,7 @@ module Engine
             'count' => 1,
             'color' => 'red',
             'code' =>
-            'city=revenue:yellow_20|green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
+            'city=revenue:green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
                   'icon=image:18_cz/50;label=PR',
           },
           '8898' =>
@@ -194,7 +194,7 @@ module Engine
             'count' => 1,
             'color' => 'red',
             'code' =>
-            'city=revenue:yellow_20|green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
+            'city=revenue:green_30|brown_40|gray_50;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1;' \
                   'icon=image:18_cz/50;label=BY',
           },
           '8866p' =>


### PR DESCRIPTION
[testcase - full game](https://gist.github.com/benjaminxscott/67d6827b148d7439576e2296d8d5d220)

The production game doesn't have a yellow value, since it's impossible to lay the tiles in yellow
![Screenshot 2021-02-28 at 7 48 36 PM](https://user-images.githubusercontent.com/1711810/109449718-fe981a80-79fd-11eb-99d9-913db13bd43e.png)

after this change:
![Screenshot 2021-02-28 at 7 47 25 PM](https://user-images.githubusercontent.com/1711810/109449649-d9a3a780-79fd-11eb-872c-c88e6af8ec15.png)
