### PR TITLE
market: fix width of cells with right border

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -101,6 +101,7 @@ module View
         unless (types & BORDER_TYPES).empty?
           style[:borderRightWidth] = "#{BORDER * 4}px"
           style[:borderRightColor] = COLOR_MAP[:purple]
+          style[:width] = "#{WIDTH_TOTAL - 2 * PAD - 2 * BORDER - 3}px"
         end
         if color == :black
           style[:color] = 'gainsboro'


### PR DESCRIPTION
noticable on 2d-markets like 18SJ:
ante
![image](https://user-images.githubusercontent.com/33390595/111902441-c6548c80-8a3d-11eb-85cb-e60cec403035.png)
post
![image](https://user-images.githubusercontent.com/33390595/111902445-c94f7d00-8a3d-11eb-89ed-96129df0f47b.png)
