### PR TITLE
1873 Reassign switchers, Tokening

### DIFF
--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -5,6 +5,7 @@ require 'view/game/buy_companies'
 require 'view/game/special_buy'
 require 'view/game/buy_trains'
 require 'view/game/convert'
+require 'view/game/switch_trains'
 require 'view/game/company'
 require 'view/game/corporation'
 require 'view/game/player'
@@ -35,6 +36,7 @@ module View
           left << h(RouteSelector) if @current_actions.include?('run_routes')
           left << h(Dividend) if @current_actions.include?('dividend')
           left << h(Convert) if @current_actions.include?('convert')
+          left << h(SwitchTrains) if @current_actions.include?('switch_trains')
           if @current_actions.include?('buy_train') || @current_actions.include?('scrap_train')
             left << h(IssueShares) if @current_actions.include?('sell_shares')
             left << h(BuyTrains)

--- a/assets/app/view/game/switch_trains.rb
+++ b/assets/app/view/game/switch_trains.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+require 'view/game/alternate_corporations'
+
+module View
+  module Game
+    class SwitchTrains < Snabberb::Component
+      include Actionable
+      include AlternateCorporations
+
+      def render
+        step = @game.round.active_step
+        @corporation = @game.current_entity
+
+        click = lambda do
+          process_action(Engine::Action::SwitchTrains.new(@game.current_entity, slots: slots))
+        end
+
+        props = {
+          style: {
+            padding: '0.2rem 0.2rem',
+          },
+          on: { click: click },
+        }
+
+        children = []
+
+        children << h(:h3, step.help_text) if step.respond_to?(:help_text)
+        children << h('button', props, step.description)
+
+        @slot_checkboxes = {}
+        if step.respond_to?(:slot_view) && (view = step.slot_view(@corporation))
+          children << send("render_#{view}")
+        end
+
+        h(:div, children)
+      end
+
+      # return checkbox values for slots (if any)
+      def slots
+        return if @slot_checkboxes.empty?
+
+        @slot_checkboxes.keys.map do |k|
+          k if Native(@slot_checkboxes[k]).elm.checked
+        end.compact
+      end
+    end
+  end
+end

--- a/lib/engine/action/switch_trains.rb
+++ b/lib/engine/action/switch_trains.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class SwitchTrains < Base
+      attr_reader :slots
+
+      def initialize(entity, slots: nil)
+        super(entity)
+        @slots = slots
+      end
+
+      def self.h_to_args(h, _game)
+        {
+          slots: h['slots']&.map { |m| m.to_i },
+        }
+      end
+
+      def args_to_h
+        {
+          'slots' => @slots,
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -6,6 +6,7 @@ require_relative 'step/buy_sell_par_shares'
 require_relative 'step/draft'
 require_relative 'step/track'
 require_relative 'step/destinate'
+require_relative 'step/token'
 require_relative 'step/reassign_switcher'
 require_relative 'step/route'
 require_relative 'step/dividend'
@@ -19,7 +20,8 @@ module Engine
       class Game < Game::Base
         include_meta(G1873::Meta)
 
-        attr_reader :mine_12, :corporation_info, :minor_info, :mhe, :mine_graph, :nwe, :reserved_tiles
+        attr_reader :mine_12, :corporation_info, :minor_info, :mhe, :mine_graph, :nwe, :reserved_tiles,
+                    :track_graph
         attr_accessor :premium, :premium_order
 
         CURRENCY_FORMAT_STR = '%d ℳ'
@@ -47,8 +49,9 @@ module Engine
         SELL_AFTER = :first
         SELL_BUY_ORDER = :sell_buy
         MARKET_SHARE_LIMIT = 80
+        SOLD_OUT_INCREASE = false
 
-        TRACK_RESTRICTION = :restrictive # FIXME: needs to be very_restrictive when implemented
+        TRACK_RESTRICTION = :restrictive
 
         SELL_MOVEMENT = :down_share
 
@@ -75,6 +78,7 @@ module Engine
         MIN_BID_INCREMENT = 10
         MHE_START_PRICE = 120
         HW_BONUS = 50
+        TOKEN_PRICE = 100
 
         MAINTENANCE_BY_PHASE = {
           '1' => {},
@@ -109,6 +113,7 @@ module Engine
           },
         }.freeze
 
+        # tiles to be laid to complete concession
         CONCESSION_TILES = {
           # HBE
           'B17' => { entity: 'HBE', tile: '78', exits: [0, 4], cost: 0 },
@@ -130,6 +135,33 @@ module Engine
           'H3' => { entity: 'KEZ', tile: '78', exits: [3, 5], cost: 100 },
           # GHE
           'H19' => { entity: 'GHE', tile: '78', exits: [1, 3], cost: 150 },
+        }.freeze
+
+        # exits on portions of concession routes without starting tokens
+        CONCESSION_ROUTE_EXITS = {
+          # HBE
+          'B17' => [0, 4],
+          'C16' => [0, 3], # preprinted tile
+          # NWE
+          'C8' => [0, 3],
+          'D7' => [0, 3],
+          'E6' => [0, 3],
+          'F5' => [3, 5], # preprinted tile
+          'H7' => [2, 4],
+          'H9' => [0, 1], # preprinted tile
+          'I8' => [0, 3],
+          # WBE
+          'C10' => [2, 4],
+          'C12' => [1, 4],
+          'C14' => [1, 5],
+          # SHE
+          'F3' => [0, 3],
+          'G2' => [0, 3],
+          # KEZ
+          'H3' => [3, 5],
+          # GHE
+          'H17' => [4, 5], # preprinted tile
+          'H19' => [1, 3],
         }.freeze
 
         STATE_NETWORK = %w[
@@ -183,6 +215,11 @@ module Engine
           @minor_info = load_minor_extended
           @corporation_info = load_corporation_extended
 
+          @concession_route_corporations = {}
+          @corporations.select { |c| concession_incomplete?(c) }.each do |rr|
+            concession_routes(rr).flatten.each { |h| @concession_route_corporations[h] = rr }
+          end
+
           @mine_12 = @minors.find { |m| m.id == '12' }
           @mhe = @corporations.find { |c| c.id == 'MHE' }
           @nwe = @corporations.find { |c| c.id == 'NWE' }
@@ -205,16 +242,22 @@ module Engine
           @mhe.trains.first.buyable = false
 
           @mine_graph = Graph.new(self, home_as_token: true, no_blocking: true)
+
+          # can't trace paths from a flipped token for the purposes of laying track
+          @track_graph = Graph.new(self, skip_track: :broad, check_tokens: true)
+
           @reserved_tiles = Hash.new { |h, k| h[k] = {} }
           @state_network_hexes = STATE_NETWORK.map { |h| hex_by_id(h) }
         end
 
+        # used for laying tokens and running routes
         def init_graph
           Graph.new(self, skip_track: :broad)
         end
 
+        # select graph for laying track
         def graph_for_entity(entity)
-          entity.minor? ? @mine_graph : @graph
+          entity.minor? ? @mine_graph : @track_graph
         end
 
         def load_minor_extended
@@ -287,6 +330,39 @@ module Engine
           end
         end
 
+        def skip_token?(corporation, city)
+          return false unless railway?(corporation)
+
+          city.tokens.find { |t| t&.corporation == corporation }&.status == :flipped
+        end
+
+        def update_tokens(corporation, routes)
+          return unless railway?(corporation)
+
+          visited_tokens = {}
+
+          routes.each do |route|
+            route.visited_stops.each do |node|
+              next unless node.city?
+
+              node.tokens.each do |token|
+                next if !token || token.corporation != corporation
+
+                visited_tokens[token] = true
+              end
+            end
+          end
+
+          route_hexes = concession_routes(corporation).flatten
+          corporation.placed_tokens.each do |token|
+            token.status = if visited_tokens[token] || route_hexes.include?(token.city.hex.id)
+                             nil
+                           else
+                             :flipped
+                           end
+          end
+        end
+
         def convert!(corporation)
           shares = @_shares.values.select { |share| share.corporation == corporation }
 
@@ -308,6 +384,7 @@ module Engine
             end
             new_shares = 5.times.map { |i| Share.new(corporation, percent: 10, index: i + 5) }
             @corporation_info[corporation][:slots] = 5 if public_mine?(corporation)
+            increase_tokens!(corporation) if railway?(corporation)
             @log << "#{corporation.name} converts to a 10 share corporation"
           else
             raise GameError, 'Cannot convert 10 share corporation'
@@ -324,6 +401,13 @@ module Engine
           corporation.share_holders[owner] += share.percent if owner
           owner.shares_by_corporation[corporation] << share
           @_shares[share.id] = share
+        end
+
+        def increase_tokens!(corporation)
+          num_new_tokens = @corporation_info[corporation][:extra_tokens]
+          new_tokens = num_new_tokens.times.map { |_i| Token.new(corporation, price: TOKEN_PRICE) }
+          corporation.tokens.concat(new_tokens)
+          @log << "#{corporation.name} receives #{num_new_tokens} more tokens"
         end
 
         def buy_train(operator, train, price = nil)
@@ -566,6 +650,17 @@ module Engine
           entity.corporation? && @corporation_info[entity][:type] == :railway
         end
 
+        def concession_blocks?(city)
+          hex = city.hex
+          return false unless (exits = CONCESSION_ROUTE_EXITS[hex.id])
+          return false unless concession_incomplete?(@concession_route_corporations[hex.id])
+          # take care of OO tile. Only care about city along concession route
+          return false unless info && (city.exits & exits).size == exits.size
+
+          # must be two slots available for another RR to put a token here
+          city.slots - city.tokens.count { |c| c } > 1
+        end
+
         def concession_pending?(entity)
           entity.corporation? &&
             @corporation_info[entity][:type] == :railway &&
@@ -581,14 +676,20 @@ module Engine
         def concession_route_done?(entity)
           return true unless concession_incomplete?(entity)
 
-          concession_hexes(entity).all? do |hex|
+          concession_tile_hexes(entity).all? do |hex|
             info = CONCESSION_TILES[hex.id]
             (hex.tile.exits & info[:exits]).size == info[:exits].size
           end
         end
 
-        def concession_hexes(entity)
+        def concession_tile_hexes(entity)
           CONCESSION_TILES.keys.select { |h| CONCESSION_TILES[h][:entity] == entity.name }.map { |h| hex_by_id(h) }
+        end
+
+        def concession_routes(entity)
+          return unless railway?(entity)
+
+          @corporation_info[entity][:concession_routes]
         end
 
         def concession_complete!(entity)
@@ -668,7 +769,6 @@ module Engine
           ])
         end
 
-        # FIXME
         def new_auction_round
           @log << "-- #{round_description('Auction')} --"
           G1873::Round::Auction.new(self, [
@@ -683,12 +783,11 @@ module Engine
           ])
         end
 
-        # FIXME
         def operating_round(round_num)
           Engine::Round::Operating.new(self, [
             G1873::Step::Track,
             G1873::Step::Destinate,
-            # G1873::Step::Token,
+            G1873::Step::Token,
             G1873::Step::ReassignSwitcher,
             G1873::Step::Route,
             G1873::Step::Dividend,
@@ -754,13 +853,13 @@ module Engine
           @corporations.reject { |c| @corporation_info[c][:type] == :external }
         end
 
-        def concession_hex(hex)
+        def concession_tile(hex)
           CONCESSION_TILES[hex.id]
         end
 
         # concession route in this hex
         def reserve_tile!(hex, tile)
-          return false unless (ch = concession_hex(hex))
+          return false unless (ch = concession_tile(hex))
 
           # look for an upgrade to the tile being laid that has the exits
           # needed by the concession route
@@ -790,7 +889,7 @@ module Engine
         end
 
         def add_tile_reservation!(hex, tile)
-          ch = concession_hex(hex)
+          ch = concession_tile(hex)
 
           @log << "Reserving tile ##{tile.name} for #{ch[:entity]} concession route"
 
@@ -808,7 +907,7 @@ module Engine
         def free_tile_reservation!(hex, tile)
           return if @reserved_tiles[hex.id].empty?
 
-          ch = concession_hex(hex)
+          ch = concession_tile(hex)
           return unless (ch[:exits] & tile.exits).size != ch[:exits].size
 
           @tiles << @reserved_tiles[hex.id][:tile] if @reserved_tiles[hex.id][:tile] != tile
@@ -867,9 +966,8 @@ module Engine
           @log << "Mine #{entity.name} is now connected to state railway network" unless old
         end
 
-        # FIXME: take care of compulsory train
-        def must_buy_train?(_entity)
-          false
+        def must_buy_train?(entity)
+          concession_pending?(entity)
         end
 
         def sellable_bundles(player, corporation)
@@ -1542,7 +1640,7 @@ module Engine
               extended: {
                 type: :railway,
                 concession_phase: '1',
-                concession_routes: [%w[G20 H19 G17 I18]],
+                concession_routes: [%w[G20 H19 H17 I18]],
                 concession_cost: 150,
                 concession_pending: true,
                 concession_incomplete: true,
@@ -2054,7 +2152,7 @@ module Engine
               %w[
                 H17
               ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
-                'path=a:5,b:_0,track:narrow;upgrade=cost:100,terrain:mountain;frame=color:purple',
+                'path=a:5,b:_0,track:narrow;upgrade=cost:100,terrain:mountain',
             },
             gray: {
               %w[

--- a/lib/engine/game/g_1873/step/convert.rb
+++ b/lib/engine/game/g_1873/step/convert.rb
@@ -27,7 +27,10 @@ module Engine
           end
 
           def skip!
-            log_skip(current_entity) if !@acted && current_entity && current_entity != @game.mhe
+            if !@acted && current_entity && current_entity != @game.mhe &&
+                (current_entity.minor? || current_entity.total_shares < 10)
+              log_skip(current_entity)
+            end
             pass!
           end
 

--- a/lib/engine/game/g_1873/step/reassign_switcher.rb
+++ b/lib/engine/game/g_1873/step/reassign_switcher.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class ReassignSwitcher < Engine::Step::Base
+          BUY_ACTIONS = %w[switch_trains pass].freeze
+
+          def actions(entity)
+            return [] if entity != current_entity
+            return [] unless @game.public_mine?(entity)
+            return [] unless reassign_possible?(entity)
+
+            BUY_ACTIONS
+          end
+
+          def pass_description
+            @acted ? 'Done (Reassign)' : 'Skip (Reassign)'
+          end
+
+          def skip!
+            return super if @game.public_mine?(current_entity)
+
+            pass!
+          end
+
+          # don't bother with this step if all mines have the same level of switcher
+          def reassign_possible?(entity)
+            !@game.public_mine_mines(entity).map { |m| @game.switcher_size(m) || 0 }.uniq.one?
+          end
+
+          def description
+            'Reassign Switchers'
+          end
+
+          def help_text
+            'Select exactly two mines to swap switchers between'
+          end
+
+          def slot_view(entity)
+            return unless @game.public_mine?(entity)
+
+            'submines'
+          end
+
+          def process_switch_trains(action)
+            entity = action.entity
+            slots = action.slots
+
+            raise GameError, 'Exactly 2 mines must be selected' if slots.size != 2
+            raise GameError, 'Illegal slot' if slots.max >= @game.public_mine_mines(entity).size
+            raise GameError, 'Illegal slot' if slots.min.negative?
+
+            @game.swap_switchers(entity, slots)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/step/route.rb
+++ b/lib/engine/game/g_1873/step/route.rb
@@ -15,6 +15,7 @@ module Engine
           end
 
           def skip!
+            @game.update_tokens(current_entity, [])
             return super if !@game.any_mine?(current_entity) && current_entity != @game.mhe
 
             if @game.any_mine?(current_entity)
@@ -29,9 +30,12 @@ module Engine
             super
 
             entity = action.entity
+
             maintenance = @game.maintenance_costs(entity)
             @round.maintenance = maintenance
             @log << "#{entity.name} owes #{@game.format_currency(maintenance)} for maintenance" if maintenance.positive?
+
+            @game.update_tokens(entity, action.routes)
           end
 
           def round_state

--- a/lib/engine/game/g_1873/step/token.rb
+++ b/lib/engine/game/g_1873/step/token.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/token'
+
+module Engine
+  module Game
+    module G1873
+      module Step
+        class Token < Engine::Step::Token
+          TOKEN_REPLACE_COST = 50
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] unless @game.railway?(entity)
+            return [] unless can_place_token?(entity)
+
+            ACTIONS
+          end
+
+          def can_place_token?(entity)
+            current_entity == entity &&
+              !@round.tokened &&
+              !available_tokens(entity).empty? &&
+              entity.cash >= TOKEN_REPLACE_COST
+          end
+
+          def process_place_token(action)
+            entity = action.entity
+            city = action.city
+            slot = action.slot
+            token = action.token
+            hex = city.hex
+            tile = hex.tile
+
+            if !@game.loading && !@game.graph.connected_nodes(entity)[city]
+              city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
+              raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
+            end
+
+            raise GameError, 'Token is already used' if token.used
+            raise GameError, 'No token available to place' unless (new_token = entity.unplaced_tokens.first)
+
+            # only one per hex
+            if tile.cities.any? { |c| c.tokened_by?(entity) }
+              raise GameError, "#{entity.name} cannot lay token on #{id} #{hex.id}"
+            end
+
+            token.status = nil
+            if (old_token = city.tokens[slot])&.status == :flipped && old_token&.corporation != entity
+              # replace token
+              #
+              raise GameError, 'Cannot pay cost to replace a token' if entity.cash < TOKEN_REPLACE_COST
+
+              old_token.remove!
+              old_token.status = nil
+              city.exchange_token(new_token)
+
+              entity.spend(TOKEN_REPLACE_COST, old_token.corporation)
+              @game.log << "#{entity.name} replaces #{old_token.corporation.name} token on #{hex.id} for "\
+                "#{@game.format_currency(TOKEN_REPLACE_COST)} (paid to #{old_token.corporation.name})"
+
+              @round.tokened = true
+              @game.graph.clear
+            else
+              # place new token
+              #
+              if @game.concession_blocks?(city)
+                raise GameError, "Cannot lay on #{city.id}. Must leave room for concession RR"
+              end
+
+              super
+            end
+
+            @game.track_graph.clear
+          end
+
+          def check_legal_placement(_entity, city, _token)
+            return unless @game.concession_blocks?(city)
+
+            raise GameError, "Cannot lay on #{city.id} Must leave room for concession RR"
+          end
+
+          def can_replace_token?(_entity, token)
+            token.status == :flipped
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -16,6 +16,7 @@ module Engine
       @home_as_token = opts[:home_as_token] || false
       @no_blocking = opts[:no_blocking] || false
       @skip_track = opts[:skip_track]
+      @check_tokens = opts[:check_tokens]
     end
 
     def clear
@@ -100,6 +101,7 @@ module Engine
       @game.hexes.each do |hex|
         hex.tile.cities.each do |city|
           next unless city.tokened_by?(corporation)
+          next if @check_tokens && @game.skip_token?(corporation, city)
 
           hex.neighbors.each { |e, _| hexes[hex][e] = true }
           nodes[city] = true


### PR DESCRIPTION
* New step, action and UI for a public mine to move switchers around prior to production (per the rules)
* Add crazy 1873 tokening rules:
** tokens not used in running a route get flipped to the inactive side (except for those on its concession route)
** RR can replace an inactive token from another RR with it's own for half-price
** Running routes and tokening treat inactive tokens normally
** Laying tiles ignore inactive tokens from the corp laying the tile (yes, a new graph, thanks for asking)
** Can't token out a "village" on a concession route before the RR with the concession runs the first time

Common file edits:
* new parameter to graph to restrict tokens for a company
* new action and UI: switch_trains

![1873_reassign_switcher](https://user-images.githubusercontent.com/8494213/110189371-1693e380-7ddc-11eb-9dee-708694b0f536.png)
