### PR TITLE
1862: tile rendering fixes, hidden tiles

### DIFF
--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -14,6 +14,7 @@ module View
         needs :tile
         needs :town
         needs :width, default: 8
+        needs :show_revenue
 
         REVENUE_DISPLACEMENT = 42
         REVENUE_EDGE_DISPLACEMENT = 25
@@ -114,7 +115,7 @@ module View
                           'stroke-width': 4,
                         })]
 
-          children << render_revenue
+          children << render_revenue if @show_revenue
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, { key: "#{@town.id}-d" }, children)
         end

--- a/assets/app/view/game/part/town_location.rb
+++ b/assets/app/view/game/part/town_location.rb
@@ -152,7 +152,7 @@ module View
         def town_rotation_angles(tile, town, edges)
           edge_a, = edges
 
-          if town.exits.size == 2 && tile.stops.one?
+          if center_town?(tile, town)
             case town_track_type(edges)
             when :straight
               [min_edge(edges) * 60]
@@ -194,11 +194,16 @@ module View
           end
         end
 
+        # center two-exit town on the track if there isn't any more track on the tile
+        def center_town?(tile, town)
+          town.exits.size == 2 && tile.exits.size == 2
+        end
+
         # Returns an array of weights, location and rotations
         def town_position(tile, town, edges)
           edge_a, = edges
 
-          if town.exits.size == 2 && tile.stops.one?
+          if center_town?(tile, town)
             angles, positions = case town_track_type(edges)
                                 when :straight
                                   [[edge_a * 60], [0]]

--- a/assets/app/view/game/part/town_rect.rb
+++ b/assets/app/view/game/part/town_rect.rb
@@ -16,6 +16,7 @@ module View
         needs :town
         needs :color, default: 'black'
         needs :width, default: 8
+        needs :show_revenue
 
         # bias away from top and bottom if possible
         EDGE_TOWN_REVENUE_REGIONS = {
@@ -80,6 +81,8 @@ module View
         end
 
         def render_revenue
+          return unless @show_revenue
+
           revenues = @town.uniq_revenues
           return if revenues.size > 1
 
@@ -96,7 +99,7 @@ module View
           edges = normalized_edges(@edge, @town.exits)
 
           if @town.exits.size == 2
-            if @num_cts == 1
+            if center_town?(@tile, @town)
               angle = town_rotation_angles(@tile, @town, edges)[0]
               reverse_side = town_track_type(edges) == :sharp
 

--- a/assets/app/view/game/part/towns.rb
+++ b/assets/app/view/game/part/towns.rb
@@ -13,14 +13,15 @@ module View
         needs :tile
         needs :region_use
         needs :routes
+        needs :show_revenue
 
         def render
           @tile.towns.map do |town|
             if town.rect?
-              h(TownRect, town: town, region_use: @region_use,
+              h(TownRect, town: town, region_use: @region_use, show_revenue: @show_revenue,
                           color: value_for(town, :color), width: value_for(town, :width))
             else
-              h(TownDot, town: town, tile: @tile, region_use: @region_use,
+              h(TownDot, town: town, tile: @tile, region_use: @region_use, show_revenue: @show_revenue,
                          color: value_for(town, :color), width: value_for(town, :width))
             end
           end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -39,6 +39,9 @@ module View
 
         return false if revenue.uniq.size > 1
 
+        # avoid obcsuring track with revenues
+        return true if @tile.cities.empty? && @tile.city_towns.size == 2 && @tile.exits.size > 4
+
         return false if @tile.cities.sum(&:slots) < 3 && @tile.city_towns.size == 2
 
         true
@@ -55,7 +58,10 @@ module View
         render_revenue = should_render_revenue?
         children << render_tile_part(Part::Track, routes: @routes) if !@tile.paths.empty? || !@tile.stubs.empty?
         children << render_tile_part(Part::Cities, show_revenue: !render_revenue) unless @tile.cities.empty?
-        children << render_tile_part(Part::Towns, routes: @routes) unless @tile.towns.empty?
+
+        unless @tile.towns.empty?
+          children << render_tile_part(Part::Towns, routes: @routes, show_revenue: !render_revenue)
+        end
 
         borders = render_tile_part(Part::Borders) if @tile.borders.any?(&:type)
         # OO tiles have different rules...

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -39,7 +39,7 @@ module View
 
         return false if revenue.uniq.size > 1
 
-        # avoid obcsuring track with revenues
+        # avoid obscuring track with revenues
         return true if @tile.cities.empty? && @tile.city_towns.size == 2 && @tile.exits.size > 4
 
         return false if @tile.cities.sum(&:slots) < 3 && @tile.city_towns.size == 2

--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -90,6 +90,7 @@ module View
             num = remaining[name]&.size || 0
             unavailable = num.positive? ? nil : 'None Left'
             tile = tiles.first
+            next if tile.hidden
 
             render_tile_blocks(name,
                                tile: tile,
@@ -98,7 +99,7 @@ module View
                                layout: @game.layout,
                                clickable: true,
                                extra_children: render_tile_selector(remaining, tile))
-          end
+          end.compact
         else
           all_tiles = @game.all_tiles.sort.group_by(&:name)
           children = @game.tile_groups.flat_map do |group|
@@ -107,6 +108,7 @@ module View
               num = remaining[name]&.size || 0
               unavailable = num.positive? ? nil : 'None Left'
               tile = all_tiles[name].first
+              next if tile.hidden
 
               render_tile_blocks(name,
                                  tile: tile,
@@ -124,6 +126,8 @@ module View
               tile_a = all_tiles[name_a].first
               tile_b = all_tiles[name_b].first
 
+              next if tile_a.hidden && tile_b.hidden # can't hide one side of tile
+
               render_tile_sides(name_a,
                                 name_b,
                                 tile_a: tile_a,
@@ -136,7 +140,7 @@ module View
                                 extra_children_b: render_tile_selector(remaining, tile_b, shift: 1))
 
             end
-          end
+          end.compact
         end
 
         props = {

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1872,6 +1872,7 @@ module Engine
           count = val['count'] == 'unlimited' ? 1 : val['count']
           color = val['color']
           code = val['code']
+          hidden = !!val['hidden']
           Array.new(count) do |i|
             Tile.from_code(
               name,
@@ -1879,7 +1880,8 @@ module Engine
               code,
               index: i,
               reservation_blocks: self.class::TILE_RESERVATION_BLOCKS_OTHERS,
-              unlimited: val['count'] == 'unlimited'
+              unlimited: val['count'] == 'unlimited',
+              hidden: hidden
             )
           end
         end

--- a/lib/engine/game/g_1862/map.rb
+++ b/lib/engine/game/g_1862/map.rb
@@ -14,18 +14,21 @@ module Engine
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0;path=a:2,b:_0;path=a:1,b:3',
+            'hidden' => 1,
+            'code' => 'town=revenue:20,loc:0;path=a:0,b:_0;path=a:2,b:_0;path=a:1,b:3',
           },
           '16_1b' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:20;path=a:1,b:_0;path=a:3,b:_0;path=a:0,b:2',
+            'hidden' => 1,
+            'code' => 'town=revenue:20,loc:3;path=a:1,b:_0;path=a:3,b:_0;path=a:0,b:2',
           },
           '16_2' =>
           {
             'count' => 2,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0;path=a:3,b:_0;path=a:0,b:_1;path=a:2,b:_1',
           },
           '17' => 5,
@@ -33,12 +36,14 @@ module Engine
           {
             'count' => 5,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:3',
           },
           '17_2' =>
           {
             'count' => 5,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1',
           },
           '18' => 5,
@@ -46,18 +51,21 @@ module Engine
           {
             'count' => 5,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:1,b:2',
           },
           '18_1b' =>
           {
             'count' => 5,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:0,b:3',
           },
           '18_2' =>
           {
             'count' => 5,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:0,b:_1;path=a:3,b:_1',
           },
           '19' => 4,
@@ -65,31 +73,36 @@ module Engine
           {
             'count' => 4,
             'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:2,b:4',
+            'hidden' => 1,
+            'code' => 'town=revenue:20,loc:0;path=a:0,b:_0;path=a:3,b:_0;path=a:2,b:4',
           },
           '19_1b' =>
           {
             'count' => 4,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:2,b:_0;path=a:4,b:_0;path=a:0,b:3',
           },
           '19_2' =>
           {
             'count' => 4,
             'color' => 'green',
-            'code' => 'town=revenue:20;town=revenue:0;path=a:2,b:_0;path=a:4,b:_0;path=a:0,b:_1;path=a:3,b:_1',
+            'hidden' => 1,
+            'code' => 'town=revenue:20;town=revenue:20;path=a:2,b:_0;path=a:4,b:_0;path=a:0,b:_1;path=a:3,b:_1',
           },
           '20' => 6,
           '20_1' =>
           {
             'count' => 6,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:1,b:4',
           },
           '20_2' =>
           {
             'count' => 6,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:1,b:_1;path=a:4,b:_1',
           },
           '21' => 2,
@@ -97,18 +110,21 @@ module Engine
           {
             'count' => 2,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:4',
           },
           '21_1b' =>
           {
             'count' => 2,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:3,b:_0;path=a:4,b:_0;path=a:0,b:2',
           },
           '21_2' =>
           {
             'count' => 2,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:3,b:_0;path=a:4,b:_0;path=a:0,b:_1;path=a:2,b:_1',
           },
           '22' => 2,
@@ -116,18 +132,21 @@ module Engine
           {
             'count' => 2,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:2,b:3',
           },
           '22_1b' =>
           {
             'count' => 2,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:2,b:_0;path=a:3,b:_0;path=a:0,b:4',
           },
           '22_2' =>
           {
             'count' => 2,
             'color' => 'green',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:2,b:_0;path=a:3,b:_0;path=a:0,b:_1;path=a:4,b:_1',
           },
           '53y' =>
@@ -158,26 +177,38 @@ module Engine
           {
             'count' => 4,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:3;path=a:2,b:5',
           },
           '778_1b' =>
           {
             'count' => 4,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:2,b:_0;path=a:5,b:_0;path=a:1,b:3;path=a:0,b:4',
           },
           '778_2a' =>
           {
             'count' => 4,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:2,b:_1;path=a:5,b:_1;'\
               'path=a:1,b:3',
+          },
+          '778_2b' =>
+          {
+            'count' => 4,
+            'color' => 'brown',
+            'hidden' => 1,
+            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1;'\
+              'path=a:2,b:5',
           },
           '778_3' =>
           {
             'count' => 4,
             'color' => 'brown',
-            'code' => 'town=revenue:20;town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;'\
+            'hidden' => 1,
+            'code' => 'town=revenue:20;town=revenue:20,loc:2;town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;'\
             'path=a:2,b:_1;path=a:5,b:_1;path=a:1,b:_2;path=a:3,b:_2',
           },
           '779' =>
@@ -190,24 +221,28 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:5;path=a:2,b:3',
           },
           '779_1b' =>
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:1,b:_0;path=a:5,b:_0;path=a:0,b:4;path=a:2,b:3',
           },
           '779_1c' =>
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:2,b:_0;path=a:3,b:_0;path=a:0,b:4;path=a:1,b:5',
           },
           '779_2a' =>
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:5,b:_1;'\
               'path=a:2,b:3',
           },
@@ -215,6 +250,7 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:2,b:_1;path=a:3,b:_1;'\
               'path=a:1,b:5',
           },
@@ -222,6 +258,7 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0;path=a:5,b:_0;path=a:2,b:_1;path=a:3,b:_1;'\
               'path=a:0,b:4',
           },
@@ -229,8 +266,9 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;town=revenue:20;path=a:1,b:_0;path=a:5,b:_0;'\
-            'path=a:2,b:_1;path=a:3,b:_1;path=a:0,b:_2;path=a:4,b:_2',
+              'path=a:2,b:_1;path=a:3,b:_1;path=a:0,b:_2;path=a:4,b:_2',
           },
           '780' =>
           {
@@ -242,18 +280,21 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:1,b:2;path=a:4,b:5',
           },
           '780_1b' =>
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:0,b:3;path=a:4,b:5',
           },
           '780_2a' =>
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:1,b:_1;path=a:2,b:_1;'\
               'path=a:4,b:5',
           },
@@ -261,6 +302,7 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_1;path=a:5,b:_1;'\
               'path=a:0,b:3',
           },
@@ -268,6 +310,7 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;town=revenue:20;path=a:1,b:_0;path=a:2,b:_0;'\
               'path=a:4,b:_1;path=a:5,b:_1;path=a:0,b:_2;path=a:3,b:_2',
           },
@@ -295,12 +338,14 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:1,b:4;path=a:2,b:5',
           },
           '798_2' =>
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;path=a:1,b:_1;path=a:4,b:_1;'\
               'path=a:2,b:5',
           },
@@ -308,6 +353,7 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
+            'hidden' => 1,
             'code' => 'town=revenue:20;town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:3,b:_0;'\
               'path=a:1,b:_1;path=a:4,b:_1;path=a:2,b:_2;path=a:5,b:_2',
           },

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -18,7 +18,7 @@ module Engine
                   :name, :opposite, :reservations, :upgrades
     attr_reader :borders, :cities, :color, :edges, :junction, :nodes, :labels,
                 :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
-                :city_towns, :unlimited, :stubs, :partitions, :id, :frame
+                :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :hidden
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -193,6 +193,7 @@ module Engine
       @unlimited = opts[:unlimited] || false
       @labels = []
       @opposite = nil
+      @hidden = opts[:hidden] || false
       @id = "#{@name}-#{@index}"
 
       separate_parts
@@ -209,7 +210,8 @@ module Engine
                index: @index + 1,
                location_name: @location_name,
                reservation_blocks: @reservation_blocks,
-               unlimited: @unlimited)
+               unlimited: @unlimited,
+               hidden: @hidden)
     end
 
     def <=>(other)


### PR DESCRIPTION
- Add "hidden" attribute to tiles and hide those tiles on the manifest
- Treat tiles that have only one town like multi-town tiles if there are other paths on the tile (i.e. don't center them in the track)
- When a tile has over two towns all with the same revenue, only render a single revenue

This is all pretty much common code changes except for the 1862 tiles.

Old tile rendering for 1862:
![62_manifest_before](https://user-images.githubusercontent.com/8494213/114465964-1211d600-9ba5-11eb-86d7-fdc168c72379.png)


New tile rendering:
![62_manifest_after](https://user-images.githubusercontent.com/8494213/114465981-18a04d80-9ba5-11eb-9827-befa10d80369.png)
