### PR TITLE
[1822] Destination Tokens when Simple Logos is turned on

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -3401,6 +3401,7 @@ module Engine
             corporation = corporation_by_id(corp)
             corporation.add_ability(ability)
             corporation.tokens << Engine::Token.new(corporation, logo: "/logos/1822/#{corp}_DEST.svg",
+                                                                 simple_logo: "/logos/1822/#{corp}_DEST.svg",
                                                                  type: :destination)
             hex_by_id(destination).tile.icons << Part::Icon.new("../icons/1822/#{corp}_DEST", "#{corp}_destination")
           end


### PR DESCRIPTION
- When simple logos was turned on, you didnt see which tokens where the destination tokens.

fixes #4235