### PR TITLE
[1822] Discard Train

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -245,7 +245,7 @@ module Engine
             name: '5P',
             distance: 5,
             num: 1,
-            price: 0,
+            price: 500,
           },
           {
             name: 'P+',
@@ -686,7 +686,9 @@ module Engine
         def crowded_corps
           @crowded_corps ||= corporations.select do |c|
             trains = c.trains.count { |t| !extra_train?(t) }
-            trains > train_limit(c)
+            crowded = trains > train_limit(c)
+            crowded |= extra_train_permanent_count(c) > 1
+            crowded
           end
         end
 
@@ -939,7 +941,7 @@ module Engine
             G1822::Step::PendingToken,
             G1822::Step::FirstTurnHousekeeping,
             Engine::Step::AcquireCompany,
-            Engine::Step::DiscardTrain,
+            G1822::Step::DiscardTrain,
             G1822::Step::SpecialChoose,
             G1822::Step::SpecialTrack,
             G1822::Step::SpecialToken,
@@ -951,7 +953,7 @@ module Engine
             G1822::Step::BuyTrain,
             G1822::Step::MinorAcquisition,
             G1822::Step::PendingToken,
-            Engine::Step::DiscardTrain,
+            G1822::Step::DiscardTrain,
             G1822::Step::IssueShares,
           ], round_num: round_num)
         end
@@ -1672,6 +1674,10 @@ module Engine
 
         def extra_train_permanent?(train)
           self.class::EXTRA_TRAIN_PERMANENTS.include?(train.name)
+        end
+
+        def extra_train_permanent_count(corporation)
+          corporation.trains.count { |train| extra_train_permanent?(train) }
         end
 
         def find_corporation(company)

--- a/lib/engine/game/g_1822/step/discard_train.rb
+++ b/lib/engine/game/g_1822/step/discard_train.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/discard_train'
+
+module Engine
+  module Game
+    module G1822
+      module Step
+        class DiscardTrain < Engine::Step::DiscardTrain
+          def process_discard_train(action)
+            train = action.train
+            if @game.extra_train_permanent?(train)
+              @game.remove_train(train)
+              @log << "#{action.entity.name} discards #{train.name}, #{train.name} is removed from the game"
+            else
+              @game.depot.reclaim_train(train)
+              @log << "#{action.entity.name} discards #{train.name}"
+            end
+          end
+
+          def trains(corporation)
+            if @game.extra_train_permanent_count(corporation) > 1
+              return corporation.trains.select { |t| @game.extra_train_permanent?(t) }
+            end
+
+            corporation.trains.reject { |t| @game.extra_train?(t) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822/step/discard_train.rb
+++ b/lib/engine/game/g_1822/step/discard_train.rb
@@ -9,10 +9,13 @@ module Engine
         class DiscardTrain < Engine::Step::DiscardTrain
           def process_discard_train(action)
             train = action.train
+
             if @game.extra_train_permanent?(train)
               @game.remove_train(train)
               @log << "#{action.entity.name} discards #{train.name}, #{train.name} is removed from the game"
             else
+              # Remove any variants on the train before reclaiming it
+              train.variants.select! { |v| v == train.name }
               @game.depot.reclaim_train(train)
               @log << "#{action.entity.name} discards #{train.name}"
             end

--- a/lib/engine/game/g_1822_mrs/game.rb
+++ b/lib/engine/game/g_1822_mrs/game.rb
@@ -633,7 +633,7 @@ module Engine
             name: '5P',
             distance: 5,
             num: 1,
-            price: 0,
+            price: 500,
           },
           {
             name: 'P+',

--- a/lib/engine/game/g_1822_nrs/game.rb
+++ b/lib/engine/game/g_1822_nrs/game.rb
@@ -455,7 +455,7 @@ module Engine
             name: '5P',
             distance: 5,
             num: 1,
-            price: 0,
+            price: 500,
           },
           {
             name: 'P+',


### PR DESCRIPTION
- Set value of the 5P to 500. If its discarded other can buy it for the same amount as a normal 5.
- If you discard a 2P or LP they are removed from the game.
- If you acquire a minor with LP or 2P, and the major already have a LP or a 2P you must discard one of them.
- Before discarding a train, remove all variants except the selected when the train was bought.

fixes #4789
fixes #4812
fixes #4985

This will break a few games.