### PR TITLE
[1846] fix Little Miami Undo bug

### DIFF
--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -54,7 +54,7 @@ module Engine
         LSL_HEXES = %w[E4 E6].freeze
         LSL_ICON = 'sbl'
 
-        LM_HEXES = [].freeze
+        LITTLE_MIAMI_HEXES = [].freeze
 
         MEAT_HEXES = %w[C14 F7].freeze
         STEAMBOAT_HEXES = %w[B1 C2 F7 F9].freeze


### PR DESCRIPTION
Remove the `@checked_little_miami_graph_before ||=` in
`check_little_miami_graph_before!`; that caused an issue if one Little Miami
action was done and then the user refreshed, or if both actions were done and
then one was undone; due to the `loading`, check, this caused the
`check_little_miami_graph_before!` logic to be skipped on the first Little Miami
action and then executed on the first.

Move that check so that `check_little_miami_graph_before!` is only called before
any Little Miami actions have been made; also move the initialization of
`@little_miami_hexes_laid` from the `after!` check so it can also be used for
this

[Fixes #5490]