### PR TITLE
1870: Add the PriceProtection step to the OR

### DIFF
--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -41,7 +41,12 @@ module View
           elsif @current_actions.include?('sell_shares') && entity.player?
             left << h(CashCrisis)
           elsif @current_actions.include?('buy_shares') || @current_actions.include?('sell_shares')
-            left << h(IssueShares)
+            if @step.respond_to?(:price_protection) && (price_protection = @step.price_protection)
+              left << h(Corporation, corporation: price_protection.corporation)
+              left << h(BuySellShares, corporation: price_protection.corporation)
+            else
+              left << h(IssueShares)
+            end
           elsif @current_actions.include?('corporate_buy_shares')
             left << h(CorporateBuyShares)
           elsif @current_actions.include?('corporate_sell_shares')

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -812,6 +812,7 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::BuyTrain,
             [G1870::Step::BuyCompany, blocks: true],
+            G1870::Step::PriceProtection,
           ], round_num: round_num)
         end
 

--- a/lib/engine/game/g_1870/step/price_protection.rb
+++ b/lib/engine/game/g_1870/step/price_protection.rb
@@ -26,7 +26,9 @@ module Engine
           end
 
           def active_entities
-            @round.sell_queue.map(&:president)
+            return [] if @round.sell_queue.empty?
+
+            [@round.sell_queue.first.president]
           end
 
           def purchasable_companies(_entity = nil)

--- a/lib/engine/game/g_1870/step/price_protection.rb
+++ b/lib/engine/game/g_1870/step/price_protection.rb
@@ -7,7 +7,7 @@ module Engine
   module Game
     module G1870
       module Step
-        class PriceProtection < Engine::Step::Base
+        class PriceProtection < Engine::Step::BuySellParShares
           def actions(entity)
             return [] if !entity.player? || entity != current_entity
 
@@ -22,7 +22,11 @@ module Engine
           end
 
           def round_state
-            { sell_queue: [] }
+            super.merge(sell_queue: [])
+          end
+
+          def active_entities
+            @round.sell_queue.map(&:president)
           end
 
           def purchasable_companies(_entity = nil)
@@ -60,24 +64,23 @@ module Engine
               price: price
             )
 
-            @round.goto_entity!(player)
+            @round.goto_entity!(player) if @round.entities[@round.entity_index].player?
 
             num_presentation = @game.share_pool.num_presentation(bundle)
             @log << "#{player.name} price protects #{num_presentation} "\
                     "of #{bundle.corporation.name} for #{@game.format_currency(price)}"
           end
 
-          def skip!(action)
-            return process_pass(action, true) if price_protection
+          def skip!
+            return process_pass(nil, true) if price_protection
 
-            super
+            super if current_entity
           end
 
           def process_pass(_action, forced = false)
             bundle = @round.sell_queue.shift
 
             corporation = bundle.corporation
-            player = bundle.president
             price = corporation.share_price.price
 
             previous_ignore = corporation.share_price.type == :ignore_one_sale
@@ -89,7 +92,7 @@ module Engine
 
             verb = forced ? 'can\'t' : 'doesn\'t'
             num_presentation = @game.share_pool.num_presentation(bundle)
-            @log << "#{player.name} #{verb} price protect #{num_presentation} of #{corporation.name}"
+            @log << "#{corporation.owner.name} #{verb} price protect #{num_presentation} of #{corporation.name}"
 
             if current_ignore && !previous_ignore
               @log << "#{corporation.name} hits the ledge"
@@ -97,12 +100,8 @@ module Engine
             end
 
             @game.log_share_price(corporation, price)
-          end
 
-          def active_entities
-            return [] unless @round.sell_queue.any?
-
-            @round.sell_queue.map(&:president)
+            @round.recalculate_order if @round.respond_to?(:recalculate_order)
           end
         end
       end

--- a/lib/engine/game/g_1870/step/price_protection.rb
+++ b/lib/engine/game/g_1870/step/price_protection.rb
@@ -66,6 +66,8 @@ module Engine
               price: price
             )
 
+            # Price protecting a share counts as an action, which changes what player
+            # gets to act next. But not if done during an OR
             @round.goto_entity!(player) if @round.entities[@round.entity_index].player?
 
             num_presentation = @game.share_pool.num_presentation(bundle)


### PR DESCRIPTION
When there's an ebuy, if shares are sold, the president can also protect
them. Had to add the step to the OR and that required changing some
assumptions.