### PR TITLE
Fixes #4189

### DIFF
--- a/lib/engine/game/g_1817_wo/game.rb
+++ b/lib/engine/game/g_1817_wo/game.rb
@@ -622,8 +622,16 @@ module Engine
           hexes.any? { |h| h.tile.cities.any? { |c| c.tokens.count(&:nil?).positive? } }
         end
 
+        def can_place_second_token(corporation)
+          return false if !tokenable_location_exists? || !corp_has_new_zealand?(corporation)
+
+          # Does the corp have a second token already?
+          corporation.tokens[1] && !corporation.tokens[1].city
+        end
+
+        # This must be idempotent.
         def place_second_token(corporation)
-          return unless tokenable_location_exists?
+          return unless can_place_second_token(corporation)
 
           hex = hex_by_id(corporation.coordinates)
 
@@ -717,7 +725,7 @@ module Engine
 
           G1817::Round::Stock.new(self, [
             Engine::Step::DiscardTrain,
-            Engine::Step::HomeToken,
+            G1817WO::Step::HomeToken,
             G1817WO::Step::BuySellParShares,
           ])
         end

--- a/lib/engine/game/g_1817_wo/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1817_wo/step/buy_sell_par_shares.rb
@@ -29,7 +29,7 @@ module Engine
 
           def add_tokens(entity, tokens)
             super
-            @game.place_second_token(entity) if @game.corp_has_new_zealand?(entity)
+            @game.place_second_token(entity)
           end
         end
       end

--- a/lib/engine/game/g_1817_wo/step/home_token.rb
+++ b/lib/engine/game/g_1817_wo/step/home_token.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/home_token'
+
+module Engine
+  module Game
+    module G1817WO
+      module Step
+        class HomeToken < Engine::Step::HomeToken
+          def process_place_token(action)
+            # super.process_place_token modifies token; grab corporation out of it first
+            corporation = token.corporation
+            super
+            @game.place_second_token(corporation)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The problem was that in the case when there is no choice for the size of the IPOed corporation nor any contest for the bid the home token (NZ) gets laid AFTER attempting to purchase tokens. The fix here is to add a hook to the HomeToken step in the stock round so that the second token can be laid then
Fixes #4189