### PR TITLE
1828: Fix tile rendering for Altoona and Virginia Coalfields.

### DIFF
--- a/assets/app/view/game/part/location_name.rb
+++ b/assets/app/view/game/part/location_name.rb
@@ -27,7 +27,7 @@ module View
                    when 4
                      [l_top, l_bottom]
                    else
-                     [l_center, l_up40, l_down40]
+                     [l_center, l_up40, l_down40, l_down24]
                    end
           end
 
@@ -209,23 +209,18 @@ module View
           loc = { x: 0, y: y }
 
           if layout == :flat
-            loc[:region_weights_in] = {
-              TRACK_TO_EDGE_3 => 1,
-              UPPER_CENTER => 1,
-              [6, 10] => 0.25,
-              TOP_ROW => 0.1,
+            loc[:region_weights] = {
+              [0, 2, 4, 6, 8, 10] => 0.7,
+              [1, 3, 7, 9] => 0.2,
             }
-            loc[:region_weights_out] = { UPPER_CENTER => 1, [6, 10] => 0.25 }
           else
             # slight extra nudge to clear the revenue circle
             loc[:y] -= 2
 
-            loc[:region_weights_in] = {
-              [2, 6, 7, 8] => 1,
-              [3, 5] => 0.5,
-              [0, 1] => 0.1,
+            loc[:region_weights] = {
+              [2, 3, 5, 6] => 1,
+              [0, 1, 7, 8] => 0.2,
             }
-            loc[:region_weights_out] = { [2, 6, 7, 8] => 1, [3, 5] => 0.25 }
           end
           loc
         end
@@ -249,7 +244,18 @@ module View
 
         def l_down24
           loc = { x: 0, y: 24 }
-          loc[:region_weights] = layout == :flat ? BOTTOM_MIDDLE_ROW : [11, 15, 16, 17, 19, 21]
+
+          if layout == :flat
+            loc[:region_weights] = {
+              [13, 15, 17] => 1,
+              [12, 14, 16, 18] => 0.4,
+            }
+          elsif layout == :pointy
+            loc[:region_weights] = {
+              [11, 15, 16, 19] => 0.8,
+              [9, 10, 13, 14] => 0.2,
+            }
+          end
           loc
         end
 
@@ -257,23 +263,15 @@ module View
           loc = { x: 0, y: 40 }
 
           if layout == :flat
-            loc[:region_weights_in] = {
-              TRACK_TO_EDGE_0 => 1,
-              LOWER_CENTER => 1,
-              [13, 17] => 0.25,
-              BOTTOM_ROW => 0.1,
-            }
-            loc[:region_weights_out] = {
-              LOWER_CENTER => 1,
-              [13, 14, 16, 17] => 0.25,
+            loc[:region_weights] = {
+              [13, 15, 17, 19, 21, 23] => 0.7,
+              [14, 16, 20, 22] => 0.2,
             }
           elsif layout == :pointy
-            loc[:region_weights_in] = {
-              [15, 16, 21, 17] => 1,
-              [18, 20] => 0.5,
-              [22, 23] => 0.1,
+            loc[:region_weights] = {
+              [17, 18, 20, 21] => 1,
+              [15, 16, 22, 23] => 0.2,
             }
-            loc[:region_weights_out] = { [15, 16, 21, 17] => 1, [11, 18, 19, 20] => 0.25 }
           end
           loc
         end

--- a/assets/app/view/game/part/revenue.rb
+++ b/assets/app/view/game/part/revenue.rb
@@ -10,38 +10,51 @@ module View
       class Revenue < Base
         include SmallItem
 
+        FLAT_MULTI_REVENUE_LOCATIONS =
+          [
+            {
+              region_weights: { CENTER => 1.5 },
+              x: 0,
+              y: 0,
+            },
+            {
+              region_weights: { TOP_MIDDLE_ROW => 1.5 },
+              x: 0,
+              y: -48,
+            },
+            {
+              region_weights: { BOTTOM_MIDDLE_ROW => 1.5 },
+              x: 0,
+              y: 45,
+            },
+          ].freeze
+
+        POINTY_MULTI_REVENUE_LOCATIONS =
+          [
+            {
+              region_weights: { CENTER => 1.5 },
+              x: 0,
+              y: 0,
+            },
+            {
+              region_weights: { [2, 6, 7, 8] => 1.5, [3, 5] => 0.5 },
+              x: 0,
+              y: -55,
+            },
+            {
+              region_weights: { [15, 16, 21, 17] => 1.5, [18, 20] => 0.5 },
+              x: 0,
+              y: 55,
+            },
+          ].freeze
+
         def preferred_render_locations
           if multi_revenue?
-
-            top_weights = if layout == :flat
-                            { TOP_MIDDLE_ROW => 1.5 }
-                          else
-                            { [2, 6, 7, 8] => 1.5, [3, 5] => 0.5 }
-                          end
-
-            bottom_weights = if layout == :flat
-                               { BOTTOM_MIDDLE_ROW => 1.5 }
-                             else
-                               { [15, 16, 21, 17] => 1.5, [18, 20] => 0.5 }
-                             end
-
-            [
-              {
-                region_weights: { CENTER => 1.5 },
-                x: 0,
-                y: 0,
-              },
-              {
-                region_weights: top_weights,
-                x: 0,
-                y: -48,
-              },
-              {
-                region_weights: bottom_weights,
-                x: 0,
-                y: 45,
-              },
-            ]
+            if layout == :flat
+              FLAT_MULTI_REVENUE_LOCATIONS
+            else
+              POINTY_MULTI_REVENUE_LOCATIONS
+            end
           elsif layout == :flat
             SMALL_ITEM_LOCATIONS
           else

--- a/assets/app/view/game/part/small_item.rb
+++ b/assets/app/view/game/part/small_item.rb
@@ -108,6 +108,12 @@ module View
           y: 65,
         }.freeze
 
+        PP_WIDE_BOTTOM_LEFT_CORNER = {
+          region_weights: [13, 14, 15, 19],
+          x: -52,
+          y: 25,
+        }.freeze
+
         SMALL_ITEM_LOCATIONS = [P_RIGHT_CORNER,
                                 P_LEFT_CORNER,
                                 P_BOTTOM_RIGHT_CORNER,
@@ -127,7 +133,8 @@ module View
                                PP_WIDE_BOTTOM_CORNER].freeze
 
         POINTY_WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
-                                      PP_WIDE_BOTTOM_CORNER].freeze
+                                      PP_WIDE_BOTTOM_CORNER,
+                                      PP_WIDE_BOTTOM_LEFT_CORNER].freeze
       end
     end
   end


### PR DESCRIPTION
- Add bottom-left corner as another location for wide small items on pointy maps
- Nudge multi-revenue up on top and down on bottom a bit on pointy maps
- Add down 24 as a location name option and fix weighting to be better representative of where the text actually goes

I compared my local version vs 18xx.games base maps for 1817, 1822, 1830, 1846, 1860, 1861, 1867, 1889, 18AL, 18Chesapeake, 18CZ, 18CO, and 18MEX and all looked the same to me (18MEX actually a bit better).