### PR TITLE
allow upgrade icons to be resized in tile def

### DIFF
--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -8,6 +8,7 @@ module View
       class Upgrade < Base
         needs :cost
         needs :terrains, default: []
+        needs :size, default: nil
 
         P_CENTER = {
           region_weights: CENTER,
@@ -70,10 +71,10 @@ module View
         def render_part
           cost = h('text.number', { attrs: { fill: 'black' } }, @cost)
 
-          delta_x = -10
+          delta_x = -(size / 2)
 
           terrain = @terrains.map.with_index do |t, index|
-            delta_y = 5 + (20 * index)
+            delta_y = 5 + (size * index)
             {
               mountain: mountain(delta_x: delta_x, delta_y: delta_y),
               water: water(delta_x: delta_x, delta_y: delta_y),
@@ -111,10 +112,14 @@ module View
               href: "/icons/#{icon}.svg",
               x: delta_x,
               y: delta_y,
-              height: SIZE,
-              width: SIZE,
+              height: size,
+              width: size,
             },
           )
+        end
+
+        def size
+          @size ||= SIZE
         end
       end
     end

--- a/assets/app/view/game/part/upgrades.rb
+++ b/assets/app/view/game/part/upgrades.rb
@@ -18,6 +18,7 @@ module View
               cost: upgrade.cost,
               terrains: upgrade.terrains,
               tile: @tile,
+              size: upgrade.size,
             )
           end
         end

--- a/lib/engine/part/upgrade.rb
+++ b/lib/engine/part/upgrade.rb
@@ -5,11 +5,12 @@ require_relative 'base'
 module Engine
   module Part
     class Upgrade < Base
-      attr_reader :cost, :terrains
+      attr_reader :cost, :terrains, :size
 
-      def initialize(cost, terrains = nil)
+      def initialize(cost, terrains = nil, size = nil)
         @cost = cost.to_i
         @terrains = terrains&.map(&:to_sym) || []
+        @size = size&.to_i
       end
 
       def upgrade?

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -131,7 +131,7 @@ module Engine
       when 'label'
         Part::Label.new(params)
       when 'upgrade'
-        Part::Upgrade.new(params['cost'], params['terrain']&.split('|'))
+        Part::Upgrade.new(params['cost'], params['terrain']&.split('|'), params['size'])
       when 'border'
         Part::Border.new(params['edge'], params['type'], params['cost'])
       when 'junction'


### PR DESCRIPTION
make cow skulls bigger in 1868WY

#5011

before on the left, after on the right:

![Screenshot 2021-04-29 203106](https://user-images.githubusercontent.com/1045173/116641427-f2f7a000-a929-11eb-8ce7-1303f50f3262.png)