### PR TITLE
spreadsheet: align column widths

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -17,6 +17,8 @@ module View
 
       needs :game
 
+      PLAYER_COL_MAX_WIDTH = '5rem'
+
       def render
         @spreadsheet_sort_by = Lib::Storage['spreadsheet_sort_by']
         @spreadsheet_sort_order = Lib::Storage['spreadsheet_sort_order']
@@ -188,7 +190,9 @@ module View
           h(:tr, [
             h(:th, { style: { paddingBottom: '0.3rem' } }, render_sort_link('SYM', :id)),
             *@game.players.map do |p|
-              h('th.name.nowrap', p == @game.priority_deal_player ? pd_props : '', render_sort_link(p.name, p.id))
+              props = p == @game.priority_deal_player ? pd_props : { style: {} }
+              props[:style][:minWidth] = PLAYER_COL_MAX_WIDTH if p.companies.size > 1
+              h('th.name.nowrap', props, render_sort_link(p.name, p.id))
             end,
             h(:th, render_sort_link(@game.ipo_name, :ipo_shares)),
             h(:th, render_sort_link('Market', :market_shares)),
@@ -417,7 +421,16 @@ module View
       end
 
       def render_companies(entity)
-        h('td.padded_number', entity.companies.map(&:sym).join(', '))
+        if entity.player?
+          props = {
+            style: {
+              maxWidth: PLAYER_COL_MAX_WIDTH,
+              whiteSpace: 'normal',
+            },
+          }
+          props[:style][:width] = PLAYER_COL_MAX_WIDTH if entity.companies.size > 1
+        end
+        h('td.right', props, entity.companies.map(&:sym).join(', '))
       end
 
       def render_player_companies

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -344,7 +344,7 @@ text.number {
 }
 
 .name {
-  min-width: 3rem;
+  min-width: 3.5rem;
   max-width: 5rem;
 }
 


### PR DESCRIPTION
part 6 of #4317

Fixed width of 5rem for all player columns would be simpler, but would also waste space – a lot if player names are short and companies per player are few.