### PR TITLE
1862: buy trains

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -229,7 +229,7 @@ module View
             end
           end
           event_text = event_text.flat_map { |e| [h('span.nowrap', e), ', '] }[0..-2]
-          name = (train.name == first_train&.name ? '→ ' : '') + @game.info_train_name(train)
+          name = (train.sym == first_train&.sym ? '→ ' : '') + @game.info_train_name(train)
 
           train_content = [
             h(:td, name),

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -172,12 +172,11 @@ module View
 
         rust_schedule, obsolete_schedule = rust_obsolete_schedule
         trs = @game.depot.upcoming.group_by(&:name).map do |name, trains|
-          names_to_prices = trains.first.names_to_prices
           events = []
           events << h('div.left', "rusts #{rust_schedule[name].join(', ')}") if rust_schedule[name]
           events << h('div.left', "obsoletes #{obsolete_schedule[name].join(', ')}") if obsolete_schedule[name]
-          tds = [h(:td, names_to_prices.keys.join(', ')),
-                 h("td#{price_str_class}", names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
+          tds = [h(:td, @game.info_train_name(trains.first)),
+                 h("td#{price_str_class}", @game.info_train_price(trains.first)),
                  h('td.right', "×#{trains.size}")]
           tds << h('td.right', events) if events.size.positive?
 
@@ -230,11 +229,11 @@ module View
             end
           end
           event_text = event_text.flat_map { |e| [h('span.nowrap', e), ', '] }[0..-2]
-          name = (train.name == first_train&.name ? '→ ' : '') + names_to_prices.keys.join(', ')
+          name = (train.name == first_train&.name ? '→ ' : '') + @game.info_train_name(train)
 
           train_content = [
             h(:td, name),
-            h("td#{price_str_class}", names_to_prices.values.map { |p| @game.format_currency(p) }.join(', ')),
+            h("td#{price_str_class}", @game.info_train_price(train)),
             h('td.center', "#{remaining.size} / #{trains.size}"),
           ]
 

--- a/lib/engine/action/buy_train.rb
+++ b/lib/engine/action/buy_train.rb
@@ -6,9 +6,10 @@ require_relative 'base'
 module Engine
   module Action
     class BuyTrain < Base
-      attr_reader :train, :price, :exchange, :variant, :shell, :slots, :extra_due
+      attr_reader :train, :price, :exchange, :variant, :shell, :slots, :extra_due, :warranties
 
-      def initialize(entity, train:, price:, variant: nil, exchange: nil, shell: nil, slots: nil, extra_due: nil)
+      def initialize(entity, train:, price:, variant: nil, exchange: nil, shell: nil, slots: nil,
+                     extra_due: nil, warranties: nil)
         super(entity)
         @train = train
         @price = price
@@ -17,6 +18,7 @@ module Engine
         @shell = shell
         @slots = slots
         @extra_due = extra_due
+        @warranties = warranties
       end
 
       def self.h_to_args(h, game)
@@ -28,6 +30,7 @@ module Engine
           shell: shell_by_name(h['shell'], game),
           slots: h['slots']&.map { |m| m.to_i },
           extra_due: h['extra_due'],
+          warranties: h['warranties'],
         }
       end
 
@@ -40,6 +43,7 @@ module Engine
           'shell' => @shell&.name,
           'slots' => @slots,
           'extra_due' => @extra_due ? true : nil,
+          'warranties' => @warranties,
         }
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2294,6 +2294,14 @@ module Engine
         corporations.sort_by(&:name)
       end
 
+      def info_train_name(train)
+        train.names_to_prices.keys.join(', ')
+      end
+
+      def info_train_price(train)
+        train.names_to_prices.values.map { |p| format_currency(p) }.join(', ')
+      end
+
       def info_on_trains(phase)
         Array(phase[:on]).first
       end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1441,8 +1441,7 @@ module Engine
         end
 
         def info_train_name(train)
-          train.names_to_prices.keys.find { |n| /^[A-H]$/ =~ n } + ': ' +
-            train.names_to_prices.keys.reject { |n| /^[A-H]$/ =~ n }.join(', ')
+          train.sym + ': ' + train.names_to_prices.keys.reject { |n| n == train.sym }.join(', ')
         end
 
         def info_train_price(train)

--- a/lib/engine/game/g_1862/step/buy_train.rb
+++ b/lib/engine/game/g_1862/step/buy_train.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          WARRANTY_COST = 50
+
+          def actions(entity)
+            return [] if entity != current_entity || buyable_trains(entity).empty?
+            return [] if entity.share_price&.type == :close
+            return %w[buy_train] if must_buy_train?(entity)
+
+            super
+          end
+
+          def room?(entity, _shell = nil)
+            if @game.phase.available?('G')
+              entity.trains.size < @game.train_limit(entity)
+            else
+              entity.trains.empty? || room_for_any_type?(entity)
+            end
+          end
+
+          def room_for_any_type?(entity)
+            trains = entity.trains.group_by { |t| @game.train_type(t) }
+            trains.keys.size < 3 || trains.values.any? { |v| v.size < @game.train_limit_by_type(entity) }
+          end
+
+          def room_for_type?(entity, type)
+            trains = entity.trains.group_by { |t| @game.train_type(t) }
+            (trains[type]&.size || 0) < @game.train_limit_by_type(entity)
+          end
+
+          def buyable_trains(entity)
+            depot_trains = @depot.depot_trains
+            other_trains = @depot.other_trains(entity)
+
+            depot_trains = [@depot.min_depot_train] if entity.cash < @depot.min_depot_price
+
+            other_trains.reject! { |t| entity.cash < @game.used_train_price(t) }
+            other_trains.select! { |t| room_for_type?(entity, @game.train_type(t)) }
+
+            depot_trains + other_trains
+          end
+
+          def buyable_train_variants(train, entity)
+            return [] unless buyable_trains(entity).any? { |bt| bt.variants[bt.name] }
+
+            variants = train.variants.values
+            return variants if train.owned_by_corporation?
+
+            variants.reject! { |v| /^[A-H]$/ =~ v[:name] }
+            variants.select! { |v| room_for_type?(entity, @game.train_type_by_name(v[:name])) }
+            variants
+          end
+
+          def check_spend(action)
+            warranties = action.warranties || 0
+            return unless action.entity.cash < action.price + (warranties * WARRANTY_COST)
+
+            raise GameError "#{action.entity} cannot afford warranty cost of "\
+              "#{@game.format_currency(warranties * WARRANTY_COST)}"
+          end
+
+          def buy_train_action(action)
+            entity = action.entity
+            train = action.train
+            warranties = action.warranties || 0
+            if warranties.positive?
+              if warranties > warranty_limit(train)
+                raise GameError "Can only purchase #{warranty_limit(train)} warranties for train"
+              end
+
+              entity.spend(warranties * WARRANTY_COST, @game.bank)
+              suffix = warranties > 1 ? 'ies' : 'y'
+              @log << "#{entity.name} pays #{@game.format_currency(warranties * WARRANTY_COST)} "\
+                "for #{warranties} warrant#{suffix}"
+            end
+
+            super
+
+            warranties.times { train.name = train.name + '*' }
+          end
+
+          def president_may_contribute?(_entity, _shell = nil)
+            false
+          end
+
+          def fixed_price(train)
+            @game.used_train_price(train)
+          end
+
+          def warranty_text
+            'Warranties (each)'
+          end
+
+          def warranty_max
+            /A|D/.match?(@depot.depot_trains.first.sym) ? 2 : 3
+          end
+
+          def warranty_limit(train)
+            /A|D/.match?(train.sym) ? 2 : 3
+          end
+
+          def warranty_cost
+            @game.format_currency(WARRANTY_COST)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/buy_train.rb
+++ b/lib/engine/game/g_1862/step/buy_train.rb
@@ -53,7 +53,7 @@ module Engine
             variants = train.variants.values
             return variants if train.owned_by_corporation?
 
-            variants.reject! { |v| /^[A-H]$/ =~ v[:name] }
+            variants.reject! { |v| v[:name] == train.sym }
             variants.select! { |v| room_for_type?(entity, @game.train_type_by_name(v[:name])) }
             variants
           end
@@ -99,11 +99,15 @@ module Engine
           end
 
           def warranty_max
-            /A|D/.match?(@depot.depot_trains.first.sym) ? 2 : 3
+            warranty_limit(@depot.depot_trains.first)
           end
 
           def warranty_limit(train)
-            /A|D/.match?(train.sym) ? 2 : 3
+            if train.sym.include?('A') || train.sym.include?('D')
+              2
+            else
+              3
+            end
           end
 
           def warranty_cost

--- a/lib/engine/game/g_1862/step/dividend.rb
+++ b/lib/engine/game/g_1862/step/dividend.rb
@@ -56,6 +56,8 @@ module Engine
             kind = action.kind.to_sym
             payout = dividend_options(entity)[kind]
 
+            handle_warranties!(entity)
+
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
               routes,
               action,
@@ -134,6 +136,18 @@ module Engine
 
           def movement_str(times, dir)
             "#{times / 2} #{dir}"
+          end
+
+          def handle_warranties!(entity)
+            # remove one warranty from each train and see if it rusts
+            entity.trains.each do |train|
+              train.name = train.name[0..-2] if train.name.include?('*')
+              next unless @game.deferred_rust.include?(train) && !train.name.include?('*')
+
+              @log << "#{train.name} rusts after warranty expired"
+              @game.deferred_rust.delete(train)
+              @game.rust(train)
+            end
           end
         end
       end


### PR DESCRIPTION
Implement most of the buy_trains step for 1862, except for the emergency train buying rules.
- separate limits for each train type (freight/local/express) until phase G
- trains are now lettered A-H with the actual trains being options
- trains bought across companies are fixed price
- add train warranties that can be bought with new trains from depot
- warranties are kept track of by appending a number of *s to the name, every OR one * is removed
- implement deferred rusting due to warranties

This PR has several common file changes:
- UI::GameInfo, Engine::Game::Base - I needed to add control over how the train types and prices were displayed
- UI::BuyTrains - above, plus UI element for warranty purchases, fixed prices for used trains
- Action::BuyTrains - warranties

Old game info:
![old_info](https://user-images.githubusercontent.com/8494213/115795669-91fe2400-a38d-11eb-8c51-dd597c59e1d0.png)

New game info:
![new_info](https://user-images.githubusercontent.com/8494213/115795716-af32f280-a38d-11eb-9906-b75e68f65773.png)

New buy train UI:
![new_buy_trains](https://user-images.githubusercontent.com/8494213/115796207-aabb0980-a38e-11eb-81d4-bdf4da369d62.png)
