### PR TITLE
1846: IC tile lay from free to discount

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -237,6 +237,8 @@ module Engine
       # :lawson Tile type like 1817, 1822
       TILE_TYPE = :normal
 
+      TILE_COST = 0
+
       IMPASSABLE_HEX_COLORS = %i[blue gray red].freeze
 
       EVENTS_TEXT = {

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -69,8 +69,6 @@ module Engine
           major: [70, 80, 90, 100],
         }.freeze
 
-        TILE_COST = 0
-
         INITIAL_CITY_PAR = {
           'W' => 95,
           'V' => 85,

--- a/lib/engine/game/g_1846/entities.rb
+++ b/lib/engine/game/g_1846/entities.rb
@@ -392,7 +392,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                free: true,
+                discount: 20,
                 description: 'Free tile lay: E5, F6, G5, H6, J4',
                 desc_detail: 'May lay yellow tiles for free on hexes marked with an IC-icon (E5, '\
                              'F6, G5, H6 and J4).',

--- a/lib/engine/step/track_and_token.rb
+++ b/lib/engine/step/track_and_token.rb
@@ -46,7 +46,8 @@ module Engine
 
         @game.abilities(entity, :tile_lay) do |ability|
           ability.hexes.each do |hex_id|
-            free = true if ability.free && @game.hex_by_id(hex_id).tile.preprinted
+            free = true if (ability.free || ability.discount >= @game.class::TILE_COST) &&
+                           @game.hex_by_id(hex_id).tile.preprinted
           end
         end
 


### PR DESCRIPTION
Also change `Step::TrackAndToken#can_lay_tile?` so that if a discount is at
least as high as the tile's normal base cost, it counts as free

This fixes the edge case where IC still needs to pay for the bridge between J4
and J6; the implementation before this commit makes it completely free.

[Fixes #5476]

See also #5501

----

Validated against all 1846-family games in my local DB copy, it checks out