### PR TITLE
1870: Improve/simplify upgrade of P Hexes

### DIFF
--- a/lib/engine/game/g_1870/step/track.rb
+++ b/lib/engine/game/g_1870/step/track.rb
@@ -8,8 +8,6 @@ module Engine
     module G1870
       module Step
         class Track < Engine::Step::Track
-          P_HEXES = %w[J5 B11 C18 N17].freeze
-
           def lay_tile(action, extra_cost: 0, entity: nil, spender: nil)
             raise GameError,
                   'Cannot upgrade the tile in the same turn' if action.hex == @round.river_special_tile_lay
@@ -22,9 +20,9 @@ module Engine
 
             super
 
-            old_tile.label = nil if %i[yellow green].include?(old_tile.color) && old_tile.label.to_s == 'P'
-            return unless P_HEXES.include?(action.hex.coordinates)
+            return unless old_tile.label.to_s == 'P'
 
+            old_tile.label = nil if %i[yellow green].include?(old_tile.color)
             action.tile.label = 'P' if %i[yellow green].include?(action.tile.color)
           end
         end


### PR DESCRIPTION
Fort Wort was not on the list, so I removed the list to avoid duplicating information.

This requires archiving games.