### PR TITLE
1856: fix borrowed trains being marked as having operated

### DIFF
--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1817,6 +1817,7 @@ module Engine
           entity = action.entity
           train = action.train
           buy_train(entity, train, :free)
+          train.operated = false
           @borrowed_trains[entity] = train
           @log << "#{entity.name} borrows a #{train.name}"
         end


### PR DESCRIPTION
Fixes #5729 