### PR TITLE
1870: Fix check_connections (reverts max_nodes)

### DIFF
--- a/lib/engine/game/g_1870/step/check_connection.rb
+++ b/lib/engine/game/g_1870/step/check_connection.rb
@@ -32,9 +32,10 @@ module Engine
             return unless (home = @game.home_hex(corporation))
             return if corporation.trains.empty?
 
+            home_node = home.tile.cities.first # Each tile with a city has exactly one node
             max_nodes = corporation.trains.map(&:distance).max
-            destination.tile.nodes.first&.walk(corporation: corporation, max_nodes: max_nodes) do |path, _|
-              return true if path.hex.id == home.id
+            destination.tile.nodes.first&.walk(corporation: corporation) do |_, _, visited|
+              return true if visited[home_node] && visited.size <= max_nodes
             end
 
             false

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -155,7 +155,7 @@ module Engine
         local_nodes = {}
 
         node.walk(visited: visited, corporation: walk_corporation, skip_track: @skip_track,
-                  tile_type: @game.class::TILE_TYPE) do |path, _|
+                  tile_type: @game.class::TILE_TYPE) do |path, _, _|
           next if paths[path]
 
           paths[path] = true

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -56,18 +56,17 @@ module Engine
         counter: Hash.new(0),
         skip_track: nil,
         tile_type: :normal,
-        max_nodes: nil, &block
+        &block
       )
         return if visited[self]
 
         visited[self] = true
-        return if max_nodes && visited.size > max_nodes
 
         paths.each do |node_path|
           next if node_path.track == skip_track
 
           node_path.walk(visited: visited_paths, counter: counter, on: on, tile_type: tile_type) do |path, vp, ct|
-            yield path, vp
+            yield path, vp, visited
             next if path.terminal?
 
             path.nodes.each do |next_node|
@@ -82,7 +81,7 @@ module Engine
                 visited_paths: vp,
                 skip_track: skip_track,
                 tile_type: tile_type,
-                max_nodes: max_nodes, &block
+                &block
               )
             end
           end


### PR DESCRIPTION
max_nodes wasn't behaving as I expected and I can't figure out why. This version loses a slight performance improvement, but I think it's cleaner and more robust.