### PR TITLE
[1822] Multiple E-Trains

### DIFF
--- a/lib/engine/game/g_1822/step/buy_train.rb
+++ b/lib/engine/game/g_1822/step/buy_train.rb
@@ -20,6 +20,7 @@ module Engine
             if action.exchange
               upgrade_train_action(action)
             else
+              check_e_train(action)
               buy_train_action(action)
             end
             pass! unless can_buy_train?(action.entity)
@@ -51,6 +52,15 @@ module Engine
             @game.take_player_loan(entity, difference)
             @log << "#{entity.name} takes a loan of #{@game.format_currency(difference)} with "\
                     "#{@game.format_currency(@game.player_loan_interest(difference))} in interest"
+          end
+
+          def check_e_train(action)
+            return if !action.variant || (action.variant && action.variant != @game.class::E_TRAIN)
+
+            corporation = action.entity
+            return if corporation.trains.none? { |t| t.name == @game.class::E_TRAIN }
+
+            raise GameError, "#{corporation.id} can only own one E-train"
           end
 
           def must_take_loan?(entity)


### PR DESCRIPTION
- A corporation should only be able to buy one E train.

fixes #5020

This can break games if there is a corporation that have bought 2 E, this should be a very edge case.