### PR TITLE
[1846] emit list of privates in the game

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -278,6 +278,8 @@ module Engine
               end
               place_second_token(corporation)
             end
+            @log << "Privates in the game: #{@companies.reject { |c| c.name.include?('Pass') }.map(&:name).join(', ')}"
+            @log << "Corporations in the game: #{@corporations.map(&:name).join(', ')}"
           end
 
           @cert_limit = init_cert_limit


### PR DESCRIPTION
closes #1869 

This adds loglines for which private companies and corps are currently in the game

![image](https://user-images.githubusercontent.com/1711810/124308602-61213480-db1e-11eb-8e08-737ae30c9e2b.png)
