### PR TITLE
1862: disambiguate multiple offboards on one hex

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -160,6 +160,7 @@ module View
 
         if @actions.include?('run_routes')
           touch_node(nodes[0]) if nodes.one?
+          disambiguate_node(nodes) if nodes.count(&:offboard?) > 1
           return
         end
 

--- a/assets/app/view/game/runnable.rb
+++ b/assets/app/view/game/runnable.rb
@@ -8,6 +8,15 @@ module View
         base.needs :selected_route, store: true, default: nil
       end
 
+      def disambiguate_node(nodes)
+        current_actions = @game.active_step.current_actions
+
+        return if !current_actions.include?('run_routes') || !@selected_route
+
+        @selected_route.disambiguate_node(nodes)
+        store(:selected_route, @selected_route)
+      end
+
       def touch_node(node)
         current_actions = @game.active_step.current_actions
 

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -24,6 +24,7 @@ module Engine
       @node_chains = {}
       @connection_data = nil
       @last_node = nil
+      @last_offboard = []
       @stops = nil
     end
 
@@ -42,6 +43,7 @@ module Engine
       @halts = nil
       @connection_data = nil
       @last_node = nil
+      @last_offboard = []
     end
 
     def cycle_halts
@@ -161,6 +163,37 @@ module Engine
 
       @halts = nil
       @routes.each { |r| r.clear_cache!(all: true) }
+    end
+
+    # hex with multiple offboards was clicked - determine which one to
+    # connect to the route
+    #
+    # we pick the one next to the first/last node in connected_data
+    # If both nodes could connect, cycle through them
+    def disambiguate_node(nodes)
+      onodes = nodes.select(&:offboard?)
+
+      # find first and last nodes in current route
+      list = connection_data.any? ? [head[:left], tail[:right]] : [@last_node]
+      return if list.empty?
+
+      # if those match either of the nodes in the tile, use it and remember it
+      if (match = onodes.find { |n| list.include?(n) })
+        touch_node(match)
+        @last_offboard = [match]
+        return
+      end
+
+      # otherwise use a node on the tile that connects to the current route
+      # if multiple, ignore the most recently used one
+      candidates = onodes.select { |node| list.any? { |last| select(last, node)[0] } }
+      if candidates.size > 1
+        touch_node((candidates - @last_offboard)[0])
+        @last_offboard = []
+      elsif candidates.one?
+        touch_node(candidates[0])
+        @last_offboard = []
+      end
     end
 
     def paths

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -174,7 +174,7 @@ module Engine
       onodes = nodes.select(&:offboard?)
 
       # find first and last nodes in current route
-      list = connection_data.any? ? [head[:left], tail[:right]] : [@last_node]
+      list = connection_data.empty? ? [@last_node].compact : [head[:left], tail[:right]]
       return if list.empty?
 
       # if those match either of the nodes in the tile, use it and remember it


### PR DESCRIPTION
I added these nifty red hexes with lines through them and two offboards to make the 1862 map look correct.
The problem is that the existing code can't deal with multiple offboards on one hex for the purpose of selecting a route. This is because it doesn't know which node to use for the touch_node method in route.

This PR fixes that by creating a "disambiguation" front end to touch_node for hexes with two offboards.

Hopefully, more than just 1862 can make use of it.

Example:
![disambiguation](https://user-images.githubusercontent.com/8494213/115180351-9b884300-a092-11eb-8eb7-e1f5db3c05f9.png)
