### PR TITLE
Clarify confirmation to purchase from other player

### DIFF
--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -39,7 +39,7 @@ module View
         opts = {
           color: :yellow,
           click: click,
-          message: "This action requires consent from #{player.name}!",
+          message: "Click confirm if #{player.name} has already consented to this action.",
         }
         store(:confirm_opts, opts, skip: false)
       end


### PR DESCRIPTION
Clarify that the player is confirming that they *already have* consent to buy another player's stuff (not just confirming that they need consent).