### PR TITLE
Fixed Next SR Position for not Pass 

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -158,8 +158,8 @@ module View
         order = @game.next_sr_player_order
         trs << render_priority_deal(priority_props) if order == :after_last_to_act &&
                                                        @player == @game.priority_deal_player
-        trs << render_next_sr_position(priority_props) if %i[first_to_pass most_cash].include?(order) &&
-                                                          @game.next_sr_position(@player)
+        trs << render_next_sr_position(priority_props, order) if %i[first_to_pass most_cash].include?(order) &&
+                                                          @game.next_sr_position(@player, order)
 
         h(:table, trs)
       end
@@ -170,8 +170,8 @@ module View
         ])
       end
 
-      def render_next_sr_position(priority_props)
-        position = @game.next_sr_position(@player) + 1
+      def render_next_sr_position(priority_props, order)
+        position = @game.next_sr_position(@player, order) + 1
 
         h(:tr, [
           h(:td, 'Next SR'),

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -158,7 +158,7 @@ module View
         order = @game.next_sr_player_order
         trs << render_priority_deal(priority_props) if order == :after_last_to_act &&
                                                        @player == @game.priority_deal_player
-        trs << render_next_sr_position(priority_props, order) if %i[first_to_pass most_cash].include?(order) &&
+        trs << render_next_sr_position(priority_props) if %i[first_to_pass most_cash].include?(order) &&
                                                           @game.next_sr_position(@player)
 
         h(:table, trs)

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -159,7 +159,7 @@ module View
         trs << render_priority_deal(priority_props) if order == :after_last_to_act &&
                                                        @player == @game.priority_deal_player
         trs << render_next_sr_position(priority_props, order) if %i[first_to_pass most_cash].include?(order) &&
-                                                          @game.next_sr_position(@player, order)
+                                                          @game.next_sr_position(@player)
 
         h(:table, trs)
       end
@@ -170,8 +170,8 @@ module View
         ])
       end
 
-      def render_next_sr_position(priority_props, order)
-        position = @game.next_sr_position(@player, order) + 1
+      def render_next_sr_position(priority_props)
+        position = @game.next_sr_position(@player) + 1
 
         h(:tr, [
           h(:td, 'Next SR'),

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2052,9 +2052,9 @@ module Engine
         end
       end
 
-      def next_sr_position(entity, order)
+      def next_sr_position(entity)
         player_order = if @round.current_entity&.player?
-                         order == :first_to_pass ? @round.pass_order : []
+                         next_sr_player_order == :first_to_pass ? @round.pass_order : []
                        else
                          @players
                        end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2052,8 +2052,12 @@ module Engine
         end
       end
 
-      def next_sr_position(entity)
-        player_order = @round.current_entity&.player? ? @round.pass_order : @players
+      def next_sr_position(entity, order)
+        player_order = if @round.current_entity&.player?
+                         order == :first_to_pass ? @round.pass_order : []
+                       else
+                         @players
+                       end
         player_order.reject(&:bankrupt).index(entity)
       end
 


### PR DESCRIPTION
@crericha I fixed the issue that the priority for next SR is shown in the current SR. The passing order is only acknowledged for first_pass.

I checked for 1828 and 18CZ and both work as expected.
