### PR TITLE
Make it possible to override orientation check

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1366,6 +1366,11 @@ module Engine
         true
       end
 
+      def override_legal_tile_rotation?(_entity, _hex, _tile)
+        # Return true to skip further general checks for legal tile rotation
+        false
+      end
+
       def can_par?(corporation, parrer)
         return false if corporation.par_via_exchange && corporation.par_via_exchange.owner != parrer
         return false if corporation.needs_token_to_par && corporation.tokens.empty?

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -333,6 +333,7 @@ module Engine
 
       def legal_tile_rotation?(entity, hex, tile)
         return false unless @game.legal_tile_rotation?(entity, hex, tile)
+        return true if @game.override_legal_tile_rotation?(entity, hex, tile)
 
         old_paths = hex.tile.paths
         old_ctedges = hex.tile.city_town_edges


### PR DESCRIPTION
This is needed for 1893, when upgrading Leverkusen hex, from
yellow to green.

Yellow Leverkusen hex has two towns, each on a separate track.
The green Leverkusen hex hex have track at same edges, but the
track makes an X with a city in the middle. It does remove the
towns.