### PR TITLE
1862: change freight route distance calc; add alt logos

### DIFF
--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1580,30 +1580,14 @@ module Engine
           false
         end
 
-        # adjust end of set of routes to neighbor node if end is an offboard
-        def adjust_end(set, setend)
-          return setend unless setend.offboard?
-
-          # find route in set that has this end
-          end_route = set.find { |r| r.visited_stops.include?(setend) }
-          # find chain in route that has this end
-          end_chain = end_route.chains.find { |c| c[:nodes].include?(setend) }
-          # return other node in chain
-          end_chain[:nodes].find { |n| n != setend }
-        end
-
         # from https://www.redblobgames.com/grids/hexagons
         def doubleheight_coordinates(hex)
           [hex.id[0].ord - 'A'.ord, hex.id[1..-1].to_i]
         end
 
         # given a freight route set, find number of intervening hexes
-        # between ends. If an end is an offboard, calculate distance as if end
-        # is last hex before offboard and add 1
-        def hex_crow_distance(set, setend_a, setend_b)
-          end_a = adjust_end(set, setend_a)
-          end_b = adjust_end(set, setend_b)
-
+        # between ends.
+        def hex_crow_distance(_set, end_a, end_b)
           x_a, y_a = doubleheight_coordinates(end_a.hex)
           x_b, y_b = doubleheight_coordinates(end_b.hex)
 
@@ -1611,11 +1595,7 @@ module Engine
           # this game essentially uses double-height coordinates
           dx = (x_a - x_b).abs
           dy = (y_a - y_b).abs
-          distance = end_a == end_b ? -1 : [0, dx + [0, (dy - dx) / 2].max - 1].max
-
-          # adjust for offboards
-          distance += 1 if end_a != setend_a
-          distance += 1 if end_b != setend_b
+          distance = [0, dx + [0, (dy - dx) / 2].max - 1].max
 
           [0, distance].max
         end

--- a/public/logos/1862/ECR.alt.svg
+++ b/public/logos/1862/ECR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="#0a1172"/><text x="4" y="5.0999999" fill="#ffffff" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">ECR</text></svg>

--- a/public/logos/1862/EH.alt.svg
+++ b/public/logos/1862/EH.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff0"/><text x="4" y="5.0999999" fill="#a35215" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">E&amp;H</text></g></svg>

--- a/public/logos/1862/ENR.alt.svg
+++ b/public/logos/1862/ENR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff0"/><text x="4" y="5.0999999" fill="#0492c2" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">ENR</text></g></svg>

--- a/public/logos/1862/ESR.alt.svg
+++ b/public/logos/1862/ESR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#5dbb63"/><text x="4" y="5.0999999" fill="#30430f" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">ESR</text></g></svg>

--- a/public/logos/1862/EUR.alt.svg
+++ b/public/logos/1862/EUR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff3030"/><text x="4" y="5.0999999" fill="#710193" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">EUR</text></g></svg>

--- a/public/logos/1862/FDR.alt.svg
+++ b/public/logos/1862/FDR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff6a06"/><text x="4" y="5.0999999" fill="#c0000f" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">FDR</text></g></svg>

--- a/public/logos/1862/IB.alt.svg
+++ b/public/logos/1862/IB.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#a0a0a0"/><text x="4" y="5.0999999" fill="#000000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">I&amp;B</text></g></svg>

--- a/public/logos/1862/LD.alt.svg
+++ b/public/logos/1862/LD.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff6a06"/><text x="4" y="5.0999999" fill="#0a1172" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">L&amp;D</text></g></svg>

--- a/public/logos/1862/LE.alt.svg
+++ b/public/logos/1862/LE.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff0"/><text x="4" y="5.0999999" fill="#d0000f" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">L&amp;E</text></g></svg>

--- a/public/logos/1862/LH.alt.svg
+++ b/public/logos/1862/LH.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#a1caf1"/><text x="4" y="5.0999999" fill="#b00000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">L&amp;H</text></g></svg>

--- a/public/logos/1862/NB.alt.svg
+++ b/public/logos/1862/NB.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="#c0c0c0"/><text x="4" y="5.0999999" fill="#b64900" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">N&amp;B</text></svg>

--- a/public/logos/1862/NE.alt.svg
+++ b/public/logos/1862/NE.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#c0c0c0"/><text x="4" y="5.0999999" fill="#355e3b" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">N&amp;E</text></g></svg>

--- a/public/logos/1862/NGC.alt.svg
+++ b/public/logos/1862/NGC.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff0"/><text x="4" y="5.0999999" fill="#000000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">NGC</text></g></svg>

--- a/public/logos/1862/NS.alt.svg
+++ b/public/logos/1862/NS.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#a1caf1"/><text x="4" y="5.0999999" fill="#082567" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">N&amp;S</text></g></svg>

--- a/public/logos/1862/SVR.alt.svg
+++ b/public/logos/1862/SVR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#d2b55b"/><text x="4" y="5.0999999" fill="#355e3b" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">SVR</text></g></svg>

--- a/public/logos/1862/WF.alt.svg
+++ b/public/logos/1862/WF.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#c7ea46"/><text x="4" y="5.0999999" fill="#0b6622" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">W&amp;F</text></g></svg>

--- a/public/logos/1862/WNR.alt.svg
+++ b/public/logos/1862/WNR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#d2b55b"/><text x="4" y="5.0999999" fill="#ff0000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">WNR</text></g></svg>

--- a/public/logos/1862/WSTI.alt.svg
+++ b/public/logos/1862/WSTI.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ff0"/><text x="4" y="5.0999999" fill="#8b008b" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">WStI</text></g></svg>

--- a/public/logos/1862/WVR.alt.svg
+++ b/public/logos/1862/WVR.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#ffc0c0"/><text x="4" y="5.0999999" fill="#8b008b" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">WVR</text></g></svg>

--- a/public/logos/1862/YN.alt.svg
+++ b/public/logos/1862/YN.alt.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><g><circle cx="4" cy="4" r="4" fill="#f00"/><text x="4" y="5.0999999" fill="#000000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" word-spacing="0px" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">Y&amp;N</text></g></svg>


### PR DESCRIPTION
Fixes #5379 

After some debate, simplified Freight route hex-distance bonus calculation:

![New_HexDist](https://user-images.githubusercontent.com/8494213/119043490-5481bc00-b976-11eb-8783-ca590d1381ef.png)
