### PR TITLE
improve fuzzy matching

### DIFF
--- a/lib/engine/game/g_1817_wo/meta.rb
+++ b/lib/engine/game/g_1817_wo/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_DESIGNER = 'Mark Voyer & Brennan Sheremeto'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817WO'
-        GAME_LOCATION = 'Earth.'
+        GAME_LOCATION = 'Earth'
         GAME_RULES_URL = {
           '1817WO' =>
                           'https://docs.google.com/document/d/1g9QnttpJa8yOCOTnfPaU9hfAZFFzg-rAs_WGy9T38J0/',

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -27,10 +27,12 @@ module Engine
     {
       G1817 => ['1817'],
       G1822 => ['1822'],
+      G1830 => %w[1830 Robber],
       G1846 => %w[1846 46],
       G1846TwoPlayerVariant => ['1846 2p Variant'],
       G1849 => ['1849', 'Sicilian Railways'],
       G1849Boot => ['1849Boot', '1849K2S', 'Two Sicilies'],
+      G1860 => %w[1860 Wight],
       G1873 => ['Harzbahn 1873', '1873', '73'],
       G1889 => ['1889', 'Shikoku', 'Shikoku: 1889', 'History of Shikoku Railways'],
       G18Chesapeake => %w[18Chesapeake Chessie],


### PR DESCRIPTION
- match against `full_title` and `SUPERTITLE` (in addition to `title` and
  `SUBTITLE`)
- once list of candidates is compiled, also use individual words from each
  candidate (e.g., put "Wight" in the list for 1860)
- create `fuzzy_candidates` hash just once
- in `closest_title()`, don't upcase the given title if it matches a real
  title (avoids doing unnecessary checks for "18Chesapeake" for example; old
  code was converting it to "18CHESAPEAKE" then failing to find a match in the
  initialized `fuzzy_titles`, so then it had to calculate the distance against
  all candidate strings from all games)
- remove unnecessary period from end of 1817WO's location
- add a couple `closet_title()` specs for individual subtitle words