### PR TITLE
18ireland: Implement EMR rules

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -204,6 +204,10 @@ module Engine
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = false # corporation must issue shares before ebuy (if possible)
       EBUY_SELL_MORE_THAN_NEEDED = false # true if corporation may continue to sell shares even though enough funds
       EBUY_CAN_SELL_SHARES = true # true if a player can sell shares for ebuy
+
+      # if sold more than needed then cannot then buy a cheaper train in the depot.
+      EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN = false
+
       # when is the home token placed? on...
       # operate
       # float
@@ -864,7 +868,7 @@ module Engine
       end
 
       def sellable_turn?
-        self.class::SELL_AFTER == :first ? @turn > 1 : true
+        self.class::SELL_AFTER == :first ? (@turn > 1 || !@round.stock?) : true
       end
 
       def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)

--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -16,6 +16,8 @@ module Engine
         HOME_TOKEN_TIMING = :par
         SELL_BUY_ORDER = :sell_buy
         MUST_BUY_TRAIN = :always
+        EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
+        EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN = true
 
         ASSIGNMENT_TOKENS = {
           'CDSPC' => '/icons/18_ireland/port_token.svg',
@@ -109,14 +111,14 @@ module Engine
             num: 6,
             distance: 2,
             price: 80,
-            rusts_on: '4H',
+            rusts_on: '6H',
           },
           {
             name: "1H'",
             num: 6,
             distance: 1,
             price: 40,
-            rusts_on: '6H',
+            rusts_on: '8H',
             reserved: true,
           },
           {
@@ -463,6 +465,11 @@ module Engine
           hexes.select do |hex|
             hex.tile.cities.any? { |city| city.tokenable?(corporation, free: true) }
           end
+        end
+
+        def buying_power(entity, **)
+          # Cannot issue shares to buy trains
+          entity.cash
         end
 
         def issuable_shares(entity)

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -114,6 +114,12 @@ module Engine
         if entity.cash < @depot.min_depot_price
           depot_trains = [@depot.min_depot_train] if @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST
 
+          if @game.class::EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN
+            depot_trains.reject! do |t|
+              t.price < spend_minmax(entity, t).first
+            end
+          end
+
           if @last_share_sold_price
             if @game.class::EBUY_OTHER_VALUE
               other_trains.reject! { |t| t.price < spend_minmax(entity, t).first }

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -129,8 +129,6 @@ module Engine
       .reverse
     end
 
-    private
-
     def share_price(row, column)
       @market[row]&.[](column)
     end


### PR DESCRIPTION
Correct the rusting timing
Make selling of shares possible if EMR happens in the first round

Also, remove private from stock_market as 18ireland merger requires finding a stock price
by row and column