### PR TITLE
1870: Enforce "must sell down to 60%" rule during EMR (fixes #4566)

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -621,7 +621,7 @@ module Engine
             Engine::Step::Route,
             G1870::Step::Dividend,
             Engine::Step::DiscardTrain,
-            Engine::Step::BuyTrain,
+            G1870::Step::BuyTrain,
             [G1870::Step::BuyCompany, { blocks: true }],
             G1870::Step::PriceProtection,
             G1870::Step::CheckConnection,

--- a/lib/engine/game/g_1870/step/buy_train.rb
+++ b/lib/engine/game/g_1870/step/buy_train.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1870
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def can_sell?(entity, bundle)
+            super && bundle.corporation.holding_ok?(entity, -bundle.percent)
+          end
+
+          def selling_minimum_shares?(bundle)
+            super || !bundle.corporation.holding_ok?(bundle.owner, -bundle.percent + 1)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
During EMR force selling down to 60% if holding above 60% and selling
some share. Now to consider "the minimum" a player must sell, we can't
only look and the money. We may also need allow selling more than 10%
when the player holds more than 60%.