### PR TITLE
1828: Refactorings to use round variables

### DIFF
--- a/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
@@ -55,7 +55,7 @@ module Engine
           end
 
           def shorted?
-            @current_actions.any? { |x| x.instance_of?(Action::Short) }
+            @round.current_actions.any? { |x| x.instance_of?(Action::Short) }
           end
 
           def redeemable_shares(entity)
@@ -82,7 +82,7 @@ module Engine
             return [] if @corporate_action && @corporate_action.entity != entity
 
             actions = []
-            if @current_actions.none?
+            if @round.current_actions.none?
               actions << 'take_loan' if @game.can_take_loan?(entity) && !@corporate_action.is_a?(Action::BuyShares)
               actions << 'buy_shares' unless @game.redeemable_shares(entity).empty?
             end
@@ -174,7 +174,7 @@ module Engine
             return par_corporation if @winning_bid
 
             unless @auctioning
-              @current_actions << @corporate_action
+              @round.current_actions << @corporate_action
               return super
             end
 
@@ -226,7 +226,7 @@ module Engine
             else
               @log << "#{entity.name} auctions #{corporation.name} for #{@game.format_currency(price)}"
               @round.last_to_act = action.entity
-              @current_actions.clear
+              @round.current_actions.clear
               @game.place_home_token(action.corporation)
             end
             super(action)

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -1034,7 +1034,7 @@ module Engine
           tiles
         end
 
-        TILE_LAYS = [{ lay: true, upgrade: true, cannot_reuse_same_hex: true, cost: 0 }].freeze
+        TILE_LAYS = [{ lay: true, upgrade: :not_if_upgraded, cannot_reuse_same_hex: true, cost: 0 }].freeze
         EXTRA_TILE_LAY_CORPS = %w[B&M NYH].freeze
 
         def tile_lays(entity)

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -1034,16 +1034,18 @@ module Engine
           tiles
         end
 
+        TILE_LAYS = [{ lay: true, upgrade: true, cannot_reuse_same_hex: true, cost: 0 }].freeze
         EXTRA_TILE_LAY_CORPS = %w[B&M NYH].freeze
 
         def tile_lays(entity)
           tile_lays = super
-          tile_lays += [{ lay: true, upgrade: :not_if_upgraded }] if entity.system?
+          tile_lays += [{ lay: true, upgrade: :not_if_upgraded, cannot_reuse_same_hex: true }] if entity.system?
           (entity.system? ? entity.corporations.map(&:name) : [entity.name]).each do |corp_name|
             tile_lays += [
               {
                 lay: :not_if_upgraded,
                 upgrade: false,
+                cannot_reuse_same_hex: true,
                 cost: 40,
               },
             ] if EXTRA_TILE_LAY_CORPS.include?(corp_name)
@@ -1317,7 +1319,7 @@ module Engine
         end
 
         def can_run_route?(entity)
-          return false if entity.id == 'C&P' && !@round.last_tile_lay
+          return false if entity.id == 'C&P' && @round.laid_hexes.empty?
 
           super
         end

--- a/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/buy_sell_par_shares'
+require_relative 'exchange'
 
 module Engine
   module Game
@@ -54,7 +55,7 @@ module Engine
 
           def process_failed_merge(action)
             @log << "#{action.entity.name} failed to merge #{action.corporations.map(&:name).join(' and ')}"
-            @current_actions << action
+            @round.current_actions << action
           end
 
           def can_buy_multiple?(entity, corporation)
@@ -62,7 +63,7 @@ module Engine
           end
 
           def num_shares_bought(corporation)
-            @current_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
+            @round.current_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
           end
 
           def can_merge_any?(entity)
@@ -86,10 +87,6 @@ module Engine
 
           def get_par_prices(entity, _corp)
             @game.par_prices.select { |p| p.price * 2 <= entity.cash }
-          end
-
-          def stock_action(action)
-            @current_actions << action
           end
         end
       end

--- a/lib/engine/game/g_1828/step/route.rb
+++ b/lib/engine/game/g_1828/step/route.rb
@@ -28,7 +28,7 @@ module Engine
           def route_uses_tile_lay(routes)
             tile_used = false
             stops = routes.first.visited_stops
-            tile = @round.last_tile_lay
+            tile = @round.laid_hexes.first&.tile
 
             if tile.nodes.any?
               tile_used = (stops & tile.nodes).any?

--- a/lib/engine/game/g_1828/step/special_track.rb
+++ b/lib/engine/game/g_1828/step/special_track.rb
@@ -13,11 +13,8 @@ module Engine
           include Engine::Step::TrackLayWhenCompanySold
 
           def process_lay_tile(action)
-            if action.entity.id == 'E&K' && !@company
-              track_step = @round.steps.find { |step| step.is_a?(Track) }
-              raise GameError, "Cannot use #{action.entity.name} after a tile upgrade" if track_step.upgraded
-
-              track_step.no_upgrades = true
+            if action.entity.id == 'E&K' && !@company && @round.upgraded_track
+              raise GameError, "Cannot use #{action.entity.name} after a tile upgrade"
             end
 
             super

--- a/lib/engine/game/g_1828/step/special_track.rb
+++ b/lib/engine/game/g_1828/step/special_track.rb
@@ -15,11 +15,11 @@ module Engine
           def process_lay_tile(action)
             super
 
-            if action.entity.id == 'E&K' && action.tile.hex.id != 'E7'
-              raise GameError, "Cannot use #{action.entity.name} after a tile upgrade" if @round.upgraded_track
-              
-              @round.upgraded_track = true
-            end
+            return if action.entity.id != 'E&K' || action.tile.hex.id == 'E7'
+
+            raise GameError, "Cannot use #{action.entity.name} after a tile upgrade" if @round.upgraded_track
+
+            @round.upgraded_track = true
           end
         end
       end

--- a/lib/engine/game/g_1828/step/special_track.rb
+++ b/lib/engine/game/g_1828/step/special_track.rb
@@ -13,11 +13,13 @@ module Engine
           include Engine::Step::TrackLayWhenCompanySold
 
           def process_lay_tile(action)
-            if action.entity.id == 'E&K' && !@company && @round.upgraded_track
-              raise GameError, "Cannot use #{action.entity.name} after a tile upgrade"
-            end
-
             super
+
+            if action.entity.id == 'E&K' && action.tile.hex.id != 'E7'
+              raise GameError, "Cannot use #{action.entity.name} after a tile upgrade" if @round.upgraded_track
+              
+              @round.upgraded_track = true
+            end
           end
         end
       end

--- a/lib/engine/game/g_1828/step/swap_train.rb
+++ b/lib/engine/game/g_1828/step/swap_train.rb
@@ -29,6 +29,10 @@ module Engine
             super
           end
 
+          def log_skip
+            super if current_entity&.system?
+          end
+
           def process_swap_train(action)
             train = action.train
             entity = action.entity

--- a/lib/engine/game/g_1828/step/swap_train.rb
+++ b/lib/engine/game/g_1828/step/swap_train.rb
@@ -29,8 +29,8 @@ module Engine
             super
           end
 
-          def log_skip
-            super if current_entity&.system?
+          def log_skip(entity)
+            super if entity&.system?
           end
 
           def process_swap_train(action)

--- a/lib/engine/game/g_1828/step/track.rb
+++ b/lib/engine/game/g_1828/step/track.rb
@@ -9,40 +9,6 @@ module Engine
       module Step
         class Track < Engine::Step::Track
           include AcquireVaTunnelCoalMarker
-
-          attr_accessor :no_upgrades
-          attr_reader :upgraded
-
-          def setup
-            super
-            @no_upgrades = false
-            @round.last_tile_lay = nil
-          end
-
-          def round_state
-            super.merge(
-              {
-                last_tile_lay: nil,
-              }
-            )
-          end
-
-          def get_tile_lay(entity)
-            action = super
-            return unless action
-
-            action[:upgrade] = false if @no_upgrades
-            action
-          end
-
-          def process_lay_tile(action)
-            if @round.last_tile_lay && action.hex == @round.last_tile_lay.hex
-              raise GameError, 'Cannot lay and upgrade the same tile in the same turn'
-            end
-
-            @round.last_tile_lay = action.tile
-            super
-          end
         end
       end
     end

--- a/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
@@ -28,7 +28,7 @@ module Engine
 
           def pass!
             @passed = true
-            if @current_actions.empty?
+            if @round.current_actions.empty?
               @round.pass_order |= [current_entity]
               current_entity.pass!
             else
@@ -57,11 +57,11 @@ module Engine
           end
 
           def just_parred(corporation)
-            @current_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation }
+            @round.current_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation }
           end
 
           def num_shares_bought(corporation)
-            @current_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
+            @round.current_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
           end
         end
       end

--- a/lib/engine/game/g_1860/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1860/step/buy_sell_par_shares.rb
@@ -33,7 +33,7 @@ module Engine
           end
 
           def pass_description
-            if @current_actions.empty?
+            if @round.current_actions.empty?
               'Pass (Certificates)'
             else
               'Done (Certificates)'

--- a/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
@@ -8,11 +8,11 @@ module Engine
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
           def actions(entity)
-            return [] if @current_actions.last&.entity&.corporation?
+            return [] if @round.current_actions.last&.entity&.corporation?
 
             if entity.corporation? && entity.owned_by?(current_entity)
               actions = []
-              actions << 'buy_shares' if @current_actions.none? &&
+              actions << 'buy_shares' if @round.current_actions.none? &&
                                          entity.operated? &&
                                          entity.num_ipo_shares < 4
 

--- a/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
@@ -28,8 +28,8 @@ module Engine
           def can_buy_multiple?(_entity, corporation)
             return false unless @game.railway?(corporation)
 
-            @current_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation } &&
-              @current_actions.none? { |x| x.is_a?(Action::BuyShares) }
+            @round.current_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation } &&
+              @round.current_actions.none? { |x| x.is_a?(Action::BuyShares) }
           end
 
           def can_sell?(entity, bundle)

--- a/lib/engine/game/g_1877/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1877/step/buy_sell_par_shares.rb
@@ -13,7 +13,7 @@ module Engine
             return [] if @corporate_action && @corporate_action.entity != entity
 
             actions = []
-            if @current_actions.none?
+            if @round.current_actions.none?
               actions << 'take_loan' if @game.can_take_loan?(entity) && !@corporate_action.is_a?(Action::BuyShares)
               actions << 'buy_shares' unless @game.redeemable_shares(entity).empty?
               actions << 'buy_train' if can_buy_train?(entity)

--- a/lib/engine/game/g_1893/step/par_and_buy_actions.rb
+++ b/lib/engine/game/g_1893/step/par_and_buy_actions.rb
@@ -17,6 +17,6 @@ module ParAndBuy
     allow_president_change = action.bundle.corporation.presidents_share.buyable
     buy_shares(action.entity, action.bundle, swap: action.swap, allow_president_change: allow_president_change)
     @round.last_to_act = action.entity
-    @current_actions << action
+    @round.current_actions << action
   end
 end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -110,6 +110,7 @@ module Engine
           actions.concat(available_actions)
           break if step.blocking?
         end
+        puts actions.uniq
         actions.uniq
       end
 

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -110,7 +110,6 @@ module Engine
           actions.concat(available_actions)
           break if step.blocking?
         end
-        puts actions.uniq
         actions.uniq
       end
 

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -30,7 +30,7 @@ module Engine
       end
 
       def log_pass(entity)
-        return @log << "#{entity.name} passes" if @current_actions.empty?
+        return @log << "#{entity.name} passes" if @round.current_actions.empty?
         return if bought? && sold?
 
         action = bought? ? 'to sell' : 'to buy'
@@ -53,7 +53,7 @@ module Engine
       end
 
       def pass_description
-        if @current_actions.empty?
+        if @round.current_actions.empty?
           'Pass (Share)'
         else
           'Done (Share)'
@@ -61,9 +61,11 @@ module Engine
       end
 
       def round_state
-        # What the player has sold/shorted since the start of the round
         {
+          # What the player has sold/shorted since the start of the round
           players_sold: Hash.new { |h, k| h[k] = {} },
+          # Actions taken by the player on this turn
+          current_actions: [],
           # What the player did last turn
           players_history: Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = [] } },
         }
@@ -79,7 +81,7 @@ module Engine
 
         @round.players_history[current_entity].clear
 
-        @current_actions = []
+        @round.current_actions = []
       end
 
       # Returns if a share can be bought via a normal buy actions
@@ -120,8 +122,8 @@ module Engine
       def can_sell_order?
         case @game.class::SELL_BUY_ORDER
         when :sell_buy_or_buy_sell
-          !(@current_actions.uniq(&:class).size == 2 &&
-            self.class::PURCHASE_ACTIONS.include?(@current_actions.last.class))
+          !(@round.current_actions.uniq(&:class).size == 2 &&
+            self.class::PURCHASE_ACTIONS.include?(@round.current_actions.last.class))
         when :sell_buy
           !bought?
         when :sell_buy_sell
@@ -139,7 +141,7 @@ module Engine
 
       def track_action(action, corporation, player_action = true)
         @round.last_to_act = action.entity.player
-        @current_actions << action if player_action
+        @round.current_actions << action if player_action
         @round.players_history[action.entity.player][corporation] << action
       end
 
@@ -168,7 +170,7 @@ module Engine
 
       def pass!
         super
-        if @current_actions.any?
+        if @round.current_actions.any?
           @round.pass_order.delete(current_entity)
           current_entity.unpass!
         else
@@ -179,8 +181,8 @@ module Engine
 
       def can_buy_multiple?(_entity, corporation)
         corporation.buy_multiple? &&
-         @current_actions.none? { |x| x.is_a?(Action::Par) } &&
-         @current_actions.none? { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation != corporation }
+         @round.current_actions.none? { |x| x.is_a?(Action::Par) } &&
+         @round.current_actions.none? { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation != corporation }
       end
 
       def can_sell_any?(entity)
@@ -257,11 +259,11 @@ module Engine
       end
 
       def bought?
-        @current_actions.any? { |x| self.class::PURCHASE_ACTIONS.include?(x.class) }
+        @round.current_actions.any? { |x| self.class::PURCHASE_ACTIONS.include?(x.class) }
       end
 
       def sold?
-        @current_actions.any? { |x| x.instance_of?(Action::SellShares) }
+        @round.current_actions.any? { |x| x.instance_of?(Action::SellShares) }
       end
 
       def process_buy_company(action)
@@ -277,7 +279,7 @@ module Engine
 
         entity.companies << company
         entity.spend(price, owner.nil? ? @game.bank : owner)
-        @current_actions << action
+        @round.current_actions << action
         @log << "#{owner ? '-- ' : ''}#{entity.name} buys #{company.name} from "\
                 "#{owner ? owner.name : 'the market'} for #{@game.format_currency(price)}"
       end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -193,15 +193,24 @@ module Engine
       end
 
       def can_buy_shares?(entity, shares)
-        min_share = nil
+        return false if shares.empty?
 
+        corporation = shares.first.corporation
+        if @round.players_sold[entity][corporation] || (bought? && !can_buy_multiple?(entity, corporation))
+          return false
+        end
+
+        min_share = nil
         shares.each do |share|
           next unless share.buyable
 
           min_share = share if !min_share || share.percent < min_share.percent
         end
 
-        can_buy?(entity, min_share&.to_bundle)
+        bundle = min_share&.to_bundle
+        return unless bundle
+
+        entity.cash >= bundle.price && can_gain?(entity, bundle)
       end
 
       def can_buy_any_from_market?(entity)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -196,9 +196,7 @@ module Engine
         return false if shares.empty?
 
         corporation = shares.first.corporation
-        if @round.players_sold[entity][corporation] || (bought? && !can_buy_multiple?(entity, corporation))
-          return false
-        end
+        return false if @round.players_sold[entity][corporation] || (bought? && !can_buy_multiple?(entity, corporation))
 
         min_share = nil
         shares.each do |share|


### PR DESCRIPTION
- Move buy_sell_par_share step's @current_actions array to round, so it can be used by other steps.
- Refactor 1828 steps to leverage current_actions and track round variables
- Small refactoring to buy_sell_par_share::can_buy_shares? for a 5% performance improvement
- Don't log skipping the swap train step for non-systems

Games 29466, 28559, and 27021 are expected failures due to illegal tile lays.