### PR TITLE
[1870] fix can_sell? to check for cert limit before corp % limit

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1596,7 +1596,7 @@ module Engine
         @last_game_action_id == @round_history.last
       end
 
-      def can_hold_above_limit?(_entity)
+      def can_hold_above_corp_limit?(_entity)
         false
       end
 

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -1056,7 +1056,7 @@ module Engine
           tile_lays
         end
 
-        def can_hold_above_limit?(_entity)
+        def can_hold_above_corp_limit?(_entity)
           true
         end
 

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -719,7 +719,7 @@ module Engine
           []
         end
 
-        def can_hold_above_limit?(_entity)
+        def can_hold_above_corp_limit?(_entity)
           true
         end
 

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -101,11 +101,11 @@ module Engine
       end
 
       def must_sell?(entity)
-        return false if @game.can_hold_above_limit?(entity)
         return false unless can_sell_any?(entity)
+        return true if @game.num_certs(entity) > @game.cert_limit
 
-        @game.num_certs(entity) > @game.cert_limit ||
-          !@game.corporations.all? { |corp| corp.holding_ok?(entity) }
+        !@game.can_hold_above_corp_limit?(entity) &&
+          @game.corporations.any? { |corp| !corp.holding_ok?(entity) }
       end
 
       def can_sell?(entity, bundle)


### PR DESCRIPTION
also rename `can_hold_above_limit?` for clarity; there the "limit" is the
percentage of a corporation that one player is allowed to hold, not the "cert
limit"

[Fixes #5019]

----

I validated against all titles, just a few 1870 games broke and need pinning/archiving.