### PR TITLE
18Ireland: Fix Irish Mail and DD tile lays

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1980,6 +1980,8 @@ module Engine
             x, y = xy
             neighbor = coordinates[[hex.x + x, hex.y + y]]
             next unless neighbor
+
+            hex.all_neighbors[direction] = neighbor
             next if self.class::IMPASSABLE_HEX_COLORS.include?(neighbor.tile.color) && !neighbor.targeting?(hex)
             next if hex.tile.borders.any? { |border| border.edge == direction && border.type == :impassable }
 

--- a/lib/engine/game/g_18_ireland/step/narrow_track.rb
+++ b/lib/engine/game/g_18_ireland/step/narrow_track.rb
@@ -48,6 +48,30 @@ module Engine
               raise
             end
           end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            return false unless @game.legal_tile_rotation?(entity, hex, tile)
+
+            # this is the same as the base definition but with the 1867 check removed
+            # this seems to have a problem with the DD tile.
+            # @todo: fix the base defintion.
+
+            old_paths = hex.tile.paths
+            old_ctedges = hex.tile.city_town_edges
+
+            new_paths = tile.paths
+            new_exits = tile.exits
+            new_ctedges = tile.city_town_edges
+            extra_cities = [0, new_ctedges.size - old_ctedges.size].max
+
+            new_exits.all? { |edge| hex.neighbors[edge] } &&
+              !(new_exits & hex_neighbors(entity, hex)).empty? &&
+              old_paths.all? { |path| new_paths.any? { |p| path <= p } } &&
+              # Count how many cities on the new tile that aren't included by any of the old tile.
+              # Make sure this isn't more than the number of new cities added.
+              # 1836jr30 D6 -> 54 adds more cities
+              extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } }
+          end
         end
       end
     end

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -7,7 +7,7 @@ module Engine
     include Assignable
 
     attr_accessor :x, :y, :ignore_for_axes, :location_name
-    attr_reader :coordinates, :empty, :layout, :neighbors, :tile, :original_tile
+    attr_reader :coordinates, :empty, :layout, :neighbors, :all_neighbors, :tile, :original_tile
 
     DIRECTIONS = {
       flat: {
@@ -70,6 +70,7 @@ module Engine
       @layout = layout
       @x, @y = self.class.init_x_y(@coordinates, axes)
       @neighbors = {}
+      @all_neighbors = {}
       @location_name = location_name
       tile.location_name = location_name
       @original_tile = @tile = tile

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -104,6 +104,16 @@ module Engine
 
         hex.lay(tile)
 
+        # Impassable hex is no longer impassible, update neighbors
+        if @game.class::IMPASSABLE_HEX_COLORS.include?(old_tile.color)
+          hex.all_neighbors.each do |direction, neighbor|
+            next if hex.tile.borders.any? { |border| border.edge == direction && border.type == :impassable }
+
+            neighbor.neighbors[neighbor.neighbor_direction(hex)] = hex
+            hex.neighbors[direction] = neighbor
+          end
+        end
+
         graph.clear
         free = false
         discount = 0


### PR DESCRIPTION
Irish Mail turns an impassible Red into and connected tile, update
the neighbors of the adjacent tiles so it is now connected.

1867 tile rule was impacting 18ireland DD tile, until a better solution
can be find specialise the 18Ireland version without that check