### PR TITLE
18AL: Change rule link (fixes #3536)

### DIFF
--- a/lib/engine/game/g_18_al/meta.rb
+++ b/lib/engine/game/g_18_al/meta.rb
@@ -13,7 +13,8 @@ module Engine
         GAME_DESIGNER = 'Mark Derrick'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18AL'
         GAME_LOCATION = 'Alabama, USA'
-        GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
+        # Does not load: GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/37924/18al-rules-v164-booklet'
 
         PLAYER_RANGE = [3, 5].freeze
         OPTIONAL_RULES = [


### PR DESCRIPTION
The previous link do no longer load. Use an A5 booklet version instead
from BGG.