### PR TITLE
[1822] Timing was wrong on M&GNR

### DIFF
--- a/assets/app/view/game/round/choices.rb
+++ b/assets/app/view/game/round/choices.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module View
+  module Game
+    module Round
+      class Choices < Snabberb::Component
+        needs :game
+
+        def render
+          round = @game.round
+          @step = round.active_step
+          entity = @step.current_entity
+          @current_actions = round.actions_for(entity)
+
+          children = []
+          children << h(Choose) if @current_actions.include?('choose')
+
+          div_props = {
+            style: {
+              display: 'flex',
+              maxWidth: '100%',
+              width: 'max-content',
+            },
+          }
+
+          h(:div, div_props, children)
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -394,6 +394,8 @@ module View
         end
       when Engine::Round::Draft
         h(Game::Round::Auction, game: @game, user: @user, before_process_pass: @before_process_pass)
+      when Engine::Round::Choices
+        h(Game::Round::Choices, game: @game)
       when Engine::Round::Auction
         h(Game::Round::Auction, game: @game, user: @user)
       when Engine::Round::Merger

--- a/lib/engine/game/g_1822/round/choices.rb
+++ b/lib/engine/game/g_1822/round/choices.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/choices'
+
+module Engine
+  module Game
+    module G1822
+      module Round
+        class Choices < Engine::Round::Choices
+          def name
+            'Choose'
+          end
+
+          def select_entities
+            @game.choices_entities
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822/step/choose.rb
+++ b/lib/engine/game/g_1822/step/choose.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1822
+      module Step
+        class Choose < Engine::Step::Base
+          ACTIONS = %w[choose pass].freeze
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] unless find_company(entity)
+
+            ACTIONS
+          end
+
+          def choice_name
+            return "Choose for #{@company.name}" if @company
+
+            'Choose'
+          end
+
+          def choices
+            return @game.company_choices(@company, :choose) if @company
+
+            {}
+          end
+
+          def description
+            'Choose'
+          end
+
+          def process_choose(action)
+            @game.company_made_choice(@company, action.choice, :choose)
+            @company = nil
+            pass!
+          end
+
+          def skip!
+            pass!
+          end
+
+          def find_company(entity)
+            @company = @game.company_by_id(@game.class::COMPANY_MGNR)
+            return nil if !@company || @company&.owner != entity
+
+            @company
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/round/choices.rb
+++ b/lib/engine/round/choices.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Round
+    class Choices < Base
+      def name
+        'Choices'
+      end
+
+      def self.short_name
+        'Choices'
+      end
+    end
+  end
+end


### PR DESCRIPTION
- I first did the private M&GNR as an ability you can choose during the stockround. This is a choice you should have between stock round and operation round, but before player order is determined. You must be able to use this power if you won the bid for it during the current stock round.

**Changes to base code**
- View::Game::Round::Choices. Made a very simple round view which only shows the Choose component.
- View::GamePage. Added the round view above to the case where its selected what view to show.
- Engine::Round::Choices. Added a base round for the choices view.

**1822 Specific**
- Added a Choices round and a Choose step to have the player choose if he want to double his cash before the turn order is determined.

fixes #4241
fixes #4242

This will break all games where the M&GNR company have been acquired from a bid box. But the solution above is the correct timing of that power and better to fix it now :)