### PR TITLE
Add step_passed method to Round, to replace a line that's used often

### DIFF
--- a/lib/engine/game/g_1817/round/operating.rb
+++ b/lib/engine/game/g_1817/round/operating.rb
@@ -44,7 +44,7 @@ module Engine
           def pay_interest!(entity)
             @cash_crisis_due_to_interest = nil
             return if @paid_loans[entity]
-            return unless @steps.any? { |step| step.passed? && step.is_a?(Engine::Step::BuyTrain) }
+            return unless step_passed?(Engine::Step::BuyTrain)
 
             @paid_loans[entity] = true
             return if entity.loans.empty?

--- a/lib/engine/game/g_1817_wo/round/operating.rb
+++ b/lib/engine/game/g_1817_wo/round/operating.rb
@@ -11,7 +11,7 @@ module Engine
             @cash_crisis_due_to_interest = nil
             return if @paid_loans[entity]
 
-            return unless @steps.any? { |step| step.passed? && step.is_a?(Engine::Step::BuyTrain) }
+            return unless step_passed?(Engine::Step::BuyTrain)
 
             @paid_loans[entity] = true
             return if entity.loans.empty? && !@game.corp_has_new_zealand?(entity)

--- a/lib/engine/game/g_1856/round/operating.rb
+++ b/lib/engine/game/g_1856/round/operating.rb
@@ -52,9 +52,7 @@ module Engine
           def force_repay_loans!(entity)
             loans_to_payoff = entity.loans.size - @game.maximum_loans(entity)
             @cash_crisis_due_to_forced_repay = nil
-            return unless @steps.any? do |step|
-                            step.passed? && step.is_a?(Engine::Step::BuyTrain)
-                          end && loans_to_payoff.positive?
+            return unless step_passed?(Engine::Step::BuyTrain) && loans_to_payoff.positive?
 
             bank = @game.bank
             owed = 100 * loans_to_payoff
@@ -83,7 +81,7 @@ module Engine
           def pay_interest!(entity)
             @cash_crisis_due_to_interest = nil
             return if @paid_interest[entity]
-            return unless @steps.any? { |step| step.passed? && step.is_a?(Engine::Step::Route) }
+            return unless step_passed?(Engine::Step::Route)
 
             # Log interest owed now so that if no interest is owed it is clear
             # why a corporation only gets $90 when taking a loan after this

--- a/lib/engine/game/g_1856/step/loan.rb
+++ b/lib/engine/game/g_1856/step/loan.rb
@@ -25,13 +25,13 @@ module Engine
           def can_payoff?(entity)
             (loan = entity.loans[0]) &&
               entity.cash >= loan.amount &&
-              @round.steps.any? { |step| step.passed? && step.is_a?(Engine::Step::BuyTrain) }
+              @round.step_passed? && step.is_a?(Engine::Step::BuyTrain)
           end
 
           def blocks?
             return false if @game.post_nationalization
 
-            @round.steps.any? { |step| step.passed? && step.is_a?(Engine::Step::BuyTrain) }
+            @round.step_passed?(Engine::Step::BuyTrain)
           end
 
           def process_take_loan(action)

--- a/lib/engine/game/g_18_fl/step/special_token.rb
+++ b/lib/engine/game/g_18_fl/step/special_token.rb
@@ -9,8 +9,8 @@ module Engine
         class SpecialToken < Engine::Step::SpecialToken
           def can_lay_token?(tokener)
             !@game.round.laid_token[tokener] &&
-            @game.round.steps.any? { |step| step.passed? && step.is_a?(G18FL::Step::Track) } &&
-            @game.round.steps.none? { |step| step.passed? && step.is_a?(Engine::Step::Route) }
+              @game.round.step_passed?(G18FL::Step::Track) &&
+              !@game.round.step_passed?(Engine::Step::Route)
           end
 
           def process_place_token(action)

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -119,6 +119,10 @@ module Engine
         @steps.find { |step| step.active? && step.actions(entity).include?(action) }
       end
 
+      def step_passed?(action_klass)
+        @steps.any? { |step| step.passed? && step.is_a?(action_klass) }
+      end
+
       def active_step(entity = nil)
         return @steps.find { |step| step.active? && step.actions(entity).any? } if entity
 


### PR DESCRIPTION
I created this method for #4301 because otherwise the line would be too big. Then I realised it's also used in a bunch of other places, so I thought it would be nice to have them all together.

I'm not sure the name of the method is very auto-explanatory. If someone has a better suggestion...