### PR TITLE
[1822] Mid Wales

### DIFF
--- a/assets/app/view/game/part/track_node_path.rb
+++ b/assets/app/view/game/part/track_node_path.rb
@@ -437,8 +437,8 @@ module View
           # terminal tapered track only supported for centered city/town
           props[:attrs].merge!(
             transform: "rotate(#{rotation})",
-            d: "M #{terminal_start_x} 60 L #{terminal_start_x} 87 L #{terminal_end_x} 87 "\
-               "L #{terminal_end_x} 60 L #{point_x} 25 Z",
+            d: "M #{terminal_start_x} 70 L #{terminal_start_x} 87 L #{terminal_end_x} 87 "\
+               "L #{terminal_end_x} 70 L #{point_x} 35 Z",
             fill: @color,
             stroke: 'none',
             'stroke-linecap': 'butt',

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2211,7 +2211,7 @@ module Engine
             ['E26'] =>
               'path=a:0,b:4,lanes:2',
             ['E28'] =>
-              'city=revenue:yellow_10|green_20|brown_20|gray_30,slots:3;path=a:0,b:_0,lanes:2,terminal:1;'\
+              'city=revenue:yellow_10|green_20|brown_20|gray_30,slots:3,loc:1.5;path=a:0,b:_0,lanes:2,terminal:1;'\
               'path=a:3,b:_0,lanes:2,terminal:1;path=a:4,b:_0,lanes:2,terminal:1;path=a:5,b:_0,lanes:2,terminal:1',
             ['E30'] =>
               'path=a:3,b:5,lanes:2',


### PR DESCRIPTION
**Changes to base code**
- View::Game::Part::TrackNodePath. Made the terminal arrow a little bit narrower and decreased the height a little bit. Many offboard cities have 2 slots, the arrows was under the cities and it looked like it had a normal connection. Ive looked att a few other games with an offboard city and terminal arrow. And it looks good with only one city as well.

**1822 Specific**
- Change a little bit on the map around Mid Wales

fixes #4327

This have no effect on current games.