### PR TITLE
For portability, use find rather than stat

### DIFF
--- a/scripts/data_dir.sh
+++ b/scripts/data_dir.sh
@@ -18,11 +18,9 @@ mkdir -p db/data
 if [[ $1 == 'podman' ]]; then
   db_uid=1000
   mapped_db_uid=$(($(grep "^$USER:" /etc/subuid | cut -d: -f2) - 1 + db_uid))
-  if [[ $(stat -f%u db/data) -ne $mapped_db_uid ]]; then
-    sudo chown -R $mapped_db_uid:$mapped_db_uid db/data
-  fi
+  find db/data -prune -type d ! -user $mapped_db_uid -exec \
+       sudo chown -R $mapped_db_uid:$mapped_db_uid \;
 else
-  if [[ $(stat -f%u db/data) == '0' ]]; then
-    sudo chown -R "$USER":"$USER" db/data
-  fi
+  find db/data -prune -type d -user root -exec \
+       sudo chown -R "$USER":"$USER" \;
 fi


### PR DESCRIPTION
Contrary to the commit message of da1f300, POSIX does not specify a `stat` command.  It turns out that BSD `stat` uses `-f` to specify a format, whereas GNU `stat` uses `-c`.

Work around this by using `find` instead.