### PR TITLE
company display on cards incl. company size

### DIFF
--- a/assets/app/view/game/companies.rb
+++ b/assets/app/view/game/companies.rb
@@ -26,7 +26,7 @@ module View
         table_props = {
           style: {
             padding: '0 0.5rem 0.2rem',
-            grid: @game.show_value_of_companies?(@owner) ? 'auto / 4fr 1fr 1fr' : 'auto / 5fr 1fr',
+            grid: @game.show_value_of_companies?(@owner) ? 'auto / 1fr auto auto' : 'auto / 1fr auto',
             gap: '0 0.3rem',
           },
         }

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -212,7 +212,7 @@ module View
                         @game.format_currency(company.revenue)
                       end
 
-        [h('div.nowrap', name_props, company.name + extra.join(',')),
+        [h('div.nowrap', name_props, extra.join(' - ') + ": " + company.name),
          @game.show_value_of_companies?(company.owner) ? h('div.right', @game.format_currency(company.value)) : '',
          h('div.padded_number', revenue_str),
          @hidden_divs[company.sym]]

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -180,14 +180,33 @@ module View
       end
 
       def render_company_on_card(company)
+        title_str = @game.respond_to?(:company_size) ? "#{@game.company_size(company)} company: " : ''
+        title_str += company.name
+        company_name_str = @game.respond_to?(:company_size_str) ? "#{@game.company_size_str(company)} " : ''
+        company_name_str += company.name
+
+        extra = []
+        if (uses = company.ability_uses)
+          extra << "#{uses[0]}/#{uses[1]}"
+          title_str += if uses[0].zero?
+                         ', ability already used'
+                       elsif uses[1] > 1
+                         ", #{uses[0]} ability use#{uses[0] > 1 ? 's' : ''} left"
+                       else
+                         ', ability still usable'
+                       end
+        end
+        extra << " #{@game.company_status_str(company)}" if @game.company_status_str(company)
+
         name_props = {
+          attrs: { title: "#{title_str}, click to toggle description" },
           style: {
-            display: 'inline-block',
             cursor: 'pointer',
+            grid: '1fr / 1fr auto',
+            gap: '0 0.2rem',
           },
           on: { click: ->(event) { toggle_desc(event, company) } },
         }
-
         hidden_props = {
           style: {
             display: 'none',
@@ -197,22 +216,14 @@ module View
             fontSize: '80%',
           },
         }
-
         @hidden_divs[company.sym] = h(:div, hidden_props, company.desc)
-
-        extra = []
-        if (uses = company.ability_uses)
-          extra << " (#{uses[0]}/#{uses[1]})"
-        end
-        extra << " #{@game.company_status_str(@company)}" if @game.company_status_str(@company)
-
         revenue_str = if @game.respond_to?(:company_revenue_str)
                         @game.company_revenue_str(company)
                       else
                         @game.format_currency(company.revenue)
                       end
 
-        [h('div.nowrap', name_props, extra.join(' - ') + ": " + company.name),
+        [h(:div, name_props, [h('span.nowrap', company_name_str), h(:span, extra)]),
          @game.show_value_of_companies?(company.owner) ? h('div.right', @game.format_currency(company.value)) : '',
          h('div.padded_number', revenue_str),
          @hidden_divs[company.sym]]

--- a/lib/engine/game/g_18_cz/entities.rb
+++ b/lib/engine/game/g_18_cz/entities.rb
@@ -327,7 +327,7 @@ module Engine
 
         COMPANIES = [
             {
-              name: 'Small #1',
+              name: 'Plan - Tachau',
               value: 25,
               revenue: 5,
               sym: 'S1',
@@ -388,7 +388,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Small #2',
+              name: 'Melnik – Mscheno',
               value: 30,
               revenue: 5,
               sym: 'S2',
@@ -449,7 +449,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Small #3',
+              name: 'Zwittau – Politschka',
               value: 35,
               revenue: 5,
               sym: 'S3',
@@ -510,7 +510,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Small #4',
+              name: 'Strakonitz – Blatna – Bresnitz',
               value: 40,
               revenue: 5,
               sym: 'S4',
@@ -571,7 +571,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Small #5',
+              name: 'Martinitz – Rochlitz',
               value: 45,
               revenue: 5,
               sym: 'S5',
@@ -632,7 +632,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Small #6',
+              name: 'Martinitz – Rochlitz',
               value: 50,
               revenue: 5,
               sym: 'S6',
@@ -693,7 +693,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Medium #1',
+              name: 'Raudnitz – Kmetnowes',
               value: 40,
               revenue: 10,
               sym: 'M1',
@@ -777,7 +777,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Medium #2',
+              name: 'Schweißing – Haid',
               value: 45,
               revenue: 10,
               sym: 'M2',
@@ -861,7 +861,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Medium #3',
+              name: 'Deutschbrod – Tischnowitz',
               value: 50,
               revenue: 10,
               sym: 'M3',
@@ -945,7 +945,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Medium #4',
+              name: 'Troppau – Grätz',
               value: 55,
               revenue: 10,
               sym: 'M4',
@@ -1029,7 +1029,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Medium #5',
+              name: 'Hannsdorf – Mährisch Altstadt',
               value: 60,
               revenue: 10,
               sym: 'M5',
@@ -1113,7 +1113,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Medium #6',
+              name: 'Friedland - Bila',
               value: 65,
               revenue: 10,
               sym: 'M6',
@@ -1197,7 +1197,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Large #1',
+              name: 'Aujezd – Luhatschowitz',
               value: 55,
               revenue: 20,
               sym: 'L1',
@@ -1290,7 +1290,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Large #2',
+              name: 'Neuhaus – Wobratain',
               value: 60,
               revenue: 20,
               sym: 'L2',
@@ -1383,7 +1383,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Large #3',
+              name: 'Opočno – Dobruschka',
               value: 65,
               revenue: 20,
               sym: 'L3',
@@ -1476,7 +1476,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Large #4',
+              name: 'Wekelsdorf – Parschnitz – Trautenau',
               value: 70,
               revenue: 20,
               sym: 'L4',
@@ -1569,7 +1569,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Large #5',
+              name: 'Nezamislitz – Morkowitz',
               value: 75,
               revenue: 20,
               sym: 'L5',
@@ -1662,7 +1662,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Large #6',
+              name: 'Taus – Tachau',
               value: 80,
               revenue: 20,
               sym: 'L6',

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -112,7 +112,7 @@ module Engine
           5 => 'Small',
           10 => 'Medium',
           20 => 'Large',
-        }
+        }.freeze
 
         TWO_PLAYER_CORP_TO_REMOVE = %w[OFE MW KFN PR Ug].freeze
         TWO_PLAYER_COMPANIES_TO_REMOVE = {
@@ -751,8 +751,12 @@ module Engine
                   end
         end
 
-        def company_status_str(company)
+        def company_size(company)
           COMPANY_REVENUE_TO_TYPE[company.revenue]
+        end
+
+        def company_size_str(company)
+          COMPANY_REVENUE_TO_TYPE[company.revenue][0]
         end
       end
     end

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -108,6 +108,12 @@ module Engine
           '8E' => :large,
         }.freeze
 
+        COMPANY_REVENUE_TO_TYPE = {
+          5 => 'Small',
+          10 => 'Medium',
+          20 => 'Large',
+        }
+
         TWO_PLAYER_CORP_TO_REMOVE = %w[OFE MW KFN PR Ug].freeze
         TWO_PLAYER_COMPANIES_TO_REMOVE = {
           5 => 40,
@@ -743,6 +749,10 @@ module Engine
                   else
                     "#{@players.first.name} has priority deal"
                   end
+        end
+
+        def company_status_str(company)
+          COMPANY_REVENUE_TO_TYPE[company.revenue]
         end
       end
     end


### PR DESCRIPTION
closes #3867

player/corp cards: company display revised
- company size included
- company name truncated if necessary
- company_status_str not truncated!
- title added

![image](https://user-images.githubusercontent.com/33390595/112859092-ca725100-90b2-11eb-832d-25f4f82bdbf9.png)
![image](https://user-images.githubusercontent.com/33390595/112859105-cf370500-90b2-11eb-8d98-645064ee3ab5.png)
![image](https://user-images.githubusercontent.com/33390595/112859114-d1995f00-90b2-11eb-8e9d-fe5624d26a2d.png)

(Magnus is fine with the layout changes to 1822’s cards.)
