### PR TITLE
1870: Show destinations on map

### DIFF
--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -243,6 +243,8 @@ module View
 
           region_weights =
             case @city.slots(all: true)
+            when 0
+              []
             when 1
               CENTER
             when (2..4)

--- a/assets/app/view/game/part/small_item.rb
+++ b/assets/app/view/game/part/small_item.rb
@@ -105,7 +105,31 @@ module View
         PP_WIDE_BOTTOM_CORNER = {
           region_weights: [17, 18, 20, 21, 22, 23],
           x: 0,
-          y: 65,
+          y: 60,
+        }.freeze
+
+        PP_TALL_LEFT_CORNER = {
+          region_weights: [12, 13, 14, 19],
+          x: -60,
+          y: 0,
+        }.freeze
+
+        PP_TALL_RIGHT_CORNER = {
+          region_weights: [4, 9, 10, 11],
+          x: 60,
+          y: 0,
+        }.freeze
+
+        PP_WIDER_TOP_CORNER = {
+          region_weights: [4, 10, 12, 13],
+          x: 0,
+          y: -16,
+        }.freeze
+
+        PP_WIDER_BOTTOM_CORNER = {
+          region_weights: [10, 11, 13, 19],
+          x: 0,
+          y: 16,
         }.freeze
 
         PP_WIDE_BOTTOM_LEFT_CORNER = {
@@ -135,6 +159,12 @@ module View
         POINTY_WIDE_ITEM_LOCATIONS = [PP_WIDE_TOP_CORNER,
                                       PP_WIDE_BOTTOM_CORNER,
                                       PP_WIDE_BOTTOM_LEFT_CORNER].freeze
+
+        POINTY_TALL_ITEM_LOCATIONS = [PP_TALL_LEFT_CORNER,
+                                      PP_TALL_RIGHT_CORNER].freeze
+
+        POINTY_WIDER_ITEM_LOCATIONS = [PP_WIDER_BOTTOM_CORNER,
+                                       PP_WIDER_TOP_CORNER].freeze
       end
     end
   end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1593,6 +1593,10 @@ module Engine
 
       def progress_information; end
 
+      def assignment_tokens(assignment)
+        self.class::ASSIGNMENT_TOKENS[assignment]
+      end
+
       private
 
       def init_graph

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -824,6 +824,14 @@ module Engine
 
         def setup
           river_company.max_price = river_company.value
+
+          @corporations.each do |corporation|
+            ability = abilities(corporation, :assign_hexes)
+            hex = hexes.find { |h| h.name == ability.hexes.first }
+
+            hex.assign!(corporation)
+            ability.description = "Destination: #{hex.location_name} (#{hex.name})"
+          end
         end
 
         def event_companies_buyable!

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -7,13 +7,15 @@ module Engine
     include Entity
 
     attr_accessor :coordinates
-    attr_reader :color, :city, :loans, :logo, :simple_logo, :operating_history, :text_color, :tokens, :trains
+    attr_reader :color, :city, :loans, :logo, :logo_filename, :simple_logo,
+                :operating_history, :text_color, :tokens, :trains
 
     def init_operator(opts)
       @cash = 0
       @trains = []
       @operating_history = {}
-      @logo = "/logos/#{opts[:logo]}.svg"
+      @logo_filename = "#{opts[:logo]}.svg"
+      @logo = "/logos/#{@logo_filename}"
       @simple_logo = opts[:simple_logo] ? "/logos/#{opts[:simple_logo]}.svg" : @logo
       @coordinates = opts[:coordinates]
       @city = opts[:city]


### PR DESCRIPTION
Trying to split the connection run PR. The rest (using auto actions) will come when this one is merged.

This is a bit complicated because some tiles are really busy and I had to create new was for assignments to be rendered:

![image](https://user-images.githubusercontent.com/3337865/109871485-263bec80-7c63-11eb-9f85-fd8f072e96e8.png)

![image](https://user-images.githubusercontent.com/3337865/109871528-305deb00-7c63-11eb-9d92-d4be0dd99917.png)

![image](https://user-images.githubusercontent.com/3337865/109871831-83d03900-7c63-11eb-9227-21b4b6f9e47a.png)
