### PR TITLE
[18CZ] use standard round notation for endgame trigger

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -2551,7 +2551,7 @@ module Engine
             'At the end of each set of ORs the next available train will be exported
            (removed, triggering phase change as if purchased)',
           ]
-          @timeline.append("Game ends after OR #{@last_or}")
+          @timeline.append("Game ends after OR #{OR_SETS.size}.#{OR_SETS.last}")
           @timeline.append("Current value of each private company is #{COMPANY_VALUES[[0, @or - 1].max]}")
           @timeline.append("Next set of Operating Rounds will have #{OR_SETS[@turn - 1]} ORs")
         end


### PR DESCRIPTION
Use "SR.OR" instead of "13 ORs"

Generic to variants

![Screenshot 2021-02-28 at 8 25 25 PM](https://user-images.githubusercontent.com/1711810/109452141-f0e59380-7a03-11eb-9038-3eb2bf4b5c79.png)
