### PR TITLE
1870: Fix bug that broke game rendering at the end of the auction.

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -10,7 +10,7 @@ module Engine
       class Game < Game::Base
         include_meta(G1870::Meta)
 
-        attr_accessor :connection_run, :reissued
+        attr_accessor :sell_queue, :connection_run, :reissued
 
         register_colors(black: '#37383a',
                         orange: '#f48221',
@@ -652,6 +652,7 @@ module Engine
         end
 
         def setup
+          @sell_queue = []
           @connection_run = {}
           @reissued = {}
 
@@ -765,7 +766,7 @@ module Engine
         end
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
-          @round.sell_queue << [bundle, bundle.corporation.owner]
+          @sell_queue << [bundle, bundle.corporation.owner]
 
           @share_pool.sell_shares(bundle)
         end
@@ -775,7 +776,7 @@ module Engine
             next 0 unless s.corporation.counts_for_limit
             next 0 unless s.counts_for_limit
             # Don't count shares that have been sold and will go to yellow unless protected
-            next 0 if @round.sell_queue.any? do |bundle, _|
+            next 0 if @sell_queue.any? do |bundle, _|
               bundle.corporation == s.corporation &&
                 !stock_market.find_share_price(s.corporation, Array.new(bundle.num_shares, :up)).counts_for_limit
             end

--- a/lib/engine/game/g_1870/step/price_protection.rb
+++ b/lib/engine/game/g_1870/step/price_protection.rb
@@ -21,12 +21,8 @@ module Engine
             'Price protect shares'
           end
 
-          def round_state
-            super.merge(sell_queue: [])
-          end
-
           def active_entities
-            return [] if @round.sell_queue.empty?
+            return [] if @game.sell_queue.empty?
 
             [price_protection_entity]
           end
@@ -36,11 +32,11 @@ module Engine
           end
 
           def price_protection
-            @round.sell_queue.dig(0, 0)
+            @game.sell_queue.dig(0, 0)
           end
 
           def price_protection_entity
-            @round.sell_queue.dig(0, 1)
+            @game.sell_queue.dig(0, 1)
           end
 
           def can_sell?
@@ -57,7 +53,7 @@ module Engine
           end
 
           def process_buy_shares(action)
-            bundle, = @round.sell_queue.shift
+            bundle, = @game.sell_queue.shift
 
             player = action.entity
             price = bundle.price
@@ -88,7 +84,7 @@ module Engine
           end
 
           def process_pass(_action, forced = false)
-            bundle, corporation_owner = @round.sell_queue.shift
+            bundle, corporation_owner = @game.sell_queue.shift
 
             corporation = bundle.corporation
             price = corporation.share_price.price


### PR DESCRIPTION
Moved sell_queue from round to game, because it now is checked at all times (and was already available almost anywhere anyway)