### PR TITLE
1873: allow other corps to place reserved tile on target hex

### DIFF
--- a/lib/engine/game/g_1873/step/track.rb
+++ b/lib/engine/game/g_1873/step/track.rb
@@ -119,7 +119,12 @@ module Engine
           end
 
           def potential_tiles(entity, hex)
-            return super unless @game.concession_incomplete?(entity)
+            unless @game.concession_incomplete?(entity)
+              # allow using reserved tile for this hex. Legality is checked after placement
+              return super unless @game.reserved_tiles[hex.id][:tile]
+
+              return (super + [@game.reserved_tiles[hex.id][:tile]]).uniq
+            end
 
             if !@game.concession_tile(hex)
               # can only lay in concession hexes


### PR DESCRIPTION
Fixes #5534 

No pins needed.

![reserved](https://user-images.githubusercontent.com/8494213/120230322-4fd9c500-c20c-11eb-8d8e-3177ef8c62bb.png)
