### PR TITLE
[1846, bug fix] don't set passed to true in `G1846::Step::Assign#pass!`

### DIFF
--- a/lib/engine/game/g_1846/step/assign.rb
+++ b/lib/engine/game/g_1846/step/assign.rb
@@ -91,7 +91,6 @@ module Engine
           end
 
           def pass!
-            super
             @round.start_operating
           end
 


### PR DESCRIPTION
With the old code, if 1) the steamboat company is owned by the player that owns the corporation
that owns the meat packing company (MPC), and 2) that corporation is operating first,
and 3) the player passes on assigning the steamboat company at the beginning of
the round, then that corporation will not be able to assign the meat packing
company, as the Assign step is already marked as passed, and is not unpassed
until `next_entity!` is called

[Fixes #3996]