### PR TITLE
Simplify discard trains

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -325,10 +325,12 @@ module View
       end
 
       def discarded_trains
-        rows = @depot.discarded.map do |train|
+        rows = @depot.discarded.group_by(&:name).map do |_sym, trains|
+          train = trains.first
           h(:tr, [
             h(:td, train.name),
             h(:td, @game.format_currency(train.price)),
+            h('td.right', trains.size),
           ])
         end
 
@@ -337,6 +339,7 @@ module View
             h(:tr, [
               h(:th, 'Type'),
               h(:th, 'Price'),
+              h(:th, 'Available'),
             ]),
           ]),
           h(:tbody, rows),


### PR DESCRIPTION
18ireland has a lot of trains in the discard, simplify it

![Screenshot from 2021-04-29 22-24-12](https://user-images.githubusercontent.com/71923/116622246-4d016100-a93c-11eb-88ee-4ac585874073.png)
to
![Screenshot from 2021-04-29 22-23-42](https://user-images.githubusercontent.com/71923/116622271-54286f00-a93c-11eb-8ef0-c3c749369432.png)



fixes #5154