### PR TITLE
[1822] Destination token

### DIFF
--- a/lib/engine/game/g_1822/step/token.rb
+++ b/lib/engine/game/g_1822/step/token.rb
@@ -37,19 +37,11 @@ module Engine
             entity = action.entity
             city = action.city
 
-            if entity.corporation? && entity.type == :major
-              destination_token = entity.find_token_by_type(:destination)
-              if destination_token && city.hex.name == @game.class::DESTINATIONS[entity.id]
-                raise GameError, "Can't place token on #{city.hex.name}, that hex is reserved for destination token. "\
-                                 'Please undo this move and place your destination token'
-              end
-
-              if city.tokened_by?(entity)
-                hex = city.hex
-                city_string = city.hex.tile.cities.size > 1 ? " city #{city.index}" : ''
-                raise GameError, "Can't place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
-                                 'tokens in the same city'
-              end
+            if entity.corporation? && entity.type == :major && city.tokened_by?(entity)
+              hex = city.hex
+              city_string = city.hex.tile.cities.size > 1 ? " city #{city.index}" : ''
+              raise GameError, "Can't place token on #{hex.name}#{city_string} because #{entity.id} cant have 2 "\
+                               'tokens in the same city'
             end
 
             check_tokenable = city.hex.name != @game.class::LONDON_HEX


### PR DESCRIPTION
- Added a check when you press skip to see if we have a connection to the destination. If we do you cant skip this step. The check is wrapped around a game.loading block.
- Removed the check in the token step where you check if you try to token the destination hex.

fixes #4318

This have no effect on current games since the check is in a game.loading block. Only affects new actions.