### PR TITLE
1862: implement mergers and acquisitions

### DIFF
--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -69,6 +69,7 @@ module View
             left << h(Player, player: entity, game: @game)
           elsif entity.operator? && entity.floated?
             left << h(Corporation, corporation: entity)
+            left << h(Corporation, corporation: @step.show_other) if @step.respond_to?(:show_other) && @step.show_other
           elsif (company = entity).company?
             left << h(Company, company: company)
 

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -23,7 +23,8 @@ module Engine
     include Spender
 
     attr_accessor :ipoed, :par_via_exchange, :max_ownership_percent, :float_percent, :capitalization, :second_share,
-                  :type, :floatable, :original_par_price, :reservation_color, :min_price, :ipo_owner
+                  :type, :floatable, :original_par_price, :reservation_color, :min_price, :ipo_owner,
+                  :always_market_price
     attr_reader :companies, :name, :full_name, :fraction_shares, :id, :needs_token_to_par,
                 :presidents_share
     attr_writer :par_price, :share_price

--- a/lib/engine/game/g_1862/step/acquire.rb
+++ b/lib/engine/game/g_1862/step/acquire.rb
@@ -18,17 +18,7 @@ module Engine
           end
 
           def process_choose(action)
-            if action.choice == :first
-              @log << "#{@merging.last.name} (non-survivor) will merge into #{@merging.first.name} (survivor)"
-              survivor = @merging.first
-              nonsurvivor = @merging.last
-            else
-              @log << "#{@merging.first.name} (non-survivor) will merge into #{@merging.last.name} (survivor)"
-              survivor = @merging.last
-              nonsurvivor = @merging.first
-            end
-            @game.start_merge(action.entity, survivor, nonsurvivor, :acquire)
-            @merging = nil
+            choose_action(action, :acquire)
           end
         end
       end

--- a/lib/engine/game/g_1862/step/acquire.rb
+++ b/lib/engine/game/g_1862/step/acquire.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'merge'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class Acquire < G1862::Step::Merge
+          def merge_name
+            'Acquire'
+          end
+
+          def description
+            return 'Choose Survivor' if @merging
+
+            'Acquire Corporation'
+          end
+
+          def process_choose(action)
+            if action.choice == :first
+              @log << "#{@merging.last.name} (non-survivor) will merge into #{@merging.first.name} (survivor)"
+              survivor = @merging.first
+              nonsurvivor = @merging.last
+            else
+              @log << "#{@merging.first.name} (non-survivor) will merge into #{@merging.last.name} (survivor)"
+              survivor = @merging.last
+              nonsurvivor = @merging.first
+            end
+            @game.start_merge(action.entity, survivor, nonsurvivor, :acquire)
+            @merging = nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
@@ -9,6 +9,15 @@ module Engine
         class BuySellParShares < Engine::Step::BuySellParShares
           UNCHARTERED_TOKEN_COST = 40
 
+          def can_buy_any_from_ipo?(entity)
+            @game.corporations.each do |corporation|
+              next unless corporation.ipoed
+              return true if can_buy_shares?(entity, corporation.ipo_shares)
+            end
+
+            false
+          end
+
           def can_sell?(entity, bundle)
             return unless bundle
 

--- a/lib/engine/game/g_1862/step/buy_train.rb
+++ b/lib/engine/game/g_1862/step/buy_train.rb
@@ -24,6 +24,7 @@ module Engine
 
           def actions(entity)
             return [] if entity != current_entity
+            return [] if @game.skip_round[entity]
             return [] if buyable_trains(entity).empty? && !must_buy_train?(entity)
             return [] if entity.share_price&.type == :close
             return %w[buy_train] if can_buy_depot_train?(entity) && must_buy_train?(entity)
@@ -37,7 +38,7 @@ module Engine
           end
 
           def log_skip(entity)
-            super unless must_ebuy?(entity)
+            super if !must_ebuy?(entity) && !@game.skip_round[entity]
           end
 
           def pass!

--- a/lib/engine/game/g_1862/step/dividend.rb
+++ b/lib/engine/game/g_1862/step/dividend.rb
@@ -15,6 +15,22 @@ module Engine
             HUDSON_TYPES
           end
 
+          def actions(entity)
+            return [] if @game.skip_round[entity]
+
+            super
+          end
+
+          def skip!
+            return super unless @game.skip_round[current_entity]
+
+            pass!
+          end
+
+          def log_skip(entity)
+            super unless @game.skip_round[entity]
+          end
+
           def actual_dividend_types(entity, revenue, subsidy)
             hudson_allowed?(entity, revenue, subsidy) ? HUDSON_TYPES : DIVIDEND_TYPES
           end

--- a/lib/engine/game/g_1862/step/merge.rb
+++ b/lib/engine/game/g_1862/step/merge.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class Merge < Engine::Step::Base
+          def actions(entity)
+            return [] if !entity.corporation? || entity != current_entity
+            return [] if entity.receivership? || @game.skip_round[entity]
+
+            return ['choose'] if @merging
+
+            %w[merge pass]
+          end
+
+          def log_skip(entity)
+            super unless @game.skip_round[entity]
+          end
+
+          def auto_actions(entity)
+            return super if @merging
+
+            return [Engine::Action::Pass.new(entity)] if mergeable_candidates(entity).empty?
+
+            super
+          end
+
+          def merge_name
+            'Merge'
+          end
+
+          def merger_auto_pass_entity
+            current_entity
+          end
+
+          def can_merge?(entity)
+            mergeable_candidates(entity).any?
+          end
+
+          def description
+            return 'Choose Survivor' if @merging
+
+            'Merge with Major Corporation'
+          end
+
+          def process_merge(action)
+            @merging = [action.entity, action.corporation]
+            @log << "#{@merging.first.name} and #{@merging.last.name} will merge"
+          end
+
+          def process_choose(action)
+            if action.choice == :first
+              @log << "#{@merging.last.name} (non-survivor) will merge into #{@merging.first.name} (survivor)"
+              survivor = @merging.first
+              nonsurvivor = @merging.last
+            else
+              @log << "#{@merging.first.name} (non-survivor) will merge into #{@merging.last.name} (survivor)"
+              survivor = @merging.last
+              nonsurvivor = @merging.first
+            end
+            @game.start_merge(action.entity, survivor, nonsurvivor, :merge)
+            @merging = nil
+          end
+
+          def mergeable_type(corporation)
+            "Corporations that can merge with #{corporation.name}"
+          end
+
+          def mergeable_candidates(corporation)
+            # Mergeable candidates must be connected by track
+            parts = @game.graph.connected_nodes(corporation).keys
+              .reject { |n| @game.class::LONDON_TOKEN_HEXES.include?(n.hex.id) }
+            mergeable = parts.select(&:city?).flat_map { |c| c.tokens.compact.map(&:corporation) }
+            mergeable.uniq.reject { |c| c == corporation }
+          end
+
+          def mergeable(corporation)
+            mergeable_candidates(corporation)
+          end
+
+          def choice_name
+            'Select Corporation to Survive'
+          end
+
+          def choices
+            {
+              first: "#{@merging.first.full_name} (#{@merging.first.name})",
+              last: "#{@merging.last.full_name} (#{@merging.last.name})",
+            }
+          end
+
+          def show_other_players
+            false
+          end
+
+          def show_other
+            @merging ? @merging.last : nil
+          end
+
+          def round_state
+            {
+              converted: nil,
+              merge_type: nil,
+              converts: [],
+              share_dealing_players: [],
+              share_dealing_multiple: [],
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/option_share.rb
+++ b/lib/engine/game/g_1862/step/option_share.rb
@@ -62,21 +62,14 @@ module Engine
           end
 
           def choices
-            if pending_option[:percent] > 10
-              {
-                sell: "Sell #{pending_option[:share].corporation.name} #{pending_option[:percent]}% option "\
-                  "share (Director's certificate) for #{@game.format_currency(pending_option[:sell_price])}",
-                redeem: "Redeem (buy) #{pending_option[:share].corporation.name} #{pending_option[:percent]}% option "\
-                  "share (Director's certificate) for #{@game.format_currency(pending_option[:redeem_price])}",
-              }
-            else
-              {
-                sell: "Sell #{pending_option[:share].corporation.name} option share "\
-                  "for #{@game.format_currency(pending_option[:sell_price])}",
-                redeem: "Redeem (buy) #{pending_option[:share].corporation.name} option share "\
-                  "for #{@game.format_currency(pending_option[:redeem_price])}",
-              }
-            end
+            percent_str = pending_option[:percent] > 10 ? '' : "#{pending_option[:percent]}% "
+            share_str = pending_option[:percent] > 10 ? "(Director's certificate) " : ''
+            {
+              sell: "Sell #{pending_option[:share].corporation.name} #{percent_str}option share #{share_str}"\
+                "for #{@game.format_currency(pending_option[:sell_price])}",
+              redeem: "Redeem (buy) #{pending_option[:share].corporation.name} #{percent_str}option share #{share_str}"\
+                "for #{@game.format_currency(pending_option[:redeem_price])}",
+            }
           end
 
           def round_state

--- a/lib/engine/game/g_1862/step/option_share.rb
+++ b/lib/engine/game/g_1862/step/option_share.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class OptionShare < Engine::Step::Base
+          def actions(entity)
+            return [] unless entity == pending_entity
+
+            ['choose']
+          end
+
+          def description
+            'Option share choice'
+          end
+
+          def active_entities
+            [pending_entity]
+          end
+
+          def active?
+            pending_entity
+          end
+
+          def pending_entity
+            pending_option[:entity]
+          end
+
+          def pending_option
+            @round.pending_options&.first || {}
+          end
+
+          def process_choose(action)
+            entity = action.entity
+            share = pending_option[:share]
+            if action.choice == :sell
+              @game.bank.spend(pending_option[:sell_price], entity)
+              @game.transfer_share(share, @game.share_pool)
+              @log << "#{entity.name} sells #{pending_option[:share].corporation.name} #{pending_option[:percent]}% "\
+                "option share for #{@game.format_currency(pending_option[:sell_price])}"
+            else
+              entity.spend(pending_option[:redeem_price], @game.bank)
+              @log << "#{entity.name} redeems #{pending_option[:share].corporation.name} #{pending_option[:percent]}% "\
+                "option share for #{@game.format_currency(pending_option[:redeem_price])}"
+            end
+
+            @round.pending_options.shift
+            @game.continue_merge_option(entity)
+          end
+
+          def choice_name
+            if pending_option[:entity].corporation?
+              'Sell or Buy option (partial) share on behalf of surviving company'
+            elsif pending_option[:percent] > 10
+              'Sell or Buy option (partial) share - may allow retaining presidency'
+            else
+              'Sell or Buy option (partial) share'
+            end
+          end
+
+          def choices
+            if pending_option[:percent] > 10
+              {
+                sell: "Sell #{pending_option[:share].corporation.name} #{pending_option[:percent]}% option "\
+                  "share (Director's certificate) for #{@game.format_currency(pending_option[:sell_price])}",
+                redeem: "Redeem (buy) #{pending_option[:share].corporation.name} #{pending_option[:percent]}% option "\
+                  "share (Director's certificate) for #{@game.format_currency(pending_option[:redeem_price])}",
+              }
+            else
+              {
+                sell: "Sell #{pending_option[:share].corporation.name} option share "\
+                  "for #{@game.format_currency(pending_option[:sell_price])}",
+                redeem: "Redeem (buy) #{pending_option[:share].corporation.name} option share "\
+                  "for #{@game.format_currency(pending_option[:redeem_price])}",
+              }
+            end
+          end
+
+          def round_state
+            {
+              pending_options: [],
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/redeem_share.rb
+++ b/lib/engine/game/g_1862/step/redeem_share.rb
@@ -12,6 +12,7 @@ module Engine
             available_actions = []
             return available_actions unless entity.corporation?
             return available_actions if entity != current_entity
+            return available_actions if @game.skip_round[entity]
 
             available_actions << 'buy_shares' unless redeemable_shares(entity).empty?
             available_actions << 'pass' if blocks? && !available_actions.empty?
@@ -20,7 +21,7 @@ module Engine
           end
 
           def log_skip(entity)
-            super if entity.type == :major
+            super unless @game.skip_round[entity]
           end
 
           def description

--- a/lib/engine/game/g_1862/step/remove_tokens.rb
+++ b/lib/engine/game/g_1862/step/remove_tokens.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1862
+      module Step
+        class RemoveTokens < Engine::Step::Base
+          def description
+            'Choose token to remove'
+          end
+
+          def actions(entity)
+            return [] unless entity == pending_entity
+
+            %w[remove_token]
+          end
+
+          def active?
+            pending_entity
+          end
+
+          def active_entities
+            [pending_entity]
+          end
+
+          def pending_entity
+            pending_removal[:survivor]
+          end
+
+          def pending_removal
+            @round.pending_removals&.first || {}
+          end
+
+          def round_state
+            {
+              pending_removals: [],
+            }
+          end
+
+          def hexes
+            pending_removal[:hexes]
+          end
+
+          def corps
+            [pending_removal[:survivor], pending_removal[:nonsurvivor]]
+          end
+
+          def can_replace_token?(entity, token)
+            available_hex(entity, token.city.hex) && corps.include?(token.corporation)
+          end
+
+          def process_remove_token(action)
+            entity = action.entity
+            city = action.city
+            token = city.tokens[action.slot]
+            hex = city.hex
+            raise GameError, "Cannot remove #{token.corporation.name} token" unless can_replace_token?(entity, token)
+
+            @log << "#{entity.name} removes token from #{hex.name} (#{hex.location_name})"
+            token.destroy!
+
+            count = @round.pending_removals[0][:count] - 1
+            @round.pending_removals[0][:count] = count
+
+            return unless count.zero?
+
+            @round.pending_removals.shift
+            @game.finish_merge
+          end
+
+          def available_hex(entity, hex)
+            return false unless entity == pending_entity
+
+            hexes.include?(hex)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862/step/route.rb
+++ b/lib/engine/game/g_1862/step/route.rb
@@ -7,6 +7,16 @@ module Engine
     module G1862
       module Step
         class Route < Engine::Step::Route
+          def actions(entity)
+            return [] if @game.skip_round[entity]
+
+            super
+          end
+
+          def log_skip(entity)
+            super unless @game.skip_round[entity]
+          end
+
           def process_run_routes(action)
             super
 

--- a/lib/engine/game/g_1862/step/token.rb
+++ b/lib/engine/game/g_1862/step/token.rb
@@ -9,8 +9,13 @@ module Engine
         class Token < Engine::Step::Token
           def actions(entity)
             return [] if entity.corporation? && entity.receivership?
+            return [] if @game.skip_round[entity]
 
             super
+          end
+
+          def log_skip(entity)
+            super unless @game.skip_round[entity]
           end
 
           def description

--- a/lib/engine/game/g_1862/step/track.rb
+++ b/lib/engine/game/g_1862/step/track.rb
@@ -7,6 +7,16 @@ module Engine
     module G1862
       module Step
         class Track < Engine::Step::Track
+          def actions(entity)
+            return [] if @game.skip_round[entity]
+
+            super
+          end
+
+          def log_skip(entity)
+            super unless @game.skip_round[entity]
+          end
+
           def lay_tile_action(action, entity: nil, spender: nil)
             tile_lay = get_tile_lay(action.entity)
             if action.tile.label.to_s == 'N' && !(tile_lay && tile_lay[:upgrade])


### PR DESCRIPTION
Add support for complicated merger and acquisition process. Also implements refinancing. Also implements corporation bankruptcy.

Common file edits:
- Engine::Corporation - make always_market_price an attr_accessor
- UI::Round::Operating - allow display of a second corporation (helps with merge)