### PR TITLE
[1822] Tax haven market share

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -3549,7 +3549,8 @@ module Engine
           spender = company.owner
           bundle = company_tax_haven_bundle(choice)
           corporation = bundle.corporation
-          @share_pool.transfer_shares(bundle, @tax_haven, spender: spender, receiver: corporation,
+          receiver = bundle.owner == @share_pool ? @bank : corporation
+          @share_pool.transfer_shares(bundle, @tax_haven, spender: spender, receiver: receiver,
                                                           price: bundle.price, allow_president_change: false)
           @log << "#{spender.name} spends #{format_currency(bundle.price)} and tax haven gains a share of "\
                   "#{corporation.name}."


### PR DESCRIPTION
- If its a market share tax haven buys the money should go to the bank.

fixes #4443

This change might affect games that bought a market share and then spent the money the corporation got.