### PR TITLE
Fix off-by-one bug on max_nodes of node.walk

### DIFF
--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -59,7 +59,7 @@ module Engine
         return if visited[self]
 
         visited[self] = true
-        return if max_nodes && visited.size >= max_nodes
+        return if max_nodes && visited.size > max_nodes
 
         paths.each do |node_path|
           next if node_path.track == skip_track


### PR DESCRIPTION
This was requiring an N+1 train to find a route with N stops
Fixes #4645