### PR TITLE
1873: use dup when scrapping trains; fix buy_train validation for switchers

### DIFF
--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -662,7 +662,7 @@ module Engine
           @log << "#{minor.name} is closed"
 
           # any machines/switchers are trashed
-          minor.trains.each { |t| scrap_train(t) }
+          minor.trains.dup.each { |t| scrap_train(t) }
 
           if minor.owner && minor.cash.positive?
             @log << "#{minor.name} transfers #{format_currency(minor.cash)} to #{minor.owner.name}"
@@ -745,10 +745,12 @@ module Engine
 
           # toss any trains that have maintenance costs
           if railway?(entity)
-            entity.trains.each { |t| scrap_train(t) if train_maintenance(t.name).positive? }
+            entity.trains.dup.each { |t| scrap_train(t) if train_maintenance(t.name).positive? }
           else
             public_mine_mines(entity).each do |mine|
-              mine.trains.each { |t| scrap_train(t) if train_maintenance(t.name).positive? }
+              mine.trains.dup.each do |t|
+                scrap_train(t) if train_maintenance(t.name).positive?
+              end
             end
           end
 

--- a/lib/engine/game/g_1873/step/buy_train.rb
+++ b/lib/engine/game/g_1873/step/buy_train.rb
@@ -116,6 +116,8 @@ module Engine
           end
 
           def illegal_depot_buy?(train, entity)
+            return false if @game.train_is_switcher?(train)
+
             # indie mines can't buy same size machine
             (entity.minor? && train.distance <= minor_distance(entity)) ||
               # public mines have to have at least one mine with a smaller machine

--- a/lib/engine/game/g_1873/step/route.rb
+++ b/lib/engine/game/g_1873/step/route.rb
@@ -19,7 +19,7 @@ module Engine
 
             maintenance = @game.maintenance_costs(current_entity)
             @round.maintenance = maintenance
-            if maintenance.positive?
+            if maintenance.positive? && @game.railway?(current_entity)
               @log << "#{current_entity.name} owes #{@game.format_currency(maintenance)} for maintenance"
             end
 


### PR DESCRIPTION
Fixes #4704 