### PR TITLE
[1822] P5-LC&DR

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1467,7 +1467,9 @@ module Engine
           return {} if time != :token || !company.owner&.corporation?
 
           choices = {}
-          choices['exchange'] = 'Move an exchange station token to the available station token section'
+          if exchange_tokens(company.owner).positive?
+            choices['exchange'] = 'Move an exchange station token to the available station token section'
+          end
           choices
         end
 


### PR DESCRIPTION
- If you dont have any exchange tokens. You shouldnt have the option to move an exchange token to available with the P5 ability.

fixes #4893

This shouldnt break any of the current games.