### PR TITLE
fix "par" home token timing for corporations with full cap

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -213,9 +213,10 @@ module Engine
       EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN = false
 
       # when is the home token placed? on...
-      # operate
+      # par
       # float
-      # operating_round // 1889 places on first operating round
+      # operating_round (start of next OR)
+      # operate (corporation's first OR turn)
       HOME_TOKEN_TIMING = :operate
 
       DISCARDED_TRAINS = :discard # discard or remove
@@ -1486,16 +1487,17 @@ module Engine
       end
 
       def after_par(corporation)
-        return unless corporation.capitalization == :incremental
+        if corporation.capitalization == :incremental
+          all_companies_with_ability(:shares) do |company, ability|
+            next unless corporation.name == ability.shares.first.corporation.name
 
-        all_companies_with_ability(:shares) do |company, ability|
-          next unless corporation.name == ability.shares.first.corporation.name
-
-          amount = ability.shares.sum { |share| corporation.par_price.price * share.num_shares }
-          @bank.spend(amount, corporation)
-          @log << "#{corporation.name} receives #{format_currency(amount)}
+            amount = ability.shares.sum { |share| corporation.par_price.price * share.num_shares }
+            @bank.spend(amount, corporation)
+            @log << "#{corporation.name} receives #{format_currency(amount)}
                    from #{company.name}"
+          end
         end
+
         place_home_token(corporation) if self.class::HOME_TOKEN_TIMING == :par
       end
 

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -27,7 +27,7 @@ module Engine
         POOL_SHARE_DROP = :each
         CAPITALIZATION = :incremental
         SELL_BUY_ORDER = :sell_buy
-        HOME_TOKEN_TIMING = :float
+        HOME_TOKEN_TIMING = :par
 
         MUST_EMERGENCY_ISSUE_BEFORE_EBUY = true
         MUST_BUY_TRAIN = :always


### PR DESCRIPTION
General changes (easier to see with the ignore whitespace option selected):

* change the capitalization condition in `after_par` before the shares check to
  an if block instead of a guard statement so that the final `place_home_token`
  call will be reached with any capitalization (ie in 1868WY's phase 5)

1868WY:

* change `HOME_TOKEN_TIMING` to `:par`
    * fixes UP's token being placed when it's parred/floated in the ISR
    * combined with change in `Game::Base`, fixes home token placement in phase
      5 and later, when float/capitalization is changed to 60%/full

[Issue #5011]