### PR TITLE
Remove loans from 1856 UI after nationalization

### DIFF
--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -861,7 +861,7 @@ module Engine
         end
 
         def interest_rate
-          10
+          @post_nationalization ? nil : 10
         end
 
         def national_token_price
@@ -883,6 +883,8 @@ module Engine
         end
 
         def interest_owed_for_loans(loans)
+          return 0 if @post_nationalization
+
           interest_rate * loans
         end
 
@@ -1458,7 +1460,7 @@ module Engine
           end
           # Leftover cash is transferred
           major.spend(major.cash, national) if major.cash.positive?
-          @loans += major.loans.pop(major.loans.size)
+          @loans.concat(major.loans.pop(major.loans.size))
           # Tunnel / Bridge rights are transferred
           if tunnel?(major)
             if tunnel?(national)
@@ -1778,6 +1780,7 @@ module Engine
           # (It was artificially high to avoid forced discard triggering early)
           @nationalization_train_discard_trigger = true
           @post_nationalization = true
+          @total_loans = 0
         end
 
         # Creates and returns a token for the national


### PR DESCRIPTION
Fixes #5885 (bank relies on `interest_rate`, corporations `@total_loans`)
Fixes #5886 by using `concat` and not `+=` (I verified this with puts, the loans are put back)