### PR TITLE
Display bonus tokens on map in 1856

### DIFF
--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -603,7 +603,7 @@ module Engine
           red: {
             ['A20'] =>
                      'offboard=revenue:yellow_30|brown_50|black_60;path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1',
-            ['A14'] => 'border=edge:4',
+            ['A14'] => 'border=edge:4;icon=image:1856/tunnel;icon=image:1856/tunnel',
             ['B13'] =>
                    'offboard=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:5,b:_0,terminal:1;border=edge:1',
             ['H5'] =>
@@ -625,7 +625,8 @@ module Engine
                    'offboard=revenue:yellow_20|brown_30|black_50,hide:1,groups:Lower Canada;'\
                    'path=a:2,b:_0,terminal:1;border=edge:3',
             ['P19'] =>
-                   'offboard=revenue:yellow_30|brown_40,hide:1,groups:Buffalo;path=a:2,b:_0,terminal:1;border=edge:3',
+                   'offboard=revenue:yellow_30|brown_40,hide:1,groups:Buffalo;path=a:2,b:_0,terminal:1;border=edge:3'\
+                   ';icon=image:1856/bridge;icon=image:1856/bridge',
             ['P17'] =>
                    'offboard=revenue:yellow_30|brown_40,groups:Buffalo;'\
                    'path=a:1,b:_0,terminal:1;path=a:2,b:_0,terminal:1;border=edge:0',
@@ -718,6 +719,9 @@ module Engine
         BARRIE_HEX = 'M4'
         LONDON_HEX = 'F15'
         HAMILTON_HEX = 'L15'
+
+        TUNNEL_TOKEN_HEX = 'A14'
+        BRIDGE_TOKEN_HEX = 'P19'
 
         # This is unlimited in 1891
         # They're also 5% shares if there are more than 20 shares. It's weird.
@@ -985,11 +989,6 @@ module Engine
           # CGR flags
           @national_ever_owned_permanent = false
 
-          # 1 of each right is reserved w/ the private when it gets bought in. This leaves 2 extra to sell.
-          available_tokens = @optional_rules&.include?(:unlimited_bonus_tokens) ? 99 : 2
-          @available_bridge_tokens = available_tokens
-          @available_tunnel_tokens = available_tokens
-
           @destination_statuses = {}
 
           # Corp -> Borrowed Train
@@ -999,6 +998,10 @@ module Engine
           )
           national.add_ability(self.class::NATIONAL_IMMOBILE_SHARE_PRICE_ABILITY)
           national.add_ability(self.class::NATIONAL_FORCED_WITHHOLD_ABILITY)
+        end
+
+        def unlimited_bonus_tokens?
+          @optional_rules&.include?(:unlimited_bonus_tokens)
         end
 
         def icon_path(corp)
@@ -1166,18 +1169,26 @@ module Engine
           corporation.capitalization = :incremental if corporation.capitalization == :escrow
         end
 
+        def tunnel_token_available?
+          hex_by_id(TUNNEL_TOKEN_HEX).tile.icons.any? { |icon| icon.name == 'tunnel' }
+        end
+
+        def bridge_token_available?
+          hex_by_id(BRIDGE_TOKEN_HEX).tile.icons.any? { |icon| icon.name == 'bridge' }
+        end
+
         def can_buy_tunnel_token?(entity)
           return false unless entity.corporation?
           return false if tunnel.owned_by_player?
 
-          @available_tunnel_tokens.positive? && !tunnel?(entity) && buying_power(entity) >= RIGHT_COST
+          tunnel_token_available? && !tunnel?(entity) && buying_power(entity) >= RIGHT_COST
         end
 
         def can_buy_bridge_token?(entity)
           return false unless entity.corporation?
           return false if bridge.owned_by_player?
 
-          @available_bridge_tokens.positive? && !bridge?(entity) && buying_power(entity) >= RIGHT_COST
+          bridge_token_available? && !bridge?(entity) && buying_power(entity) >= RIGHT_COST
         end
 
         def buy_tunnel_token(entity)
@@ -1185,7 +1196,14 @@ module Engine
           seller_name = tunnel.closed? ? 'the bank' : tunnel.owner.name
           @log << "#{entity.name} buys a tunnel token from #{seller_name} for #{format_currency(RIGHT_COST)}"
           entity.spend(RIGHT_COST, seller)
-          @available_tunnel_tokens -= 1
+
+          unless unlimited_bonus_tokens?
+            tile_icons = hex_by_id(TUNNEL_TOKEN_HEX).tile.icons
+            tile_icons.delete_at(tile_icons.index { |icon| icon.name == 'tunnel' })
+
+            graph.clear
+          end
+
           grant_right(entity, :tunnel)
         end
 
@@ -1194,7 +1212,13 @@ module Engine
           seller_name = bridge.closed? ? 'the bank' : bridge.owner.name
           @log << "#{entity.name} buys a bridge token from #{seller_name} for #{format_currency(RIGHT_COST)}"
           entity.spend(RIGHT_COST, seller)
-          @available_bridge_tokens -= 1
+
+          unless unlimited_bonus_tokens?
+            tile_icons = hex_by_id(BRIDGE_TOKEN_HEX).tile.icons
+            tile_icons.delete_at(tile_icons.index { |icon| icon.name == 'bridge' })
+
+            graph.clear
+          end
           grant_right(entity, :bridge)
         end
 
@@ -1206,6 +1230,14 @@ module Engine
         def bridge?(corporation)
           # abilities will return an array if many or an Ability if one. [*foo(bar)] gets around that
           corporation.all_abilities.any? { |ability| ability.type == :hex_bonus && ability.hexes.include?('P17') }
+        end
+
+        def add_bridge_marker_to_buffalo
+          hex_by_id(BRIDGE_TOKEN_HEX).tile.icons << Engine::Part::Icon.new('1856/bridge', 'bridge')
+        end
+
+        def add_tunnel_marker_to_sarnia
+          hex_by_id(TUNNEL_TOKEN_HEX).tile.icons << Engine::Part::Icon.new('1856/tunnel', 'tunnel')
         end
 
         def grant_right(corporation, type)
@@ -1229,8 +1261,8 @@ module Engine
 
         def event_close_companies!
           # The tokens reserved for the company's buyer are sent to the bank if closed before being bought in
-          @available_bridge_tokens += 1 if bridge.owned_by_player?
-          @available_tunnel_tokens += 1 if tunnel.owned_by_player?
+          add_bridge_marker_to_buffalo if bridge.owned_by_player? && !unlimited_bonus_tokens?
+          add_tunnel_marker_to_sarnia if tunnel.owned_by_player? && !unlimited_bonus_tokens?
           super
         end
 
@@ -1431,7 +1463,7 @@ module Engine
           if tunnel?(major)
             if tunnel?(national)
               @log << "#{national.name} already has a tunnel token, the token is returned to the bank pool"
-              @available_tunnel_tokens += 1
+              add_tunnel_marker_to_sarnia unless unlimited_bonus_tokens?
             else
               @log << "#{national.name} gets #{major.name}'s tunnel token"
               grant_right(national, :tunnel)
@@ -1440,7 +1472,7 @@ module Engine
           if bridge?(major)
             if bridge?(national)
               @log << "#{national.name} already has a bridge token, the token is returned to the bank pool"
-              @available_bridge_tokens += 1
+              add_bridge_marker_to_buffalo unless unlimited_bonus_tokens?
             else
               @log << "#{national.name} gets #{major.name}'s bridge token"
               grant_right(national, :bridge)

--- a/public/icons/1856/bridge.svg
+++ b/public/icons/1856/bridge.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.02 34.02"><circle cx="50%" cy="50%" r="49%" fill="#000"/><text font-family="TimesNewRomanPS-BoldMT"  x="50%" y="62%" text-anchor="middle" font-weight="700" font-size="12" fill="#fff">bridge</text></svg>

--- a/public/icons/1856/tunnel.svg
+++ b/public/icons/1856/tunnel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.02 34.02"><circle cx="50%" cy="50%" r="49%" fill="#000"/><text font-family="TimesNewRomanPS-BoldMT"  x="50%" y="62%" text-anchor="middle" font-weight="700" font-size="12" fill="#fff">tunnel</text></svg>


### PR DESCRIPTION
This also makes the tokens on the map the canonical source of truth as to how many tokens are left for purchase (like 1828.games)
![image](https://user-images.githubusercontent.com/2993555/123968119-f4befd80-d984-11eb-9c0c-e34ba519d7c5.png)
![image](https://user-images.githubusercontent.com/2993555/123968171-00122900-d985-11eb-98fb-e11d3e84768e.png)
![image](https://user-images.githubusercontent.com/2993555/123968880-a9f1b580-d985-11eb-95cf-dfb826b33088.png)
