### PR TITLE
[1822] E-trains

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -527,19 +527,8 @@ module Engine
             variants: [
               {
                 name: 'E',
-                distance: [
-                  {
-                    'nodes' => %w[city offboard],
-                    'pay' => 99,
-                    'visit' => 99,
-                    'multiplier' => 2,
-                  },
-                  {
-                    'nodes' => ['town'],
-                    'pay' => 0,
-                    'visit' => 99,
-                  },
-                ],
+                distance: 99,
+                multiplier: 2,
                 price: 1000,
               },
             ],


### PR DESCRIPTION
[1822] E-trains

- Changed the distance of the train to just have a number instead of a array with nodes. Doesnt use the normal revenue calculation so no need for the array.

fixes #4383

This have no effect on current games.