### PR TITLE
1862: make track semi-restrictive

### DIFF
--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -420,7 +420,7 @@ module Engine
         MARKET_SHARE_LIMIT = 100
         CERT_LIMIT_INCLUDES_PRIVATES = false
 
-        TRACK_RESTRICTION = :permissive
+        TRACK_RESTRICTION = :semi_restrictive
 
         SOLD_OUT_INCREASE = false
 


### PR DESCRIPTION
Fixes #5426 

Shouldn't need archiving since track restrictions are not checked when loading.