### PR TITLE
1862: Dividends

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -21,7 +21,7 @@ module View
 
         store(:routes, @step.routes, skip: true)
 
-        payout_options = @step.dividend_types.map do |type|
+        payout_options = options.keys.map do |type|
           option = options[type]
           text =
             case type
@@ -32,7 +32,7 @@ module View
             when :half
               'Half Pay'
             else
-              type
+              @step.respond_to?(:dividend_name) ? @step.dividend_name(type) : type
             end
 
           corp_income = option[:corporation] + option[:divs_to_corporation]

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -10,6 +10,8 @@ require_relative 'step/buy_sell_par_shares'
 require_relative 'step/home_upgrade'
 require_relative 'step/track'
 require_relative 'step/token'
+require_relative 'step/route'
+require_relative 'step/dividend'
 
 module Engine
   module Game
@@ -702,8 +704,8 @@ module Engine
             # G1862::Step::Merge,
             G1862::Step::Track,
             G1862::Step::Token,
-            Engine::Step::Route,
-            Engine::Step::Dividend,
+            G1862::Step::Route,
+            G1862::Step::Dividend,
             # G1862::Step::Refinance,
             Engine::Step::BuyTrain,
             # G1862::Step::RedeemStock,

--- a/lib/engine/game/g_1862/step/dividend.rb
+++ b/lib/engine/game/g_1862/step/dividend.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+require_relative '../../../operating_info'
+require_relative '../../../action/dividend'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class Dividend < Engine::Step::Dividend
+          HUDSON_TYPES = %i[hudson payout withhold].freeze
+
+          def dividend_types
+            HUDSON_TYPES
+          end
+
+          def actual_dividend_types(entity, revenue, subsidy)
+            hudson_allowed?(entity, revenue, subsidy) ? HUDSON_TYPES : DIVIDEND_TYPES
+          end
+
+          def hudson_delta(entity, revenue)
+            entity.share_price.price - revenue
+          end
+
+          def hudson_allowed?(entity, revenue, subsidy)
+            revenue > 10 &&
+              revenue < entity.share_price.price &&
+              (entity.cash + subsidy) >= hudson_delta(entity, revenue)
+          end
+
+          def dividend_name(type)
+            if type == :hudson
+              'G Hudson Manoeuvre'
+            else
+              type
+            end
+          end
+
+          def dividend_options(entity)
+            revenue = @game.routes_revenue(routes)
+            subsidy = @game.routes_subsidy(routes)
+            actual_dividend_types(entity, revenue, subsidy).map do |type|
+              payout = send(type, entity, revenue, subsidy)
+              payout[:divs_to_corporation] = 0
+              net_revenue = revenue
+              net_revenue += hudson_delta(entity, revenue) if type == :hudson
+              [type, payout.merge(share_price_change(entity, payout[:per_share].positive? ? net_revenue : 0))]
+            end.to_h
+          end
+
+          def process_dividend(action)
+            entity = action.entity
+            revenue = @game.routes_revenue(routes)
+            subsidy = @game.routes_subsidy(routes)
+            kind = action.kind.to_sym
+            payout = dividend_options(entity)[kind]
+
+            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
+              routes,
+              action,
+              revenue,
+              @round.laid_hexes
+            )
+
+            entity.trains.each { |train| train.operated = true }
+
+            @round.routes = []
+
+            log_run_payout(entity, kind, revenue, subsidy, action, payout)
+            if kind == :hudson && payout[:corporation].negative?
+              entity.spend(-payout[:corporation], @game.bank)
+            elsif payout[:corporation].positive?
+              @game.bank.spend(payout[:corporation], entity)
+            end
+            payout_shares(entity, revenue) if payout[:per_share].positive?
+            change_share_price(entity, payout)
+
+            pass!
+          end
+
+          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
+            unless HUDSON_TYPES.include?(kind)
+              @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
+            end
+
+            if payout[:per_share].zero? && payout[:corporation].zero?
+              @log << "#{entity.name} does not run"
+            elsif payout[:per_share].zero?
+              @log << "#{entity.name} withholds #{@game.format_currency(revenue)}"
+            end
+            if kind == :hudson && payout[:corporation].negative?
+              @log << "#{entity.name} spends #{@game.format_currency(-payout[:corporation])} "\
+                'for George Hudson Manoeuvre'
+            elsif kind == :hudson
+              @log << "#{entity.name} earns reduced subsidy of #{@game.format_currency(payout[:corporation])} "\
+                'for George Hudson Manoeuvre'
+            elsif subsidy.positive?
+              @log << "#{entity.name} earns subsidy of #{@game.format_currency(subsidy)}"
+            end
+          end
+
+          def share_price_change(entity, revenue)
+            if revenue.positive?
+              curr_price = entity.share_price.price
+              if revenue >= curr_price && revenue < 2 * curr_price
+                { share_direction: :right, share_times: 2 }
+              elsif revenue >= 2 * curr_price && revenue < 3 * curr_price
+                { share_direction: :right, share_times: 4 }
+              elsif revenue >= 3 * curr_price && revenue < 4 * curr_price
+                { share_direction: :right, share_times: 6 }
+              elsif revenue >= 4 * curr_price
+                { share_direction: :right, share_times: 8 }
+              else
+                {}
+              end
+            else
+              { share_direction: :left, share_times: 2 }
+            end
+          end
+
+          def withhold(_entity, revenue, subsidy)
+            { corporation: revenue + subsidy, per_share: 0 }
+          end
+
+          def payout(entity, revenue, subsidy)
+            { corporation: subsidy, per_share: payout_per_share(entity, revenue) }
+          end
+
+          def hudson(entity, revenue, subsidy)
+            diff = hudson_delta(entity, revenue)
+            { corporation: subsidy - diff, per_share: payout_per_share(entity, revenue + diff) }
+          end
+
+          def movement_str(times, dir)
+            "#{times / 2} #{dir}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/route.rb
+++ b/lib/engine/game/g_1862/step/route.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/route'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class Route < Engine::Step::Route
+          def process_run_routes(action)
+            super
+
+            entity = action.entity
+            @round.routes.each do |route|
+              subsidy = route.subsidy
+              if subsidy.positive?
+                @log << "#{entity.name} runs a #{route.train.name} train for a subsidy of "\
+                  "#{@game.format_currency(subsidy)}"
+              end
+            end
+          end
+
+          def chart(entity)
+            curr_price = entity.share_price.price
+            [
+              ['Revenue', 'Price Change'],
+              [@game.format_currency(0), '1 ←'],
+              ["≥ #{@game.format_currency(1)}", 'none'],
+              ["≥ #{@game.format_currency(curr_price)}", '1 →'],
+              ["≥ #{@game.format_currency(2 * curr_price)}", '2 →'],
+              ["≥ #{@game.format_currency(3 * curr_price)}", '3 →'],
+              ["≥ #{@game.format_currency(4 * curr_price)}", '4 →'],
+            ]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement 1862 dividends. Mostly borrowed from 1860 (due to subsidies), but also added new dividend type: the George Hudson Manouevre. This is a way to boost share price by stealing corporate money to increase revenue.

I had to change the common UI:Dividend file for two reasons:
- It was written assuming the dividend choices are fixed for the entire game. Not true here since the Hudson Manouevre requires certain conditions to be true
- I wanted to be able to control the text on the button.

Example of the GHM:
![Hudson](https://user-images.githubusercontent.com/8494213/115325637-39d6e000-a149-11eb-84c8-060d79a79671.png)
