### PR TITLE
[1822] Refactor graph walk

### DIFF
--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -97,6 +97,7 @@ module Engine
       hexes = Hash.new { |h, k| h[k] = {} }
       nodes = {}
       paths = {}
+      connections = Hash.new { |h, k| h[k] = false }
 
       @game.hexes.each do |hex|
         hex.tile.cities.each do |city|
@@ -155,7 +156,8 @@ module Engine
 
         walk_corporation = @no_blocking ? nil : corporation
 
-        node.walk(visited: visited, corporation: walk_corporation, skip_track: @skip_track) do |path|
+        node.walk(visited: visited, corporation: walk_corporation, skip_track: @skip_track,
+                  connections: connections) do |path|
           paths[path] = true
           path.nodes.each do |p_node|
             nodes[p_node] = true

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -44,34 +44,46 @@ module Engine
       # on: see Path::Walk
       # corporation: If set don't walk on adjacent nodes which are blocked for the passed corporation
       # skip_track: If passed, don't walk on track of that type (ie: :broad track for 1873)
+      # connections: a mutable hashset of path connections
+      # max_nodes: max depth of nodes we will try to walk
       #
       # This method recursively bubbles up yielded values from nested Node::Walk and Path::Walk calls
-      def walk(visited: nil, on: nil, corporation: nil, visited_paths: {}, visited_edges: nil, skip_track: nil)
+      def walk(visited: nil, on: nil, corporation: nil, visited_paths: {}, visited_edges: nil, skip_track: nil,
+               connections: nil, max_nodes: nil)
         return if visited&.[](self)
 
         visited = visited&.dup || {}
         visited_edges = visited_edges&.dup || {}
         visited[self] = true
+        return if max_nodes && visited.size >= max_nodes
 
         paths.each do |node_path|
           next if node_path.track == skip_track
 
-          node_path.walk(visited: visited_paths, on: on, visited_edges: visited_edges) do |path, vp, ve|
-            yield path
-            path.nodes.each do |next_node|
-              next if next_node == self
-              next if corporation && next_node.blocks?(corporation)
-              next if path.terminal?
+          if connections
+            node_path.walk(visited: visited_paths, on: on, visited_edges: visited_edges, skip_track: skip_track,
+                           corporation: corporation, connections: connections, visited_nodes: visited,
+                           current_node: self, max_nodes: max_nodes) do |path|
+              yield path
+            end
+          else
+            node_path.walk(visited: visited_paths, on: on, visited_edges: visited_edges) do |path, vp, ve|
+              yield path
+              path.nodes.each do |next_node|
+                next if next_node == self
+                next if corporation && next_node.blocks?(corporation)
+                next if path.terminal?
 
-              next_node.walk(
-                visited: visited,
-                on: on,
-                corporation: corporation,
-                # Is merging what we passed into node_path.walk with what it gave us actually neccessary?
-                visited_paths: visited_paths.merge(vp),
-                visited_edges: visited_edges.merge(ve),
-                skip_track: skip_track,
-              ) { |p| yield p }
+                next_node.walk(
+                  visited: visited,
+                  on: on,
+                  corporation: corporation,
+                  # Is merging what we passed into node_path.walk with what it gave us actually neccessary?
+                  visited_paths: visited_paths.merge(vp),
+                  visited_edges: visited_edges.merge(ve),
+                  skip_track: skip_track,
+                ) { |p| yield p }
+              end
             end
           end
         end


### PR DESCRIPTION
**Changes to base code**
- Engine::Part::Node. Added a new method graph_walk. I opted to make a new method just for the walk called from the graph. Reason for this is in the first step i didnt want to mess with the walk which is called from different games in example 1856 and 1860.
- Engine::Part::Path. Added a new method graph_walk. Reason for the new method is the same as above. The orginal walk is aslo called when you lay a tile with the chain parameter. I didnt want to touch theese in the first round of refactor.
- Engine::Graph. Calling the new graph_walk method. path_node is a mutable hash to pass down if we are starting from multiple token nodes. No need to traverse paths we already is done with.


**1822 Specific**
- No changes here.

fixes #4346
fixes #4354

This have no effect on current games.