### PR TITLE
[18NY] Tile lays

### DIFF
--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -39,7 +39,7 @@ module Engine
                       end
             @in_process = true
             if @game.company_ability_extra_track?(entity)
-              upgraded_extra_track = upgraded_track?(action)
+              upgraded_extra_track = upgraded_track?(action.hex.tile, action.tile, action.hex)
               raise GameError, 'Cannot lay an extra upgrade' if upgraded_extra_track && @extra_laided_track
 
               lay_tile(action, spender: spender)

--- a/lib/engine/game/g_1822/step/tracker.rb
+++ b/lib/engine/game/g_1822/step/tracker.rb
@@ -81,14 +81,14 @@ module Engine
           [total_cost, types]
         end
 
-        def upgraded_track(action)
-          @round.upgraded_track = upgraded_track?(action)
+        def upgraded_track(from, to, hex)
+          @round.upgraded_track = upgraded_track?(from, to, hex)
         end
 
-        def upgraded_track?(action)
+        def upgraded_track?(_from, to, hex)
           # London yellow tile counts as an upgrade
-          tile_color = action.tile.color
-          tile_color != :yellow || (tile_color == :yellow && action.hex.name == @game.class::LONDON_HEX)
+          tile_color = to.color
+          tile_color != :yellow || (tile_color == :yellow && hex.name == @game.class::LONDON_HEX)
         end
       end
     end

--- a/lib/engine/game/g_1862/step/track.rb
+++ b/lib/engine/game/g_1862/step/track.rb
@@ -16,9 +16,9 @@ module Engine
             super
           end
 
-          def upgraded_track(action)
+          def upgraded_track(_from, to, _hex)
             # this also takes care of adding small stations, since that is never yellow to yellow
-            @round.upgraded_track = true if action.tile.color != :yellow || action.tile.label.to_s == 'N'
+            @round.upgraded_track = true if to.color != :yellow || to.label.to_s == 'N'
           end
 
           def update_tile_lists(tile, old_tile)

--- a/lib/engine/game/g_18_cz/step/home_track.rb
+++ b/lib/engine/game/g_18_cz/step/home_track.rb
@@ -95,8 +95,8 @@ module Engine
               old_paths.all? { |path| new_paths.any? { |p| path <= p } }
           end
 
-          def upgraded_track(action)
-            @round.upgraded_track = true if action.tile.color != :yellow && action.tile.color != :red
+          def upgraded_track(_from, to, _hex)
+            @round.upgraded_track = true if to.color != :yellow && to.color != :red
           end
         end
       end

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -293,6 +293,54 @@ module Engine
           @erie_canal_private.close!
         end
 
+        def upgrades_to?(from, to, special = false, selected_company: nil)
+          return true if town_to_city_upgrade?(from, to)
+
+          super
+        end
+
+        def town_to_city_upgrade?(from, to)
+          return false unless @phase.tiles.include?(:green)
+
+          case from.name
+          when '3'
+            to.name == '5'
+          when '4'
+            to.name == '57'
+          when '58'
+            to.name == '6'
+          else
+            false
+          end
+        end
+
+        def upgrades_to_correct_label?(from, to)
+          # Handle hexes that change from standard tiles to special city tiles
+          case from.hex.name
+          when 'E3'
+            return true if to.name == 'X35'
+            return false if to.color == :gray
+          when 'D8'
+            return true if to.name == 'X13'
+            return false if to.color == :green
+          when 'D12'
+            return true if to.name == 'X24'
+            return false if to.color == :brown
+          when 'K19'
+            return true if to.name == 'X21'
+            return false if to.color == :brown
+          end
+
+          super
+        end
+
+        def legal_tile_rotation?(entity, hex, tile)
+          # NYC tiles have a specific rotation
+          return tile.rotation.zero? if hex.id == 'J20' && %w[X11 X22].include?(tile.name)
+
+          super
+        end
+
         def upgrade_cost(tile, _hex, entity, spender)
           terrain_cost = tile.upgrades.sum(&:cost)
           discounts = 0

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -37,6 +37,8 @@ module Engine
 
         ALL_COMPANIES_ASSIGNABLE = true
 
+        TRACK_RESTRICTION = :permissive
+
         # Two lays with one being an upgrade. Tile lays cost 20
         TILE_LAYS = [
           { lay: true, upgrade: true, cost: 20, cannot_reuse_same_hex: true },

--- a/lib/engine/game/g_18_ny/step/track.rb
+++ b/lib/engine/game/g_18_ny/step/track.rb
@@ -13,6 +13,16 @@ module Engine
             @game.tile_lay(action.hex, old_tile, action.tile)
           end
 
+          def legal_tile_rotation?(entity, hex, tile)
+            # Only need to make sure exits stay consistent for town to city upgrade
+            old_tile = hex.tile
+            if @game.town_to_city_upgrade?(old_tile, tile)
+              return old_tile.paths.all? { |old| tile.paths.any? { |new| old.exits == new.exits } }
+            end
+
+            super
+          end
+
           # Prevent terrain discounts from being applied implicitly.
           def border_cost_discount(_entity, _spender, _border, _cost, _hex)
             0

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -44,8 +44,9 @@ module Engine
 
       def lay_tile_action(action, entity: nil, spender: nil)
         tile = action.tile
+        old_tile = action.hex.tile
         tile_lay = get_tile_lay(action.entity)
-        raise GameError, 'Cannot lay an upgrade now' if tile.color != :yellow && !(tile_lay && tile_lay[:upgrade])
+        raise GameError, 'Cannot lay an upgrade now' if old_tile.color != :white && !(tile_lay && tile_lay[:upgrade])
         raise GameError, 'Cannot lay a yellow now' if tile.color == :yellow && !(tile_lay && tile_lay[:lay])
         if tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(action.hex)
           raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
@@ -54,13 +55,13 @@ module Engine
         extra_cost = tile.color == :yellow ? tile_lay[:cost] : tile_lay[:upgrade_cost]
 
         lay_tile(action, extra_cost: extra_cost, entity: entity, spender: spender)
-        upgraded_track(action)
+        upgraded_track(old_tile, tile, action.hex)
         @round.num_laid_track += 1
         @round.laid_hexes << action.hex
       end
 
-      def upgraded_track(action)
-        @round.upgraded_track = true if action.tile.color != :yellow
+      def upgraded_track(from, _to, _hex)
+        @round.upgraded_track = true if from.color != :white
       end
 
       def tile_lay_abilities_should_block?(entity)


### PR DESCRIPTION
- Permissive tile lays
- Yellow towns can upgrade to yellow cities once green tiles are available
- Some cities start off as normal city tiles and later become special city tiles
- Some NYC tiles have a required rotation
- Refactor tile upgrades, so that yellow -> yellow is an upgrade

Ran against 5/2 DB and all games passed.