### PR TITLE
[18CZ] Fixed Laying of ATE token

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -252,7 +252,7 @@ module Engine
           G18CZ::Round::Operating.new(self, [
             G18CZ::Step::HomeTrack,
             G18CZ::Step::SellCompanyAndSpecialTrack,
-            Engine::Step::HomeToken,
+            G18CZ::Step::HomeToken,
             G18CZ::Step::ReduceTokens,
             G18CZ::Step::BuyCompany,
             G18CZ::Step::Track,

--- a/lib/engine/game/g_18_cz/step/home_token.rb
+++ b/lib/engine/game/g_18_cz/step/home_token.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/home_token'
+
+module Engine
+  module Game
+    module G18CZ
+      module Step
+        class HomeToken < Engine::Step::HomeToken
+          def process_place_token(action)
+            # the ATE home token can be placed again, and in that time the corporation could have more tokens.
+            # The Home Token should always be free
+            token.price = 0
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #4851

The issue here is that in 18CZ the corporation can get new tokens before the home token is permanent.

When upgrading the home track of ATE to green a new token is placed, but the price of that token is now 100.

I also tried to not increase the price for tokens that cost 0, but if a corporation has  a  token also in B9, and then ATE buys that corporation, one token has to be removed, and that token needs to cost 100 and not 0 even if that was the home token.