### PR TITLE
1870: Fix stock movements (fixes #5067)

### DIFF
--- a/lib/engine/game/g_1870/stock_market.rb
+++ b/lib/engine/game/g_1870/stock_market.rb
@@ -6,6 +6,15 @@ module Engine
   module Game
     module G1870
       class StockMarket < Engine::StockMarket
+        def move_up(corporation)
+          r, c = corporation.share_price.coordinates
+          return super if r.positive?
+          return if c + 1 >= @market[r].size
+
+          move_right(corporation)
+          move_down(corporation)
+        end
+
         def move_right(corporation)
           r, c = corporation.share_price.coordinates
 


### PR DESCRIPTION
Preserve order when hitting the soft ledge (don't go down to come back up)
When hitting the ceiling, move right and down instead