### PR TITLE
[1846] don't skip MC/O&I second tile lay on Message

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -453,6 +453,8 @@ module Engine
         end
 
         def check_special_tile_lay(action)
+          return if action.is_a?(Engine::Action::Message)
+
           company = @last_action&.entity
           return unless special_tile_lay?(@last_action)
           return unless (ability = abilities(company, :tile_lay))


### PR DESCRIPTION
this doesn't explain how a whole corporation got skipped in #4941, but it does
fix the issue

[Fixes #4941]

----

This breaks a few 1846 games - `[11362, 23182, 35294]`