### PR TITLE
Show previous trains to make it easier to value corps in 1817

### DIFF
--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -74,6 +74,13 @@ module Engine
       @depot_trains = nil
     end
 
+    def forget_train(train)
+      @trains.delete(train)
+      @upcoming.delete(train)
+      @discarded.delete(train)
+      @depot_trains = nil
+    end
+
     def add_train(train)
       train.owner = self
       @trains << train

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1854,6 +1854,7 @@ module Engine
           train = train_by_id(train_id)
           @depot.remove_train(train)
           train.buyable = buyable
+          train.reserved = true
           train
         end
 

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -1497,7 +1497,7 @@ module Engine
           TRAINS_REMOVE_2_PLAYER.each do |train_name, count|
             trains = depot.upcoming.select { |t| t.name == train_name }.reverse.take(count)
 
-            trains.each { |t| depot.remove_train(t) }
+            trains.each { |t| depot.forget_train(t) }
           end
 
           # Standard game, remove 2 privates randomly

--- a/lib/engine/game/g_1882/game.rb
+++ b/lib/engine/game/g_1882/game.rb
@@ -592,6 +592,7 @@ module Engine
           train.events, first.events = first.events.partition { |e| e['type'] != 'nwr' }
 
           @log << "#{corporation.name} adds an extra #{train.name} train to the depot"
+          train.reserved = false
           @depot.unshift_train(train)
         end
 
@@ -606,6 +607,7 @@ module Engine
             train = depot.upcoming.reverse.find { |t| t.name == train_name }
             @sc_reserve_trains << train
             depot.remove_train(train)
+            train.reserved = true
           end
 
           # Due to SC adding an extra train this isn't quite a phase change, so the event needs to be tied to a train.

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -7,7 +7,8 @@ module Engine
   class Train
     include Ownable
 
-    attr_accessor :obsolete, :operated, :events, :variants, :obsolete_on, :rusted, :rusts_on, :index, :name, :distance
+    attr_accessor :obsolete, :operated, :events, :variants, :obsolete_on, :rusted, :rusts_on, :index, :name,
+                  :distance, :reserved
     attr_reader :available_on, :discount, :multiplier, :sym, :variant
     attr_writer :buyable
 
@@ -28,6 +29,7 @@ module Engine
       @obsolete = false
       @operated = false
       @events = (opts[:events] || []).select { |e| @index == (e[:when] || 0) }
+      @reserved = opts[:reserved] || false
       init_variants(opts[:variants])
     end
 
@@ -54,7 +56,7 @@ module Engine
       @variant = @variants[new_variant]
       @variant.each { |k, v| instance_variable_set("@#{k}", v) }
 
-      # Remove the @local vaiable, this to get the local? method evaluate the new variant
+      # Remove the @local variable, this to get the local? method evaluate the new variant
       remove_instance_variable(:@local) if defined?(@local)
     end
 

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -379,7 +379,7 @@ describe 'Assets' do
       expect(render(app_route: '/game/1#entities', **needs)).to include('entities', 'Player 1', 'Awa Railroad')
       expect(render(app_route: '/game/1#map', **needs)).to include('Kotohira')
       expect(render(app_route: '/game/1#market', **needs)).to include('The Bank', 'Cash', 'Par value')
-      expect(render(app_route: '/game/1#info', **needs)).to include('Upcoming', 'Shikoku: 1889')
+      expect(render(app_route: '/game/1#info', **needs)).to include('Trains', 'Game Phases', 'Shikoku: 1889')
       expect(render(app_route: '/game/1#tiles', **needs)).to include('492')
       expect(render(app_route: '/game/1#spreadsheet', **needs)).to include('Value')
       expect(render(app_route: '/game/1#tools', **needs)).to include('Clone this')


### PR DESCRIPTION
fixes #3563

1822 - Hide trains that are on privates (Pullmans etc)
1882 - Hide the SC trains until they are used
1861/67 - Forget the trains existed for 2 player games