### PR TITLE
[18Neb] adds HomeToken step to Stock Round in 18Neb

### DIFF
--- a/lib/engine/game/g_18_neb/game.rb
+++ b/lib/engine/game/g_18_neb/game.rb
@@ -337,6 +337,7 @@ module Engine
                 owner_type: 'corporation',
                 hexes: %w[K3 K5 K7 J8 L8 L10],
                 count: 2,
+                closed_when_used_up: true,
                 remove: 5,
               },
             ],
@@ -501,11 +502,11 @@ module Engine
             name: 'NebKota',
             logo: '18_neb/NR',
             shares: [40, 20, 20, 20],
-            type: 'local',
             tokens: [0, 40],
             coordinates: 'C3',
             max_ownership_percent: 100,
             color: '#000000',
+            type: 'local',
             always_market_price: true,
             reservation_color: nil,
           },
@@ -629,6 +630,16 @@ module Engine
           Round::Auction.new(self, [
             Engine::Step::CompanyPendingPar,
             G18NEB::Step::PriceFindingAuction,
+          ])
+        end
+
+        def stock_round
+          Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::HomeToken,
+            Engine::Step::SpecialTrack,
+            Engine::Step::BuySellParShares,
           ])
         end
 

--- a/lib/engine/game/g_18_neb/game.rb
+++ b/lib/engine/game/g_18_neb/game.rb
@@ -337,7 +337,6 @@ module Engine
                 owner_type: 'corporation',
                 hexes: %w[K3 K5 K7 J8 L8 L10],
                 count: 2,
-                closed_when_used_up: true,
                 remove: 5,
               },
             ],


### PR DESCRIPTION
Adds custom stock_round method to 18Neb with Engine::Step::HomeToken so that Local Railroad Corporations can set home token when they float in phase 5. 
