### PR TITLE
[1822] fix LNWR corp name 

### DIFF
--- a/lib/engine/game/g_1822/entities.rb
+++ b/lib/engine/game/g_1822/entities.rb
@@ -1341,7 +1341,7 @@ module Engine
           },
           {
             sym: 'LNWR',
-            name: 'London and North West Railway',
+            name: 'London and North Western Railway',
             logo: '1822/LNWR',
             tokens: [0, 100],
             type: 'major',


### PR DESCRIPTION
s.b. "London and North Western Railway" 

Using [this image for reference](https://cf.geekdo-images.com/-_bF1QrqIJnqo_meIjInvw__imagepage/img/_VicQtx5IEa4rmxqle9DhnXcA-M=/fit-in/900x600/filters:no_upscale():strip_icc()/pic4787413.jpg)

closes #4929