### PR TITLE
[1822] Sold-out companies

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2879,6 +2879,11 @@ module Engine
           stock_round
         end
 
+        def init_stock_market
+          G1822::StockMarket.new(game_market, self.class::CERT_LIMIT_TYPES,
+                                 multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
+        end
+
         def must_buy_train?(entity)
           entity.trains.none? { |t| !extra_train?(t) } &&
           !depot.depot_trains.empty?

--- a/lib/engine/game/g_1822/stock_market.rb
+++ b/lib/engine/game/g_1822/stock_market.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../../stock_market'
+
+module Engine
+  module Game
+    module G1822
+      class StockMarket < Engine::StockMarket
+        def move_up(corporation)
+          r, c = corporation.share_price.coordinates
+
+          if r.positive? && share_price(r - 1, c)
+            r -= 1
+          else
+            r += 1
+            c += 1
+          end
+          move(corporation, r, c)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- At the end of the stock round, if 100% of any company is in players hands the stock market token for each such company rises one space vertically on the stock market, if possible. If the token is already at the top of the chart, it moves diagonally one space down to the right.

fixes #4343

This change might affect games that bought a share with the wrong price.