### PR TITLE
1817: Skips incorrectly if auction is automatically resolved

### DIFF
--- a/lib/engine/game/g_1817/step/selection_auction.rb
+++ b/lib/engine/game/g_1817/step/selection_auction.rb
@@ -60,7 +60,7 @@ module Engine
               add_bid(action)
             else
               selection_bid(action)
-              next_entity!
+              next_entity! if auctioning
             end
           end
 


### PR DESCRIPTION
Occurs only if the initial bid causes all other players to be skipped

fixes #4750