### PR TITLE
[1822] Incorrect revenue for cardiff brown tile

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -163,7 +163,7 @@ module Engine
               'count' => 1,
               'color' => 'brown',
               'code' =>
-                'city=revenue:50,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=C',
+                'city=revenue:40,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=C',
             },
           'X7' =>
             {


### PR DESCRIPTION
fixes #4437

This change doesnt affect any of the current inprogress games.
