### PR TITLE
revert calculated colors for 9+ players

### DIFF
--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -85,11 +85,7 @@ module Lib
         players = players.rotate(player_idx)
       end
 
-      players.map.with_index do |p, idx|
-        color = route_prop(idx % ROUTE_COLORS.size, 'color')
-        color = convert_rgba_to_hex(convert_hex_to_rgba(color, 0.5)) if idx > ROUTE_COLORS.size - 1
-        [p, color]
-      end.to_h
+      players.map.with_index { |p, idx| [p, route_prop(idx, 'color')] }.to_h
     end
   end
 end


### PR DESCRIPTION
now that we have 16 colors by default it’s cruft
can be reintroduced if there’ll ever be a game with 17+ players … 🤦