### PR TITLE
Add support to buy minor in SR (fixes #5725)

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -64,12 +64,12 @@ module View
           children.concat(render_corporations)
           children.concat(render_mergeable_entities) if @current_actions.include?('merge')
           children.concat(render_player_companies) if @current_actions.include?('sell_company')
-          if @step.respond_to?(:purchasable_minors) && @step.purchasable_minors(@current_entity).any?
+          if @step.respond_to?(:purchasable_minors) && !@step.purchasable_minors(@current_entity).empty?
             children.concat(render_purchasable_minors)
           end
           children.concat(render_bank_companies)
           children << h(Players, game: @game)
-          if @step.respond_to?(:purchasable_companies) && @step.purchasable_companies(@current_entity).any?
+          if @step.respond_to?(:purchasable_companies) && !@step.purchasable_companies(@current_entity).empty?
             children << h(BuyCompanyFromOtherPlayer, game: @game)
           end
           children << h(StockMarket, game: @game)

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -64,7 +64,9 @@ module View
           children.concat(render_corporations)
           children.concat(render_mergeable_entities) if @current_actions.include?('merge')
           children.concat(render_player_companies) if @current_actions.include?('sell_company')
-          children.concat(render_buyable_minors)
+          if @step.respond_to?(:purchasable_minors) && @step.purchasable_minors(@current_entity).any?
+            children.concat(render_purchasable_minors)
+          end
           children.concat(render_bank_companies)
           children << h(Players, game: @game)
           if @step.respond_to?(:purchasable_companies) && @step.purchasable_companies(@current_entity).any?
@@ -377,7 +379,7 @@ module View
           [h(Bid, entity: @current_entity, corporation: company)]
         end
 
-        def render_buyable_minors
+        def render_purchasable_minors
           props = {
             style: {
               display: 'inline-block',
@@ -385,7 +387,7 @@ module View
             },
           }
 
-          @step.buyable_minors.map do |minor|
+          @step.purchasable_minors.map do |minor|
             children = [h(Corporation, corporation: minor)]
             children << render_minor_input(minor) if @selected_corporation == minor
             h(:div, props, children)
@@ -393,11 +395,7 @@ module View
         end
 
         def render_minor_input(minor)
-          minor_actions = []
-
-          minor_actions.concat(render_minor_buy(minor))
-
-          h(:div, { style: { textAlign: 'center', margin: '1rem' } }, minor_actions)
+          h(:div, { style: { textAlign: 'center', margin: '1rem' } }, render_minor_buy(minor))
         end
 
         def render_minor_buy(minor)

--- a/lib/engine/game/g_1893/step/buy_minor.rb
+++ b/lib/engine/game/g_1893/step/buy_minor.rb
@@ -27,4 +27,8 @@ module BuyMinor
     company.owner = player
     player.companies << company
   end
+
+  def initial_minor_price(minor)
+    @game.minor_starting_treasury(minor)
+  end
 end

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -43,7 +43,7 @@ module Engine
           def can_buy_any_minors?(entity)
             return false unless @game.num_certs(entity) < @game.cert_limit
 
-            @game.buyable_minors(entity).select { |m| can_buy_minor?(entity, m) }.any?
+            @game.buyable_minors(entity).any? { |m| can_buy_minor?(entity, m) }
           end
 
           def can_buy_minor?(entity, minor)
@@ -53,7 +53,7 @@ module Engine
             entity.cash >= initial_minor_price(minor)
           end
 
-          def buyable_minors
+          def purchasable_minors
             @game.draftable_minors
           end
 

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -13,6 +13,7 @@ module Engine
           FIRST_SR_ACTIONS = %w[buy_company pass].freeze
           EXCHANGE_ACTIONS = %w[buy_shares pass].freeze
           SELL_COMPANY_ACTIONS = %w[sell_company pass].freeze
+          BUY_MINOR_ACTIONS = %w[buy_corporation pass].freeze
 
           def actions(entity)
             return EXCHANGE_ACTIONS if entity == @game.fdsd && @game.rag.ipoed
@@ -24,6 +25,7 @@ module Engine
             result.concat(FIRST_SR_ACTIONS) if can_buy_company?(entity)
             result.concat(EXCHANGE_ACTIONS) if can_exchange?(entity)
             result.concat(SELL_COMPANY_ACTIONS) if can_sell_any_companies?(entity)
+            result.concat(BUY_MINOR_ACTIONS) if can_buy_any_minors?(entity)
             result
           end
 
@@ -36,6 +38,23 @@ module Engine
 
           def can_sell_any_companies?(entity)
             sellable_companies(entity).any? && !bought?
+          end
+
+          def can_buy_any_minors?(entity)
+            return false unless @game.num_certs(entity) < @game.cert_limit
+
+            @game.buyable_minors(entity).select { |m| can_buy_minor?(entity, m) }.any?
+          end
+
+          def can_buy_minor?(entity, minor)
+            return false unless minor.minor?
+            return false if bought?
+
+            entity.cash >= initial_minor_price(minor)
+          end
+
+          def buyable_minors
+            @game.draftable_minors
           end
 
           def can_sell_company?(company)
@@ -98,6 +117,15 @@ module Engine
             end
 
             @round.last_to_act = entity
+          end
+
+          def process_buy_corporation(action)
+            player = action.entity
+            minor = action.minor
+            price = action.price
+            draft_object(minor, player, price)
+
+            @round.last_to_act = player
           end
 
           def process_sell_shares(action)

--- a/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
+++ b/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
@@ -99,7 +99,7 @@ module Engine
           def min_bid(entity)
             return entity.min_bid if entity.company?
 
-            @game.minor_starting_treasury(entity) - @current_reduction
+            initial_minor_price(entity) - @current_reduction
           end
 
           def min_purchase(entity)

--- a/lib/engine/game/g_1893/step/starting_package_initial_auction.rb
+++ b/lib/engine/game/g_1893/step/starting_package_initial_auction.rb
@@ -85,7 +85,7 @@ module Engine
           def min_bid(entity)
             return entity.value if entity.company?
 
-            @game.minor_starting_treasury(entity)
+            initial_minor_price(entity)
           end
 
           def max_place_bid(_player, _object)


### PR DESCRIPTION
General: Show any buyable minors in stock round, and add a Buy button if
this can be bought.

1893: Implement buy_corporation for minors during buy_sell_par_shares step.