### PR TITLE
make town dots on track more noticeable with a white outline

### DIFF
--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -114,7 +114,7 @@ module View
             transform: translate.to_s,
             r: radius,
             fill: (@town.halt? ? 'gray' : @color),
-            stroke: (@town.halt? ? @color : 'none'),
+            stroke: (@town.halt? ? @color : 'white'),
             'stroke-width': 4,
           }
 


### PR DESCRIPTION
sample partial tile manifest from 1868WY:

![image](https://user-images.githubusercontent.com/1045173/116787903-0c9d0280-aa64-11eb-95b1-6e9ce454b393.png)
