### PR TITLE
fix 18CZ currency format

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -17,7 +17,7 @@ module Engine
                         yellow: '#ffe600',
                         lightRed: '#F3B1B3')
 
-        CURRENCY_FORMAT_STR = 'K%d'
+        CURRENCY_FORMAT_STR = '%d K'
 
         BANK_CASH = 99_999
 


### PR DESCRIPTION
Lonny obviously had trouble deciding which format to use (more so in the EN rulebook than in the DE edn.), but physical game components do use `%d K`.
@Zwergenpunk agreed.