### PR TITLE
Make the "extra token" visually distinct from a normal token

### DIFF
--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -285,6 +285,7 @@ module View
                             edge: @edge,
                             token: token,
                             slot_index: slot_index,
+                            extra_token: @city.extra_tokens.include?(token),
                             radius: SLOT_RADIUS,
                             reservation: @city.reservations[slot_index],
                             tile: @tile,

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -20,6 +20,7 @@ module View
         needs :slot_index, default: 0
         needs :city
         needs :edge
+        needs :extra_token, default: false
         needs :radius
         needs :selected_company, default: nil, store: true
         needs :tile_selector, default: nil, store: true
@@ -55,13 +56,31 @@ module View
             radius -= 4
           end
 
-          children << h(:circle, attrs: { r: @radius, fill: color })
+          props = {
+            on: { click: ->(event) { on_click(event) } },
+            attrs: { transform: '' },
+          }
+
+          props[:attrs][:transform] = rotation_for_layout if @edge
+
+          circle_attrs = { r: @radius, fill: color }
+          if @extra_token
+            children << h(:defs, [
+              h(:filter, { attrs: { id: 'shadow', x: '-50%', y: '-50%', width: '200%', height: '200%' } }, [
+                h(:feOffset, attrs: { result: 'offOut', in: 'SourceAlpha', dx: 2, dy: 2 }),
+                h(:feGaussianBlur, attrs: { result: 'blurOut', in: 'offOut', stdDeviation: '5' }),
+                h(:feBlend, attrs: { in: 'SourceGraphic', in2: 'blurOut', mode: 'normal' }),
+              ]),
+            ])
+            circle_attrs[:filter] = 'url(#shadow)'
+
+            # The shadow makes the token look larger, this offsets the effect a little
+            props[:attrs][:transform] += ' scale(0.95)'
+          end
+
+          children << h(:circle, attrs: circle_attrs)
           children << reservation if @reservation && !@token
           children << h(Token, token: @token, radius: radius) if @token
-
-          props = { on: { click: ->(event) { on_click(event) } } }
-
-          props[:attrs] = { transform: rotation_for_layout } if @edge
 
           h(:g, props, children)
         end


### PR DESCRIPTION
Adds a shadow around the extra token so that it's possible to distinguish it

![image](https://user-images.githubusercontent.com/3337865/109861580-5bdad880-7c57-11eb-8f69-c25688965ae2.png)
