### PR TITLE
1873: production, dividends, buying trains

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -138,9 +138,7 @@ module View
         scrappable_trains = step.scrappable_trains(@corporation) if step.respond_to?(:scrappable_trains)
         unless scrappable_trains.empty?
           children << h(:h3, h3_props, 'Trains to Scrap')
-          children << h(:div, div_props, [
-            *scrap_trains(scrappable_trains),
-          ])
+          children << h(:div, div_props, scrap_trains(scrappable_trains))
         end
 
         discountable_trains = @game.discountable_trains_for(@corporation)

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -2,12 +2,14 @@
 
 require 'view/game/actionable'
 require 'view/game/emergency_money'
+require 'view/game/alternate_corporations'
 
 module View
   module Game
     class BuyTrains < Snabberb::Component
       include Actionable
       include EmergencyMoney
+      include AlternateCorporations
       needs :show_other_players, default: nil, store: true
       needs :corporation, default: nil
       needs :active_shell, default: nil, store: true
@@ -127,6 +129,20 @@ module View
           ])
         end
 
+        @slot_checkboxes = {}
+        if step.respond_to?(:slot_view) && (view = step.slot_view(@corporation))
+          children << send("render_#{view}")
+        end
+
+        scrappable_trains = []
+        scrappable_trains = step.scrappable_trains(@corporation) if step.respond_to?(:scrappable_trains)
+        unless scrappable_trains.empty?
+          children << h(:h3, h3_props, 'Trains to Scrap')
+          children << h(:div, div_props, [
+            *scrap_trains(scrappable_trains),
+          ])
+        end
+
         discountable_trains = @game.discountable_trains_for(@corporation)
 
         if discountable_trains.any? && step.discountable_trains_allowed?(@corporation)
@@ -198,6 +214,7 @@ module View
                 price: price,
                 variant: name,
                 shell: @active_shell,
+                slots: slots,
               ))
             end
 
@@ -211,7 +228,17 @@ module View
         end
       end
 
+      # return checkbox values for slots (if any)
+      def slots
+        return if @slot_checkboxes.empty?
+
+        @slot_checkboxes.keys.map do |k|
+          k if Native(@slot_checkboxes[k]).elm.checked
+        end.compact
+      end
+
       def other_trains(other_corp_trains)
+        step = @game.round.active_step
         hidden_trains = false
         trains_to_buy = other_corp_trains.flat_map do |other, trains|
           trains.group_by(&:name).flat_map do |name, group|
@@ -225,35 +252,64 @@ module View
               attrs: price_range(group[0]),
             )
 
+            extra_due_checkbox = nil
             buy_train_click = lambda do
               price = input.JS['elm'].JS['value'].to_i
+              extra_due = extra_due_checkbox && Native(extra_due_checkbox).elm.checked
               buy_train = lambda do
                 process_action(Engine::Action::BuyTrain.new(
                   @corporation,
                   train: group[0],
                   price: price,
                   shell: @active_shell,
+                  slots: get_slots,
+                  extra_due: extra_due,
                 ))
               end
 
-              if other.owner == @corporation.owner
+              if other_owner(other) == @corporation.owner
                 buy_train.call
               else
-                check_consent(other.owner, buy_train)
+                check_consent(other_owner(other), buy_train)
               end
             end
 
             count = group.size
 
-            if @show_other_players || other.owner == @corporation.owner
-              [h(:div, name),
-               h('div.nowrap', "#{other.name} (#{count > 1 ? "#{count}, " : ''}#{other.owner.name})"),
-               input,
-               h('button.no_margin', { on: { click: buy_train_click } }, 'Buy')]
-            else
-              hidden_trains = true
-              nil
+            real_name = other_owner(other) != other.owner ? " [#{other_owner(other).name}]" : ''
+
+            line = if @show_other_players || other_owner(other) == @corporation.owner
+                     [h(:div, name),
+                      h('div.nowrap',
+                        "#{other.name} (#{count > 1 ? "#{count}, " : ''}#{other.owner.name}#{real_name})"),
+                      input,
+                      h('button.no_margin', { on: { click: buy_train_click } }, 'Buy')]
+                   else
+                     hidden_trains = true
+                     nil
+                   end
+
+            if line && step.respond_to?(:extra_due) && step.extra_due(group[0])
+              extra_due_checkbox = h(
+                'input.no_margin',
+                style: {
+                  width: '1rem',
+                  height: '1rem',
+                  padding: '0 0 0 0.2rem',
+                },
+                attrs: {
+                  type: 'checkbox',
+                  id: 'extra_due',
+                  name: 'extra_due',
+                }
+              )
+
+              line << h(:div, '')
+              line << h(:div, step.extra_due_text(group[0]))
+              line << h(:div, step.extra_due_prompt)
+              line << h(:div, [extra_due_checkbox])
             end
+            line
           end
         end.compact
 
@@ -275,6 +331,29 @@ module View
                              'Hide trains from other players')
         end
         trains_to_buy
+      end
+
+      # need to abstract due to corporations owning minors owning trains
+      def other_owner(other)
+        step = @game.round.active_step
+        step.respond_to?(:real_owner) ? step.real_owner(other) : other.owner
+      end
+
+      def scrap_trains(scrappable_trains)
+        step = @game.round.active_step
+        scrappable_trains.flat_map do |train|
+          scrap = lambda do
+            process_action(Engine::Action::ScrapTrain.new(
+              @corporation,
+              train: train,
+            ))
+          end
+
+          [h(:div, train.name),
+           h('div.nowrap', train.owner.name),
+           h('div.right', step.scrap_info(train)),
+           h('button.no_margin', { on: { click: scrap } }, step.scrap_button_text(train))]
+        end
       end
 
       def price_range(train)

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -35,7 +35,7 @@ module View
           left << h(RouteSelector) if @current_actions.include?('run_routes')
           left << h(Dividend) if @current_actions.include?('dividend')
           left << h(Convert) if @current_actions.include?('convert')
-          if @current_actions.include?('buy_train')
+          if @current_actions.include?('buy_train') || @current_actions.include?('scrap_train')
             left << h(IssueShares) if @current_actions.include?('sell_shares')
             left << h(BuyTrains)
           elsif @current_actions.include?('sell_shares') && entity.player?

--- a/lib/engine/action/buy_train.rb
+++ b/lib/engine/action/buy_train.rb
@@ -6,15 +6,17 @@ require_relative 'base'
 module Engine
   module Action
     class BuyTrain < Base
-      attr_reader :train, :price, :exchange, :variant, :shell
+      attr_reader :train, :price, :exchange, :variant, :shell, :slots, :extra_due
 
-      def initialize(entity, train:, price:, variant: nil, exchange: nil, shell: nil)
+      def initialize(entity, train:, price:, variant: nil, exchange: nil, shell: nil, slots: nil, extra_due: nil)
         super(entity)
         @train = train
         @price = price
         @variant = variant
         @exchange = exchange
         @shell = shell
+        @slots = slots
+        @extra_due = extra_due
       end
 
       def self.h_to_args(h, game)
@@ -24,6 +26,8 @@ module Engine
           variant: h['variant'],
           exchange: game.train_by_id(h['exchange']),
           shell: shell_by_name(h['shell'], game),
+          slots: h['slots']&.map { |m| m.to_i },
+          extra_due: h['extra_due'],
         }
       end
 
@@ -34,6 +38,8 @@ module Engine
           'variant' => @variant,
           'exchange' => @exchange&.id,
           'shell' => @shell&.name,
+          'slots' => @slots,
+          'extra_due' => @extra_due ? true : nil,
         }
       end
 

--- a/lib/engine/action/scrap_train.rb
+++ b/lib/engine/action/scrap_train.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+# this is identical to the DiscardTrain action, but this can occur in a buy_trains step
+module Engine
+  module Action
+    class ScrapTrain < Base
+      attr_reader :train
+
+      def initialize(entity, train:)
+        super(entity)
+        @train = train
+      end
+
+      def self.h_to_args(h, game)
+        {
+          train: game.train_by_id(h['train']),
+        }
+      end
+
+      def args_to_h
+        { 'train' => @train.id }
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -871,30 +871,6 @@ module Engine
           @corporation_info[entity][:mines]
         end
 
-        # find the best mine slot for a machine out of the legal candidates (ones that have a smaller machine)
-        def find_machine_slot(entity, new_size)
-          mines = public_mine_mines(entity)
-          candidates = mines.each_index.map { |i| i }.select { |i| machine_size(mines[i]) < new_size }
-          candidates.max do |c|
-            mines.each_index.map { |i| i }.sum do |i|
-              calculate_mine_revenue(mines[i], (c == i ? new_size : machine_size(mines[i])), nil)
-            end
-          end
-        end
-
-        # find the best mine slot for a switcher, first based on switcher sizes, then maximizing
-        # revenue
-        def find_switcher_slot(entity, new_size)
-          mines = public_mine_mines(entity)
-          min_size = mines.map { |m| switcher_size(m) || 0 }.min
-          candidates = mines.each_index.map { |i| i }.select { |i| (switcher_size(mines[i]) || 0) == min_size }
-          candidates.max do |c|
-            mines.each_index.map { |i| i }.sum do |i|
-              calculate_mine_revenue(mines[i], 1, (c == i ? new_size : switcher_size(mines[i])))
-            end
-          end
-        end
-
         def add_train_to_slot(entity, slot, train)
           mine = public_mine_mines(entity)[slot]
           if train_is_machine?(train) && (old_machine = machine(mine))

--- a/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
@@ -18,6 +18,12 @@ module Engine
             []
           end
 
+          def can_ipo_any?(entity)
+            !bought? && @game.corporations.any? do |c|
+              @game.can_par?(c, entity) && (@game.public_mine?(c) || can_buy?(entity, c.shares.first&.to_bundle))
+            end
+          end
+
           # FIXME: need to deal with receivership first and second buy
           def can_buy_multiple?(_entity, corporation)
             return false unless @game.railway?(corporation)

--- a/lib/engine/game/g_1873/step/buy_train.rb
+++ b/lib/engine/game/g_1873/step/buy_train.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def actions(entity)
+            return [] if entity.company? || entity == @game.mhe
+            return [] if entity != current_entity
+
+            actions = []
+            actions << 'buy_train' if can_really_buy_train?(entity)
+            actions << 'scrap_train' if can_scrap_train?(entity)
+            actions << 'pass' unless actions.empty?
+            actions
+          end
+
+          def pass_description
+            if @acted
+              'Done (Trains)'
+            elsif @game.concession_pending?(current_entity)
+              'Skip (Trains) Warning: Compulsory Train Required'
+            else
+              'Skip (Trains)'
+            end
+          end
+
+          def skip!
+            if @game.concession_pending?(current_entity)
+              @log << "#{current_entity.name} has not purchased its compulsory train"
+              @game.insolvent!(current_entity)
+            elsif current_entity == @game.mhe
+              @game.mhe_buy_train
+            else
+              return super
+            end
+
+            pass!
+          end
+
+          def pass!
+            if @game.concession_pending?(current_entity)
+              @log << "#{current_entity.name} has not purchased its compulsory train"
+              @game.insolvent!(current_entity)
+            end
+
+            super
+          end
+
+          # annoyingly needed because super process_buy_train checks this to see to automatically pass!
+          def can_buy_train?(entity = nil, _shell = nil)
+            can_really_buy_train?(entity) || can_scrap_train?(entity)
+          end
+
+          def can_really_buy_train?(entity = nil)
+            entity ||= current_entity
+
+            # indie mines can't buy 1Ms
+            return false if entity.minor? && !@game.phase.available?('2')
+
+            if @game.switcher_price
+              # force creation of a switcher
+              @game.next_switcher
+            end
+
+            # FIXME: need to correct for entity-specific variants?
+            !buyable_trains(entity).empty?
+          end
+
+          def minor_distance(entity)
+            entity.trains.find { |t| @game.train_is_machine?(t) }&.distance || 1
+          end
+
+          def public_mine_min_distance(entity)
+            @game.public_mine_mines(entity).map { |m| minor_distance(m) }.min
+          end
+
+          def buyable_depot_trains(entity)
+            @depot.depot_trains.reject do |t|
+              t.variants.values.all? { |v| v[:price] > entity.cash }
+            end
+          end
+
+          def buyable_trains(entity)
+            depot_trains = buyable_depot_trains(entity)
+            other_trains = @depot.other_trains(entity)
+            other_trains = [] if entity.cash.zero?
+            other_trains.reject! do |ot|
+              @game.train_is_machine?(ot) || @game.any_mine?(entity) && @game.train_is_train?(ot) ||
+                ot.owner.owner && @game.public_mine?(ot.owner.owner) && ot.owner.owner == entity
+            end
+
+            # indie mines can't buy same size machine
+            depot_trains.reject! { |t| t.distance <= minor_distance(entity) } if entity.minor?
+
+            # public mines have to have at least one mine with a smaller machine
+            depot_trains.reject! { |t| t.distance <= public_mine_min_distance(entity) } if @game.public_mine?(entity)
+
+            switchers = if (sp = @game.switcher_price)
+                          entity.cash >= sp ? [@game.next_switcher] : []
+                        else
+                          []
+                        end
+
+            (depot_trains + switchers + other_trains).compact
+          end
+
+          def buyable_train_variants(train, entity)
+            return [] unless buyable_trains(entity).any? { |bt| bt.variants[bt.name] }
+
+            variants = train.variants.values
+            variants.reject! do |v|
+              (v[:name].include?('M') && (@game.railway?(entity) || !train.from_depot?)) ||
+                (v[:name].include?('T') && @game.any_mine?(entity))
+            end
+            return variants unless train.from_depot?
+
+            variants.reject! { |v| entity.cash < v[:price] }
+            variants
+          end
+
+          def can_scrap_train?(entity)
+            if entity.minor?
+              @game.switcher(entity)
+            elsif @game.public_mine?(entity)
+              @game.public_mine_mines(entity).any? { |m| @game.switcher(m) }
+            else
+              # RRs can voluntarily scrap switchers
+              # and any trains if they have at least two (the NWE can't scrap a train
+              # if the only one left would be a 1T)
+              return true if entity.trains.any? { |t| @game.train_is_switcher?(t) }
+
+              trains = entity.trains.select { |t| @game.train_is_train?(t) }
+              trains.size > 1
+            end
+          end
+
+          def scrappable_trains(entity)
+            if entity.minor?
+              # indie mines can only voluntarily scrap switchers
+              [@game.switcher(entity)].compact
+            elsif @game.public_mine?(entity)
+              # public mines can only voluntarily scrap switchers
+              @game.public_mine_mines(entity).map { |m| @game.switcher(m) }.compact
+            else
+              # RRs can voluntarily scrap switchers
+              # and any trains if they have at least two (the NWE can't scrap a train
+              # if the only one left would be a 1T)
+              switchers = entity.trains.select { |t| @game.train_is_switcher?(t) }
+              trains = entity.trains.select { |t| @game.train_is_train?(t) }
+              trains = [] if trains.one?
+              if entity == @game.nwe && trains.size == 2 && trains.any? { |t| t.name == '1T' }
+                trains.select! { |t| t.name == '1T' }
+              end
+              (trains + switchers).compact
+            end
+          end
+
+          def process_buy_train(action)
+            entity = action.entity
+            train = action.train
+            slots = action.slots
+            if @game.concession_pending?(entity)
+              if entity == @game.nwe && action.train.distance == 1
+                raise GameError, 'NWE must puchase at least a 2T for its compulsory train'
+              end
+
+              @game.concession_unpend!(entity)
+            end
+
+            scrap_mine_train(entity, action.train) if entity.minor?
+
+            old_owner = train.owner
+
+            super
+
+            maint_due = @game.train_maintenance(train.name)
+            if maint_due.positive? && action.extra_due
+              # seller must pay maintenance
+              raise GameError, 'Seller has insufficient funds to pay maintenance' if old_owner.cash < maint_due
+
+              old_owner.spend(maint_due, @game.bank)
+              @log << "#{old_owner.name} pays #{@game.format_currency(maint_due)} for maintenance"
+            elsif maint_due.positive?
+              # buyer must pay maintenance
+              raise GameError, 'Buyer has insufficient funds to pay maintenance' if entity.cash < maint_due
+
+              entity.spend(maint_due, @game.bank)
+              @log << "#{entity.name} pays #{@game.format_currency(maint_due)} for maintenance"
+            end
+
+            allocate_machines!(entity, train, slots) if @game.train_is_machine?(train) && @game.public_mine?(entity)
+            allocate_switcher!(entity, train, slots) if @game.train_is_switcher?(train) && @game.public_mine?(entity)
+          end
+
+          def process_scrap_train(action)
+            entity = action.entity
+            train = action.train
+
+            raise GameError, 'Cannot scrap a Machine voluntarily' if @game.train_is_machine?(train)
+
+            if @game.train_is_train?(train) && @game.railway?(entity) && entity.trains.one?
+              raise GameError, 'Cannot scrap last train'
+            end
+
+            @game.scrap_train(train)
+          end
+
+          def scrap_mine_train(entity, new_train)
+            if @game.train_is_machine?(new_train)
+              @game.scrap_train(entity.trains.find { |t| @game.train_is_machine?(t) })
+            elsif @game.train_is_switcher?(new_train)
+              @game.scrap_train(entity.trains.find { |t| @game.train_is_switcher?(t) })
+            end
+          end
+
+          def scrap_info(train)
+            "Maintenance: #{@game.format_currency(@game.train_maintenance(train.name))}"
+          end
+
+          def scrap_button_text(_train)
+            'Scrap'
+          end
+
+          def spend_minmax(entity, train)
+            [1, [train.price * 2, entity.cash].min]
+          end
+
+          def real_owner(entity)
+            @game.public_mine?(entity.owner) ? entity.owner.owner : entity.owner
+          end
+
+          # we just added a machine to a public mine, we have to replicate and move it
+          # to a set of its subsidiary mines
+          # Up to N of size N machines will be distributed
+          def allocate_machines!(entity, bought_train, slots)
+            entity.trains.delete(bought_train)
+            submines = @game.public_mine_mines(entity)
+            slots_needed = submines.count { |m| minor_distance(m) < bought_train.distance }
+            num_to_fill = [slots_needed, bought_train.distance].min
+
+            if !slots || num_to_fill != slots.size
+              raise GameError, "Need to select #{num_to_fill} target mines for machines"
+            end
+
+            trains = @game.replicate_machines(bought_train, num_to_fill)
+            slots.each do |slot|
+              if minor_distance(submines[slot]) >= bought_train.distance
+                raise GameError, 'Must select a mine with machine size less than new machine size'
+              end
+
+              @game.add_train_to_slot(entity, slot, trains.shift)
+            end
+          end
+
+          # we just added a switcher to a public mine, we have to move it to one of its
+          # subsidiary mines
+          def allocate_switcher!(entity, bought_train, slots)
+            entity.trains.delete(bought_train)
+
+            raise GameError, 'Need to select exactly one target mine for switcher' if !slots || !slots.one?
+
+            @game.add_train_to_slot(entity, slots.first, bought_train)
+          end
+
+          def slot_view(entity)
+            return unless @game.public_mine?(entity)
+
+            'submines'
+          end
+
+          def extra_due(train)
+            @game.train_maintenance(train.name).positive?
+          end
+
+          def extra_due_text(train)
+            "Maint Due: #{@game.format_currency(@game.train_maintenance(train.name))}"
+          end
+
+          def extra_due_prompt
+            'Seller Pays:'
+          end
+
+          def checkbox_prompt
+            'Select mines to receive purchased machines or switcher using checkboxes:'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/step/buy_train.rb
+++ b/lib/engine/game/g_1873/step/buy_train.rb
@@ -89,8 +89,8 @@ module Engine
             other_trains = @depot.other_trains(entity)
             other_trains = [] if entity.cash.zero?
             other_trains.reject! do |ot|
-              @game.train_is_machine?(ot) || @game.any_mine?(entity) && @game.train_is_train?(ot) ||
-                ot.owner.owner && @game.public_mine?(ot.owner.owner) && ot.owner.owner == entity
+              @game.train_is_machine?(ot) || (@game.any_mine?(entity) && @game.train_is_train?(ot)) ||
+                (ot.owner.owner && @game.public_mine?(ot.owner.owner) && ot.owner.owner == entity)
             end
 
             # indie mines can't buy same size machine
@@ -129,12 +129,10 @@ module Engine
               @game.public_mine_mines(entity).any? { |m| @game.switcher(m) }
             else
               # RRs can voluntarily scrap switchers
-              # and any trains if they have at least two (the NWE can't scrap a train
-              # if the only one left would be a 1T)
+              # and any trains if they have at least two
               return true if entity.trains.any? { |t| @game.train_is_switcher?(t) }
 
-              trains = entity.trains.select { |t| @game.train_is_train?(t) }
-              trains.size > 1
+              entity.trains.count { |t| @game.train_is_train?(t) } > 1
             end
           end
 

--- a/lib/engine/game/g_1873/step/concession_auction.rb
+++ b/lib/engine/game/g_1873/step/concession_auction.rb
@@ -25,6 +25,10 @@ module Engine
             auctioning ? [auctioning] : @companies
           end
 
+          def finished?
+            @companies.empty? || entities.all?(&:passed?)
+          end
+
           def process_pass(action)
             entity = action.entity
 
@@ -56,7 +60,7 @@ module Engine
           end
 
           def actions(entity)
-            return [] if @companies.empty?
+            return [] if finished?
 
             correct = false
 

--- a/lib/engine/game/g_1873/step/dividend.rb
+++ b/lib/engine/game/g_1873/step/dividend.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+require_relative '../../../step/half_pay'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class Dividend < Engine::Step::Dividend
+          DIVIDEND_TYPES = %i[payout half withhold].freeze
+          include Engine::Step::HalfPay
+
+          def actions(entity)
+            return [] if entity.minor? || entity == @game.mhe
+            return [] if entity.company?
+            return [] unless total_revenue(entity).positive?
+
+            ACTIONS
+          end
+
+          def skip!
+            revenue = total_revenue(current_entity)
+            process_dividend(Action::Dividend.new(
+              current_entity,
+              kind: revenue.positive? ? 'payout' : 'withhold',
+            ))
+
+            current_entity.operating_history[[@game.turn, @round.round_num]] =
+              OperatingInfo.new([], @game.actions.last, revenue)
+          end
+
+          def total_revenue(entity)
+            return @game.mhe_income if entity == @game.mhe
+            return 0 - @round.maintenance if routes.empty? && @game.railway?(entity)
+
+            @game.routes_revenue(routes) - @round.maintenance
+          end
+
+          def dividend_options(entity)
+            revenue = total_revenue(entity)
+            dividend_types.map do |type|
+              payout = send(type, entity, revenue)
+              payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
+              [type, payout.merge(share_price_change(entity, revenue - payout[:corporation]))]
+            end.to_h
+          end
+
+          def process_dividend(action)
+            entity = action.entity
+            kind = action.kind.to_sym
+
+            revenue = total_revenue(entity)
+
+            if (revenue + entity.cash).negative?
+              @log << "#{entity.name} loses #{@game.format_currency(-revenue)} and cannot pay out of treasury"
+              if entity.minor?
+                # zero out cash so owner doesn't get anything
+                entity.spend(entity.cash, @game.bank) if entity.cash.positive?
+                @game.close_mine!(entity)
+              else
+                @game.insolvent!(entity)
+              end
+              return
+            end
+
+            # assumption: withholding only
+            if revenue.negative?
+              @log << "#{entity.name} pays #{@game.format_currency(-revenue)} from treasury"
+              entity.spend(-revenue, @game.bank)
+            end
+
+            payout = dividend_options(entity)[kind]
+
+            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
+              routes,
+              action,
+              revenue
+            )
+
+            entity.trains.each { |train| train.operated = true }
+            @round.routes = []
+
+            log_run_payout(entity, kind, revenue, action, payout)
+
+            @game.bank.spend(payout[:corporation], entity) if payout[:corporation].positive?
+
+            payout_shares(entity, revenue - payout[:corporation]) if payout[:per_share].positive?
+
+            change_share_price(entity, payout)
+
+            pass!
+          end
+
+          # shares in IPO and pool never pay
+          def corporation_dividends(_entity, _per_share)
+            0
+          end
+
+          def share_price_change(entity, revenue = 0)
+            return {} if entity.minor?
+            return {} if entity == @game.mhe && @game.mhe.trains.any? { |t| t.name == '5T' }
+
+            price = entity.share_price.price
+            return { share_direction: :left, share_times: 1 } unless revenue.positive?
+
+            times = [(revenue / price).to_i, 3].min
+            if times.positive?
+              { share_direction: :right, share_times: times }
+            else
+              {}
+            end
+          end
+
+          def payout(entity, revenue)
+            return super if entity.corporation?
+
+            amount = revenue / 2
+            { corporation: amount, per_share: amount }
+          end
+
+          def payout_shares(entity, revenue)
+            return super if entity.corporation?
+
+            @log << "#{entity.owner.name} receives #{@game.format_currency(revenue)}"
+            @game.bank.spend(revenue, entity.owner)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/step/route.rb
+++ b/lib/engine/game/g_1873/step/route.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/route'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class Route < Engine::Step::Route
+          def actions(entity)
+            return [] if entity.minor? || @game.public_mine?(entity) || entity == @game.mhe
+            return [] if entity.company?
+
+            super
+          end
+
+          def skip!
+            return super if !@game.any_mine?(current_entity) && current_entity != @game.mhe
+
+            if @game.any_mine?(current_entity)
+              @game.update_mine_revenue(@round, current_entity) if @round.routes.empty?
+            end
+
+            pass!
+          end
+
+          def process_run_routes(action)
+            super
+
+            entity = action.entity
+            maintenance = @game.maintenance_costs(entity)
+            @round.maintenance = maintenance
+            @log << "#{entity.name} owes #{@game.format_currency(maintenance)} for maintenance" if maintenance.positive?
+          end
+
+          def round_state
+            {
+              routes: [],
+              maintenance: 0,
+            }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Common file changes:
* UI::BuyTrain - changes to support scrapping trains, buying trains for subsidiary mines, and paying maintenance upon purchase
* UI::Operating - small change to support scrapping trains via new action
* Action:: BuyTrain - new parameters for "slots" and "extra_due" (first for subsidiary mines, second for when seller pays maintenance costs)
* Action::ScrapTrain - new action to support scrapping trains during the buy_trains step

Changes to 1873 code:
* Various bug fixes
* Calculation of mine revenue (indie and public)
* Calculation of maintenance costs for all
* Dividend step to take maintenance costs and mine revenue into account
* Implement MHE operation
* Major change to buy_train to implement all the various and sundry 1873 train purchase rules, including:
* Creating switchers on the fly
* Creating multiple machines distributing them to subsidiary mines
* Scrapping trains, including auto-scrapping of machines and switchers

![1873_new_buy_trains](https://user-images.githubusercontent.com/8494213/109572583-bf73d300-7aaa-11eb-9d6c-7e1b92ba28e4.png)
