### PR TITLE
[1822] Pullman Trains

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2329,6 +2329,7 @@ module Engine
         EXTRA_TRAIN_PULLMAN = 'P+'
         EXTRA_TRAIN_PERMANENTS = %w[2P LP].freeze
         LOCAL_TRAINS = %w[L LP].freeze
+        E_TRAIN = 'E'
 
         LIMIT_TOKENS_AFTER_MERGER = 9
 

--- a/lib/engine/game/g_1822/step/route.rb
+++ b/lib/engine/game/g_1822/step/route.rb
@@ -12,7 +12,9 @@ module Engine
 
             @pullman_train ||= nil
             actions = ACTIONS.dup
-            actions << 'choose' if !@pullman_train && find_pullman_train(entity)
+            if !@pullman_train && find_pullman_train(entity) && !pullman_train_choices(entity).empty?
+              actions << 'choose'
+            end
             actions
           end
 
@@ -55,7 +57,9 @@ module Engine
           end
 
           def pullman_train_choices(entity)
-            @game.route_trains(entity).reject { |t| @game.class::LOCAL_TRAINS.include?(t.name) }
+            @game.route_trains(entity).reject do |t|
+              @game.class::LOCAL_TRAINS.include?(t.name) || t.name == @game.class::E_TRAIN
+            end
           end
 
           def find_pullman_train(entity)


### PR DESCRIPTION
[1822] Pullman Trains

- You shouldnt be able to attach a pullman to a e-train.

fixes #4453

This change might affect games if someone attached a pullman to an e-train.
