### PR TITLE
18Carolinas: track rules

### DIFF
--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -37,8 +37,10 @@ module View
           left = []
           left << render_mode_button if @step.respond_to?(:mode_enabled?) && @step.mode_enabled?
           left << h(SpecialBuy) if @current_actions.include?('special_buy')
-          left << h(RouteSelector) if @current_actions.include?('run_routes') && !@step.alternate_selector?
-          left << h(TrackConversion) if @current_actions.include?('run_routes') && @step.alternate_selector?
+          if @current_actions.include?('run_routes')
+            left << h(RouteSelector) unless @step.conversion?
+            left << h(TrackConversion) if @step.conversion?
+          end
           left << h(Dividend) if @current_actions.include?('dividend')
           left << h(Convert) if @current_actions.include?('convert')
           left << h(SwitchTrains) if @current_actions.include?('switch_trains')

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -38,8 +38,7 @@ module View
           left << render_mode_button if @step.respond_to?(:mode_enabled?) && @step.mode_enabled?
           left << h(SpecialBuy) if @current_actions.include?('special_buy')
           if @current_actions.include?('run_routes')
-            left << h(RouteSelector) unless @step.conversion?
-            left << h(TrackConversion) if @step.conversion?
+            left << (@step.conversion? ? h(TrackConversion) : h(RouteSelector))
           end
           left << h(Dividend) if @current_actions.include?('dividend')
           left << h(Convert) if @current_actions.include?('convert')

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -38,8 +38,7 @@ module View
           left << render_mode_button if @step.respond_to?(:mode_enabled?) && @step.mode_enabled?
           left << h(SpecialBuy) if @current_actions.include?('special_buy')
           if @current_actions.include?('run_routes')
-            left << h(RouteSelector) unless @step.conversion?
-            left << h(TrackConversion) if @step.conversion?
+            left << @step.conversion? ? h(TrackConversion) : h(RouteSelector)
           end
           left << h(Dividend) if @current_actions.include?('dividend')
           left << h(Convert) if @current_actions.include?('convert')

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -38,7 +38,8 @@ module View
           left << render_mode_button if @step.respond_to?(:mode_enabled?) && @step.mode_enabled?
           left << h(SpecialBuy) if @current_actions.include?('special_buy')
           if @current_actions.include?('run_routes')
-            left << @step.conversion? ? h(TrackConversion) : h(RouteSelector)
+            left << h(RouteSelector) unless @step.conversion?
+            left << h(TrackConversion) if @step.conversion?
           end
           left << h(Dividend) if @current_actions.include?('dividend')
           left << h(Convert) if @current_actions.include?('convert')

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -24,6 +24,7 @@ module View
     module Round
       class Operating < Snabberb::Component
         needs :game
+        needs :mode, store: true, default: nil
 
         def render
           round = @game.round
@@ -34,6 +35,7 @@ module View
           entity = entity.owner if entity.company? && !round.active_entities.one?
 
           left = []
+          left << render_mode_button if @step.respond_to?(:mode_enabled?) && @step.mode_enabled?
           left << h(SpecialBuy) if @current_actions.include?('special_buy')
           left << h(RouteSelector) if @current_actions.include?('run_routes')
           left << h(Dividend) if @current_actions.include?('dividend')
@@ -124,6 +126,14 @@ module View
           ]
 
           h(:div, children)
+        end
+
+        def render_mode_button
+          pressed = lambda do
+            store(:mode, @step.change_mode)
+          end
+
+          h('button.small', { on: { click: pressed } }, @step.mode_text)
         end
       end
     end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -37,7 +37,8 @@ module View
           left = []
           left << render_mode_button if @step.respond_to?(:mode_enabled?) && @step.mode_enabled?
           left << h(SpecialBuy) if @current_actions.include?('special_buy')
-          left << h(RouteSelector) if @current_actions.include?('run_routes')
+          left << h(RouteSelector) if @current_actions.include?('run_routes') && !@step.alternate_selector?
+          left << h(TrackConversion) if @current_actions.include?('run_routes') && @step.alternate_selector?
           left << h(Dividend) if @current_actions.include?('dividend')
           left << h(Convert) if @current_actions.include?('convert')
           left << h(SwitchTrains) if @current_actions.include?('switch_trains')

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -330,12 +330,12 @@ module View
           buttons << h('button.small', { on: { click: auto } }, 'Auto')
         end
         if @step.respond_to?(:variable_trains?) && @step.variable_trains?(@game.current_entity)
-          buttons << h('button.small', { on: { click: add_train } }, 'Add Train')
-          buttons << h('button.small', { on: { click: remove_train } }, 'Remove Train')
+          buttons << h('button.small', { on: { click: add_train } }, '+ Train')
+          buttons << h('button.small', { on: { click: remove_train } }, '- Train')
         end
         if @step.respond_to?(:variable_distance?) && @step.variable_distance?(@game.current_entity)
-          buttons << h('button.small', { on: { click: increase_train } }, 'Increase Train')
-          buttons << h('button.small', { on: { click: decrease_train } }, 'Decrease Train')
+          buttons << h('button.small', { on: { click: increase_train } }, '+ Train')
+          buttons << h('button.small', { on: { click: decrease_train } }, '- Train')
         end
         h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
           h(:div, buttons),

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -29,8 +29,10 @@ module View
         trains = @game.route_trains(@game.round.current_entity)
         operating = @game.round.current_entity.operating_history
         last_run = operating[operating.keys.max]&.routes
+        step = @game.active_step
         return [] unless last_run
         return [] if @abilities&.any?
+        return [] if step.respond_to?(:prefill_routes?) && !step.prefill_routes?(@game.round.current_entity)
 
         halts = operating[operating.keys.max]&.halts
         last_run.map do |train, connection_hexes|
@@ -49,7 +51,7 @@ module View
       end
 
       def render
-        step = @game.active_step
+        @step = @game.active_step
         current_entity = @game.round.current_entity
         if @selected_company&.owner == current_entity
           ability = @game.abilities(@selected_company, :hex_bonus, time: 'route')
@@ -125,7 +127,11 @@ module View
           children = []
           if route
             revenue, invalid = begin
-              [@game.format_revenue_currency(route.revenue), nil]
+              if @step.respond_to?(:route_revenue_str)
+                [@step.route_revenue_str(route.revenue), nil]
+              else
+                [@game.format_revenue_currency(route.revenue), nil]
+              end
             rescue Engine::GameError => e
               ['N/A', e.to_s]
             end
@@ -158,7 +164,7 @@ module View
               padding: '0 0 0.4rem 0.4rem',
             },
           }
-          train_name = step.respond_to?(:train_name) ? step.train_name(current_entity, train) : train.name
+          train_name = @step.respond_to?(:train_name) ? @step.train_name(current_entity, train) : train.name
           [
             h(:tr, [h('td.middle', [h(:div, { style: style, on: { click: onclick } }, train_name)]), *children]),
             invalid ? h(:tr, [h(:td, invalid_props, invalid)]) : '',
@@ -183,23 +189,35 @@ module View
           },
         }
 
-        instructions = 'Click revenue centers, again to cycle paths.'
-        instructions += ' Click button under Revenue to pick number of halts.' if render_halts
+        if @step.respond_to?(:instructions)
+          instructions = @step.instructions
+        else
+          instructions = 'Click revenue centers, again to cycle paths.'
+          instructions += ' Click button under Revenue to pick number of halts.' if render_halts
+        end
+
+        h3_text = @step.respond_to?(:section_header) ? @step.section_header : 'Select Routes'
+
+        table_header = if @step.respond_to?(:show_table_header?) && !@step.show_table_header?
+                         h(:thead, [])
+                       else
+                         h(:thead, [
+                           h(:tr, [
+                             h(:th, 'Train'),
+                             h(:th, 'Used'),
+                             h(:th, 'Revenue'),
+                             h(:th, th_route_props, 'Route'),
+                           ]),
+                         ])
+                       end
 
         h(:div, div_props, [
-          h(:h3, 'Select Routes'),
+          h(:h3, h3_text),
           h('div.small_font', description),
           h('div.small_font', instructions),
           train_help,
           h(:table, table_props, [
-            h(:thead, [
-              h(:tr, [
-                h(:th, 'Train'),
-                h(:th, 'Used'),
-                h(:th, 'Revenue'),
-                h(:th, th_route_props, 'Route'),
-              ]),
-            ]),
+            table_header,
             h(:tbody, trains),
           ]),
           actions(render_halts),
@@ -258,31 +276,68 @@ module View
           store(:routes, @routes)
         end
 
+        add_train = lambda do
+          @step.add_train(@routes)
+          store(:routes, @routes)
+        end
+
+        remove_train = lambda do
+          @step.remove_train(@routes)
+          store(:routes, @routes)
+        end
+
+        increase_train = lambda do
+          @step.increase_train(@selected_route)
+          store(:routes, @routes)
+        end
+
+        decrease_train = lambda do
+          @step.decrease_train(@selected_route)
+          store(:routes, @routes)
+        end
+
         submit_style = {
           minWidth: '6.5rem',
           marginTop: '1rem',
           padding: '0.2rem 0.5rem',
         }
 
-        revenue = begin
-          @game.format_revenue_currency(@game.routes_revenue(active_routes))
-        rescue Engine::GameError
-          '(Invalid Route)'
-        end
+        revenue = if @step.respond_to?(:total_str)
+                    begin
+                      @step.total_str(@game.routes_revenue(active_routes))
+                    rescue Engine::GameError
+                      @step.revenue_fail
+                    end
+                  else
+                    begin
+                      "Submit #{@game.format_revenue_currency(@game.routes_revenue(active_routes))}"
+                    rescue Engine::GameError
+                      '(Invalid Route)'
+                    end
+                  end
 
         render_halts ||= @game.respond_to?(:routes_subsidy) && @game.routes_subsidy(active_routes).positive?
         subsidy = render_halts ? " + #{@game.format_currency(@game.routes_subsidy(active_routes))} (subsidy)" : ''
-        buttons = [
-          h('button.small', { on: { click: clear } }, 'Clear Train'),
-          h('button.small', { on: { click: clear_all } }, 'Clear All'),
-          h('button.small', { on: { click: reset_all } }, 'Reset'),
-        ]
-        if @game_data.dig('settings', 'auto_routing') || @game_data['mode'] == :hotseat
+
+        show_ct_button = !@step.respond_to?(:show_clear_train_button?) || @step.show_clear_train_button?
+        show_ca_button = !@step.respond_to?(:show_clear_all_button?) || @step.show_clear_all_button?
+        show_auto_button = !@step.respond_to?(:show_auto_button?) || @step.show_auto_button?
+        buttons = []
+        buttons << h('button.small', { on: { click: clear } }, 'Clear Train') if show_ct_button
+        buttons << h('button.small', { on: { click: clear_all } }, 'Clear All') if show_ca_button
+        buttons << h('button.small', { on: { click: reset_all } }, 'Reset')
+        if (@game_data.dig('settings', 'auto_routing') || @game_data['mode'] == :hotseat) && show_auto_button
           buttons << h('button.small', { on: { click: auto } }, 'Auto')
+        end
+        if @step.respond_to?(:variable_trains?) && @step.variable_trains?(@game.current_entity)
+          buttons << h('button.small', { on: { click: add_train } }, 'Add Train')
+          buttons << h('button.small', { on: { click: remove_train } }, 'Remove Train')
+          buttons << h('button.small', { on: { click: increase_train } }, 'Increase Train')
+          buttons << h('button.small', { on: { click: decrease_train } }, 'Decrease Train')
         end
         h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
           h(:div, buttons),
-          h(:button, { style: submit_style, on: { click: submit } }, 'Submit ' + revenue + subsidy),
+          h(:button, { style: submit_style, on: { click: submit } }, revenue + subsidy),
         ])
       end
 

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -332,6 +332,8 @@ module View
         if @step.respond_to?(:variable_trains?) && @step.variable_trains?(@game.current_entity)
           buttons << h('button.small', { on: { click: add_train } }, 'Add Train')
           buttons << h('button.small', { on: { click: remove_train } }, 'Remove Train')
+        end
+        if @step.respond_to?(:variable_distance?) && @step.variable_distance?(@game.current_entity)
           buttons << h('button.small', { on: { click: increase_train } }, 'Increase Train')
           buttons << h('button.small', { on: { click: decrease_train } }, 'Decrease Train')
         end

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -334,8 +334,8 @@ module View
           buttons << h('button.small', { on: { click: remove_train } }, '- Train')
         end
         if @step.respond_to?(:variable_distance?) && @step.variable_distance?(@game.current_entity)
-          buttons << h('button.small', { on: { click: increase_train } }, '+ Train')
-          buttons << h('button.small', { on: { click: decrease_train } }, '- Train')
+          buttons << h('button.small', { on: { click: increase_train } }, '+ Size')
+          buttons << h('button.small', { on: { click: decrease_train } }, '- Size')
         end
         h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
           h(:div, buttons),

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -282,7 +282,7 @@ module View
         end
 
         remove_train = lambda do
-          @step.remove_train(@routes)
+          @step.remove_train(@selected_route)
           store(:routes, @routes)
         end
 

--- a/assets/app/view/game/track_conversion.rb
+++ b/assets/app/view/game/track_conversion.rb
@@ -16,7 +16,7 @@ module View
       # Due to the way this and the map hook up routes needs to have
       # an entry, but that route is not valid at zero length
       def active_routes
-        @routes.select { |r| r.chains.any? }
+        @routes.reject { |r| r.chains.empty? }
       end
 
       def render
@@ -95,9 +95,8 @@ module View
               padding: '0 0 0.4rem 0.4rem',
             },
           }
-          train_name = 'Segment:'
           [
-            h(:tr, [h('td.middle', [h(:div, { style: style, on: { click: onclick } }, train_name)]), *children]),
+            h(:tr, [h('td.middle', [h(:div, { style: style, on: { click: onclick } }, 'Segment:')]), *children]),
             invalid ? h(:tr, [h(:td, invalid_props, invalid)]) : '',
           ]
         end
@@ -127,7 +126,7 @@ module View
             h(:tbody, trains),
           ]),
           actions,
-        ].compact)
+        ])
       end
 
       def cleanup

--- a/assets/app/view/game/track_conversion.rb
+++ b/assets/app/view/game/track_conversion.rb
@@ -46,7 +46,7 @@ module View
             unless (route = @routes.find { |t| t.train == train })
               route = Engine::Route.new(@game, @game.phase, train, abilities: @abilities, routes: @routes)
               @routes << route
-              store(:routes, @routes)
+              store(:routes, @routes, skip: true)
             end
             store(:selected_route, route)
           end

--- a/assets/app/view/game/track_conversion.rb
+++ b/assets/app/view/game/track_conversion.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require 'lib/settings'
+require 'view/game/actionable'
+
+module View
+  module Game
+    class TrackConversion < Snabberb::Component
+      include Actionable
+      include Lib::Settings
+
+      needs :routes, store: true, default: []
+      needs :selected_route, store: true, default: nil
+
+      # Get routes that have a length greater than zero
+      # Due to the way this and the map hook up routes needs to have
+      # an entry, but that route is not valid at zero length
+      def active_routes
+        @routes.select { |r| r.chains.any? }
+      end
+
+      def render
+        @step = @game.active_step
+        current_entity = @game.round.current_entity
+
+        trains = @game.conversion_trains(current_entity)
+
+        train_help =
+          if (helps = @game.train_help(current_entity, trains, @routes)).any?
+            h('ul',
+              { style: { 'padding-left': '20px' } },
+              helps.map { |help| h('li', [h('p.small_font', help)]) })
+          end
+
+        if !@selected_route && (first_train = trains[0])
+          route = Engine::Route.new(@game, @game.phase, first_train, abilities: @abilities, routes: @routes)
+          @routes << route
+          store(:routes, @routes, skip: true)
+          store(:selected_route, route, skip: true)
+        end
+
+        @routes.each(&:clear_cache!)
+
+        trains = trains.flat_map do |train|
+          onclick = lambda do
+            unless (route = @routes.find { |t| t.train == train })
+              route = Engine::Route.new(@game, @game.phase, train, abilities: @abilities, routes: @routes)
+              @routes << route
+              store(:routes, @routes)
+            end
+            store(:selected_route, route)
+          end
+
+          selected = @selected_route&.train == train
+
+          style = {
+            border: "solid 3px #{selected ? color_for(:font) : color_for(:bg)}",
+            display: 'inline-block',
+            cursor: selected ? 'default' : 'pointer',
+            margin: '0.1rem 0rem',
+            padding: '3px 6px',
+            minWidth: '1.5rem',
+            textAlign: 'center',
+            whiteSpace: 'nowrap',
+          }
+
+          route = active_routes.find { |t| t.train == train }
+          children = []
+          if route
+            _revenue, invalid = begin
+              # need this call to force errors
+              [route.revenue.to_s, nil]
+            rescue Engine::GameError => e
+              ['N/A', e.to_s]
+            end
+
+            bg_color = route_prop(@routes.index(route), :color)
+            style[:backgroundColor] = bg_color
+            style[:color] = contrast_on(bg_color)
+
+            td_props = { style: { paddingRight: '0.8rem' } }
+
+            children << h('td.right.middle', td_props, "#{route.distance_str} Stops")
+            children << h(:td, route.revenue_str)
+          elsif !selected
+            style[:border] = '1px solid'
+            style[:padding] = '5px 8px'
+          end
+
+          invalid_props = {
+            attrs: {
+              colspan: '4',
+            },
+            style: {
+              padding: '0 0 0.4rem 0.4rem',
+            },
+          }
+          train_name = 'Segment:'
+          [
+            h(:tr, [h('td.middle', [h(:div, { style: style, on: { click: onclick } }, train_name)]), *children]),
+            invalid ? h(:tr, [h(:td, invalid_props, invalid)]) : '',
+          ]
+        end
+
+        div_props = {
+          key: 'route_selector',
+          hook: {
+            destroy: -> { cleanup },
+          },
+        }
+        table_props = {
+          style: {
+            marginTop: '0.5rem',
+            textAlign: 'left',
+          },
+        }
+
+        instructions = 'Click revenue centers, again to cycle paths. '\
+          'Must be from city/offboard to city/offboard'
+        h3_text = 'Select Segment for Conversion'
+
+        h(:div, div_props, [
+          h(:h3, h3_text),
+          h('div.small_font', instructions),
+          train_help,
+          h(:table, table_props, [
+            h(:tbody, trains),
+          ]),
+          actions,
+        ].compact)
+      end
+
+      def cleanup
+        store(:selected_route, nil, skip: true)
+        store(:routes, [], skip: true)
+      end
+
+      def actions(_render_halts)
+        submit = lambda do
+          process_action(Engine::Action::RunRoutes.new(@game.current_entity, routes: active_routes))
+          cleanup
+        end
+
+        clear_all = lambda do
+          @routes.each(&:reset!)
+          store(:routes, @routes)
+        end
+
+        submit_style = {
+          minWidth: '6.5rem',
+          marginTop: '1rem',
+          padding: '0.2rem 0.5rem',
+        }
+
+        submit_text = begin
+          # need this call to force errors
+          @step.total_str(active_routes)
+        rescue Engine::GameError
+          @step.revenue_fail
+        end
+
+        buttons = [h('button.small', { on: { click: clear_all } }, 'Clear')]
+        h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
+          h(:div, buttons),
+          h(:button, { style: submit_style, on: { click: submit } }, submit_text),
+        ])
+      end
+    end
+  end
+end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1060,6 +1060,10 @@ module Engine
         city.tokened_by?(entity)
       end
 
+      def check_route_token(_route, token)
+        raise GameError, 'Route must contain token' unless token
+      end
+
       def check_overlap(routes)
         tracks = {}
 

--- a/lib/engine/game/g_1860/step/route.rb
+++ b/lib/engine/game/g_1860/step/route.rb
@@ -83,6 +83,10 @@ module Engine
             pass!
           end
 
+          def alternate_selector?
+            false
+          end
+
           def available_hex(_entity, _hex)
             true
           end

--- a/lib/engine/game/g_1860/step/route.rb
+++ b/lib/engine/game/g_1860/step/route.rb
@@ -83,7 +83,7 @@ module Engine
             pass!
           end
 
-          def alternate_selector?
+          def conversion?
             false
           end
 

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -421,8 +421,12 @@ module Engine
           status
         end
 
-        def route_trains(entity)
-          return [@conversion_train] if @round.active_step.instance_of?(Engine::Game::G18Carolinas::Step::Track)
+        def conversion_trains
+          [@conversion_train]
+        end
+
+        def check_route_token(route, token)
+          return if route.train.name == 'Convert'
 
           super
         end
@@ -432,6 +436,12 @@ module Engine
             raise GameError, 'Route must be specified' if visits.empty?
             raise GameError, 'Route cannot begin/end in a town' if visits.first.town? || visits.last.town?
           end
+
+          super
+        end
+
+        def check_connected(route, token)
+          return if route.train.name == 'Convert'
 
           super
         end

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -5,6 +5,7 @@ require_relative '../base'
 require_relative 'entities'
 require_relative 'map'
 require_relative 'step/buy_sell_par_shares_companies'
+require_relative 'step/track'
 
 module Engine
   module Game
@@ -14,7 +15,7 @@ module Engine
         include Entities
         include Map
 
-        attr_reader :tile_groups
+        attr_reader :conversion_train, :tile_groups, :north_hexes, :south_hexes
 
         register_colors(green: '#237333',
                         red: '#d81e3e',
@@ -157,6 +158,13 @@ module Engine
         COMPANY_SALE_FEE = 30
         ADDED_TOKEN_PRICE = 100
 
+        CONVERSION_DISTANCE = [{ 'nodes' => %w[city offboard], 'pay' => 2, 'visit' => 2 },
+                               { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }].freeze
+
+        TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
+
+        C_TILES = %w[C1 C2 C3 C4 C5 C6 C7 C8 C9].freeze
+
         def init_tile_groups
           [
             %w[1 1s],
@@ -170,7 +178,7 @@ module Engine
             %w[9 9s],
             %w[55 55s],
             %w[56 56s],
-            %w[57 7s],
+            %w[57 57s],
             %w[58 58s],
             %w[C1 C2],
             %w[C3 C4],
@@ -208,19 +216,51 @@ module Engine
           ]
         end
 
+        def update_opposites
+          by_name = @tiles.group_by(&:name)
+          @tile_groups.each do |grp|
+            next unless grp.size == 2
+
+            name_a, name_b = grp
+            num = by_name[name_a].size
+            if num != by_name[name_b].size
+              raise GameError, "Sides of double-sided tiles need to have same number (#{name_a}, #{name_b})"
+            end
+
+            num.times.each do |idx|
+              tile_a = tile_by_id("#{name_a}-#{idx}")
+              tile_b = tile_by_id("#{name_b}-#{idx}")
+
+              tile_a.opposite = tile_b
+              tile_b.opposite = tile_a
+            end
+          end
+        end
+
         def init_share_pool
           SharePool.new(self, allow_president_sale: true)
         end
 
         def setup
           @tile_groups = init_tile_groups
-          @highest_layer = 1
+          update_opposites
+          @unused_tiles = []
 
+          # find north and south hexes
+          @north_hexes = []
+          @south_hexes = []
+          @hexes.each do |hex|
+            tile = hex.tile
+            @north_hexes << hex if tile.frame&.color == NORTH_COLOR || tile.frame&.color2 == NORTH_COLOR
+            @south_hexes << hex if tile.frame&.color == SOUTH_COLOR || tile.frame&.color2 == SOUTH_COLOR
+          end
+
+          @highest_layer = 1
           # randomize layers (tranches) with one North and one South in each
           @layer_by_corp = {}
-          @north = @corporations.select { |c| NORTH_CORPORATIONS.include?(c.name) }.sort_by { rand }
-          @south = @corporations.select { |c| SOUTH_CORPORATIONS.include?(c.name) }.sort_by { rand }
-          @north.zip(@south).each_with_index do |corps, idx|
+          @north_corps = @corporations.select { |c| NORTH_CORPORATIONS.include?(c.name) }.sort_by { rand }
+          @south_corps = @corporations.select { |c| SOUTH_CORPORATIONS.include?(c.name) }.sort_by { rand }
+          @north_corps.zip(@south_corps).each_with_index do |corps, idx|
             layer = idx + 1
             corps.each do |corp|
               @layer_by_corp[corp] = layer
@@ -245,7 +285,7 @@ module Engine
               player.companies << company
               company.owner = player
             else
-              corp = [@north[0], @south[0]][idx - 4]
+              corp = [@north_corps[0], @south_corps[0]][idx - 4]
               price = par_prices(corp)[0]
               @stock_market.set_par(corp, price)
               share = corp.ipo_shares.first
@@ -257,6 +297,12 @@ module Engine
               after_par(corp)
             end
           end
+
+          @conversion_train = Train.new(name: 'Convert', distance: CONVERSION_DISTANCE, price: 0,
+                                        index: @depot.trains.size)
+          @conversion_train.owner = nil
+          @depot.trains << @conversion_train
+          update_cache(:trains)
         end
 
         def can_ipo?(corp)
@@ -297,12 +343,60 @@ module Engine
           Round::Operating.new(self, [
             Engine::Step::Bankrupt,
             Engine::Step::HomeToken,
-            Engine::Step::Track,
+            G18Carolinas::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,
             Engine::Step::Dividend,
             Engine::Step::BuyTrain,
           ], round_num: round_num)
+        end
+
+        def upgrades_to?(from, to, special = false, selected_company: nil)
+          standard = to.paths.any? { |p| p.track == :broad }
+          southern = to.paths.any? { |p| p.track != :broad }
+
+          north = @north_hexes.include?(from.hex)
+          south = @south_hexes.include?(from.hex)
+
+          # Can only ever lay standard track in the North
+          return false if north && !south && southern
+
+          # Can only ever lay southern track in the South before phase 5
+          return false if !north && south && standard && !@phase.available?('5')
+
+          # handle C tiles specially
+          return false if from.label.to_s == 'C' && to.color == :yellow && from.cities.size != to.cities.size
+
+          super
+        end
+
+        def update_tile_lists!(tile, old_tile)
+          @tiles.delete(tile)
+          if tile.opposite
+            @tiles.delete(tile.opposite)
+            @unused_tiles << tile.opposite
+          end
+
+          return if old_tile.preprinted
+
+          @tiles << old_tile
+          return unless old_tile.opposite
+
+          @unused_tiles.delete(old_tile.opposite)
+          @tiles << old_tile.opposite
+        end
+
+        def flip_tile!(hex)
+          old = hex.tile
+          return if old.color != :yellow && old.color != :green
+          return if C_TILES.include?(old.name)
+
+          new = old.opposite
+          @log << "Flipping tile #{old.name} to #{new.name} in hex #{hex.id}"
+
+          new.rotate!(old.rotation)
+          update_tile_lists(new, old)
+          hex.lay(new)
         end
 
         def sorted_corporations
@@ -325,6 +419,27 @@ module Engine
           status << %w[Receivership bold] if corp.receivership?
 
           status
+        end
+
+        def route_trains(entity)
+          return [@conversion_train] if @round.active_step.instance_of?(Engine::Game::G18Carolinas::Step::Track)
+
+          super
+        end
+
+        def check_distance(route, visits)
+          if route.train.name == 'Convert'
+            raise GameError, 'Route must be specified' if visits.empty?
+            raise GameError, 'Route cannot begin/end in a town' if visits.first.town? || visits.last.town?
+          end
+
+          super
+        end
+
+        def check_other(route)
+          return unless route.train.name == 'Convert'
+
+          raise GameError, 'Route must have Southern track' unless route.paths.any? { |p| p.track != :broad }
         end
       end
     end

--- a/lib/engine/game/g_18_carolinas/map.rb
+++ b/lib/engine/game/g_18_carolinas/map.rb
@@ -86,211 +86,211 @@ module Engine
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:1,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:1,b:_0,track:dual;path=a:_0,b:3,track:dual;path=a:0,b:_1,track:dual;path=a:_1,b:4,track:dual',
           },
           '2s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:2,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:dual;path=a:_0,b:3,track:dual;path=a:1,b:_1,track:dual;path=a:_1,b:2,track:dual',
           },
           '3s' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:dual;path=a:_0,b:1,track:dual',
           },
           '4s' =>
           {
             'count' => 3,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:dual;path=a:_0,b:3,track:dual',
           },
           '5s' =>
           {
             'count' => 4,
             'color' => 'yellow',
-            'code' => 'city=revenue:20;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow',
+            'code' => 'city=revenue:20;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual',
           },
           '6s' =>
           {
             'count' => 4,
             'color' => 'yellow',
-            'code' => 'city=revenue:20;path=a:0,b:_0,track:narrow;path=a:2,b:_0,track:narrow',
+            'code' => 'city=revenue:20;path=a:0,b:_0,track:dual;path=a:2,b:_0,track:dual',
           },
           '7s' =>
           {
             'count' => 3,
             'color' => 'yellow',
-            'code' => 'path=a:0,b:1,track:narrow',
+            'code' => 'path=a:0,b:1,track:dual',
           },
           '8s' =>
           {
             'count' => 13,
             'color' => 'yellow',
-            'code' => 'path=a:0,b:2,track:narrow',
+            'code' => 'path=a:0,b:2,track:dual',
           },
           '9s' =>
           {
             'count' => 10,
             'color' => 'yellow',
-            'code' => 'path=a:0,b:3,track:narrow',
+            'code' => 'path=a:0,b:3,track:dual',
           },
           '55s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:dual;path=a:_0,b:3,track:dual;path=a:1,b:_1,track:dual;path=a:_1,b:4,track:dual',
           },
           '56s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:3,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:dual;path=a:_0,b:2,track:dual;path=a:1,b:_1,track:dual;path=a:_1,b:3,track:dual',
           },
           '57s' =>
           {
             'count' => 4,
             'color' => 'yellow',
-            'code' => 'city=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
+            'code' => 'city=revenue:20;path=a:0,b:_0,track:dual;path=a:_0,b:3,track:dual',
           },
           '58s' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:dual;path=a:_0,b:2,track:dual',
           },
           'C1' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'city=revenue:40,loc:1;city=revenue:40,loc:4;path=a:0,b:_0;path=a:5,b:_1,track:narrow;label=C',
+            'code' => 'city=revenue:40,loc:1;city=revenue:40,loc:4;path=a:0,b:_0;path=a:5,b:_1,track:dual;label=C',
           },
           'C2' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'city=revenue:40;path=a:0,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
+            'code' => 'city=revenue:40;path=a:0,b:_0,track:dual;path=a:5,b:_0,track:dual;label=C',
           },
           'C3' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'city=revenue:40,loc:2;city=revenue:40,loc:4;path=a:1,b:_0;path=a:5,b:_1,track:narrow;label=C',
+            'code' => 'city=revenue:40,loc:2;city=revenue:40,loc:4;path=a:1,b:_0;path=a:5,b:_1,track:dual;label=C',
           },
           'C4' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'city=revenue:40;path=a:1,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
+            'code' => 'city=revenue:40;path=a:1,b:_0,track:dual;path=a:5,b:_0,track:dual;label=C',
           },
           '12s' =>
           {
             'count' => 3,
             'color' => 'green',
-            'code' => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow',
+            'code' => 'city=revenue:30;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:2,b:_0,track:dual',
           },
           '13s' =>
           {
             'count' => 8,
             'color' => 'green',
-            'code' => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+            'code' => 'city=revenue:30;path=a:0,b:_0,track:dual;path=a:2,b:_0,track:dual;path=a:4,b:_0,track:dual',
           },
           '14s' =>
           {
             'count' => 3,
             'color' => 'green',
-            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:3,b:_0,track:dual;path=a:4,b:_0,track:dual',
           },
           '15s' =>
           {
             'count' => 3,
             'color' => 'green',
-            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
+            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:2,b:_0,track:dual;path=a:3,b:_0,track:dual',
           },
           '16s' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'path=a:0,b:2,track:narrow;path=a:1,b:3,track:narrow',
+            'code' => 'path=a:0,b:2,track:dual;path=a:1,b:3,track:dual',
           },
           '19s' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:2,b:4,track:narrow',
+            'code' => 'path=a:0,b:3,track:dual;path=a:2,b:4,track:dual',
           },
           '20s' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:1,b:4,track:narrow',
+            'code' => 'path=a:0,b:3,track:dual;path=a:1,b:4,track:dual',
           },
           '23s' =>
           {
             'count' => 3,
             'color' => 'green',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:4,track:narrow',
+            'code' => 'path=a:0,b:3,track:dual;path=a:0,b:4,track:dual',
           },
           '24s' =>
           {
             'count' => 3,
             'color' => 'green',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:2,track:narrow',
+            'code' => 'path=a:0,b:3,track:dual;path=a:0,b:2,track:dual',
           },
           '25s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'path=a:0,b:2,track:narrow;path=a:0,b:4,track:narrow',
+            'code' => 'path=a:0,b:2,track:dual;path=a:0,b:4,track:dual',
           },
           '26s' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:5,track:narrow',
+            'code' => 'path=a:0,b:3,track:dual;path=a:0,b:5,track:dual',
           },
           '27s' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:1,track:narrow',
+            'code' => 'path=a:0,b:3,track:dual;path=a:0,b:1,track:dual',
           },
           '28s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'path=a:0,b:4,track:narrow;path=a:0,b:5,track:narrow',
+            'code' => 'path=a:0,b:4,track:dual;path=a:0,b:5,track:dual',
           },
           '29s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'path=a:0,b:2,track:narrow;path=a:0,b:1,track:narrow',
+            'code' => 'path=a:0,b:2,track:dual;path=a:0,b:1,track:dual',
           },
           '87s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:2,b:_0,track:dual;path=a:3,b:_0,track:dual',
           },
           '88s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:3,b:_0,track:dual;path=a:4,b:_0,track:dual',
           },
           'C5' =>
           {
             'count' => 4,
             'color' => 'green',
-            'code' => 'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0,track:narrow;label=C',
+            'code' => 'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0,track:dual;label=C',
           },
           'C6' =>
           {
             'count' => 4,
             'color' => 'green',
-            'code' => 'city=revenue:50,slots:2;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
+            'code' => 'city=revenue:50,slots:2;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:5,b:_0,track:dual;label=C',
           },
           'C7' =>
           {
@@ -312,6 +312,9 @@ module Engine
           },
         }.freeze
         # rubocop:enable Layout/LineLength
+
+        NORTH_COLOR = '#00a651'
+        SOUTH_COLOR = '#fdba12'
 
         # rubocop:disable Layout/LineLength
         HEXES = {
@@ -343,11 +346,11 @@ module Engine
             E23
             F16
             F18
-            ] => 'frame=color:#00a651',
+            ] => "frame=color:#{NORTH_COLOR}",
             %w[
             B6
             G17
-            ] => 'frame=color:#00a651,color2:#fdba12',
+            ] => "frame=color:#{NORTH_COLOR},color2:#{SOUTH_COLOR}",
             %w[
             E3
             F2
@@ -370,29 +373,29 @@ module Engine
             I9
             I13
             J8
-            ] => 'frame=color:#fdba12',
+            ] => "frame=color:#{SOUTH_COLOR}",
             %w[
             C17
-            ] => 'city=revenue:0;upgrade=cost:40,terrain:water;frame=color:#00a651',
+            ] => "city=revenue:0;upgrade=cost:40,terrain:water;frame=color:#{NORTH_COLOR}",
             %w[
             G9
-            ] => 'city=revenue:0;upgrade=cost:40,terrain:water;label=C;frame=color:#fdba12',
+            ] => "city=revenue:0;upgrade=cost:40,terrain:water;label=C;frame=color:#{SOUTH_COLOR}",
             %w[
             H6
-            ] => 'city=revenue:0;upgrade=cost:40,terrain:water;frame=color:#fdba12',
+            ] => "city=revenue:0;upgrade=cost:40,terrain:water;frame=color:#{SOUTH_COLOR}",
             %w[
             D10
-            ] => 'city=revenue:30,loc:5;city=revenue:0,loc:2;path=a:0,b:_0,track:narrow;upgrade=cost:40,terrain:water;label=C;frame=color:#00a651,color2:#fdba12',
+            ] => "city=revenue:30,loc:5;city=revenue:0,loc:2;path=a:0,b:_0,track:dual;upgrade=cost:40,terrain:water;label=C;frame=color:#{NORTH_COLOR},color2:#{SOUTH_COLOR}",
             %w[
             G5
             F4
-            ] => 'upgrade=cost:40,terrain:water;frame=color:#fdba12',
+            ] => "upgrade=cost:40,terrain:water;frame=color:#{SOUTH_COLOR}",
             %w[
             C15
-            ] => 'town=revenue:0;town=revenue:0;frame=color:#00a651',
+            ] => "town=revenue:0;town=revenue:0;frame=color:#{NORTH_COLOR}",
             %w[
             E7
-            ] => 'town=revenue:0;town=revenue:0;frame=color:#fdba12',
+            ] => "town=revenue:0;town=revenue:0;frame=color:#{SOUTH_COLOR}",
             %w[
             D4
             D8
@@ -400,33 +403,33 @@ module Engine
             C13
             C21
             E15
-            ] => 'city=revenue:0;frame=color:#00a651',
+            ] => "city=revenue:0;frame=color:#{NORTH_COLOR}",
             %w[
             E9
             E5
             G13
             H16
             I11
-            ] => 'city=revenue:0;frame=color:#fdba12',
+            ] => "city=revenue:0;frame=color:#{SOUTH_COLOR}",
             %w[
             C9
             D12
             F20
-            ] => 'town=revenue:0;frame=color:#00a651',
+            ] => "town=revenue:0;frame=color:#{NORTH_COLOR}",
             %w[
             G11
             I15
             J10
-            ] => 'town=revenue:0;frame=color:#fdba12',
+            ] => "town=revenue:0;frame=color:#{SOUTH_COLOR}",
             %w[
             H12
-            ] => 'town=revenue:0;upgrade=cost:40,terrain:water;frame=color:#fdba12',
+            ] => "town=revenue:0;upgrade=cost:40,terrain:water;frame=color:#{SOUTH_COLOR}",
             %w[
             J12
-            ] => 'city=revenue:0;label=C;frame=color:#fdba12',
+            ] => "city=revenue:0;label=C;frame=color:#{SOUTH_COLOR}",
             %w[
             G19
-            ] => 'city=revenue:30,loc:0;city=revenue:0,loc:3;path=a:1,b:_0,track:narrow;label=C;frame=color:#00a651,color2:#fdba12',
+            ] => "city=revenue:30,loc:0;city=revenue:0,loc:3;path=a:1,b:_0,track:dual;label=C;frame=color:#{NORTH_COLOR},color2:#{SOUTH_COLOR}",
           },
           red: {
             %w[
@@ -448,16 +451,16 @@ module Engine
             ] => 'junction;path=a:5,b:_0,terminal:1',
             %w[
             B4
-            ] => 'path=a:0,b:4,track:narrow',
+            ] => 'path=a:0,b:4,track:dual',
             %w[
             C3
-            ] => 'path=a:0,b:3,track:narrow;junction;path=a:5,b:_0,terminal:1',
+            ] => 'path=a:0,b:3,track:dual;junction;path=a:5,b:_0,terminal:1',
             %w[
             D2
-            ] => 'path=a:0,b:3,track:narrow;junction;path=a:4,b:_0,terminal:1',
+            ] => 'path=a:0,b:3,track:dual;junction;path=a:4,b:_0,terminal:1',
             %w[
             E1
-            ] => 'path=a:3,b:4,track:narrow',
+            ] => 'path=a:3,b:4,track:dual',
           },
         }.freeze
         # rubocop:enable Layout/LineLength

--- a/lib/engine/game/g_18_carolinas/step/track.rb
+++ b/lib/engine/game/g_18_carolinas/step/track.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G18Carolinas
+      module Step
+        class Track < Engine::Step::Track
+          LAY_ACTIONS = %w[lay_tile pass].freeze
+          CONVERT_ACTIONS = %w[run_routes pass].freeze
+          ALL_ACTIONS = %w[lay_tile run_routes pass].freeze
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] if entity.company? || !can_lay_tile?(entity) && @mode == :new_track
+            return ALL_ACTIONS if @game.loading && @game.phase.available?('5')
+
+            @mode == :new_track ? LAY_ACTIONS : CONVERT_ACTIONS
+          end
+
+          def setup
+            @mode = :new_track
+            super
+          end
+
+          def update_tile_lists(tile, old_tile)
+            @game.update_tile_lists!(tile, old_tile)
+          end
+
+          def mode_enabled?
+            @game.phase.available?('5')
+          end
+
+          def mode_text
+            @mode == :new_track ? 'Track Conversion Mode' : 'Tile Lay/Upgrade Mode'
+          end
+
+          def change_mode
+            return :new_track unless @game.phase.available?('5')
+
+            @mode = @mode == :new_track ? :convert_segment : :new_track
+          end
+
+          def prefill_routes?(_entity)
+            false
+          end
+
+          def instructions
+            'Click revenue centers, again to cycle paths. Must be from city/offboard to city/offboard'
+          end
+
+          def section_header
+            'Select Segment for Conversion'
+          end
+
+          def show_table_header?
+            false
+          end
+
+          def show_clear_train_button?
+            false
+          end
+
+          def show_clear_all_button?
+            false
+          end
+
+          def show_auto_button?
+            false
+          end
+
+          def total_str(_revenue)
+            'Convert Segment'
+          end
+
+          def revenue_fail
+            'Invalid Segment'
+          end
+
+          def route_revenue_str(_rev)
+            '---'
+          end
+
+          def process_run_routes(action)
+            hexes_to_flip = action.routes[0].all_hexes.select { |h| h.tile.paths.any? { |p| p.track != :broad } }
+            raise GameError, 'No tiles with Southern Track submitted' if hexes_to_flip.empty?
+
+            hexes_to_flip.each { |h| @game.flip_tile!(h) }
+            pass!
+          end
+
+          def available_hex(entity, hex)
+            return super if @mode == :new_track
+
+            @game.graph_for_entity(entity).reachable_hexes(entity)[hex]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_carolinas/step/track.rb
+++ b/lib/engine/game/g_18_carolinas/step/track.rb
@@ -29,6 +29,8 @@ module Engine
           end
 
           def mode_enabled?
+            return false if @round.num_laid_track.positive?
+
             @game.phase.available?('5')
           end
 
@@ -38,48 +40,24 @@ module Engine
 
           def change_mode
             return :new_track unless @game.phase.available?('5')
+            return :new_track if @round.num_laid_track.positive?
 
             @mode = @mode == :new_track ? :convert_segment : :new_track
-          end
-
-          def prefill_routes?(_entity)
-            false
           end
 
           def instructions
             'Click revenue centers, again to cycle paths. Must be from city/offboard to city/offboard'
           end
 
-          def section_header
-            'Select Segment for Conversion'
-          end
+          def total_str(active_routes)
+            raise GameError, 'No routes' if active_routes.empty?
 
-          def show_table_header?
-            false
-          end
-
-          def show_clear_train_button?
-            false
-          end
-
-          def show_clear_all_button?
-            false
-          end
-
-          def show_auto_button?
-            false
-          end
-
-          def total_str(_revenue)
+            _rev = @game.routes_revenue(active_routes) # force check
             'Convert Segment'
           end
 
           def revenue_fail
             'Invalid Segment'
-          end
-
-          def route_revenue_str(_rev)
-            '---'
           end
 
           def process_run_routes(action)
@@ -88,6 +66,10 @@ module Engine
 
             hexes_to_flip.each { |h| @game.flip_tile!(h) }
             pass!
+          end
+
+          def alternate_selector?
+            true
           end
 
           def available_hex(entity, hex)

--- a/lib/engine/game/g_18_carolinas/step/track.rb
+++ b/lib/engine/game/g_18_carolinas/step/track.rb
@@ -68,7 +68,7 @@ module Engine
             pass!
           end
 
-          def alternate_selector?
+          def conversion?
             true
           end
 

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -296,9 +296,9 @@ module Engine
           if !connection_data.empty? && visited.size < 2 && !@train.local?
             raise GameError, 'Route must have at least 2 stops'
           end
-          unless (token = visited.find { |stop| @game.city_tokened_by?(stop, corporation) })
-            raise GameError, 'Route must contain token'
-          end
+
+          token = visited.find { |stop| @game.city_tokened_by?(stop, corporation) }
+          @game.check_route_token(self, token)
 
           visited.flat_map(&:groups).flatten.group_by(&:itself).each do |key, group|
             raise GameError, "Cannot use group #{key} more than once" unless group.one?

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -47,6 +47,10 @@ module Engine
         abilities.uniq.each { |type| @game.abilities(action.entity, type, time: 'route')&.use! }
       end
 
+      def alternate_selector?
+        false
+      end
+
       def available_hex(entity, hex)
         @game.graph_for_entity(entity).reachable_hexes(entity)[hex]
       end

--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -47,7 +47,7 @@ module Engine
         abilities.uniq.each { |type| @game.abilities(action.entity, type, time: 'route')&.use! }
       end
 
-      def alternate_selector?
+      def conversion?
         false
       end
 


### PR DESCRIPTION
Implement all track rules, including track conversion operation.
Make all "Southern" track dual gauge instead of narrow gauge (so Graph will work correctly for mixed segments).
Finish implementing dual-sided tiles

Common file changes:
UI::Round::Operating - add optional "mode" button, alternate route selector view
UI::TrackConversion - new view
Engine::Route - moved token check to game
Engine::Game::Base - move an Engine::Route check method here
Engine::Step::Route - added default alternate_selector? method

Mode Button:
![mode_button](https://user-images.githubusercontent.com/8494213/123329801-6ec13380-d4fa-11eb-9b09-9d2c42e733a5.png)

Track Conversion Mode:
![Revamped_Conversion](https://user-images.githubusercontent.com/8494213/123471725-742e8480-d5b3-11eb-80f0-8856832ba831.png)
