### PR TITLE
1856: Game ends when a player is forced to buy a national share but is unable to

### DIFF
--- a/spec/fixtures/1856/README.md
+++ b/spec/fixtures/1856/README.md
@@ -19,3 +19,6 @@ hotseat002: (needs replacement)
 
  hotseat005:
  * Train buy bankruptcy
+
+ hotseat006:
+ * False Presidency game end


### PR DESCRIPTION
This is the last and most edge-casey of the rules to implement for 1856. There isn't any pre-existing structure for players to go bankrupt in a stockround and since this scenario so so unlikely to happen (At this point in a game a player can usually scrounge up enough capital to buy a single share) that instead of implementing a proper bankruptcy button like in the Buy Trains step the Buy Sell shares step for 1856 forces the player to keep on selling shares until they are either able to buy the share they are obligated to buy or if they are out of share to sell it ends the game