### PR TITLE
1860: no out-of-turn exchanges; allow some exchanges after parring

### DIFF
--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1917,6 +1917,10 @@ module Engine
 
           corporation.tokens.find_index(token).zero?
         end
+
+        def entity_can_use_company?(entity, company)
+          company.owner == entity
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #4999 
Fixes #5505 

This will require some games to be pinned.