### PR TITLE
Adds a Certificate Limit table to the info tab for games that provide the information

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -33,8 +33,31 @@ module View
         children.concat(discarded_trains) if @depot.discarded.any?
         children.concat(phases)
         children.concat(timeline) if timeline
+        children.concat(cert_limit_table) if @game.cert_limit_table
         children.concat(endgame)
         children << h(GameMeta, game: @game)
+      end
+
+      def cert_limit_table
+        [
+          h(:h3, 'Certificate Limit'),
+          h(:div, { style: { overflowX: 'auto' } }, [
+            h(:table, [
+              h(:thead, [
+                h(:tr, [
+                  h(:th, 'Certs'),
+                  h(:th, @game.cert_limit_table_header_str),
+                ]),
+              ]),
+              h(:tbody, @game.cert_limit_table.map do |index, limit|
+                h(:tr, [
+                  h(:td, (index == @game.cert_limit_table_current_index ? '→ ' : '') + limit.to_s),
+                  h(:td, index),
+                ])
+              end),
+            ]),
+          ]),
+        ]
       end
 
       def timeline

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1711,6 +1711,24 @@ module Engine
         true
       end
 
+      # /!\ This does nothing to affect game logic /!\
+      # This should return either false or a hash mapping an unique string to a certificate limit
+      # the string key is some sort of status or identifier to distinguish the condition
+      # for the certificate limit to be at that value
+      def cert_limit_table
+        nil
+      end
+
+      # This will return the string corresponding to the current cert limit in cert_limit_table
+      def cert_limit_table_current_index
+        nil
+      end
+
+      # This will describe in the Info tab what the index string means
+      def cert_limit_table_header_str
+        nil
+      end
+
       def hex_blocked_by_ability?(_entity, ability, hex)
         ability.hexes.include?(hex.id)
       end

--- a/lib/engine/game/g_1836_jr56/game.rb
+++ b/lib/engine/game/g_1836_jr56/game.rb
@@ -570,6 +570,19 @@ module Engine
           ], round_num: round_num)
         end
 
+        # 1836jr56 has a static cert limit so a cert limit table doesn't help
+        def cert_limit_table
+          nil
+        end
+
+        def cert_limit_table_current_index
+          nil
+        end
+
+        def cert_limit_table_header_str
+          nil
+        end
+
         def event_close_companies!
           @log << '-- Event: Private companies close --'
           @companies.each do |company|

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1033,6 +1033,25 @@ module Engine
           POST_NATIONALIZATION_CERT_LIMIT[num_corporations][@players.size]
         end
 
+        def cert_limit_table
+          { 'Pre-Nationalization' => PRE_NATIONALIZATION_CERT_LIMIT[@players.size] }
+          .merge(
+            POST_NATIONALIZATION_CERT_LIMIT.map do |corps, cert_limit|
+              ["#{corps} corporations remaining", cert_limit[@players.size]]
+            end.to_h
+          )
+        end
+
+        def cert_limit_table_current_index
+          return 'Pre-Nationalization' unless @post_nationalization
+
+          "#{num_corporations} corporations remaining"
+        end
+
+        def cert_limit_table_header_str
+          'Status'
+        end
+
         def destination_connected?(corp)
           (corp.capitalization || corp.capitalization_type) == :escrow && hexes_connected?(*@destinations[corp.id])
         end


### PR DESCRIPTION
By default this is not enabled. It is enabled for 1856 to so that this fixes #5711 and 1836jr56 turns it back off.

Pictures (note, the table is filtered down to the player count)
![image](https://user-images.githubusercontent.com/2993555/123895004-21472b00-d92d-11eb-98fe-be34c36fae88.png)
![image](https://user-images.githubusercontent.com/2993555/123895045-358b2800-d92d-11eb-80c8-f779df437278.png)
