### PR TITLE
[1893] Show double cert (fixed #5756)

### DIFF
--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -944,6 +944,8 @@ module Engine
         def setup
           [hdsk_reserved_share, ekb_reserved_share, kfbe_reserved_share, ksz_reserved_share,
            kbe_reserved_share, bkb_reserved_share].each { |info| info[:share].buyable = false }
+          kfbe_reserved_share[:share].double_cert = true
+          bkb_reserved_share[:share].double_cert = true
 
           @companies.each do |c|
             c.owner = @bank


### PR DESCRIPTION
AGV and HGK have a 20% certificate each, besides the 20% president share.
This is now shown with a 'd', similar to 1849.