### PR TITLE
1893: Various minor fixes

### DIFF
--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -29,6 +29,20 @@ module Engine
 
         MUST_SELL_IN_BLOCKS = false
 
+        GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
+
+        # Move down one step for a whole block, not per share
+        SELL_MOVEMENT = :down_block
+
+        # Cannot sell until operated
+        SELL_AFTER = :operate
+
+        # Sell zero or more, then Buy zero or one
+        SELL_BUY_ORDER = :sell_buy
+
+        # New track must be usable
+        TRACK_RESTRICTION = :restrictive
+
         TILES = {
           '3' => 2,
           '4' => 4,
@@ -619,17 +633,6 @@ module Engine
         LAYOUT = :flat
 
         AXES = { x: :number, y: :letter }.freeze
-
-        GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
-
-        # Move down one step for a whole block, not per share
-        SELL_MOVEMENT = :down_block
-
-        # Cannot sell until operated
-        SELL_AFTER = :operate
-
-        # Sell zero or more, then Buy zero or one
-        SELL_BUY_ORDER = :sell_buy
 
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
           'remove_tile_block' => ['Remove tile block', 'Rhine may be passed. N5 P5 becomes possible to lay tiles in'],

--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -2,6 +2,7 @@
 
 require_relative '../base'
 require_relative 'meta'
+require_relative '../stubs_are_restricted'
 
 module Engine
   module Game
@@ -955,6 +956,8 @@ module Engine
 
           @green_leverkusen_tile ||= @tiles.find { |t| t.name == LEVERKUSEN_GREEN_TILE }
         end
+
+        include StubsAreRestricted
 
         def upgrades_to?(from, to, special = false)
           # Leverkusen can upgrade double dits to one city

--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -1117,6 +1117,7 @@ module Engine
             puts("Mergable #{mergable.name} has no trains")
           end
 
+          mergable.ipoed = true
           @log << "#{mergable.name} have been completly founded and now floats"
         end
 

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -49,6 +49,12 @@ module Engine
             false
           end
 
+          def ipo_type(corporation)
+            return super if corporation != @game.agv && corporation != @game.hgk
+
+            'Cannot be parred - formed via merge'
+          end
+
           def first_sr_passed?(entity)
             @game.passers_first_stock_round.include?(entity)
           end

--- a/lib/engine/game/g_1893/step/buy_train.rb
+++ b/lib/engine/game/g_1893/step/buy_train.rb
@@ -17,6 +17,19 @@ module Engine
             []
           end
 
+          def round_state
+            super.merge(
+              {
+                discountable_trains_bought: [],
+              }
+            )
+          end
+
+          def discountable_trains_allowed?(entity)
+            # A corporation/minor cannot do two discount buys during its turn
+            !@round.discountable_trains_bought.include?(entity)
+          end
+
           def buyable_trains(entity)
             # Trains owned by minor cannot be bought by a corporation
             buyable = super.reject { |t| entity.corporation? && t.owner.minor? }
@@ -25,6 +38,14 @@ module Engine
             buyable.select!(&:from_depot?) unless @game.phase.status.include?('can_buy_trains')
 
             buyable
+          end
+
+          def process_buy_train(action)
+            super
+
+            return unless action.exchange
+
+            @round.discountable_trains_bought << action.entity
           end
         end
       end

--- a/lib/engine/game/g_1893/step/buy_train.rb
+++ b/lib/engine/game/g_1893/step/buy_train.rb
@@ -16,6 +16,16 @@ module Engine
 
             []
           end
+
+          def buyable_trains(entity)
+            # Trains owned by minor cannot be bought by a corporation
+            buyable = super.reject { |t| entity.corporation? && t.owner.minor? }
+
+            # Can't buy trains from other minor or corporations in phase 1 and 2
+            buyable.select!(&:from_depot?) unless @game.phase.status.include?('can_buy_trains')
+
+            buyable
+          end
         end
       end
     end

--- a/lib/engine/game/g_1893/step/dividend.rb
+++ b/lib/engine/game/g_1893/step/dividend.rb
@@ -21,6 +21,13 @@ module Engine
             super
           end
 
+          # In 1893, shares in market does not pay to corporation
+          def dividends_for_entity(entity, holder, per_share)
+            return 0 if entity.corporation? && holder == @game.share_pool
+
+            super
+          end
+
           private
 
           def routeless_minor?(entity)


### PR DESCRIPTION
Some minor fixes in 1893:

1. Trains owned by minors cannot be bought by corporations
2. Shares in market does not bring dividend to corporation
3. 1893 is restrictive when it comes to tile lay/upgrade
4. Can at most buy one discounted train per turn
5. AGV/HGK should not be parrable - IPOed via merge
6. Leverkusen hex uses special tiles