### PR TITLE
Make it possible to draft minors for a min_bid

### DIFF
--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -254,10 +254,19 @@ module View
         def render_minor_input(minor)
           minor_actions = []
 
+          minor_actions.concat(render_minor_buy(minor))
           minor_actions.concat(render_minor_choose(minor))
           minor_actions.concat(render_minor_place_bid(minor))
 
           h(:div, { style: { textAlign: 'center', margin: '1rem' } }, minor_actions)
+        end
+
+        def render_minor_buy(minor)
+          return [] if !@step.respond_to?(:may_draft?) || !@step.may_draft?(minor)
+
+          price = @step.min_bid(minor)
+          buy_str = "Buy for #{@game.format_currency(price)}"
+          [h(:button, { on: { click: -> { create_minor_buy_bid(minor) } } }, buy_str)]
         end
 
         def render_minor_choose(minor)
@@ -340,6 +349,16 @@ module View
             @current_entity,
             minor: minor,
             price: 0
+          ))
+          store(:selected_corporation, nil, skip: true)
+        end
+
+        def create_minor_buy_bid(target)
+          hide!
+          process_action(Engine::Action::Bid.new(
+            @current_entity,
+            minor: target,
+            price: @step.min_bid(target),
           ))
           store(:selected_corporation, nil, skip: true)
         end


### PR DESCRIPTION
Some games (e.g. 1893) has the possibility to draft a minor for
its "face value". Have added a may_draft?(minor) method that if
this return true, then a "Buy for XX" button appear during auction/draft.
The XX is the amount that is returned by min_bid(minor).
Buying the minor will result in a bid action with minor set,
and price the min_bid.

Default is that no such button appear. The step need to implement
may_draft?(minor) and have it return true for it to appear.