### PR TITLE
1873: 17+ routes, tokening checks reserved tile, player value

### DIFF
--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -62,7 +62,7 @@ module Lib
     end
 
     def route_prop_string(index, prop)
-      "r#{index}_#{prop}"
+      "r#{index % ROUTE_COLORS.size}_#{prop}"
     end
 
     def change_favicon(active)


### PR DESCRIPTION
Fixes #4936 
Fixes #4952 
Fixes #4955 

Common file change: UI:Lib:Settings - unlimited routes by cycling through colors