### PR TITLE
Fix privates not working in **56

### DIFF
--- a/lib/engine/game/g_1856/step/bankrupt.rb
+++ b/lib/engine/game/g_1856/step/bankrupt.rb
@@ -11,7 +11,9 @@ module Engine
             active_entities.any?
           end
 
-          def actions(_entity)
+          def actions(entity)
+            return [] if entity.company?
+
             ACTIONS
           end
 


### PR DESCRIPTION
The privates broke in the last deploy; the bankruptcy fix broke the ability to use privates in the UI. This fixes it
Fixes #5648 