### PR TITLE
[1840] Made scrapping view more generic and added to route step

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -144,13 +144,6 @@ module View
           children << send("render_#{view}")
         end
 
-        scrappable_trains = []
-        scrappable_trains = step.scrappable_trains(@corporation) if step.respond_to?(:scrappable_trains)
-        unless scrappable_trains.empty?
-          children << h(:h3, 'Trains to Scrap')
-          children << h(:div, div_props, scrap_trains(scrappable_trains))
-        end
-
         discountable_trains = @game.discountable_trains_for(@corporation)
 
         if discountable_trains.any? && step.discountable_trains_allowed?(@corporation)
@@ -406,23 +399,6 @@ module View
       def other_owner(other)
         step = @game.round.active_step
         step.respond_to?(:real_owner) ? step.real_owner(other) : other.owner
-      end
-
-      def scrap_trains(scrappable_trains)
-        step = @game.round.active_step
-        scrappable_trains.flat_map do |train|
-          scrap = lambda do
-            process_action(Engine::Action::ScrapTrain.new(
-              @corporation,
-              train: train,
-            ))
-          end
-
-          [h(:div, train.name),
-           h('div.nowrap', train.owner.name),
-           h('div.right', step.scrap_info(train)),
-           h('button.no_margin', { on: { click: scrap } }, step.scrap_button_text(train))]
-        end
       end
 
       def price_range(train)

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -40,7 +40,7 @@ module View
           left << h(Convert) if @current_actions.include?('convert')
           left << h(SwitchTrains) if @current_actions.include?('switch_trains')
           left << h(ReassignTrains) if @current_actions.include?('reassign_trains')
-          if @current_actions.include?('buy_train') || @current_actions.include?('scrap_train')
+          if @current_actions.include?('buy_train')
             left << h(IssueShares) if @current_actions.include?('sell_shares')
             left << h(BuyTrains)
           elsif @current_actions.include?('borrow_train')
@@ -65,6 +65,7 @@ module View
           elsif @current_actions.include?('buy_corporation')
             left << h(BuyCorporation)
           end
+          left << h(ScrapTrains) if @current_actions.include?('scrap_train')
           left << h(Loans, corporation: entity) if (%w[take_loan payoff_loan] & @current_actions).any?
 
           if entity.player?

--- a/assets/app/view/game/scrap_trains.rb
+++ b/assets/app/view/game/scrap_trains.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+
+module View
+  module Game
+    class ScrapTrains < Snabberb::Component
+      include Actionable
+
+      def render
+        @corporation = @game.round.active_step.current_entity
+        step = @game.round.active_step
+
+        scrappable_trains = step.scrappable_trains(@corporation)
+        return nil if scrappable_trains.empty?
+
+        div_props = {
+          style: {
+            display: 'grid',
+            grid: 'auto / minmax(0.7rem, auto) 1fr auto auto',
+            gap: '0.5rem',
+            alignItems: 'center',
+          },
+        }
+
+        h(:div, [
+          h(:h3, 'Trains to Scrap'),
+          h(:div, div_props, scrap_trains(scrappable_trains)),
+        ])
+      end
+
+      def scrap_trains(scrappable_trains)
+        step = @game.round.active_step
+        scrappable_trains.flat_map do |train|
+          scrap = lambda do
+            process_action(Engine::Action::ScrapTrain.new(
+              @corporation,
+              train: train,
+            ))
+          end
+
+          [h(:div, train.name),
+           h('div.nowrap', train.owner.name),
+           h('div.right', step.scrap_info(train)),
+           h('button.no_margin', { on: { click: scrap } }, step.scrap_button_text(train))]
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -332,7 +332,7 @@ module Engine
             G1840::Step::BuyCompany,
             Engine::Step::HomeToken,
             G1840::Step::TrackAndToken,
-            Engine::Step::Route,
+            G1840::Step::Route,
             G1840::Step::Dividend,
             [G1840::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
@@ -636,6 +636,18 @@ module Engine
           return if route.corporation.type == :city
 
           super
+        end
+
+        def scrappable_trains(entity)
+          corporate_card_minors(entity).flat_map(&:trains) + entity.trains
+        end
+
+        def scrap_info(train)
+          "Maintenance: #{format_currency(train_maintenance(train.sym))}"
+        end
+
+        def scrap_button_text
+          'Scrap'
         end
       end
     end

--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -31,22 +31,19 @@ module Engine
           end
 
           def scrappable_trains(entity)
-            @game.corporate_card_minors(entity).flat_map(&:trains) + entity.trains
+            @game.scrappable_trains(entity)
           end
 
           def scrap_info(train)
-            "Maintenance: #{@game.format_currency(@game.train_maintenance(train.sym))}"
+            @game.scrap_info(train)
           end
 
           def scrap_button_text(_train)
-            'Scrap'
+            @game.scrap_button_text
           end
 
           def process_scrap_train(action)
-            entity = action.entity
-            train = action.train
-
-            @game.scrap_train(train, entity)
+            @game.scrap_train(action.train, action.entity)
           end
 
           def must_buy_train?(entity)

--- a/lib/engine/game/g_1840/step/route.rb
+++ b/lib/engine/game/g_1840/step/route.rb
@@ -10,11 +10,32 @@ module Engine
           def actions(entity)
             return [] if !entity.corporation? || entity.type == :major
 
-            super
+            base = super
+
+            base << 'scrap_train' if entity.type == :minor && !entity.trains.empty?
+            base
           end
 
           def log_skip(entity)
             @log << "#{entity.name} skips #{description.downcase}" unless entity.type == :major
+          end
+
+          def scrappable_trains(entity)
+            return [] if entity.type != :minor
+
+            @game.scrappable_trains(entity)
+          end
+
+          def scrap_info(train)
+            @game.scrap_info(train)
+          end
+
+          def scrap_button_text(_train)
+            @game.scrap_button_text
+          end
+
+          def process_scrap_train(action)
+            @game.scrap_train(action.train, action.entity)
           end
         end
       end


### PR DESCRIPTION
In 1840 it is theoretically always possible to scrap a train. That is not so easy to implement, so I asked Lonny whats the minimum viable option. For now we can scrap trains when buying trains and in the route selection. That should probably be enough.

This PR extracts the scrap_train view to be an own component and can be shown independend of buy_train.

I tested with 1873 and looking at the logic in operating.rb it should behave nearly the same as before.