### PR TITLE
1870: Fix error on closing corporation (fixes #4987)

### DIFF
--- a/lib/engine/game/g_1870/step/check_connection.rb
+++ b/lib/engine/game/g_1870/step/check_connection.rb
@@ -53,13 +53,17 @@ module Engine
             ACTIONS
           end
 
+          # This step should not be passed
+          # This prevents the force_next_entity! from trying
+          def pass!; end
+
           def process_destination_connection(action)
             action.corporations.each do |corporation|
               @game.log << "-- #{corporation.name} can connect to its destination --"
 
               @round.connection_runs[corporation] = @game.destination_hex(corporation)
             end
-            pass!
+            @passed = true
           end
         end
       end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -177,10 +177,10 @@ module Engine
         super
         if @round.current_actions.any?
           @round.pass_order.delete(current_entity)
-          current_entity.unpass!
+          current_entity&.unpass!
         else
           @round.pass_order |= [current_entity]
-          current_entity.pass!
+          current_entity&.pass!
         end
       end
 


### PR DESCRIPTION
The pass! on PriceProtection may be called during the Stock Round
while on the turn closed corporation and it inherits BuySellParShares

force_next_entity! tries to pass! every step, but we still want to run
through the CheckConnection