### PR TITLE
Fix 'x%' to float appearing in phase 6 in 1856 instead of 'y%' to operate

### DIFF
--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1527,7 +1527,7 @@ module Engine
 
         def float_str(entity)
           return 'Floats in phase 6' if entity == national
-          return super if entity.corporation && entity.capitalization_type == :full
+          return super if entity.corporation && (entity.capitalization || entity.capitalization_type) == :full
 
           "#{percent_to_operate}%* to operate" if entity.corporation? && entity.floatable
         end


### PR DESCRIPTION
fixes #5561 