### PR TITLE
1846: "tokens" to "markers" for event descriptions

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -226,7 +226,7 @@ module Engine
                       },
                     ],
                     events: [
-                      { 'type' => 'remove_tokens' },
+                      { 'type' => 'remove_markers' },
                       { 'type' => 'remove_reservations' },
 ],
 
@@ -732,7 +732,7 @@ module Engine
 
         TILE_COST = 20
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
-          'remove_tokens' => ['Remove Tokens', 'Remove Steamboat and Meat Packing markers'],
+          'remove_markers' => ['Remove Markers', 'Remove Steamboat and Meat Packing markers'],
           'remove_reservations' => ['Remove Reservations', 'Remove reserved token slots for corporations']
         ).freeze
 
@@ -1072,7 +1072,7 @@ module Engine
           @log << '-- Event: Reserved token slots removed --'
         end
 
-        def event_remove_tokens!
+        def event_remove_markers!
           removals = Hash.new { |h, k| h[k] = {} }
 
           @corporations.each do |corp|

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -663,7 +663,7 @@ module Engine
         MEAT_REVENUE_DESC = 'Citrus'
 
         EVENTS_TEXT = G1846::Game::EVENTS_TEXT.merge(
-          'remove_tokens' => ['Remove Tokens', 'Remove LA Steamship and LA Citrus tokens']
+          'remove_markers' => ['Remove Markers', 'Remove LA Steamship and LA Citrus markers']
         ).freeze
 
         include StubsAreRestricted


### PR DESCRIPTION
More consistent terminology, distinguishing corporations' station tokens and private companies' revenue markers https://boardgamegeek.com/thread/2565191/article/36594885#36594885

Validated against all 1846/1846 2p/18LA games in the database.