### PR TITLE
[1822] Treasury

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2739,6 +2739,10 @@ module Engine
           [hex_by_id(self.class::LONDON_HEX)] if corporation.id == self.class::MINOR_14_ID
         end
 
+        def ipo_name(_entity = nil)
+          'Treasury'
+        end
+
         def issuable_shares(entity)
           return [] if !entity.corporation? || (entity.corporation? && entity.type != :major)
           return [] if entity.num_ipo_shares.zero? || entity.operating_history.size < 2


### PR DESCRIPTION
- Renamed IPO to Treasury

fixes #4536

This change does not affect any of the currect games.
