### PR TITLE
1862: differentiate between permits types on markers on map

### DIFF
--- a/assets/app/view/game/part/large_icons.rb
+++ b/assets/app/view/game/part/large_icons.rb
@@ -115,24 +115,44 @@ module View
 
         def render_part
           children = @icons.map.with_index do |icon, index|
-            # large icons can have player colors
-            color = 'white'
+            # large icons can have player colors or shape decorations
             radius = LARGE_RADIUS
             adjust = 0
+
+            dx = (((index - (@icons.size - 1) / 2.0) * -DELTA_X) + LARGE_RADIUS).round(2)
+            dy = LARGE_RADIUS.round(2)
+            decor = h(:circle, attrs: { r: LARGE_RADIUS, fill: 'white', cx: dx, cy: dy })
+
             show_player_colors = setting_for(:show_player_colors, @game)
-            if show_player_colors && (owner = icon&.owner) && @game.players.include?(owner)
+            if (decoration = @game.decorate_marker(icon))
+              color = decoration[:color]
+              case decoration[:shape]
+              when :circle
+                radius -= 4
+                adjust = 4
+                decor = h(:circle, attrs: { r: LARGE_RADIUS, fill: color, cx: dx, cy: dy })
+              when :diamond
+                radius -= 4
+                adjust = 4
+                size = LARGE_RADIUS - 4
+                decor = h(:polygon, attrs: { points: diamond_points(size, dx, dy), fill: color })
+              else # hexagon
+                radius -= 2
+                adjust = 2
+                decor = h(:polygon, attrs: { points: hex_points(LARGE_RADIUS, dx, dy), fill: color })
+              end
+            elsif show_player_colors && (owner = icon&.owner) && @game.players.include?(owner)
               color = player_colors(@game.players)[owner]
               radius -= 4
               adjust = 4
+              decor = h(:circle, attrs: { r: LARGE_RADIUS, fill: color, cx: dx, cy: dy })
             end
 
             icon_x_pos = ((index - (@icons.size - 1) / 2.0) * -DELTA_X + adjust).round(2)
             icon_y_pos = adjust.round(2)
-            ring_x_pos = (((index - (@icons.size - 1) / 2.0) * -DELTA_X) + LARGE_RADIUS).round(2)
-            ring_y_pos = LARGE_RADIUS.round(2)
 
             h(:g, [
-              h(:circle, attrs: { r: LARGE_RADIUS, fill: color, cx: ring_x_pos, cy: ring_y_pos }),
+              decor,
               h(:image,
                 attrs: {
                   href: icon.image,
@@ -141,12 +161,32 @@ module View
                   width: "#{radius * 2}px",
                   height: "#{radius * 2}px",
                 }),
-            ])
+            ].compact)
           end
 
           h(:g, { attrs: { transform: "#{rotation_for_layout} translate(#{-LARGE_RADIUS} #{-LARGE_RADIUS})" } }, [
               h(:g, { attrs: { transform: translate } }, children),
             ])
+        end
+
+        def diamond_points(r, cx, cy)
+          s = r * Math.sqrt(2.0)
+          "#{(cx - s).round(2)},#{cy.round(2)} "\
+            "#{cx.round(2)},#{(cy - s).round(2)} "\
+            "#{(cx + s).round(2)},#{cy.round(2)} "\
+            "#{cx.round(2)},#{(cy + s).round(2)}"
+        end
+
+        def hex_points(r, cx, cy)
+          s = r * 2 / Math.sqrt(3.0)
+          f60 = Math.sin(60 / 180 * Math::PI)
+          f30 = Math.sin(30 / 180 * Math::PI)
+          "#{(cx - s).round(2)},#{cy.round(2)} "\
+            "#{(cx - s * f30).round(2)},#{(cy - s * f60).round(2)} "\
+            "#{(cx + s * f30).round(2)},#{(cy - s * f60).round(2)} "\
+            "#{(cx + s).round(2)},#{cy.round(2)} "\
+            "#{(cx + s * f30).round(2)},#{(cy + s * f60).round(2)} "\
+            "#{(cx - s * f30).round(2)},#{(cy + s * f60).round(2)}"
         end
       end
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2524,6 +2524,10 @@ module Engine
       def separate_treasury?
         false
       end
+
+      def decorate_marker(_icon)
+        nil
+      end
     end
   end
 end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -613,7 +613,7 @@ module Engine
         def add_marker(corporation)
           hex = @hexes.find { |h| h.id == corporation.coordinates } # hex_by_id doesn't work here
           image = "1862/#{corporation.id}".upcase.delete('&')
-          marker = Part::Icon.new(image, nil, true, nil, hex.tile.preprinted, large: true, owner: nil)
+          marker = Part::Icon.new(image, nil, true, nil, hex.tile.preprinted, large: true, owner: corporation)
           hex.tile.icons << marker
         end
 
@@ -2319,6 +2319,21 @@ module Engine
 
         def liquidity(player)
           player_value(player)
+        end
+
+        def decorate_marker(icon)
+          return nil if !(corporation = icon.owner) || !icon.owner.corporation?
+
+          color = available_to_start?(corporation) ? 'white' : 'black'
+          shape = case @permits[corporation]&.first
+                  when :local
+                    :diamond
+                  when :express
+                    :circle
+                  else
+                    :hexagon
+                  end
+          { color: color, shape: shape }
         end
       end
     end


### PR DESCRIPTION
Corp markers (large icons) on map now indicate the type of permit and whether they are available to start.

![markers](https://user-images.githubusercontent.com/8494213/118740248-9ab90d00-b808-11eb-82f8-9501c5f46054.png)
