### PR TITLE
8.4.1 in the 18FL rules states that a player is not forced to buy the cheapest train from the pool/depot when EMR

### DIFF
--- a/lib/engine/game/g_18_fl/step/buy_train.rb
+++ b/lib/engine/game/g_18_fl/step/buy_train.rb
@@ -11,10 +11,8 @@ module Engine
             depot_trains = @depot.depot_trains
             other_trains = @depot.other_trains(entity)
 
-            if entity.cash < @depot.min_depot_price
-              depot_trains = [@depot.min_depot_train]
-
-              other_trains.reject! { |t| t.price < spend_minmax(entity, t).first } if @last_share_sold_price
+            if entity.cash < (@depot.min_depot_price) && @last_share_sold_price
+              other_trains.reject! { |t| t.price < spend_minmax(entity, t).first }
             end
 
             # A corp with zero cash may buy trains from other corps if and only if the president sells no shares.


### PR DESCRIPTION
I don't think this will break any games because it won't make EMR any easier for anyone and EMR isn't auto-skipped if there is no choice of which train to buy