### PR TITLE
18Carolinas: routes and dividends

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -238,6 +238,7 @@ module View
         end
 
         reset_all = lambda do
+          @game.reset_adjustable_trains!(@routes)
           @selected_route = nil
           store(:selected_route, @selected_route)
           @routes.clear
@@ -256,6 +257,26 @@ module View
             routes: @routes.reject { |r| r.paths.empty? },
           )
           store(:routes, @routes)
+        end
+
+        add_train = lambda do
+          @game.add_route_train(@routes)
+          store(:routes, @routes)
+        end
+
+        delete_train = lambda do
+          @game.delete_route_train(@selected_route)
+          store(:routes, @routes)
+        end
+
+        increase_train = lambda do
+          @game.increase_route_train(@selected_route)
+          store(:selected_route, @selected_route)
+        end
+
+        decrease_train = lambda do
+          @game.decrease_route_train(@selected_route)
+          store(:selected_route, @selected_route)
         end
 
         submit_style = {
@@ -279,6 +300,14 @@ module View
         ]
         if @game_data.dig('settings', 'auto_routing') || @game_data['mode'] == :hotseat
           buttons << h('button.small', { on: { click: auto } }, 'Auto')
+        end
+        if @game.adjustable_train_list?
+          buttons << h('button.small', { on: { click: add_train } }, '+Train')
+          buttons << h('button.small', { on: { click: delete_train } }, '-Train')
+        end
+        if @game.adjustable_train_sizes?
+          buttons << h('button.small', { on: { click: increase_train } }, '+Size')
+          buttons << h('button.small', { on: { click: decrease_train } }, '-Size')
         end
         h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
           h(:div, buttons),

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2572,6 +2572,16 @@ module Engine
         nil
       end
 
+      def adjustable_train_list?
+        false
+      end
+
+      def adjustable_train_sizes?
+        false
+      end
+
+      def reset_adjustable_trains!; end
+
       def operation_round_short_name
         self.class::OPERATION_ROUND_SHORT_NAME
       end

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -4,10 +4,6 @@ require_relative 'meta'
 require_relative '../base'
 require_relative 'entities'
 require_relative 'map'
-require_relative 'step/buy_sell_par_shares_companies'
-require_relative 'step/track'
-require_relative 'step/route'
-require_relative 'step/dividend'
 
 module Engine
   module Game
@@ -534,7 +530,7 @@ module Engine
           train = route.train
           corp = train.owner
           return if train.distance == MAX_TRAIN
-          return if route.routes.map(&:train).sum(&:distance) >= @corporation_power[corp]
+          return if route.routes.sum { |r| r.train.distance } >= @corporation_power[corp]
 
           train.distance += 1
           train.name = train.distance.to_s

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -6,6 +6,8 @@ require_relative 'entities'
 require_relative 'map'
 require_relative 'step/buy_sell_par_shares_companies'
 require_relative 'step/track'
+require_relative 'step/route'
+require_relative 'step/dividend'
 
 module Engine
   module Game
@@ -15,7 +17,7 @@ module Engine
         include Entities
         include Map
 
-        attr_reader :conversion_train, :tile_groups, :north_hexes, :south_hexes
+        attr_reader :tile_groups, :north_hexes, :south_hexes
 
         register_colors(green: '#237333',
                         red: '#d81e3e',
@@ -73,6 +75,13 @@ module Engine
             distance: 99,
             price: 1,
             num: 64,
+          },
+          {
+            name: 'Convert',
+            distance: [{ 'nodes' => %w[city offboard], 'pay' => 2, 'visit' => 2 },
+                       { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
+            price: 0,
+            num: 1,
           },
         ].freeze
 
@@ -158,10 +167,19 @@ module Engine
         COMPANY_SALE_FEE = 30
         ADDED_TOKEN_PRICE = 100
 
-        CONVERSION_DISTANCE = [{ 'nodes' => %w[city offboard], 'pay' => 2, 'visit' => 2 },
-                               { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }].freeze
-
         TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
+
+        MIN_TRAIN = {
+          '2' => 2,
+          '3' => 2,
+          '4' => 2,
+          '5' => 3,
+          '6' => 4,
+          '7' => 5,
+          '8' => 6,
+        }.freeze
+
+        MAX_TRAIN = 16
 
         C_TILES = %w[C1 C2 C3 C4 C5 C6 C7 C8 C9].freeze
 
@@ -298,11 +316,16 @@ module Engine
             end
           end
 
-          @conversion_train = Train.new(name: 'Convert', distance: CONVERSION_DISTANCE, price: 0,
-                                        index: @depot.trains.size)
-          @conversion_train.owner = nil
-          @depot.trains << @conversion_train
-          update_cache(:trains)
+          @conversion_train = @depot.trains.find { |t| t.name == 'Convert' }
+
+          # initialize corp trains
+          @corporation_trains = {}
+          @corporation_power = {}
+          @corporations.each do |corp|
+            8.times { buy_train(corp, @depot.depot_trains[0], :free) }
+            @corporation_trains[corp] = nil
+            @corporation_power[corp] = 5 # FIXME: set to 0 after testing
+          end
         end
 
         def can_ipo?(corp)
@@ -345,8 +368,8 @@ module Engine
             Engine::Step::HomeToken,
             G18Carolinas::Step::Track,
             Engine::Step::Token,
-            Engine::Step::Route,
-            Engine::Step::Dividend,
+            G18Carolinas::Step::Route,
+            G18Carolinas::Step::Dividend,
             Engine::Step::BuyTrain,
           ], round_num: round_num)
         end
@@ -431,6 +454,100 @@ module Engine
           super
         end
 
+        def enough_power?(entity)
+          return false unless entity.corporation?
+
+          @corporation_power[entity] >= MIN_TRAIN[@phase.name]
+        end
+
+        def load_corporation_trains(entity)
+          operating = entity.operating_history
+          last_run = operating[operating.keys.max]&.routes
+          return [] unless last_run
+
+          last_run.keys
+        end
+
+        def route_trains(entity)
+          @corporation_trains[entity] ||= load_corporation_trains(entity)
+
+          # adjust trains that don't meet lower limit
+          # - this may cause an illegal set of routes, but will preserve previous run
+          @corporation_trains[entity].each do |t|
+            if t.distance < MIN_TRAIN[@phase.name]
+              t.distance = MIN_TRAIN[@phase.name]
+              t.name = MIN_TRAIN[@phase.name].to_s
+            end
+          end
+
+          if @corporation_trains[entity].empty? && @corporation_power[entity] >= MIN_TRAIN[@phase.name]
+            train = entity.trains[0]
+            train.distance = MIN_TRAIN[@phase.name]
+            train.name = MIN_TRAIN[@phase.name].to_s
+            @corporation_trains[entity] = [train]
+          end
+          @corporation_trains[entity]
+        end
+
+        # after running routes, update sizes of trains actually used
+        def update_route_trains(entity, routes)
+          @corporation_trains[entity] = nil
+          routes.each do |route|
+            next if route.visited_stops.empty?
+
+            train = route.train
+            train.distance = route.visited_stops.size
+            train.name = train.distance.to_s
+          end
+        end
+
+        def adjustable_train_list?
+          true
+        end
+
+        def adjustable_train_sizes?
+          true
+        end
+
+        def reset_adjustable_trains!(routes)
+          @corporation_trains[routes[0].train.owner] = nil
+        end
+
+        def add_route_train(routes)
+          entity = routes[0].train.owner
+          trains = @corporation_trains[entity]
+          current_distance = trains.sum(&:distance)
+          return if @corporation_power[entity] - current_distance < MIN_TRAIN[@phase.name]
+
+          new_train = entity.trains.find { |t| !trains.include?(t) }
+          new_train.distance = MIN_TRAIN[@phase.name]
+          new_train.name = MIN_TRAIN[@phase.name].to_s
+          @corporation_trains[entity] << new_train
+        end
+
+        def delete_route_train(route)
+          train = route.train
+          @corporation_trains[train.owner].delete(train)
+        end
+
+        def increase_route_train(route)
+          train = route.train
+          corp = train.owner
+          return if train.distance == MAX_TRAIN
+          return if route.routes.map(&:train).sum(&:distance) >= @corporation_power[corp]
+
+          train.distance += 1
+          train.name = train.distance.to_s
+        end
+
+        def decrease_route_train(route)
+          train = route.train
+          return if train.distance == MIN_TRAIN[@phase.name]
+
+          train.distance -= 1
+          train.name = train.distance.to_s
+        end
+
         def check_distance(route, visits)
           if route.train.name == 'Convert'
             raise GameError, 'Route must be specified' if visits.empty?
@@ -447,9 +564,17 @@ module Engine
         end
 
         def check_other(route)
-          return unless route.train.name == 'Convert'
+          if route.train.name == 'Convert'
+            raise GameError, 'Route must have Southern track' unless route.paths.any? { |p| p.track != :broad }
+          else
+            if route.routes.sum { |r| r.train.distance } > @corporation_power[route.train.owner]
+              raise GameError, 'Train sizes exceed train power'
+            end
 
-          raise GameError, 'Route must have Southern track' unless route.paths.any? { |p| p.track != :broad }
+            track_types = {}
+            route.paths.each { |path| track_types[path.track] = 1 }
+            raise GameError, 'Train cannot use more than one gauge' unless track_types.keys.one?
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_carolinas/step/dividend.rb
+++ b/lib/engine/game/g_18_carolinas/step/dividend.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+
+module Engine
+  module Game
+    module G18Carolinas
+      module Step
+        class Dividend < Engine::Step::Dividend
+          def share_price_change(entity, revenue)
+            curr_price = entity.share_price.price
+            if revenue > curr_price / 2 && revenue < curr_price
+              {}
+            elsif revenue >= curr_price && revenue < 2 * curr_price
+              { share_direction: :right, share_times: 1 }
+            elsif revenue >= 2 * curr_price && revenue < 3 * curr_price
+              { share_direction: :right, share_times: 2 }
+            elsif revenue >= 3 * curr_price && revenue < 4 * curr_price
+              { share_direction: :right, share_times: 3 }
+            elsif revenue >= 4 * curr_price
+              { share_direction: :right, share_times: 4 }
+            else
+              { share_direction: :left, share_times: 1 }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_carolinas/step/route.rb
+++ b/lib/engine/game/g_18_carolinas/step/route.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/route'
+
+module Engine
+  module Game
+    module G18Carolinas
+      module Step
+        class Route < Engine::Step::Route
+          def actions(entity)
+            return [] if !entity.operator? || !@game.enough_power?(entity) || !@game.can_run_route?(entity)
+
+            ACTIONS
+          end
+
+          def chart(entity)
+            curr_price = entity.share_price.price
+            [
+              ['Revenue', 'Price Change'],
+              ["< #{@game.format_currency(curr_price / 2)}", '1 ←'],
+              ["≥ #{@game.format_currency(curr_price / 2)}", 'none'],
+              ["≥ #{@game.format_currency(curr_price)}", '1 →'],
+              ["≥ #{@game.format_currency(2 * curr_price)}", '2 →'],
+              ["≥ #{@game.format_currency(3 * curr_price)}", '3 →'],
+              ["≥ #{@game.format_currency(4 * curr_price)}", '4 →'],
+            ]
+          end
+
+          def process_run_routes(action)
+            @game.update_route_trains(action.entity, action.routes)
+
+            super
+          end
+
+          def variable_trains?(_entity)
+            true
+          end
+
+          def variable_distance?(_entity)
+            true
+          end
+
+          def add_train(routes)
+            @game.add_train(routes[0].corporation)
+          end
+
+          def remove_train(route)
+            @game.delete_train(route)
+          end
+
+          def increase_train(route)
+            @game.increase_train(route)
+          end
+
+          def decrease_train(route)
+            @game.decrease_train(route)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_carolinas/step/route.rb
+++ b/lib/engine/game/g_18_carolinas/step/route.rb
@@ -39,22 +39,6 @@ module Engine
           def variable_distance?(_entity)
             true
           end
-
-          def add_train(routes)
-            @game.add_train(routes[0].corporation)
-          end
-
-          def remove_train(route)
-            @game.delete_train(route)
-          end
-
-          def increase_train(route)
-            @game.increase_train(route)
-          end
-
-          def decrease_train(route)
-            @game.decrease_train(route)
-          end
         end
       end
     end


### PR DESCRIPTION
Implement running trains and dividends.
Adds concept of "variable" train lists for a corp. User controls train mix being run subject to constraint of current "train power" (which is hard-coded for the time being).

Common file changes:
UI::RouteSelector - add UI elements to add and delete trains, and to change the size of the currently selected train.
Engine::Game::Base - default methods for the above.

Example:
![variable_trains](https://user-images.githubusercontent.com/8494213/124030908-e76d3780-d9b3-11eb-968d-1c6113299204.png)
