### PR TITLE
[1822] Purchase of redeemed treasury share in phase 6+

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2727,6 +2727,9 @@ module Engine
           end
 
           super
+
+          # Make sure after its floated its incremental.
+          corporation.capitalization = :incremental if corporation.type == :major
         end
 
         def format_currency(val)


### PR DESCRIPTION
- After a major company have floated, make sure its capitalization is switch back to incremental if was full for a little while during phase 6+.

fixes #4686

This shouldnt break any of the current games.