### PR TITLE
[1840] Replace city token

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -973,7 +973,7 @@ module Engine
       end
 
       def can_run_route?(entity)
-        @graph.route_info(entity)&.dig(:route_available)
+        graph_for_entity(entity).route_info(entity)&.dig(:route_available)
       end
 
       def must_buy_train?(entity)

--- a/lib/engine/game/g_1840/entities.rb
+++ b/lib/engine/game/g_1840/entities.rb
@@ -264,7 +264,7 @@ module Engine
           {
             sym: '3',
             name: 'Linie 3',
-            logo: '1840/2',
+            logo: '1840/3',
             tokens: [0, 20, 40, 60, 80, 100],
             type: 'minor',
             always_market_price: true,

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -554,7 +554,7 @@ module Engine
         def check_track_type(route)
           corporation = route.train.owner
           track_types = route.chains.flat_map { |item| item[:paths] }.flat_map(&:track).uniq
-          puts(track_types - [:narrow])
+
           if corporation.type == :city && !(track_types - [:narrow]).empty?
             raise GameError,
                   'Route may only contain narrow tracks'
@@ -568,7 +568,6 @@ module Engine
         def graph_for_entity(entity)
           return @city_graph if entity.type == :city
 
-          puts entity.type
           @graph
         end
       end

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -190,7 +190,7 @@ module Engine
           'Pu1' => { 'Y1' => -400, 'O1' => -300, 'R1' => -100, 'Pu1' => 200 },
         }.freeze
 
-        attr_reader :tram_corporations, :major_corporations, :tram_owned_by_corporation
+        attr_reader :tram_corporations, :major_corporations, :tram_owned_by_corporation, :city_graph
 
         def setup
           @intern_cr_phase_counter = 0
@@ -238,6 +238,12 @@ module Engine
           @corporations.concat(@major_corporations)
           @corporations.concat(@city_corporations)
           @corporations.concat(@tram_corporations)
+
+          @city_graph = Graph.new(self, skip_track: :broad)
+        end
+
+        def init_graph
+          Graph.new(self, skip_track: :narrow)
         end
 
         def new_auction_round
@@ -548,15 +554,22 @@ module Engine
         def check_track_type(route)
           corporation = route.train.owner
           track_types = route.chains.flat_map { |item| item[:paths] }.flat_map(&:track).uniq
-
+          puts(track_types - [:narrow])
           if corporation.type == :city && !(track_types - [:narrow]).empty?
             raise GameError,
                   'Route may only contain narrow tracks'
           end
 
-          return if (track_types - [:broad]).empty?
+          return if corporation.type != :minor || (track_types - ['broad']).empty?
 
           raise GameError, 'Route may only contain broad tracks'
+        end
+
+        def graph_for_entity(entity)
+          return @city_graph if entity.type == :city
+
+          puts entity.type
+          @graph
         end
       end
     end

--- a/lib/engine/game/g_1840/step/special_token.rb
+++ b/lib/engine/game/g_1840/step/special_token.rb
@@ -70,15 +70,16 @@ module Engine
               token.destroy!
             end
 
-            token.price = 0
+            action.token.price = 0
 
             place_token(
               entity,
               city,
               action.token,
-              connected: true,
               extra_action: true,
             )
+
+            @game.city_graph.clear
             @round.pending_special_tokens.shift
           end
 

--- a/lib/engine/game/g_1840/step/track_and_token.rb
+++ b/lib/engine/game/g_1840/step/track_and_token.rb
@@ -9,6 +9,18 @@ module Engine
         class TrackAndToken < Engine::Step::TrackAndToken
           def process_place_token(action)
             entity = action.entity
+            city = action.city
+            token = city.tokens[action.slot]
+            hex = city.hex
+
+            if token&.corporation&.type == :city
+              check_connected(entity, city, hex)
+              spender = @game.owning_major_corporation(entity)
+              spender.spend(40, @game.bank)
+              @log << "#{entity.name} removes token from #{hex.name} (#{hex.location_name})"\
+                      "for #{@game.format_currency(40)}"
+              token.destroy!
+            end
 
             spender = @game.owning_major_corporation(entity)
             place_token(entity, action.city, action.token, spender: spender)
@@ -84,6 +96,10 @@ module Engine
 
           def show_other
             @game.owning_major_corporation(current_entity)
+          end
+
+          def can_replace_token?(_entity, _token)
+            true
           end
         end
       end

--- a/lib/engine/game/g_1840/step/track_and_token.rb
+++ b/lib/engine/game/g_1840/step/track_and_token.rb
@@ -24,6 +24,7 @@ module Engine
 
             spender = @game.owning_major_corporation(entity)
             place_token(entity, city, action.token, spender: spender)
+
             @game.city_graph.clear
             @tokened = true
             pass! unless can_lay_tile?(entity)

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -48,7 +48,7 @@ module Engine
       end
 
       def available_hex(entity, hex)
-        @game.graph.reachable_hexes(entity)[hex]
+        @game.graph_for_entity(entity).reachable_hexes(entity)[hex]
       end
 
       def round_state

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -145,10 +145,11 @@ module Engine
       end
 
       def check_connected(entity, city, hex)
-        if !@game.loading && !@game.graph.connected_nodes(entity)[city]
-          city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
-          raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
-        end
+        puts @game.graph.connected_nodes(entity)[city], city
+        return if @game.loading || @game.graph.connected_nodes(entity)[city]
+
+        city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
+        raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
       end
     end
   end

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -145,7 +145,6 @@ module Engine
       end
 
       def check_connected(entity, city, hex)
-        puts @game.graph.connected_nodes(entity)[city], city
         return if @game.loading || @game.graph.connected_nodes(entity)[city]
 
         city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -45,10 +45,7 @@ module Engine
         hex = city.hex
         extra_action ||= special_ability.extra_action if special_ability&.type == :token
 
-        if !@game.loading && connected && !@game.graph.connected_nodes(entity)[city]
-          city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
-          raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
-        end
+        check_connected(entity, city, hex) if connected
 
         if special_ability&.type == :token && special_ability.city && special_ability.city != city.index
           raise GameError, "#{special_ability.owner.name} can only place token on #{hex.name} city "\
@@ -145,6 +142,13 @@ module Engine
         end
 
         [token, nil]
+      end
+
+      def check_connected(entity, city, hex)
+        if !@game.loading && !@game.graph.connected_nodes(entity)[city]
+          city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
+          raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
+        end
       end
     end
   end


### PR DESCRIPTION
Adds a new graph for city corporations and adds replacing of city tokens.

Changes some references of `@graph` in base game or `@game.graph` to `graph_for_entity`.  I think we should use in general functions always `graph_for_entity` which is more flexible than just accessing the default graph.

Also extracted the `check_connected` method since I need that code in another place again