### PR TITLE
[1822] Dont count yellow london as upgrade

### DIFF
--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -87,11 +87,6 @@ module Engine
             return nil if color != :white && !tile_lay[:upgrade]
             return nil if color != :white && tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(hex)
 
-            # London yellow tile counts as an upgrade
-            if hex.tile.color == :white && @round.num_laid_track.positive? && hex.name == @game.class::LONDON_HEX
-              return nil
-            end
-
             # Middleton Railway can only lay track on hexes with one town
             return nil if entity.id == @game.class::COMPANY_MTONR && (hex.tile.towns.empty? || hex.tile.towns.size > 1)
 

--- a/lib/engine/game/g_1822/step/track.rb
+++ b/lib/engine/game/g_1822/step/track.rb
@@ -72,11 +72,6 @@ module Engine
             return nil if color != :white && !tile_lay[:upgrade]
             return nil if color != :white && tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(hex)
 
-            # London yellow tile counts as an upgrade
-            if hex.tile.color == :white && @round.num_laid_track.positive? && hex.name == @game.class::LONDON_HEX
-              return nil
-            end
-
             connected
           end
         end

--- a/lib/engine/game/g_1822/step/tracker.rb
+++ b/lib/engine/game/g_1822/step/tracker.rb
@@ -81,14 +81,8 @@ module Engine
           [total_cost, types]
         end
 
-        def upgraded_track(from, to, hex)
-          @round.upgraded_track = upgraded_track?(from, to, hex)
-        end
-
-        def upgraded_track?(_from, to, hex)
-          # London yellow tile counts as an upgrade
-          tile_color = to.color
-          tile_color != :yellow || (tile_color == :yellow && hex.name == @game.class::LONDON_HEX)
+        def upgraded_track?(from, _to, _hex)
+          from.color != :white
         end
       end
     end


### PR DESCRIPTION
- Removed the restriction of yellow london counted as an upgrade.

fixes #5090

This shouldnt break any games.