### PR TITLE
1817: Warn about liquidation on the train step and ask for confirmation.

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -271,7 +271,7 @@ module View
               end
 
               if other_owner(other) == @corporation.owner
-                if @corporation.loans.any? && !@game.can_pay_interest?(@corporation, -price)
+                if !@corporation.loans.empty? && !@game.can_pay_interest?(@corporation, -price)
                   # We don't support nested confirmed, it's unlikely you'll buy from another player.
                   opts = {
                     color: :yellow,

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -271,7 +271,18 @@ module View
               end
 
               if other_owner(other) == @corporation.owner
-                buy_train.call
+                if @corporation.loans.any? && !@game.can_pay_interest?(@corporation, -price)
+                  # We don't support nested confirmed, it's unlikely you'll buy from another player.
+                  opts = {
+                    color: :yellow,
+                    click: buy_train,
+                    message: "Buying train at #{@game.format_currency(price)} will cause "\
+                    "#{@corporation.name} to be liquidated.",
+                  }
+                  store(:confirm_opts, opts, skip: false)
+                else
+                  buy_train.call
+                end
               else
                 check_consent(other_owner(other), buy_train)
               end

--- a/lib/engine/game/g_1817/step/buy_train.rb
+++ b/lib/engine/game/g_1817/step/buy_train.rb
@@ -10,7 +10,7 @@ module Engine
         class BuyTrain < Engine::Step::BuyTrain
           def pass_description
             text = 'Trains'
-            text += ', Liquidate' if current_entity.loans.any? && !@game.can_pay_interest?(current_entity)
+            text += ', Liquidate' if !current_entity.loans.empty? && !@game.can_pay_interest?(current_entity)
             @acted ? "Done (#{text})" : "Skip (#{text})"
           end
 

--- a/lib/engine/game/g_1817/step/buy_train.rb
+++ b/lib/engine/game/g_1817/step/buy_train.rb
@@ -8,6 +8,12 @@ module Engine
     module G1817
       module Step
         class BuyTrain < Engine::Step::BuyTrain
+          def pass_description
+            text = 'Trains'
+            text += ', Liquidate' if current_entity.loans.any? && !@game.can_pay_interest?(current_entity)
+            @acted ? "Done (#{text})" : "Skip (#{text})"
+          end
+
           def should_buy_train?(entity)
             :liquidation if entity.trains.empty?
           end


### PR DESCRIPTION
Being at train limit causes the turn to skip. Get confirmation if buying a train
will cause themselves to go into liquidation.

fixes #2600