### PR TITLE
[1822] Reservation color

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -23,9 +23,9 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent, :capitalization, :second_share,
-                  :type, :floatable, :original_par_price
+                  :type, :floatable, :original_par_price, :reservation_color
     attr_reader :companies, :min_price, :name, :full_name, :fraction_shares, :id, :needs_token_to_par,
-                :presidents_share, :reservation_color
+                :presidents_share
     attr_writer :par_price, :share_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2277,6 +2277,8 @@ module Engine
         BIDDING_BOX_CONCESSION_COUNT = 3
         BIDDING_BOX_PRIVATE_COUNT = 3
 
+        BIDDING_BOX_MINOR_COLOR = '#c6e9af'
+
         BIDDING_BOX_START_MINOR = 'M24'
         BIDDING_BOX_START_CONCESSION = 'C1'
         BIDDING_BOX_START_PRIVATE = 'P1'
@@ -3305,6 +3307,11 @@ module Engine
           @bidbox_minors_cache = bank_companies(self.class::COMPANY_MINOR_PREFIX)
                                    .first(self.class::BIDDING_BOX_MINOR_COUNT)
                                    .map(&:id)
+
+          # Set the reservation color of all the minors in the bid boxes
+          @bidbox_minors_cache.each do |company_id|
+            corporation_by_id(company_id[1..-1]).reservation_color = self.class::BIDDING_BOX_MINOR_COLOR
+          end
         end
 
         def can_gain_extra_train?(entity, train)

--- a/lib/engine/game/g_1822/round/stock.rb
+++ b/lib/engine/game/g_1822/round/stock.rb
@@ -87,6 +87,7 @@ module Engine
 
             # Find the correct minor in the corporations
             minor = @game.find_corporation(company)
+            minor.reservation_color = :white
 
             # Get the correct par price according to phase
             current_phase = @game.phase.name.to_i


### PR DESCRIPTION
**Changes to base code**
- Engine::Corporation. Moved reservation_color from attr_reader to attr_accessor. Reason for this it to be able to set the reservation color of the minors which is in the bid box. This so you easly can see them on the map.

**1822 Specific**
- When we refill the bank minors, also set the reservation color of them so you can see them on the map.

fixes #4328
On #4376 it solves 1.

This change doesnt affect any of the current inprogress games.