### PR TITLE
add GET /api/profile, closes #5612

### DIFF
--- a/routes/profile.rb
+++ b/routes/profile.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Api
+  hash_routes :api do |hr|
+    hr.on 'profile' do |r|
+      # '/api/profile/*'
+      r.is do
+        # '/api/profile'
+        r.get do
+          not_authorized! unless user
+
+          # '/api/profile'
+          r.is do
+            { games: Game.home_games(user, **request.params).map(&:to_h) }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add API `GET /api/profile`

Requires the `auth_token` header and returns a list of all user games for the moment.

```
$ curl -H "Cookie: auth_token=f72e86b1c94c5ae52a7c9ae8f16b3adf" http://localhost:9292/api/profile

{"games":[{"id":1,"description":"","user":{"id":1,"name":"test"},"players":[{"id":2,"name":"a"},{"id":3,"name":"b"},{"id":1,"name":"test"}],"max_players":3,"title":"1817","settings":{"seed":2081211746,"unlisted":false,"auto_routing":false,"player_order":null,"optional_rules":[]},"user_settings":null,"status":"finished","turn":1,"round":"Auction Round","acting":[2],"result":{"a":420,"b":420,"test":420},"actions":[],"loaded":false,"created_at":1622974815,"updated_at":1622974893}]}
```