### PR TITLE
tiles tab/page: toggle tile name

### DIFF
--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
+require 'lib/settings'
 require 'view/tiles'
 
 module View
   module Game
     class TileManifest < Tiles
+      include Lib::Settings
+
       needs :game
       needs :tile_selector, default: nil, store: true
+
+      def render
+        h(:div, [render_tile_manifest, render_toggle_button])
+      end
 
       def render_tile_selector(remaining, tile, shift: 0)
         return [] unless @tile_selector
@@ -55,7 +62,27 @@ module View
         [h(:div, parent_props, [h(:div, props, [selector])])]
       end
 
-      def render
+      def render_toggle_button
+        toggle = lambda do
+          toggle_setting(@hide_tile_names)
+          update
+        end
+
+        props = {
+          style: {
+            margin: '0 0 0 1vmin',
+          },
+          on: {
+            click: toggle,
+          },
+        }
+
+        h(:div, [
+          h(:'button.small', props, "Tile Names #{setting_for(@hide_tile_names, @game) ? '❌' : '✅'}"),
+        ])
+      end
+
+      def render_tile_manifest
         remaining = @game.tiles.group_by(&:name)
 
         if @game.tile_groups.empty?
@@ -117,6 +144,7 @@ module View
             margin: '3vmin 1vmin',
           },
         }
+
         h('div#tile_manifest', props, children)
       end
     end

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require 'lib/settings'
 require 'view/game/hex'
 
 module View
   class Tiles < Snabberb::Component
+    include Lib::Settings
+
     WIDTH = 80
     HEIGHT = 97
     LINE_PROPS = {

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -105,78 +105,46 @@ module View
       extra_children_a: [],
       extra_children_b: []
     )
-      props = {
+      block_props = {
         style: {
           width: "#{2 * (WIDTH * scale + 2)}px",
           height: "#{HEIGHT * scale}px",
         },
       }
 
-      tile_a ||= Engine::Tile.for(name_a)
-      tile_b ||= Engine::Tile.for(name_b)
+      text = []
+      double_sided_tiles = [[name_a, tile_a], [name_b, tile_b]].map do |name, tile|
+        tile ||= Engine::Tile.for(name)
+        tile.rotate!(0)
+        text << "##{name}" unless setting_for(@hide_tile_names)
+        hex = Engine::Hex.new('A1', layout: layout, tile: tile)
+        hex.x = 0
+        hex.y = 0
 
-      rotations = [0]
-
-      rotations.map do |rotation|
-        tile_a.rotate!(rotation)
-        tile_b.rotate!(rotation)
-
-        unless setting_for(@hide_tile_names)
-          text_a = tile_a.preprinted ? '' : '#'
-          text_a += name_a
-          text_a += "-#{rotation}" unless rotations == [0]
-
-          text_b = tile_b.preprinted ? '' : '#'
-          text_b += name_b
-          text_b += "-#{rotation}" unless rotations == [0]
-
-          text = "#{text_a} / #{text_b}"
-        end
-        count = tile_b.unlimited ? '∞' : num.to_s
-
-        hex_a = Engine::Hex.new('A1',
-                                layout: layout,
-                                tile: tile_a)
-        hex_a.x = 0
-        hex_a.y = 0
-
-        hex_b = Engine::Hex.new('A1',
-                                layout: layout,
-                                tile: tile_b)
-        hex_b.x = 0
-        hex_b.y = 0
-
-        h('div.tile__block', props, [
-            *extra_children_a,
-            *extra_children_b,
-            h(:div, LINE_PROPS, [
-              h(:div, TEXT_PROPS, text),
-              h(:div, COUNT_PROPS, count),
-            ]),
-            h("svg#tile_#{name_a}", { style: { width: '50%', height: '100%' } }, [
-              h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
-                h(
-                  Game::Hex,
-                  hex: hex_a,
-                  role: :tile_page,
-                  unavailable: unavailable,
-                  clickable: clickable,
-                ),
-              ]),
-            ]),
-            h("svg#tile_#{name_b}", { style: { width: '50%', height: '100%' } }, [
-              h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
-                h(
-                  Game::Hex,
-                  hex: hex_b,
-                  role: :tile_page,
-                  unavailable: unavailable,
-                  clickable: clickable,
-                ),
-              ]),
-            ]),
+        h("svg#tile_#{name}", { style: { width: '50%', height: '100%' } }, [
+          h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
+            h(
+              Game::Hex,
+              hex: hex,
+              role: :tile_page,
+              unavailable: unavailable,
+              clickable: clickable,
+            ),
+          ]),
         ])
       end
+      text = text.join(' / ') unless setting_for(@hide_tile_names)
+      count = tile_b.unlimited ? '∞' : num.to_s
+
+      h('div.tile__block', block_props, [
+          *extra_children_a,
+          *extra_children_b,
+          h(:div, LINE_PROPS, [
+            h(:div, TEXT_PROPS, text),
+            h(:div, COUNT_PROPS, count),
+          ]),
+          *double_sided_tiles,
+      ])
     end
   end
 end

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -6,6 +6,25 @@ module View
   class Tiles < Snabberb::Component
     WIDTH = 80
     HEIGHT = 97
+    LINE_PROPS = {
+      style: {
+        height: '0.9rem',
+        padding: '0 0.7rem 0 0.2rem',
+      },
+    }.freeze
+    TEXT_PROPS = {
+      style: {
+        float: 'left',
+        fontSize: '70%',
+      },
+    }.freeze
+    COUNT_PROPS = {
+      style: {
+        float: 'right',
+        lineHeight: '0.9rem',
+      },
+    }.freeze
+
     def render_tile_blocks(
       name,
       layout: nil,
@@ -19,7 +38,7 @@ module View
       clickable: false,
       extra_children: []
     )
-      props = {
+      block_props = {
         style: {
           width: "#{WIDTH * scale}px",
           height: "#{HEIGHT * scale}px",
@@ -35,14 +54,12 @@ module View
       rotations.map do |rotation|
         tile.rotate!(rotation)
 
-        text = tile.preprinted ? '' : '#'
-        text += name
-        text += "-#{rotation}" unless rotations == [0]
-        if tile.unlimited
-          text += ' × ∞'
-        elsif num
-          text += " × #{num}"
+        unless setting_for(@hide_tile_names)
+          text = tile.preprinted ? '' : '#'
+          text += name
+          text += "-#{rotation}" unless rotations == [0]
         end
+        count = tile.unlimited ? '∞' : num.to_s
 
         hex = Engine::Hex.new(hex_coordinates || 'A1',
                               layout: layout,
@@ -51,9 +68,12 @@ module View
         hex.x = 0
         hex.y = 0
 
-        h("div#tile_#{name}.tile__block", props, [
+        h("div#tile_#{name}.tile__block", block_props, [
             *extra_children,
-            h(:div, { style: { textAlign: 'center', fontSize: '12px' } }, text),
+            h(:div, LINE_PROPS, [
+              h(:div, TEXT_PROPS, text),
+              h(:div, COUNT_PROPS, count),
+            ]),
             h(:svg, { style: { width: '100%', height: '100%' } }, [
               h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
                 h(
@@ -65,7 +85,7 @@ module View
                 ),
               ]),
             ]),
-        ])
+          ])
       end
     end
 
@@ -98,20 +118,18 @@ module View
         tile_a.rotate!(rotation)
         tile_b.rotate!(rotation)
 
-        text_a = tile_a.preprinted ? '' : '#'
-        text_a += name_a
-        text_a += "-#{rotation}" unless rotations == [0]
+        unless setting_for(@hide_tile_names)
+          text_a = tile_a.preprinted ? '' : '#'
+          text_a += name_a
+          text_a += "-#{rotation}" unless rotations == [0]
 
-        text_b = tile_b.preprinted ? '' : '#'
-        text_b += name_b
-        text_b += "-#{rotation}" unless rotations == [0]
+          text_b = tile_b.preprinted ? '' : '#'
+          text_b += name_b
+          text_b += "-#{rotation}" unless rotations == [0]
 
-        text = "#{text_a} / #{text_b}"
-        if tile_b.unlimited
-          text += ' × ∞'
-        elsif num
-          text += " × #{num}"
+          text = "#{text_a} / #{text_b}"
         end
+        count = tile_b.unlimited ? '∞' : num.to_s
 
         hex_a = Engine::Hex.new('A1',
                                 layout: layout,
@@ -128,7 +146,10 @@ module View
         h('div.tile__block', props, [
             *extra_children_a,
             *extra_children_b,
-            h(:div, { style: { textAlign: 'center', fontSize: '12px' } }, text),
+            h(:div, LINE_PROPS, [
+              h(:div, TEXT_PROPS, text),
+              h(:div, COUNT_PROPS, count),
+            ]),
             h("svg#tile_#{name_a}", { style: { width: '50%', height: '100%' } }, [
               h(:g, { attrs: { transform: "scale(#{scale * 0.4})" } }, [
                 h(

--- a/assets/app/view/tiles_page.rb
+++ b/assets/app/view/tiles_page.rb
@@ -179,16 +179,46 @@ module View
         )
       end
 
-      rendered_tiles = game.tiles.sort.group_by(&:name).flat_map do |name, tiles_|
-        render_tile_blocks(
-          name,
-          layout: game.layout,
-          tile: tiles_.first,
-          num: tiles_.size,
-          rotations: @rotations,
-          location_name: @location_name,
-        )
-      end
+      all_tiles = game.tiles.sort.group_by(&:name)
+      rendered_tiles =
+        if game.tile_groups.empty?
+          all_tiles.flat_map do |name, tiles_|
+            render_tile_blocks(
+              name,
+              layout: game.layout,
+              tile: tiles_.first,
+              num: tiles_.size,
+              rotations: @rotations,
+              location_name: @location_name,
+            )
+          end
+        else
+          game.tile_groups.flat_map do |group|
+            if group.one?
+              name = group.first
+              render_tile_blocks(
+                name,
+                layout: game.layout,
+                tile: all_tiles[name].first,
+                num: all_tiles[name].size,
+                rotations: @rotations,
+                location_name: @location_name,
+              )
+            else
+              name_a, name_b = group
+              tile_a = all_tiles[name_a].first
+              tile_b = all_tiles[name_b].first
+              render_tile_sides(
+                name_a,
+                name_b,
+                layout: game.layout,
+                tile_a: tile_a,
+                tile_b: tile_b,
+                num: all_tiles[name_a].size
+              )
+            end
+          end
+        end
 
       h("div#hexes_and_tiles_#{game_class.title}", [
           h(:h2, game_class.full_title),

--- a/assets/app/view/tiles_page.rb
+++ b/assets/app/view/tiles_page.rb
@@ -200,7 +200,19 @@ module View
               h(:h3, "#{game_class.title} Map Hexes"),
               *rendered_map_hexes,
             ]),
+          render_toggle_button,
         ])
+    end
+
+    def render_toggle_button
+      toggle = lambda do
+        toggle_setting(@hide_tile_names)
+        update
+      end
+
+      h(:div, [
+        h(:'button.small', { on: { click: toggle } }, "Tile Names #{setting_for(@hide_tile_names) ? '❌' : '✅'}"),
+      ])
     end
   end
 end


### PR DESCRIPTION
- tile name toggleable on tiles tab and /tiles (partly closes #4868)
- tile name + count rendering revised
- fixed rendering of double sided tiles (18Mag) on /tiles
- refactoring of double sided tiles rendering

ante
![image](https://user-images.githubusercontent.com/33390595/113505892-e017c880-9541-11eb-98a4-3798e5c4c7fe.png)

post
![image](https://user-images.githubusercontent.com/33390595/113505906-e9a13080-9541-11eb-851e-94d95d986466.png).![image](https://user-images.githubusercontent.com/33390595/113505914-ee65e480-9541-11eb-9136-6a44fc539a19.png)
