### PR TITLE
18MEX Baja variant fixes

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2437,6 +2437,8 @@ module Engine
             end
           return true unless corporation
 
+          return false unless token_ability_from_owner_usable?(ability, corporation)
+
           tokened_hexes = []
 
           corporation.tokens.each do |token|
@@ -2447,6 +2449,10 @@ module Engine
         else
           true
         end
+      end
+
+      def token_ability_from_owner_usable?(ability, corporation)
+        ability.from_owner ? corporation.find_token_by_type : true
       end
     end
   end

--- a/lib/engine/game/g_1882/game.rb
+++ b/lib/engine/game/g_1882/game.rb
@@ -724,6 +724,10 @@ module Engine
         def token_note
           'N = neutral token'
         end
+
+        def token_ability_from_owner_usable?(_ability, _corporation)
+          true
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -322,7 +322,8 @@ module Engine
             name: 'Compagnie Du Boleo',
             value: 30,
             revenue: 5,
-            desc: 'May play token in Santa Rosalia at no cost and in addition to regular token lay.',
+            desc: 'May play token in Santa Rosalia at no cost and in addition to regular '\
+                  'token lay. May be purchased by a corporation for $15-$30, from Phase 2.',
             abilities: [
               {
                 type: 'token',


### PR DESCRIPTION
* better baja private wording [Fixes #5099]

* if owning corp has no tokens left on charter, ability tokens with `from_owner`
  should cause `ability_usable?` to return `false` [Fixes #5044]

    * exception: in 1882, the NWR ability moves a token on the map so it still
      works if the owning corp has none left