### PR TITLE
[1822] Better logging when phase revenue companies close

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -733,7 +733,7 @@ module Engine
             next if !company || company&.closed? || !@phase_revenue[company_id]
 
             @log << "#{company.name} closes"
-              # "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "
+            # "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "
             if @phase_revenue[company.id].cash.positive?
               @phase_revenue[company.id].spend(@phase_revenue[company.id].cash, @bank)
             end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -727,13 +727,12 @@ module Engine
         end
 
         def event_phase_revenue!
-          @log << '-- Event: P15-HR and P20-C&WR now close with money returned to the bank --'
+          @log << '-- Event: Phase revenue companies now close with money returned to the bank --'
           self.class::PRIVATE_PHASE_REVENUE.each do |company_id|
             company = @companies.find { |c| c.id == company_id }
             next if !company || company&.closed? || !@phase_revenue[company_id]
 
             @log << "#{company.name} closes"
-            # "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "
             if @phase_revenue[company.id].cash.positive?
               @phase_revenue[company.id].spend(@phase_revenue[company.id].cash, @bank)
             end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -732,9 +732,8 @@ module Engine
             company = @companies.find { |c| c.id == company_id }
             next if !company || company&.closed? || !@phase_revenue[company_id]
 
-            @log << "#{company.name} "\
-              # "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "\
-              'closes'
+            @log << "#{company.name} closes"
+              # "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "
             if @phase_revenue[company.id].cash.positive?
               @phase_revenue[company.id].spend(@phase_revenue[company.id].cash, @bank)
             end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -732,7 +732,7 @@ module Engine
             company = @companies.find { |c| c.id == company_id }
             next if !company || company&.closed? || !@phase_revenue[company_id]
 
-            @log << "#{company.name} (#{format_currency(@phase_revenue[company.id].cash)}, #{company.owner.name}) closes"
+            @log << "#{company.name} (#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) closes"
             if @phase_revenue[company.id].cash.positive?
               @phase_revenue[company.id].spend(@phase_revenue[company.id].cash, @bank)
             end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -727,13 +727,13 @@ module Engine
         end
 
         def event_phase_revenue!
-          @log << '-- Event: Phase revenue companies now close with money returned to the bank --'
+          @log << '-- Event: P15-HR and P20-C&WR now close with money returned to the bank --'
           self.class::PRIVATE_PHASE_REVENUE.each do |company_id|
             company = @companies.find { |c| c.id == company_id }
             next if !company || company&.closed? || !@phase_revenue[company_id]
 
             @log << "#{company.name} "\
-              "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "\
+              # "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "\
               'closes'
             if @phase_revenue[company.id].cash.positive?
               @phase_revenue[company.id].spend(@phase_revenue[company.id].cash, @bank)

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -732,7 +732,9 @@ module Engine
             company = @companies.find { |c| c.id == company_id }
             next if !company || company&.closed? || !@phase_revenue[company_id]
 
-            @log << "#{company.name} (#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) closes"
+            @log << "#{company.name} "\
+              "(#{format_currency(@phase_revenue[company_id].cash)}, #{company.owner.name}) "\
+              'closes'
             if @phase_revenue[company.id].cash.positive?
               @phase_revenue[company.id].spend(@phase_revenue[company.id].cash, @bank)
             end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -727,11 +727,12 @@ module Engine
         end
 
         def event_phase_revenue!
-          @log << '-- Event: P15-HR and P20-C&WR now closes and its money returned to the bank --'
+          @log << '-- Event: Phase revenue companies now close with money returned to the bank --'
           self.class::PRIVATE_PHASE_REVENUE.each do |company_id|
             company = @companies.find { |c| c.id == company_id }
             next if !company || company&.closed? || !@phase_revenue[company_id]
 
+            @log << "#{company.name} (#{format_currency(@phase_revenue[company.id].cash)}, #{company.owner.name}) closes"
             if @phase_revenue[company.id].cash.positive?
               @phase_revenue[company.id].spend(@phase_revenue[company.id].cash, @bank)
             end


### PR DESCRIPTION
Companies P15-HR and P20-C&WR close at beginning of phase 7 if player-owned (in `def event_phase_revenue!`).
Rather than generic statement, report to log the balance and owner of each closing company.
See issue https://github.com/tobymao/18xx/issues/5168 .