### PR TITLE
save map options per title

### DIFF
--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -22,6 +22,7 @@ module Lib
       notifications: true,
       simple_logos: false,
       red_logo: false,
+      show_location_names: true,
       bg: DARK ? '#000000' : '#ffffff',
       bg2: DARK ? '#dcdcdc' : '#d3d3d3',
       font: DARK ? '#ffffff' : '#000000',
@@ -41,17 +42,15 @@ module Lib
     end
 
     def setting_for(option, game = nil)
-      if game
-        Lib::Storage["#{option}_#{game.class.title}"] || Lib::Storage[option]
-      else
-        setting = @user&.dig(:settings, option)
-        setting.nil? ? SETTINGS[option] : setting
-      end
+      [game ? Lib::Storage["#{option}_#{game.class.title}"] : @user&.dig(:settings, option),
+       Lib::Storage[option],
+       SETTINGS[option]].compact.first
     end
 
-    def save_setting(option, game, value)
+    def toggle_setting(option, game = nil)
+      value = !setting_for(option, game)
       Lib::Storage[option] = value
-      Lib::Storage["#{option}_#{game.class.title}"] = value
+      Lib::Storage["#{option}_#{game.class.title}"] = value if game
     end
 
     alias color_for setting_for

--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -40,9 +40,18 @@ module Lib
       SETTINGS[option]
     end
 
-    def setting_for(option)
-      setting = @user&.dig(:settings, option)
-      setting.nil? ? SETTINGS[option] : setting
+    def setting_for(option, game = nil)
+      if game
+        Lib::Storage["#{option}_#{game.class.title}"] || Lib::Storage[option]
+      else
+        setting = @user&.dig(:settings, option)
+        setting.nil? ? SETTINGS[option] : setting
+      end
+    end
+
+    def save_setting(option, game, value)
+      Lib::Storage[option] = value
+      Lib::Storage["#{option}_#{game.class.title}"] = value
     end
 
     alias color_for setting_for

--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -20,7 +20,6 @@ module Lib
 
     SETTINGS = {
       notifications: true,
-      simple_logos: false,
       red_logo: false,
       show_location_names: true,
       bg: DARK ? '#000000' : '#ffffff',

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -620,7 +620,7 @@ module View
       end
 
       def logo_for_user(entity)
-        setting_for(:simple_logos) ? entity.simple_logo : entity.logo
+        setting_for(:show_simple_logos, @game) ? entity.simple_logo : entity.logo
       end
 
       def can_assign_corporation?

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -620,7 +620,7 @@ module View
       end
 
       def logo_for_user(entity)
-        setting_for(:show_simple_logos, @game) ? entity.simple_logo : entity.logo
+        setting_for(:simple_logos, @game) ? entity.simple_logo : entity.logo
       end
 
       def can_assign_corporation?

--- a/assets/app/view/game/entity_list.rb
+++ b/assets/app/view/game/entity_list.rb
@@ -56,7 +56,7 @@ module View
           if entity.corporation? || entity.minor?
             size = TOKEN_SIZES[@game.corporation_size(entity)]
             logo_props = {
-              attrs: { src: setting_for(:simple_logos) ? entity.simple_logo : entity.logo },
+              attrs: { src: setting_for(:show_simple_logos, @game) ? entity.simple_logo : entity.logo },
               style: {
                 padding: "#{TOKEN_SIZES[:large] - size}rem 0.4rem 0 0",
                 height: "#{size}rem",

--- a/assets/app/view/game/entity_list.rb
+++ b/assets/app/view/game/entity_list.rb
@@ -56,7 +56,7 @@ module View
           if entity.corporation? || entity.minor?
             size = TOKEN_SIZES[@game.corporation_size(entity)]
             logo_props = {
-              attrs: { src: setting_for(:show_simple_logos, @game) ? entity.simple_logo : entity.logo },
+              attrs: { src: setting_for(:simple_logos, @game) ? entity.simple_logo : entity.logo },
               style: {
                 padding: "#{TOKEN_SIZES[:large] - size}rem 0.4rem 0 0",
                 height: "#{size}rem",

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -2,7 +2,6 @@
 
 require 'lib/hex'
 require 'lib/settings'
-require 'lib/storage'
 require 'lib/tile_selector'
 require 'view/game/actionable'
 require 'view/game/runnable'
@@ -55,8 +54,9 @@ module View
           children << h(
             Tile,
             tile: @tile,
-            show_coords: Lib::Storage['show_coords'] && (@role == :map),
-            routes: @routes
+            show_coords: setting_for(:show_coords, @game) && (@role == :map),
+            routes: @routes,
+            game: @game
           )
         end
         children << h(TriangularGrid) if Lib::Params['grid']

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -14,6 +14,7 @@ module View
       def render
         children = [
           player_colors_controls,
+          simple_logos_controls,
           location_names_controls,
           hex_coord_controls,
           starting_map_controls,
@@ -34,6 +35,19 @@ module View
         end
 
         render_button("Player Colors #{show_player_colors ? '✅' : '❌'}", on_click)
+      end
+
+      def simple_logos_controls
+        title = @game&.class&.title
+        show_simple_logos = Lib::Storage["show_simple_logos_#{title}"] || Lib::Storage['show_simple_logos']
+
+        on_click = lambda do
+          Lib::Storage['show_simple_logos'] = !show_simple_logos
+          Lib::Storage["show_simple_logos_#{title}"] = !show_simple_logos
+          update
+        end
+
+        render_button("Simple Logos #{show_simple_logos ? '✅' : '❌'}", on_click)
       end
 
       def location_names_controls

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'lib/settings'
-require 'lib/storage'
 
 module View
   module Game
@@ -13,10 +12,10 @@ module View
 
       def render
         children = [
-          player_colors_controls,
-          simple_logos_controls,
-          location_names_controls,
-          hex_coord_controls,
+          render_controls('Player Colors', :show_player_colors),
+          render_controls('Simple Logos', :simple_logos),
+          render_controls('Location Names', :show_location_names),
+          render_controls('Hex Coordinates', :show_coords),
           starting_map_controls,
           route_controls,
         ].compact
@@ -24,48 +23,13 @@ module View
         h('div#map_controls', children)
       end
 
-      def player_colors_controls
-        title = @game&.class&.title
-        show_player_colors = Lib::Storage["show_player_colors_#{title}"] || Lib::Storage['show_player_colors']
-
+      def render_controls(label, option)
         on_click = lambda do
-          Lib::Storage['show_player_colors'] = !show_player_colors
-          Lib::Storage["show_player_colors_#{title}"] = !show_player_colors
+          toggle_setting(option, @game)
           update
         end
 
-        render_button("Player Colors #{show_player_colors ? '✅' : '❌'}", on_click)
-      end
-
-      def simple_logos_controls
-        title = @game&.class&.title
-        show_simple_logos = Lib::Storage["show_simple_logos_#{title}"] || Lib::Storage['show_simple_logos']
-
-        on_click = lambda do
-          Lib::Storage['show_simple_logos'] = !show_simple_logos
-          Lib::Storage["show_simple_logos_#{title}"] = !show_simple_logos
-          update
-        end
-
-        render_button("Simple Logos #{show_simple_logos ? '✅' : '❌'}", on_click)
-      end
-
-      def location_names_controls
-        on_click = lambda do
-          Lib::Storage['hide_location_names'] = !Lib::Storage['hide_location_names']
-          update
-        end
-
-        render_button("Location Names #{Lib::Storage['hide_location_names'] ? '❌' : '✅'}", on_click)
-      end
-
-      def hex_coord_controls
-        on_click = lambda do
-          Lib::Storage['show_coords'] = !Lib::Storage['show_coords']
-          update
-        end
-
-        render_button("Hex Coordinates #{Lib::Storage['show_coords'] ? '✅' : '❌'}", on_click)
+        render_button("#{label} #{setting_for(option, @game) ? '✅' : '❌'}", on_click)
       end
 
       def starting_map_controls

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -58,7 +58,7 @@ module View
 
           children = [h(:circle, attrs: { r: @radius, fill: color })]
           children << reservation if @reservation && !@token
-          children << h(Token, token: @token, radius: radius) if @token
+          children << h(Token, token: @token, radius: radius, game: @game) if @token
 
           props = {
             on: { click: ->(event) { on_click(event) } },

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -4,7 +4,6 @@ require 'view/game/actionable'
 require 'view/game/part/base'
 require 'view/game/token'
 require 'lib/settings'
-require 'lib/storage'
 require 'lib/tile_selector'
 require 'lib/token_selector'
 
@@ -49,8 +48,7 @@ module View
         def render_part
           color = @reservation&.corporation? && @reservation&.reservation_color || 'white'
           radius = @radius
-          show_player_colors = Lib::Storage["show_player_colors_#{@game&.class&.title}"] ||
-                               Lib::Storage['show_player_colors']
+          show_player_colors = setting_for(:show_player_colors, @game)
           if show_player_colors && (owner = @token&.corporation&.owner) && @game.players.include?(owner)
             color = player_colors(@game.players)[owner]
             radius -= 4

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -202,7 +202,7 @@ module View
         }
         logo_props = {
           attrs: {
-            src: setting_for(:show_simple_logos, @game) ? corporation.simple_logo : corporation.logo,
+            src: setting_for(:simple_logos, @game) ? corporation.simple_logo : corporation.logo,
           },
           style: {
             height: '20px',

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -202,7 +202,7 @@ module View
         }
         logo_props = {
           attrs: {
-            src: setting_for(:simple_logos) ? corporation.simple_logo : corporation.logo,
+            src: setting_for(:show_simple_logos, @game) ? corporation.simple_logo : corporation.logo,
           },
           style: {
             height: '20px',

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -229,7 +229,7 @@ module View
       end
 
       def logo_for_user(entity)
-        setting_for(:show_simple_logos, @game) ? entity.simple_logo : entity.logo
+        setting_for(:simple_logos, @game) ? entity.simple_logo : entity.logo
       end
 
       def render

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -229,7 +229,7 @@ module View
       end
 
       def logo_for_user(entity)
-        setting_for(:simple_logos) ? entity.simple_logo : entity.logo
+        setting_for(:show_simple_logos, @game) ? entity.simple_logo : entity.logo
       end
 
       def render

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -16,6 +16,7 @@ module View
     class Tile < Snabberb::Component
       include Lib::Settings
 
+      needs :game, default: nil
       needs :tile
       needs :routes, default: []
       needs :show_coords, default: nil
@@ -73,7 +74,7 @@ module View
         children << borders if borders
         children << render_tile_part(Part::Partitions) unless @tile.partitions.empty?
 
-        children << rendered_loc_name if rendered_loc_name && setting_for(:show_location_names)
+        children << rendered_loc_name if rendered_loc_name && setting_for(:show_location_names, @game)
         children << render_coords if @show_coords
 
         children.flatten!

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'lib/storage'
+require 'lib/settings'
 require 'view/game/part/blocker'
 require 'view/game/part/borders'
 require 'view/game/part/cities'
@@ -14,6 +14,8 @@ require 'view/game/part/upgrades'
 module View
   module Game
     class Tile < Snabberb::Component
+      include Lib::Settings
+
       needs :tile
       needs :routes, default: []
       needs :show_coords, default: nil
@@ -71,7 +73,7 @@ module View
         children << borders if borders
         children << render_tile_part(Part::Partitions) unless @tile.partitions.empty?
 
-        children << rendered_loc_name if rendered_loc_name && !Lib::Storage['hide_location_names']
+        children << rendered_loc_name if rendered_loc_name && setting_for(:show_location_names)
         children << render_coords if @show_coords
 
         children.flatten!

--- a/assets/app/view/game/token.rb
+++ b/assets/app/view/game/token.rb
@@ -28,7 +28,7 @@ module View
       def render_token
         h(
           :image, attrs: {
-            href: setting_for(:show_simple_logos, @game) ? @token.simple_logo : @token.logo,
+            href: setting_for(:simple_logos, @game) ? @token.simple_logo : @token.logo,
             x: -@radius,
             y: -@radius,
             height: (2 * @radius),

--- a/assets/app/view/game/token.rb
+++ b/assets/app/view/game/token.rb
@@ -7,6 +7,7 @@ module View
     class Token < Snabberb::Component
       include Lib::Settings
 
+      needs :game
       needs :token
       needs :radius
       needs :user, default: nil, store: true
@@ -27,7 +28,7 @@ module View
       def render_token
         h(
           :image, attrs: {
-            href: setting_for(:simple_logos) ? @token.simple_logo : @token.logo,
+            href: setting_for(:show_simple_logos, @game) ? @token.simple_logo : @token.logo,
             x: -@radius,
             y: -@radius,
             height: (2 * @radius),

--- a/assets/app/view/game/token_selector.rb
+++ b/assets/app/view/game/token_selector.rb
@@ -36,7 +36,7 @@ module View
 
           props = {
             attrs: {
-              src: setting_for(:show_simple_logos, @game) ? token.simple_logo : token.logo,
+              src: setting_for(:simple_logos, @game) ? token.simple_logo : token.logo,
             },
             on: {
               click: click,

--- a/assets/app/view/game/token_selector.rb
+++ b/assets/app/view/game/token_selector.rb
@@ -36,7 +36,7 @@ module View
 
           props = {
             attrs: {
-              src: setting_for(:simple_logos) ? token.simple_logo : token.logo,
+              src: setting_for(:show_simple_logos, @game) ? token.simple_logo : token.logo,
             },
             on: {
               click: click,

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -45,7 +45,6 @@ module View
         h('div#settings__options', [
           render_checkbox('Turn and Message Emails', :notifications),
           render_checkbox('Red 18xx.games Logo', :red_logo),
-          render_checkbox('Simple Corporation Logos', :simple_logos),
         ]),
         h('div#settings__colors', { style: { maxWidth: '38rem' } }, [
           render_color('Main Background', :bg, color_for(:bg)),
@@ -108,7 +107,7 @@ module View
     end
 
     def reset_settings
-      %i[simple_logos red_logo].each { |e| input_elm(e).checked = default_for(e) }
+      input_elm(:red_logo).checked = default_for(:red_logo)
       %i[bg font bg2 font2 your_turn hotseat_game].each { |e| input_elm(e).value = default_for(e) }
       TILE_COLORS.each { |color, hex_color| input_elm(color).value = hex_color }
       ROUTE_COLORS.each_with_index do |hex_color, index|

--- a/models/user.rb
+++ b/models/user.rb
@@ -16,7 +16,7 @@ class User < Base
       "r#{index}_#{prop}"
     end
   end + %w[
-    consent notifications simple_logos red_logo bg font bg2 font2 your_turn hotseat_game
+    consent notifications red_logo bg font bg2 font2 your_turn hotseat_game
     white yellow green brown gray red blue
   ]).freeze
 

--- a/spec/assets/app/view/game/part/slot_spec.rb
+++ b/spec/assets/app/view/game/part/slot_spec.rb
@@ -35,7 +35,7 @@ module View
               slot.render
 
               # assert
-              expect(slot).to have_received(:h).with(Token, token: token, radius: radius)
+              expect(slot).to have_received(:h).with(Token, token: token, radius: radius, game: nil)
             end
           end
 


### PR DESCRIPTION
In addition to adding a simple_logos button to map controls (closes #4278) this also allows saving options for location names and hex coords _per title_. (Mainly because it’s more code efficient that way, but I guess some people might appreciate it.)
Option for simple_logos in profile is gone.
Default settings are the same as before. All affected buttons are designed to toggle the status of both the per-title option _and_ the corresponding default option. This way it’s possible to toggle all options in any game and save title specific settings in any game of that title.