### PR TITLE
1862: end game and receivership

### DIFF
--- a/assets/app/view/game/entity_list.rb
+++ b/assets/app/view/game/entity_list.rb
@@ -65,7 +65,7 @@ module View
             children << h(:img, logo_props)
           end
 
-          owner = " (#{entity.owner.name.truncate})" if !entity.player? && entity.owner
+          owner = " (#{@game.acting_for_entity(entity).name.truncate})" if !entity.player? && entity.owner
           owner = ' (CLOSED)' if entity.closed?
           children << h(:span, "#{entity.name}#{owner}")
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -561,6 +561,10 @@ module Engine
         end
       end
 
+      def acting_for_entity(entity)
+        entity&.owner
+      end
+
       def player_log(entity, msg)
         @log << "-- #{msg}" if entity.id == @user
       end

--- a/lib/engine/game/g_1862/meta.rb
+++ b/lib/engine/game/g_1862/meta.rb
@@ -13,7 +13,7 @@ module Engine
         GAME_SUBTITLE = 'Railway Mania in the Eastern Counties'
         GAME_DESIGNER = 'Mike Hutton'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1862'
-        GAME_LOCATION = 'England'
+        GAME_LOCATION = 'Eastern Counties, England'
         GAME_PUBLISHER = :gmt_games
         GAME_RULES_URL = 'https://gmtwebsiteassets.s3-us-west-2.amazonaws.com/1862/1862_TRAIN_RULES-Final.pdf'
 

--- a/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
@@ -9,6 +9,21 @@ module Engine
         class BuySellParShares < Engine::Step::BuySellParShares
           UNCHARTERED_TOKEN_COST = 40
 
+          def can_buy?(entity, bundle)
+            return unless bundle&.buyable
+
+            corporation = bundle.corporation
+            entity.cash >= bundle.price && can_gain?(entity, bundle) &&
+              !@round.players_sold[entity][corporation] &&
+              (can_buy_multiple?(entity, corporation, bundle.owner) || !bought?) &&
+              can_buy_presidents_share?(entity, bundle, corporation)
+          end
+
+          # can never directly buy president's share from market
+          def can_buy_presidents_share?(_entity, share, corporation)
+            share.percent < corporation.presidents_percent || share.owner != @game.share_pool
+          end
+
           def can_buy_any_from_ipo?(entity)
             @game.corporations.each do |corporation|
               next unless corporation.ipoed

--- a/lib/engine/game/g_1862/step/merge.rb
+++ b/lib/engine/game/g_1862/step/merge.rb
@@ -9,7 +9,7 @@ module Engine
         class Merge < Engine::Step::Base
           def actions(entity)
             return [] if !entity.corporation? || entity != current_entity
-            return [] if entity.receivership? || @game.skip_round[entity]
+            return [] if entity.receivership? || @game.skip_round[entity] || @game.lner
 
             return ['choose'] if @merging
 

--- a/lib/engine/game/g_1862/step/redeem_share.rb
+++ b/lib/engine/game/g_1862/step/redeem_share.rb
@@ -9,11 +9,12 @@ module Engine
       module Step
         class RedeemShare < Engine::Step::IssueShares
           def actions(entity)
-            available_actions = []
-            return available_actions unless entity.corporation?
-            return available_actions if entity != current_entity
-            return available_actions if @game.skip_round[entity]
+            return [] unless entity.corporation?
+            return [] if entity != current_entity
+            return [] if entity.receivership?
+            return [] if @game.skip_round[entity]
 
+            available_actions = []
             available_actions << 'buy_shares' unless redeemable_shares(entity).empty?
             available_actions << 'pass' if blocks? && !available_actions.empty?
 

--- a/lib/engine/game/g_1862/step/route.rb
+++ b/lib/engine/game/g_1862/step/route.rb
@@ -17,6 +17,14 @@ module Engine
             super unless @game.skip_round[entity]
           end
 
+          def help
+            return super unless current_entity.receivership?
+
+            "#{current_entity.name} is in receivership (it has no president). Most of its "\
+              "actions are automated, but the majority share owner (#{@game.acting_for_entity(current_entity).name}) "\
+              "must manually run its trains. Please enter the best route you see for #{current_entity.name}."
+          end
+
           def process_run_routes(action)
             super
 

--- a/lib/engine/game/g_1862/step/token.rb
+++ b/lib/engine/game/g_1862/step/token.rb
@@ -9,7 +9,7 @@ module Engine
         class Token < Engine::Step::Token
           def actions(entity)
             return [] if entity.corporation? && entity.receivership?
-            return [] if @game.skip_round[entity]
+            return [] if @game.skip_round[entity] || @game.lner
 
             super
           end

--- a/lib/engine/game/g_1862/step/track.rb
+++ b/lib/engine/game/g_1862/step/track.rb
@@ -8,7 +8,8 @@ module Engine
       module Step
         class Track < Engine::Step::Track
           def actions(entity)
-            return [] if @game.skip_round[entity]
+            return [] if entity.corporation? && entity.receivership?
+            return [] if @game.skip_round[entity] || @game.lner
 
             super
           end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -71,7 +71,7 @@ module Engine
         @current_operator = entity
         @current_operator_acted = false
         entity.trains.each { |train| train.operated = false }
-        @log << "#{entity.owner.name} operates #{entity.name}" unless finished?
+        @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
         @game.place_home_token(entity) if @home_token_timing == :operate
         skip_steps
         next_entity! if finished?


### PR DESCRIPTION
Adds game end conditions and completes receivership rules
Fixes a problem with train owners not being adjusted after a merge
Fixes a problem with shares not moved from originator to survivor after a merge

Common file changes:
- Game::Base
- Round::Operating
- UI::EntityList

All of the above were changed to add and use an "acting_for_entity" method used to show which player is operating on behalf of a corporation/minor. This was needed because the 1862 rules specify that the majority shareholder makes the decisions of a receivership corp (instead of "The Market").