### PR TITLE
[1840] Added Train Config and train buying

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -65,11 +65,18 @@ module View
 
         must_take_loan = step.must_take_loan?(@corporation) if step.respond_to?(:must_take_loan?)
         if must_take_loan
-          children << h(:div, "#{player.name} does not have enough liquidity to "\
-                              "contribute towards #{@corporation.name} buying a train "\
-                              "from the Depot. #{@corporation.name} must buy a "\
-                              "train from another corporation, or #{player.name} must "\
-                              "take a loan of at least #{@game.format_currency(share_funds_required)}")
+          text = "#{player.name} does not have enough liquidity to "\
+          "contribute towards #{@corporation.name} buying a train "\
+          'from the Depot. '
+
+          if @game.class::ALLOW_TRAIN_BUY_FROM_OTHERS
+            text += "#{@corporation.name} must buy a "\
+            'train from another corporation, or'
+          end
+
+          text += "#{player.name} must " \
+          "take a loan of at least #{@game.format_currency(share_funds_required)}"
+          children << h(:div, text)
         end
 
         if @must_buy_train &&

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -229,7 +229,7 @@ module View
             end
           end
           event_text = event_text.flat_map { |e| [h('span.nowrap', e), ', '] }[0..-2]
-          name = (train.sym == first_train&.sym ? '→ ' : '') + @game.info_train_name(train)
+          name = (@game.info_available_train(first_train, train) ? '→ ' : '') + @game.info_train_name(train)
 
           train_content = [
             h(:td, name),

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2383,6 +2383,10 @@ module Engine
         train.names_to_prices.keys.join(', ')
       end
 
+      def info_available_train(first_train, train)
+        train.sym == first_train&.sym
+      end
+
       def info_train_price(train)
         train.names_to_prices.values.map { |p| format_currency(p) }.join(', ')
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -226,6 +226,8 @@ module Engine
 
       MUST_BUY_TRAIN = :route # When must the company buy a train if it doesn't have one (route, never, always)
 
+      ALLOW_TRAIN_BUY_FROM_OTHERS = true # Allows train buy from other corporations
+
       # Default tile lay, one tile either upgrade or lay at zero cost
       # allows multiple lays, value must be either true, false or :not_if_upgraded
       TILE_LAYS = [{ lay: true, upgrade: true, cost: 0 }].freeze

--- a/lib/engine/game/g_1840/entities.rb
+++ b/lib/engine/game/g_1840/entities.rb
@@ -49,6 +49,7 @@ module Engine
               distance: 99,
               price: 100,
               num: 5,
+              available_on: '1',
               variants: [
                 {
                   name: 'Y2',
@@ -61,6 +62,7 @@ module Engine
               distance: 99,
               price: 300,
               num: 5,
+              available_on: '1',
               variants: [
                 {
                   name: 'O2',
@@ -77,6 +79,7 @@ module Engine
               distance: 99,
               price: 500,
               num: 5,
+              available_on: '1',
               variants: [
                 {
                   name: 'R2',
@@ -93,6 +96,7 @@ module Engine
               distance: 99,
               price: 600,
               num: 5,
+              available_on: '1',
               variants: [
                 {
                   name: 'Pi2',
@@ -109,6 +113,7 @@ module Engine
               distance: 99,
               price: 800,
               num: 5,
+              available_on: '1',
               variants: [
                 {
                   name: 'Pu2',

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -451,7 +451,7 @@ module Engine
 
         def info_train_name(train)
           names = train.names_to_prices.keys.sort
-          active_variant = (available_trains & train.variants.keys).first
+          active_variant = active_variant(train)
           return names.join(', ') unless active_variant
 
           names -= [active_variant]
@@ -459,19 +459,23 @@ module Engine
         end
 
         def info_available_train(_first_train, train)
-          !(available_trains & train.variants.keys).empty?
+          !active_variant(train).nil?
         end
 
         def info_train_price(train)
           name_and_prices = train.names_to_prices.sort_by { |k, _v| k }.to_h
 
-          active_variant = (available_trains & train.variants.keys).first
+          active_variant = active_variant(train)
           return name_and_prices.values.map { |p| format_currency(p) }.join(', ') unless active_variant
 
           active_price = name_and_prices[active_variant]
           name_and_prices.delete(active_variant)
 
           "#{active_price}, (#{name_and_prices.values.map { |p| format_currency(p) }.join(', ')})"
+        end
+
+        def active_variant(train)
+          (available_trains & train.variants.keys).first
         end
 
         def available_trains
@@ -502,7 +506,7 @@ module Engine
         end
 
         def maintenance_costs(corporation)
-          corporation.trains.inject(0) { |sum, train| sum + train_maintenance(train.sym) }
+          corporation.trains.sum { |train| train_maintenance(train.sym) }
         end
 
         def train_maintenance(train_sym)

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -447,12 +447,19 @@ module Engine
 
         def info_available_train(_first_train, train)
           !(available_trains & train.variants.keys).empty?
-          # train.sym == first_train&.sym
         end
 
         def info_train_price(train)
-          # TODO:  prices
-          train.names_to_prices.values.map { |p| format_currency(p) }.join(', ')
+          puts train.names_to_prices
+          name_and_prices = train.names_to_prices.sort_by { |k, _v| k }.to_h
+
+          active_variant = (available_trains & train.variants.keys).first
+          return name_and_prices.values.map { |p| format_currency(p) }.join(', ') unless active_variant
+
+          active_price = name_and_prices[active_variant]
+          name_and_prices.delete(active_variant)
+
+          "#{active_price}, (#{name_and_prices.values.map { |p| format_currency(p) }.join(', ')})"
         end
 
         def available_trains

--- a/lib/engine/game/g_1840/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1840/step/buy_sell_par_shares.rb
@@ -35,6 +35,10 @@ module Engine
 
             track_action(action, action.bundle.corporation)
           end
+
+          def visible_corporations
+            @game.corporations.reject { |item| item.type == :minor }
+          end
         end
       end
     end

--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -15,6 +15,15 @@ module Engine
 
             []
           end
+
+          def buyable_trains(entity)
+            super
+          end
+
+          def buyable_train_variants(train, entity)
+            base = super
+            base.select { |item| @game.available_trains.include?(item[:name]) }
+          end
         end
       end
     end

--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -11,18 +11,74 @@ module Engine
             return [] if entity.minor?
             return [] if entity != current_entity
             return [] if entity.type == :city
-            return %w[buy_train pass] if can_buy_train?(entity)
+
+            actions = []
+
+            actions << 'scrap_train' unless scrappable_trains(entity).empty?
+
+            return actions + %w[buy_train] if president_may_contribute?(entity)
+            return actions + %w[buy_train pass] if can_buy_train?(entity)
 
             []
           end
 
-          def buyable_trains(entity)
-            super.select { |item| item.owner == @game.depot }
+          def buyable_train_variants(train, _entity)
+            train.variants.values.select { |item| @game.available_trains.include?(item[:name]) }
           end
 
-          def buyable_train_variants(train, entity)
-            base = super
-            base.select { |item| @game.available_trains.include?(item[:name]) }
+          def room?(entity, _shell = nil)
+            scrappable_trains(entity).size < @game.train_limit(entity)
+          end
+
+          def scrappable_trains(entity)
+            @game.corporate_card_minors(entity).flat_map(&:trains) + entity.trains
+          end
+
+          def scrap_info(train)
+            "Maintenance: #{@game.format_currency(@game.train_maintenance(train.sym))}"
+          end
+
+          def scrap_button_text(_train)
+            'Scrap'
+          end
+
+          def process_scrap_train(action)
+            entity = action.entity
+            train = action.train
+
+            @game.scrap_train(train, entity)
+          end
+
+          def must_buy_train?(entity)
+            scrappable_trains(entity).size.zero?
+          end
+
+          def must_take_loan?(corporation)
+            price = cheapest_train_price(corporation)
+            (@game.buying_power(corporation) + corporation.owner.cash) < price
+          end
+
+          def cheapest_train_price(corporation)
+            cheapest_train = buyable_trains(corporation).min_by(&:price)
+            cheapeast_variant = buyable_train_variants(cheapest_train, corporation).first
+            cheapeast_variant[:price]
+          end
+
+          def try_take_player_loan(player, cost)
+            return unless cost.positive?
+            return unless cost > player.cash
+
+            difference = cost - player.cash
+
+            loan_count = (difference / 100.to_f).ceil
+            loan_amount = loan_count * 100
+
+            @game.increase_debt(player, loan_amount)
+
+            @log << "#{player.name} takes a loan of #{@game.format_currency(loan_amount)}. " \
+                    "The player value is decreased by #{@game.format_currency(loan_amount * 2)}."
+
+            @game.bank.spend(loan_amount, player)
           end
         end
       end

--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -17,7 +17,7 @@ module Engine
           end
 
           def buyable_trains(entity)
-            super
+            super.select { |item| item.owner == @game.depot }
           end
 
           def buyable_train_variants(train, entity)

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -109,7 +109,7 @@ module Engine
 
       def buyable_trains(entity)
         depot_trains = @depot.depot_trains
-        other_trains = @depot.other_trains(entity)
+        other_trains = @game.class::ALLOW_TRAIN_BUY_FROM_OTHERS ? @depot.other_trains(entity) : []
 
         if entity.cash < @depot.min_depot_price
           depot_trains = [@depot.min_depot_train] if @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST


### PR DESCRIPTION
Global Changes: 
- game/base: Adds a constant  `ALLOW_TRAIN_BUY_FROM_OTHERS = true ` which is needed for a text snippet (and is now also used in the available_trains method)

This should not affect any game since no game has that variable set to false (except 1840 of course)

- game_info: Extracts active train setting to a function, so that multiple arrows are possible:
![image](https://user-images.githubusercontent.com/7661170/117589281-e42e9b80-b128-11eb-832b-f083f69bcd83.png)


Game specific:
- Adds Train Configuration
- Adds EBuy
- Adds Player Debt