### PR TITLE
allow zigzag markets to be flipped; match 18CZ's market to physical board

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -172,7 +172,7 @@ module View
         [h(:div, { style: { width: 'max-content' } }, row)]
       end
 
-      def grid_zigzag
+      def grid_zigzag(zigzag)
         box_style = box_style_1d
 
         half_box_style = box_style_1d
@@ -203,8 +203,8 @@ module View
         shorter_row = row1.size > row0.size ? row0 : row1
         shorter_row << h(:div, style: cell_style(half_box_style, @game.stock_market.market.first.last.types))
 
-        [h(:div, { style: { width: 'max-content' } }, row0),
-         h(:div, { style: { width: 'max-content' } }, row1)]
+        rows = zigzag == :flip ? [row1, row0] : [row0, row1]
+        rows.map { |row| h(:div, { style: { width: 'max-content' } }, row) }
       end
 
       def grid_2d
@@ -253,8 +253,8 @@ module View
         )
 
         grid = if @game.stock_market.one_d?
-                 if @game.stock_market.zigzag?
-                   grid_zigzag
+                 if !!(zigzag = @game.stock_market.zigzag)
+                   grid_zigzag(zigzag)
                  else
                    grid_1d
                  end

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -2651,7 +2651,7 @@ module Engine
         end
 
         def init_stock_market
-          StockMarket.new(self.class::MARKET, [], zigzag: true)
+          StockMarket.new(self.class::MARKET, [], zigzag: :flip)
         end
 
         def init_player_debts

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -4,7 +4,7 @@ require_relative 'share_price'
 
 module Engine
   class StockMarket
-    attr_reader :market, :par_prices, :has_close_cell
+    attr_reader :market, :par_prices, :has_close_cell, :zigzag
 
     def initialize(market, unlimited_types, multiple_buy_types: [], zigzag: nil)
       @par_prices = []
@@ -30,10 +30,6 @@ module Engine
 
     def one_d?
       @one_d ||= @market.one?
-    end
-
-    def zigzag?
-      !!@zigzag
     end
 
     def set_par(corporation, share_price)


### PR DESCRIPTION
1860 and 1862 markets are unaffected by this change.

Before:

![Screenshot 2021-03-27 111740](https://user-images.githubusercontent.com/1045173/112728687-1627cd80-8eee-11eb-94d2-5fa8a9269d91.png)

After:

![Screenshot 2021-03-27 111532](https://user-images.githubusercontent.com/1045173/112728619-cf39d800-8eed-11eb-9ad0-beaf0bc2fe2c.png)

Physical Board:

![File_000](https://user-images.githubusercontent.com/1045173/112728774-77e83780-8eee-11eb-8fd8-6147eb861858.jpeg)

