### PR TITLE
1862: add refinance as an option; add missing stock value

### DIFF
--- a/assets/app/view/game/convert.rb
+++ b/assets/app/view/game/convert.rb
@@ -19,7 +19,9 @@ module View
           on: { click: click },
         }
 
-        h(:div, [h('button', props, @game.round.active_step.description)])
+        step = @game.round.active_step
+        text = step.respond_to?(:convert_text) ? step.convert_text(@game.current_entity) : step.description
+        h(:div, [h('button', props, text)])
       end
     end
   end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -122,6 +122,7 @@ module Engine
              375i
              400j
              430j
+             460j
              495j
              530j
              570j


### PR DESCRIPTION
Fixes #5449 
Fixes #5453 

Modified UI::Convert to allow specifying text on button

Unlikely this will require archiving games. If it invalidates a lot of games, then something is wrong.