### PR TITLE
[1870] fix valid hexes for P3 (SCC)

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -289,7 +289,7 @@ module Engine
             abilities: [
               {
                 type: 'assign_hexes',
-                hexes: %w[B9 B11 D5 E12 F5 H13 J3 J5 L11 M2 M6 N1 N7],
+                hexes: %w[B9 B11 D5 E12 F5 H13 J3 J5 L11 M2 M6 N7],
                 when: 'owning_corp_or_turn',
                 count: 1,
                 owner_type: 'corporation',

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -289,7 +289,7 @@ module Engine
             abilities: [
               {
                 type: 'assign_hexes',
-                hexes: %w[B9 B11 D5 E12 F5 H13 J3 J5 L11 M2 M14 N7],
+                hexes: %w[B9 B11 D5 E12 F5 H13 J3 J5 L11 M2 M6 N1 N7],
                 when: 'owning_corp_or_turn',
                 count: 1,
                 owner_type: 'corporation',


### PR DESCRIPTION
closes #5151 

References:

> "P3 (SCC) token may be placed in any city west of the Mississippi. Cities located in the same hex as any portion of the Mississippi river are not allowed."

Rules: http://www.hexagonia.com/rules/MFG_1870.pdf
Map: https://18xx.games/map/1870