### PR TITLE
[18CZ] "Martinitz-Rochlitz" local RR duplicated

### DIFF
--- a/lib/engine/game/g_18_cz/entities.rb
+++ b/lib/engine/game/g_18_cz/entities.rb
@@ -510,7 +510,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Strakonitz – Blatna – Bresnitz',
+              name: 'Wolframs - Teltsch',
               value: 40,
               revenue: 5,
               sym: 'S4',
@@ -571,7 +571,7 @@ module Engine
               color: nil,
             },
             {
-              name: 'Martinitz – Rochlitz',
+              name: 'Strakonitz – Blatna – Bresnitz',
               value: 45,
               revenue: 5,
               sym: 'S5',


### PR DESCRIPTION
"Wolframs-Teltsch" missing and an extra "Martinitz-Rochlitz", relative to the printed rulebook.
Edit puts in W-T as S4 (replacing S-B-B), and moves S-B-B to S5 (replacing M-R), matching order in rulebook.

![20210601_181842](https://user-images.githubusercontent.com/82781561/120401584-dc1be300-c305-11eb-861c-0cb26115824f.jpg)
