### PR TITLE
[1822] P10 doesnt reduce track laying cost

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -3181,7 +3181,8 @@ module Engine
         end
 
         def upgrade_cost(tile, hex, entity)
-          abilities = entity.all_abilities.select do |a|
+          operator = entity.company? ? entity.owner : entity
+          abilities = operator.all_abilities.select do |a|
             a.type == :tile_discount && (!a.hexes || a.hexes.include?(hex.name))
           end
 
@@ -3189,7 +3190,7 @@ module Engine
             total_cost = upgrade.cost
             abilities.each do |ability|
               discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
-              log_cost_discount(entity, ability, discount)
+              log_cost_discount(operator, ability, discount)
               total_cost -= discount
             end
             total_cost


### PR DESCRIPTION
- When using a tilelay private, make sure to check discount as well.

fixes #4533

This change might affect the currect games.