### PR TITLE
[18CZ] Optimized EMR Info

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -16,13 +16,19 @@ module View
 
       def render_president_contributions
         player = @corporation.owner
+        step = @game.round.active_step
 
         children = []
 
         verb = @must_buy_train ? 'must' : 'may'
 
+        cheapest_train_price = if step.respond_to?(:cheapest_train_price)
+                                 step.cheapest_train_price(@corporation)
+                               else
+                                 @depot.min_depot_price
+                               end
         cash = @corporation.cash + player.cash
-        share_funds_required = @depot.min_depot_price - cash
+        share_funds_required = cheapest_train_price - cash
         share_funds_allowed = if @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST
                                 share_funds_required
                               else
@@ -30,42 +36,41 @@ module View
                               end
         share_funds_possible = @game.liquidity(player, emergency: true) - player.cash
 
-        if @depot.min_depot_price > @corporation.cash
+        if cheapest_train_price > @corporation.cash
           children << h(:div, "#{player.name} #{verb} contribute "\
-                              "#{@game.format_currency(@depot.min_depot_price - @corporation.cash)} "\
+                              "#{@game.format_currency(cheapest_train_price - @corporation.cash)} "\
                               "for #{@corporation.name} to afford a train from the Depot.")
         end
 
         children << h(:div, "#{player.name} has #{@game.format_currency(player.cash)} in cash.")
 
-        if share_funds_allowed.positive?
+        if share_funds_allowed.positive? && @game.class::EBUY_CAN_SELL_SHARES
           children << h(:div, "#{player.name} has #{@game.format_currency(share_funds_possible)} "\
                               'in sellable shares.')
         end
 
-        if share_funds_required.positive?
+        if share_funds_required.positive? && @game.class::EBUY_CAN_SELL_SHARES
           children << h(:div, "#{player.name} #{verb} sell shares to raise at least "\
                               "#{@game.format_currency(share_funds_required)}.")
         end
 
         if share_funds_allowed.positive? &&
            (share_funds_allowed != share_funds_required) &&
-           (share_funds_possible >= share_funds_allowed)
+           (share_funds_possible >= share_funds_allowed) && @game.class::EBUY_CAN_SELL_SHARES
           children << h(:div, "#{player.name} may continue to sell shares until raising up to "\
                               "#{@game.format_currency(share_funds_allowed)}.")
         end
 
-        step = @game.round.active_step
         must_take_loan = step.must_take_loan?(@corporation) if step.respond_to?(:must_take_loan?)
         if must_take_loan
           children << h(:div, "#{player.name} does not have enough liquidity to "\
                               "contribute towards #{@corporation.name} buying a train "\
                               "from the Depot. #{@corporation.name} must buy a "\
                               "train from another corporation, or #{player.name} must "\
-                              "take a loan of #{@game.format_currency(share_funds_required)}")
+                              "take a loan of at least #{@game.format_currency(share_funds_required)}")
         end
 
-        if @must_buy_train && share_funds_possible < share_funds_required && must_take_loan.nil?
+        if @must_buy_train && share_funds_possible < share_funds_required && !must_take_loan
           children << h(:div, "#{player.name} does not have enough liquidity to "\
                               "contribute towards #{@corporation.name} buying a train "\
                               "from the Depot. #{@corporation.name} must buy a "\

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -44,21 +44,23 @@ module View
 
         children << h(:div, "#{player.name} has #{@game.format_currency(player.cash)} in cash.")
 
-        if share_funds_allowed.positive? && @game.class::EBUY_CAN_SELL_SHARES
-          children << h(:div, "#{player.name} has #{@game.format_currency(share_funds_possible)} "\
-                              'in sellable shares.')
-        end
+        if @game.class::EBUY_CAN_SELL_SHARES
+          if share_funds_allowed.positive?
+            children << h(:div, "#{player.name} has #{@game.format_currency(share_funds_possible)} "\
+                                'in sellable shares.')
+          end
 
-        if share_funds_required.positive? && @game.class::EBUY_CAN_SELL_SHARES
-          children << h(:div, "#{player.name} #{verb} sell shares to raise at least "\
-                              "#{@game.format_currency(share_funds_required)}.")
-        end
+          if share_funds_required.positive?
+            children << h(:div, "#{player.name} #{verb} sell shares to raise at least "\
+                                "#{@game.format_currency(share_funds_required)}.")
+          end
 
-        if share_funds_allowed.positive? &&
-           (share_funds_allowed != share_funds_required) &&
-           (share_funds_possible >= share_funds_allowed) && @game.class::EBUY_CAN_SELL_SHARES
-          children << h(:div, "#{player.name} may continue to sell shares until raising up to "\
-                              "#{@game.format_currency(share_funds_allowed)}.")
+          if share_funds_allowed.positive? &&
+             (share_funds_allowed != share_funds_required) &&
+             (share_funds_possible >= share_funds_allowed)
+            children << h(:div, "#{player.name} may continue to sell shares until raising up to "\
+                                "#{@game.format_currency(share_funds_allowed)}.")
+          end
         end
 
         must_take_loan = step.must_take_loan?(@corporation) if step.respond_to?(:must_take_loan?)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -202,7 +202,7 @@ module Engine
       EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = true # if ebuying from depot, must buy cheapest train
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = false # corporation must issue shares before ebuy (if possible)
       EBUY_SELL_MORE_THAN_NEEDED = false # true if corporation may continue to sell shares even though enough funds
-
+      EBUY_CAN_SELL_SHARES = true # true if a player can sell shares for ebuy
       # when is the home token placed? on...
       # operate
       # float

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -2427,6 +2427,7 @@ module Engine
 
         EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false # if ebuying from depot, must buy cheapest train
         EBUY_OTHER_VALUE = false # allow ebuying other corp trains for up to face
+        EBUY_CAN_SELL_SHARES = false # player cannot sell shares
 
         STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(
           par: :red,

--- a/lib/engine/game/g_18_cz/step/buy_train.rb
+++ b/lib/engine/game/g_18_cz/step/buy_train.rb
@@ -84,7 +84,7 @@ module Engine
 
           def must_take_loan?(corporation)
             price = cheapest_train_price(corporation)
-            @game.buying_power(corporation) < price
+            (@game.buying_power(corporation) + corporation.owner.cash) < price
           end
         end
       end

--- a/lib/engine/game/g_18_cz/step/buy_train.rb
+++ b/lib/engine/game/g_18_cz/step/buy_train.rb
@@ -74,6 +74,18 @@ module Engine
           end
 
           def check_for_cheapest_train(entity, train); end
+
+          def cheapest_train_price(corporation)
+            cheapest_train = @depot.min_depot_train.variants.values.find do |item|
+              @game.train_of_size?(item, corporation.type)
+            end
+            cheapest_train[:price]
+          end
+
+          def must_take_loan?(corporation)
+            price = cheapest_train_price(corporation)
+            @game.buying_power(corporation) < price
+          end
         end
       end
     end


### PR DESCRIPTION
Adjusted the buy_train presidency_contribution to show the correct infos for 18cz.

Added a global constant to allow selling shares, which will then hide all the selling shares information.

Also needed to add a overload for the cheapest price since in 18CZ the cheapest variant of a type is needed.

closes #4100