### PR TITLE
fix wrong method for slots in UI:buy_train

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -260,7 +260,7 @@ module View
                   train: group[0],
                   price: price,
                   shell: @active_shell,
-                  slots: get_slots,
+                  slots: slots,
                   extra_due: extra_due,
                 ))
               end


### PR DESCRIPTION
I changed the method name at one point, but missed a call.