### PR TITLE
prevent Safari from autocompleting chatbars

### DIFF
--- a/assets/app/view/chat.rb
+++ b/assets/app/view/chat.rb
@@ -42,7 +42,9 @@ module View
 
       chatbar_props = {
         attrs: {
+          autocomplete: 'off',
           placeholder: 'Send a message (Please keep discussions to 18xx)',
+          type: 'text',
         },
         style: {
           width: '100%',

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -54,7 +54,9 @@ module View
               }, [@user['name'] + ':']),
             h('input#chatbar',
               attrs: {
+                autocomplete: 'off',
                 title: 'hotkey: c – esc to leave',
+                type: 'text',
                 value: @chat_input,
               },
               style: {


### PR DESCRIPTION
fixes #4656 – [fingers crossed](https://caniuse.com/input-autocomplete-onoff) …