### PR TITLE
1862: fix tile 61y

### DIFF
--- a/lib/engine/game/g_1862/map.rb
+++ b/lib/engine/game/g_1862/map.rb
@@ -160,7 +160,7 @@ module Engine
           {
             'count' => 3,
             'color' => 'brown',
-            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:4,b:_0;label=Y',
+            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y',
           },
           '201' => 2,
           '202' => 4,


### PR DESCRIPTION
Fixes #5522 

This shouldn't require archiving games (since illegal rotations with the new leg aren't checked when loading actions).