### PR TITLE
1862: fix chartered corp treasury buys; check london connection for links

### DIFF
--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -29,7 +29,7 @@ module Engine
         include Entities
         include Map
 
-        attr_accessor :chartered, :base_tiles, :deferred_rust, :skip_round, :permits, :lner
+        attr_accessor :chartered, :base_tiles, :deferred_rust, :skip_round, :permits, :lner, :london_nodes
 
         register_colors(black: '#000000',
                         orange: '#f48221',
@@ -492,15 +492,13 @@ module Engine
             D15
         ].freeze
 
-        LONDON_FULL_HEXES = %w[
+        LONDON_HEXES = %w[
+            A12
             A14
             B15
             C14
             D15
         ].freeze
-
-        LONDON_HALF_HEX = 'A12'
-        LONDON_HALF_EXIT = 5
 
         IPSWITCH_HEX = 'F11'
         HARWICH_HEX = 'F13'
@@ -544,6 +542,9 @@ module Engine
           @global_stops = nil
           @deferred_rust = []
           @merging = nil
+          @london_nodes = LONDON_HEXES.map do |h|
+            hex_by_id(h).tile.nodes.find { |n| n.offboard? && n.groups.include?('London') }
+          end
         end
 
         def setup_preround
@@ -1526,10 +1527,7 @@ module Engine
         end
 
         def london_hex?(stop)
-          return true if LONDON_FULL_HEXES.include?(stop.hex.id)
-          return false unless LONDON_HALF_HEX == stop.hex.id
-
-          stop.exits.include?(LONDON_HALF_EXIT)
+          @london_nodes.include?(stop)
         end
 
         def check_london(visits)

--- a/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
@@ -24,6 +24,21 @@ module Engine
             share.percent < corporation.presidents_percent || share.owner != @game.share_pool
           end
 
+          def can_buy_any?(entity)
+            (can_buy_any_from_market?(entity) ||
+             can_buy_any_from_ipo?(entity) ||
+             can_buy_any_from_treasury?(entity))
+          end
+
+          def can_buy_any_from_treasury?(entity)
+            @game.corporations.each do |corporation|
+              next unless corporation.ipoed
+              return true if can_buy_shares?(entity, corporation.shares)
+            end
+
+            false
+          end
+
           def can_buy_any_from_ipo?(entity)
             @game.corporations.each do |corporation|
               next unless corporation.ipoed

--- a/lib/engine/game/g_1862/step/token.rb
+++ b/lib/engine/game/g_1862/step/token.rb
@@ -30,13 +30,23 @@ module Engine
           end
 
           def can_token_london?(entity)
-            @round.num_laid_track.zero? && !@game.london_link?(entity)
+            @round.num_laid_track.zero? && !@game.london_link?(entity) && london_reachable?(entity)
+          end
+
+          def london_reachable?(entity)
+            @game.london_nodes.any? do |node|
+              @game.graph.connected_nodes(entity)[node]
+            end
           end
 
           def place_token(entity, city, token, connected: true, extra_action: false,
                           special_ability: nil, check_tokenable: true)
             hex = city.hex
             return super unless @game.class::LONDON_TOKEN_HEXES.include?(hex.id)
+
+            if !@game.loading && !london_reachable?(entity)
+              raise GameError, 'Must be connected to London to place rail link'
+            end
 
             raise GameError, 'Cannot build rail link after laying track' unless @round.num_laid_track.zero?
             raise GameError, 'Token/rail link already placed this turn' if @round.tokened
@@ -45,17 +55,14 @@ module Engine
 
             city.place_token(entity, token, free: true, check_tokenable: check_tokenable)
 
-            @log << "#{entity.name} builds a rail link to London"
+            @log << "#{entity.name} builds a rail link (token) to London"
 
             @round.tokened = true
           end
 
           def available_hex(entity, hex)
-            if @game.class::LONDON_TOKEN_HEXES.include?(hex.id)
-              can_token_london?(entity)
-            else
-              @game.graph.reachable_hexes(entity)[hex]
-            end
+            @game.graph.reachable_hexes(entity)[hex] ||
+              (can_token_london?(entity) && @game.class::LONDON_TOKEN_HEXES.include?(hex.id))
           end
         end
       end


### PR DESCRIPTION
FIxes #5481 
Fixes #5484 

Games where someone tokened London illegally will need to be archived.