### PR TITLE
open hotseat in new tab (without error)

### DIFF
--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -163,7 +163,7 @@ module GameManager
   end
 
   def self.url(game, path = '')
-    "/game/#{game['id']}#{path}"
+    "/#{game[:mode] == :hotseat ? 'hotseat' : 'game'}/#{game['id']}#{path}"
   end
 
   def url(game, path = '')


### PR DESCRIPTION
Ultimately prevents redirection of `/hotseat/hs_yqfgmjqg_1595751670` to `/game/hs_yqfgmjqg_1595751670` which leads to "Page not found".