### PR TITLE
[1822] Destination token

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -3733,7 +3733,8 @@ module Engine
 
         def place_destination_token(entity, hex, token)
           city = hex.tile.cities.first
-          city.place_token(entity, token, free: true, check_tokenable: false, cheater: 0)
+          cheater_slot = city.slots
+          city.place_token(entity, token, free: true, check_tokenable: false, cheater: cheater_slot)
           hex.tile.icons.reject! { |icon| icon.name == "#{entity.id}_destination" }
 
           ability = entity.all_abilities.find { |a| a.type == :destination }

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -3733,8 +3733,7 @@ module Engine
 
         def place_destination_token(entity, hex, token)
           city = hex.tile.cities.first
-          cheater_slot = city.slots
-          city.place_token(entity, token, free: true, check_tokenable: false, cheater: cheater_slot)
+          city.place_token(entity, token, free: true, check_tokenable: false, cheater: city.slots)
           hex.tile.icons.reject! { |icon| icon.name == "#{entity.id}_destination" }
 
           ability = entity.all_abilities.find { |a| a.type == :destination }


### PR DESCRIPTION
- Fixed the cheater token so in the very rare case when Manchester is all tokened out and LYR places its destination token and then LNWR places its destination token. It removed LYRS token.

fixes #4616

This change does not break any of the current games.
