### PR TITLE
1870: Move destination setup to init_hexes (fixes #4848)

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -623,8 +623,8 @@ module Engine
           'Treasury'
         end
 
-        def setup
-          river_company.max_price = river_company.value
+        def init_hexes(companies, corporations)
+          hexes = super
 
           @corporations.each do |corporation|
             ability = abilities(corporation, :assign_hexes)
@@ -633,6 +633,12 @@ module Engine
             hex.assign!(corporation)
             ability.description = "Destination: #{hex.location_name} (#{hex.name})"
           end
+
+          hexes
+        end
+
+        def setup
+          river_company.max_price = river_company.value
         end
 
         def event_companies_buyable!


### PR DESCRIPTION
This makes the destination tokens visible when on the "Starting Map"