### PR TITLE
[1822] Minors shouldnt be able to run E trains

### DIFF
--- a/lib/engine/game/g_1822/step/route.rb
+++ b/lib/engine/game/g_1822/step/route.rb
@@ -9,6 +9,7 @@ module Engine
         class Route < Engine::Step::Route
           def actions(entity)
             return [] if !entity.operator? || @game.route_trains(entity).empty? || !@game.can_run_route?(entity)
+            return [] if entity.corporation? && entity.type == :minor && only_e_train?(entity)
 
             @pullman_train ||= nil
             actions = ACTIONS.dup
@@ -54,6 +55,10 @@ module Engine
 
             @orginal_train = nil
             @pullman_train = nil
+          end
+
+          def only_e_train?(entity)
+            @game.route_trains(entity).reject { |t| t.name == @game.class::E_TRAIN }.empty?
           end
 
           def pullman_train_choices(entity)

--- a/lib/engine/game/g_1822/step/route.rb
+++ b/lib/engine/game/g_1822/step/route.rb
@@ -58,7 +58,7 @@ module Engine
           end
 
           def only_e_train?(entity)
-            @game.route_trains(entity).reject { |t| t.name == @game.class::E_TRAIN }.empty?
+            @game.route_trains(entity).none? { |t| t.name != @game.class::E_TRAIN }
           end
 
           def pullman_train_choices(entity)


### PR DESCRIPTION
- If a minor only have an E-train, skip the run routes step.

fixes #5079

This will probably break a game or two if there was a minor who owned a E-Train.