### PR TITLE
1828: Allow player to retain soon-to-be system share and trade for a system share from another

### DIFF
--- a/lib/engine/game/g_1828/step/merger.rb
+++ b/lib/engine/game/g_1828/step/merger.rb
@@ -326,15 +326,10 @@ module Engine
             merger_share = entity.shares_of(@merger).reject(&:president).first
             target_share = entity.shares_of(@target).reject(&:president).first
 
-            num_system_shares = total_shares / 2
             if @player_selection
               @odd_share = @player_selection.include?(@merger.name) ? merger_share : target_share
               @player_selection = nil
-            elsif !merger_share || entity.num_shares_of(@merger) <= num_system_shares
-              @odd_share = target_share
-            elsif !target_share
-              @odd_share = merger_share
-            elsif entity.player?
+            elsif entity.player? && merger_share && target_share
               choices = merging_corporations.map do |c|
                 "#{c.name} (#{@game.format_currency(c.share_price.price)})"
               end
@@ -343,7 +338,7 @@ module Engine
                                                 choices: choices)
               nil
             else
-              @odd_share = entity.shares_of(@merger).first
+              @odd_share = merger_share || target_share
             end
           end
 


### PR DESCRIPTION
Ruling from JC. If you have an odd number of shares to trade, you can retain a share that will become a system share, even if you don't have enough other soon-to-be system shares. The player can get the other system share from another source.

Situation
GT merging into PR
P1: 2 PRR, 3 GT

Before:
P1 was forced to hold on to the GT share because the 2 PRRs are needed in the 2:1 exchange as they will become system shares

After:
P1 can keep 1 PRR share as the odd share. The first system share comes from combining a PRR and a GT. The second system share comes from a trade of a GT share for a PRR share from another source. The original PRR share is retained for the single share exchange step.