### PR TITLE
[1822] Local trains can only use same token once

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2286,7 +2286,9 @@ module Engine
           merthyr_tydfil_pontypool = {}
 
           routes.each do |route|
-            local_token_hex << route.head[:left].hex.id if route.train.local? && !route.connections.empty?
+            if route.train.local? && !route.connections.empty?
+              local_token_hex.concat(route.visited_stops.select(&:city?).map { |n| n.hex.id })
+            end
 
             route.paths.each do |path|
               a = path.a
@@ -2317,7 +2319,7 @@ module Engine
           end
 
           local_token_hex.group_by(&:itself).each do |k, v|
-            raise GameError, "Local train can only use the token on #{k[0]} once" if v.size > 1
+            raise GameError, "Local train can only use the token on #{k} once" if v.size > 1
           end
 
           # Check Merthyr Tydfil and Pontypool, only one of the 2 tracks may be used


### PR DESCRIPTION
- If you select the towns and city in a specific order you could go around the check i had for the L-train to only use one city token once. Modified it a bit to stop all different cases.

This shouldnt break any games, since the check is when you select the route not under process_run_routes.
