### PR TITLE
1862: full fix for clearing train operated flag on merge

### DIFF
--- a/lib/engine/game/g_1862/entities.rb
+++ b/lib/engine/game/g_1862/entities.rb
@@ -265,7 +265,7 @@ module Engine
           },
           {
             sym: 'WVR',
-            name: 'Waveney Vally Railway',
+            name: 'Waveney Valley Railway',
             logo: '1862/WVR',
             simple_logo: '1862/WVR.alt',
             float_percent: 50,

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -2123,12 +2123,10 @@ module Engine
           # cash
           nonsurvivor.spend(nonsurvivor.cash, survivor) if nonsurvivor.cash.positive?
           # trains
-          nonsurvivor.trains.each do |t|
-            t.owner = survivor
-            t.operated = false
-          end
+          nonsurvivor.trains.each { |t| t.owner = survivor }
           survivor.trains.concat(nonsurvivor.trains)
           nonsurvivor.trains.clear
+          survivor.trains.each { |t| t.operated = false }
           # permits
           @permits[survivor].concat(@permits[nonsurvivor])
           @permits[survivor].uniq!


### PR DESCRIPTION
Fixes #5392 

Also fixed typo in name of "Waveney Valley Railway"