### PR TITLE
1817: PSM should close if tile cannot be laid

### DIFF
--- a/lib/engine/game/g_1817/step/track.rb
+++ b/lib/engine/game/g_1817/step/track.rb
@@ -19,9 +19,6 @@ module Engine
 
             # PSM loses it's special if something else goes on F13
             psm = @game.company_by_id(@game.class::PITTSBURGH_PRIVATE_NAME)
-            return unless (ability = @game.abilities(psm, :tile_lay))
-
-            psm.remove_ability(ability)
             @game.log << "#{psm.name} closes as it can no longer be used"
             psm.close!
           end


### PR DESCRIPTION
PSM seems to have no closed properly since the ability refactor

fixes #4974