### PR TITLE
1846: Reset "last share sold" stuff on bankruptcy to fix train restrictions

### DIFF
--- a/lib/engine/game/g_1846/step/bankrupt.rb
+++ b/lib/engine/game/g_1846/step/bankrupt.rb
@@ -59,6 +59,11 @@ module Engine
               end
             end
 
+            # reset last share sold stuff so that the new president isn't
+            # restricted from buying any trains
+            @game.active_step.last_share_issued_price = nil
+            @game.active_step.last_share_sold_price = nil
+
             @game.minors
               .select { |minor| minor.owner == player }
               .each { |minor| @game.close_corporation(minor, quiet: true) }

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -7,6 +7,9 @@ module Engine
   module Step
     module Train
       include EmergencyMoney
+
+      attr_accessor :last_share_issued_price, :last_share_sold_price
+
       def can_buy_train?(entity = nil, _shell = nil)
         entity ||= current_entity
 


### PR DESCRIPTION
[Fixes #5319]