### PR TITLE
1860, 1862: highlight home token

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -59,13 +59,10 @@ module View
             fill: color,
           }
 
-          if @game&.highlight_token?(@token)
+          if (highlight = @game&.highlight_token?(@token))
             radius -= 3
-            token_attrs.merge!(
-              stroke: 'white',
-              'stroke-width': '3px',
-              filter: 'drop-shadow(8px 8px 2px #444)',
-            )
+            token_attrs[:stroke] = 'white'
+            token_attrs[:'stroke-width'] = '3px'
           end
 
           children = [h(:circle, attrs: token_attrs)]
@@ -81,6 +78,9 @@ module View
           if @extra_token
             props[:attrs][:transform] += ' scale(0.95)'
             props[:attrs][:filter] = 'drop-shadow(0 0 6px #000)'
+          elsif highlight
+            # make it look like an extra tall token
+            props[:attrs][:filter] = 'drop-shadow(8px 8px 2px #444)'
           end
 
           h(:g, props, children)

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -61,11 +61,11 @@ module View
 
           if @game&.highlight_token?(@token)
             radius -= 3
-            token_attrs.merge!({
-                                 stroke: 'white',
-                                 'stroke-width': '3px',
-                                 filter: 'drop-shadow(8px 8px 2px #444)',
-                               })
+            token_attrs.merge!(
+              stroke: 'white',
+              'stroke-width': '3px',
+              filter: 'drop-shadow(8px 8px 2px #444)',
+            )
           end
 
           children = [h(:circle, attrs: token_attrs)]

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -59,7 +59,7 @@ module View
             fill: color,
           }
 
-          if @game.highlight_token?(@token)
+          if @game&.highlight_token?(@token)
             radius -= 3
             token_attrs.merge!({
                                  stroke: 'white',

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -75,12 +75,12 @@ module View
             attrs: { transform: '' },
           }
           props[:attrs][:transform] = rotation_for_layout if @edge
-          if @extra_token
-            props[:attrs][:transform] += ' scale(0.95)'
-            props[:attrs][:filter] = 'drop-shadow(0 0 6px #000)'
-          elsif highlight
+          if highlight
             # make it look like an extra tall token
             props[:attrs][:filter] = 'drop-shadow(8px 8px 2px #444)'
+          elsif @extra_token
+            props[:attrs][:transform] += ' scale(0.95)'
+            props[:attrs][:filter] = 'drop-shadow(0 0 6px #000)'
           end
 
           h(:g, props, children)

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -54,7 +54,21 @@ module View
             radius -= 4
           end
 
-          children = [h(:circle, attrs: { r: @radius, fill: color })]
+          token_attrs = {
+            r: @radius,
+            fill: color,
+          }
+
+          if @game.highlight_token?(@token)
+            radius -= 3
+            token_attrs.merge!({
+                                 stroke: 'white',
+                                 'stroke-width': '3px',
+                                 filter: 'drop-shadow(8px 8px 2px #444)',
+                               })
+          end
+
+          children = [h(:circle, attrs: token_attrs)]
           children << reservation if @reservation && !@token
           children << render_boom if @city&.boom
           children << h(Token, token: @token, radius: radius, game: @game) if @token

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2358,6 +2358,10 @@ module Engine
         "#{count_available_tokens(corporation)}/#{corporation.tokens.size}"
       end
 
+      def highlight_token?(_token)
+        false
+      end
+
       def show_value_of_companies?(entity)
         entity.player?
       end

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1910,6 +1910,13 @@ module Engine
         def bank_sort(entities)
           entities.sort_by(&:name).sort_by { |e| corp_layer(e) }
         end
+
+        def highlight_token?(token)
+          return false unless token
+          return false unless (corporation = token.corporation)
+
+          corporation.tokens.find_index(token).zero?
+        end
       end
     end
   end


### PR DESCRIPTION
Both 1860 and 1862 have the requirement that at least one route must contain the home token. It is helpful to highlight this token on the map.

Fixes #4946 

Examples:
![1860_highlight](https://user-images.githubusercontent.com/8494213/117207482-3a11e500-adb1-11eb-93e2-bcca385cbd54.png)

![token_hightlight](https://user-images.githubusercontent.com/8494213/117207503-3ed69900-adb1-11eb-9ddf-43a8f40c92ad.png)

![token_highight_players](https://user-images.githubusercontent.com/8494213/117207519-4302b680-adb1-11eb-915a-c6da473b4c82.png)
