### PR TITLE
1873: insolvency and end game

### DIFF
--- a/assets/app/view/game/button/buy_share.rb
+++ b/assets/app/view/game/button/buy_share.rb
@@ -18,21 +18,22 @@ module View
         needs :action, default: Engine::Action::BuyShares
 
         def render
+          bundle = @share.to_bundle
           show_percentage = @percentages_available > 1 ||
-                            @share.percent != @share.corporation.share_percent && !@share.president
-          reduced_price = @game.format_currency(@share.price - @swap_share.price) if @swap_share
+                            bundle.percent != bundle.corporation.share_percent && !bundle.presidents_share
+          reduced_price = @game.format_currency(bundle.price - @swap_share.price) if @swap_share
 
           text = @prefix.to_s
           text += " #{@partial_percent}% of" if @partial_percent
-          text += " #{@share.percent}%" if show_percentage
+          text += " #{bundle.percent}%" if show_percentage
           text += " #{@source} Share"
           text += " (#{reduced_price} + #{@swap_share.percent}% Share)" if @swap_share
 
-          h(:button, { on: { click: -> { buy_share(@entity, @share, swap: @swap_share) } } }, text)
+          h(:button, { on: { click: -> { buy_shares(@entity, bundle, swap: @swap_share) } } }, text)
         end
 
-        def buy_share(entity, share, swap: nil)
-          process_action(@action.new(entity, shares: share, swap: swap))
+        def buy_shares(entity, bundle, swap: nil)
+          process_action(@action.new(entity, shares: bundle.shares, swap: swap))
         end
       end
     end

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -19,8 +19,12 @@ module View
         @ipo_shares = @corporation.ipo_shares.group_by(&:percent).values
           .map(&:first).sort_by(&:percent).reverse
 
-        @pool_shares = @game.share_pool.shares_by_corporation[@corporation].group_by(&:percent).values
-          .map(&:first).sort_by(&:percent).reverse
+        @pool_shares = if @step.respond_to?(:pool_shares)
+                         @step.pool_shares(@corporation)
+                       else
+                         @game.share_pool.shares_by_corporation[@corporation].group_by(&:percent).values
+                           .map(&:first).sort_by(&:percent).reverse
+                       end
 
         children = []
 
@@ -61,7 +65,7 @@ module View
       def render_market_shares
         @pool_shares.map do |share|
           next unless @step.can_buy?(@current_entity, share)
-          next if share.president && @pool_shares.size > 1
+          next if share.to_bundle.presidents_share && @pool_shares.size > 1
 
           h(Button::BuyShare,
             share: share,

--- a/lib/engine/game/g_1873/step/buy_mine.rb
+++ b/lib/engine/game/g_1873/step/buy_mine.rb
@@ -12,6 +12,7 @@ module Engine
           def actions(entity)
             return [] if entity != current_entity
             return [] unless @game.public_mine?(entity)
+            return [] if entity.receivership?
             return [] unless @game.any_slot_available?(entity)
 
             BUY_ACTIONS
@@ -39,8 +40,8 @@ module Engine
             'mines'
           end
 
-          def buyable_entities(_entity)
-            @game.buyable_private_mines
+          def buyable_entities(entity)
+            @game.buyable_private_mines(entity)
           end
 
           def price_range(buyer, mine)

--- a/lib/engine/game/g_1873/step/concession_auction.rb
+++ b/lib/engine/game/g_1873/step/concession_auction.rb
@@ -54,7 +54,7 @@ module Engine
           def active_entities
             active_auction do |_, bids|
               return [bids.min_by(&:price).entity]
-            end
+            end if @auctioning
 
             super
           end
@@ -107,6 +107,7 @@ module Engine
             player = bid.entity
             @bids.delete(company)
             buy_company(player, company, price)
+            @round.next_entity_index!
           end
 
           def active_auction
@@ -145,15 +146,13 @@ module Engine
 
             bids = @bids[@auctioning]
 
-            players = entities
-            players.rotate!(players.find_index(starter))
-            players.each_with_index do |player, idx|
+            entities.rotate(entities.find_index(starter)).each_with_index do |player, idx|
               next if player == starter
               next if max_bid(player, @auctioning) <= start_price
 
               bids << (Engine::Action::Bid.new(player,
                                                corporation: @auctioning,
-                                               price: idx - players.size))
+                                               price: idx - entities.size))
             end
           end
 

--- a/lib/engine/game/g_1873/step/convert.rb
+++ b/lib/engine/game/g_1873/step/convert.rb
@@ -37,6 +37,7 @@ module Engine
           def can_convert?(entity)
             return true if entity.minor?
             return false unless entity.corporation?
+            return false if entity.receivership?
             return false unless entity.total_shares < 10
             return false unless entity.num_market_shares.zero? && entity.num_ipo_shares.zero?
 

--- a/lib/engine/game/g_1873/step/dividend.rb
+++ b/lib/engine/game/g_1873/step/dividend.rb
@@ -14,6 +14,7 @@ module Engine
           def actions(entity)
             return [] if entity.minor? || entity == @game.mhe
             return [] if entity.company?
+            return [] if entity.corporation? && entity.receivership?
             return [] unless total_revenue(entity).positive?
 
             ACTIONS
@@ -22,9 +23,11 @@ module Engine
           def skip!
             @round.clear_cache!
             revenue = total_revenue(current_entity)
+            receivership = current_entity.corporation? && current_entity.receivership? &&
+              current_entity != @game.mhe
             process_dividend(Action::Dividend.new(
               current_entity,
-              kind: revenue.positive? ? 'payout' : 'withhold',
+              kind: revenue.positive? && !receivership ? 'payout' : 'withhold',
             ))
 
             current_entity.operating_history[[@game.turn, @round.round_num]] =
@@ -55,9 +58,8 @@ module Engine
 
             if (revenue + entity.cash).negative?
               @log << "#{entity.name} loses #{@game.format_currency(-revenue)} and cannot pay out of treasury"
+              entity.spend(entity.cash, @game.bank) if entity.cash.positive? # zero out cash
               if entity.minor?
-                # zero out cash so owner doesn't get anything
-                entity.spend(entity.cash, @game.bank) if entity.cash.positive?
                 @game.close_mine!(entity)
               else
                 @game.insolvent!(entity)
@@ -69,6 +71,15 @@ module Engine
             if revenue.negative?
               @log << "#{entity.name} pays #{@game.format_currency(-revenue)} from treasury"
               entity.spend(-revenue, @game.bank)
+            end
+
+            # receivership: withhold and no price change
+            if entity.corporation? && entity.receivership? && entity != @game.mhe
+              return unless revenue.positive?
+
+              @game.bank.spend(revenue, entity)
+              @log << "Insolvent #{entity.name} withholds #{@game.format_currency(revenue)}"
+              return
             end
 
             payout = dividend_options(entity)[kind]
@@ -89,6 +100,9 @@ module Engine
             payout_shares(entity, revenue - payout[:corporation]) if payout[:per_share].positive?
 
             change_share_price(entity, payout)
+
+            # special case: QLB completes concession at start of train buy phase (i.e. here)
+            @game.concession_unpend!(entity) if @game.concession_pending?(entity) && entity == @game.qlb
 
             pass!
           end

--- a/lib/engine/game/g_1873/step/draft.rb
+++ b/lib/engine/game/g_1873/step/draft.rb
@@ -52,11 +52,14 @@ module Engine
 
           def actions(entity)
             return [] if finished?
+            return [] if entity != current_entity
+            return %w[bid] if @game.premium_winner
 
-            entity == current_entity ? ACTIONS : []
+            ACTIONS
           end
 
           def process_bid(action)
+            @game.premium_winner = nil
             company = action.company
             player = action.entity
             price = action.price
@@ -69,6 +72,7 @@ module Engine
               minor.owner = player
               minor.float!
               company.close!
+              @game.companies.delete(company)
             else
               player.companies << company
             end
@@ -103,8 +107,8 @@ module Engine
 
             @companies.each do |c|
               if (minor = @game.get_mine(c))
-                @game.companies.delete(c)
                 @game.close_mine!(minor)
+                @game.companies.delete(c)
               end
             end
             @round.reset_entity_index!

--- a/lib/engine/game/g_1873/step/form.rb
+++ b/lib/engine/game/g_1873/step/form.rb
@@ -82,9 +82,9 @@ module Engine
           # else all open private mines
           def mergeable_entities
             available_mines = if target_mines.empty?
-                                @game.open_private_mines.select { |m| m.owner == owner }
+                                @game.mergeable_private_mines(buyer).select { |m| m.owner == owner }
                               else
-                                @game.open_private_mines - [target_mines.first[:mine]]
+                                @game.mergeable_private_mines(buyer) - [target_mines.first[:mine]]
                               end
 
             if @game.turn == 1 && target_mines.empty?

--- a/lib/engine/game/g_1873/step/premium.rb
+++ b/lib/engine/game/g_1873/step/premium.rb
@@ -164,6 +164,7 @@ module Engine
             @order << player
             @game.premium = price
             @game.premium_order = @order.uniq.reverse
+            @game.premium_winner = player
           end
         end
       end

--- a/lib/engine/game/g_1873/step/reassign_switcher.rb
+++ b/lib/engine/game/g_1873/step/reassign_switcher.rb
@@ -27,9 +27,22 @@ module Engine
             pass!
           end
 
-          # don't bother with this step if all mines have the same level of switcher
+          # don't bother with this step if:
+          # - no mines have switchers, or
+          # - no mines are connected, or
+          # - all have switchers and all are connected, or
+          # - all have switchers and all are the same size
+          #
+          # since revenue can't change with reassignment
+          #
           def reassign_possible?(entity)
-            !@game.public_mine_mines(entity).map { |m| @game.switcher_size(m) || 0 }.uniq.one?
+            num_mines = @game.public_mine_mines(entity).size
+            num_switchers = @game.public_mine_mines(entity).count { |m| @game.switcher(m) }
+            num_sizes = @game.public_mine_mines(entity).map { |m| @game.switcher_size(m) || 0 }.uniq.size
+            num_can_use = @game.public_mine_mines(entity).count { |m| @game.connected_mine?(m) }
+            num_switchers.positive? &&
+              num_can_use.positive? &&
+              (num_switchers < num_mines || (num_can_use < num_mines && num_sizes > 1))
           end
 
           def description

--- a/lib/engine/game/g_1873/step/route.rb
+++ b/lib/engine/game/g_1873/step/route.rb
@@ -26,6 +26,15 @@ module Engine
             pass!
           end
 
+          def help
+            return super unless current_entity.receivership?
+
+            "#{current_entity.name} is in receivership (it went insolvent). Most of its "\
+              'actions are automated, but it must have a player manually run its trains. '\
+              'Please see "Harzbahn 1873" Rules of Play Section 6.2 and enter the '\
+              "mandated routes for #{current_entity.name}."
+          end
+
           def process_run_routes(action)
             super
 

--- a/lib/engine/game/g_1873/step/token.rb
+++ b/lib/engine/game/g_1873/step/token.rb
@@ -12,6 +12,7 @@ module Engine
           def actions(entity)
             return [] unless entity == current_entity
             return [] unless @game.railway?(entity)
+            return [] if entity.receivership?
             return [] unless can_place_token?(entity)
 
             ACTIONS
@@ -40,9 +41,8 @@ module Engine
             raise GameError, 'Token is already used' if token.used
             raise GameError, 'No token available to place' unless (new_token = entity.unplaced_tokens.first)
 
-            # only one per hex
             if tile.cities.any? { |c| c.tokened_by?(entity) }
-              raise GameError, "#{entity.name} cannot lay token on #{id} #{hex.id}"
+              raise GameError, "Cannot lay on #{hex.id}. Can only have one token per hex"
             end
 
             token.status = nil
@@ -72,12 +72,6 @@ module Engine
             end
 
             @game.diesel_graph.clear
-          end
-
-          def check_legal_placement(_entity, city, _token)
-            return unless @game.concession_blocks?(city)
-
-            raise GameError, "Cannot lay on #{city.id} Must leave room for concession RR"
           end
 
           def can_replace_token?(_entity, token)


### PR DESCRIPTION
I apologize for the number of files in this - in addition to adding the insolvency and end of game rules, a playthrough to test these things found a fair number of  bugs that needed to be fixed.

Common file edits:
- UI: buy_sell_shares and UI::Button:buy_share - added ability to buy a bundle instead of a single share. This is needed because even though the presidency in a 10-share corp is only 10%, you are required to buy at least two when taking a corp out of receivership.

This PR represents full functionality for 1873. I believe the game is completely playable (latent bugs notwithstanding), but it needs a few usability tweaks before it is ready for the masses. 