### PR TITLE
1828.Games: Transfer all shares held by the merging corporations into the system ipo

### DIFF
--- a/lib/engine/game/g_1828/step/merger.rb
+++ b/lib/engine/game/g_1828/step/merger.rb
@@ -253,8 +253,8 @@ module Engine
           end
 
           def combine_ipo_shares
-            @merger.shares_of(@merger).dup.each { |s| s.transfer(@ipo) }
-            @target.shares_of(@target).dup.each { |s| s.transfer(@ipo) }
+            @merger.shares.dup.each { |s| s.transfer(@ipo) }
+            @target.shares.dup.each { |s| s.transfer(@ipo) }
           end
 
           def exchange_pairs(entity)


### PR DESCRIPTION
Fixes a bug where shares of target, that were traded to merger, weren't being transferred to the system ipo.