### PR TITLE
1873: fix maintenance when no trains; fix repayment of reimbursed track costs

### DIFF
--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -22,7 +22,7 @@ module Engine
 
         attr_reader :mine_12, :corporation_info, :diesel_graph, :hw, :minor_info, :mhe, :mine_graph, :nwe, :qlb,
                     :reserved_tiles, :subtrains
-        attr_accessor :premium, :premium_order, :premium_winner
+        attr_accessor :premium, :premium_order, :premium_winner, :reimbursed_hexes
 
         CURRENCY_FORMAT_STR = '%d ℳ'
         BANK_CASH = 100_000
@@ -239,6 +239,8 @@ module Engine
           @switcher_index = 0
           @machine_index = trains.size
           @next_switcher = nil
+
+          @reimbursed_hexes = Hash.new { |h, k| h[k] = 0 }
 
           @subtrains = Hash.new { |h, k| h[k] = [] }
           @subtrain_index = {}

--- a/lib/engine/game/g_1873/step/buy_train.rb
+++ b/lib/engine/game/g_1873/step/buy_train.rb
@@ -31,7 +31,7 @@ module Engine
             if @acted
               'Done (Trains)'
             elsif @game.concession_pending?(current_entity)
-              'Skip (Trains) Warning: Compulsory Train Required'
+              'Pass (Trains) Warning: Compulsory Train Required'
             else
               'Skip (Trains)'
             end
@@ -82,12 +82,7 @@ module Engine
               dt.price > entity.cash || (entity == @game.nwe && dt.distance < 2)
             end
 
-            # can't force a player to buy from another player
-            other_trains = @depot.other_trains(entity).reject do |ot|
-              !@game.train_is_train?(ot) || ot.owner.owner != entity.owner || (entity == @game.nwe && ot.distance < 2)
-            end
-
-            !depot_trains.empty? || !other_trains.empty?
+            !depot_trains.empty?
           end
 
           def minor_distance(entity)

--- a/lib/engine/game/g_1873/step/route.rb
+++ b/lib/engine/game/g_1873/step/route.rb
@@ -15,8 +15,16 @@ module Engine
           end
 
           def skip!
+            return pass! if current_entity == @game.mhe
+
+            maintenance = @game.maintenance_costs(current_entity)
+            @round.maintenance = maintenance
+            if maintenance.positive?
+              @log << "#{current_entity.name} owes #{@game.format_currency(maintenance)} for maintenance"
+            end
+
             @game.update_tokens(current_entity, [])
-            return super if !@game.any_mine?(current_entity) && current_entity != @game.mhe
+            return super unless @game.any_mine?(current_entity)
 
             if @game.any_mine?(current_entity)
               @game.update_mine_revenue(@round, current_entity) if @round.routes.empty?

--- a/lib/engine/game/g_1873/step/track.rb
+++ b/lib/engine/game/g_1873/step/track.rb
@@ -54,6 +54,7 @@ module Engine
 
             # check to see if concession is complete
             if @game.concession_incomplete?(entity) && @game.concession_route_done?(entity)
+              pay_remaining_concession_cost!(entity)
               @game.concession_complete!(entity)
               @round.num_laid_track = 2 # prevent any more tiles this turn
             end
@@ -77,8 +78,8 @@ module Engine
             # deal with case where concession route happened to be completed
             # before railroad even got to it's first OR
             if @game.concession_incomplete?(entity) && @game.concession_route_done?(entity)
+              pay_remaining_concession_cost!(entity)
               @game.concession_complete!(entity)
-              pay_full_concession_cost!(entity)
             end
 
             return false if !@game.concession_incomplete?(entity) && @round.non_double_tile
@@ -169,28 +170,32 @@ module Engine
               reimburse = true
             elsif ch && !follows_path
               raise GameError, 'Tile must complete concession route'
-            elsif ch && cost != ch[:cost]
-              cost += ch[:cost]
-              @log << "#{entity.owner} must pay for previously reimbused tile cost"\
-                "of #{@game.format_currency(ch[:cost])}"
             end
 
             @game.advance_concession_phase!(ch_entity) if reimburse && hex.id != 'D15'
 
-            super
+            spender.spend(cost, @game.bank) if cost.positive?
+
+            @log << "#{spender.name}"\
+              "#{spender == entity ? '' : " (#{entity.sym})"}"\
+              "#{cost.zero? ? '' : " spends #{@game.format_currency(cost)} and"}"\
+              " lays tile ##{tile.name}"\
+              " with rotation #{rotation} on #{hex.name}"\
+              "#{tile.location_name.to_s.empty? ? '' : " (#{tile.location_name})"}"
 
             return unless reimburse && cost.positive?
 
             @game.bank.spend(cost, entity.owner)
             @log << "#{entity.owner.name} is reimbursed for building the tile"
+            @game.reimbursed_hexes[hex] = cost
           end
 
-          def pay_full_concession_cost!(entity)
-            total_cost = @game.concession_tile_hexes(entity).sum { |h| @game.concession_tile(h)[:cost] }
+          def pay_remaining_concession_cost!(entity)
+            total_cost = @game.concession_tile_hexes(entity).sum { |h| @game.reimbursed_hexes[h] }
             return unless total_cost.positive?
 
-            @log << "#{entity.name} had entire concession route previously built"
-            @log << "#{entity.name} pays entire concession cost of #{@game.format_currency(total_cost)}"
+            @log << "#{entity.name} had portions of concession route previously built"
+            @log << "#{entity.name} pays remaining concession cost of #{@game.format_currency(total_cost)}"
             entity.spend(total_cost, @game.bank)
           end
         end


### PR DESCRIPTION
Fixes #4697 
Fixes #4700 

Also modified buy_train step to disable the "Pass" button for a compulsory train if and only if there is an affordable train from the bank (depot).