### PR TITLE
[18CZ] Added Train Info for Corporation

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -2630,7 +2630,15 @@ module Engine
         end
 
         def status_str(corp)
-          corp.type.capitalize
+          train_type = case corp.type
+                       when :small
+                         'Normal '
+                       when :medium
+                         'Plus-'
+                       else
+                         'E-'
+                       end
+          "#{corp.type.capitalize} / #{train_type}Trains"
         end
 
         def block_lay_for_purple_tiles


### PR DESCRIPTION
Show the train-type on corpo card

![image](https://user-images.githubusercontent.com/7661170/109550415-8ac64280-7acf-11eb-9365-edadd4111a28.png)


closes #4051