### PR TITLE
show player colors per title

### DIFF
--- a/assets/app/lib/storage.rb
+++ b/assets/app/lib/storage.rb
@@ -4,7 +4,7 @@ module Lib
   module Storage
     def self.[](key)
       value = `localStorage.getItem(#{key})`
-      JSON.parse(value) if value
+      JSON.parse(value) if value && !value.empty?
     end
 
     def self.[]=(key, value)

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -12,7 +12,6 @@ module View
       needs :show_starting_map, default: false, store: true
       needs :historical_routes, default: [], store: true
       needs :game, default: nil, store: true
-      needs :show_player_colors, default: nil, store: true
 
       def render
         children = [
@@ -27,12 +26,13 @@ module View
       end
 
       def player_colors_controls
-        show_player_colors = Lib::Storage['show_player_colors']
+        title = @game&.class&.title
+        show_player_colors = Lib::Storage["show_player_colors_#{title}"] || Lib::Storage['show_player_colors']
 
         on_click = lambda do
-          new_value = !show_player_colors
-          Lib::Storage['show_player_colors'] = new_value
-          store(:show_player_colors, new_value)
+          Lib::Storage['show_player_colors'] = !show_player_colors
+          Lib::Storage["show_player_colors_#{title}"] = !show_player_colors
+          update
         end
 
         render_button("#{show_player_colors ? 'Hide' : 'Show'} Player Colors", on_click)

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -49,7 +49,9 @@ module View
         def render_part
           color = @reservation&.corporation? && @reservation&.reservation_color || 'white'
           radius = @radius
-          if (owner = @token&.corporation&.owner) && Lib::Storage['show_player_colors'] && @game.players.include?(owner)
+          show_player_colors = Lib::Storage["show_player_colors_#{@game&.class&.title}"] ||
+                               Lib::Storage['show_player_colors']
+          if show_player_colors && (owner = @token&.corporation&.owner) && @game.players.include?(owner)
             color = player_colors(@game.players)[owner]
             radius -= 4
           end


### PR DESCRIPTION
This allows overriding show_player_colors per title. For now in parallel to the general option, so it’s still just one click to show/hide player colors for all titles – unless one had configured many titles beforehand.
I wouldn’t mind getting rid of the general option completely, because most people (on Slack back then) said they only use it on select titles anyway.

[Addition to lib/storage and & due to specs failing otherwise.]

PS: The same MO would work for #4278