### PR TITLE
[1822] Minor changes

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -364,6 +364,7 @@ module Engine
           'P39' => 'Canterbury',
           'P41' => 'Dover',
           'P43' => 'English Channel',
+          'Q30' => 'Norwich',
           'Q44' => 'France',
         }.freeze
 
@@ -1271,7 +1272,8 @@ module Engine
             sym: 'M14',
             value: 100,
             revenue: 0,
-            desc: 'A 50% director’s certificate in the associated minor company. Starting location is M38.',
+            desc: 'A 50% director’s certificate in the associated minor company. Starting location is M38. Home '\
+                  'token cost £20, placing home token counts as first tile lay. ',
             abilities: [],
             color: '#ffffff',
             text_color: 'black',
@@ -3792,13 +3794,13 @@ module Engine
               c.id != self.class::COMPANY_LCDR && self.class::PLUS_EXPANSION_BIDBOX_2.include?(c.id)
             end
             privates.delete(company)
-            @log << "#{company.id}-#{company.name} have been removed from the game"
+            @log << "#{company.name} have been removed from the game"
 
             # Remove two of the bidbox 3 privates
             2.times.each do |_|
               company = privates.find { |c| self.class::PLUS_EXPANSION_BIDBOX_3.include?(c.id) }
               privates.delete(company)
-              @log << "#{company.id}-#{company.name} have been removed from the game"
+              @log << "#{company.name} have been removed from the game"
             end
           end
 


### PR DESCRIPTION
- Missed Q30's city name.
- Some more information on minor 14 and its home token cost.
- Removed the dubble company id when you start 1822+.

On #4376 it solves 2.