### PR TITLE
use .dup on visited_edges to prevent sideeffects from branchs

### DIFF
--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -46,10 +46,11 @@ module Engine
       # skip_track: If passed, don't walk on track of that type (ie: :broad track for 1873)
       #
       # This method recursively bubbles up yielded values from nested Node::Walk and Path::Walk calls
-      def walk(visited: nil, on: nil, corporation: nil, visited_paths: {}, visited_edges: {}, skip_track: nil)
+      def walk(visited: nil, on: nil, corporation: nil, visited_paths: {}, visited_edges: nil, skip_track: nil)
         return if visited&.[](self)
 
         visited = visited&.dup || {}
+        visited_edges = visited_edges&.dup || {}
         visited[self] = true
 
         paths.each do |node_path|

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -117,10 +117,11 @@ module Engine
       #  * If `chain` is nil `walk` will yield to a block, providing this Part and the visited Paths including this one
 
       # on: HashSet of Paths that we want to *exclusively* walk on
-      def walk(skip: nil, jskip: nil, visited: nil, visited_edges: {}, on: nil, chain: nil)
+      def walk(skip: nil, jskip: nil, visited: nil, visited_edges: nil, on: nil, chain: nil)
         return if visited&.[](self)
 
         visited = visited&.dup || {}
+        visited_edges = visited_edges&.dup || {}
         visited[self] = true
 
         if chain

--- a/spec/fixtures/18MEX/README.md
+++ b/spec/fixtures/18MEX/README.md
@@ -1,0 +1,3 @@
+18MEX Hotseat game manifest
+hotseat01
+ * This game verifies that routing up and down both lanes of the brown mexico city tile is allowed


### PR DESCRIPTION
This also adds the README.md that was supposed to be added with the hotseat game fixture in 18MEX but didn't get added succesfully