### PR TITLE
1889 Beginner Game rules

### DIFF
--- a/lib/engine/game/g_1889/game.rb
+++ b/lib/engine/game/g_1889/game.rb
@@ -297,7 +297,6 @@ module Engine
             revenue: 20,
             desc: 'No special abilities.',
             sym: 'SIR',
-            min_players: 3,
             color: nil,
           },
           {
@@ -459,6 +458,14 @@ module Engine
 
           company = company_by_id('ER')
           current_entity == company ? [@round.company_sellers[company]] : super
+        end
+
+        def setup
+          if two_player? && !@optional_rules.include?(:beginner_game)
+            sir = company_by_id('SIR')
+            sir.close!
+            @round.active_step.companies.delete(sir)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1889/game.rb
+++ b/lib/engine/game/g_1889/game.rb
@@ -475,6 +475,24 @@ module Engine
           6 => %w[DR SIR ER SMR MF TR],
         }.freeze
 
+        BEGINNER_GAME_PRIVATE_REVENUES = {
+          'TR' => 5,
+          'MF' => 15,
+          'ER' => 15,
+          'SMR' => 20,
+          'DR' => 20,
+          'SIR' => 25,
+        }.freeze
+
+        BEGINNER_GAME_PRIVATE_VALUES = {
+          'TR' => 20,
+          'MF' => 40,
+          'ER' => 40,
+          'SMR' => 60,
+          'DR' => 60,
+          'SIR' => 90,
+        }.freeze
+
         def setup
           remove_company(company_by_id('SIR')) if two_player? && !beginner_game?
           return unless beginner_game?
@@ -536,6 +554,8 @@ module Engine
         def neuter_company(company)
           company.abilities.clear
           company.desc = 'Closes when the first 5 train is bought. Cannot be purchased by a corporation'
+          company.value = BEGINNER_GAME_PRIVATE_VALUES[company.sym]
+          company.revenue = BEGINNER_GAME_PRIVATE_REVENUES[company.sym]
           company.add_ability(Ability::NoBuy.new(type: 'no_buy'))
         end
 

--- a/lib/engine/game/g_1889/game.rb
+++ b/lib/engine/game/g_1889/game.rb
@@ -471,8 +471,8 @@ module Engine
           2 => %w[DR SIR],
           3 => %w[DR SIR ER],
           4 => %w[DR SIR ER SMR],
-          5 => %w[DR SIR ER SMR MF],
-          6 => %w[DR SIR ER SMR MF TR],
+          5 => %w[DR SIR ER SMR TR],
+          6 => %w[DR SIR ER SMR TR MF],
         }.freeze
 
         BEGINNER_GAME_PRIVATE_REVENUES = {

--- a/lib/engine/game/g_1889/meta.rb
+++ b/lib/engine/game/g_1889/meta.rb
@@ -24,7 +24,7 @@ module Engine
           {
             sym: :beginner_game,
             short_name: 'Beginner Game',
-            desc: 'Beginner Game (simpler privates, more tiles available)',
+            desc: 'Simpler privates, more tiles available',
           },
         ].freeze
       end

--- a/lib/engine/game/g_1889/meta.rb
+++ b/lib/engine/game/g_1889/meta.rb
@@ -20,6 +20,13 @@ module Engine
         GAME_DROPDOWN_TITLE = 'Shikoku: 1889'
 
         PLAYER_RANGE = [2, 6].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :beginner_game,
+            short_name: 'Beginner Game',
+            desc: 'Beginner Game (simpler privates, more tiles available)',
+          },
+        ].freeze
       end
     end
   end


### PR DESCRIPTION
For the additional tiles, I would've preferred to add tiles but it looks like the canonical way to use `optional_tiles` is to add the optional tiles to the roster and remove them in the method.

![image](https://user-images.githubusercontent.com/2993555/124162765-d46a6e00-da6c-11eb-8caf-8b0025f2132c.png)
![image](https://user-images.githubusercontent.com/2993555/124162796-de8c6c80-da6c-11eb-85e9-91140a12adbd.png)
![image](https://user-images.githubusercontent.com/2993555/124162946-0e3b7480-da6d-11eb-949e-b2f4b18c799a.png)

Side effect of having the beginner tiles in the manifest the way they are: upgrades are slightly more complicated:
![image](https://user-images.githubusercontent.com/2993555/124163233-607c9580-da6d-11eb-8972-42d2f14e56e5.png)

