### PR TITLE
[1822MRS] Added 2-player Variant

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -311,6 +311,7 @@ module Engine
         BIDDING_BOX_START_PRIVATE = 'P1'
 
         BIDDING_TOKENS = {
+		  '2': 7,
           '3': 6,
           '4': 5,
           '5': 4,

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -311,7 +311,7 @@ module Engine
         BIDDING_BOX_START_PRIVATE = 'P1'
 
         BIDDING_TOKENS = {
-		  '2': 7,
+          '2': 7,
           '3': 6,
           '4': 5,
           '5': 4,

--- a/lib/engine/game/g_1822_mrs/game.rb
+++ b/lib/engine/game/g_1822_mrs/game.rb
@@ -11,8 +11,8 @@ module Engine
 
         BIDDING_BOX_START_MINOR = 'M24'
         BIDDING_BOX_START_MINOR_ADV = 'M14'
-
-        CERT_LIMIT = { 3 => 18, 4 => 14, 5 => 11, 6 => 9, 7 => 8 }.freeze
+		
+        CERT_LIMIT = { 2 => 27, 3 => 18, 4 => 14, 5 => 11, 6 => 9, 7 => 8 }.freeze
 
         DESTINATIONS = {
           'LNWR' => 'I22',
@@ -34,7 +34,7 @@ module Engine
           'SWR' => 3,
         }.freeze
 
-        STARTING_CASH = { 3 => 500, 4 => 375, 5 => 300, 6 => 250, 7 => 215 }.freeze
+        STARTING_CASH = { 2 => 750, 3 => 500, 4 => 375, 5 => 300, 6 => 250, 7 => 215 }.freeze
 
         STARTING_COMPANIES = %w[P1 P2 P5 P6 P7 P8 P9 P10 P11 P12 P13 P14 P15 P16 P18
                                 C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
@@ -43,6 +43,10 @@ module Engine
         STARTING_COMPANIES_ADVANCED = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12
                                          C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
                                          M16 16 M17 M18 M19 M20 M21 M24].freeze
+										 
+		STARTING_COMPANIES_2Player = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12
+                                         C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
+                                         M16 16 M17 M18 M19 M20 M21 M24].freeze								 
 
         STARTING_CORPORATIONS = %w[7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 24
                                    LNWR GWR LBSCR SECR MR LYR SWR].freeze
@@ -677,9 +681,9 @@ module Engine
         end
 
         def starting_companies
-          return self.class::STARTING_COMPANIES_ADVANCED if optional_advanced?
-
-          self.class::STARTING_COMPANIES
+		  return self.class::STARTING_COMPANIES_ADVANCED if optional_advanced?
+ 		  return self.class::STARTING_COMPANIES_2Player if @players.size == 2
+		  self.class::STARTING_COMPANIES
         end
 
         def optional_advanced?

--- a/lib/engine/game/g_1822_mrs/game.rb
+++ b/lib/engine/game/g_1822_mrs/game.rb
@@ -11,7 +11,7 @@ module Engine
 
         BIDDING_BOX_START_MINOR = 'M24'
         BIDDING_BOX_START_MINOR_ADV = 'M14'
-		
+
         CERT_LIMIT = { 2 => 27, 3 => 18, 4 => 14, 5 => 11, 6 => 9, 7 => 8 }.freeze
 
         DESTINATIONS = {
@@ -43,10 +43,10 @@ module Engine
         STARTING_COMPANIES_ADVANCED = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12
                                          C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
                                          M16 16 M17 M18 M19 M20 M21 M24].freeze
-										 
-		STARTING_COMPANIES_2Player = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12
-                                         C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
-                                         M16 16 M17 M18 M19 M20 M21 M24].freeze								 
+
+        STARTING_COMPANIES_TWOPLAYER = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12
+                                          C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
+                                          M16 16 M17 M18 M19 M20 M21 M24].freeze
 
         STARTING_CORPORATIONS = %w[7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 24
                                    LNWR GWR LBSCR SECR MR LYR SWR].freeze
@@ -681,9 +681,10 @@ module Engine
         end
 
         def starting_companies
-		  return self.class::STARTING_COMPANIES_ADVANCED if optional_advanced?
- 		  return self.class::STARTING_COMPANIES_2Player if @players.size == 2
-		  self.class::STARTING_COMPANIES
+          return self.class::STARTING_COMPANIES_ADVANCED if optional_advanced?
+          return self.class::STARTING_COMPANIES_TWOPLAYER if @players.size == 2
+
+          self.class::STARTING_COMPANIES
         end
 
         def optional_advanced?

--- a/lib/engine/game/g_1822_mrs/meta.rb
+++ b/lib/engine/game/g_1822_mrs/meta.rb
@@ -21,7 +21,7 @@ module Engine
         GAME_TITLE = '1822MRS'
         GAME_IS_VARIANT_OF = G1822::Meta
 
-        PLAYER_RANGE = [3, 7].freeze
+        PLAYER_RANGE = [2, 7].freeze
 
         OPTIONAL_RULES = [
           {


### PR DESCRIPTION
Adds the 2 player variant to 1822MRS.  Variant is automatically activated when 2-players are selected.  Checkbox for Advanced still overrides Box 1 Minor placement (M14 instead of M24)