### PR TITLE
1873: add and use large icons

### DIFF
--- a/assets/app/view/game/part/icons.rb
+++ b/assets/app/view/game/part/icons.rb
@@ -25,7 +25,7 @@ module View
         end
 
         def load_from_tile
-          @icons = @tile.icons
+          @icons = @tile.icons.reject(&:large)
           @num_cities = @tile.cities.size
         end
 

--- a/assets/app/view/game/part/large_icons.rb
+++ b/assets/app/view/game/part/large_icons.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'view/game/part/base'
+require 'lib/settings'
+
+module View
+  module Game
+    module Part
+      class LargeIcons < Base
+        include Lib::Settings
+
+        needs :game, default: nil, store: true
+
+        P_WIDE_LEFT_CORNER = {
+          region_weights: [5, 6, 7, 12, 13, 14],
+          x: -60,
+          y: 0,
+        }.freeze
+
+        P_WIDE_UPPER_LEFT_CORNER = {
+          region_weights: [0, 1, 2, 6, 7, 8],
+          x: -30,
+          y: -52,
+        }.freeze
+
+        P_WIDE_BOTTOM_LEFT_CORNER = {
+          region_weights: [13, 14, 15, 19, 20, 21],
+          x: -30,
+          y: 52,
+        }.freeze
+
+        P_WIDE_RIGHT_CORNER = {
+          region_weights: [9, 10, 11, 16, 17, 18],
+          x: 60,
+          y: 0,
+        }.freeze
+
+        P_WIDE_UPPER_RIGHT_CORNER = {
+          region_weights: [2, 3, 4, 8, 9, 10],
+          x: 30,
+          y: -52,
+        }.freeze
+
+        P_WIDE_BOTTOM_RIGHT_CORNER = {
+          region_weights: [15, 16, 17, 21, 22, 23],
+          x: 30,
+          y: 52,
+        }.freeze
+
+        PP_WIDE_LEFT_CORNER = {
+          region_weights: [5, 6, 7, 12, 13, 14],
+          x: -52,
+          y: -30,
+        }.freeze
+
+        PP_WIDE_UPPER_LEFT_CORNER = {
+          region_weights: [0, 1, 2, 6, 7, 8],
+          x: 0,
+          y: -60,
+        }.freeze
+
+        PP_WIDE_BOTTOM_LEFT_CORNER = {
+          region_weights: [13, 14, 15, 19, 20, 21],
+          x: -52,
+          y: 30,
+        }.freeze
+
+        PP_WIDE_RIGHT_CORNER = {
+          region_weights: [9, 10, 11, 16, 17, 18],
+          x: 52,
+          y: 30,
+        }.freeze
+
+        PP_WIDE_UPPER_RIGHT_CORNER = {
+          region_weights: [2, 3, 4, 8, 9, 10],
+          x: 52,
+          y: -30,
+        }.freeze
+
+        PP_WIDE_BOTTOM_RIGHT_CORNER = {
+          region_weights: [15, 16, 17, 21, 22, 23],
+          x: 0,
+          y: 60,
+        }.freeze
+
+        LARGE_ITEM_LOCATIONS = [P_WIDE_LEFT_CORNER,
+                                P_WIDE_UPPER_LEFT_CORNER,
+                                P_WIDE_BOTTOM_LEFT_CORNER,
+                                P_WIDE_RIGHT_CORNER,
+                                P_WIDE_UPPER_RIGHT_CORNER,
+                                P_WIDE_BOTTOM_RIGHT_CORNER].freeze
+
+        POINTY_LARGE_ITEM_LOCATIONS = [PP_WIDE_LEFT_CORNER,
+                                       PP_WIDE_UPPER_LEFT_CORNER,
+                                       PP_WIDE_BOTTOM_LEFT_CORNER,
+                                       PP_WIDE_RIGHT_CORNER,
+                                       PP_WIDE_UPPER_RIGHT_CORNER,
+                                       PP_WIDE_BOTTOM_RIGHT_CORNER].freeze
+
+        LARGE_RADIUS = 25
+        DELTA_X = (LARGE_RADIUS * 2) + 2
+
+        def preferred_render_locations
+          if layout == :flat
+            LARGE_ITEM_LOCATIONS
+          else
+            POINTY_LARGE_ITEM_LOCATIONS
+          end
+        end
+
+        def load_from_tile
+          # multiple large icons not supported
+          @icons = @tile.icons.select(&:large)
+        end
+
+        def render_part
+          children = @icons.map.with_index do |icon, index|
+            # large icons can have player colors
+            color = 'white'
+            radius = LARGE_RADIUS
+            adjust = 0
+            show_player_colors = setting_for(:show_player_colors, @game)
+            if show_player_colors && (owner = icon&.owner) && @game.players.include?(owner)
+              color = player_colors(@game.players)[owner]
+              radius -= 4
+              adjust = 4
+            end
+
+            icon_x_pos = ((index - (@icons.size - 1) / 2.0) * -DELTA_X + adjust).round(2)
+            icon_y_pos = adjust.round(2)
+            ring_x_pos = (((index - (@icons.size - 1) / 2.0) * -DELTA_X) + LARGE_RADIUS).round(2)
+            ring_y_pos = LARGE_RADIUS.round(2)
+
+            h(:g, [
+              h(:circle, attrs: { r: LARGE_RADIUS, fill: color, cx: ring_x_pos, cy: ring_y_pos }),
+              h(:image,
+                attrs: {
+                  href: icon.image,
+                  x: icon_x_pos,
+                  y: icon_y_pos,
+                  width: "#{radius * 2}px",
+                  height: "#{radius * 2}px",
+                }),
+            ])
+          end
+
+          h(:g, { attrs: { transform: "#{rotation_for_layout} translate(#{-LARGE_RADIUS} #{-LARGE_RADIUS})" } }, [
+              h(:g, { attrs: { transform: translate } }, children),
+            ])
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -67,7 +67,8 @@ module View
         children << render_tile_part(Part::Blocker)
         rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
         @tile.reservations.each { |x| children << render_tile_part(Part::Reservation, reservation: x) }
-        children << render_tile_part(Part::Icons) unless @tile.icons.empty?
+        children << render_tile_part(Part::Icons) unless @tile.icons.reject(&:large).empty?
+        children << render_tile_part(Part::LargeIcons) unless @tile.icons.select(&:large).empty?
 
         children << render_tile_part(Part::Assignments) unless @tile.hex&.assignments&.empty?
         # borders should always be the top layer

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -67,8 +67,9 @@ module View
         children << render_tile_part(Part::Blocker)
         rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
         @tile.reservations.each { |x| children << render_tile_part(Part::Reservation, reservation: x) }
-        children << render_tile_part(Part::Icons) unless @tile.icons.reject(&:large).empty?
-        children << render_tile_part(Part::LargeIcons) unless @tile.icons.select(&:large).empty?
+        large, normal = @tile.icons.partition(&:large)
+        children << render_tile_part(Part::Icons) unless normal.empty?
+        children << render_tile_part(Part::LargeIcons) unless large.empty?
 
         children << render_tile_part(Part::Assignments) unless @tile.hex&.assignments&.empty?
         # borders should always be the top layer

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -628,29 +628,26 @@ module Engine
           minor.owner = nil
 
           # flip token to closed side
-          open_name = "#{minor.id}_open"
           closed_image = "1873/#{minor.id}_closed"
-          @hexes.each do |hex|
-            if (icon = hex.tile.icons.find { |i| i.name == open_name })
-              hex.tile.icons[hex.tile.icons.find_index(icon)] =
-                Part::Icon.new(closed_image, nil, true, nil, hex.tile.preprinted)
-            end
-          end
+          tile = hex_by_id(minor.coordinates).tile
+          return unless (icon = tile.icons.find(&:large))
+
+          tile.icons[tile.icons.find_index(icon)] =
+            Part::Icon.new(closed_image, nil, true, nil, tile.preprinted, large: true, owner: nil)
         end
 
+        # also used for ownership change
         def open_mine!(minor)
-          @log << "#{minor.name} is opened"
+          @log << "#{minor.name} is opened" unless @minor_info[minor][:open]
           @minor_info[minor][:open] = true
 
           # flip token to open side
-          closed_name = "#{minor.id}_closed"
           open_image = "1873/#{minor.id}_open"
-          @hexes.each do |hex|
-            if (icon = hex.tile.icons.find { |i| i.name == closed_name })
-              hex.tile.icons[hex.tile.icons.find_index(icon)] =
-                Part::Icon.new(open_image, nil, true, nil, hex.tile.preprinted)
-            end
-          end
+          tile = hex_by_id(minor.coordinates).tile
+          return unless (icon = tile.icons.find(&:large))
+
+          tile.icons[tile.icons.find_index(icon)] =
+            Part::Icon.new(open_image, nil, true, nil, tile.preprinted, large: true, owner: minor.owner)
         end
 
         def insolvent!(entity)
@@ -2697,7 +2694,7 @@ module Engine
                 I8
               ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
                   'border=edge:2,type:impassable;'\
-                  'icon=image:1873/8_open,sticky:1',
+                  'icon=image:1873/8_open,sticky:1,large:1',
               %w[
                 H7
               ] => 'upgrade=cost:100,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
@@ -2714,7 +2711,7 @@ module Engine
                 G2
               ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1;'\
                   'border=edge:4,type:impassable;border=edge:5,type:impassable;'\
-                  'icon=image:1873/9_open,sticky:1',
+                  'icon=image:1873/9_open,sticky:1,large:1',
               %w[
                 F3
               ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1',
@@ -2771,24 +2768,24 @@ module Engine
                 D11
               ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable;'\
                 'border=edge:2,type:impassable;border=edge:3,type:impassable;'\
-                'icon=image:1873/4_open,sticky:1',
+                'icon=image:1873/4_open,sticky:1,large:1',
               %w[
                 D13
               ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;'\
                 'border=edge:2,type:impassable;border=edge:3,type:impassable;'\
-                'icon=image:1873/5_open,sticky:1',
+                'icon=image:1873/5_open,sticky:1,large:1',
               %w[
                 D17
               ] => 'town=revenue:0;',
               %w[
                 E8
               ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:4,type:impassable;'\
-                'icon=image:1873/1_open,sticky:1',
+                'icon=image:1873/1_open,sticky:1,large:1',
               %w[
                 E10
               ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable;'\
                 'border=edge:4,type:impassable;'\
-                'icon=image:1873/6_open,sticky:1',
+                'icon=image:1873/6_open,sticky:1,large:1',
               %w[
                 E16
                 G12
@@ -2801,38 +2798,38 @@ module Engine
               %w[
                 I14
               ] => 'town=revenue:0;upgrade=cost:50,terrain:mountain;'\
-                'icon=image:1873/7_open,sticky:1',
+                'icon=image:1873/7_open,sticky:1,large:1',
               %w[
                 I16
               ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;'\
-                'icon=image:1873/3_open,sticky:1',
+                'icon=image:1873/3_open,sticky:1,large:1',
             },
             yellow: {
               %w[
                 D9
               ] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
                 'border=edge:4,type:impassable;frame=color:purple;'\
-                'icon=image:1873/10_open,sticky:1',
+                'icon=image:1873/10_open,sticky:1,large:1',
               %w[
                 D15
               ] => 'city=revenue:40,slots:2;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;'\
                 'path=a:5,b:_0,track:narrow;label=B;frame=color:purple;'\
-                'icon=image:1873/12_open,sticky:1',
+                'icon=image:1873/12_open,sticky:1,large:1',
               %w[
                 E4
               ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
                 'border=edge:3,type:impassable;frame=color:purple;'\
-                'icon=image:1873/2_open,sticky:1',
+                'icon=image:1873/2_open,sticky:1,large:1',
               %w[
                 F11
               ] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
                 'frame=color:purple;'\
-                'icon=image:1873/SM_open,sticky:1',
+                'icon=image:1873/SM_open,sticky:1,large:1',
               %w[
                 G4
               ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
                 'border=edge:1,type:impassable;border=edge:3,type:impassable;frame=color:purple;'\
-                'icon=image:1873/14_open,sticky:1',
+                'icon=image:1873/14_open,sticky:1,large:1',
             },
             green: {
               %w[
@@ -2856,7 +2853,7 @@ module Engine
                 F7
               ] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;'\
                 'path=a:3,b:_1,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                'icon=image:1873/11_open,sticky:1',
+                'icon=image:1873/11_open,sticky:1,large:1',
               %w[
                 G6
               ] => 'city=revenue:40;path=a:2,b:_0,track:narrow;'\
@@ -2884,29 +2881,29 @@ module Engine
                 B13
               ] => 'city=slots:2,revenue:yellow_30|green_70|brown_60|gray_60;'\
                 'path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
-                'frame=color:purple;icon=image:1873/ZW_open,sticky:1',
+                'frame=color:purple;icon=image:1873/ZW_open,sticky:1,large:1',
               %w[
                 C4
               ] => 'city=revenue:yellow_50|green_80|brown_120|gray_150;path=a:5,b:_0,track:narrow',
               %w[
                 C6
               ] => 'town=revenue:0;path=a:0,b:_0,track:narrow;'\
-                'icon=image:1873/SBC6_open,sticky:1',
+                'icon=image:1873/SBC6_open,sticky:1,large:1',
               %w[
                 E18
               ] => 'city=revenue:30,slots:2;path=a:1,b:_0,track:narrow;'\
                 'path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
-                'icon=image:1873/PM_open,sticky:1',
+                'icon=image:1873/PM_open,sticky:1,large:1',
               %w[
                 F15
               ] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
                 'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:purple;'\
-                'icon=image:1873/15_open,sticky:1',
+                'icon=image:1873/15_open,sticky:1,large:1',
               %w[
                 H9
               ] => 'city=revenue:30,slots:2;path=a:0,b:_0,track:narrow;'\
                 'path=a:1,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
-                'icon=image:1873/SBH9_open,sticky:1',
+                'icon=image:1873/SBH9_open,sticky:1,large:1',
               %w[
                 I2
               ] => 'city=revenue:yellow_40|green_50|brown_80|gray_120;path=a:1,b:_0;'\
@@ -2919,7 +2916,7 @@ module Engine
                 I18
               ] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
                 'path=a:2,b:_0,track:narrow;frame=color:purple;'\
-                'icon=image:1873/13_open,sticky:1',
+                'icon=image:1873/13_open,sticky:1,large:1',
               %w[
                 J7
               ] => 'city=revenue:yellow_60|green_80|brown_120|gray_180;path=a:1,b:_0;'\

--- a/lib/engine/game/g_1873/step/buy_mine.rb
+++ b/lib/engine/game/g_1873/step/buy_mine.rb
@@ -80,7 +80,7 @@ module Engine
 
             # buyer gets formerly independent mines and their cash
             # machines and switchers stay with mines
-            @game.open_mine!(mine) unless mine.owner
+            @game.open_mine!(mine)
             @game.add_mine(entity, mine)
 
             pass!

--- a/lib/engine/game/g_1873/step/draft.rb
+++ b/lib/engine/game/g_1873/step/draft.rb
@@ -71,6 +71,7 @@ module Engine
             if (minor = @game.get_mine(company))
               minor.owner = player
               minor.float!
+              @game.open_mine!(minor)
               company.close!
               @game.companies.delete(company)
             else

--- a/lib/engine/part/icon.rb
+++ b/lib/engine/part/icon.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative '../ownable'
 
 module Engine
   module Part
     class Icon < Base
-      attr_accessor :preprinted
-      attr_reader :image, :name, :sticky
+      include Ownable
 
-      def initialize(image, name = nil, sticky = true, blocks_lay = nil, preprinted = true)
+      attr_accessor :preprinted
+      attr_reader :image, :name, :sticky, :large
+
+      def initialize(image, name = nil, sticky = true, blocks_lay = nil, preprinted = true, large: false, owner: nil)
         @image = "/icons/#{image}.svg"
         @name = name || image.split('/')[-1]
         @sticky = !!sticky
         @preprinted = preprinted
         @blocks_lay = !!blocks_lay
+        @large = !!large
+        @owner = owner
       end
 
       def blocks_lay?

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -138,7 +138,8 @@ module Engine
         cache << junction
         junction
       when 'icon'
-        Part::Icon.new(params['image'], params['name'], params['sticky'], params['blocks_lay'])
+        Part::Icon.new(params['image'], params['name'], params['sticky'], params['blocks_lay'],
+                       large: params['large'])
       when 'stub'
         Part::Stub.new(params['edge'].to_i)
       when 'partition'


### PR DESCRIPTION
Added a "large" flag to Engine::Part::Icon and support for it in Engine::Tile.
Added a new UI element: LargeIcons and modified UI::Part::Icons and UI::Tile to support it.

Large icons are ownable and the LargeIcons UI uses that to show player ownership ala Tokens.

Modified 1873 to use large icons for mines and factories.

![large_icons](https://user-images.githubusercontent.com/8494213/111545041-0dd7d180-873b-11eb-8f79-9a9d4b2f200b.png)

**With player colors.**
![large_icons_colors](https://user-images.githubusercontent.com/8494213/111545066-1a5c2a00-873b-11eb-9649-5cced05631fd.png)
