### PR TITLE
Show end game conditions in UI, and simplify code

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -33,6 +33,7 @@ module View
         children.concat(discarded_trains) if @depot.discarded.any?
         children.concat(phases)
         children.concat(timeline) if timeline
+        children.concat(endgame)
         children << h(GameMeta, game: @game)
       end
 
@@ -419,6 +420,38 @@ module View
         end
 
         props
+      end
+
+      def endgame
+        rows = @game.class::GAME_END_CHECK.map do |reason, timing|
+          reason_str = @game.class::GAME_END_REASONS_TEXT[reason]
+          if reason == :bankrupt
+            reason_str = case @game.class::BANKRUPTCY_ENDS_GAME_AFTER
+                         when :one
+                           'Any '
+                         when :all_but_one
+                           'All but one '
+                         end + reason_str
+          end
+          h(:tr, [
+            h(:td, reason_str),
+            h(:td, @game.class::GAME_END_REASONS_TIMING_TEXT[timing]),
+          ])
+        end
+
+        table = h(:table, [
+          h(:thead, [
+            h(:tr, [
+              h(:th, 'Reason'),
+              h(:th, 'Timing'),
+            ]),
+          ]),
+          h(:tbody, rows),
+        ])
+        [
+         h(:h3, 'Reasons for End of Game'),
+         table,
+        ]
       end
     end
   end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1719,7 +1719,7 @@ module Engine
         when :one
           @players.any?(&:bankrupt)
         when :all_but_one
-          @players.reject(&:bankrupt).one?
+          @players.count { |p| !p.bankrupt } == 1
         end
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -102,6 +102,10 @@ module Engine
       GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
 
       BANKRUPTCY_ALLOWED = true
+      # How many players does bankrupcy cause to end the game
+      # one - as soon as any player goes bankrupt
+      # all_but_one - all but one
+      BANKRUPTCY_ENDS_GAME_AFTER = :one
 
       BANK_CASH = 12_000
 
@@ -252,6 +256,23 @@ module Engine
         liquidation: 'Liquidation',
         repar: 'Par value after bankruptcy',
         ignore_one_sale: 'Ignore first share sold when moving price',
+      }.freeze
+
+      GAME_END_REASONS_TEXT = {
+        bankrupt: 'player is bankrupt', # this is prefixed in the UI
+        bank: 'The bank runs out of money',
+        stock_market: 'Corporation enters end game trigger on stock market',
+        final_train: 'The final train is purchased',
+        final_phase: 'The final phase is entered',
+        custom: 'Unknown custom reason', # override on subclasses
+      }.freeze
+
+      GAME_END_REASONS_TIMING_TEXT = {
+        immediate: 'Ends immediately',
+        current_round: 'End of the current round',
+        current_or: 'Ends at the next end of an OR',
+        full_or: 'Ends at the next end of a complete OR set',
+        one_more_full_or_set: 'Finish the current OR set, then end after the next complete OR set',
       }.freeze
 
       OPERATING_ROUND_NAME = 'Operating'
@@ -1693,6 +1714,15 @@ module Engine
         self.class::ASSIGNMENT_TOKENS[assignment]
       end
 
+      def bankruptcy_limit_reached?
+        case self.class::BANKRUPTCY_ENDS_GAME_AFTER
+        when :one
+          @players.any?(&:bankrupt)
+        when :all_but_one
+          @players.reject(&:bankrupt).one?
+        end
+      end
+
       private
 
       def init_graph
@@ -2256,10 +2286,6 @@ module Engine
 
       def bank_cash
         @bank.cash
-      end
-
-      def bankruptcy_limit_reached?
-        @players.any?(&:bankrupt)
       end
 
       def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -895,13 +895,14 @@ module Engine
         ALL_COMPANIES_ASSIGNABLE = true
         SELL_AFTER = :after_ipo
         OBSOLETE_TRAINS_COUNT_FOR_LIMIT = true
+        BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
         ASSIGNMENT_TOKENS = {
           'bridge' => '/icons/1817/bridge_token.svg',
           'mine' => '/icons/1817/mine_token.svg',
         }.freeze
 
-        GAME_END_CHECK = { bankrupt: :immediate, custom: :one_more_full_or_set }.freeze
+        GAME_END_CHECK = { bankrupt: :immediate, final_phase: :one_more_full_or_set }.freeze
 
         CERT_LIMIT_CHANGE_ON_BANKRUPTCY = true
 
@@ -979,10 +980,6 @@ module Engine
         def init_stock_market
           @owner_when_liquidated = {}
           super
-        end
-
-        def bankruptcy_limit_reached?
-          @players.reject(&:bankrupt).one?
         end
 
         def init_loans
@@ -1540,10 +1537,6 @@ module Engine
 
         def round_end
           G1817::Round::Acquisition
-        end
-
-        def custom_end_game_reached?
-          @final_operating_rounds
         end
 
         def final_operating_rounds

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -921,7 +921,11 @@ module Engine
 
         TILE_RESERVATION_BLOCKS_OTHERS = true
 
-        GAME_END_CHECK = { bankrupt: :immediate, stock_market: :current_round, custom: :one_more_full_or_set }.freeze
+        GAME_END_CHECK = {
+          bankrupt: :immediate,
+          stock_market: :current_round,
+          final_phase: :one_more_full_or_set,
+        }.freeze
 
         SELL_BUY_ORDER = :sell_buy_sell
 
@@ -1103,10 +1107,6 @@ module Engine
         def event_remove_corporations!
           @log << "-- Event: #{EVENTS_TEXT['remove_corporations'][1]}. --"
           @log << 'Unparred corporations will be removed at the beginning of the next stock round'
-        end
-
-        def custom_end_game_reached?
-          @phase.current[:name] == 'Purple'
         end
 
         def new_stock_round

--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -140,6 +140,7 @@ module Engine
         HOME_TOKEN_TIMING = :float
         MUST_BUY_TRAIN = :always
         CERT_LIMIT_COUNTS_BANKRUPTED = true
+        BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
         ORANGE_GROUP = [
           'Lake Shore Line',
@@ -575,10 +576,6 @@ module Engine
           self.class::LSL_HEXES.each do |hex|
             hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::LSL_ICON }
           end
-        end
-
-        def bankruptcy_limit_reached?
-          @players.reject(&:bankrupt).one?
         end
 
         def sellable_bundles(player, corporation)

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -125,6 +125,14 @@ module Engine
 
         BANKRUPTCY_ALLOWED = true
 
+        BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
+
+        GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or, stock_market: :after_max_operates }.freeze
+
+        GAME_END_REASONS_TIMING_TEXT = Base::GAME_END_REASONS_TIMING_TEXT.merge(
+          after_max_operates: 'After corporation finishes operating'
+        ).freeze
+
         CLOSED_CORP_RESERVATIONS_REMOVED = false
 
         EBUY_OTHER_VALUE = false
@@ -252,7 +260,7 @@ module Engine
         end
 
         def game_end_check
-          return %i[custom after_max_operates] if @max_value_reached
+          return %i[stock_market after_max_operates] if @max_value_reached
 
           return %i[bank full_or] if @bank.broken?
 

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -856,6 +856,9 @@ module Engine
         TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded_or_city, upgrade: false }].freeze
 
         GAME_END_CHECK = { stock_market: :current_or, bank: :current_or, custom: :immediate }.freeze
+        GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(
+          custom: 'Nationalization complete'
+        )
 
         PAR_RANGE = {
           1 => [74, 100],

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -952,7 +952,7 @@ module Engine
         SELL_AFTER = :operate
         SELL_BUY_ORDER = :sell_buy
         EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
-        GAME_END_CHECK = { bank: :current_or, custom: :one_more_full_or_set }.freeze
+        GAME_END_CHECK = { bank: :current_or, final_phase: :one_more_full_or_set }.freeze
 
         HEX_WITH_O_LABEL = %w[J12].freeze
         HEX_UPGRADES_FOR_O = %w[201 202 203 207 208 621 622 623 801 X8].freeze
@@ -1462,10 +1462,6 @@ module Engine
           return Engine::Round::Operating if phase.name.to_i >= 8
 
           G1867::Round::Merger
-        end
-
-        def custom_end_game_reached?
-          @final_operating_rounds
         end
 
         def final_operating_rounds

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -61,6 +61,10 @@ module Engine
 
         GAME_END_CHECK = { stock_market: :current_or, custom: :one_more_full_or_set }.freeze
 
+        GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(
+          custom: 'Phase 5 is entered'
+        )
+
         RAILWAY_MIN_BID = 100
         MIN_BID_INCREMENT = 10
         MHE_START_PRICE = 120

--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -196,14 +196,11 @@ module Engine
         SHANNON_COMPANY = 'RSSC'
         SHANNON_HEXES = %w[F10 D16].freeze
         KEEP_COMPANIES = 5
+        BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
         # used for laying tokens, running routes, mergers
         def init_graph
           Graph.new(self, skip_track: :narrow)
-        end
-
-        def bankruptcy_limit_reached?
-          @players.reject(&:bankrupt).one?
         end
 
         def tile_lays(entity)

--- a/lib/engine/game/g_18_ms/game.rb
+++ b/lib/engine/game/g_18_ms/game.rb
@@ -149,7 +149,7 @@ module Engine
         ].freeze
 
         # Game will end after 10 ORs (or 11 in case of optional rule) - checked in end_now? below
-        GAME_END_CHECK = {custom: :current_or}.freeze
+        GAME_END_CHECK = { custom: :current_or }.freeze
 
         GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(
           custom: 'Fixed number of ORs'

--- a/lib/engine/game/g_18_ms/game.rb
+++ b/lib/engine/game/g_18_ms/game.rb
@@ -149,7 +149,11 @@ module Engine
         ].freeze
 
         # Game will end after 10 ORs (or 11 in case of optional rule) - checked in end_now? below
-        GAME_END_CHECK = {}.freeze
+        GAME_END_CHECK = {custom: :current_or}.freeze
+
+        GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(
+          custom: 'Fixed number of ORs'
+        )
 
         BANKRUPTCY_ALLOWED = false
 

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -138,6 +138,10 @@ module Engine
         # Game end after the ORs in the third turn, of if any company reach 24
         GAME_END_CHECK = { stock_market: :current_or, custom: :full_or }.freeze
 
+        GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(
+          custom: 'End of Turn 3'
+        )
+
         BANKRUPTCY_ALLOWED = false
 
         STARTING_CASH_SMALL_MAP = { 2 => 40, 3 => 28, 4 => 23, 5 => 22 }.freeze

--- a/spec/lib/engine/games/g_1828_spec.rb
+++ b/spec/lib/engine/games/g_1828_spec.rb
@@ -66,18 +66,6 @@ module Engine
         expect(erie_home_tile.cities[0].available_slots).to eq(0)
         expect(erie_home_tile.cities[1].available_slots).to eq(0)
       end
-
-      it 'should trigger end game at purple phase' do
-        player_1.cash = 10_000
-        stock_market.set_par(corporation, game.par_prices.first)
-        5.times { game.share_pool.buy_shares(player_1, corporation.shares.first) }
-
-        next_or!
-        %w[3 5 3+D 6 8E D].each do |train_name|
-          phase.buying_train!(corporation, game.trains.find { |t| t.name == train_name })
-        end
-        expect(game.custom_end_game_reached?).to be_truthy
-      end
     end
 
     context 'VA Coalfields' do


### PR DESCRIPTION
Show the end game conditions on the info page.
Remove custom code for one vs last but one bankrupcy.
Remove custom code for last phase.

fixes #3974
![Screenshot from 2021-04-30 21-41-11](https://user-images.githubusercontent.com/71923/116756482-1abb3680-aa04-11eb-8fc6-8dcc009eaab4.png)

1849 could do with some improvement as i'm not sure it supports bankrupcy at all, and it'd be good to refactor the rounds based approach of 18MS and 18ZOO