### PR TITLE
[1822] E-buy train

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -33,6 +33,8 @@ module Engine
 
         CERT_LIMIT = { 3 => 26, 4 => 20, 5 => 16, 6 => 13, 7 => 11 }.freeze
 
+        EBUY_OTHER_VALUE = false
+
         STARTING_CASH = { 3 => 700, 4 => 525, 5 => 420, 6 => 350, 7 => 300 }.freeze
 
         CAPITALIZATION = :incremental


### PR DESCRIPTION
-  Company should not be allowed to cross-buy using director's contribution during EMR.

fixes #4333