### PR TITLE
1856: Waterloo cannot be used outside of a corporation's OR now

### DIFF
--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -363,6 +363,7 @@ module Engine
                         {
                           type: 'tile_lay',
                           owner_type: 'corporation',
+                          when: 'track',
                           consume_tile_lay: true,
                           count: 1,
                           hexes: ['I12'],


### PR DESCRIPTION
Fixes #5627 