### PR TITLE
1873: fix obsolete method name

### DIFF
--- a/lib/engine/game/g_1873/step/token.rb
+++ b/lib/engine/game/g_1873/step/token.rb
@@ -18,6 +18,11 @@ module Engine
             ACTIONS
           end
 
+          def skip!
+            log_skip(current_entity) if !@acted && current_entity && @game.railway?(current_entity)
+            pass!
+          end
+
           def can_place_token?(entity)
             current_entity == entity &&
               !@round.tokened &&

--- a/lib/engine/game/g_1873/step/track.rb
+++ b/lib/engine/game/g_1873/step/track.rb
@@ -186,7 +186,7 @@ module Engine
           end
 
           def pay_full_concession_cost!(entity)
-            total_cost = @game.concession_tile_hexes(entity).sum { |h| @game.concession_tile_hex(h)[:cost] }
+            total_cost = @game.concession_tile_hexes(entity).sum { |h| @game.concession_tile(h)[:cost] }
             return unless total_cost.positive?
 
             @log << "#{entity.name} had entire concession route previously built"


### PR DESCRIPTION
Changed a method name a while back but missed one call.

Fixes #4662 