### PR TITLE
fix fuzzy matching so "1873" goes to "Harzbahn 1873" instead of "1870"

### DIFF
--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -51,15 +51,18 @@ module Engine
     title = title.upcase
 
     @fuzzy_titles[title] ||= GAME_METAS.max_by do |m|
+      class_name = m.name.split('::')[-2]
+
       titles = [
         m.title,
+        m.title.split(' '),
         m::GAME_LOCATION,
         m::GAME_SUBTITLE,
-        m.name.split('::')[-2],
+        class_name,
+        class_name.sub(/^G/, ''),
+        class_name.sub(/^G18/, ''),
         *m::GAME_ALIASES,
-      ].compact
-
-      titles = titles.concat(titles.map { |t| t.sub(/^G?18/, '') }).uniq
+      ].flatten.compact.uniq
 
       titles.map do |t|
         JaroWinkler.distance(title, t.upcase)

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -21,3 +21,31 @@ describe Engine do
     end
   end
 end
+
+module Engine
+  module Game
+    {
+      G1817 => ['1817'],
+      G1822 => ['1822'],
+      G1846 => %w[1846 46],
+      G1846TwoPlayerVariant => ['1846 2p Variant'],
+      G1849 => ['1849', 'Sicilian Railways'],
+      G1849Boot => ['1849Boot', '1849K2S', 'Two Sicilies'],
+      G1873 => ['Harzbahn 1873', '1873', '73'],
+      G1889 => ['1889', 'Shikoku', 'Shikoku: 1889', 'History of Shikoku Railways'],
+      G18Chesapeake => %w[18Chesapeake Chessie],
+      G18ChesapeakeOffTheRails => ['ChesapeakeOTR', 'OTR', '18Chesapeake: Off the Rails'],
+      G18LosAngeles => ['18 Los Angeles', '18LosAngeles', '18LA'],
+    }.each do |game_module, fuzzy_titles|
+      expected_title = game_module.const_get('Meta').title
+
+      describe 'closest_title' do
+        fuzzy_titles.each do |fuzzy|
+          it "matches '#{fuzzy}' to '#{expected_title}'" do
+            expect(Engine.closest_title(fuzzy)).to eq(expected_title)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- add individual words of the main title to the list of things to match (so
  "Harzbahn" and "1873" both get compared instead of just "Harzbahn 1873")
- only sub `/^G?18/` on the class name (so "G1873" gets transformed to
  both "1873" and "73" instead of just "73")
- add unit tests for closest_title() to cover weird cases like "Harzbahn 1873",
  "18LA", and subclasses where the title is the base title plus more, like
  "18Chesapeake: Off the Rails"

[Fixes #4583]