### PR TITLE
1862: Stock Round

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -373,12 +373,14 @@ module View
         other_corp_rows = entities_rows(@game.corporations.reject { |c| c == @corporation })
 
         num_ipo_shares = share_number_str(@corporation.num_ipo_shares - @corporation.num_ipo_reserved_shares)
-        if !num_ipo_shares.empty? && @corporation.capitalization != @game.class::CAPITALIZATION
+        if @game.respond_to?(:reissued?) && @game.reissued?(@corporation) && !num_ipo_shares.empty?
           num_ipo_shares = '* ' + num_ipo_shares
         end
         dc = @corporation.shares_of(@corporation).any?(&:double_cert)
         dc_reserved = @corporation.reserved_shares.any?(&:double_cert)
         double_cert = dc && !dc_reserved
+
+        num_treasury_shares = share_number_str(@corporation.num_treasury_shares)
 
         pool_rows = []
         if !num_ipo_shares.empty? || double_cert || @corporation.capitalization != :full
@@ -386,6 +388,14 @@ module View
             h('td.left', @game.ipo_name(@corporation)),
             h('td.right', shares_props, (double_cert ? 'd ' : '') + num_ipo_shares),
             h('td.padded_number', share_price_str(@corporation.par_price)),
+          ])
+        end
+
+        if !num_treasury_shares.empty? && !@corporation.ipo_is_treasury?
+          pool_rows << h('tr.ipo', [
+            h('td.left', 'Treasury'),
+            h('td.right', shares_props, num_treasury_shares),
+            h('td.padded_number', share_price_str(@corporation.share_price)),
           ])
         end
 

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -25,6 +25,7 @@ module View
         white: '#ffffff',
         olive: '#d1e189',
         purple: '#9a4eae',
+        peach: '#ffe5b4',
       }.freeze
 
       # All markets

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -23,7 +23,7 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent, :capitalization, :second_share,
-                  :type, :floatable, :original_par_price, :reservation_color, :min_price
+                  :type, :floatable, :original_par_price, :reservation_color, :min_price, :ipo_owner
     attr_reader :companies, :name, :full_name, :fraction_shares, :id, :needs_token_to_par,
                 :presidents_share
     attr_writer :par_price, :share_price
@@ -35,14 +35,16 @@ module Engine
       @id = sym
       @full_name = name
 
-      shares = (opts[:shares] || SHARES).map.with_index do |percent, index|
-        Share.new(self, president: index.zero?, percent: percent, index: index)
+      @ipo_owner = opts[:ipo_owner] || self
+      corp_shares = (opts[:shares] || SHARES).map.with_index do |percent, index|
+        Share.new(self, owner: @ipo_owner, president: index.zero?, percent: percent, index: index)
       end
+      corp_shares.each { |share| @ipo_owner.shares_by_corporation[self] << share }
+      share_holders[@ipo_owner] = corp_shares.sum(&:percent)
 
-      shares.each { |share| shares_by_corporation[self] << share }
-      @fraction_shares = shares.find { |s| (s.percent % 10).positive? }
-      @presidents_share = shares.first
-      @second_share = shares[1]
+      @fraction_shares = corp_shares.find { |s| (s.percent % 10).positive? }
+      @presidents_share = corp_shares.first
+      @second_share = corp_shares[1]
 
       @share_price = nil
       @par_price = nil
@@ -121,15 +123,19 @@ module Engine
     end
 
     def num_ipo_shares
-      num_shares_of(self)
+      @ipo_owner.num_shares_of(self)
     end
 
     def reserved_shares
-      shares_by_corporation[self].reject(&:buyable)
+      @ipo_owner.shares_by_corporation[self].reject(&:buyable)
     end
 
     def num_ipo_reserved_shares
       reserved_shares.sum(&:percent) / share_percent
+    end
+
+    def num_treasury_shares
+      num_shares_of(self)
     end
 
     def num_player_shares
@@ -154,6 +160,10 @@ module Engine
       end
     end
 
+    def ipo_is_treasury?
+      @ipo_owner == self
+    end
+
     def corporate_share_holders
       share_holders.select { |s_h, _| s_h.corporation? && s_h != self }
     end
@@ -163,6 +173,10 @@ module Engine
     end
 
     def ipo_shares
+      @ipo_owner.shares.select { |share| share.corporation == self }
+    end
+
+    def treasury_shares
       shares.select { |share| share.corporation == self }
     end
 
@@ -175,13 +189,14 @@ module Engine
     def floated?
       return false unless @floatable
 
-      @floated ||= percent_of(self) <= 100 - @float_percent - (@float_excludes_market ? percent_in_market : 0)
+      @floated ||= @ipo_owner.percent_of(self) <= 100 - @float_percent -
+        (@float_excludes_market ? percent_in_market : 0)
     end
 
     def percent_to_float
       return 0 if @floated
 
-      percent_of(self) - (100 - @float_percent - (@float_excludes_market ? percent_in_market : 0))
+      @ipo_owner.percent_of(self) - (100 - @float_percent - (@float_excludes_market ? percent_in_market : 0))
     end
 
     def percent_in_market

--- a/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          UNCHARTERED_TOKEN_COST = 40
+
+          def can_sell?(entity, bundle)
+            return unless bundle
+
+            corporation = bundle.corporation
+
+            timing = @game.check_sale_timing(entity, corporation)
+
+            timing &&
+              !(@game.class::MUST_SELL_IN_BLOCKS && @round.players_sold[entity][corporation] == :now) &&
+              can_sell_order? &&
+              can_dump?(entity, bundle) &&
+              check_share_timing(entity, bundle)
+          end
+
+          # can't sell partial president's share to pool if pool doesn't have enough
+          def can_dump?(entity, bundle)
+            corp = bundle.corporation
+            return true if !bundle.presidents_share || bundle.percent >= corp.presidents_percent
+
+            max_shares = corp.player_share_holders.reject { |p, _| p == entity }.values.max || 0
+            return true if max_shares >= corp.presidents_percent
+
+            diff = bundle.shares.sum(&:percent) - bundle.percent
+
+            pool_shares = @game.share_pool.percent_of(corp) || 0
+            pool_shares >= diff
+          end
+
+          # can't sell any shares bought this round
+          def check_share_timing(entity, bundle)
+            corporation = bundle.corporation
+            total_shares = corporation.share_holders[entity]
+            total_shares - @round.bought_shares[entity][corporation] >= bundle.percent
+          end
+
+          def process_par(action)
+            corporation = action.corporation
+            corporation.capitalization = :incremental
+            corporation.tokens.pop # 3 -> 2
+            raise GameError, 'Wrong number of tokens for Unchartered Company' if corporation.tokens.size != 2
+
+            @round.bought_shares[action.entity][corporation] += 30
+            super
+          end
+
+          def process_buy_shares(action)
+            corporation = action.bundle.corporation
+            @round.bought_shares[action.entity][corporation] += action.bundle.percent
+            super
+          end
+
+          def visible_corporations
+            @game.sorted_corporations
+          end
+
+          def get_par_prices(entity, _corp)
+            @game.repar_prices.select { |p| p.price * 3 <= entity.cash }
+          end
+
+          def round_state
+            super.merge(
+              {
+                bought_shares: Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = 0 } },
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
@@ -46,7 +46,7 @@ module Engine
 
           def process_par(action)
             corporation = action.corporation
-            corporation.capitalization = :incremental
+            @game.convert_to_incremental!(corporation)
             corporation.tokens.pop # 3 -> 2
             raise GameError, 'Wrong number of tokens for Unchartered Company' if corporation.tokens.size != 2
 

--- a/lib/engine/game/g_1862/step/buy_tokens.rb
+++ b/lib/engine/game/g_1862/step/buy_tokens.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class BuyTokens < Engine::Step::Base
+          UNCHARTERED_TOKEN_COST = 40
+
+          def actions(entity)
+            return [] unless @round.buy_tokens&.owner == entity
+
+            %w[choose]
+          end
+
+          def active_entities
+            [@round.buy_tokens&.owner]
+          end
+
+          def active?
+            !!@round.buy_tokens
+          end
+
+          def current_entity
+            @round.buy_tokens&.owner
+          end
+
+          def description
+            'Buy Tokens' if @round.buy_tokens
+          end
+
+          def process_choose(action)
+            corporation = @round.buy_tokens
+            @game.purchase_tokens!(corporation, action.choice)
+
+            @round.buy_tokens = nil
+            pass!
+          end
+
+          def choice_available?(entity)
+            @round.buy_tokens == entity
+          end
+
+          def choice_name
+            'Number of Tokens to Buy'
+          end
+
+          def choices
+            Array.new(6) do |i|
+              next unless (i + 2) * UNCHARTERED_TOKEN_COST <= @round.buy_tokens.cash
+
+              [i + 2, "#{i + 2} (#{@game.format_currency((i + 2) * UNCHARTERED_TOKEN_COST)})"]
+            end.compact.to_h
+          end
+
+          def visible_corporations
+            [@round.buy_tokens]
+          end
+
+          def round_state
+            super.merge(
+              {
+                buy_tokens: nil,
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/charter_auction.rb
+++ b/lib/engine/game/g_1862/step/charter_auction.rb
@@ -132,6 +132,7 @@ module Engine
           end
 
           def process_par(action)
+            action.corporation.capitalization = :full # FIXME: does this need to be changed?
             super
 
             if action.entity.cash >= action.share_price.price

--- a/lib/engine/game/g_1862/step/charter_auction.rb
+++ b/lib/engine/game/g_1862/step/charter_auction.rb
@@ -132,7 +132,7 @@ module Engine
           end
 
           def process_par(action)
-            action.corporation.capitalization = :full # FIXME: does this need to be changed?
+            @game.convert_to_full!(action.corporation)
             super
 
             if action.entity.cash >= action.share_price.price

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -10,7 +10,7 @@ module Engine
       class Game < Game::Base
         include_meta(G1870::Meta)
 
-        attr_accessor :connection_run
+        attr_accessor :connection_run, :reissued
 
         register_colors(black: '#37383a',
                         orange: '#f48221',
@@ -648,6 +648,7 @@ module Engine
 
         def setup
           @connection_run = {}
+          @reissued = {}
 
           river_company.max_price = river_company.value
         end
@@ -803,6 +804,10 @@ module Engine
           end
 
           raise GameError, 'At least one train has to run from the home station to the destination'
+        end
+
+        def reissued?(corporation)
+          @reissued[corporation]
         end
       end
     end

--- a/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1870/step/buy_sell_par_shares.rb
@@ -90,6 +90,7 @@ module Engine
               @log << "#{corporation.name}'s par price is now #{@game.format_currency(new_par)}"
             end
             corporation.capitalization = :incremental
+            @game.reissued[corporation] = true
 
             action.bundle.shares.each do |s|
               s.buyable = true

--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -42,7 +42,7 @@ module Engine
     end
 
     def price_per_share
-      share_price = @owner == corporation ? corporation.par_price : corporation.share_price
+      share_price = @owner == corporation.ipo_owner ? corporation.par_price : corporation.share_price
       share_price&.price || corporation.min_price
     end
 

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -192,7 +192,8 @@ module Engine
 
       # handle selling president's share to the pool
       # if partial, move shares from pool to old president
-      if @allow_president_sale && max_shares <= 10 && bundle.presidents_share && to_entity == self
+      if @allow_president_sale && max_shares < corporation.presidents_percent && bundle.presidents_share &&
+          to_entity == self
         corporation.owner = self
         @log << "President's share sold to pool. #{corporation.name} enters receivership"
         return unless bundle.partial?
@@ -212,7 +213,7 @@ module Engine
       end
 
       # skip the rest if no player can be president yet
-      return if @allow_president_sale && max_shares <= 10
+      return if @allow_president_sale && max_shares < corporation.presidents_percent
 
       majority_share_holders = presidency_check_shares(corporation).select { |_, p| p == max_shares }.keys
 

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -55,9 +55,11 @@ module Engine
       share_str = "a #{bundle.percent}% share "
       share_str += "of #{corporation.name}" unless entity == corporation
 
-      from = if bundle.owner.corporation?
-               (bundle.owner == bundle.corporation ? "the #{@game.ipo_name(corporation)}" : bundle.owner.name)
-             elsif bundle.owner.player?
+      from = if bundle.owner == corporation.ipo_owner
+               "the #{@game.ipo_name(corporation)}"
+             elsif bundle.owner.corporation? && bundle.owner == corporation
+               'the Treasury'
+             elsif bundle.owner.corporation? || bundle.owner.player?
                bundle.owner.name
              else
                'the market'
@@ -89,6 +91,7 @@ module Engine
         transfer_shares(bundle, entity)
       else
         receiver = if (%i[escrow incremental].include?(corporation.capitalization) && bundle.owner.corporation?) ||
+                       (bundle.owner.corporation? && !corporation.ipo_is_treasury?) ||
                        bundle.owner.player?
                      bundle.owner
                    else

--- a/lib/engine/share_price.rb
+++ b/lib/engine/share_price.rb
@@ -15,6 +15,7 @@ module Engine
       'a' => :acquisition,
       'r' => :repar,
       'i' => :ignore_one_sale,
+      'j' => :ignore_two_sales,
       's' => :safe_par,
       'P' => :par_overlap,
       'x' => :par_1,

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -162,7 +162,7 @@ module Engine
         raise GameError, "#{corporation.name} cannot be parred" unless @game.can_par?(corporation, entity)
 
         @game.stock_market.set_par(corporation, share_price)
-        share = corporation.shares.first
+        share = corporation.ipo_shares.first
         buy_shares(entity, share.to_bundle)
         @game.after_par(corporation)
         track_action(action, action.corporation)


### PR DESCRIPTION
SR is now mostly complete

This required changing the following common elements:
- Engine::Corporation - allow the bank to own IPO shares. Needed because a chartered company in 1862 can have shares both in IPO and in the treasury.
- Engine::Share - distinguish between IPO and treasury purchase prices
- Engine::SharePool - distinguish between IPO and treasury purchases
- Step::BuySellParShares - use ipo_shares rather than shares for parring (consequence of the above)
- UI::Corporation - show shares in treasury in addition to IPO
- UI::BuySellShares - allow buying shares from treasury in addition to IPO

1870 needed to be tweaked because it made assumptions about corporation.capitialization that was specific to 1870 for reissuing shares. I created a game method for 1870 for this.

A word about the Corporation changes. I originally thought that I could make all full cap corporations have IPO shares owned by the bank, but this was going to require a lot of error-prone work to track down everywhere the assumption that IPO shares are owned by the corp in every game we have. Instead I implemented an option to Corporation that allowed the IPO share owner to be specified. It defaults to the existing behavior.

![IPO_Treasury](https://user-images.githubusercontent.com/8494213/113366912-d3179100-9317-11eb-8100-6d8e6c70b161.png)
