### PR TITLE
[18CZ] make CZ's end condition more clear

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -74,6 +74,14 @@ module Engine
 
         OR_SETS = [1, 1, 1, 1, 2, 2, 2, 3].freeze
 
+        GAME_END_REASONS_TEXT = Base::EVENTS_TEXT.merge(
+          custom: 'End of Game',
+        ).freeze
+
+        GAME_END_REASONS_TIMING_TEXT = Base::EVENTS_TEXT.merge(
+          full_or: 'Ends after the last OR set',
+        ).freeze
+
         GAME_END_CHECK = { custom: :full_or }.freeze
 
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(


### PR DESCRIPTION
Override the base class constant so we have a better description of the endgame condition

before:
![image](https://user-images.githubusercontent.com/1711810/121818060-d396a700-cc39-11eb-9e02-785e37f099fe.png)

after:
![image](https://user-images.githubusercontent.com/1711810/121818053-c5e12180-cc39-11eb-81a9-adf290cfd410.png)
