### PR TITLE
1862: spreadsheet and bug fixes

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2511,6 +2511,10 @@ module Engine
       def token_ability_from_owner_usable?(ability, corporation)
         ability.from_owner ? corporation.find_token_by_type : true
       end
+
+      def separate_treasury?
+        false
+      end
     end
   end
 end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -142,7 +142,7 @@ module Engine
             train_limit: 3, # per type
             tiles: [:yellow],
             operating_rounds: 1,
-            status: ['three_per', 'first_rev'],
+            status: %w[three_per first_rev],
           },
           {
             name: 'B',
@@ -150,7 +150,7 @@ module Engine
             train_limit: 3, # 3 type
             tiles: %i[yellow green],
             operating_rounds: 2,
-            status: ['three_per', 'first_rev'],
+            status: %w[three_per first_rev],
           },
           {
             name: 'C',
@@ -158,7 +158,7 @@ module Engine
             train_limit: 3, # per type
             tiles: %i[yellow green],
             operating_rounds: 2,
-            status: ['three_per', 'middle_rev'],
+            status: %w[three_per middle_rev],
           },
           {
             name: 'D',
@@ -166,7 +166,7 @@ module Engine
             train_limit: 3, # per type
             tiles: %i[yellow green brown],
             operating_rounds: 3,
-            status: ['three_per', 'middle_rev'],
+            status: %w[three_per middle_rev],
           },
           {
             name: 'E',
@@ -174,7 +174,7 @@ module Engine
             train_limit: 2, # per type
             tiles: %i[yellow green brown],
             operating_rounds: 3,
-            status: ['two_per', 'last_rev'],
+            status: %w[two_per last_rev],
           },
           {
             name: 'F',
@@ -182,7 +182,7 @@ module Engine
             train_limit: 2, # per type
             tiles: %i[yellow green brown],
             operating_rounds: 3,
-            status: ['two_per', 'last_rev'],
+            status: %w[two_per last_rev],
           },
           {
             name: 'G',
@@ -190,7 +190,7 @@ module Engine
             train_limit: 3, # across all types
             tiles: %i[yellow green brown],
             operating_rounds: 3,
-            status: ['three_total', 'last_rev'],
+            status: %w[three_total last_rev],
           },
           {
             name: 'H',
@@ -198,7 +198,7 @@ module Engine
             train_limit: 3, # across all types
             tiles: %i[yellow green brown],
             operating_rounds: 3,
-            status: ['three_total', 'last_rev'],
+            status: %w[three_total last_rev],
           },
         ].freeze
 
@@ -1632,7 +1632,9 @@ module Engine
         def revenue_for(route, stops)
           return freight_revenue(route, stops) if train_type(route.train) == :freight
 
-          stops.sum { |stop| stop_on_other_route?(route, stop) ? 0 : game_route_revenue(stop, route.phase, route.train) }
+          stops.sum do |stop|
+            stop_on_other_route?(route, stop) ? 0 : game_route_revenue(stop, route.phase, route.train)
+          end
         end
 
         def hex_on_other_route?(this_route, hex)

--- a/lib/engine/game/g_1862/map.rb
+++ b/lib/engine/game/g_1862/map.rb
@@ -488,101 +488,101 @@ module Engine
           blue: {
             %w[
             E0
-            ] => 'offboard=revenue:yellow_80|green_90|brown_100,groups:North0;'\
+            ] => 'offboard=revenue:white_80|gray_90|purple_100,groups:North0;'\
               'border=edge:1;border=edge:5',
             %w[
             D1
-            ] => 'offboard=revenue:yellow_80|green_90|brown_100,groups:North0,hide:1;path=a:5,b:_0;'\
+            ] => 'offboard=revenue:white_80|gray_90|purple_100,groups:North0,hide:1;path=a:5,b:_0;'\
               'border=edge:1,type:divider;border=edge:4',
             %w[
             F1
-            ] => 'offboard=revenue:yellow_80|green_90|brown_100,groups:North0,hide:1;path=a:1,b:_0;'\
-              'offboard=revenue:yellow_80|green_90|brown_100,groups:North1,hide:1;path=a:0,b:_1;'\
+            ] => 'offboard=revenue:white_80|gray_90|purple_100,groups:North0,hide:1;path=a:1,b:_0;'\
+              'offboard=revenue:white_80|gray_90|purple_100,groups:North1,hide:1;path=a:0,b:_1;'\
               'partition=a:1,b:4,type:divider;border=edge:2;border=edge:5',
             %w[
             C2
-            ] => 'offboard=revenue:yellow_80|green_90|brown_100,groups:North;path=a:0,b:_0;'\
+            ] => 'offboard=revenue:white_80|gray_90|purple_100,groups:North;path=a:0,b:_0;'\
               'border=edge:4,type:divider',
             %w[
             G2
-            ] => 'offboard=revenue:yellow_80|green_90|brown_100,groups:North1;border=edge:2',
+            ] => 'offboard=revenue:white_80|gray_90|purple_100,groups:North1;border=edge:2',
             %w[
             I4
-            ] => 'offboard=revenue:yellow_80|green_100|brown_120,groups:NorthEast;path=a:1,b:_0;'\
+            ] => 'offboard=revenue:white_80|gray_100|purple_120,groups:NorthEast;path=a:1,b:_0;'\
               'border=edge:0',
             %w[
             I6
-            ] => 'offboard=revenue:yellow_80|green_100|brown_120,groups:NorthEast,hide:1;path=a:2,b:_0;'\
-              'offboard=revenue:yellow_60|green_90|brown_120,groups:East,hide:1;path=a:1,b:_1;'\
+            ] => 'offboard=revenue:white_80|gray_100|purple_120,groups:NorthEast,hide:1;path=a:2,b:_0;'\
+              'offboard=revenue:white_60|gray_90|purple_120,groups:East,hide:1;path=a:1,b:_1;'\
               'partition=a:2,b:5,type:divider;border=edge:3;border=edge:0',
             %w[
             I8
-            ] => 'offboard=revenue:yellow_60|green_90|brown_120,groups:East;path=a:2,b:_0;'\
+            ] => 'offboard=revenue:white_60|gray_90|purple_120,groups:East;path=a:2,b:_0;'\
               'border=edge:3;border=edge:1',
             %w[
             H9
-            ] => 'offboard=revenue:yellow_60|green_90|brown_120,groups:East,hide:1;path=a:3,b:_0;'\
+            ] => 'offboard=revenue:white_60|gray_90|purple_120,groups:East,hide:1;path=a:3,b:_0;'\
               'border=edge:4;border=edge:0,type:divider',
             %w[
             H11
-            ] => 'offboard=revenue:yellow_70|green_100|brown_130,groups:Denmark,hide:1;path=a:1,b:_0;'\
+            ] => 'offboard=revenue:white_70|gray_100|purple_130,groups:Denmark,hide:1;path=a:1,b:_0;'\
               'border=edge:0;border=edge:3,type:divider',
             %w[
             H13
-            ] => 'offboard=revenue:yellow_70|green_100|brown_130,groups:Denmark;path=a:2,b:_0;'\
+            ] => 'offboard=revenue:white_70|gray_100|purple_130,groups:Denmark;path=a:2,b:_0;'\
               'border=edge:3;border=edge:1',
             %w[
             G14
-            ] => 'offboard=revenue:yellow_70|green_100|brown_130,groups:Denmark,hide:1;path=a:3,b:_0;'\
-              'offboard=revenue:yellow_60|green_90|brown_120,groups:Holland,hide:1;path=a:2,b:_1;'\
+            ] => 'offboard=revenue:white_70|gray_100|purple_130,groups:Denmark,hide:1;path=a:3,b:_0;'\
+              'offboard=revenue:white_60|gray_90|purple_120,groups:Holland,hide:1;path=a:2,b:_1;'\
               'border=edge:4;border=edge:1;partition=a:3,b:0,type:divider',
             %w[
             F15
-            ] => 'offboard=revenue:yellow_70|green_100|brown_130,groups:Holland;path=a:3,b:_0;'\
+            ] => 'offboard=revenue:white_70|gray_100|purple_130,groups:Holland;path=a:3,b:_0;'\
               'border=edge:4',
           },
           red: {
             %w[
             A2
-            ] => 'offboard=revenue:yellow_40|green_90|brown_140,hide:1,groups:Midlands;path=a:5,b:_0;'\
+            ] => 'offboard=revenue:white_40|gray_90|purple_140,hide:1,groups:Midlands;path=a:5,b:_0;'\
               'border=edge:0',
             %w[
             A4
-            ] => 'offboard=revenue:yellow_40|green_90|brown_140,hide:1,groups:Midlands;path=a:4,b:_0;path=a:5,b:_0;'\
+            ] => 'offboard=revenue:white_40|gray_90|purple_140,hide:1,groups:Midlands;path=a:4,b:_0;path=a:5,b:_0;'\
               'border=edge:0;border=edge:3',
             %w[
             A6
-            ] => 'offboard=revenue:yellow_40|green_90|brown_140,groups:Midlands;path=a:4,b:_0;path=a:5,b:_0;'\
+            ] => 'offboard=revenue:white_40|gray_90|purple_140,groups:Midlands;path=a:4,b:_0;path=a:5,b:_0;'\
               'border=edge:0;border=edge:3',
             %w[
             A8
-            ] => 'offboard=revenue:yellow_40|green_90|brown_140,groups:Midlands,hide:1;path=a:4,b:_0;'\
-              'offboard=revenue:yellow_70|green_100|brown_120,groups:West,hide:1;path=a:5,b:_1;'\
+            ] => 'offboard=revenue:white_40|gray_90|purple_140,groups:Midlands,hide:1;path=a:4,b:_0;'\
+              'offboard=revenue:white_70|gray_100|purple_120,groups:West,hide:1;path=a:5,b:_1;'\
               'border=edge:0;border=edge:3;partition=a:2,b:5,type:divider',
             %w[
             A10
-            ] => 'offboard=revenue:yellow_70|green_100|brown_120,groups:West;path=a:4,b:_0;path=a:5,b:_0;'\
+            ] => 'offboard=revenue:white_70|gray_100|purple_120,groups:West;path=a:4,b:_0;path=a:5,b:_0;'\
               'border=edge:0;border=edge:3',
             %w[
             A12
-            ] => 'offboard=revenue:yellow_100|green_150|brown_200,groups:London,hide:1;path=a:5,b:_0;'\
-              'offboard=revenue:yellow_70|green_100|brown_120,groups:West,hide:1;path=a:4,b:_1;'\
+            ] => 'offboard=revenue:white_100|gray_150|purple_200,groups:London,hide:1;path=a:5,b:_0;'\
+              'offboard=revenue:white_70|gray_100|purple_120,groups:West,hide:1;path=a:4,b:_1;'\
               'border=edge:0;border=edge:3;partition=a:2,b:5,type:divider',
             %w[
             A14
-            ] => 'offboard=revenue:yellow_100|green_150|brown_200,groups:London,hide:1;path=a:4,b:_0;'\
+            ] => 'offboard=revenue:white_100|gray_150|purple_200,groups:London,hide:1;path=a:4,b:_0;'\
               'border=edge:5;border=edge:3',
             %w[
             C14
-            ] => 'offboard=revenue:yellow_100|green_150|brown_200,groups:London;path=a:2,b:_0;path=a:3,b:_0;'\
+            ] => 'offboard=revenue:white_100|gray_150|purple_200,groups:London;path=a:2,b:_0;path=a:3,b:_0;'\
               'path=a:4,b:_0;border=edge:5;border=edge:1',
             %w[
             B15
-            ] => 'offboard=revenue:yellow_100|green_150|brown_200,groups:London,hide:1;path=a:3,b:_0;'\
+            ] => 'offboard=revenue:white_100|gray_150|purple_200,groups:London,hide:1;path=a:3,b:_0;'\
               'border=edge:2;city=revenue:0,slots:2;border=edge:4',
             %w[
             D15
-            ] => 'offboard=revenue:yellow_100|green_150|brown_200,groups:London,hide:1;path=a:3,b:_0;path=a:4,b:_0;'\
+            ] => 'offboard=revenue:white_100|gray_150|purple_200,groups:London,hide:1;path=a:3,b:_0;path=a:4,b:_0;'\
               'border=edge:2;city=revenue:0,slots:2',
           },
         }.freeze

--- a/lib/engine/game/g_1862/step/acquire.rb
+++ b/lib/engine/game/g_1862/step/acquire.rb
@@ -14,7 +14,7 @@ module Engine
           def description
             return 'Choose Survivor' if @merging
 
-            'Acquire Corporation'
+            'Acquire'
           end
 
           def process_choose(action)

--- a/lib/engine/game/g_1862/step/buy_train.rb
+++ b/lib/engine/game/g_1862/step/buy_train.rb
@@ -220,7 +220,12 @@ module Engine
           end
 
           def warranty_text
-            'Warranties (each)'
+            train = @depot.depot_trains.first
+            if train.sym.include?('A') || train.sym.include?('D')
+              'Additional Warranties (each)'
+            else
+              'Warranties (each)'
+            end
           end
 
           def warranty_max

--- a/lib/engine/game/g_1862/step/charter_auction.rb
+++ b/lib/engine/game/g_1862/step/charter_auction.rb
@@ -207,7 +207,7 @@ module Engine
             resolve_bids
           end
 
-          def min_required(entity)
+          def min_required(_entity)
             highest_bid(@auctioning).price + min_increment + min_par * 3
           end
 

--- a/lib/engine/game/g_1862/step/dividend.rb
+++ b/lib/engine/game/g_1862/step/dividend.rb
@@ -169,7 +169,7 @@ module Engine
 
           def handle_warranties!(entity)
             # remove one warranty from each train and see if it rusts
-            entity.trains.each do |train|
+            entity.trains.dup.each do |train|
               train.name = train.name[0..-2] if train.name.include?('*')
               next unless @game.deferred_rust.include?(train) && !train.name.include?('*')
 

--- a/lib/engine/game/g_1862/step/merge.rb
+++ b/lib/engine/game/g_1862/step/merge.rb
@@ -43,7 +43,7 @@ module Engine
           def description
             return 'Choose Survivor' if @merging
 
-            'Merge with Major Corporation'
+            'Merge'
           end
 
           def process_merge(action)


### PR DESCRIPTION
This adds an optional column to the spreadsheet view. This is needed to show treasury shares separately from IPO shares (which are indeed separate in 1862). So obviously this touches UI::Spreadsheet as well as Game::Base

There are also a number of fixes for bugs found in a playthrough:
* Sort bank entities by start phase
* Offboard values are not indexed by tile color in 1862. Fixes that.
* Bug with sometimes ignoring a bid of 0
* Use "Additional Warranties" if trains come with a warranty
* I missed a dup when "delayed" rusting trains owned by a player
* Add home hex markers back when restarting a corp
* Fix player value and liquidity
* Mergers had superfluous "major" in some of the descriptions and log messages.

This should be the last PR prior to going alpha.

New column:
![new_column](https://user-images.githubusercontent.com/8494213/118339350-d6d13280-b4d5-11eb-8df3-9db7e20c3085.png)
