### PR TITLE
Added &nbsp; to currency formats with space

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -88,7 +88,7 @@ module View
             textAlign: 'left',
           },
         }
-        share_props = { style: { width: '2.9rem' } }
+        share_props = { style: { width: '2.7rem' } }
 
         if corporation_interest_penalty?(entity)
           corporation_penalty = "#{entity.name} has " +

--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -88,7 +88,7 @@ module View
             textAlign: 'left',
           },
         }
-        share_props = { style: { width: '2.7rem' } }
+        share_props = { style: { width: '2.9rem' } }
 
         if corporation_interest_penalty?(entity)
           corporation_penalty = "#{entity.name} has " +

--- a/lib/engine/game/g_1836_jr30/game.rb
+++ b/lib/engine/game/g_1836_jr30/game.rb
@@ -9,7 +9,7 @@ module Engine
       class Game < Game::Base
         include_meta(G1836Jr30::Meta)
 
-        CURRENCY_FORMAT_STR = '%d F'
+        CURRENCY_FORMAT_STR = '%d F'
 
         BANK_CASH = 6000
 

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -24,7 +24,7 @@ module Engine
                     :track_graph
         attr_accessor :premium, :premium_order
 
-        CURRENCY_FORMAT_STR = '%d ℳ'
+        CURRENCY_FORMAT_STR = '%d ℳ'
         BANK_CASH = 100_000
         CERT_LIMIT = {
           2 => 99,

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -17,7 +17,7 @@ module Engine
                         yellow: '#ffe600',
                         lightRed: '#F3B1B3')
 
-        CURRENCY_FORMAT_STR = '%d K'
+        CURRENCY_FORMAT_STR = '%d K'
 
         BANK_CASH = 99_999
 
@@ -2884,7 +2884,7 @@ module Engine
         end
 
         def format_currency(val)
-          return format('%0.1f K', val) if (val - val.to_i).positive?
+          return format('%0.1f K', val) if (val - val.to_i).positive?
 
           self.class::CURRENCY_FORMAT_STR % val
         end

--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -11,7 +11,7 @@ module Engine
 
         attr_reader :tile_groups, :unused_tiles, :sik, :skev, :ldsteg, :mavag, :raba, :snw, :gc, :terrain_tokens
 
-        CURRENCY_FORMAT_STR = '%d Ft'
+        CURRENCY_FORMAT_STR = '%d Ft'
         BANK_CASH = 100_000
         CERT_LIMIT = {
           2 => 10,

--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -23,7 +23,7 @@ module Engine
           yellow: '#FFF500' # MYJ
         )
 
-        CURRENCY_FORMAT_STR = '%d kr'
+        CURRENCY_FORMAT_STR = '%d kr'
 
         BANK_CASH = 12_000
 


### PR DESCRIPTION
In 18CZ and 1836jr is a unneeded line break

Before:
![image](https://user-images.githubusercontent.com/7661170/110202817-5f46ad80-7e6b-11eb-9ac4-c490f0ebae7a.png)

After:
![image](https://user-images.githubusercontent.com/7661170/110202777-358d8680-7e6b-11eb-9658-0804f8c8ccac.png)
