### PR TITLE
This fixes subsidy handling not being able to handle revenue_for throwing an error

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -270,7 +270,11 @@ module View
           '(Invalid Route)'
         end
 
-        render_halts ||= @game.respond_to?(:routes_subsidy) && @game.routes_subsidy(active_routes).positive?
+        render_halts ||= begin
+          @game.respond_to?(:routes_subsidy) && @game.routes_subsidy(active_routes).positive?
+        rescue Engine::GameError
+          false
+        end
         subsidy = render_halts ? " + #{@game.format_currency(@game.routes_subsidy(active_routes))} (subsidy)" : ''
         buttons = [
           h('button.small', { on: { click: clear } }, 'Clear Train'),


### PR DESCRIPTION
I messed around with 18VA last night to see how much effort it would be to implement it. It looks like it wouldn't be too much effort using 18FL as a base and I got pretty far with it. I'm splitting up the progress into several PRs

Without this, if a game that has a subsidy throws a GameError during `revenue_for` (for example 1836jr does this to enforce legal use of the port) will log it out to the console instead to the train view as it normally would be