### PR TITLE
[1822] Phase 6 floated companies

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2715,12 +2715,16 @@ module Engine
         end
 
         def float_corporation(corporation)
-          super
-          return if !@phase.status.include?('full_capitalisation') || corporation.type != :major
+          if @phase.status.include?('full_capitalisation') && corporation.type == :major
+            # Transfer any money corporation have gotten during phase 5 with incremental floating
+            corporation.spend(corporation.cash, @bank) if corporation.cash.positive?
 
-          bundle = ShareBundle.new(corporation.shares_of(corporation))
-          @share_pool.transfer_shares(bundle, @share_pool)
-          @log << "#{corporation.name}'s remaining shares are transferred to the Market"
+            bundle = ShareBundle.new(corporation.shares_of(corporation))
+            @share_pool.transfer_shares(bundle, @share_pool)
+            @log << "#{corporation.name}'s remaining shares are transferred to the Market"
+          end
+
+          super
         end
 
         def format_currency(val)

--- a/lib/engine/game/g_1822/step/dividend.rb
+++ b/lib/engine/game/g_1822/step/dividend.rb
@@ -76,6 +76,10 @@ module Engine
             entity.type == :minor ? revenue / 2.0 : (revenue / 2 / entity.total_shares).to_i * entity.total_shares
           end
 
+          def holder_for_corporation(entity)
+            entity
+          end
+
           def log_run_payout(entity, kind, revenue, subsidy, _action, payout)
             @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays half" if kind == 'half'
 


### PR DESCRIPTION
- Clear all cash from a corporation when it floats in phase 6. Then it will get the full cap.
- Make sure that its only ipo shares which payes money to the corporation.

fixes #4476
fixes #4506

This change might affect games if they used the money the corporation got extra from incorrect floating or revenue.
