### PR TITLE
[1840] Update map.rb to add missing hex

### DIFF
--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -235,7 +235,7 @@ module Engine
         THREE_PLAYER_SMALL_REMOVE =  %w[A1 A3 A5 A7 A9 A11 A15 A25 A27 A29 B2 B4 B6 B8 B10 B26 B28 C1 C3 C5 C7 C9 C27
                                         C29 D2 D4 D6 D8 D26 D28 E1 E3 E5 E7 F2 F4 F6 F8 G1 G3 G5].freeze
 
-        TWO_PLAYER_REMOVE = %w[B12 C11 D10 E9 E11 F10 G7 G9 G11 H4 H6 H8 H10 I1 I3 I5 I7 I9 I11 J4 J6 J8 J10 K7].freeze
+        TWO_PLAYER_REMOVE = %w[B12 C11 D2 D10 E9 E11 F10 G7 G9 G11 H4 H6 H8 H10 I1 I3 I5 I7 I9 I11 J4 J6 J8 J10 K7].freeze
 
         THREE_PLAYER_SMALL_ADD = {
           gray: { ['B10'] => 'town=revenue:10;path=a:4,b:_0;path=a:5,b:_0' },

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -235,7 +235,7 @@ module Engine
         THREE_PLAYER_SMALL_REMOVE =  %w[A1 A3 A5 A7 A9 A11 A15 A25 A27 A29 B2 B4 B6 B8 B10 B26 B28 C1 C3 C5 C7 C9 C27
                                         C29 D2 D4 D6 D8 D26 D28 E1 E3 E5 E7 F2 F4 F6 F8 G1 G3 G5].freeze
 
-        TWO_PLAYER_REMOVE = %w[B12 C11 D2 D10 E9 E11 F10 G7 G9 G11 H4 H6 H8 H10 I1 I3 I5 I7 I9 I11 J4 J6 J8 J10 K7].freeze
+        TWO_PLAYER_REMOVE = %w[B12 C11 D10 E9 E11 F10 G7 G9 G11 H4 H6 H8 H10 I1 I3 I5 I7 I9 I11 J4 J6 J8 J10 K7].freeze
 
         THREE_PLAYER_SMALL_ADD = {
           gray: { ['B10'] => 'town=revenue:10;path=a:4,b:_0;path=a:5,b:_0' },

--- a/lib/engine/game/g_1840/map.rb
+++ b/lib/engine/game/g_1840/map.rb
@@ -310,7 +310,7 @@ module Engine
                        'path=a:0,b:_1;path=a:5,b:_1',
           },
           white: {
-            %w[B4 B6 B8 B18 B24 C3 C5 C11 C19 C23 C25 C27 D8 D10 D14 D16 E5 E9 E25 E27 F4 F16 F26 G7 G9 G13 G27 G29
+            %w[B4 B6 B8 B18 B24 C3 C5 C11 C19 C23 C25 C27 D2 D8 D10 D14 D16 E5 E9 E25 E27 F4 F16 F26 G7 G9 G13 G27 G29
                H4 H6 H8 H14 H18 H24 H26 I17 I19 I23 I25 I29 J6 J8 J12 J14 J18 J20 J24] => '',
             %w[B12 C15 D4 D24 D26 E3 E11 E15 F14 F18 F20 F22 F28 G15 G25 H20 H28 I21 J10 J16 J26 J28] =>
             'city=revenue:0',
@@ -448,6 +448,7 @@ module Engine
           'H28' => 'Erdberg',
           'I1' => 'Hütteldorf',
           'I9' => 'Gaudenzdorf',
+          'I11' => 'Wien',
           'I15' => 'Margareten',
           'I21' => 'Nikolsdorf',
           'I27' => 'Aspangbahnhof',


### PR DESCRIPTION
Added empty hex D2, which does appear on the published map. Also added Wien name to hex I11, as it's on the published board. Fixes bug #5818