### PR TITLE
Improve granulality of auto actions for mergers

### DIFF
--- a/lib/engine/action/program_merger_pass.rb
+++ b/lib/engine/action/program_merger_pass.rb
@@ -6,20 +6,30 @@ require_relative 'program_enable'
 module Engine
   module Action
     class ProgramMergerPass < ProgramEnable
-      attr_reader :corporations, :rounds
+      attr_reader :corporations_by_round, :options
 
-      def initialize(entity, corporations:, rounds:)
+      def initialize(entity, corporations_by_round:, options:)
         super(entity)
-        @corporations = corporations
-        @rounds = rounds
+        @corporations_by_round = corporations_by_round
+        @options = options
       end
 
       def self.h_to_args(h, game)
-        { corporations: h['corporations']&.map { |c| game.corporation_by_id(c) }, rounds: h['rounds'] }
+        {
+          corporations_by_round: h['corporations_by_round']&.map do |r, v|
+                                   [r, v&.map do |c|
+                                         game.corporation_by_id(c)
+                                       end]
+                                 end.to_h,
+          options: h['options'],
+        }
       end
 
       def args_to_h
-        { 'corporations' => @corporations.map(&:id), 'rounds' => @rounds }
+        {
+          'corporations_by_round' => @corporations_by_round&.map { |r, v| [r, v.map(&:id)] }.to_h,
+          'options' => @options,
+        }
       end
 
       def self.description

--- a/lib/engine/game/g_1817/step/acquire.rb
+++ b/lib/engine/game/g_1817/step/acquire.rb
@@ -54,6 +54,10 @@ module Engine
             @offer
           end
 
+          def others_acted?
+            !@round.acquired.empty?
+          end
+
           def can_take_loan?(entity)
             entity == @buyer && @game.can_take_loan?(entity) && !@passed_take_loans
           end
@@ -375,6 +379,7 @@ module Engine
             # If not aquired by the bank
             @round.offering.delete(acquired_corp)
             @winner = nil
+            @round.acquired << acquired_corp
             setup_auction
           end
 
@@ -478,6 +483,12 @@ module Engine
 
           def setup
             setup_auction
+          end
+
+          def round_state
+            {
+              acquired: [],
+            }
           end
 
           private

--- a/lib/engine/game/g_1817/step/conversion.rb
+++ b/lib/engine/game/g_1817/step/conversion.rb
@@ -36,6 +36,10 @@ module Engine
             current_entity
           end
 
+          def others_acted?
+            !@round.converts.empty?
+          end
+
           def process_convert(action)
             corporation = action.entity
             before = corporation.total_shares

--- a/lib/engine/game/g_1867/step/merge.rb
+++ b/lib/engine/game/g_1867/step/merge.rb
@@ -48,6 +48,10 @@ module Engine
             current_entity unless @converting || @merge_major
           end
 
+          def others_acted?
+            !@round.converts.empty?
+          end
+
           def pass_description
             return 'Done Adding Corporations' if @merging
 
@@ -104,6 +108,7 @@ module Engine
             # Replace the entity with the new one.
             @round.entities[@round.entity_index] = target
             @round.converted = target
+            @round.converts << target
             @round.merge_type = :convert
             # All players are eligable to buy shares unlike merger
             @round.share_dealing_players = @game.players.rotate(@game.players.index(target.owner))
@@ -227,6 +232,7 @@ module Engine
 
             @merging = nil
             @round.converted = target
+            @round.converts << target
             @round.merge_type = :merge
 
             @round.share_dealing_players = players
@@ -322,6 +328,7 @@ module Engine
             {
               converted: nil,
               merge_type: nil,
+              converts: [],
               share_dealing_players: [],
               share_dealing_multiple: [],
             }

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -303,7 +303,7 @@ module Engine
       def corporation_secure?(corporation)
         # Can any other player steal the corporation?
 
-        (corporation.owner.percent_of(corporation, ceil: false)) >= corporation_secure_percent
+        (corporation.owner.percent_of(corporation)) >= corporation_secure_percent
       end
 
       def action_is_shenanigan?(entity, action, corporation, share_to_buy)
@@ -322,7 +322,7 @@ module Engine
               return "#{action.entity.player.name} bought on corporation #{corporation.name} and is unsecure"
             end
 
-            percentage = corporation.owner.percent_of(corporation, ceil: false) + share_to_buy.percent
+            percentage = corporation.owner.percent_of(corporation) + share_to_buy.percent
             # If next share is bought, is the corp secure? Then it's safe to buy...
             return if percentage > corporation_secure_percent
 
@@ -339,7 +339,7 @@ module Engine
             end.max(&:percent)
 
             if bigger_share
-              other_percent = action.entity.percent_of(corporation, ceil: false) + bigger_share.percent
+              other_percent = action.entity.percent_of(corporation) + bigger_share.percent
               if percentage < other_percent
                 "#{action.entity.player.name} has bought, shares exist that could allow them to gain presidency"
               end

--- a/lib/engine/step/programmer_merger_pass.rb
+++ b/lib/engine/step/programmer_merger_pass.rb
@@ -11,12 +11,16 @@ module Engine
       end
 
       def activate_program_merger_pass(entity, program)
+        if @game.actions.last != program && program.options&.include?('disable_others') && others_acted?
+          return [Action::ProgramDisable.new(entity.player,
+                                             reason: 'Other players have acted and requested to stop')]
+        end
+
         pass_entity = merger_auto_pass_entity
         return unless pass_entity
 
         # Check to see if the round and corps include the current one
-        return unless program.rounds.include?(@round.class.short_name)
-        return unless program.corporations.include?(pass_entity)
+        return unless program.corporations_by_round&.dig(@round.class.short_name)&.include?(pass_entity)
 
         # Corporation and round matchs, pass!
         [Action::Pass.new(entity)]

--- a/spec/fixtures/1817NA/25363.json
+++ b/spec/fixtures/1817NA/25363.json
@@ -10197,15 +10197,10 @@
       "entity_type": "player",
       "id": 953,
       "created_at": 1614238394,
-      "corporations": [
-        "GT",
-        "NYOW",
-        "PLE"
-      ],
-      "rounds": [
-        "MR",
-        "AR"
-      ]
+      "corporations_by_round": {
+        "MR": ["GT", "NYOW", "PLE"],
+        "AR": ["GT", "NYOW", "PLE"]
+      }
     },
     {
       "type": "lay_tile",
@@ -11573,15 +11568,10 @@
       "entity_type": "player",
       "id": 1062,
       "created_at": 1614272572,
-      "corporations": [
-        "GT",
-        "NYOW",
-        "PLE"
-      ],
-      "rounds": [
-        "MR",
-        "AR"
-      ]
+      "corporations_by_round": {
+	"MR": ["GT", "NYOW", "PLE"],
+	"AR": ["GT", "NYOW", "PLE"]
+      }
     },
     {
       "type": "take_loan",

--- a/spec/fixtures/1822/hs_lxemeslq_30797.json
+++ b/spec/fixtures/1822/hs_lxemeslq_30797.json
@@ -2713,7 +2713,7 @@
           "entity": 671,
           "entity_type": "player",
           "created_at": 1615652117,
-          "reason": "Bid exceeded on P16"
+          "reason": "No longer winning bids on P1"
         }
       ]
     },
@@ -2820,7 +2820,7 @@
           "entity": 671,
           "entity_type": "player",
           "created_at": 1615652525,
-          "reason": "Bid exceeded on P1"
+          "reason": "No longer winning bids on P1"
         }
       ]
     },

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -30,7 +30,7 @@ module Engine
 
   AUTO_FIXTURES = [
     '1861/29683.json', # token pass
-    '1830/29133.json', # buy till float
+    ['1830/29133.json', 150], # buy till float
     '1817NA/25363.json', # pass in merger
     '1882/hs_iopxwxht_26178.json', # Auto-pass pass
     '1882/hs_fxmfdndg_26178.json', # Auto-pass disable (shares sold)
@@ -42,6 +42,7 @@ module Engine
   ].freeze
 
   AUTO_FIXTURES.each do |fixture_name|
+    fixture_name, max_action = fixture_name if fixture_name.is_a?(Array)
     fixture = FIXTURES_DIR + '/' + fixture_name
     game_title = File.basename(File.dirname(fixture))
     filename = File.basename(fixture)
@@ -57,18 +58,27 @@ module Engine
           actions.compact.each do |action|
             next unless action['auto_actions']
 
+            break if max_action && action['id'] >= max_action
+
             # Run game as per the spec
             spec_game = Game.load(data, at_action: action['id'])
 
             # Process game to previous action
             auto_game = Game.load(data, at_action: action['id'] - 1)
+
             # Add the action but without the auto actions
             clone = action.dup
             clone.delete('auto_actions')
-            auto_game.process_action(action, add_auto_actions: true)
+            auto_game.process_action(clone, add_auto_actions: true)
+
+            # Remove time the actions were created at
+            spec_last = spec_game.actions.last.to_h
+            spec_last['auto_actions']&.each { |a| a.delete('created_at') }
+            auto_last = auto_game.actions.last.to_h
+            auto_last['auto_actions']&.each { |a| a.delete('created_at') }
 
             expect(spec_game.result).to eq(auto_game.result)
-            expect(spec_game.actions.last.to_h).to eq(auto_game.actions.last.to_h)
+            expect(spec_last).to eq(auto_last)
           end
         end
       end


### PR DESCRIPTION
Can now specify differently for AR and MR.
Add option to fail-safe if other people start merging

fixes #4164

Fix the unit tests for auto-actions which actually didn't check
and fix specs and other breakages

(Will cause existing merger passes to stop, but will do so without issue)