### PR TITLE
1873: share conversion, buying and closing mines

### DIFF
--- a/assets/app/view/game/alternate_corporations.rb
+++ b/assets/app/view/game/alternate_corporations.rb
@@ -271,14 +271,15 @@ module View
 
         rows += (@game.corporation_info[@corporation][:slots] - mines.size).times.map do |_i|
           h('tr', row_props, [
-            h('td', { attrs: { colspan: '2' } }, [h('div', empty_cell_props, '(empty slot)')]),
+            h('td', { attrs: { colspan: '3' } }, [h('div', empty_cell_props, '(empty slot)')]),
           ])
         end
 
         table_props = { style: { borderCollapse: 'collapse' } }
 
         step = @game.round.active_step
-        text = use_checkboxes ? step.checkbox_prompt : '' if step.respond_to?(:checkbox_prompt)
+        text = ''
+        text = step.checkbox_prompt if step.respond_to?(:checkbox_prompt) && use_checkboxes
 
         h('div', { style: { padding: '0.5rem' } }, [
           text,

--- a/assets/app/view/game/buy_corporation.rb
+++ b/assets/app/view/game/buy_corporation.rb
@@ -16,10 +16,12 @@ module View
         @corporation = @game.current_entity
         children = []
 
+        children << h(:h3, @step.buyable_text(@corporation)) if @step.respond_to?(:buyable_text)
+
         hidden_corps = false
         @show_other_players = true if @step.show_other_players
-        @game.corporations.select { |item| @step.can_buy?(@corporation, item) }.each do |target|
-          if @show_other_players || target.owner == @corporation.owner
+        @step.buyable_entities(@corporation).each do |target|
+          if @show_other_players || target.owner == @corporation.owner || !target.owner
             children << h(Corporation, corporation: target, selected_corporation: @selected_corporation)
             children << render_input if target == @selected_corporation
           else
@@ -30,11 +32,11 @@ module View
         if hidden_corps
           children << h('button',
                         { on: { click: -> { store(:show_other_players, true) } } },
-                        'Show corporations from other players')
+                        "Show #{@step.buyable_types} from other players")
         elsif @show_other_players
           children << h('button',
                         { on: { click: -> { store(:show_other_players, false) } } },
-                        'Hide corporations from other players')
+                        "Hide #{@step.buyable_types} from other players")
         end
 
         h(:div, children)
@@ -43,7 +45,7 @@ module View
       def render_input
         min_price, max_price = @step.price_range(@corporation, @selected_corporation)
 
-        h(BuyValueInput, value: @selected_corporation.share_price.price, min_value: min_price,
+        h(BuyValueInput, value: @step.buy_value(@selected_corporation), min_value: min_price,
                          max_value: max_price,
                          size: max_price,
                          selected_entity: @selected_corporation)

--- a/assets/app/view/game/buy_value_input.rb
+++ b/assets/app/view/game/buy_value_input.rb
@@ -26,10 +26,15 @@ module View
         buy_click = lambda do
           price = input.JS['elm'].JS['value'].to_i
           buy = lambda do
-            if @selected_entity.corporation?
+            if @selected_entity.corporation? || @selected_entity.minor?
+              to_merge = if @selected_corporation.corporation?
+                           { corporation: @selected_entity }
+                         else
+                           { minor: @selected_entity }
+                         end
               process_action(Engine::Action::BuyCorporation.new(
                 @corporation,
-                corporation: @selected_entity,
+                **to_merge,
                 price: price,
               ))
               store(:selected_corporation, nil, skip: true)

--- a/lib/engine/action/buy_corporation.rb
+++ b/lib/engine/action/buy_corporation.rb
@@ -5,24 +5,27 @@ require_relative 'base'
 module Engine
   module Action
     class BuyCorporation < Base
-      attr_reader :entity, :corporation, :price
+      attr_reader :entity, :corporation, :minor, :price
 
-      def initialize(entity, corporation:, price:)
+      def initialize(entity, price:, corporation: nil, minor: nil)
         super(entity)
         @corporation = corporation
+        @minor = minor
         @price = price
       end
 
       def self.h_to_args(h, game)
         {
           corporation: game.corporation_by_id(h['corporation']),
+          minor: game.minor_by_id(h['minor']),
           price: h['price'],
         }
       end
 
       def args_to_h
         {
-          'corporation' => @corporation.id,
+          'corporation' => @corporation&.id,
+          'minor' => @minor&.id,
           'price' => @price,
         }
       end

--- a/lib/engine/game/g_1873/step/buy_mine.rb
+++ b/lib/engine/game/g_1873/step/buy_mine.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class BuyMine < Engine::Step::Base
+          BUY_ACTIONS = %w[buy_corporation pass].freeze
+
+          def actions(entity)
+            return [] if entity != current_entity
+            return [] unless @game.public_mine?(entity)
+            return [] unless @game.any_slot_available?(entity)
+
+            BUY_ACTIONS
+          end
+
+          def skip!
+            return super if @game.public_mine?(current_entity)
+
+            pass!
+          end
+
+          def description
+            'Buy Independent Mines'
+          end
+
+          def show_other_players
+            false
+          end
+
+          def buyable_text(corporation)
+            "Mines that can be bought by #{corporation.name}:"
+          end
+
+          def buyable_types
+            'mines'
+          end
+
+          def buyable_entities(_entity)
+            @game.buyable_private_mines
+          end
+
+          def price_range(buyer, mine)
+            if mine.owner
+              [1, 2 * @game.mine_face_value(mine)]
+            else
+              [@game.mine_face_value(mine), [@game.mine_face_value(mine), buyer.cash].min]
+            end
+          end
+
+          def buy_value(mine)
+            mine.owner ? 1 : @game.mine_face_value(mine)
+          end
+
+          def process_buy_corporation(action)
+            entity = action.entity
+            mine = action.minor
+            price = action.price
+
+            raise GameError, 'no room for mine' unless @game.any_slot_available?(entity)
+            if mine.owner && (!price.positive? || price > 2 * @game.mine_face_value(mine))
+              raise GameError, "price must be between 1 and #{2 * @game.mine_face_value(mine)}"
+            end
+            if !mine.owner && price != @game.mine_face_value(mine)
+              raise GameError, "price for closed mine must be face value: #{@game.mine_face_value(mine)}"
+            end
+            raise GameError, "#{entity.name} cannot afford price of #{price}" if price > entity.cash
+
+            if mine.owner
+              @log << "#{entity.id} buys #{mine.name} from #{mine.owner.name} for #{@game.format_currency(price)}"
+              entity.spend(price, mine.owner)
+            else
+              @log << "#{entity.id} buys #{mine.name} from bank for #{@game.format_currency(price)}"
+              entity.spend(price, @game.bank)
+            end
+
+            # buyer gets formerly independent mines and their cash
+            # machines and switchers stay with mines
+            @game.open_mine!(mine) unless mine.owner
+            @game.add_mine(entity, mine)
+
+            pass!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/step/convert.rb
+++ b/lib/engine/game/g_1873/step/convert.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class Convert < Engine::Step::Base
+          def actions(entity)
+            return %w[convert pass] if can_convert?(entity)
+
+            []
+          end
+
+          def description
+            return 'Close Mine' if current_entity.minor?
+            return 'Convert to 5 Share' if current_entity.total_shares == 2
+
+            'Convert to 10 Share'
+          end
+
+          def pass_description
+            return 'Stay Open' if current_entity.minor?
+
+            'Do not convert'
+          end
+
+          def skip!
+            log_skip(current_entity) if !@acted && current_entity && current_entity != @game.mhe
+            pass!
+          end
+
+          def can_convert?(entity)
+            return true if entity.minor?
+            return false unless entity.corporation?
+            return false unless entity.total_shares < 10
+            return false unless entity.num_market_shares.zero? && entity.num_ipo_shares.zero?
+
+            entity.total_shares < 5 || entity.owner.num_shares_of(entity) >= 2
+          end
+
+          def process_convert(action)
+            entity = action.entity
+            if entity.minor?
+              @game.close_mine!(entity)
+            else
+              @game.convert!(entity)
+            end
+
+            pass!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/step/dividend.rb
+++ b/lib/engine/game/g_1873/step/dividend.rb
@@ -20,6 +20,7 @@ module Engine
           end
 
           def skip!
+            @round.clear_cache!
             revenue = total_revenue(current_entity)
             process_dividend(Action::Dividend.new(
               current_entity,

--- a/lib/engine/game/g_1873/step/route.rb
+++ b/lib/engine/game/g_1873/step/route.rb
@@ -19,6 +19,7 @@ module Engine
 
             if @game.any_mine?(current_entity)
               @game.update_mine_revenue(@round, current_entity) if @round.routes.empty?
+              @round.clear_cache!
             end
 
             pass!

--- a/lib/engine/game/g_18_cz/step/buy_corporation.rb
+++ b/lib/engine/game/g_18_cz/step/buy_corporation.rb
@@ -115,6 +115,18 @@ module Engine
             @game.log << "#{destination.name} takes #{transferred.map(&:name).join(', ')} from #{source.name}"
           end
 
+          def buyable_entities(corporation)
+            @game.corporations.select { |item| can_buy?(corporation, item) }
+          end
+
+          def buyable_types
+            'corporations'
+          end
+
+          def buy_value(corporation)
+            corporation.share_price.price
+          end
+
           def price_range(_corporation, corporation_to_buy)
             max_price = (corporation_to_buy.share_price.price * 1.5).ceil
             min_price = (corporation_to_buy.share_price.price * 0.5).ceil


### PR DESCRIPTION
* Add voluntary closing of indie mines
* Add 10 share conversion for RRs and 5 and 10 share conversions for public mines
* Add mine purchasing for public mines
* Deal with president changes upon purchase of compulsory train for concessions (RRs)

Common files:
* modified UI::buy_corporation and UI::BuyValueInput (used by 18CZ) to make it general enough to buy minors (mines)
* modified 18CZ::Step::BuyCorporation to add the methods needed for above
* modified Action::BuyCorporation to allow purchase of minors