### PR TITLE
1893: Complete merge actions

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -1254,7 +1254,7 @@ module Engine
 
           # Transfer Coal Railway cash and trains to Regional. Remove CR token.
           if minor.cash.positive?
-            @log << "#{regional.name} recieves the #{minor.name} treasury of #{format_currency(minor.cash)}"
+            @log << "#{regional.name} receives the #{minor.name} treasury of #{format_currency(minor.cash)}"
             minor.spend(minor.cash, regional)
           end
           unless minor.trains.empty?

--- a/lib/engine/game/g_1893/round/merger.rb
+++ b/lib/engine/game/g_1893/round/merger.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/merger'
+
+module Engine
+  module Game
+    module G1893
+      module Round
+        class Merger < Engine::Round::Stock
+          attr_accessor :offering, :voters, :votes, :yes, :no, :done
+
+          def self.short_name
+            'MR'
+          end
+
+          def self.round_name
+            'Merger Round'
+          end
+
+          def setup
+            super
+
+            skip_steps
+            next_entity! if @offering.empty? || merger_candidates_for(current_entity).empty?
+          end
+
+          def finished?
+            @offering.empty? && @game.potential_discard_trains.empty?
+          end
+
+          def merge_target
+            @offering.first
+          end
+
+          def handle_vote(choice)
+            percent = @votes[current_entity]
+            case choice
+            when :yes
+              @log << "#{current_entity.name} approves merge of #{names(merger_candidates_for(current_entity))}"
+              @yes += percent
+              @done = @yes >= 50
+              @log << "Yes has #{@yes}, No has #{@no}"
+              return unless @done
+
+              @log << "-- #{merge_target.name} are founded due to a 50%+ Yes vote"
+              @log << "#{names(merger_candidates)} are merged into #{merge_target.name}"
+
+              merge_target == @game.agv ? @game.found_agv : @game.found_hgk
+            when :no
+              @log << "#{current_entity.name} declines merge of #{names(merger_candidates_for(current_entity))}"
+              @no += percent
+              @done = @no > 50
+              @log << "Yes has #{@yes}, No has #{@no}"
+              return unless @done
+
+              @log << "#{names(merger_candidates)} are not merged into #{merge_target.name} at this time"
+            end
+            @offering.delete(merge_target)
+          end
+
+          def current_entity
+            @voters[@entity_index]
+          end
+
+          def select_entities
+            @offering = []
+            @voters = []
+            @votes = {}
+            @yes = 0
+            @no = 0
+            if @game.agv_auto_found
+              @log << "-- #{@game.agv.name} is founded as phase 5 has been reached"
+              @log << "#{names(merger_candidates(@game.agv))} are merged into #{@game.agv.name}"
+              @game.found_agv
+            elsif @game.agv_mergable
+              add_merge_info_agv
+            else
+              skip_message(@game.agv)
+            end
+            if @game.hgk_auto_found
+              @log << "-- #{game.hgk.name} is founded as phase 6 has been reached"
+              @log << "#{names(merger_candidates(@game.hgk))} are merged into #{@game.hgk.name}"
+              @game.found_hgk
+            elsif @game.hgk_mergable
+              add_merge_info_hgk
+            else
+              skip_message(@game.hgk)
+            end
+            return @game.players if @offering.empty?
+
+            @no = 100 - @votes.sum { |_player, percent| percent }
+            @voters
+          end
+
+          def merger_candidates(mergable = nil)
+            @game.mergers(mergable || @game.round.merge_target)
+          end
+
+          def merger_candidates_for(player)
+            merger_candidates.select { |c| c.owner == player }
+          end
+
+          def names(merger_candidates)
+            merger_candidates.map(&:name).join(', ')
+          end
+
+          private
+
+          def add_merge_info_agv
+            @offering << @game.agv
+            add_player_vote_info_for_reserved_share(@game.ekb_reserved_share)
+            add_player_vote_info_for_reserved_share(@game.ksz_reserved_share)
+            add_player_vote_info_for_reserved_share(@game.bkb_reserved_share)
+            add_players_vote_info_for_bought_shares(@game.agv)
+          end
+
+          def add_merge_info_hgk
+            @offering << @game.hgk
+            add_player_vote_info_for_reserved_share(@game.kfbe_reserved_share)
+            add_player_vote_info_for_reserved_share(@game.kbe_reserved_share)
+            add_player_vote_info_for_reserved_share(@game.hdsk_reserved_share)
+            add_players_vote_info_for_bought_shares(@game.hgk)
+          end
+
+          def add_player_vote_info_for_reserved_share(reserved_share)
+            player = reserved_share[:minor] ? reserved_share[:minor].owner : reserved_share[:private].owner
+            add_player_vote_info(player, reserved_share[:share].percent)
+          end
+
+          def add_player_vote_info(player, percent)
+            if @voters.include?(player)
+              @votes[player] += percent
+              @log << "Player #{player} adds another #{percent} votes, to get #{@votes[player]}"
+            else
+              @voters << player
+              @log << "Player #{player} has #{percent} votes"
+              @votes[player] = percent
+            end
+          end
+
+          def add_players_vote_info_for_bought_shares(corporation)
+            @game.players.each do |player|
+              percent = 10 * player.num_shares_of(corporation, ceil: false)
+              next unless percent.positive?
+
+              add_player_vote_info(player, percent)
+            end
+          end
+
+          def skip_message(mergable)
+            @log << if mergable.floated?
+                      "#{mergable.name} merge already done - skipped during MR"
+                    else
+                      "#{mergable.name} not yet available for merge - skipped during MR"
+                    end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -7,12 +7,12 @@ require_relative 'par_and_buy_actions'
 module Engine
   module Game
     module G1893
-      FIRST_SR_ACTIONS = %w[buy_company pass].freeze
-
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
           include ParAndBuy
           include BuyMinor
+
+          FIRST_SR_ACTIONS = %w[buy_company pass].freeze
 
           def actions(entity)
             return [] unless entity&.player?

--- a/lib/engine/game/g_1893/step/merger.rb
+++ b/lib/engine/game/g_1893/step/merger.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1893
+      module Step
+        class Merger < Engine::Step::Base
+          ACTIONS = %w[special_buy].freeze
+
+          def round_state
+            {
+              choice_done: false,
+            }
+          end
+
+          def actions(entity)
+            return [] if entity.company?
+            return [] unless choice_available?
+            return [] if @game.round.merger_candidates_for(@game.round.current_entity).empty?
+
+            ACTIONS
+          end
+
+          def description
+            "Merge of #{merge_target.name}"
+          end
+
+          def active_entities
+            @game.round.voters
+          end
+
+          def merge_target
+            @game.round.offering.first
+          end
+
+          def buyable_items(_entity)
+            return [] unless choice_available?
+
+            [Item.new(description: :yes, cost: 0),
+             Item.new(description: :no, cost: 0)]
+          end
+
+          def item_str(item)
+            case item.description
+            when :yes
+              "Yes (#{@game.round.yes}% so far)"
+            when :no
+              "No (#{@game.round.no}% so far)"
+            end
+          end
+
+          def help
+            names = @game.round.names(@game.round.merger_candidates_for(@game.round.current_entity))
+            "Vote Yes or No to merge #{names} into #{merge_target.name}. " \
+            '50% Yes votes is required to execute merge. If No votes exceed 50% merge is postponed. ' \
+            'Note! Even if declined, there is an automatic merge at the start of the Merge Round following '\
+            'the next phase change.'
+          end
+
+          def active?
+            choice_available?
+          end
+
+          def blocking?
+            choice_available?
+          end
+
+          def purchasable_companies(_entity = nil)
+            []
+          end
+
+          def process_special_buy(action)
+            @round.choice_done = true
+            @log << "Name: #{action.item.description}"
+            @round.handle_vote(action.item.description)
+            @round.next_entity!
+          end
+
+          def choice_available?
+            !@game.round.offering.empty? || !@game.round.done
+          end
+
+          def can_sell?
+            false
+          end
+
+          def ipo_type(_entity) end
+
+          def swap_sell(_player, _corporation, _bundle, _pool_share); end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1893/step/potential_discard_trains_after_merge.rb
+++ b/lib/engine/game/g_1893/step/potential_discard_trains_after_merge.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/discard_train'
+
+module Engine
+  module Game
+    module G1893
+      module Step
+        class PotentialDiscardTrainsAfterMerge < Engine::Step::DiscardTrain
+          ACTIONS = %w[discard_train pass].freeze
+
+          def actions(entity)
+            return [] unless @game.potential_discard_trains.include?(entity)
+
+            ACTIONS
+          end
+
+          def description
+            'Optional Discard of Any Trains'
+          end
+
+          def log_skip(entity)
+            super unless entity.corporation?
+          end
+
+          def crowded_corps
+            return [] if @game.potential_discard_trains.empty?
+
+            [discarding_entity]
+          end
+
+          def process_discard_train(action)
+            train = action.train
+            @game.depot.reclaim_train(train)
+            @log << "#{action.entity.name} discards a #{train.name} train"
+            return unless action.entity.trains.empty?
+
+            @game.potential_discard_trains.delete(action.entity)
+          end
+
+          def process_pass(action)
+            if action.entity.trains.size > @game.train_limit(action.entity)
+              raise GameError, "#{action.entity.name} exceeds train limit of #{@ŋame.train_limit(action.entity)}"
+            end
+
+            @game.potential_discard_trains.delete(action.entity)
+            super
+          end
+
+          def trains(corporation)
+            corporation.trains
+          end
+
+          def context_entities
+            [discarding_entity]
+          end
+
+          def active_context_entity
+            discarding_entity.owner
+          end
+
+          private
+
+          def discarding_entity
+            @game.potential_discard_trains.first
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
+++ b/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
@@ -92,6 +92,8 @@ module Engine
           end
 
           def min_bid(company)
+            return unless company
+
             company&.min_bid
           end
 


### PR DESCRIPTION
Added Merge step for AGV and HGK. This will either do an auto
merge if late phase, and/or give the possibility to vote if merge
should take place or not.

If merge - minors + private (in case of HGK) are merged into
AGV/HGK which floats. Resources moved to AGV/HGK. Reserved
shares are exchanged.

Added a discard trains step which is used as the director of
the floated merged corporation may discard any train.

Potential Merger round takes place betwee Stock Round and Operating
Round as well as between first OR and second OR in each turn.