### PR TITLE
app routing: match game IDs to any string

### DIFF
--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -91,7 +91,7 @@ class App < Snabberb::Component
   end
 
   def render_game
-    match = @app_route.match(%r{(hotseat|game|fixture)\/((18.*\/)?(hs.*_)?\d+)})
+    match = @app_route.match(%r{(hotseat|game|fixture)\/((18.*\/)?(.*))})
 
     if !@game_data&.any? # this is a hotseat game
       if @app_route.include?('tutorial')


### PR DESCRIPTION
allows for descriptively named game json fixtures to be accessed
at `/fixture/<title>/<fixture_name>`

This is useful on #4588 where there are fixtures named to describe whether certain powers work or not