### PR TITLE
[1868WY] DTC Boomtown/Boom City effects and bonuses

### DIFF
--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -299,7 +299,7 @@ module View
           children << render_box(slots.size) if slots.size.between?(2, 6)
           children.concat(slots)
 
-          if @show_revenue && @city.paths.any? && (revenue = render_revenue)
+          if @show_revenue && @city&.paths&.any? && (revenue = render_revenue)
             children << revenue
           end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1745,6 +1745,12 @@ module Engine
         end
       end
 
+      def update_tile_lists(tile, old_tile)
+        add_extra_tile(tile) if tile.unlimited
+        @tiles.delete(tile)
+        @tiles << old_tile unless old_tile.preprinted
+      end
+
       private
 
       def init_graph

--- a/lib/engine/game/g_1868_wy/map.rb
+++ b/lib/engine/game/g_1868_wy/map.rb
@@ -443,6 +443,85 @@ module Engine
           },
         }.freeze
 
+        TILE_UPGRADES = {
+          # town + city -> city
+          'YG' => ['GG'],
+          'YL' => ['GL'],
+
+          # Brown Boomtown
+          '14b' => ['B5b'],
+          '15b' => ['B5b'],
+          '619b' => ['B5b'],
+
+          # Brown Boom City
+          '14B' => ['B5B'],
+          '15B' => ['B5B'],
+          '619B' => ['B5B'],
+
+          # Brown double Boomtown
+          '941a1' => ['B5bb'],
+          '941a2' => ['B5bb'],
+          '941a3' => ['B5bb'],
+          '942a1' => ['B5bb'],
+          '942a2' => ['B5bb'],
+          '942a3' => ['B5bb'],
+          '943a1' => ['B5bb'],
+          '943a2' => ['B5bb'],
+          '943a3' => ['B5bb'],
+          '944a1' => ['B5bb'],
+
+          # Brown Double Boom City
+          '941A1' => ['B5BB'],
+          '941A2' => ['B5BB'],
+          '941A3' => ['B5BB'],
+          '942A1' => ['B5BB'],
+          '942A2' => ['B5BB'],
+          '942A3' => ['B5BB'],
+          '943A1' => ['B5BB'],
+          '943A2' => ['B5BB'],
+          '943A3' => ['B5BB'],
+          '944A1' => ['B5BB'],
+
+          # Brown double Boomtown -> Gray double Boomtown
+          'B5bb' => ['5bb'],
+
+          # Brown Double Boom City -> Gray Double Boom City
+          'B5BB' => ['5BB'],
+        }.freeze
+
+        BOOMTOWN_TO_BOOMCITY_TILES = {
+          'Y5b' => %w[Y5B],
+          'Y6b' => %w[Y6B],
+          'Y57b' => %w[Y57B],
+          '961bb' => %w[961Bb 961bB],
+          '962bb' => %w[962Bb 962bB],
+          '963bb' => %w[963Bb 963bB],
+
+          '14b' => %w[14B],
+          '15b' => %w[15B],
+          '619b' => %w[619B],
+
+          '941a1' => %w[941A1],
+          '941a2' => %w[941A2],
+          '941a3' => %w[941A3],
+
+          '942a1' => %w[942A1],
+          '942a2' => %w[942A2],
+          '942a3' => %w[942A3],
+
+          '943a1' => %w[943A1],
+          '943a2' => %w[943A2],
+          '943a3' => %w[943A3],
+
+          '944a1' => %w[944A1],
+
+          'B5b' => %w[B5B],
+          'B5bb' => %w[B5BB],
+
+          '5b' => %w[5B],
+          '5bb' => %w[5BB],
+        }.freeze
+
         LOCATION_NAMES = {
           'A1' => 'Independence Creek',
           'A13' => 'Billings',
@@ -566,11 +645,11 @@ module Engine
             %w[B14 E15] => 'town=revenue:0,boom:1;upgrade=terrain:water,cost:20',
             %w[B24] => 'town=revenue:0,boom:1;upgrade=terrain:water,cost:10;upgrade=terrain:cow_skull,cost:10,size:40'\
                        'town=revenue:0,boom:1',
-            %w[C15] => 'town=revenue:0,boom:1;town=revenue:0,boom:1;upgrade=terrain:water,cost:20',
+            %w[C15] => 'town=revenue:0,boom:1,loc:4;town=revenue:0,boom:1,loc:1;upgrade=terrain:water,cost:20',
             %w[B16 C9 F18 F20 G19 L22 N18 N26] => 'upgrade=cost:60,terrain:mountain',
             %w[B18 D10 I5 I7 L24] => 'upgrade=cost:40,terrain:mountain',
             %w[M3 M19 M21] => 'upgrade=cost:30,terrain:mountain;town=revenue:0,boom:1',
-            %w[L4] => 'upgrade=cost:40,terrain:mountain;town=revenue:0,boom:1;town=revenue:0,boom:1',
+            %w[L4] => 'upgrade=cost:40,terrain:mountain;town=revenue:0,boom:1,loc:4;town=revenue:0,boom:1,loc:1',
             %w[I23] => 'city=revenue:0;label=C',
             %w[F8 H4 L26] => 'upgrade=cost:50,terrain:mountain',
             %w[L2 L10] => 'upgrade=cost:30,terrain:mountain',
@@ -578,7 +657,7 @@ module Engine
             %w[L20 M9] => 'upgrade=cost:20,terrain:mountain;upgrade=cost:20,terrain:water',
             %w[G9] => 'upgrade=cost:20,terrain:mountain;upgrade=cost:10,terrain:water;town=revenue:0',
             %w[G23] => 'upgrade=cost:20,terrain:mountain;town=revenue:0,boom:1',
-            %w[D26] => 'town=revenue:0,boom:1;town=revenue:0,boom:1',
+            %w[D26] => 'town=revenue:0,boom:1,loc:4;town=revenue:0,boom:1,loc:1',
             %w[F26] => 'upgrade=terrain:cow_skull,cost:10,size:40;town=revenue:0,boom:1',
             %w[F22] => 'upgrade=terrain:cow_skull,cost:10,size:40;upgrade=terrain:water,cost:10;town=revenue:0,boom:1',
             %w[I11] => 'city=revenue:0',
@@ -629,7 +708,8 @@ module Engine
                          'border=edge:2,type:mountain;border=edge:3,type:mountain',
             %w[K7] => 'upgrade=cost:20,terrain:mountain;upgrade=cost:10,terrain:water;'\
                       'border=edge:2,type:mountain;border=edge:3,type:mountain',
-            %w[K11] => 'upgrade=cost:20,terrain:cow_skull,size:40;town=revenue:0,boom:1;town=revenue:0,boom:1;'\
+            %w[K11] => 'upgrade=cost:20,terrain:cow_skull,size:40;'\
+                       'town=revenue:0,boom:1,loc:4;town=revenue:0,boom:1,loc:1;'\
                        'border=edge:2,type:mountain;border=edge:3,type:mountain',
             %w[K13] => 'upgrade=terrain:cow_skull,cost:20,size:40;'\
                        'border=edge:2,type:mountain;border=edge:3,type:mountain',

--- a/lib/engine/game/g_1868_wy/step/boom_track.rb
+++ b/lib/engine/game/g_1868_wy/step/boom_track.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/tracker'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class BoomTrack < Engine::Step::Base
+          include Engine::Step::Tracker
+
+          def description
+            'Boom Track'
+          end
+
+          def help
+            'Players who laid original track must resolve pending Boom City upgrades'
+          end
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] unless entity.minor?
+            return [] unless blocks?
+
+            ['lay_tile']
+          end
+
+          def process_lay_tile(action)
+            lay_tile(action, spender: @game.tile_layers[action.hex])
+            @game.postprocess_boom_lay_tile(action)
+          end
+
+          def blocks?
+            !@game.pending_boom_tile_lays.empty?
+          end
+
+          def can_lay_tile?(_entity)
+            blocks?
+          end
+
+          def available_hex(_entity, hex)
+            @game.pending_boom_tile_lays.key?(hex)
+          end
+
+          def potential_tiles(_entity, hex)
+            @game.pending_boom_tile_lays[hex] || []
+          end
+
+          def legal_tile_rotation?(_entity, hex, tile)
+            if @game.pending_boom_tile_lays[hex].include?(tile)
+              hex.tile.exits.sort == tile.exits.sort
+            else
+              false
+            end
+          end
+
+          def check_track_restrictions!(entity, old_tile, new_tile); end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/step/track.rb
+++ b/lib/engine/game/g_1868_wy/step/track.rb
@@ -25,6 +25,15 @@ module Engine
               @game.buying_power(entity).positive? &&
               @game.track_points_available(corporation) == (@game.class::YELLOW_POINT_COST - 1)
           end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            if (tile.name == @game.class::BROWN_DOUBLE_BOOMCITY_TILE) ||
+               ((upgrades = @game.class::TILE_UPGRADES[hex.tile.name]) && upgrades.include?(tile.name))
+              hex.tile.exits & tile.exits == hex.tile.exits
+            else
+              super
+            end
+          end
         end
       end
     end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -205,10 +205,7 @@ module Engine
       end
 
       def update_tile_lists(tile, old_tile)
-        @game.add_extra_tile(tile) if tile.unlimited
-
-        @game.tiles.delete(tile)
-        @game.tiles << old_tile unless old_tile.preprinted
+        @game.update_tile_lists(tile, old_tile)
       end
 
       def pay_tile_cost!(entity, tile, rotation, hex, spender, cost, _extra_cost)


### PR DESCRIPTION
General changes:

* move `Engine::Step::Tracker#update_tile_lists()` logic into a method on the
  `Game` class so it can be called from the `Game`, not just from the `Step`

1868 Wyoming-specific changes:

* add some locs to double Boomtown preprinted tiles to control which one becomes
  the Boom City

* when a hex's DTC (development token count) hits 3, 4, or 5, it Booms
    * 3: one Boomtown -> Boom City (tile replacement, or update preprinted tile)
    * 4: revenue increases by 10
    * 5: in brown Boom City -> Double Boom City (tile replacement; two slots);
         affects future upgrades for green tiles with one Boomtown and one Boom
         City
* when a Booming tile needs a replacement, it can't be done automatically if
  are multiple Boomtowns/Boom Cities on it, or if there are insufficient Gray
  tiles (other colors are unlimited, except for labeled tiles but
  those don't Boom)
    * use new `BoomTrack` step for manually resolving these tile lays
    * the player who placed the tile that is being upgraded is the one who
      chooses the Boom City tile
    * the tile naming convention allows for some shortcuts in tile logic, where
      names can be compared/manipulated instead of looking at the tile parts
        * "b" for Boomtown
        * "B" for Boom City
        * "a" for double Boomtown in Green
        * "A" for Boomtown+Boom City in Green
        * "bb" for double Boomtown in Yellow/Brown/Gray
        * "BB" for Double Boom City in Yellow/Brown/Gray
        * "Bb" or "bB" for Boomtown+Boom City in Yellow

* fix tile laying options for Boomtowns and Boom Cities vs standard towns
  and cities (i.e., don't allow Boomtown tiles on regular town hexes)

* use new `TILE_UPGRADES` constant in `map.rb` to explicitly list tile upgrades
  that bend the normal rules, rather than writing logic to handle the weird cases


[#5011]