### PR TITLE
[1822] Train removed when bid on last minor

### DIFF
--- a/lib/engine/game/g_1822/round/stock.rb
+++ b/lib/engine/game/g_1822/round/stock.rb
@@ -60,9 +60,6 @@ module Engine
             # Refill the minors bidbox
             @game.bidbox_minors_refill!
 
-            # If the minors is empty and no minor was removed. Remove a train
-            remove_first_train if !remove_minor && @game.bidbox_minors.empty?
-
             # Increase player loans with 50% interest
             @game.add_interest_player_loans!
 


### PR DESCRIPTION
- Dont export a train when there is a bid on the last minor.

fixes #4569

This change might affect the currect games.