### PR TITLE
1873: show map on starting draft

### DIFF
--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -411,9 +411,10 @@ module View
 
         # show the map if there are minors to pick from
         def render_map
-          return nil unless @step.available.any?(&:minor?)
+          show = @step.available.any?(&:minor?) || (@step.respond_to?(:show_map) && @step.show_map)
+          return nil unless show
 
-          h(Game::Map, game: @game)
+          h(Game::Map, game: @game, opacity: 1.0)
         end
       end
     end

--- a/lib/engine/game/g_1873/step/draft.rb
+++ b/lib/engine/game/g_1873/step/draft.rb
@@ -124,6 +124,10 @@ module Engine
 
             company.value
           end
+
+          def show_map
+            true
+          end
         end
       end
     end


### PR DESCRIPTION
Like 18Mag, it's very useful to show the map during the initial draft. Unlike 18Mag, minors aren't directly on offer so the UI::Round::Auction will call step.show_map if it exists.