### PR TITLE
mobile browsers: prevent copy popup on route selection

### DIFF
--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -114,6 +114,12 @@ th, td {
   vertical-align: top;
 }
 
+svg {
+  user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+}
+
 #game_info tbody > tr:hover, #bank.card tr:hover, #upcoming_trains.card tr:hover {
   background-color: gainsboro;
   color: black;


### PR DESCRIPTION
… and any other svgs. fixes #4430
It might affect other browsers, too, hence the browser prefixes.