### PR TITLE
tools cleanup

### DIFF
--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -45,15 +45,19 @@ module View
         end
 
         buttons = [
-          h(:button, { on: { click: -> { store(:show_json, !@show_json) } } },
-            "#{@show_json ? 'Hide' : 'Show'} Game Data"),
-          h(:button, { on: { click: copy_data } }, 'Copy Game Data'),
+          h(:h3, 'Game Data'),
+          h(:button, {
+              on: { click: -> { store(:show_json, !@show_json) } },
+              style: { width: '4.2rem' },
+            },
+            (@show_json ? 'Hide' : 'Show').to_s),
+          h(:button, { on: { click: copy_data } }, 'Copy'),
           h('a.button_link', {
               attrs: {
                 href: "data:text/plain;charset=utf-8,#{`encodeURI(self.json)`}",
                 download: "#{@game_data[:id]}.json",
               },
-            }, 'Download Game Data'),
+            }, 'Download'),
         ]
 
         if @allow_delete
@@ -66,8 +70,8 @@ module View
         end
 
         if @allow_clone
-          buttons << h(:button, { on: { click: clone_game } }, 'Clone Game')
-          buttons << h(:label, 'Clone this game to play around in hotseat mode')
+          buttons << h(:button, { on: { click: clone_game }, style: { marginRight: '0.3rem' } }, 'Clone Game')
+          buttons << h(:label, 'to play around in hotseat mode')
         end
 
         h('div.margined', buttons)

--- a/assets/app/view/game/notepad.rb
+++ b/assets/app/view/game/notepad.rb
@@ -7,27 +7,19 @@ module View
   module Game
     class Notepad < Form
       include Actionable
-      needs :user_notes, default: nil, store: true
 
       def render_content
         return h(:div) if @game_data[:mode] == :hotseat || !@game.players.map(&:name).include?(@user&.dig('name'))
-
-        saved_notes = @game_data&.dig('user_settings', 'notepad')
-
-        @user_notes ||= saved_notes
-        saved = (@user_notes == saved_notes)
 
         notepad = render_input(
           '',
           id: :notepad,
           el: :textarea,
           attrs: {
-            placeholder: 'Private notepad, will not be seen by other players',
+            placeholder: 'Contents are autosaved and will not be seen by other players.',
+            title: 'Private notepad with autosave. Contents will not be seen by other players.',
             rows: 10,
             cols: 80,
-          },
-          container_style: {
-            display: 'block',
           },
           input_style: {
             width: '40rem',
@@ -35,26 +27,15 @@ module View
             margin: '0.5rem 0',
           },
           on: {
-            change: -> { local_save },
+            change: -> { save_user_settings({ notepad: params['notepad'] }) },
           },
-          children: @user_notes
+          children: @game_data.dig('user_settings', 'notepad')
         )
 
         h(:div, [
+          h(:h3, 'Private Notepad'),
           notepad,
-          render_button("Save Notepad#{saved ? '' : ' (Unsaved)'}") { submit },
-          ])
-      end
-
-      def local_save
-        # non-persistently save the notepad in case the user switches tabs
-        store(:user_notes, params['notepad'])
-      end
-
-      def submit
-        setting = { notepad: params['notepad'] }
-        save_user_settings(setting)
-        store(:user_notes, params['notepad'])
+        ])
       end
     end
   end

--- a/assets/app/view/game/rename_hotseat.rb
+++ b/assets/app/view/game/rename_hotseat.rb
@@ -11,19 +11,20 @@ module View
       def render_content
         return h(:div) if @game_data[:mode] != :hotseat
 
-        description = @game_data&.dig('description')
-
         h(:div, [
-          render_input('Hotseat Description:',
+          render_input('Hotseat Description',
                        placeholder: 'Add a title',
                        id: :description,
-                       attrs: { value: description }),
-          render_button('Save') { submit },
+                       attrs: {
+                         title: 'Edit hotseat description',
+                         value: @game_data[:description],
+                       },
+                       on: { change: -> { submit } }),
         ])
       end
 
       def submit
-        @game_data['description'] = params['description']
+        @game_data[:description] = params['description']
         store(:game_data, @game_data, skip: true)
 
         Lib::Storage[@game_data[:id]] = @game_data

--- a/assets/app/view/game/tools.rb
+++ b/assets/app/view/game/tools.rb
@@ -41,23 +41,24 @@ module View
       end
 
       def end_game
-        end_game = if @confirm_endgame
-                     confirm = lambda do
-                       store(:confirm_endgame, false)
-                       player = @game.players.find { |p| p.name == @user&.dig('name') }
-                       process_action(Engine::Action::EndGame.new(player || @game.current_entity))
-                       # Go to main page
-                       store(:app_route, @app_route.split('#').first)
-                     end
-                     [
-                       h(:button, { on: { click: confirm } }, 'Confirm End Game'),
-                       h(:button, { on: { click: -> { store(:confirm_endgame, false) } } }, 'Cancel'),
-                     ]
-                   else
-                     [
-                       h(:button, { on: { click: -> { store(:confirm_endgame, true) } } }, 'End Game'),
-                     ]
-                   end
+        end_game =
+          if @confirm_endgame
+            confirm = lambda do
+              store(:confirm_endgame, false)
+              player = @game.players.find { |p| p.name == @user&.dig('name') }
+              process_action(Engine::Action::EndGame.new(player || @game.current_entity))
+              # Go to main page
+              store(:app_route, @app_route.split('#').first)
+            end
+            [
+              h(:button, { on: { click: -> { store(:confirm_endgame, false) } }, style: { width: '7rem' } }, 'Cancel'),
+              h(:button, { on: { click: confirm } }, 'Confirm End Game'),
+            ]
+          else
+            [
+              h(:button, { on: { click: -> { store(:confirm_endgame, true) } }, style: { width: '7rem' } }, 'End Game'),
+            ]
+          end
 
         h('div.margined', end_game)
       end

--- a/assets/app/view/game/tools.rb
+++ b/assets/app/view/game/tools.rb
@@ -35,7 +35,7 @@ module View
         end
 
         h('div.margined', [
-          h(:button, { on: { click: toggle } }, "#{mode ? 'Disable' : 'Enable'} Master Mode"),
+          h(:button, { on: { click: toggle } }, "Master Mode #{mode ? '✅' : '❌'}"),
           h(:label, "#{mode ? 'You can' : 'Enable to'} move for others"),
         ])
       end

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -382,7 +382,7 @@ describe 'Assets' do
       expect(render(app_route: '/game/1#info', **needs)).to include('Trains', 'Game Phases', 'Shikoku: 1889')
       expect(render(app_route: '/game/1#tiles', **needs)).to include('492')
       expect(render(app_route: '/game/1#spreadsheet', **needs)).to include('Value')
-      expect(render(app_route: '/game/1#tools', **needs)).to include('Clone this')
+      expect(render(app_route: '/game/1#tools', **needs)).to include('Clone Game')
       expect(render(app_route: '/game/1#auto', **needs)).to include('Auto Actions')
     end
 


### PR DESCRIPTION
- notepad & hotseat rename autosave (save buttons removed)
- master mode button with icons (same as map controls)
- end game: cancel + confirm buttons switched => accidental double-clicks don’t end the game
- game data buttons shortened, no wiggle
- headers

![image](https://user-images.githubusercontent.com/33390595/112499458-c7602380-8d87-11eb-86d2-0496dc09c230.png)
![image](https://user-images.githubusercontent.com/33390595/112499466-c929e700-8d87-11eb-8323-1e273aebcc6c.png)
