### PR TITLE
Add option to manually set player order

### DIFF
--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -150,6 +150,14 @@ module GameManager
     end
   end
 
+  def swap_players(game, player1, player2)
+    game['players'][player1], game['players'][player2] = game['players'][player2], game['players'][player1]
+    player_order = game['players'].map { |p| p['id'] }
+    @connection.safe_post(url(game, '/player_order'), { player_order: player_order }) do |data|
+      update_game(data)
+    end
+  end
+
   def user_in_game?(user, game)
     game['players'].map { |p| p['id'] }.include?(user&.dig('id'))
   end

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -31,6 +31,8 @@ module View
         inputs << h(:label, { style: @label_style }, 'Game Options')
         inputs << render_input('Invite only game', id: 'unlisted', type: :checkbox,
                                                    container_style: { paddingLeft: '0.5rem' })
+        inputs << render_input('Manually set player order', id: 'player_order', type: :checkbox,
+                                                            container_style: { paddingLeft: '0.5rem' })
         inputs << render_game_info
       when :hotseat
         inputs << h(:label, { style: @label_style }, 'Player Names')

--- a/models/game.rb
+++ b/models/game.rb
@@ -102,6 +102,7 @@ class Game < Base
     players
       .sort_by(&:id)
       .shuffle(random: Random.new(settings['seed'] || 1))
+      .sort_by.with_index { |player, i| [settings['player_order']&.find_index(player.id) || i] }
   end
 
   def archive!


### PR DESCRIPTION
I don't think any normal game will care about this feature, but it is pretty useful for tournaments.

![image](https://user-images.githubusercontent.com/3337865/116997289-83d8cd80-acd4-11eb-9754-d73678ee4cf8.png)

Only the owner can move players around and only if that option was selected when creating the game

I changed the visual of the user list a bit, because it was getting confusing with too many buttons. Now instead of commas, it's using a left border in the same way of the entities list.
This is how the player list looks like when you don't have permission to change the order:

![image](https://user-images.githubusercontent.com/3337865/116997847-3c9f0c80-acd5-11eb-85bc-592d1bbe4445.png)
