### PR TITLE
Highlight laid tiles

### DIFF
--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -30,7 +30,6 @@ module Lib
       black: '#000000',
       red: '#ec232a',
       blue: '#35A7FF',
-      purple: '#800080',
     }.freeze
 
     def self.points(scale: 1.0)

--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -33,9 +33,9 @@ module Lib
     }.freeze
 
     def self.points(scale: 1.0)
-      "#{X_R * scale},#{Y_M * scale} #{X_M_R * scale},#{Y_B * scale} "\
-      "#{X_M_L * scale},#{Y_B * scale} #{X_L * scale},#{Y_M * scale} "\
-      "#{X_M_L * scale},#{Y_T * scale} #{X_M_R * scale},#{Y_T * scale}"
+      "#{(X_R * scale).round(3)},#{(Y_M * scale).round(3)} #{(X_M_R * scale).round(3)},#{(Y_B * scale).round(3)} "\
+      "#{(X_M_L * scale).round(3)},#{(Y_B * scale).round(3)} #{(X_L * scale).round(3)},#{(Y_M * scale).round(3)} "\
+      "#{(X_M_L * scale).round(3)},#{(Y_T * scale).round(3)} #{(X_M_R * scale).round(3)},#{(Y_T * scale).round(3)}"
     end
   end
 end

--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -30,6 +30,7 @@ module Lib
       black: '#000000',
       red: '#ec232a',
       blue: '#35A7FF',
+      purple: '#800080',
     }.freeze
 
     def self.points(scale: 1.0)

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lib/hex'
+require 'lib/color'
 require 'lib/settings'
 require 'lib/tile_selector'
 require 'view/game/actionable'
@@ -14,6 +15,7 @@ module View
     class Hex < Snabberb::Component
       include Actionable
       include Runnable
+      include Lib::Color
       include Lib::Settings
 
       SIZE = 100
@@ -21,7 +23,7 @@ module View
       FRAME_COLOR_STROKE_WIDTH = 10
       FRAME_COLOR_POINTS = Lib::Hex.points(scale: 1 - ((FRAME_COLOR_STROKE_WIDTH + 1) / 2) / Lib::Hex::Y_B).freeze
 
-      HIGHLIGHT_STROKE_WIDTH = 8
+      HIGHLIGHT_STROKE_WIDTH = 6
       HIGHLIGHT_POINTS = Lib::Hex.points(scale: 1 - ((HIGHLIGHT_STROKE_WIDTH + 1) / 2) / Lib::Hex::Y_B).freeze
 
       LAYOUT = {
@@ -116,8 +118,11 @@ module View
       def hex_highlight
         polygon_props = { attrs: { points: HIGHLIGHT_POINTS } }
         polygon_props[:attrs]['fill-opacity'] = 0
-        polygon_props[:attrs]['stroke-dasharray'] = 15
+        polygon_props[:attrs]['stroke-dasharray'] = 10
         polygon_props[:attrs]['stroke-width'] = HIGHLIGHT_STROKE_WIDTH
+        if (color = @tile&.frame&.color)
+          polygon_props[:attrs]['stroke'] = contrast_on(color_for(color))
+        end
 
         [h(:polygon, polygon_props)]
       end

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -43,6 +43,7 @@ module View
         return nil if @hex.empty
 
         @selected = @hex == @tile_selector&.hex || @selected_route&.last_node&.hex == @hex
+        @laid_this_turn = @game.round.operating? && @game.round.laid_hexes.include?(@hex)
         @tile =
           if @selected && @actions.include?('lay_tile') && @tile_selector&.tile
             @tile_selector.tile
@@ -84,7 +85,8 @@ module View
         props[:attrs][:cursor] = 'pointer' if @clickable
 
         props[:on] = { click: ->(e) { on_hex_click(e) } }
-        props[:attrs]['stroke-width'] = 5 if @selected
+        props[:attrs]['stroke'] = 'blue' if !@selected && @laid_this_turn
+        props[:attrs]['stroke-width'] = 5 if @selected || @laid_this_turn
         h(:g, props, children)
       end
 

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -121,7 +121,7 @@ module View
         polygon_props[:attrs]['stroke-dasharray'] = 10
         polygon_props[:attrs]['stroke-width'] = HIGHLIGHT_STROKE_WIDTH
         if (color = @tile&.frame&.color)
-          polygon_props[:attrs]['stroke'] = contrast_on(color_for(color))
+          polygon_props[:attrs]['stroke'] = contrast_on(color)
         end
 
         [h(:polygon, polygon_props)]

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -85,8 +85,13 @@ module View
         props[:attrs][:cursor] = 'pointer' if @clickable
 
         props[:on] = { click: ->(e) { on_hex_click(e) } }
-        props[:attrs]['stroke'] = 'blue' if !@selected && @laid_this_turn
-        props[:attrs]['stroke-width'] = 5 if @selected || @laid_this_turn
+        props[:attrs]['stroke-width'] = 5 if @selected
+
+        if @laid_this_turn
+          props[:attrs]['stroke-dasharray'] = 15
+          props[:attrs]['stroke-width'] = 10
+        end
+
         h(:g, props, children)
       end
 

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -55,7 +55,18 @@ module View
           else
             @hex.tile
           end
+
         children = hex_outline
+        if (color = @tile&.frame&.color)
+          attrs = {
+            stroke: color,
+            'stroke-width': FRAME_COLOR_STROKE_WIDTH,
+            points: FRAME_COLOR_POINTS,
+          }
+          children << h(:polygon, attrs: attrs)
+        end
+        children << hex_highlight if @highlight
+
         if @tile
           children << h(
             Tile,
@@ -67,17 +78,6 @@ module View
         end
         children << h(TriangularGrid) if Lib::Params['grid']
         children << h(TileUnavailable, unavailable: @unavailable, layout: @hex.layout) if @unavailable
-
-        if (color = @tile&.frame&.color)
-          attrs = {
-            stroke: color,
-            'stroke-width': FRAME_COLOR_STROKE_WIDTH,
-            points: FRAME_COLOR_POINTS,
-          }
-          children.insert(1, h(:polygon, attrs: attrs))
-        end
-
-        children.insert(2, hex_highlight) if @highlight
 
         props = {
           key: @hex.id,

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -21,6 +21,9 @@ module View
       FRAME_COLOR_STROKE_WIDTH = 10
       FRAME_COLOR_POINTS = Lib::Hex.points(scale: 1 - ((FRAME_COLOR_STROKE_WIDTH + 1) / 2) / Lib::Hex::Y_B).freeze
 
+      HIGHLIGHT_STROKE_WIDTH = 8
+      HIGHLIGHT_POINTS = Lib::Hex.points(scale: 1 - ((HIGHLIGHT_STROKE_WIDTH + 1) / 2) / Lib::Hex::Y_B).freeze
+
       LAYOUT = {
         flat: [SIZE * 3 / 2, SIZE * Math.sqrt(3) / 2],
         pointy: [SIZE * Math.sqrt(3) / 2, SIZE * 3 / 2],
@@ -72,6 +75,8 @@ module View
           children.insert(1, h(:polygon, attrs: attrs))
         end
 
+        children << hex_highlight if @highlight
+
         props = {
           key: @hex.id,
           attrs: {
@@ -87,12 +92,7 @@ module View
         props[:on] = { click: ->(e) { on_hex_click(e) } }
         props[:attrs]['stroke-width'] = 5 if @selected
 
-        if @highlight && !@selected
-          props[:attrs]['stroke-dasharray'] = 10
-          props[:attrs]['stroke-width'] = 5 
-        end
-
-        h(:g, props, children)
+        h(:g, props, children.flatten)
       end
 
       def hex_outline
@@ -111,6 +111,15 @@ module View
         else
           [h(:polygon, polygon_props)]
         end
+      end
+
+      def hex_highlight
+        polygon_props = { attrs: { points: HIGHLIGHT_POINTS } }
+        polygon_props[:attrs]['fill-opacity'] = 0
+        polygon_props[:attrs]['stroke-dasharray'] = 15
+        polygon_props[:attrs]['stroke-width'] = HIGHLIGHT_STROKE_WIDTH
+
+        [h(:polygon, polygon_props)]
       end
 
       def translation

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -77,7 +77,7 @@ module View
           children.insert(1, h(:polygon, attrs: attrs))
         end
 
-        children << hex_highlight if @highlight
+        children.insert(2, hex_highlight) if @highlight
 
         props = {
           key: @hex.id,
@@ -94,7 +94,7 @@ module View
         props[:on] = { click: ->(e) { on_hex_click(e) } }
         props[:attrs]['stroke-width'] = 5 if @selected
 
-        h(:g, props, children.flatten)
+        h(:g, props, children)
       end
 
       def hex_outline
@@ -116,15 +116,21 @@ module View
       end
 
       def hex_highlight
-        polygon_props = { attrs: { points: HIGHLIGHT_POINTS } }
-        polygon_props[:attrs]['fill-opacity'] = 0
-        polygon_props[:attrs]['stroke-dasharray'] = 10
-        polygon_props[:attrs]['stroke-width'] = HIGHLIGHT_STROKE_WIDTH
+        polygon_props = {
+          attrs: {
+            points: HIGHLIGHT_POINTS,
+            'fill-opacity': 0,
+            pathLength: 576, # 6*96, total length of polygon border => easier dasharray arithmetic
+            'stroke-dasharray': 16,
+            'stroke-dashoffset': 8,
+            'stroke-width': HIGHLIGHT_STROKE_WIDTH,
+          },
+        }
         if (color = @tile&.frame&.color)
           polygon_props[:attrs]['stroke'] = contrast_on(color)
         end
 
-        [h(:polygon, polygon_props)]
+        h(:polygon, polygon_props)
       end
 
       def translation

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -38,12 +38,12 @@ module View
       needs :unavailable, default: nil
       needs :routes, default: []
       needs :start_pos, default: [1, 1]
+      needs :highlight, default: false
 
       def render
         return nil if @hex.empty
 
         @selected = @hex == @tile_selector&.hex || @selected_route&.last_node&.hex == @hex
-        @laid_this_turn = @game.round.operating? && @game.round.laid_hexes.include?(@hex)
         @tile =
           if @selected && @actions.include?('lay_tile') && @tile_selector&.tile
             @tile_selector.tile
@@ -87,9 +87,9 @@ module View
         props[:on] = { click: ->(e) { on_hex_click(e) } }
         props[:attrs]['stroke-width'] = 5 if @selected
 
-        if @laid_this_turn
-          props[:attrs]['stroke-dasharray'] = 15
-          props[:attrs]['stroke-width'] = 10
+        if @highlight && !@selected
+          props[:attrs]['stroke-dasharray'] = 10
+          props[:attrs]['stroke-width'] = 5 
         end
 
         h(:g, props, children)

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -38,7 +38,8 @@ module View
         step = @game.round.active_step(@selected_company)
         current_entity = @selected_company || step&.current_entity
         actions = step&.actions(current_entity) || []
-        # move the selected hex to the back so it renders highest in z space
+        # move the hexes laid this turn and selected hex to the back so they render highest in z space
+        @game.round.laid_hexes.each {|hex| @hexes << @hexes.delete(hex) } if @game.round.operating?
         selected_hex = @tile_selector&.hex
         @hexes << @hexes.delete(selected_hex) if @hexes.include?(selected_hex)
 

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -40,10 +40,11 @@ module View
         current_entity = @selected_company || step&.current_entity
         actions = step&.actions(current_entity) || []
 
-        laid_hexes = @historical_laid_hexes || @game.round.laid_hexes
+        laid_hexes = @historical_laid_hexes
+        laid_hexes = @game.round.laid_hexes if laid_hexes.none?
+
         selected_hex = @tile_selector&.hex
-        # Move the laid and selected hexes to the back so they render highest in z space
-        laid_hexes.each {|hex| @hexes << @hexes.delete(hex) }
+        # Move the selected hex to the back so they render highest in z space
         @hexes << @hexes.delete(selected_hex) if @hexes.include?(selected_hex)
 
         routes = @routes

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -41,7 +41,7 @@ module View
         actions = step&.actions(current_entity) || []
 
         laid_hexes = @historical_laid_hexes
-        laid_hexes = @game.round.laid_hexes if laid_hexes.none?
+        laid_hexes = @game.round.laid_hexes if laid_hexes.none? && @game.round.respond_to?(:laid_hexes)
 
         selected_hex = @tile_selector&.hex
         # Move the selected hex to the back so they render highest in z space

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -17,6 +17,7 @@ module View
       needs :opacity, default: nil
       needs :show_starting_map, default: false, store: true
       needs :routes, default: [], store: true
+      needs :historical_laid_hexes, default: [], store: true
       needs :historical_routes, default: [], store: true
       needs :map_zoom, default: nil, store: true
 
@@ -38,9 +39,11 @@ module View
         step = @game.round.active_step(@selected_company)
         current_entity = @selected_company || step&.current_entity
         actions = step&.actions(current_entity) || []
-        # move the hexes laid this turn and selected hex to the back so they render highest in z space
-        @game.round.laid_hexes.each {|hex| @hexes << @hexes.delete(hex) } if @game.round.operating?
+
+        laid_hexes = @historical_laid_hexes || @game.round.laid_hexes
         selected_hex = @tile_selector&.hex
+        # Move the laid and selected hexes to the back so they render highest in z space
+        laid_hexes.each {|hex| @hexes << @hexes.delete(hex) }
         @hexes << @hexes.delete(selected_hex) if @hexes.include?(selected_hex)
 
         routes = @routes
@@ -57,7 +60,8 @@ module View
             clickable: clickable,
             actions: actions,
             routes: routes,
-            start_pos: @start_pos
+            start_pos: @start_pos,
+            highlight: laid_hexes.include?(hex),
           )
         end
         @hexes.compact!

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -17,7 +17,7 @@ module View
       needs :opacity, default: nil
       needs :show_starting_map, default: false, store: true
       needs :routes, default: [], store: true
-      needs :historical_laid_hexes, default: [], store: true
+      needs :historical_laid_hexes, default: nil, store: true
       needs :historical_routes, default: [], store: true
       needs :map_zoom, default: nil, store: true
 
@@ -40,9 +40,9 @@ module View
         current_entity = @selected_company || step&.current_entity
         actions = step&.actions(current_entity) || []
 
-        laid_hexes = @historical_laid_hexes
-        laid_hexes = @game.round.laid_hexes if laid_hexes.none? && @game.round.respond_to?(:laid_hexes)
-
+        unless (laid_hexes = @historical_laid_hexes)
+          laid_hexes = @game.round.respond_to?(:laid_hexes) ? @game.round.laid_hexes : []
+        end
         selected_hex = @tile_selector&.hex
         # Move the selected hex to the back so they render highest in z space
         @hexes << @hexes.delete(selected_hex) if @hexes.include?(selected_hex)

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -8,7 +8,7 @@ module View
       include Lib::Settings
       needs :show_starting_map, default: false, store: true
       needs :historical_routes, default: [], store: true
-      needs :historical_laid_hexes, default: [], store: true
+      needs :historical_laid_hexes, default: nil, store: true
       needs :game, default: nil, store: true
 
       def render
@@ -90,7 +90,7 @@ module View
             store(:historical_laid_hexes, last_laid_hexes(operator))
           else
             store(:historical_routes, [])
-            store(:historical_laid_hexes, [])
+            store(:historical_laid_hexes, nil)
           end
         end
 

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -8,6 +8,7 @@ module View
       include Lib::Settings
       needs :show_starting_map, default: false, store: true
       needs :historical_routes, default: [], store: true
+      needs :historical_laid_hexes, default: [], store: true
       needs :game, default: nil, store: true
 
       def render
@@ -55,6 +56,11 @@ module View
         routes
       end
 
+      def last_laid_hexes(entity)
+        operating = entity.operating_history
+        operating[operating.keys.max]&.laid_hexes || []
+      end
+
       def route_controls
         return unless @game
 
@@ -81,13 +87,15 @@ module View
           operator = all_operators.find { |o| o.name == operator_name }
           if operator
             store(:historical_routes, generate_last_route(operator))
+            store(:historical_laid_hexes, last_laid_hexes(operator))
           else
             store(:historical_routes, [])
+            store(:historical_laid_hexes, [])
           end
         end
 
         @route_input = render_select(id: :route, on: { input: route_change }, children: operators)
-        h('label.inline-block', ['Show Last Route For:', @route_input])
+        h('label.inline-block', ['Show Last Route and Track For:', @route_input])
       end
 
       def render_select(id:, on: {}, children: [])

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -95,7 +95,7 @@ module View
         end
 
         @route_input = render_select(id: :route, on: { input: route_change }, children: operators)
-        h('label.inline-block', ['Show Last Route and Track For:', @route_input])
+        h('label.inline-block', ['Show Last Route and Tile For:', @route_input])
       end
 
       def render_select(id:, on: {}, children: [])

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -86,10 +86,10 @@ module View
           operator_name = Native(@route_input).elm&.value
           operator = all_operators.find { |o| o.name == operator_name }
           if operator
-            store(:historical_routes, generate_last_route(operator))
+            store(:historical_routes, generate_last_route(operator), skip: true)
             store(:historical_laid_hexes, last_laid_hexes(operator))
           else
-            store(:historical_routes, [])
+            store(:historical_routes, [], skip: true)
             store(:historical_laid_hexes, nil)
           end
         end

--- a/lib/engine/game/g_1817/step/special_track.rb
+++ b/lib/engine/game/g_1817/step/special_track.rb
@@ -22,6 +22,7 @@ module Engine
 
               # Subtract 15 from the cost cancelling the terrain cost
               lay_tile(action, extra_cost: tile_lay[:cost] - 15, entity: owner, spender: owner)
+              @round.laid_hexes << action.hex
               tile.hex.assign!('mine')
               @game.log << "#{owner.name} adds mine to #{tile.hex.name}"
               ability = abilities(action.entity)

--- a/lib/engine/game/g_1822/step/dividend.rb
+++ b/lib/engine/game/g_1822/step/dividend.rb
@@ -128,7 +128,8 @@ module Engine
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
               routes,
               action,
-              revenue
+              revenue,
+              @round.laid_hexes
             )
 
             entity.trains.each { |train| train.operated = true }

--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -43,6 +43,7 @@ module Engine
               raise GameError, 'Cannot lay an extra upgrade' if upgraded_extra_track && @extra_laided_track
 
               lay_tile(action, spender: spender)
+              @round.laid_hexes << action.hex
               if upgraded_extra_track || spender.type == :minor
                 # Use the ability an extra time, upgrade counts as 2 tile lays. Or if its a minor, they ony get one use
                 ability.use!

--- a/lib/engine/game/g_1824/step/dividend.rb
+++ b/lib/engine/game/g_1824/step/dividend.rb
@@ -33,7 +33,8 @@ module Engine
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
               routes,
               action,
-              revenue + mine_revenue
+              revenue + mine_revenue,
+              @round.laid_hexes
             )
 
             entity.trains.each { |train| train.operated = true }

--- a/lib/engine/game/g_1856/step/dividend.rb
+++ b/lib/engine/game/g_1856/step/dividend.rb
@@ -31,7 +31,8 @@ module Engine
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
               routes,
               action,
-              revenue
+              revenue,
+              @round.laid_hexes
             )
 
             entity.trains.each { |train| train.operated = true }

--- a/lib/engine/game/g_1860/step/dividend.rb
+++ b/lib/engine/game/g_1860/step/dividend.rb
@@ -29,7 +29,8 @@ module Engine
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
               routes,
               (@game.insolvent?(entity) ? @game.actions.last : action),
-              revenue
+              revenue,
+              @round.laid_hexes
             )
 
             entity.trains.each { |train| train.operated = true } unless @game.insolvent?(entity)

--- a/lib/engine/game/g_1870/step/special_track.rb
+++ b/lib/engine/game/g_1870/step/special_track.rb
@@ -17,6 +17,11 @@ module Engine
             extra_cost = owner == @game.ssw_corporation && home ? -20 : 0
             lay_tile(action, spender: spender, extra_cost: extra_cost)
 
+            # Record any track laid after the dividend step
+            if owner&.corporation? && (operating_info = owner.operating_history[[@game.turn, @round.round_num]])
+              operating_info.laid_hexes = @round.laid_hexes
+            end
+
             check_connect(action, ability)
             ability.use!
 

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -2835,27 +2835,27 @@ module Engine
               %w[
                 D9
               ] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                'border=edge:4,type:impassable;frame=color:purple;'\
+                'border=edge:4,type:impassable;frame=color:#800080;'\
                 'icon=image:1873/10_open,sticky:1,large:1',
               %w[
                 D15
               ] => 'city=revenue:40,slots:2;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;'\
-                'path=a:5,b:_0,track:narrow;label=B;frame=color:purple;'\
+                'path=a:5,b:_0,track:narrow;label=B;frame=color:#800080;'\
                 'icon=image:1873/12_open,sticky:1,large:1',
               %w[
                 E4
               ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                'border=edge:3,type:impassable;frame=color:purple;'\
+                'border=edge:3,type:impassable;frame=color:#800080;'\
                 'icon=image:1873/2_open,sticky:1,large:1',
               %w[
                 F11
               ] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                'frame=color:purple;'\
+                'frame=color:#800080;'\
                 'icon=image:1873/SM_open,sticky:1,large:1',
               %w[
                 G4
               ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                'border=edge:1,type:impassable;border=edge:3,type:impassable;frame=color:purple;'\
+                'border=edge:1,type:impassable;border=edge:3,type:impassable;frame=color:#800080;'\
                 'icon=image:1873/14_open,sticky:1,large:1',
             },
             green: {
@@ -2908,7 +2908,7 @@ module Engine
                 B13
               ] => 'city=slots:2,revenue:yellow_30|green_70|brown_60|gray_60;'\
                 'path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
-                'frame=color:purple;icon=image:1873/ZW_open,sticky:1,large:1',
+                'frame=color:#800080;icon=image:1873/ZW_open,sticky:1,large:1',
               %w[
                 C4
               ] => 'city=revenue:yellow_50|green_80|brown_120|gray_150;path=a:5,b:_0,track:narrow',
@@ -2924,7 +2924,7 @@ module Engine
               %w[
                 F15
               ] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
-                'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:purple;'\
+                'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080;'\
                 'icon=image:1873/15_open,sticky:1,large:1',
               %w[
                 H9
@@ -2942,7 +2942,7 @@ module Engine
               %w[
                 I18
               ] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
-                'path=a:2,b:_0,track:narrow;frame=color:purple;'\
+                'path=a:2,b:_0,track:narrow;frame=color:#800080;'\
                 'icon=image:1873/13_open,sticky:1,large:1',
               %w[
                 J7

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -2862,7 +2862,7 @@ module Engine
               %w[
                 B19
               ] => 'city=revenue:60;path=a:1,b:_0,track:narrow;path=a:2,b:_0;path=a:5,b:_0;'\
-                'frame=color:purple;label=HQG',
+                'frame=color:#800080;label=HQG',
               %w[
                 C16
               ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:2,b:_0,track:narrow;'\
@@ -2870,7 +2870,7 @@ module Engine
               %w[
                 E20
               ] => 'city=revenue:60;path=a:1,b:_0,track:narrow;path=a:0,b:_0;path=a:3,b:_0;'\
-                'frame=color:purple;label=HQG',
+                'frame=color:#800080;label=HQG',
               %w[
                 F5
               ] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
@@ -2884,15 +2884,15 @@ module Engine
               %w[
                 G6
               ] => 'city=revenue:40;path=a:2,b:_0,track:narrow;'\
-                'path=a:5,b:_0,track:narrow;frame=color:purple',
+                'path=a:5,b:_0,track:narrow;frame=color:#800080',
               %w[
                 G20
               ] => 'city=revenue:60;path=a:0,b:_0,track:narrow;path=a:2,b:_0;path=a:5,b:_0;'\
-                'frame=color:purple;label=HQG',
+                'frame=color:#800080;label=HQG',
               %w[
                 H13
               ] => 'city=revenue:40;path=a:2,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
-                'upgrade=cost:50,terrain:mountain;frame=color:purple',
+                'upgrade=cost:50,terrain:mountain;frame=color:#800080',
               %w[
                 H17
               ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
@@ -2903,7 +2903,7 @@ module Engine
                 B9
               ] => 'city=slots:2,revenue:yellow_60|green_80|brown_120|gray_150;'\
                 'path=a:1,b:_0;path=a:4,b:_0;path=a:0,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
-                'frame=color:purple',
+                'frame=color:#800080',
               %w[
                 B13
               ] => 'city=slots:2,revenue:yellow_30|green_70|brown_60|gray_60;'\
@@ -2934,11 +2934,11 @@ module Engine
               %w[
                 I2
               ] => 'city=revenue:yellow_40|green_50|brown_80|gray_120;path=a:1,b:_0;'\
-                'path=a:2,b:_0,track:narrow;path=a:4,b:_0;frame=color:purple',
+                'path=a:2,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080',
               %w[
                 I4
               ] => 'city=revenue:yellow_40|green_50|brown_80|gray_120;path=a:1,b:_0;'\
-                'path=a:2,b:_0,track:narrow;path=a:5,b:_0;frame=color:purple',
+                'path=a:2,b:_0,track:narrow;path=a:5,b:_0;frame=color:#800080',
               %w[
                 I18
               ] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
@@ -2947,7 +2947,7 @@ module Engine
               %w[
                 J7
               ] => 'city=revenue:yellow_60|green_80|brown_120|gray_180;path=a:1,b:_0;'\
-                'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:purple',
+                'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080',
               # implicit tiles
               %w[
                 C20

--- a/lib/engine/game/g_1873/step/dividend.rb
+++ b/lib/engine/game/g_1873/step/dividend.rb
@@ -31,7 +31,7 @@ module Engine
             ))
 
             current_entity.operating_history[[@game.turn, @round.round_num]] =
-              OperatingInfo.new([], @game.actions.last, revenue)
+              OperatingInfo.new([], @game.actions.last, revenue, @round.laid_hexes)
           end
 
           def total_revenue(entity)
@@ -87,7 +87,8 @@ module Engine
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
               routes,
               action,
-              revenue
+              revenue,
+              @round.laid_hexes
             )
 
             entity.trains.each { |train| train.operated = true }

--- a/lib/engine/game/g_1882/step/special_nwr.rb
+++ b/lib/engine/game/g_1882/step/special_nwr.rb
@@ -112,6 +112,7 @@ module Engine
 
           def process_lay_tile(action)
             lay_tile(action, entity: action.entity.owner)
+            @round.laid_hexes << action.hex
             gain_nwr_bonus(action.tile, action.entity.owner)
             ability(action.entity).use!
             @state = nil

--- a/lib/engine/game/g_1882/step/special_nwr.rb
+++ b/lib/engine/game/g_1882/step/special_nwr.rb
@@ -111,8 +111,15 @@ module Engine
           end
 
           def process_lay_tile(action)
-            lay_tile(action, entity: action.entity.owner)
+            owner = action.entity.owner
+            lay_tile(action, entity: owner)
             @round.laid_hexes << action.hex
+
+            # Record any track laid after the dividend step
+            if owner&.corporation? && (operating_info = owner.operating_history[[@game.turn, @round.round_num]])
+              operating_info.laid_hexes = @round.laid_hexes
+            end
+
             gain_nwr_bonus(action.tile, action.entity.owner)
             ability(action.entity).use!
             @state = nil

--- a/lib/engine/game/g_1889/step/special_track.rb
+++ b/lib/engine/game/g_1889/step/special_track.rb
@@ -18,6 +18,7 @@ module Engine
             raise GameError, "Not #{entity.name}'s turn: #{action.to_h}" unless entity == @company
 
             lay_tile(action, spender: @round.company_sellers[@company])
+            @round.laid_hexes << action.hex
             check_connect(action, ability)
             ability.use!
 

--- a/lib/engine/game/g_18_co/step/special_track.rb
+++ b/lib/engine/game/g_18_co/step/special_track.rb
@@ -13,6 +13,7 @@ module Engine
           def process_lay_tile(action)
             ability = abilities(action.entity)
             lay_tile(action, spender: action.entity.owner)
+            @round.laid_hexes << action.hex
             ability.use!
 
             @company = ability.count.positive? ? action.entity : nil if ability.must_lay_together

--- a/lib/engine/game/g_18_co/step/special_track.rb
+++ b/lib/engine/game/g_18_co/step/special_track.rb
@@ -11,10 +11,16 @@ module Engine
           include G18CO::Tracker
 
           def process_lay_tile(action)
+            owner = action.entity.owner
             ability = abilities(action.entity)
-            lay_tile(action, spender: action.entity.owner)
+            lay_tile(action, spender: owner)
             @round.laid_hexes << action.hex
             ability.use!
+
+            # Record any track laid after the dividend step
+            if owner&.corporation? && (operating_info = owner.operating_history[[@game.turn, @round.round_num]])
+              operating_info.laid_hexes = @round.laid_hexes
+            end
 
             @company = ability.count.positive? ? action.entity : nil if ability.must_lay_together
 

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -204,42 +204,42 @@ module Engine
             'count' => 2,
             'color' => 'green',
             'code' =>
-            'town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;frame=color:purple',
+            'town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;frame=color:#800080',
           },
           '14p' =>
           {
             'count' => 1,
             'color' => 'green',
             'code' =>
-            'city=revenue:30,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;frame=color:purple',
+            'city=revenue:30,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;frame=color:#800080',
           },
           '887p' =>
           {
             'count' => 4,
             'color' => 'green',
             'code' =>
-            'town=revenue:20;path=a:1,b:_0;path=a:3,b:_0;path=a:0,b:_0;path=a:2,b:_0;frame=color:purple',
+            'town=revenue:20;path=a:1,b:_0;path=a:3,b:_0;path=a:0,b:_0;path=a:2,b:_0;frame=color:#800080',
           },
           '15p' =>
           {
             'count' => 1,
             'color' => 'green',
             'code' =>
-            'city=revenue:30,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;frame=color:purple',
+            'city=revenue:30,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;frame=color:#800080',
           },
           '888p' =>
           {
             'count' => 2,
             'color' => 'green',
             'code' =>
-            'town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;frame=color:purple',
+            'town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;frame=color:#800080',
           },
           '889p' =>
           {
             'count' => 2,
             'color' => 'brown',
             'code' =>
-            'town=revenue:30;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;frame=color:purple',
+            'town=revenue:30;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;frame=color:#800080',
           },
           '611p' =>
           {
@@ -247,7 +247,7 @@ module Engine
             'color' => 'brown',
             'code' =>
             'city=revenue:40,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;' \
-                  'frame=color:purple',
+                  'frame=color:#800080',
           },
           '216p' =>
           {
@@ -255,7 +255,7 @@ module Engine
             'color' => 'brown',
             'code' =>
             'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y;' \
-                  'frame=color:purple',
+                  'frame=color:#800080',
           },
           '8894p' =>
           {
@@ -263,7 +263,7 @@ module Engine
             'color' => 'brown',
             'code' =>
             'city=revenue:60,slots:2;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=OO;' \
-                  'frame=color:purple',
+                  'frame=color:#800080',
           },
           '8895p' =>
           {
@@ -271,7 +271,7 @@ module Engine
             'color' => 'brown',
             'code' =>
             'city=revenue:60,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=OO;' \
-                  'frame=color:purple',
+                  'frame=color:#800080',
           },
           '8896p' =>
           {
@@ -279,7 +279,7 @@ module Engine
             'color' => 'brown',
             'code' =>
             'city=revenue:60,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;label=OO;' \
-                  'frame=color:purple',
+                  'frame=color:#800080',
           },
           '8857p' =>
           {
@@ -287,7 +287,7 @@ module Engine
             'color' => 'gray',
             'code' =>
             'city=revenue:70,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;' \
-                  'path=a:5,b:_0;label=Y;frame=color:purple',
+                  'path=a:5,b:_0;label=Y;frame=color:#800080',
           },
           '595p' =>
           {
@@ -295,7 +295,7 @@ module Engine
             'color' => 'gray',
             'code' =>
             'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;' \
-                  'path=a:5,b:_0;frame=color:purple',
+                  'path=a:5,b:_0;frame=color:#800080',
           },
         }.freeze
 

--- a/lib/engine/game/g_18_cz/step/sell_company_and_special_track.rb
+++ b/lib/engine/game/g_18_cz/step/sell_company_and_special_track.rb
@@ -47,6 +47,7 @@ module Engine
             end
 
             lay_tile(action, spender: spender)
+            @round.laid_hexes << action.hex
 
             @game.skip_default_track unless @game.purple_tile?(action.tile)
 

--- a/lib/engine/game/g_18_cz/step/sell_company_and_special_track.rb
+++ b/lib/engine/game/g_18_cz/step/sell_company_and_special_track.rb
@@ -31,13 +31,13 @@ module Engine
           end
 
           def process_lay_tile(action)
-            spender = if !action.entity.owner
-                        nil
-                      elsif action.entity.owner.corporation?
-                        action.entity.owner
-                      else
-                        @game.current_entity
-                      end
+            owner = if !action.entity.owner
+                      nil
+                    elsif action.entity.owner.corporation?
+                      action.entity.owner
+                    else
+                      @game.current_entity
+                    end
 
             unless @game.purple_tile?(action.tile)
               discount = action.hex.tile.upgrades.sum(&:cost)
@@ -46,8 +46,13 @@ module Engine
               "#{action.entity.name}"
             end
 
-            lay_tile(action, spender: spender)
+            lay_tile(action, spender: owner)
             @round.laid_hexes << action.hex
+
+            # Record any track laid after the dividend step
+            if owner&.corporation? && (operating_info = owner.operating_history[[@game.turn, @round.round_num]])
+              operating_info.laid_hexes = @round.laid_hexes
+            end
 
             @game.skip_default_track unless @game.purple_tile?(action.tile)
 

--- a/lib/engine/game/g_18_mag/step/dividend.rb
+++ b/lib/engine/game/g_18_mag/step/dividend.rb
@@ -54,7 +54,8 @@ module Engine
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
               routes,
               action,
-              amount
+              amount,
+              @round.laid_hexes
             )
 
             @round.routes = []

--- a/lib/engine/operating_info.rb
+++ b/lib/engine/operating_info.rb
@@ -4,13 +4,15 @@ module Engine
   # Information about an entities operating round
   class OperatingInfo
     attr_reader :routes, :halts, :dividend, :revenue
+    attr_accessor :laid_hexes
 
-    def initialize(runs, dividend, revenue)
+    def initialize(runs, dividend, revenue, laid_hexes)
       # Convert the route into connection hexes as upgrades may break the representation
       @routes = runs.map { |run| [run.train, run.connection_hexes] }.to_h
       @halts = runs.map { |run| [run.train, run.halts] }.to_h
       @revenue = revenue
       @dividend = dividend
+      @laid_hexes = laid_hexes
     end
   end
 end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -6,6 +6,7 @@ module Engine
   module Round
     class Operating < Base
       attr_reader :current_operator, :current_operator_acted
+      attr_accessor :laid_hexes      
 
       def self.short_name
         'OR'
@@ -21,6 +22,7 @@ module Engine
 
       def setup
         @current_operator = nil
+        @laid_hexes = []
         @home_token_timing = @game.class::HOME_TOKEN_TIMING
         @game.payout_companies
         @entities.each { |c| @game.place_home_token(c) } if @home_token_timing == :operating_round
@@ -70,6 +72,7 @@ module Engine
         entity = @entities[@entity_index]
         @current_operator = entity
         @current_operator_acted = false
+        @laid_hexes = []
         entity.trains.each { |train| train.operated = false }
         @log << "#{entity.owner.name} operates #{entity.name}" unless finished?
         @game.place_home_token(entity) if @home_token_timing == :operate

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -6,7 +6,6 @@ module Engine
   module Round
     class Operating < Base
       attr_reader :current_operator, :current_operator_acted
-      attr_accessor :laid_hexes      
 
       def self.short_name
         'OR'
@@ -22,7 +21,6 @@ module Engine
 
       def setup
         @current_operator = nil
-        @laid_hexes = []
         @home_token_timing = @game.class::HOME_TOKEN_TIMING
         @game.payout_companies
         @entities.each { |c| @game.place_home_token(c) } if @home_token_timing == :operating_round
@@ -72,7 +70,6 @@ module Engine
         entity = @entities[@entity_index]
         @current_operator = entity
         @current_operator_acted = false
-        @laid_hexes = []
         entity.trains.each { |train| train.operated = false }
         @log << "#{entity.owner.name} operates #{entity.name}" unless finished?
         @game.place_home_token(entity) if @home_token_timing == :operate

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -28,7 +28,7 @@ module Engine
         process_dividend(Action::Dividend.new(current_entity, kind: 'withhold'))
 
         current_entity.operating_history[[@game.turn, @round.round_num]] =
-          OperatingInfo.new([], @game.actions.last, 0)
+          OperatingInfo.new([], @game.actions.last, 0, @round.laid_hexes)
       end
 
       def dividend_options(entity)
@@ -51,7 +51,8 @@ module Engine
         entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
           routes,
           action,
-          revenue
+          revenue,
+          @round.laid_hexes
         )
 
         entity.trains.each { |train| train.operated = true }

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -65,7 +65,7 @@ module Engine
         ability.use!
 
         # Record any track laid after the dividend step
-        if owner&.corporation? && operating_info = owner.operating_history[[@game.turn, @game.round_num]]
+        if owner&.corporation? && operating_info = owner.operating_history[[@game.turn, @round.round_num]]
           operating_info.laid_hexes = @round.laid_hexes
         end
 

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -48,20 +48,26 @@ module Engine
         end
 
         ability = abilities(action.entity)
-        spender = if !action.entity.owner
-                    nil
-                  elsif action.entity.owner.corporation?
-                    action.entity.owner
-                  else
-                    @game.current_entity
-                  end
+        owner = if !action.entity.owner
+                  nil
+                elsif action.entity.owner.corporation?
+                  action.entity.owner
+                else
+                  @game.current_entity
+                end
         if ability.type == :teleport
-          lay_tile_action(action, spender: spender)
+          lay_tile_action(action, spender: owner)
         else
-          lay_tile(action, spender: spender)
+          lay_tile(action, spender: owner)
+          @round.laid_hexes << action.hex
           check_connect(action, ability)
         end
         ability.use!
+
+        # Record any track laid after the dividend step
+        if owner&.corporation? && operating_info = owner.operating_history[[@game.turn, @game.round_num]]
+          operating_info.laid_hexes = @round.laid_hexes
+        end
 
         if ability.type == :tile_lay
           ability.owner.close! unless ability.count.positive? || !ability.closed_when_used_up

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -65,7 +65,7 @@ module Engine
         ability.use!
 
         # Record any track laid after the dividend step
-        if owner&.corporation? && operating_info = owner.operating_history[[@game.turn, @round.round_num]]
+        if owner&.corporation? && (operating_info = owner.operating_history[[@game.turn, @round.round_num]])
           operating_info.laid_hexes = @round.laid_hexes
         end
 

--- a/lib/engine/step/track_lay_when_company_sold.rb
+++ b/lib/engine/step/track_lay_when_company_sold.rb
@@ -26,6 +26,7 @@ module Engine
         raise GameError, "Not #{entity.name}'s turn: #{action.to_h}" unless entity == @company
 
         lay_tile(action, spender: entity.owner)
+        @round.laid_hexes << action.hex
         check_connect(action, ability)
         ability.use!
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -9,12 +9,14 @@ module Engine
         {
           num_laid_track: 0,
           upgraded_track: false,
+          laid_hexes: [],
         }
       end
 
       def setup
         @round.num_laid_track = 0
         @round.upgraded_track = false
+        @round.laid_hexes = []
       end
 
       def can_lay_tile?(entity)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -9,14 +9,12 @@ module Engine
         {
           num_laid_track: 0,
           upgraded_track: false,
-          laid_hexes: [],
         }
       end
 
       def setup
         @round.num_laid_track = 0
         @round.upgraded_track = false
-        @round.laid_hexes = []
       end
 
       def can_lay_tile?(entity)


### PR DESCRIPTION
Highlights tiles laid this turn. Also highlights last tiles laid for other corporations via the  the "Show Last Route and Track For" drop-down.

For tiles with a border, uses contrast instead of black for the highlight.

![image](https://user-images.githubusercontent.com/67359577/111726297-0ac60980-883f-11eb-8e0c-a7c305936b4e.png)
