### PR TITLE
[1822] Minors market value

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2726,6 +2726,12 @@ module Engine
           ipoed.sort + others
         end
 
+        def status_str(corporation)
+          return if corporation.type != :minor || !corporation.share_price
+
+          "Market value #{format_currency(corporation.share_price.price)}"
+        end
+
         def stock_round
           G1822::Round::Stock.new(self, [
             Engine::Step::DiscardTrain,


### PR DESCRIPTION
- Uses the status_str on the corporation to see the market value of the minors. As joey pointed out its a little hard to se under all the stacks of minor token in the stock market where one specific minors value is. This is actually true for the physical game as well, its always hard to se in in which stack of minors the one you looking for.

fixes #4217