### PR TITLE
18Ireland: Unused token after 2 corp merger should be £50 rather than £0

### DIFF
--- a/lib/engine/game/g_18_ireland/step/merge.rb
+++ b/lib/engine/game/g_18_ireland/step/merge.rb
@@ -189,14 +189,6 @@ module Engine
                                           exchange: :free)
             end
 
-            move_tokens_to_surviving(target, @round.merging)
-
-            # Add the $50 token back
-            if target.tokens.size < 3
-              new_token = Engine::Token.new(target, price: 50)
-              target.tokens << new_token
-            end
-
             tokens = target.tokens.map { |t| t.city&.hex&.id }
             charter_tokens = tokens.size - tokens.compact.size
             @log << "#{target.name} has tokens (#{tokens.size}: #{tokens.compact.size} on hexes #{tokens.compact}"\

--- a/validate.rb
+++ b/validate.rb
@@ -16,10 +16,12 @@ $total_time = 0
 def run_game(game, actions = nil)
   actions ||= game.actions.map(&:to_h)
   data={'id':game.id, 'title': game.title, 'status':game.status}
+
+  $total += 1
+  time = Time.now
+  engine = Engine::Game.load(game)
   begin
-    $total += 1
-    time = Time.now
-    engine = Engine::Game.load(game).maybe_raise!
+    engine.maybe_raise!    
 
     time = Time.now - time
     $total_time += time
@@ -29,6 +31,7 @@ def run_game(game, actions = nil)
     data['result']=engine.result
   rescue Exception => e # rubocop:disable Lint/RescueException
     $count += 1
+    data['last_action']=engine.last_processed_action
     data['finished']=false
     #data['stack']=e.backtrace
     data['exception']=e


### PR DESCRIPTION
fixes #5275 

18Ireland trys to move tokens to the new corporation twice causing stray ones to appear.