### PR TITLE
[1862] Fix brown Harwich tile so it fits hex.

### DIFF
--- a/lib/engine/game/g_1862/map.rb
+++ b/lib/engine/game/g_1862/map.rb
@@ -331,7 +331,7 @@ module Engine
           {
             'count' => 1,
             'color' => 'brown',
-            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_0;label=H',
+            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:5,b:_0;label=H',
           },
           '798' => 3,
           '798_1' =>


### PR DESCRIPTION
Description of hex F13 (Harwich) has edges 134 blocked, so tile needs track on 025:
```
            F13
            ] => 'city=revenue:0;label=Y;border=edge:1,type:impassable;border=edge:3,type:impassable;'\
              'border=edge:4,type:impassable',
```