### PR TITLE
[1822] capitalize minor name

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1172,7 +1172,7 @@ module Engine
             text_color: 'black',
           },
           {
-            name: 'MINOR: 4. Newcastle & North shields Railway',
+            name: 'MINOR: 4. Newcastle & North Shields Railway',
             sym: 'M4',
             value: 100,
             revenue: 0,
@@ -1495,7 +1495,7 @@ module Engine
           },
           {
             sym: '4',
-            name: 'Newcastle & North shields Railway',
+            name: 'Newcastle & North Shields Railway',
             logo: '1822/4',
             tokens: [0],
             type: 'minor',


### PR DESCRIPTION
Based on [rulebook](https://boardgamegeek.com/filepage/219065/1822-railways-great-britain-rules)

This minor does not seem to be present in the MRS/NRS variants, so no changes to those configs