### PR TITLE
Require bundle ownership in order to sell shares

### DIFF
--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -110,6 +110,7 @@ module Engine
 
       def can_sell?(entity, bundle)
         return unless bundle
+        return false if entity != bundle.owner
 
         corporation = bundle.corporation
 

--- a/lib/engine/step/corporate_sell_shares.rb
+++ b/lib/engine/step/corporate_sell_shares.rb
@@ -42,6 +42,7 @@ module Engine
 
       def can_sell?(entity, bundle)
         return unless bundle
+        return false if entity != bundle.owner
 
         entity != bundle.corporation && !bought?(entity, bundle.corporation)
       end

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -16,6 +16,7 @@ module Engine
       end
 
       def can_sell?(entity, bundle)
+        return false if entity != bundle.owner
         return false unless @game.check_sale_timing(entity, bundle.corporation)
         return false unless sellable_bundle?(bundle)
         return true if @game.class::EBUY_SELL_MORE_THAN_NEEDED


### PR DESCRIPTION
Still don't know how it was possible to submit the action that issued shares in
1882, but this change now raises an error if that happens. The game in
question ([37905](https://18xx.games/game/37905?action=120)) was [undone to before the issuing action](https://18xx.games/game/37905?action=140), and no other games
were found where this was done (I validated against the full DB), so nothing
needs to be pinned.

[Fixes #5107]