### PR TITLE
1860: Fix typo in private company description

### DIFF
--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -595,7 +595,7 @@ module Engine
             name: 'Brading Harbour Company',
             value: 30,
             revenue: 5,
-            desc: 'Can be exchanged for a share in the BHI&R pubilc company',
+            desc: 'Can be exchanged for a share in the BHI&R public company',
             sym: 'BHC',
             abilities: [
             {


### PR DESCRIPTION
The Brading Harbour Company description had 'public' misspelt as
'pubilc'.