### PR TITLE
[18CO] removes villages from hexes array for GJGR company #4208

### DIFF
--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -457,28 +457,13 @@ module Engine
                 count: 1,
                 special: true,
                 tiles: %w[14 15],
-                hexes: %w[B10
-                          B22
-                          C7
-                          C9
+                hexes: %w[C9
                           C17
                           C21
-                          D4
                           D14
-                          D24
-                          E5
                           E7
-                          E11
-                          F8
-                          F12
-                          F20
-                          F24
                           H8
-                          H12
                           H14
-                          I21
-                          I23
-                          J6
                           K13],
               },
             ],

--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -292,6 +292,16 @@ module Engine
           %w[10a 10a 10a 15a 15a],
         ].freeze
 
+        # Hexes that are small towns. Used in special GJGR ability.
+        SMALL_TOWNS = %w[C9
+                         C17
+                         C21
+                         D14
+                         E7
+                         H8
+                         H14
+                         K13].freeze
+
         PHASES = [{ name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 2 },
                   {
                     name: '3',
@@ -457,14 +467,7 @@ module Engine
                 count: 1,
                 special: true,
                 tiles: %w[14 15],
-                hexes: %w[C9
-                          C17
-                          C21
-                          D14
-                          E7
-                          H8
-                          H14
-                          K13],
+                hexes: SMALL_TOWNS,
               },
             ],
             color: nil,

--- a/lib/engine/game/g_18_co/step/special_track.rb
+++ b/lib/engine/game/g_18_co/step/special_track.rb
@@ -13,7 +13,6 @@ module Engine
           def process_lay_tile(action)
             ability = abilities(action.entity)
             lay_tile(action, spender: action.entity.owner)
-            check_connect(action, ability)
             ability.use!
 
             @company = ability.count.positive? ? action.entity : nil if ability.must_lay_together


### PR DESCRIPTION
- removes villages from hexes array for GJGR company
- removed connected check as in the rules it states the small village does not need to be connected

fixes #4208 

Here's json for a game to test: https://gist.github.com/underhilllabs/a1e430bf314cd6fbdeb8cb2e1c2673ff