### PR TITLE
[autoroute] trains must be 'runnable' to be routed

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -19,7 +19,7 @@ module Engine
 
       nodes = @game.graph.connected_nodes(corporation).keys.sort_by do |node|
         revenue = corporation
-          .trains
+          .runnable_trains
           .map { |train| node.route_revenue(@game.phase, train) }
           .max
         [
@@ -89,7 +89,7 @@ module Engine
       now = Time.now
       train_routes = Hash.new { |h, k| h[k] = [] }
       connections.each do |_, connection|
-        corporation.trains.each do |train|
+        corporation.runnable_trains.each do |train|
           route = Engine::Route.new(
             @game,
             @game.phase,


### PR DESCRIPTION
This specifically handles the case in '46 where a minor company's train cannot operate twice in the same OR

e.g. if the minor is bought into a major in the same OR that the minor's train has operated, that train cannot operate again

Possibly this fixes autoroute bugs in other games, if they have similar concepts of "runnable" trains

closes #5694 