### PR TITLE
18Ireland bonus payouts for narrow gauge routes

### DIFF
--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -66,7 +66,8 @@ module Engine
           next if node_path.track == skip_track
 
           node_path.walk(visited: visited_paths, counter: counter, on: on, tile_type: tile_type) do |path, vp, ct|
-            yield path, vp, visited
+            ret = yield path, vp, visited
+            next if ret == :abort
             next if path.terminal?
 
             path.nodes.each do |next_node|


### PR DESCRIPTION
The effect of narrow gauge track is to add the value of town stations that
are exclusively on narrow gauge track to the first broad gauge station
they are connected to at the end (or both ends) of the narrow
gauge line. Thus, the companies in the game benefit from the construction
of narrow gauge track even though they do not operate it
directly. It is possible to string together multiple towns on a single
narrow gauge line or network.