### PR TITLE
[18MEX] improve copper canyon rendering

### DIFF
--- a/assets/app/view/game/part/location_name.rb
+++ b/assets/app/view/game/part/location_name.rb
@@ -150,7 +150,7 @@ module View
 
         # split the location name to render across multiple lines; each "segment"
         # that is returned gets rendered on its own line
-        def self.name_segments(name, max_size: 13)
+        def self.name_segments(name, max_size: 12)
           return [name] if name.size <= max_size
 
           segments = name.split(' ')

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -16,7 +16,7 @@ module View
         needs :width, default: 8
 
         REVENUE_DISPLACEMENT = 42
-        REVENUE_EDGE_DISPLACEMENT = 38
+        REVENUE_EDGE_DISPLACEMENT = 25
         REVENUE_ANGLE = -60
 
         REVENUE_REGIONS = {

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -84,7 +84,7 @@ module View
           x = render_location[:x]
           y = render_location[:y]
 
-          angle = layout == :pointy ? -60 : 0
+          angle = layout == :pointy ? REVENUE_ANGLE : 0
 
           displacement = @edge ? REVENUE_EDGE_DISPLACEMENT : REVENUE_DISPLACEMENT
 


### PR DESCRIPTION
- improve rendering of copper canyon on rotation 4

Generic change: If a location name is of length 12 (including whitespace), wrap it

addresses https://github.com/tobymao/18xx/issues/2442 (doesn't close)

![image](https://user-images.githubusercontent.com/1711810/111845929-09d6bb80-88c3-11eb-9892-80eef9aedac8.png)


Rotation 0 is still messed up, I tried tweaking [location weights](https://github.com/tobymao/18xx/blob/master/assets/app/view/game/part/location_name.rb#L21) but it didn't seem to help

![image](https://user-images.githubusercontent.com/1711810/111846073-528e7480-88c3-11eb-9d1b-b8f2763e1a29.png)
