### PR TITLE
game info cleanup

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -130,7 +130,7 @@ module View
       def train_limit_to_h(train_limit)
         return train_limit unless train_limit.is_a?(Hash)
 
-        train_limit.map { |type, limit| h('span.nowrap', "#{type} => #{limit}") }
+        train_limit.map { |type, limit| h('span.nowrap', "#{type}: #{limit}") }
           .flat_map { |e| [e, ', '] }[0..-2]
       end
 
@@ -214,7 +214,7 @@ module View
               event_name = event['type']
               if @game.class::EVENTS_TEXT[event_name]
                 events << event_name
-                event_name = "#{@game.class::EVENTS_TEXT[event_name][0]}*"
+                event_name = @game.class::EVENTS_TEXT[event_name][0]
               end
 
               event_text << if index.zero?
@@ -246,7 +246,7 @@ module View
 
             # needed for 18CZ where a train can be rusted by multiple different trains
             trains_to_rust = rust_schedule.select { |k, _v| k&.include?(key) }.values.flatten.join(', ')
-            rusts << "#{key} => #{trains_to_rust}"
+            rusts << "#{key} → #{trains_to_rust}"
             show_rusts_inline = false
           end
 

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -74,6 +74,7 @@ module View
 
           extra = []
           extra << h(:td, phase[:corporation_sizes].join(', ')) if corporation_sizes
+          extra << h(:td, row_events.map(&:first).join(', ')) if phases_events.any?
 
           h(:tr, [
             h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
@@ -82,13 +83,15 @@ module View
             h(:td, train_limit_to_h(phase[:train_limit])),
             h(:td, phase_props, phase_color.capitalize),
             *extra,
-            h(:td, row_events.map(&:first).join(', ')),
           ])
         end
 
         status_text = phases_events.uniq.map do |short, long|
           h(:tr, [h(:td, short), h(:td, long)])
         end
+
+        extra = []
+        extra << h(:th, 'New Corporation Size') if corporation_sizes
 
         if status_text.any?
           status_text = [h(:table, { style: { marginTop: '0.3rem' } }, [
@@ -100,10 +103,8 @@ module View
             ]),
             h(:tbody, status_text),
           ])]
+          extra << h(:th, 'Status')
         end
-
-        extra = []
-        extra << h(:th, 'New Corporation Size') if corporation_sizes
 
         [
           h(:h3, 'Game Phases'),
@@ -117,7 +118,6 @@ module View
                   h(:th, 'Train Limit'),
                   h(:th, 'Tiles'),
                   *extra,
-                  h(:th, 'Status'),
                 ]),
               ]),
               h(:tbody, rows),

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -75,14 +75,11 @@ module View
           extra = []
           extra << h(:td, phase[:corporation_sizes].join(', ')) if corporation_sizes
 
-          train_limit = phase[:train_limit]
-          train_limit = @game.phase.train_limit_to_s(train_limit)
-
           h(:tr, [
             h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
             h(:td, @game.info_on_trains(phase)),
             h(:td, phase[:operating_rounds]),
-            h(:td, train_limit),
+            h(:td, train_limit_to_h(phase[:train_limit])),
             h(:td, phase_props, phase_color.capitalize),
             *extra,
             h(:td, row_events.map(&:first).join(', ')),
@@ -128,6 +125,13 @@ module View
           ]),
           *status_text,
         ]
+      end
+
+      def train_limit_to_h(train_limit)
+        return train_limit unless train_limit.is_a?(Hash)
+
+        train_limit.map { |type, limit| h('span.nowrap', "#{type} => #{limit}") }
+          .flat_map { |e| [e, ', '] }[0..-2]
       end
 
       def rust_obsolete_schedule

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -265,11 +265,10 @@ module View
           h(:tr, upcoming_train_content)
         end
 
-        event_text = @game.class::EVENTS_TEXT
-          .select { |sym, _desc| events.include?(sym) }
-          .map do |_sym, desc|
-            h(:tr, [h(:td, desc[0]), h(:td, desc[1])])
-          end
+        event_text = events.uniq.map do |sym|
+          desc = @game.class::EVENTS_TEXT[sym]
+          h(:tr, [h(:td, desc[0]), h(:td, desc[1])])
+        end
 
         if event_text.any?
           event_text = [h(:table, { style: { marginTop: '0.3rem' } }, [

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -227,6 +227,7 @@ module View
               event_text << event_name unless event_text.include?(event_name)
             end
           end
+          event_text = event_text.flat_map { |e| [h('span.nowrap', e), ', '] }[0..-2]
 
           upcoming_train_content = [
             h(:td, names_to_prices.keys.join(', ')),
@@ -261,7 +262,7 @@ module View
 
           upcoming_train_content << h(:td, discounts) if show_upgrade
           upcoming_train_content << h(:td, train.available_on) if show_available
-          upcoming_train_content << h(:td, event_text.join(', ')) if event_text.any?
+          upcoming_train_content << h(:td, event_text) if event_text.any?
           h(:tr, upcoming_train_content)
         end
 

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -88,7 +88,7 @@ module View
         end
 
         status_text = phases_events.uniq.map do |short, long|
-          h(:tr, [h('td.nowrap', short), h(:td, long)])
+          h(:tr, [h('td.nowrap', { style: { maxWidth: '30vw' } }, short), h(:td, long)])
         end
 
         extra = []
@@ -267,7 +267,7 @@ module View
 
         event_text = events.uniq.map do |sym|
           desc = @game.class::EVENTS_TEXT[sym]
-          h(:tr, [h(:td, desc[0]), h(:td, desc[1])])
+          h(:tr, [h('td.nowrap', { style: { maxWidth: '30vw' } }, desc[0]), h(:td, desc[1])])
         end
 
         if event_text.any?

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -123,7 +123,7 @@ module View
                   h(:th, 'Status'),
                 ]),
               ]),
-              h('tbody.zebra', rows),
+              h(:tbody, rows),
             ]),
           ]),
           *status_text,
@@ -250,10 +250,7 @@ module View
           upcoming_train_content << if show_rusts_inline
                                       h(:td, rusts&.join(', ') || '')
                                     else
-                                      h(:td,
-                                        rusts&.map do |value|
-                                          h(:div, { style: { paddingBottom: '0.1rem' } }, value)
-                                        end || '')
+                                      h(:td, rusts&.map { |value| h(:div, value) } || '')
                                     end
 
           upcoming_train_content << h(:td, discounts&.join(' ')) if show_upgrade

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -204,8 +204,9 @@ module View
         rows = @depot.upcoming.group_by(&:name).map do |name, trains|
           train = trains.first
           discounts = train.discount&.group_by { |_k, v| v }&.map do |price, price_discounts|
-            price_discounts.map(&:first).join(', ') + ' → ' + @game.format_currency(price)
+            h('span.nowrap', "#{price_discounts.map(&:first).join(', ')} → #{@game.format_currency(price)}")
           end
+          discounts = discounts.flat_map { |e| [e, ', '] }[0..-2] if discounts
           names_to_prices = train.names_to_prices
 
           event_text = []
@@ -257,7 +258,7 @@ module View
                                       h(:td, rusts&.map { |value| h(:div, value) } || '')
                                     end
 
-          upcoming_train_content << h(:td, discounts&.join(' ')) if show_upgrade
+          upcoming_train_content << h(:td, discounts) if show_upgrade
           upcoming_train_content << h(:td, train.available_on) if show_available
           upcoming_train_content << h(:td, event_text.join(', ')) if event_text.any?
           h(:tr, upcoming_train_content)

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -62,6 +62,7 @@ module View
             row_events << @game.class::STATUS_TEXT[status] if @game.class::STATUS_TEXT[status]
           end
           phases_events.concat(row_events)
+          row_events = row_events.map(&:first).flat_map { |e| [h('span.nowrap', e), ', '] }[0..-2]
 
           phase_color = Array(phase[:tiles]).last
           bg_color = color_for(phase_color)
@@ -74,7 +75,7 @@ module View
 
           extra = []
           extra << h(:td, phase[:corporation_sizes].join(', ')) if corporation_sizes
-          extra << h(:td, row_events.map(&:first).join(', ')) if phases_events.any?
+          extra << h(:td, row_events) if phases_events.any?
 
           h(:tr, [
             h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
@@ -87,7 +88,7 @@ module View
         end
 
         status_text = phases_events.uniq.map do |short, long|
-          h(:tr, [h(:td, short), h(:td, long)])
+          h(:tr, [h('td.nowrap', short), h(:td, long)])
         end
 
         extra = []

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -259,7 +259,7 @@ module View
 
           upcoming_train_content << h(:td, discounts&.join(' ')) if show_upgrade
           upcoming_train_content << h(:td, train.available_on) if show_available
-          upcoming_train_content << h(:td, event_text.join(', '))
+          upcoming_train_content << h(:td, event_text.join(', ')) if event_text.any?
           h(:tr, upcoming_train_content)
         end
 
@@ -295,7 +295,7 @@ module View
                                      { attrs: { title: 'Available after purchase of first train of type' } },
                                      'Available')
         end
-        upcoming_train_header << h(:th, 'Events')
+        upcoming_train_header << h(:th, 'Events') if event_text.any?
 
         [
           h(:h3, 'Upcoming Trains'),

--- a/lib/engine/game/g_1877/game.rb
+++ b/lib/engine/game/g_1877/game.rb
@@ -346,7 +346,7 @@ module Engine
         SELL_AFTER = :any_time
 
         EVENTS_TEXT = Base::EVENTS_TEXT.merge('signal_end_game' => ['Signal End Game',
-                                                                    'Game Ends 3 ORs after purchase/export'\
+                                                                    'Game ends 3 ORs after purchase/export'\
                                                                     ' of first 4 train']).freeze
         def event_signal_end_game!
           @final_operating_rounds = 2

--- a/lib/engine/game/g_18_chesapeake/game.rb
+++ b/lib/engine/game/g_18_chesapeake/game.rb
@@ -560,7 +560,7 @@ module Engine
 
         def timeline
           @timeline = [
-            'At the end of each set of ORs the next available non-permanent (2,3 or 4) train will be exported
+            'At the end of each set of ORs the next available non-permanent (2, 3 or 4) train will be exported
            (removed, triggering phase change as if purchased)',
           ]
         end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -96,7 +96,7 @@ module Engine
     def train_limit_to_s(train_limit)
       return train_limit unless train_limit.is_a?(Hash)
 
-      train_limit.map { |type, limit| "#{type} => #{limit}" }.join(', ')
+      train_limit.map { |type, limit| "#{type}: #{limit}" }.join(', ')
     end
   end
 end

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -96,7 +96,7 @@ module Engine
     def train_limit_to_s(train_limit)
       return train_limit unless train_limit.is_a?(Hash)
 
-      train_limit.map { |type, limit| "#{type} => #{limit}" }.join(',')
+      train_limit.map { |type, limit| "#{type} => #{limit}" }.join(', ')
     end
   end
 end


### PR DESCRIPTION
- prevent line breaks in sub-strings of event, train limit, train upgrade and status => line breaks after `,`
- remove empty events/status columns
- event legend ordered
- `=>` replaced by `:` or `→` [The arrow breaks up the gray quite nicely in some places.]

ante
![image](https://user-images.githubusercontent.com/33390595/109678730-311b5200-7b7b-11eb-9f6c-52900267cb36.png)
post
![image](https://user-images.githubusercontent.com/33390595/109678748-34aed900-7b7b-11eb-9d37-3a322eac067c.png)

ante
![image](https://user-images.githubusercontent.com/33390595/109678764-37a9c980-7b7b-11eb-9eb8-5df543b58541.png)
post
![image](https://user-images.githubusercontent.com/33390595/109678772-3b3d5080-7b7b-11eb-9fe6-2812ea755274.png)