### PR TITLE
make fuzzy matching on /tiles and /map case insensitive

### DIFF
--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -48,6 +48,8 @@ module Engine
   end
 
   def self.closest_title(title)
+    title = title.upcase
+
     @fuzzy_titles[title] ||= GAME_METAS.max_by do |m|
       titles = [
         m.title,
@@ -59,8 +61,8 @@ module Engine
 
       titles = titles.concat(titles.map { |t| t.sub(/^G?18/, '') }).uniq
 
-      titles.uniq.map do |t|
-        JaroWinkler.distance(title, t)
+      titles.map do |t|
+        JaroWinkler.distance(title, t.upcase)
       end.max
     end.title
   end


### PR DESCRIPTION
fixes `/map/18cz` going to 1817

also get rid of a duplicate `.uniq`