### PR TITLE
[1868WY] WRC tile, fix rectangular towns, company buy-in price, train export

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1476,6 +1476,8 @@ module Engine
         extra_cities = new_tile.cities
         @cities.concat(extra_cities)
         extra_cities.each { |c| @_cities[c.id] = c }
+
+        new_tile
       end
 
       def find_share_price(price)

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -62,16 +62,21 @@ module Engine
             ['Full Capitalization', 'Railroads float at 60% and receive full capitalization'],
         ).freeze
 
+        def dotify(tile)
+          tile.towns.each { |town| town.style = :dot }
+          tile
+        end
+
         def init_tiles
-          super.each do |tile|
-            tile.towns.each { |town| town.style = :dot }
-          end
+          super.each { |tile| dotify(tile) }
         end
 
         def init_hexes(companies, corporations)
-          super.each do |hex|
-            hex.tile.towns.each { |town| town.style = :dot }
-          end
+          super.each { |hex| dotify(hex.tile) }
+        end
+
+        def add_extra_tile(tile)
+          dotify(super)
         end
 
         def ipo_name(_entity = nil)
@@ -80,6 +85,7 @@ module Engine
 
         def setup
           init_track_points
+          setup_company_price_up_to_face
 
           @late_corps, @corporations = @corporations.partition { |c| LATE_CORPORATIONS.include?(c.id) }
           @late_corps.each { |corp| corp.reservation_color = nil }
@@ -165,6 +171,20 @@ module Engine
 
         def or_round_finished
           init_track_points
+        end
+
+        def action_processed(action)
+          case action
+          when Action::LayTile
+            if action.hex.name == 'G15'
+              action.hex.tile.color = :gray
+              @log << 'Wind River Canyon turns gray; it can never be upgraded'
+            end
+          end
+        end
+
+        def or_set_finished
+          depot.export!
         end
       end
     end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -15,8 +15,8 @@ module Engine
     include Config::Tile
 
     attr_accessor :blocks_lay, :hex, :icons, :index, :legal_rotations, :location_name,
-                  :name, :opposite, :reservations, :upgrades
-    attr_reader :borders, :cities, :color, :edges, :junction, :nodes, :labels,
+                  :name, :opposite, :reservations, :upgrades, :color
+    attr_reader :borders, :cities, :edges, :junction, :nodes, :labels,
                 :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
                 :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :hidden
 


### PR DESCRIPTION
A few small changes that touch a smidge of common code

General Changes:

* make a tile's `color` a writable attr
* make `Game::Base#add_extra_tile` return the new tile so that the method can be
  overridden in subclasses and the new tile may be further modified if needed

1868WY:

* turn Wind River Canyon (WRC) gray after the yellow tile is laid; in the
  physical game, there is a special gray tile with just a gentle curve that is
  the only tile which may be placed there; it is layable in yellow and
  equivalent to a normal gentle yellow
* fix new tiles from "unlimited" stack having rectangular towns
* fix company buy-in price
* add train export

[Issue #5011]