### PR TITLE
1817WO: Shouldn't be able to redeem shares in liquidation

### DIFF
--- a/lib/engine/game/g_1817_wo/game.rb
+++ b/lib/engine/game/g_1817_wo/game.rb
@@ -617,15 +617,6 @@ module Engine
           corporation.tokens.any? { |token| token.city == @new_zealand_city }
         end
 
-        # This must be overridden to use 1817WO step
-        def redeemable_shares(entity)
-          return [] unless entity.corporation?
-          return [] unless round.steps.find { |step| step.instance_of?(G1817WO::Step::BuySellParShares) }.active?
-
-          bundles_for_corporation(share_pool, entity)
-            .reject { |bundle| entity.cash < bundle.price }
-        end
-
         def tokenable_location_exists?
           # Using hexes > tile > cities because simply using cities also gets cities
           # that are on tiles not yet laid.


### PR DESCRIPTION
1817 code checks that the share isn't in liquidation
and is otherwise identical (except some is_a? vs instance_of?)

fixes #5053