### PR TITLE
1830: No multiple brown buys from IPO by default (fixes #4456)

### DIFF
--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -60,7 +60,7 @@ module Engine
             cash = available_cash || available_cash(entity)
             cash >= bundle.price &&
               !@round.players_sold[entity][corporation] &&
-              (can_buy_multiple?(entity, corporation) || !bought?) &&
+              (can_buy_multiple?(entity, corporation, bundle.owner) || !bought?) &&
               can_gain?(entity, bundle, exchange: exchange)
           end
 

--- a/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1828/step/buy_sell_par_shares.rb
@@ -58,7 +58,7 @@ module Engine
             @round.current_actions << action
           end
 
-          def can_buy_multiple?(entity, corporation)
+          def can_buy_multiple?(entity, corporation, _owner)
             super && corporation.owner == entity && num_shares_bought(corporation) < 2
           end
 

--- a/lib/engine/game/g_1830/game.rb
+++ b/lib/engine/game/g_1830/game.rb
@@ -534,21 +534,30 @@ module Engine
 
         LAYOUT = :pointy
 
+        def stock_round
+          Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            G1830::Step::BuySellParShares,
+          ])
+        end
+
         def operating_round(round_num)
           Round::Operating.new(self, [
-            Step::Bankrupt,
-            Step::Exchange,
-            Step::SpecialTrack,
-            Step::SpecialToken,
-            Step::BuyCompany,
-            Step::HomeToken,
-            Step::Track,
-            Step::Token,
-            Step::Route,
-            Step::Dividend,
-            Step::DiscardTrain,
-            Step::BuyTrain,
-            [Step::BuyCompany, blocks: true],
+            Engine::Step::Bankrupt,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            Engine::Step::SpecialToken,
+            Engine::Step::BuyCompany,
+            Engine::Step::HomeToken,
+            Engine::Step::Track,
+            Engine::Step::Token,
+            Engine::Step::Route,
+            Engine::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            Engine::Step::BuyTrain,
+            [Engine::Step::BuyCompany, blocks: true],
           ], round_num: round_num)
         end
       end

--- a/lib/engine/game/g_1830/meta.rb
+++ b/lib/engine/game/g_1830/meta.rb
@@ -17,6 +17,13 @@ module Engine
         GAME_RULES_URL = 'https://lookout-spiele.de/upload/en_1830re.html_Rules_1830-RE_EN.pdf'
 
         PLAYER_RANGE = [3, 6].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :multiple_brown_from_ipo,
+            short_name: 'Buy Multiple Brown Shares From IPO',
+            desc: 'Mutiple brown shares may be bought from IPO as well as from pool',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_1830/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1830/step/buy_sell_par_shares.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1830
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          def can_buy_multiple?(entity, corporation, owner)
+            # Use Lookout rule by default
+            super && (owner.share_pool? || @game.optional_rules&.include?(:multiple_brown_from_ipo))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
@@ -52,7 +52,7 @@ module Engine
             @game.corporations.any? { |c| c.ipoed && can_buy?(entity, c.shares.min_by(&:percent)&.to_bundle) }
           end
 
-          def can_buy_multiple?(entity, corp)
+          def can_buy_multiple?(entity, corp, _owner)
             super || (corp.owner == entity && just_parred(corp) && num_shares_bought(corp) < 2)
           end
 

--- a/lib/engine/game/g_1860/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1860/step/buy_sell_par_shares.rb
@@ -102,7 +102,7 @@ module Engine
             corporation = bundle.corporation
             entity.cash >= bundle.price && can_gain?(entity, bundle) &&
               !@round.players_sold[entity][corporation] &&
-              (can_buy_multiple?(entity, corporation) || !bought?) &&
+              (can_buy_multiple?(entity, corporation, bundle.owner) || !bought?) &&
               can_buy_presidents_share?(entity, bundle, corporation)
           end
 

--- a/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
@@ -29,7 +29,7 @@ module Engine
             end
           end
 
-          def can_buy_multiple?(entity, corporation)
+          def can_buy_multiple?(entity, corporation, _owner)
             return unless corporation.corporation?
 
             if @reopened == corporation

--- a/lib/engine/game/g_1882/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1882/step/buy_sell_par_shares.rb
@@ -16,7 +16,7 @@ module Engine
               corporation = bundle.corporation
               entity.cash >= bundle.price_per_share && can_gain?(entity, bundle) &&
                 !@round.players_sold[entity][corporation] &&
-                (can_buy_multiple?(entity, corporation) || !bought?)
+                (can_buy_multiple?(entity, corporation, bundle.owner) || !bought?)
             else
               super
             end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -93,7 +93,7 @@ module Engine
         corporation = bundle.corporation
         entity.cash >= bundle.price &&
           !@round.players_sold[entity][corporation] &&
-          (can_buy_multiple?(entity, corporation) || !bought?) &&
+          (can_buy_multiple?(entity, corporation, bundle.owner) || !bought?) &&
           can_gain?(entity, bundle)
       end
 
@@ -179,7 +179,7 @@ module Engine
         end
       end
 
-      def can_buy_multiple?(_entity, corporation)
+      def can_buy_multiple?(_entity, corporation, _owner)
         corporation.buy_multiple? &&
          @round.current_actions.none? { |x| x.is_a?(Action::Par) } &&
          @round.current_actions.none? { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation != corporation }
@@ -195,8 +195,12 @@ module Engine
       def can_buy_shares?(entity, shares)
         return false if shares.empty?
 
-        corporation = shares.first.corporation
-        return false if @round.players_sold[entity][corporation] || (bought? && !can_buy_multiple?(entity, corporation))
+        sample_share = shares.first
+        corporation = sample_share.corporation
+        owner = sample_share.owner
+        if @round.players_sold[entity][corporation] || (bought? && !can_buy_multiple?(entity, corporation, owner))
+          return false
+        end
 
         min_share = nil
         shares.each do |share|

--- a/spec/fixtures/1830/26855.json
+++ b/spec/fixtures/1830/26855.json
@@ -28,7 +28,7 @@
   "settings": {
     "seed": 59597076,
     "unlisted": true,
-    "optional_rules": []
+    "optional_rules": ["multiple_brown_from_ipo"]
   },
   "user_settings": null,
   "status": "finished",


### PR DESCRIPTION
Added an option to use the other interpretation of the original Avalon Hill wording.

One of the fixtures actually depended on the old behavior so I enabled that option for it.