### PR TITLE
Misc corrections for 1893

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -42,6 +42,8 @@ These attributes may be set for all ability types
       used with `close` abilities
     - `owning_corp_or_turn`: usable at any point during the owning corporation's OR turn
     - `owning_player_or_turn`: usable at any point during any of the owning player's OR turns
+    - `owning_player_sr_turn`: usable at any point during any of the owning player's
+    SR turns
     - `or_between_turns`: usable at the start of any corporation's OR turn,
       before that corporation has acted
     - `stock_round`: usable any time during a Stock Round

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2468,6 +2468,8 @@ module Engine
             @round.operating? && @round.current_operator == ability.corporation
           when 'owning_player_or_turn'
             @round.operating? && @round.current_operator.player == ability.player
+          when 'owning_player_sr_turn'
+            @round.stock? && @round.current_entity == ability.player
           when 'or_between_turns'
             @round.operating? && !@round.current_operator_acted
           when 'or_start'

--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -366,7 +366,7 @@ module Engine
                     discount: { '3' => 90, '4' => 150 },
                     events: [{ 'type' => 'agv_founded' },
                              { 'type' => 'hgk_buyable' },
-                             { 'type' => 'bonds_exchanged' }],
+                             { 'type' => 'fdsd_closed' }],
                   },
                   {
                     name: '6',
@@ -392,8 +392,25 @@ module Engine
             name: 'Fond der Stadt Düsseldorf',
             value: 190,
             revenue: 20,
-            desc: 'May be exchanged against 20% shares of the Rheinbahn AG. This private cannot be sold.',
-            abilities: [{ type: 'no_buy', owner_type: 'player' }],
+            desc: 'May be exchanged against 20% shares of the Rheinbahn AG in an SR (except the first one). '\
+              'If less than 20% remains in the market the exchange will be what remains. May also be exchanged '\
+              'to par RAG in which case the private is exchanged for the 20% presidency share. '\
+              'FdSD is closed either due to the exchange or if FdSD has not been exchanged to do an exchange '\
+              'after the first SR of phase 5. An exchange is handled as a Buy action. This private '\
+              'cannot be sold.',
+            abilities: [
+              {
+                type: 'no_buy',
+                owner_type: 'player',
+              },
+              {
+                type: 'exchange',
+                corporations: ['RAG'],
+                owner_type: 'player',
+                when: 'owning_player_sr_turn',
+                from: %w[ipo market],
+              },
+            ],
             color: nil,
           },
           {
@@ -401,7 +418,8 @@ module Engine
             name: 'Eisenbahnverkehrsmittel Aktiengesellschaft',
             value: 150,
             revenue: 30,
-            desc: 'Leaves the game after the purchase of the first 6-train. This private cannot be sold.',
+            desc: 'Leaves the game after the purchase of the first 6-train. This private cannot be sold to '\
+              'any corporation.',
             abilities: [{ type: 'no_buy', owner_type: 'player' }],
             color: nil,
           },
@@ -644,12 +662,12 @@ module Engine
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
           'remove_tile_block' => ['Remove tile block', 'Rhine may be passed. N5 P5 becomes possible to lay tiles in'],
           'agv_buyable' => ['AGV buyable', 'AGV shares can be bought in the stockmarket'],
-          'agv_founded' => ['AGV founded', 'AGV is automatically founded in next Merge Round if not yet founded'],
+          'agv_founded' => ['AGV founded', 'AGV is automatically founded in next Merge Round'],
           'hgk_buyable' => ['HGK buyable', 'HGK shares can be bought in the stockmarket'],
-          'hgk_founded' => ['HGK founded', 'HGK is automatically founded in next Merge Round if not yet founded'],
-          'bonds_exchanged' => ['FdSD exchanged', 'Any remaining Fond der Stadt Düsseldorf bonds must be exchanged '\
-              'during next Stock Round'],
-          'eva_closed' => ['EVA closed', 'EVA Is closed']
+          'hgk_founded' => ['HGK founded', 'HGK is automatically founded in next Merge Round'],
+          'fdsd_closed' => ['FdSD closed at end of SR', 'Fond der Stadt Düsseldorf is closed at end of next'\
+              'Stock Round'],
+          'eva_closed' => ['EVA closed', 'EVA is closed']
         ).freeze
 
         STATUS_TEXT = Base::STATUS_TEXT.merge(
@@ -1166,8 +1184,8 @@ module Engine
           owner.shares_of(corporation).select { |s| s.percent == 20 }
         end
 
-        def event_bonds_exchanged!
-          @log << 'NOT IMPLEMENTED - bonds exchanged'
+        def event_fdsd_closed!
+          @log << 'NOT IMPLEMENTED - FdSD closed'
         end
 
         def event_eva_closed!

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -59,6 +59,11 @@ module Engine
             @game.passers_first_stock_round.include?(entity)
           end
 
+          def get_par_prices(_entity, _corporation)
+            # Exclude 120 par - these are just as starts for AGV/HGK
+            super.reject { |p| p.price == 120 }
+          end
+
           def process_pass(action)
             @game.passers_first_stock_round << action.entity if @game.turn == 1
             super

--- a/lib/engine/game/g_1893/step/par_and_buy_actions.rb
+++ b/lib/engine/game/g_1893/step/par_and_buy_actions.rb
@@ -13,11 +13,20 @@ module ParAndBuy
   end
 
   def process_buy_shares(action)
+    entity = action.entity
+    return exchange_for_rag(action, entity) if entity.company?
+
     # In case president's share is reserved, do not change presidency
-    allow_president_change = action.bundle.corporation.presidents_share.buyable
+    allow_president_change = corporation.presidents_share.buyable
     buy_shares(action.entity, action.bundle, swap: action.swap, allow_president_change: allow_president_change)
-    track_action(action, action.bundle.corporation)
+    track_action(action, corporation)
     @round.last_to_act = action.entity
+    @round.current_actions << action
+  end
+
+  def exchange_for_rag(action, entity)
+    buy_shares(entity.player, action.bundle, exchange: true, exchange_price: 0)
+    @round.last_to_act = entity.player
     @round.current_actions << action
   end
 end


### PR DESCRIPTION
1. Add a 'when' attribute for using private in SR
2. Update description on 3 events
3. Par 120 not allowed via stockmarket
4. Prepare FdsD-RAG exchange (not complete yet)