### PR TITLE
[1868WY] track points

### DIFF
--- a/lib/engine/game/g_1868_wy/step/track.rb
+++ b/lib/engine/game/g_1868_wy/step/track.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class Track < Engine::Step::Track
+          def lay_tile_action(action)
+            super
+            @game.spend_tile_lay_points(action)
+          end
+
+          def can_lay_tile?(entity)
+            return true if super
+
+            # if 1 track point remains and P7 can be bought, block in the track step
+            (corporation = entity).corporation? &&
+              @game.phase.status.include?('can_buy_companies') &&
+              @game.p7_company.owned_by_player? &&
+              @game.buying_power(entity).positive? &&
+              @game.track_points_available(corporation) == (@game.class::YELLOW_POINT_COST - 1)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Each railroad gets 6 track points
* 2 points to lay new tile, 3 points for upgrades
* P7 General Jack adds a track point to the owning railroad, so if 1 point
  remains and P7 could be bought in, the game should remain on the track step
* Set track points to 0 at end of each OR; when LNP or OSL are started, and
  their home tile doesn't have the green tile yet, it must be laid immediately
  for their home token to be placed, and this must count against their used
  track points. Therefore the track points cannot be set to 0 at the start of
  the OR (the automatic LNP/OSL green lay has not yet been implemented)

[Issue #5011]