### PR TITLE
[1822] P2 - Middleton Railway

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -599,12 +599,12 @@ module Engine
             sym: 'P2',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 2. Remove Small Station. NO LAY TRACK CHECK. Make sure the laid track is '\
-                  'valid. Allows the owning company to place a plain yellow track tile directly on an undeveloped '\
-                  'small station hex location or upgrade a small station tile of one colour to a plain track tile '\
-                  'of the next colour. This closes the company and counts as the company’s normal track laying '\
-                  'step. All other normal track laying restrictions apply. Once acquired, the private company pays '\
-                  'its revenue to the owning company until the power is exercised and the company is closed.',
+            desc: 'MAJOR/MINOR, Phase 2. Remove Small Station. Allows the owning company to place a plain yellow '\
+                  'track tile directly on an undeveloped small station hex location or upgrade a small station tile '\
+                  'of one colour to a plain track tile of the next colour. This closes the company and counts as '\
+                  'the company’s normal track laying step. All other normal track laying restrictions apply. Once '\
+                  'acquired, the private company pays its revenue to the owning company until the power is '\
+                  'exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',

--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -115,9 +115,36 @@ module Engine
             if entity.id == @game.class::COMPANY_LCDR && hex.name == @game.class::ENGLISH_CHANNEL_HEX
               return tile.rotation.zero?
             end
-            return true if entity.id == @game.class::COMPANY_MTONR
+            return legal_tile_rotation_mtonr?(entity.owner, hex, tile) if entity.id == @game.class::COMPANY_MTONR
 
             super
+          end
+
+          def legal_tile_rotation_mtonr?(entity, hex, tile)
+            return false unless @game.legal_tile_rotation?(entity, hex, tile)
+
+            old_paths = hex.tile.paths
+            old_ctedges = hex.tile.city_town_edges
+
+            new_paths = tile.paths
+            new_exits = tile.exits
+            new_ctedges = tile.city_town_edges
+            extra_cities = [0, new_ctedges.size - old_ctedges.size].max
+            multi_city_upgrade = new_ctedges.size > 1 && old_ctedges.size > 1
+
+            new_exits.all? { |edge| hex.neighbors[edge] } &&
+              !(new_exits & hex_neighbors(entity, hex)).empty? &&
+              old_paths_are_preserved(old_paths, new_paths) &&
+              extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } } &&
+              (!multi_city_upgrade ||
+                old_ctedges.all? { |oldct| new_ctedges.one? { |newct| (oldct & newct) == oldct } })
+          end
+
+          def old_paths_are_preserved(old_paths, new_paths)
+            # We are removing a town, just check the exits
+            old_exits = old_paths.flat_map(&:exits).uniq
+            new_exits = new_paths.flat_map(&:exits).uniq
+            (old_exits - new_exits).empty?
           end
 
           def potential_tiles(entity, hex)


### PR DESCRIPTION
[1822] P2 - Middleton Railway

- Saw in slack that 1856 did tile lay where you remove a town. Had a looked and took some code from there to get the P2 to work as intended with path checks.

This have no effect on current games since the check is only when you rotate the tile in the ui and not in process_lay_tile.
