### PR TITLE
1870: Only allow brown multiple buy from the market

### DIFF
--- a/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
@@ -58,6 +58,10 @@ module Engine
             entity.cash >= bundle.price && redeemable_shares(entity).include?(bundle)
           end
 
+          def can_buy_multiple?(entity, corporation, owner)
+            super && owner.share_pool?
+          end
+
           def can_sell?(entity, bundle)
             super && bundle.corporation.holding_ok?(entity, -bundle.percent)
           end


### PR DESCRIPTION
This probably should be generalised, but I don't know of other games that have this rule (other than 1830) and the 1830 optional rule makes it a nontrivial generalisation.