### PR TITLE
[18CZ] allow company terrain discounts after first lay

### DIFF
--- a/lib/engine/game/g_18_cz/step/sell_company_and_special_track.rb
+++ b/lib/engine/game/g_18_cz/step/sell_company_and_special_track.rb
@@ -90,7 +90,7 @@ module Engine
             return unless entity&.company?
 
             time = %w[special_track owning_corp_or_turn]
-            time << '%current_step%' if @round.num_laid_track.zero?
+            time << '%current_step%' if @game.tile_lays(entity.corporation)[@round.num_laid_track]
 
             abilities = @game.abilities(
               entity,


### PR DESCRIPTION
only applies to owning corporation's first OR turn

[Fixes #4815]