### PR TITLE
[1868WY] Bust when DTC drops, add BUST rounds

### DIFF
--- a/lib/engine/game/g_1868_wy/map.rb
+++ b/lib/engine/game/g_1868_wy/map.rb
@@ -344,7 +344,7 @@ module Engine
             'count' => 'unlimited',
             'color' => 'brown',
             'hidden' => 1,
-            'code' => 'junction;label=GT;'\
+            'code' => 'junction;'\
                       'path=a:_0,b:0;path=a:_0,b:1;path=a:_0,b:2;path=a:_0,b:4;path=a:_0,b:5',
           },
           'B5b' => {
@@ -377,7 +377,7 @@ module Engine
             'count' => 6,
             'color' => 'gray',
             'code' => 'town=revenue:20,boom:1;'\
-                      'path=a:_0,b:0;path=a:_0,b:1;path=a:_0,b:2;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5',
+                      'path=a:_0,b:0;path=a:_0,b:1;path=a:_0,b:2;path=a:_0,b:4;path=a:_0,b:5',
           },
           '5B' => {
             'count' => 6,
@@ -389,7 +389,7 @@ module Engine
             'count' => 'unlimited',
             'hidden' => 1,
             'color' => 'gray',
-            'code' => 'junction;label=GT;'\
+            'code' => 'junction;'\
                       'path=a:_0,b:0;path=a:_0,b:1;path=a:_0,b:2;path=a:_0,b:4;path=a:_0,b:5',
           },
           'RC' => {
@@ -520,6 +520,68 @@ module Engine
 
           '5b' => %w[5B],
           '5bb' => %w[5BB],
+        }.freeze
+
+        GHOST_TOWN_TILE = {
+          'Y5b' => '7',
+          'Y5B' => '7',
+          '963bb' => '7',
+          '963Bb' => '7',
+          '963bB' => '7',
+
+          'Y6b' => '8',
+          'Y6B' => '8',
+          '962bb' => '8',
+          '962Bb' => '8',
+          '962bB' => '8',
+
+          'Y57b' => '9',
+          'Y57B' => '9',
+          '961bb' => '9',
+          '961Bb' => '9',
+
+          '14b' => '544',
+          '14B' => '544',
+
+          '15b' => '545',
+          '15B' => '545',
+
+          '619b' => '546',
+          '619B' => '546',
+
+          '941a1' => '83',
+          '941a2' => '83',
+          '941a3' => '83',
+          '941A1' => '83',
+          '941A2' => '83',
+          '941A3' => '83',
+
+          '942a1' => '82',
+          '942a2' => '82',
+          '942a3' => '82',
+          '942A1' => '82',
+          '942A2' => '82',
+          '942A3' => '82',
+
+          '943a1' => '80',
+          '943a2' => '80',
+          '943a3' => '80',
+          '943A1' => '80',
+          '943A2' => '80',
+          '943A3' => '80',
+
+          '944a1' => '81',
+          '944A1' => '81',
+
+          'B5b' => 'B5',
+          'B5bb' => 'B5',
+          'B5B' => 'B5',
+          'B5BB' => 'B5',
+
+          '5b' => 'B5G',
+          '5bb' => 'B5G',
+          '5B' => 'B5G',
+          '5BB' => 'B5G',
         }.freeze
 
         LOCATION_NAMES = {

--- a/lib/engine/game/g_1868_wy/trains.rb
+++ b/lib/engine/game/g_1868_wy/trains.rb
@@ -16,6 +16,14 @@ module Engine
         end
 
         def self.def_train(name, price, plus_name, plus_price, num, **kwargs)
+          events =
+            if name.to_i >= 4
+              [{ 'type' => "remove_coal_dt_#{name.to_i - 2}" }]
+            else
+              []
+            end
+          events.concat(kwargs.delete(:events) || [])
+
           plus_cities, plus_towns = plus_name.split('+').map(&:to_i)
           {
             name: name,
@@ -32,6 +40,7 @@ module Engine
               },
             ],
             num: num,
+            events: events,
           }.merge(kwargs).freeze
         end
 

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -145,10 +145,11 @@ module Engine
           end
         end
 
-        new_city.reservations.concat(old_city.reservations)
+        if new_city
+          new_city.reservations.concat(old_city.reservations)
+          new_city.groups = old_city.groups
+        end
         old_city.reservations.clear
-
-        new_city.groups = old_city.groups
       end
 
       @tile.hex = nil


### PR DESCRIPTION
General Changes:

* when laying a tile, check that a new city actually exists before updating its
  reservations and groups

1868 Wyoming:

* add events for removing Coal Development Tokens 2 phases after they are placed
* remove "GT" labels from ghost town tiles, not needed for digital
  implementation
* fix tile 5b (remove extra path)
* when a Boomcity has busted below DTC of 3, its revenue is reduced to $10; in
  the next BUST Round, the tile is downgraded to a Boomtown or Ghost Town (plain
  track tile)
* add constant `GHOST_TOWN_TILE` to identify which tile replaces a tile that has
  busted to a ghost town
* cities in hexes with no tiles that bust to DTC of 0 do not become Ghost Towns
* override `next_round!` so that at the end of each OR a Bust Round happens, and
  after the second OR in a set a train exports; this train export happens before
  the Bust Round, so it could immediately cause some Boom Cities to bust