### PR TITLE
1828.Games: Fix merger bug

### DIFF
--- a/lib/engine/game/g_1828/step/merger.rb
+++ b/lib/engine/game/g_1828/step/merger.rb
@@ -410,8 +410,7 @@ module Engine
             if @player_selection
               source = @players.find { |p| p.name == @player_selection }
               @player_selection = nil
-            elsif entity.num_shares_of(@merger) >= num_needed &&
-                  [@merger, @target].sum { |c| entity.num_shares_of(c) } >= num_needed * 2
+            elsif entity.num_shares_of(@merger) >= num_needed
               source = entity
             else
               sources = [@discard, @players[1..-1], @merger, @game.share_pool].flatten.compact.select do |src|


### PR DESCRIPTION
`exchange_source` should only verify the player has enough shares of the `merger`. The check for total shares has already been done. Leads to erroneous exchanges.