### PR TITLE
spreadsheet sort enhancements

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -177,7 +177,11 @@ module View
           extra << h(:th, render_sort_link('Buying Power', :buying_power))
           extra << h(:th, render_sort_link('Interest Due', :interest))
         end
+        if (@diff_corp_sizes = @game.all_corporations.map { |c| @game.corporation_size(c) }.uniq != [:small])
+          extra << h(:th, render_sort_link('Size', :corp_size))
+        end
         @extra_size = extra.size
+
         [
           h(:tr, [
             h(:th, { style: { minWidth: '5rem' } }, ''),
@@ -337,6 +341,8 @@ module View
               @game.buying_power(corporation, full: true)
             when :interest
               @game.interest_owed(corporation) if @game.total_loans.positive?
+            when :corp_size
+              @game.corporation_size(corporation)
             when :companies
               corporation.companies.size
             else
@@ -393,6 +399,11 @@ module View
             interest_props[:style][:color] = contrast_on(color)
           end
           extra << h(:td, interest_props, @game.format_currency(@game.interest_owed(corporation)).to_s)
+        end
+        if @diff_corp_sizes
+          corp_size = @game.corporation_size(corporation)
+          corp_size = corp_size[0].capitalize if %w[small medium large].include?(corp_size)
+          extra << h(:td, corp_size)
         end
 
         h(:tr, tr_props, [

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -219,7 +219,7 @@ module View
             title: 'Sort',
             click: lambda {
               mark_sort_column(sort_by)
-              toggle_sort_order
+              toggle_sort_order if @spreadsheet_sort_by == sort_by
             },
             children: text,
           ),

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -383,7 +383,9 @@ module View
 
         order_props = { style: { paddingLeft: '1.2em' } }
         order_props[:style][:color] =
-          if corporation.operating_history.keys[-1] == current_round
+          if operating_order.zero?
+            'transparent'
+          elsif corporation.operating_history.keys[-1] == current_round
             convert_hex_to_rgba(color_for(:font2), 0.5)
           end
 

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -382,7 +382,10 @@ module View
         end
 
         order_props = { style: { paddingLeft: '1.2em' } }
-        operating_order_text = "#{operating_order}#{corporation.operating_history.keys[-1] == current_round ? '*' : ''}"
+        order_props[:style][:color] =
+          if corporation.operating_history.keys[-1] == current_round
+            convert_hex_to_rgba(color_for(:font2), 0.5)
+          end
 
         extra = []
         extra << h(:td, "#{corporation.loans.size}/#{@game.maximum_loans(corporation)}") if @game.total_loans&.nonzero?
@@ -437,7 +440,7 @@ module View
           h('td.padded_number', market_props,
             corporation.share_price ? @game.format_currency(corporation.share_price.price) : ''),
           h('td.padded_number', @game.format_currency(corporation.cash)),
-          h('td.left', order_props, operating_order_text),
+          h('td.padded_number', order_props, operating_order),
           h(:td, corporation.trains.map(&:name).join(', ')),
           h(:td, @game.token_string(corporation)),
           *extra,

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -216,6 +216,7 @@ module View
 
       def render_sort_link(text, sort_by)
         [
+          h(:span, @spreadsheet_sort_by == sort_by ? sort_order_icon : ''),
           h(
             Link,
             href: '',
@@ -226,7 +227,6 @@ module View
             },
             children: text,
           ),
-          h(:span, @spreadsheet_sort_by == sort_by ? sort_order_icon : ''),
         ]
       end
 

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -404,11 +404,7 @@ module View
           end
           extra << h(:td, interest_props, @game.format_currency(@game.interest_owed(corporation)).to_s)
         end
-        if @diff_corp_sizes
-          corp_size = @game.corporation_size(corporation)
-          corp_size = corp_size[0].capitalize if %w[small medium large].include?(corp_size)
-          extra << h(:td, corp_size)
-        end
+        extra << h(:td, @game.corporation_size_name(corporation)) if @diff_corp_sizes
 
         n_ipo_shares = num_shares_of(corporation, corporation)
         n_market_shares = num_shares_of(@game.share_pool, corporation)

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -340,7 +340,10 @@ module View
             when :companies
               corporation.companies.size
             else
-              @game.player_by_id(@spreadsheet_sort_by)&.num_shares_of(corporation)
+              p = @game.player_by_id(@spreadsheet_sort_by)
+              n = p&.num_shares_of(corporation)
+              n += 0.01 if corporation.president?(p)
+              n || 0
             end
           end
         end

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -176,7 +176,7 @@ module View
           extra << h(:th, render_sort_link('Buying Power', :buying_power))
           extra << h(:th, render_sort_link('Interest Due', :interest))
         end
-        if (@diff_corp_sizes = @game.all_corporations.map { |c| @game.corporation_size(c) }.uniq != [:small])
+        if (@diff_corp_sizes = @game.all_corporations.any? { |c| @game.corporation_size(c) != :small })
           extra << h(:th, render_sort_link('Size', :corp_size))
         end
         @extra_size = extra.size

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -410,6 +410,8 @@ module View
           extra << h(:td, corp_size)
         end
 
+        n_ipo_shares = num_shares_of(corporation, corporation)
+        n_market_shares = num_shares_of(@game.share_pool, corporation)
         h(:tr, tr_props, [
           h(:th, name_props, corporation.name),
           *@game.players.map do |p|
@@ -418,25 +420,26 @@ module View
               props[:style][:backgroundColor] = '#9e0000'
               props[:style][:color] = 'white'
             end
-            props[:style][:color] = 'transparent' if num_shares_of(p, corporation).zero?
+            n_shares = num_shares_of(p, corporation)
+            props[:style][:color] = 'transparent' if n_shares.zero?
             share_holding = corporation.president?(p) ? '*' : ''
-            share_holding += num_shares_of(p, corporation).to_s unless corporation.minor?
+            share_holding += n_shares.to_s unless corporation.minor?
             h('td.padded_number', props, share_holding)
           end,
           h('td.padded_number', {
               style: {
                 borderLeft: border_style,
-                color: num_shares_of(corporation, corporation).zero? ? 'transparent' : 'inherit',
+                color: n_ipo_shares.zero? ? 'transparent' : 'inherit',
               },
             },
-            num_shares_of(corporation, corporation)),
+            n_ipo_shares),
           h('td.padded_number', {
               style: {
                 borderRight: border_style,
-                color: num_shares_of(@game.share_pool, corporation).zero? ? 'transparent' : 'inherit',
+                color: n_market_shares.zero? ? 'transparent' : 'inherit',
               },
             },
-            "#{corporation.receivership? ? '*' : ''}#{num_shares_of(@game.share_pool, corporation)}"),
+            "#{corporation.receivership? ? '*' : ''}#{n_market_shares}"),
           h('td.padded_number', corporation.par_price ? @game.format_currency(corporation.par_price.price) : ''),
           h('td.padded_number', market_props,
             corporation.share_price ? @game.format_currency(corporation.share_price.price) : ''),

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -430,11 +430,12 @@ module View
             style: {
               maxWidth: PLAYER_COL_MAX_WIDTH,
               whiteSpace: 'normal',
+              textAlign: 'right',
             },
           }
           props[:style][:minWidth] = min_width(entity)
         end
-        h('td.right', props, entity.companies.map(&:sym).join(', '))
+        h(:td, props, entity.companies.map(&:sym).join(', '))
       end
 
       def render_player_companies

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -409,17 +409,29 @@ module View
         h(:tr, tr_props, [
           h(:th, name_props, corporation.name),
           *@game.players.map do |p|
-            sold_props = { style: {} }
+            props = { style: {} }
             if @game.round.active_step&.did_sell?(corporation, p)
-              sold_props[:style][:backgroundColor] = '#9e0000'
-              sold_props[:style][:color] = 'white'
+              props[:style][:backgroundColor] = '#9e0000'
+              props[:style][:color] = 'white'
             end
+            props[:style][:color] = 'transparent' if num_shares_of(p, corporation).zero?
             share_holding = corporation.president?(p) ? '*' : ''
             share_holding += num_shares_of(p, corporation).to_s unless corporation.minor?
-            h('td.padded_number', sold_props, share_holding)
+            h('td.padded_number', props, share_holding)
           end,
-          h('td.padded_number', { style: { borderLeft: border_style } }, num_shares_of(corporation, corporation).to_s),
-          h('td.padded_number', { style: { borderRight: border_style } },
+          h('td.padded_number', {
+              style: {
+                borderLeft: border_style,
+                color: num_shares_of(corporation, corporation).zero? ? 'transparent' : 'inherit',
+              },
+            },
+            num_shares_of(corporation, corporation)),
+          h('td.padded_number', {
+              style: {
+                borderRight: border_style,
+                color: num_shares_of(@game.share_pool, corporation).zero? ? 'transparent' : 'inherit',
+              },
+            },
             "#{corporation.receivership? ? '*' : ''}#{num_shares_of(@game.share_pool, corporation)}"),
           h('td.padded_number', corporation.par_price ? @game.format_currency(corporation.par_price.price) : ''),
           h('td.padded_number', market_props,

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -348,7 +348,7 @@ module View
               p = @game.player_by_id(@spreadsheet_sort_by)
               n = p&.num_shares_of(corporation)
               n += 0.01 if corporation.president?(p)
-              n || 0
+              n.nil? || n.zero? ? -99 : n # sort shorts between longs and 0 shares
             end
           end
         end

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -139,7 +139,6 @@ module View
           props = {
             style: {
               color: convert_hex_to_rgba(color_for(:font2), alpha),
-              padding: '0 0.15rem',
             },
           }
 
@@ -148,9 +147,9 @@ module View
                                   "Go to run #{x} of #{corporation.name}",
                                   hist[x].dividend.id - 1,
                                   { textDecoration: 'none' })
-            h(:td, props, [link_h])
+            h('td.right', props, [link_h])
           else
-            h(:td, props, revenue_text)
+            h('td.right', props, revenue_text)
           end
         else
           h(:td, '')

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2199,6 +2199,8 @@ module Engine
         :small
       end
 
+      def corporation_size_name(_entity); end
+
       def company_status_str(_company); end
 
       def status_str(_corporation); end

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -1401,6 +1401,10 @@ module Engine
           CORPORATION_SIZES[entity.total_shares]
         end
 
+        def corporation_size_name(entity)
+          entity.total_shares.to_s
+        end
+
         private
 
         def new_auction_round

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -1219,6 +1219,10 @@ module Engine
           CORPORATION_SIZES[entity.total_shares]
         end
 
+        def corporation_size_name(entity)
+          entity.type == :national ? 'Nat’l' : entity.type.capitalize
+        end
+
         def upgrades_to?(from, to, special = false)
           # O labelled tile upgrades to Ys until Grey
           return super unless self.class::HEX_WITH_O_LABEL.include?(from.hex.name)

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -2646,6 +2646,10 @@ module Engine
           entity.type
         end
 
+        def corporation_size_name(entity)
+          entity.type[0].capitalize
+        end
+
         def status_str(corp)
           train_type = case corp.type
                        when :small


### PR DESCRIPTION
- corporation size added (only shown when there are different sizes of corps available) – fixes #2152 (body text mentions corp size)
- include minors/president-status when sorting player column – fixes #3799
- shares == 0 => hidden
- operating order == 0 => hidden
- operated => grayed out instead of *; alignment changed to right
- shorts sorted between longs and 0
- sort order toggles only when currently sorted column is sorted again – instead of when changing sort column
- sort order indicator (arrow) moved to left of column header, because it gets hidden too often due to width limit of player columns
- or_history right aligned & a tad more padding

tl;dr
![image](https://user-images.githubusercontent.com/33390595/110971037-a8f73280-835a-11eb-9e37-fd8302155a6d.png)
![image](https://user-images.githubusercontent.com/33390595/110982823-4a858080-8369-11eb-8a8d-fdd869ceabe2.png)
