### PR TITLE
1893: Corrections of errors discovered during test

### DIFF
--- a/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
+++ b/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
@@ -23,9 +23,9 @@ module Engine
           def help
             return 'Select a company to auction' unless @auctioning
 
-            "Buy or Pass. If everyone passes, the price is lowered by #{@game.format_currency(10)} and a new " \
-              'buy/pass opportunity is presented. This continues until someone buys it or when price would go ' \
-              'below 50% of the value in which case the player that selected the company is force to buy it. ' \
+            "Buy (if enough cash) or Pass. If everyone passes, the price is lowered by #{@game.format_currency(10)} "\
+              'and a new buy/pass opportunity is presented. This continues until someone buys it or when price go '\
+              'below 50% of the value in which case the player that selected the company is force to buy it. '\
               'Then next player in SR order gets to select a new company to be auctioned, and so on until all ' \
               'companies are sold. Then the game continues with SR2. Note! Minors bought in this way will get the '\
               "purchase price as treasury, or #{@game.format_currency(100)}, whichever is highest."
@@ -111,7 +111,7 @@ module Engine
             @auction_triggerer = bid.entity
             target = bid_target(bid)
 
-            @game.log << "#{@auction_triggerer.name} selects #{target.name} for aution"
+            @game.log << "#{@auction_triggerer.name} selects #{target.name} for auction"
             auction_entity(target)
           end
 


### PR DESCRIPTION
- Passers during SR1 and/or initial draft, cannot act again
  during SR1 and/or initial draft
- If all players have passed during initial draft, the draft
  is completed.
- First passer during SR1 and/or initial draft will be priority
  dealer during SR2
- ADSK sell does now give money and set correct sell status
- Use correct logo for open cities
- Minor corrections of texts