### PR TITLE
1893: Allow city upgrade even if no new track is usable (fixes #5836)

### DIFF
--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -41,8 +41,8 @@ module Engine
         # Sell zero or more, then Buy zero or one
         SELL_BUY_ORDER = :sell_buy
 
-        # New track must be usable
-        TRACK_RESTRICTION = :restrictive
+        # New track must be usable, or upgrade city value
+        TRACK_RESTRICTION = :semi_restrictive
 
         # Needed for RAG exchange selection when parring
         ALL_COMPANIES_ASSIGNABLE = true


### PR DESCRIPTION
The bug was when upgrading Köln from brown to gray - which caused a
"must use new track", but gray Köln has no new track. The rules
are not explicit if it is allowed to upgrade a city tile where new
track is not reachable but my interpretation is that this should
be allowed.