### PR TITLE
profile: dedicated methods => render_checkbox

### DIFF
--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -43,9 +43,9 @@ module View
       inputs = [
         render_username,
         h('div#settings__options', [
-          render_notifications(setting_for(:notifications)),
-          render_simple_logos(setting_for(:simple_logos)),
-          render_logo_color(setting_for(:red_logo)),
+          render_checkbox('Turn and Message Emails', :notifications),
+          render_checkbox('Red 18xx.games Logo', :red_logo),
+          render_checkbox('Simple Corporation Logos', :simple_logos),
         ]),
         h('div#settings__colors', { style: { maxWidth: '38rem' } }, [
           render_color('Main Background', :bg, color_for(:bg)),
@@ -86,7 +86,7 @@ module View
         render_input('User Name', id: :name),
         render_input('Email', id: :email, type: :email, attrs: { autocomplete: 'email' }),
         render_input('Password', id: :password, type: :password, attrs: { autocomplete: 'new-password' }),
-        render_notifications,
+        render_checkbox('Turn and Message Emails', :notifications),
         h(:div, [render_button('Create Account') { submit }]),
       ]
 
@@ -131,31 +131,8 @@ module View
       ])
     end
 
-    def render_notifications(checked = true)
-      render_input(
-        'Turn and Message Emails',
-        id: :notifications,
-        type: :checkbox,
-        attrs: { checked: checked },
-      )
-    end
-
-    def render_simple_logos(checked = true)
-      render_input(
-        'Simple Corporation Logos',
-        id: :simple_logos,
-        type: :checkbox,
-        attrs: { checked: checked },
-      )
-    end
-
-    def render_logo_color(checked = false)
-      render_input(
-        'Red 18xx.games Logo',
-        id: :red_logo,
-        type: :checkbox,
-        attrs: { checked: checked },
-      )
+    def render_checkbox(label, id)
+      render_input(label, id: id, type: :checkbox, attrs: { checked: setting_for(id) })
     end
 
     def render_color(label, id, hex_color, attrs: {})


### PR DESCRIPTION
No need for multiple methods …

Order of red_logo and simple_logos changed, because general options should be rendered before game related ones.