### PR TITLE
Fix issue that stalled game/44700

### DIFF
--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1111,9 +1111,9 @@ module Engine
         end
 
         def can_par?(corporation, parrer)
-          return false if @false_national_president && parrer == @false_national_president
+          return false if corporation == national
 
-          corporation == national ? national.ipoed : super
+          super
         end
 
         #


### PR DESCRIPTION
I'm not sure why `can_par?` was implemented this way when this new way is far simpler. Maybe it was used for something else earlier in 18xx.games but I couldn't find a reason for it not to simply be that you cannot par the national