### PR TITLE
Change minor check in buy trains actions (fixes #5843)

### DIFF
--- a/lib/engine/game/g_1824/step/buy_train.rb
+++ b/lib/engine/game/g_1824/step/buy_train.rb
@@ -7,17 +7,8 @@ module Engine
     module G1824
       module Step
         class BuyTrain < Engine::Step::BuyTrain
-          def actions(entity)
-            # TODO: This needs to check it actually needs to sell shares.
-            return ['sell_shares'] if entity == current_entity.owner
-
-            return [] if entity != current_entity
-            # TODO: Not sure this is right
-            return %w[sell_shares buy_train] if president_may_contribute?(entity)
-
-            return %w[buy_train pass] if can_buy_train?(entity)
-
-            []
+          def can_entity_buy_train?
+            true
           end
 
           def process_buy_train(action)

--- a/lib/engine/game/g_1893/step/buy_train.rb
+++ b/lib/engine/game/g_1893/step/buy_train.rb
@@ -7,14 +7,8 @@ module Engine
     module G1893
       module Step
         class BuyTrain < Engine::Step::BuyTrain
-          def actions(entity)
-            return [] if entity != current_entity
-            # TODO: Not sure this is right
-            return %w[sell_shares buy_train] if president_may_contribute?(entity)
-
-            return %w[buy_train pass] if can_buy_train?(entity)
-
-            []
+          def can_entity_buy_train?
+            true
           end
 
           def round_state

--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -10,7 +10,7 @@ module Engine
 
       def actions(entity)
         # 1846 and a few others minors can't buy trains
-        return [] if entity.minor?
+        return [] unless can_entity_buy_train?(entity)
 
         # TODO: This needs to check it actually needs to sell shares.
         return ['sell_shares'] if entity == current_entity&.owner && can_ebuy_sell_shares?(current_entity)

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -29,6 +29,10 @@ module Engine
         end.size < @game.train_limit(entity)
       end
 
+      def can_entity_buy_train?(entity)
+        !entity.minor?
+      end
+
       def must_buy_train?(entity)
         @game.must_buy_train?(entity)
       end


### PR DESCRIPTION
By making the check in a method it is easy for titles to override
method if they want to allow a minor to be able to buy trains.

If instead an override of actions' method it might cause a bug
if code is forgotten - which is what happended in 1893 (and 1824).

A quick scan through of existing titles did not find any other
title where minors can buy trains so I have not updated any
other title.