### PR TITLE
[1846] change Little Miami's tile lay ability from "free" to "discount: 20"

### DIFF
--- a/lib/engine/game/g_1846/entities.rb
+++ b/lib/engine/game/g_1846/entities.rb
@@ -243,7 +243,7 @@ module Engine
                 type: 'tile_lay',
                 when: 'owning_corp_or_turn',
                 owner_type: 'corporation',
-                free: true,
+                discount: 20,
                 must_lay_together: true,
                 hexes: %w[H12 G13],
                 tiles: %w[5 6 57 14 15 619 291 292 293 294 295 296],


### PR DESCRIPTION
* partial fix for #5476; the same change is not applied to IC's ability, as
  making that change has an unexpected side effect: Currently if IC has
  insufficient cash for a track tile or token, their `TrackAndToken` step is not
  skipped, even if all of the hexes where they are allowed a free yellow tile
  already have tiles placed. When their ability is changed from `free` to
  `discount`, their `TrackAndToken` step *does* get skipped if they lack the
  funds for another action (I think this would be preferred behavior, but also
  requires a migration)

https://boardgamegeek.com/thread/2665904/article/37786321#37786321