### PR TITLE
1862: more play-though fixes

### DIFF
--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -636,7 +636,7 @@ module Engine
         end
 
         def ready_corporations
-          @offer_order.select { |corp| available_to_start?(corp) }
+          @offer_order.select { |corp| available_to_start?(corp) | corp.ipoed }
         end
 
         def available_to_start?(corporation)
@@ -1098,8 +1098,8 @@ module Engine
           status = []
           status << %w[Receivership bold] if corp.receivership?
           status << %w[Chartered bold] if @chartered[corp]
-          status << ["Phase available: #{start_phase}"] unless @phase.available?(start_phase)
-          status << ['Cannot start'] if @phase.available?(start_phase) && !legal_to_start?(corp)
+          status << ["Phase available: #{start_phase}"] if !@phase.available?(start_phase) && !corp.ipoed
+          status << ['Cannot start'] if @phase.available?(start_phase) && !legal_to_start?(corp) && !corp.ipoed
           status << ["Permits: #{@permits[corp].map(&:to_s).join(',')}"]
           status
         end
@@ -1554,7 +1554,7 @@ module Engine
           check_london(visits)
 
           return super if train_type(route.train) != :freight
-          return if (distance = route.train.distance) >= hex_route_distance(route)
+          return if route.train.distance >= (distance = hex_route_distance(route))
 
           raise GameError, "#{distance} is too many hexes for a #{route.train.name} train"
         end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1081,6 +1081,9 @@ module Engine
           # move cash to bank
           corp.spend(corp.cash, @bank) if corp.cash.positive?
 
+          # remove tokens from map
+          corp.tokens.each(&:remove!)
+
           # make it available to restart
           restart_corporation!(corp)
 


### PR DESCRIPTION
* Remove tokens from map on bankruptcy
* Fix problem with stock purchases being blocked after LNER formation
* Re-sort shares after merger/bankruptcy
* Start with all companies IPO stock in bank
* Remove unstartable corps after LNER formation
* Keep chartered flag when merging two chartered corps (only needed for solo rules)