### PR TITLE
Update pass order when skipping

### DIFF
--- a/lib/engine/game/g_18_co/step/moving_bid_auction.rb
+++ b/lib/engine/game/g_18_co/step/moving_bid_auction.rb
@@ -36,6 +36,7 @@ module Engine
 
             entity.pass!
             log_skip(entity)
+            @round.pass_order |= [current_entity]
             end_auction! if all_passed?
             @round.next_entity_index!
             skip! if active?


### PR DESCRIPTION
Fixes #5190. Ensures a player is inserted into the pass order when being skipped in case they have not ever passed.