### PR TITLE
[1846, 18LA] remove icons when appropriate

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -177,8 +177,16 @@ module Engine
         LITTLE_MIAMI_ICON = 'lm'
 
         MEAT_HEXES = %w[D6 I1].freeze
+        MEAT_ICON = 'meat'
+
         STEAMBOAT_HEXES = %w[B8 C5 D14 I1 G19].freeze
+        STEAMBOAT_ICON = 'port'
+
         BOOMTOWN_HEXES = %w[H12].freeze
+        BOOMTOWN_ICON = 'boom'
+
+        IC_HEXES = %w[E5 F6 G5 H6 J4].freeze
+        IC_ICON = 'ic'
 
         MEAT_REVENUE_DESC = 'Meat-Packing'
 
@@ -245,6 +253,9 @@ module Engine
             @round.active_step.companies.delete(company)
           end
           remove_from_group!(blue_group, @companies) do |company|
+            remove_boomtown_icons if company == boomtown
+            remove_steamboat_icons if company == steamboat
+            remove_meat_icons if company == meat_packing
             company.close!
             @round.active_step.companies.delete(company)
           end
@@ -252,6 +263,7 @@ module Engine
           corporation_removal_groups.each do |group|
             remove_from_group!(group, @corporations) do |corporation|
               place_home_token(corporation)
+              remove_ic_icons if corporation == illinois_central
               abilities(corporation, :reservation) do |ability|
                 corporation.remove_ability(ability)
               end
@@ -606,11 +618,9 @@ module Engine
             end
           end
 
-          (self.class::MEAT_HEXES + self.class::STEAMBOAT_HEXES + self.class::BOOMTOWN_HEXES).uniq.each do |hex|
-            hex_by_id(hex).tile.icons.reject! do |icon|
-              %w[meat port boom].include?(icon.name)
-            end
-          end
+          remove_boomtown_icons
+          remove_steamboat_icons
+          remove_meat_icons
 
           removals.each do |company, removal|
             hex = removal[:hex]
@@ -628,6 +638,30 @@ module Engine
         def remove_lm_icons
           self.class::LITTLE_MIAMI_HEXES.each do |hex|
             hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::LITTLE_MIAMI_ICON }
+          end
+        end
+
+        def remove_boomtown_icons
+          self.class::BOOMTOWN_HEXES.each do |hex|
+            hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::BOOMTOWN_ICON }
+          end
+        end
+
+        def remove_steamboat_icons
+          self.class::STEAMBOAT_HEXES.each do |hex|
+            hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::STEAMBOAT_ICON }
+          end
+        end
+
+        def remove_meat_icons
+          self.class::MEAT_HEXES.each do |hex|
+            hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::MEAT_ICON }
+          end
+        end
+
+        def remove_ic_icons
+          self.class::IC_HEXES.each do |hex|
+            hex_by_id(hex).tile.icons.reject! { |icon| icon.name == self.class::IC_ICON }
           end
         end
 

--- a/lib/engine/game/g_1846/step/special_track.rb
+++ b/lib/engine/game/g_1846/step/special_track.rb
@@ -8,7 +8,10 @@ module Engine
       module Step
         class SpecialTrack < Engine::Step::SpecialTrack
           def process_lay_tile(action)
-            @game.remove_lsl_icons if action.entity.id == 'LSL'
+            if action.entity.id == @game.class::LSL_ID
+              @game.remove_icons(@game.class::LSL_HEXES,
+                                 @game.class::ABILITY_ICONS[action.entity.id])
+            end
 
             super
           end

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -51,8 +51,15 @@ module Engine
           'SP' => 'C6',
         }.freeze
 
+        ABILITY_ICONS = {
+          SBL: 'sbl',
+          LAC: 'meat',
+          LAS: 'port',
+        }.freeze
+
         LSL_HEXES = %w[E4 E6].freeze
         LSL_ICON = 'sbl'
+        LSL_ID = 'SBL'
 
         LITTLE_MIAMI_HEXES = [].freeze
 
@@ -128,7 +135,7 @@ module Engine
             G1846::Step::Bankrupt,
             Engine::Step::Assign,
             G18LosAngeles::Step::SpecialToken,
-            Engine::Step::SpecialTrack,
+            G1846::Step::SpecialTrack,
             G1846::Step::BuyCompany,
             G1846::Step::IssueShares,
             G1846::Step::TrackAndToken,

--- a/spec/lib/engine/hex_spec.rb
+++ b/spec/lib/engine/hex_spec.rb
@@ -244,24 +244,29 @@ module Engine
         {
           '1846' => [
             {
-              hex: 'D6',
-              initial_icons: %w[meat],
-              lays: [{ tile: '298', rotation: 0, icons: %w[meat] },
-                     { tile: '299', rotation: 0, icons: %w[meat] },
-                     { tile: '300', rotation: 0, icons: %w[meat] }],
+              hex: 'F22',
+              initial_icons: %w[20],
+              lays: [],
             },
             {
-              hex: 'D14',
-              initial_icons: %w[port lsl],
-              lays: [{ tile: '5', rotation: 1, icons: %w[port lsl] },
-                     { tile: '14', rotation: 1, icons: %w[port lsl] },
-                     { tile: '611', rotation: 5, icons: %w[port lsl] },
-                     { tile: '51', rotation: 5, icons: %w[port lsl] }],
+              hex: 'D22',
+              initial_icons: %w[30],
+              lays: [],
             },
             {
-              hex: 'G19',
-              initial_icons: %w[port port],
-              lays: [{ tile: '14', rotation: 1, icons: %w[port port] }],
+              hex: 'C17',
+              initial_icons: %w[30],
+              lays: [],
+            },
+            {
+              hex: 'C21',
+              initial_icons: %w[30],
+              lays: [],
+            },
+            {
+              hex: 'B18',
+              initial_icons: %w[20],
+              lays: [],
             },
             {
               hex: 'J4',


### PR DESCRIPTION
Several changes related to icon cleanup

1 When a private company is removed (during setup or private closure), also remove its icons
e.g. The "hog" icon for Boomtown private will be removed from H12 if Boomtown is removed during setup

Note that this also fixes a bug in "first edition" variants where the Boomtown and Little Miami private icons were still present even after being removed at setup-time

This also applies to 18LA, for the equivalent Citrus and Port companies

Examples where privates are removed:

![no_steam](https://user-images.githubusercontent.com/1711810/121431629-81e6d780-c92e-11eb-8d7c-041acb7f219d.png)
![no_meat](https://user-images.githubusercontent.com/1711810/121431633-827f6e00-c92e-11eb-92c9-9aae58550805.png)
![no_meat2](https://user-images.githubusercontent.com/1711810/121431636-827f6e00-c92e-11eb-98d8-f87b9066a6dd.png)
![no_boom](https://user-images.githubusercontent.com/1711810/121431639-83b09b00-c92e-11eb-9fca-69316df575c5.png)

2 When the IC corporation is removed in a two-player variant context, remove its icon on related hexes 

Example when IC is removed in a 2P game
![no_ic](https://user-images.githubusercontent.com/1711810/121431637-83180480-c92e-11eb-98aa-de7613001fdd.png)

3 In 18LA, remove the label for `SBL` private after it is used (this is equivalent to LSL in 1846)

before:
![before_la_patch](https://user-images.githubusercontent.com/1711810/121760291-cf09ab80-cade-11eb-9cd2-58ec3bc20673.png)
after:
![after_la_patch](https://user-images.githubusercontent.com/1711810/121760292-d16c0580-cade-11eb-944f-011fedf28c7b.png)


--
Note that the hex test spec is changed, since the privates added in the second printing of 1846 means there will always be at least one private removed from each Blue and Orange group, which may non-deterministically remove LSL / steamboats / meat


closes #1762 