### PR TITLE
Show Progressbar for 18MS

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -360,7 +360,10 @@ module View
           # the space is nut just a space but a &nbsp in unicode;
           cells << h(:div, cell_props(item[:type], @game.round_counter == index),
                      [h('div.center', item[:value] || ' '), h('div.nowrap', "#{item[:type]} #{item[:name]}")])
-          cells << h(:div, cell_props(:Export), [train_export]) if item[:exportAfter]
+          cells << h(:div, cell_props(:Export), [
+            item[:exportAfterValue] ? h(:div, item[:exportAfterValue]) : nil,
+            train_export,
+          ].compact) if item[:exportAfter]
           cells
         end
 
@@ -374,6 +377,8 @@ module View
             [color_for(:green), contrast_on(color_for(:green)), 'space-between']
           when :Export
             [color_for(:yellow), contrast_on(color_for(:yellow)), 'center']
+          when :End
+            [color_for(:blue), contrast_on(color_for(:blue)), 'space-between']
           else
             [color_for(:bg2), color_for(:font2), 'space-between']
           end

--- a/lib/engine/game/g_18_ms/game.rb
+++ b/lib/engine/game/g_18_ms/game.rb
@@ -731,6 +731,34 @@ module Engine
           super
         end
 
+        def show_progress_bar?
+          true
+        end
+
+        def progress_information
+          base_progress = [
+            { type: :PRE },
+            { type: :SR },
+            { type: :OR, name: '1' },
+            { type: :OR, name: '2' },
+            { type: :SR },
+            { type: :OR, name: '3' },
+            { type: :OR, name: '4', exportAfter: true },
+            { type: :SR },
+            { type: :OR, name: '5' },
+            { type: :OR, name: '6', exportAfter: true },
+            { type: :SR },
+            { type: :OR, name: '7' },
+            { type: :OR, name: '8', exportAfter: true },
+            { type: :SR },
+            { type: :OR, name: '9' },
+            { type: :OR, name: '10' },
+          ]
+
+          base_progress.push({ type: :OR, name: '11' }) if @optional_rules&.include?(:or_11)
+          base_progress.push({ type: :END })
+        end
+
         private
 
         def rust_all(train, salvage)

--- a/lib/engine/game/g_18_ms/game.rb
+++ b/lib/engine/game/g_18_ms/game.rb
@@ -743,20 +743,20 @@ module Engine
             { type: :OR, name: '2' },
             { type: :SR },
             { type: :OR, name: '3' },
-            { type: :OR, name: '4', exportAfter: true },
+            { type: :OR, name: '4', exportAfter: true, exportAfterValue: '2+' },
             { type: :SR },
             { type: :OR, name: '5' },
-            { type: :OR, name: '6', exportAfter: true },
+            { type: :OR, name: '6', exportAfter: true, exportAfterValue: '3+' },
             { type: :SR },
             { type: :OR, name: '7' },
-            { type: :OR, name: '8', exportAfter: true },
+            { type: :OR, name: '8', exportAfter: true, exportAfterValue: '4+' },
             { type: :SR },
             { type: :OR, name: '9' },
             { type: :OR, name: '10' },
           ]
 
-          base_progress.push({ type: :OR, name: '11' }) if @optional_rules&.include?(:or_11)
-          base_progress.push({ type: :END })
+          base_progress << { type: :OR, name: '11' } if @optional_rules&.include?(:or_11)
+          base_progress << { type: :End }
         end
 
         private


### PR DESCRIPTION
Adds Progress bar for 18 MS
The train icons are in 18CZ for export, but I think it works for 18MS as well for the rusting. 
![image](https://user-images.githubusercontent.com/7661170/110522576-5414ab80-8111-11eb-9c7b-5fab5aaded88.png)


With OR 11 optional rule there is one more OR in the progress bar
closes #4392 