### PR TITLE
1882: Fix NWR private and OO tile if it already has a token on it

### DIFF
--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -204,16 +204,18 @@ module Engine
         if old_tile.paths.empty? &&
             !tile.paths.empty? &&
             cities.size > 1 &&
-            (token = cities.flat_map(&:tokens).find(&:itself))
-          actor = entity.company? ? entity.owner : entity
-          @round.pending_tokens << {
-            entity: actor,
-            hexes: [action.hex],
-            token: token,
-          }
-          @log << "#{actor.name} must choose city for token"
+            !(tokens = cities.flat_map(&:tokens).select(&:itself)).empty?
+          tokens.each do |token|
+            actor = entity.company? ? entity.owner : entity
+            @round.pending_tokens << {
+              entity: actor,
+              hexes: [action.hex],
+              token: token,
+            }
+            @log << "#{actor.name} must choose city for token"
 
-          token.remove!
+            token.remove!
+          end
         end
       end
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -204,7 +204,7 @@ module Engine
         if old_tile.paths.empty? &&
             !tile.paths.empty? &&
             cities.size > 1 &&
-            !(tokens = cities.flat_map(&:tokens).select(&:itself)).empty?
+            !(tokens = cities.flat_map(&:tokens).compact).empty?
           tokens.each do |token|
             actor = entity.company? ? entity.owner : entity
             @round.pending_tokens << {


### PR DESCRIPTION
The OO tile can have SC, this causes two tokens
to be present on the tile in the token choice condition which must be selected which token goes where.

fixes #4379