### PR TITLE
[1822NRS] Connectivity to minor 16

### DIFF
--- a/lib/engine/game/g_1822_nrs/game.rb
+++ b/lib/engine/game/g_1822_nrs/game.rb
@@ -50,7 +50,7 @@ module Engine
 
         STARTING_CORPORATIONS_OVERRIDE = {
           '15' => { coordinates: 'N29', city: 1 },
-          '16' => { coordinates: 'M30' },
+          '16' => { coordinates: 'M30', city: 0 },
           '29' => { coordinates: 'E26' },
           'LNWR' => { coordinates: 'N29', city: 0 },
         }.freeze


### PR DESCRIPTION
- Fixed when try to aquire minor 16 it will look for the right city in the london hex.

fixes #4835

This doesnt affect any of the current games since its a UI check.