### PR TITLE
1862: Fix Hudson manoeuvre; Obligations should not impact share limit

### DIFF
--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -418,8 +418,7 @@ module Engine
         SELL_AFTER = :any_time
         SELL_BUY_ORDER = :sell_buy
         MARKET_SHARE_LIMIT = 100
-        TRAIN_PRICE_MIN = 10
-        TRAIN_PRICE_MULTIPLE = 10
+        CERT_LIMIT_INCLUDES_PRIVATES = false
 
         TRACK_RESTRICTION = :permissive
 

--- a/lib/engine/game/g_1862/step/dividend.rb
+++ b/lib/engine/game/g_1862/step/dividend.rb
@@ -44,7 +44,7 @@ module Engine
           end
 
           def hudson_delta(entity, revenue)
-            entity.share_price.price - revenue
+            (entity.share_price.price - revenue).ceil(-1)
           end
 
           def hudson_allowed?(entity, revenue, subsidy)
@@ -79,6 +79,7 @@ module Engine
             subsidy = @game.routes_subsidy(routes)
             kind = action.kind.to_sym
             payout = dividend_options(entity)[kind]
+            revenue += hudson_delta(entity, revenue) if kind == :hudson
 
             handle_warranties!(entity)
 


### PR DESCRIPTION
Fixes #5418 
Fixes #5419 

Any game that used the Hudson Manoeuvre will likely need to be archived.