### PR TITLE
[1840]  Added dividend for major corporations, track value for city and company bonus

### DIFF
--- a/assets/app/view/game/buy_companies.rb
+++ b/assets/app/view/game/buy_companies.rb
@@ -71,11 +71,17 @@ module View
       end
 
       def render_input
-        max_price = max_purchase_price(@corporation, @selected_company)
+        step = @game.round.step_for(@corporation, 'buy_company')
+        buyer = if step.respond_to?(:spender)
+                  step.spender(@corporation)
+                else
+                  @corporation
+                end
+        max_price = max_purchase_price(buyer, @selected_company)
 
         h(BuyValueInput, value: max_price, min_value: @selected_company.min_price,
                          max_value: max_price,
-                         size: @corporation.cash.to_s.size,
+                         size: buyer.cash.to_s.size,
                          selected_entity: @selected_company)
       end
 

--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -136,7 +136,7 @@ module View
       end
 
       def render_variable(entity)
-        max = (@step.variable_max(entity) / entity.total_shares).to_i
+        max = (@step.variable_max(entity) / @step.variable_share_multiplier(entity)).to_i
 
         input = h(:input,
                   props: {
@@ -145,20 +145,23 @@ module View
                     max: max,
                     type: 'number',
                     size: max.to_s.size,
+                    step: @step.variable_input_step,
                   })
 
         h(:div,
           [
             h(:h3, { style: { margin: '0.5rem 0 0.2rem 0' } }, 'Pay Dividends'),
             @step.help_str(max),
-            input,
-            h(:button, { on: { click: -> { create_dividend(input) } } }, 'Pay Dividend'),
+            h(:div, [
+              input,
+              h(:button, { on: { click: -> { create_dividend(input) } } }, 'Pay Dividend'),
+            ]),
             dividend_chart,
         ])
       end
 
       def create_dividend(input)
-        amount = input.JS['elm'].JS['value'].to_i * @step.current_entity.total_shares
+        amount = input.JS['elm'].JS['value'].to_i * @step.variable_share_multiplier(@step.current_entity)
         process_action(Engine::Action::Dividend.new(@step.current_entity, kind: 'variable', amount: amount))
       end
 

--- a/lib/engine/game/g_1840/entities.rb
+++ b/lib/engine/game/g_1840/entities.rb
@@ -103,7 +103,7 @@ module Engine
                   price: 500,
                 },
                 {
-                  name: 'Pi2',
+                  name: 'Pi3',
                   price: 400,
                 },
               ],

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -199,6 +199,7 @@ module Engine
           @or = 0
           @active_maintainance_cost = {}
           @player_debts = Hash.new { |h, k| h[k] = 0 }
+          @last_revenue = Hash.new { |h, k| h[k] = 0 }
           @all_tram_corporations = @corporations.select { |item| item.type == :minor }
           @tram_corporations = @all_tram_corporations.reject { |item| item.id == '2' }.sort_by do
             rand
@@ -509,9 +510,19 @@ module Engine
         end
 
         def status_str(corporation)
-          return if corporation.type != :minor
+          return "Maintenance: #{format_currency(maintenance_costs(corporation))}" if corporation.type == :minor
 
-          "Maintenance: #{format_currency(maintenance_costs(corporation))}"
+          return 'Revenue' if corporation.type == :major
+        end
+
+        def status_array(corporation)
+          return if corporation.type != :major
+
+          elements = []
+          elements << "Last: #{format_currency(@last_revenue[corporation])}"
+          elements << "Next: #{format_currency(major_revenue(corporation))}"
+
+          elements
         end
 
         def maintenance_costs(corporation)
@@ -588,6 +599,10 @@ module Engine
             ['1500 - 2490', '6 →'],
             ['2500+', '7 →'],
           ]
+        end
+
+        def update_last_revenue(entity)
+          @last_revenue[entity] = major_revenue(entity)
         end
       end
     end

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -570,6 +570,25 @@ module Engine
 
           @graph
         end
+
+        def major_revenue(corporation)
+          corporate_card_minors(corporation).sum(&:cash)
+        end
+
+        def price_movement_chart
+          [
+            ['Dividend', 'Share Price Change'],
+            ['0', '1 ←'],
+            ['10 - 90', 'none'],
+            ['100 - 190', '1 →'],
+            ['200 - 390', '2 →'],
+            ['400 - 590', '3 →'],
+            ['600 - 990', '4 →'],
+            ['1000 - 1490', '5 →'],
+            ['1500 - 2490', '6 →'],
+            ['2500+', '7 →'],
+          ]
+        end
       end
     end
   end

--- a/lib/engine/game/g_1840/round/line_operating.rb
+++ b/lib/engine/game/g_1840/round/line_operating.rb
@@ -23,7 +23,7 @@ module Engine
             entity = @entities[@entity_index]
             if action.is_a?(Engine::Action::RunRoutes) && !action.routes.empty?
               process_action(Engine::Action::Dividend.new(entity,
-                                                          kind: 'payout'))
+                                                          kind: 'withhold'))
             end
             super
           end

--- a/lib/engine/game/g_1840/step/buy_company.rb
+++ b/lib/engine/game/g_1840/step/buy_company.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_company'
+
+module Engine
+  module Game
+    module G1840
+      module Step
+        class BuyCompany < Engine::Step::BuyCompany
+          def spender(entity)
+            @game.owning_major_corporation(entity)
+          end
+
+          def process_buy_company(action)
+            entity = @game.owning_major_corporation(action.entity)
+            company = action.company
+            price = action.price
+            owner = company.owner
+
+            min = company.min_price
+            max = company.max_price
+            unless price.between?(min, max)
+              raise GameError, "Price must be between #{@game.format_currency(min)} and #{@game.format_currency(max)}"
+            end
+
+            log_later = []
+            company.owner = entity
+            owner&.companies&.delete(company)
+
+            @round.just_sold_company = company
+            @round.company_sellers[company] = owner
+
+            entity.companies << company
+            pay(entity, owner, price, company)
+
+            log_later.each { |l| @log << l }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -95,9 +95,28 @@ module Engine
           def corp_dividend_options(entity, amount = 0)
             dividend_types.map do |type|
               payout = send(type, entity, amount)
-              payout[:divs_to_corporation] = 0
-              [type, payout.merge(share_price_change(entity, amount - payout[:corporation]))]
+              [type, payout.merge(share_price_change(entity, amount))]
             end.to_h
+          end
+
+          def share_price_change(entity, revenue = 0)
+            return {} if entity.minor?
+
+            return { share_direction: :left, share_times: 1 } if revenue.zero?
+
+            times = 0
+            times = 1 if revenue >= 100 && revenue <= 190
+            times = 2 if revenue >= 200 && revenue <= 390
+            times = 3 if revenue >= 499 && revenue <= 590
+            times = 4 if revenue >= 600 && revenue <= 990
+            times = 5 if revenue >= 1000 && revenue <= 1490
+            times = 6 if revenue >= 1500 && revenue <= 2490
+            times = 7 if revenue >= 2500
+            if times.positive?
+              { share_direction: :right, share_times: times }
+            else
+              {}
+            end
           end
 
           def variable(entity, amount)

--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -59,12 +59,15 @@ module Engine
           end
 
           def corp_log_run_payout(entity, amount)
-            if amount.positive?
-              @log << "#{entity.name} pays out #{@game.format_currency(amount)}"
-              return
-            end
-            @log << "#{entity.name} does not pay out"
-            # TODO: Show leftover
+            withhold_value = @game.major_revenue(entity) - amount
+            text = if amount.positive?
+                     "#{entity.name} pays out #{@game.format_currency(amount)}"
+                   else
+                     "#{entity.name} does not pay out"
+                   end
+
+            text += " and withholds #{@game.format_currency(withhold_value)}" if withhold_value.positive?
+            @log << text
           end
 
           def corp_payout_shares(entity, amount)

--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -50,7 +50,7 @@ module Engine
             @round.routes = []
 
             corp_log_run_payout(entity, amount)
-            @game.corporate_card_minors(entity).each { |item| item.spend(item.cash, entity) }
+            @game.corporate_card_minors(entity).each { |item| item.spend(item.cash, entity, check_positive: false) }
 
             corp_payout_shares(entity, amount) if amount.positive?
 

--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -7,10 +7,126 @@ module Engine
     module G1840
       module Step
         class Dividend < Engine::Step::Dividend
+          DIVIDEND_TYPES = %i[payout variable withhold].freeze
+          def actions(entity)
+            return [] if entity.company?
+
+            if entity.type == :major
+              return [] if @game.major_revenue(entity).zero?
+
+              return ACTIONS
+            end
+
+            return [] if routes.empty?
+
+            ACTIONS
+          end
+
           def change_share_price(entity, payout)
             return if entity.type == :minor
 
             super
+          end
+
+          def process_dividend(action)
+            entity = action.entity
+
+            return super if entity.type == :minor || entity.type == :city
+
+            kind = action.kind.to_sym
+            amount = action.amount || 0
+            payout = corp_dividend_options(entity, amount)[kind]
+
+            raise GameError, "Amount must be multiples of #{variable_input_step}" if amount % variable_input_step != 0
+
+            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
+              routes,
+              action,
+              amount,
+              @round.laid_hexes
+            )
+
+            @round.routes = []
+
+            corp_log_run_payout(entity, amount)
+            @game.corporate_card_minors(entity).each { |item| item.spend(item.cash, entity) }
+
+            corp_payout_shares(entity, amount) if amount.positive?
+
+            change_share_price(entity, payout)
+
+            pass!
+          end
+
+          def corp_log_run_payout(entity, amount)
+            if amount.positive?
+              @log << "#{entity.name} pays out #{@game.format_currency(amount)}"
+              return
+            end
+            @log << "#{entity.name} does not pay out"
+            # TODO: Show leftover
+          end
+
+          def corp_payout_shares(entity, amount)
+            per_share = payout_per_share(entity, amount)
+
+            payouts = {}
+            @game.players.each do |payee|
+              corp_payout_entity(entity, payee, per_share, payouts)
+            end
+
+            receivers = payouts
+              .sort_by { |_r, c| -c }
+              .map { |receiver, cash| "#{@game.format_currency(cash)} to #{receiver.name}" }.join(', ')
+
+            @log << "#{entity.name} pays out #{@game.format_currency(amount)} = "\
+              "#{@game.format_currency(per_share)} (#{receivers})"
+          end
+
+          def corp_payout_entity(entity, holder, per_share, payouts, receiver = nil)
+            amount = dividends_for_entity(entity, holder, per_share)
+            return if amount.zero?
+
+            receiver ||= holder
+            payouts[receiver] = amount
+            entity.spend(amount, receiver, check_positive: false)
+          end
+
+          def corp_dividend_options(entity, amount = 0)
+            dividend_types.map do |type|
+              payout = send(type, entity, amount)
+              payout[:divs_to_corporation] = 0
+              [type, payout.merge(share_price_change(entity, amount - payout[:corporation]))]
+            end.to_h
+          end
+
+          def variable(entity, amount)
+            { corporation: 0, per_share: payout_per_share(entity, amount) }
+          end
+
+          def min_increment
+            10
+          end
+
+          def variable_max(entity)
+            @game.major_revenue(entity)
+          end
+
+          def help_str(max)
+            "Select dividend to distribute to shareholders, between #{@game.format_currency(0)}"\
+            " and #{@game.format_currency(max)}. Leftover will be withholded to corporation."
+          end
+
+          def chart
+            @game.price_movement_chart
+          end
+
+          def variable_share_multiplier(_corporation)
+            1
+          end
+
+          def variable_input_step
+            10
           end
         end
       end

--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -46,6 +46,7 @@ module Engine
               @round.laid_hexes
             )
 
+            @game.update_last_revenue(entity)
             @round.routes = []
 
             corp_log_run_payout(entity, amount)

--- a/lib/engine/game/g_1840/step/route.rb
+++ b/lib/engine/game/g_1840/step/route.rb
@@ -12,6 +12,10 @@ module Engine
 
             super
           end
+
+          def log_skip(entity)
+            @log << "#{entity.name} skips #{description.downcase}" unless entity.type == :major
+          end
         end
       end
     end

--- a/lib/engine/game/g_1840/step/track_and_token.rb
+++ b/lib/engine/game/g_1840/step/track_and_token.rb
@@ -63,7 +63,7 @@ module Engine
           def available_hex(entity, hex)
             return @game.graph.reachable_hexes(entity)[hex] unless can_lay_tile?(entity, hex)
             return !@orange_placed if @game.orange_framed?(hex.tile)
-            return @game.graph.connected_hexes(entity)[hex] if @normal_placed
+            return @game.graph.connected_nodes(entity)[hex] if @normal_placed
 
             super
           end

--- a/lib/engine/game/g_18_mag/step/dividend.rb
+++ b/lib/engine/game/g_18_mag/step/dividend.rb
@@ -175,6 +175,14 @@ module Engine
           def chart
             @game.price_movement_chart
           end
+
+          def variable_share_multiplier(corporation)
+            corporation.total_shares
+          end
+
+          def variable_input_step
+            1
+          end
         end
       end
     end


### PR DESCRIPTION
This adds the dividend handling for major corporations, track handling for city trains (can run through tokened cities, but does not pay), and private companies (can be bought by owning major corporation and give bonus to all lines of major corporation)

This build up on the variable dividend from 18Mag, but a litle bit different. That's why I added some step methods to the view to make some parameters variable.

@roseundy can you look at the changes for 18Mag. I tested it and everything behaves as before, but a second look might not hurt.  