### PR TITLE
[1846] fix chi label position when upgraded

### DIFF
--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -148,6 +148,12 @@ module View
             x: -30,
             y: -65,
           },
+          # edge 1
+          {
+            region_weights: { [13, 14] => 1.0 },
+            x: -50,
+            y: 25,
+          },
           P_LEFT_CORNER[:pointy],
           P_BOTTOM_LEFT_CORNER[:pointy],
           # top right corner
@@ -167,12 +173,6 @@ module View
             region_weights: { [17] => 1.0, [18, 23] => 0.25 },
             x: 50,
             y: 37,
-          },
-          # edge 1
-          {
-            region_weights: { [13, 14] => 1.0 },
-            x: -50,
-            y: 25,
           },
         ].freeze
 


### PR DESCRIPTION
When upgraded to green/brown/gray, the Chicago tile has its CHI label pushed to the lower left corner, making it overlap other parts of the tile

1846 uses "pointy" tiles, and the Chi tile specifically wants to use `POINTY_MULTI_CITY_LOCATIONS`

This patch changes this type of tile to prefer other parts of the tile above the lower left corner

Checked 18CZ which is another title with pointy tiles and multi-cities, and its OOs and Prague were unchanged with this patch

before: 

![Screenshot 2021-06-20 5 36 54 PM](https://user-images.githubusercontent.com/1711810/122693340-4b427400-d1ee-11eb-91eb-b04b34b92e2f.png)

after:
![Screenshot 2021-06-20 5 36 18 PM](https://user-images.githubusercontent.com/1711810/122693335-4978b080-d1ee-11eb-90fd-eaae9510d48c.png)
