### PR TITLE
highlight bidding players

### DIFF
--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -121,7 +121,7 @@ module View
             },
           }
 
-          children = [h(Company, company: company, bids: @step.bids[company])]
+          children = [h(Company, company: company, bids: @step.bids[company], user: @user)]
           children << render_input(company) if @selected_company == company
           h(:div, props, children)
         end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -20,6 +20,7 @@ module View
         needs :selected_company, default: nil, store: true
         needs :last_player, default: nil, store: true
         needs :show_other_players, default: nil, store: true
+        needs :user, default: nil
 
         def render
           @step = @game.round.active_step
@@ -299,7 +300,7 @@ module View
 
           @game.companies.select { |c| c.owner == @game.bank }.map do |company|
             children = []
-            children << h(Company, company: company,
+            children << h(Company, company: company, user: @user,
                                    bids: (@current_actions.include?('bid') ? @step.bids[company] : nil))
             if @selected_company == company
               inputs = []

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -389,7 +389,7 @@ module View
         if !(%w[place_token lay_tile remove_token] & current_entity_actions).empty?
           h(Game::Map, game: @game)
         else
-          h(Game::Round::Stock, game: @game)
+          h(Game::Round::Stock, game: @game, user: @user)
         end
       when Engine::Round::Operating
         if current_entity_actions.include?('merge')


### PR DESCRIPTION
closes #4385

Table instead of string. Bidding players are highlighted as follows:

map: player colors ✅ / on
=> colors configured in profile are used
![image](https://user-images.githubusercontent.com/33390595/110838093-5bb78a00-82a2-11eb-9cc2-81b7dd2a04dd.png)

map: player colors ❌ / off (default) && user participating in game
=> currently winning bid = green, bidding = yellow
![image](https://user-images.githubusercontent.com/33390595/110838081-59553000-82a2-11eb-8b34-13cf32d5b33f.png)


