### PR TITLE
Fix rounding of 5% dividends in 1856

### DIFF
--- a/lib/engine/game/g_1836_jr56/game.rb
+++ b/lib/engine/game/g_1836_jr56/game.rb
@@ -608,6 +608,14 @@ module Engine
 
           revenue
         end
+
+        def format_currency(val)
+          # On dividends per share can be a float
+          # But don't show decimal points on all
+          return super if (val % 1).zero?
+
+          format('%.1<val>fF', val: val)
+        end
       end
     end
   end

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -33,7 +33,7 @@ module Engine
                         blue: '#0189d1',
                         brown: '#7b352a')
 
-        CURRENCY_FORMAT_STR = '$%d'
+        CURRENCY_FORMAT_STR = '$%f'
 
         BANK_CASH = 12_000
 
@@ -1861,6 +1861,14 @@ module Engine
 
         def train_limit(entity)
           super + Array(abilities(entity, :train_limit)).sum(&:increase)
+        end
+
+        def format_currency(val)
+          # On dividends per share can be a float
+          # But don't show decimal points on all
+          return super if (val % 1).zero?
+
+          format('$%.1<val>f', val: val)
         end
       end
     end

--- a/lib/engine/game/g_1856/step/dividend.rb
+++ b/lib/engine/game/g_1856/step/dividend.rb
@@ -19,11 +19,17 @@ module Engine
           def dividend_options(entity)
             penalty = @round.interest_penalty[entity] || 0
             revenue = @game.routes_revenue(routes) - penalty
+
             dividend_types.map do |type|
               payout = send(type, entity, revenue)
               payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
+
               [type, payout.merge(share_price_change(entity, revenue - payout[:corporation]))]
             end.to_h
+          end
+
+          def payout_per_share(entity, revenue)
+            (revenue / entity.total_shares.to_f)
           end
 
           def process_dividend(action)

--- a/lib/engine/game/g_18_ka/game.rb
+++ b/lib/engine/game/g_18_ka/game.rb
@@ -1010,6 +1010,14 @@ module Engine
 
           "../logos/18_ka/#{corp}"
         end
+
+        def format_currency(val)
+          # On dividends per share can be a float
+          # But don't show decimal points on all
+          return super if (val % 1).zero?
+
+          format('$%.1<val>c', val: val)
+        end
       end
     end
   end

--- a/spec/fixtures/1836jr56/README.md
+++ b/spec/fixtures/1836jr56/README.md
@@ -2,3 +2,5 @@
 Basic test game until end of game; nationalization
 * hotseat002.json
 Tests the privates; ended before nationalization
+* hotseat004.json
+Based on #46207; verifies proper handling of partial dividends

--- a/spec/fixtures/1836jr56/hotseat004.json
+++ b/spec/fixtures/1836jr56/hotseat004.json
@@ -1,0 +1,11259 @@
+{
+    "status": "finished",
+    "actions": [
+      {
+        "type": "bid",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 1,
+        "created_at": 1623781757,
+        "company": "RdP",
+        "price": 75
+      },
+      {
+        "type": "bid",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 2,
+        "created_at": 1623836471,
+        "company": "CdH",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 3,
+        "created_at": 1623836508,
+        "company": "RdP",
+        "price": 80
+      },
+      {
+        "type": "bid",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 4,
+        "created_at": 1623844176,
+        "company": "E-SF",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 5,
+        "created_at": 1623848769,
+        "company": "ACC",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 6,
+        "created_at": 1623850046,
+        "company": "RdP",
+        "price": 85
+      },
+      {
+        "type": "bid",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 7,
+        "created_at": 1623853973,
+        "company": "RdP",
+        "price": 90
+      },
+      {
+        "type": "bid",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 8,
+        "created_at": 1623867120,
+        "company": "RdP",
+        "price": 95
+      },
+      {
+        "type": "bid",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 9,
+        "created_at": 1623868248,
+        "company": "RdP",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 10,
+        "created_at": 1623868760
+      },
+      {
+        "type": "par",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 11,
+        "created_at": 1623869013,
+        "corporation": "B",
+        "share_price": "65,5,4"
+      },
+      {
+        "type": "par",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 12,
+        "created_at": 1623870260,
+        "corporation": "HSM",
+        "share_price": "80,2,4"
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 13,
+        "created_at": 1623870268,
+        "corporation": "HSM",
+        "until_condition": 3,
+        "from_market": false
+      },
+      {
+        "type": "par",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 14,
+        "created_at": 1623875299,
+        "corporation": "GCL",
+        "share_price": "75,3,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 15,
+        "created_at": 1623908819,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1623908817,
+            "shares": [
+              "HSM_1"
+            ],
+            "percent": 10
+          }
+        ],
+        "shares": [
+          "B_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 16,
+        "created_at": 1623924580,
+        "shares": [
+          "GCL_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 17,
+        "created_at": 1623926806,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1623926804,
+            "corporations": []
+          }
+        ],
+        "hex": "E7",
+        "tile": "57-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 18,
+        "created_at": 1623926817
+      },
+      {
+        "type": "buy_train",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 19,
+        "created_at": 1623926819,
+        "train": "2-0",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 20,
+        "created_at": 1623926821
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 21,
+        "created_at": 1623938956,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1623938955,
+            "corporations": []
+          }
+        ],
+        "hex": "I9",
+        "tile": "6-0",
+        "rotation": 1
+      },
+      {
+        "id": 22,
+        "type": "buy_train",
+        "price": 100,
+        "train": "2-1",
+        "entity": "GCL",
+        "variant": "2",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1623938959
+      },
+      {
+        "id": 23,
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1623938961
+      },
+      {
+        "id": 24,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1623938976
+      },
+      {
+        "id": 25,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1623938980
+      },
+      {
+        "type": "buy_train",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 26,
+        "created_at": 1623938984,
+        "train": "2-1",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 27,
+        "created_at": 1623939003
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 28,
+        "created_at": 1623939004
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 29,
+        "created_at": 1623941685,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1623941684,
+            "corporations": []
+          }
+        ],
+        "hex": "H4",
+        "tile": "6-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 30,
+        "created_at": 1623941695
+      },
+      {
+        "type": "buy_train",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 31,
+        "created_at": 1623941707,
+        "train": "2-2",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "id": 32,
+        "loan": 0,
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1623941710
+      },
+      {
+        "id": 33,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1623941727
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 34,
+        "created_at": 1623941739
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 35,
+        "created_at": 1623941744
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 36,
+        "created_at": 1623941751
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 37,
+        "created_at": 1623948765
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 38,
+        "created_at": 1623969261
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 39,
+        "created_at": 1623997811,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1623997809,
+            "corporations": []
+          }
+        ],
+        "hex": "F8",
+        "tile": "8-0",
+        "rotation": 2
+      },
+      {
+        "type": "take_loan",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 40,
+        "created_at": 1623997824,
+        "loan": 0
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 41,
+        "created_at": 1623997834
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 42,
+        "created_at": 1623997840,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D6",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "E7",
+              "D6"
+            ],
+            "revenue": 60,
+            "revenue_str": "E7-D6"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 43,
+        "created_at": 1623997842,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 44,
+        "created_at": 1623997844,
+        "train": "2-3",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 45,
+        "created_at": 1623997846
+      },
+      {
+        "id": 46,
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1623997848
+      },
+      {
+        "id": 47,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1623997852
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 48,
+        "created_at": 1623997859
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 49,
+        "created_at": 1624006838,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624006839,
+            "corporations": []
+          }
+        ],
+        "hex": "I7",
+        "tile": "8-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 50,
+        "created_at": 1624006841
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 51,
+        "created_at": 1624006843
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 52,
+        "created_at": 1624009810,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624009810,
+            "corporations": []
+          }
+        ],
+        "hex": "G7",
+        "tile": "5-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 53,
+        "created_at": 1624009823
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 54,
+        "created_at": 1624009835,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "G7"
+            ],
+            "revenue": 50,
+            "revenue_str": "H6-G7"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 55,
+        "created_at": 1624009846,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 56,
+        "created_at": 1624009849,
+        "loan": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 57,
+        "created_at": 1624009850,
+        "train": "2'-0",
+        "price": 100,
+        "variant": "2'"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 58,
+        "created_at": 1624009851
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 59,
+        "created_at": 1624009855
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 60,
+        "created_at": 1624009871
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 61,
+        "created_at": 1624019967
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 62,
+        "created_at": 1624026291
+      },
+      {
+        "id": 63,
+        "hex": "F10",
+        "tile": "58-0",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1624031422,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1624031425
+      },
+      {
+        "id": 64,
+        "city": "57-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031429
+      },
+      {
+        "id": 65,
+        "type": "run_routes",
+        "entity": "HSM",
+        "routes": [
+          {
+            "hexes": [
+              "D6",
+              "E7"
+            ],
+            "train": "2-0",
+            "revenue": 60,
+            "connections": [
+              [
+                "D6",
+                "E7"
+              ]
+            ],
+            "revenue_str": "D6-E7"
+          },
+          {
+            "hexes": [
+              "F10",
+              "E7"
+            ],
+            "train": "2-3",
+            "revenue": 30,
+            "connections": [
+              [
+                "E7",
+                "F8",
+                "F10"
+              ]
+            ],
+            "revenue_str": "F10-E7"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031437
+      },
+      {
+        "id": 66,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031443
+      },
+      {
+        "id": 67,
+        "type": "undo",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031455
+      },
+      {
+        "id": 68,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031457
+      },
+      {
+        "id": 69,
+        "loan": 2,
+        "type": "take_loan",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031461
+      },
+      {
+        "id": 70,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 62,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031473
+      },
+      {
+        "id": 71,
+        "loan": 2,
+        "type": "take_loan",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031476
+      },
+      {
+        "id": 72,
+        "hex": "F10",
+        "tile": "58-0",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1624031481,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1624031484
+      },
+      {
+        "id": 73,
+        "city": "57-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031487
+      },
+      {
+        "id": 74,
+        "type": "run_routes",
+        "entity": "HSM",
+        "routes": [
+          {
+            "hexes": [
+              "D6",
+              "E7"
+            ],
+            "train": "2-0",
+            "revenue": 60,
+            "connections": [
+              [
+                "D6",
+                "E7"
+              ]
+            ],
+            "revenue_str": "D6-E7"
+          },
+          {
+            "hexes": [
+              "F10",
+              "E7"
+            ],
+            "train": "2-3",
+            "revenue": 30,
+            "connections": [
+              [
+                "E7",
+                "F8",
+                "F10"
+              ]
+            ],
+            "revenue_str": "F10-E7"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031494
+      },
+      {
+        "id": 75,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031497
+      },
+      {
+        "id": 76,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 62,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624031501
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 77,
+        "created_at": 1624031511,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624031508,
+            "corporations": []
+          }
+        ],
+        "hex": "F10",
+        "tile": "58-0",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 78,
+        "created_at": 1624031517,
+        "city": "57-0-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 79,
+        "created_at": 1624031524,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D6",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E7"
+            ],
+            "revenue": 60,
+            "revenue_str": "D6-E7"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "E7",
+                "F8",
+                "F10"
+              ]
+            ],
+            "hexes": [
+              "F10",
+              "E7"
+            ],
+            "revenue": 30,
+            "revenue_str": "F10-E7"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 80,
+        "created_at": 1624031525,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 81,
+        "created_at": 1624031550
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 82,
+        "created_at": 1624031551
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 83,
+        "created_at": 1624035322,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624035320,
+            "corporations": []
+          }
+        ],
+        "hex": "G3",
+        "tile": "8-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 84,
+        "created_at": 1624035325
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 85,
+        "created_at": 1624035339,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ]
+            ],
+            "hexes": [
+              "G7",
+              "H6"
+            ],
+            "revenue": 50,
+            "revenue_str": "G7-H6"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "H6",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "H6"
+            ],
+            "revenue": 50,
+            "revenue_str": "H4-H6"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 86,
+        "created_at": 1624035377,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 87,
+        "created_at": 1624035381,
+        "loan": 2
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 88,
+        "created_at": 1624035388
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 89,
+        "created_at": 1624035390
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 90,
+        "created_at": 1624093636,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624093635,
+            "corporations": []
+          }
+        ],
+        "hex": "J6",
+        "tile": "5-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 91,
+        "created_at": 1624093645
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 92,
+        "created_at": 1624093659,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "J6",
+              "I9"
+            ],
+            "revenue": 40,
+            "revenue_str": "J6-I9"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 93,
+        "created_at": 1624093661,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 94,
+        "created_at": 1624093664
+      },
+      {
+        "id": 95,
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624093668
+      },
+      {
+        "id": 96,
+        "type": "undo",
+        "entity": 55,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624093677
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 97,
+        "created_at": 1624093685
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 98,
+        "created_at": 1624097065,
+        "shares": [
+          "HSM_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 99,
+        "created_at": 1624097075
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 100,
+        "created_at": 1624097981,
+        "shares": [
+          "B_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 101,
+        "created_at": 1624097990
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 102,
+        "created_at": 1624128325
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 103,
+        "created_at": 1624169575
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 104,
+        "created_at": 1624180905,
+        "shares": [
+          "B_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 105,
+        "created_at": 1624180910,
+        "shares": [
+          "HSM_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 106,
+        "created_at": 1624180919
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 107,
+        "created_at": 1624180923
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 108,
+        "created_at": 1624185044
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 109,
+        "created_at": 1624199363,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624199363
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 110,
+        "created_at": 1624212542,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624212539,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 111,
+        "created_at": 1624212549,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D6",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E7"
+            ],
+            "revenue": 60,
+            "revenue_str": "D6-E7"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "E7",
+                "F8",
+                "F10"
+              ]
+            ],
+            "hexes": [
+              "E7",
+              "F10"
+            ],
+            "revenue": 30,
+            "revenue_str": "E7-F10"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 112,
+        "created_at": 1624212551,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 113,
+        "created_at": 1624212554,
+        "loan": 3
+      },
+      {
+        "type": "buy_train",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 114,
+        "created_at": 1624212556,
+        "train": "3-0",
+        "price": 225,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 115,
+        "created_at": 1624212567
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 116,
+        "created_at": 1624212576
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 117,
+        "created_at": 1624212578
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 118,
+        "created_at": 1624217947,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624217947,
+            "corporations": [
+              "Nord"
+            ]
+          }
+        ],
+        "hex": "I5",
+        "tile": "8-3",
+        "rotation": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 119,
+        "created_at": 1624217965,
+        "loan": 4
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 120,
+        "created_at": 1624217970
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 121,
+        "created_at": 1624217977,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "I9",
+              "J6"
+            ],
+            "revenue": 40,
+            "revenue_str": "I9-J6"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 122,
+        "created_at": 1624217987,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 123,
+        "created_at": 1624217993
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 124,
+        "created_at": 1624217996
+      },
+      {
+        "type": "buy_company",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 125,
+        "created_at": 1624218026,
+        "company": "CdH",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 126,
+        "created_at": 1624218037
+      },
+      {
+        "id": 127,
+        "hex": "H8",
+        "tile": "8-4",
+        "type": "lay_tile",
+        "entity": "B",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "created_at": 1624218574,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 55,
+        "created_at": 1624218575
+      },
+      {
+        "id": 128,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218605
+      },
+      {
+        "id": 129,
+        "hex": "H6",
+        "tile": "121-0",
+        "type": "lay_tile",
+        "entity": "B",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "created_at": 1624218622,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 55,
+        "created_at": 1624218624
+      },
+      {
+        "id": 130,
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218630
+      },
+      {
+        "id": 131,
+        "type": "run_routes",
+        "entity": "B",
+        "routes": [
+          {
+            "hexes": [
+              "G7",
+              "H6"
+            ],
+            "train": "2-2",
+            "revenue": 70,
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ]
+            ],
+            "revenue_str": "G7-H6"
+          },
+          {
+            "hexes": [
+              "H6",
+              "H4"
+            ],
+            "train": "2'-0",
+            "revenue": 70,
+            "connections": [
+              [
+                "H6",
+                "H4"
+              ]
+            ],
+            "revenue_str": "H6-H4"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218634
+      },
+      {
+        "id": 132,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218637
+      },
+      {
+        "id": 133,
+        "loan": 5,
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218645
+      },
+      {
+        "id": 134,
+        "type": "buy_train",
+        "price": 225,
+        "train": "3-1",
+        "entity": "B",
+        "variant": "3",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218647
+      },
+      {
+        "id": 135,
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218650
+      },
+      {
+        "id": 136,
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218655
+      },
+      {
+        "id": 137,
+        "type": "undo",
+        "entity": "B",
+        "action_id": 126,
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624218668
+      },
+      {
+        "type": "buy_company",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 138,
+        "created_at": 1624218686,
+        "company": "RdP",
+        "price": 90
+      },
+      {
+        "type": "assign",
+        "entity": "RdP",
+        "entity_type": "company",
+        "id": 139,
+        "created_at": 1624218691,
+        "target": "H6",
+        "target_type": "hex"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 140,
+        "created_at": 1624218697,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624218696,
+            "corporations": []
+          }
+        ],
+        "hex": "H6",
+        "tile": "121-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 141,
+        "created_at": 1624218728
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 142,
+        "created_at": 1624218730,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ]
+            ],
+            "hexes": [
+              "G7",
+              "H6"
+            ],
+            "revenue": 90,
+            "revenue_str": "G7-H6"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "H6",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "H4"
+            ],
+            "revenue": 90,
+            "revenue_str": "H6-H4"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 143,
+        "created_at": 1624218735,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 144,
+        "created_at": 1624218740,
+        "loan": 5
+      },
+      {
+        "type": "buy_train",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 145,
+        "created_at": 1624218752,
+        "train": "3-1",
+        "price": 225,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 146,
+        "created_at": 1624218754
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 147,
+        "created_at": 1624218755
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 148,
+        "created_at": 1624223760,
+        "shares": [
+          "GCL_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 149,
+        "created_at": 1624223764
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 150,
+        "created_at": 1624258247,
+        "shares": [
+          "B_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 151,
+        "created_at": 1624258252
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 152,
+        "created_at": 1624259464,
+        "shares": [
+          "HSM_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 153,
+        "created_at": 1624259467,
+        "shares": [
+          "B_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 154,
+        "created_at": 1624259471
+      },
+      {
+        "id": 155,
+        "type": "buy_shares",
+        "entity": 4301,
+        "shares": [
+          "HSM_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624274080
+      },
+      {
+        "id": 156,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624274087
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 157,
+        "created_at": 1624274092,
+        "shares": [
+          "GCL_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 158,
+        "created_at": 1624274099
+      },
+      {
+        "id": 159,
+        "type": "buy_shares",
+        "entity": 55,
+        "shares": [
+          "HSM_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 55,
+        "created_at": 1624276175
+      },
+      {
+        "id": 160,
+        "type": "undo",
+        "entity": 55,
+        "entity_type": "player",
+        "user": 55,
+        "created_at": 1624276215
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 161,
+        "created_at": 1624276217,
+        "shares": [
+          "GCL_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 162,
+        "created_at": 1624276231
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 163,
+        "created_at": 1624276747,
+        "shares": [
+          "B_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 164,
+        "created_at": 1624276752
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 165,
+        "created_at": 1624278298
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 166,
+        "created_at": 1624279625
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 167,
+        "created_at": 1624279688,
+        "shares": [
+          "B_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 168,
+        "created_at": 1624279708,
+        "shares": [
+          "GCL_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 169,
+        "created_at": 1624279717
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 170,
+        "created_at": 1624279730
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 171,
+        "created_at": 1624292574
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 172,
+        "created_at": 1624293359,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624293362
+          }
+        ]
+      },
+      {
+        "id": 173,
+        "hex": "E11",
+        "tile": "59-0",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1624293617,
+            "entity_type": "corporation",
+            "corporations": [
+              "HSM"
+            ]
+          }
+        ],
+        "user": 45,
+        "created_at": 1624293617
+      },
+      {
+        "id": 174,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 172,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624293632
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 175,
+        "created_at": 1624293640,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624293640,
+            "corporations": []
+          }
+        ],
+        "hex": "E5",
+        "tile": "59-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 176,
+        "created_at": 1624293651,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D6",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E7"
+            ],
+            "revenue": 60,
+            "revenue_str": "D6-E7"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "E7",
+                "F8",
+                "F10"
+              ]
+            ],
+            "hexes": [
+              "E7",
+              "F10"
+            ],
+            "revenue": 30,
+            "revenue_str": "E7-F10"
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "E5",
+                "D6"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E5"
+            ],
+            "revenue": 80,
+            "revenue_str": "D6-E5"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 177,
+        "created_at": 1624293654,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 178,
+        "created_at": 1624293692
+      },
+      {
+        "id": 179,
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624293696
+      },
+      {
+        "id": 180,
+        "type": "undo",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624293708
+      },
+      {
+        "type": "take_loan",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 181,
+        "created_at": 1624293710,
+        "loan": 6
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 182,
+        "created_at": 1624293715
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 183,
+        "created_at": 1624293729
+      },
+      {
+        "id": 184,
+        "hex": "I3",
+        "tile": "121-1",
+        "type": "lay_tile",
+        "entity": "GCL",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "created_at": 1624297947,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 4301,
+        "created_at": 1624297948
+      },
+      {
+        "id": 185,
+        "city": "121-1-0",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624297959
+      },
+      {
+        "id": 186,
+        "type": "run_routes",
+        "entity": "GCL",
+        "routes": [
+          {
+            "hexes": [
+              "I3",
+              "J6"
+            ],
+            "train": "2-1",
+            "revenue": 70,
+            "connections": [
+              [
+                "I3",
+                "I5",
+                "J6"
+              ]
+            ],
+            "revenue_str": "I3-J6"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624297975
+      },
+      {
+        "id": 187,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624297979
+      },
+      {
+        "id": 188,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624297982
+      },
+      {
+        "id": 189,
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624297988
+      },
+      {
+        "id": 190,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624298019
+      },
+      {
+        "id": 191,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624298025
+      },
+      {
+        "id": 192,
+        "hex": "I9",
+        "tile": "14-0",
+        "type": "lay_tile",
+        "entity": "GCL",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "created_at": 1624298040,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 4301,
+        "created_at": 1624298041
+      },
+      {
+        "id": 193,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624298048
+      },
+      {
+        "id": 194,
+        "hex": "I9",
+        "tile": "14-0",
+        "type": "lay_tile",
+        "entity": "GCL",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "created_at": 1624298066,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 4301,
+        "created_at": 1624298067
+      },
+      {
+        "id": 195,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624298075
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 196,
+        "created_at": 1624298086,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624298085,
+            "corporations": []
+          }
+        ],
+        "hex": "J6",
+        "tile": "15-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 197,
+        "created_at": 1624298090
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 198,
+        "created_at": 1624298093,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "I9",
+              "J6"
+            ],
+            "revenue": 50,
+            "revenue_str": "I9-J6"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 199,
+        "created_at": 1624298096,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 200,
+        "created_at": 1624298098,
+        "train": "3-2",
+        "price": 225,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 201,
+        "created_at": 1624298111
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 202,
+        "created_at": 1624298117
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 203,
+        "created_at": 1624299918,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624299922,
+            "corporations": []
+          }
+        ],
+        "hex": "I7",
+        "tile": "25-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 204,
+        "created_at": 1624299927,
+        "city": "6-1-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 205,
+        "created_at": 1624300089,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ]
+            ],
+            "hexes": [
+              "G7",
+              "H6"
+            ],
+            "revenue": 90,
+            "revenue_str": "G7-H6"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "H6",
+                "I7",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "J6",
+              "H6"
+            ],
+            "revenue": 100,
+            "revenue_str": "J6-H6"
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 130,
+            "revenue_str": "H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 206,
+        "created_at": 1624300111,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 207,
+        "created_at": 1624300115
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 208,
+        "created_at": 1624300117
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 209,
+        "created_at": 1624300122
+      },
+      {
+        "id": 210,
+        "hex": "E11",
+        "tile": "59-1",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1624300300,
+            "entity_type": "corporation",
+            "corporations": [
+              "NBDS",
+              "HSM"
+            ]
+          }
+        ],
+        "user": 45,
+        "created_at": 1624300300
+      },
+      {
+        "id": 211,
+        "type": "run_routes",
+        "entity": "HSM",
+        "routes": [
+          {
+            "hexes": [
+              "D6",
+              "E5"
+            ],
+            "train": "2-0",
+            "revenue": 80,
+            "connections": [
+              [
+                "E5",
+                "D6"
+              ]
+            ],
+            "revenue_str": "D6-E5"
+          },
+          {
+            "hexes": [
+              "D6",
+              "E7"
+            ],
+            "train": "2-3",
+            "revenue": 60,
+            "connections": [
+              [
+                "E7",
+                "D6"
+              ]
+            ],
+            "revenue_str": "D6-E7"
+          },
+          {
+            "hexes": [
+              "E11",
+              "F10",
+              "E7"
+            ],
+            "train": "3-0",
+            "revenue": 70,
+            "connections": [
+              [
+                "F10",
+                "E11"
+              ],
+              [
+                "E7",
+                "F8",
+                "F10"
+              ]
+            ],
+            "revenue_str": "E11-F10-E7"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300318
+      },
+      {
+        "id": 212,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300335
+      },
+      {
+        "id": 213,
+        "type": "buy_train",
+        "price": 225,
+        "train": "3'-0",
+        "entity": "HSM",
+        "variant": "3'",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300337
+      },
+      {
+        "id": 214,
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300360
+      },
+      {
+        "id": 215,
+        "type": "buy_company",
+        "price": 57,
+        "entity": "HSM",
+        "company": "E-SF",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300365
+      },
+      {
+        "id": 216,
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300370
+      },
+      {
+        "id": 217,
+        "type": "undo",
+        "entity": "GCL",
+        "action_id": 209,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300384
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 218,
+        "created_at": 1624300399,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624300400,
+            "corporations": [
+              "NBDS",
+              "HSM"
+            ]
+          }
+        ],
+        "hex": "E11",
+        "tile": "59-1",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 219,
+        "created_at": 1624300418,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D6",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "D6"
+            ],
+            "revenue": 80,
+            "revenue_str": "E5-D6"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "E7",
+                "D6"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E7"
+            ],
+            "revenue": 60,
+            "revenue_str": "D6-E7"
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F10",
+                "F8",
+                "E7"
+              ],
+              [
+                "E11",
+                "F10"
+              ]
+            ],
+            "hexes": [
+              "E7",
+              "F10",
+              "E11"
+            ],
+            "revenue": 70,
+            "revenue_str": "E7-F10-E11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 220,
+        "created_at": 1624300426,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_company",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 221,
+        "created_at": 1624300437,
+        "company": "E-SF",
+        "price": 80
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 222,
+        "created_at": 1624300443
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 223,
+        "created_at": 1624300448
+      },
+      {
+        "id": 224,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 209,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300506
+      },
+      {
+        "id": 225,
+        "type": "redo",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624300510
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 226,
+        "created_at": 1624300514
+      },
+      {
+        "type": "take_loan",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 227,
+        "created_at": 1624302800,
+        "loan": 7
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 228,
+        "created_at": 1624302810,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624302811,
+            "corporations": []
+          }
+        ],
+        "hex": "I3",
+        "tile": "121-1",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 229,
+        "created_at": 1624302813,
+        "city": "121-1-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 230,
+        "created_at": 1624302821,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "I9",
+              "J6"
+            ],
+            "revenue": 50,
+            "revenue_str": "I9-J6"
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "I3",
+                "J2"
+              ],
+              [
+                "J6",
+                "I5",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "J2",
+              "I3",
+              "J6"
+            ],
+            "revenue": 100,
+            "revenue_str": "J2-I3-J6"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 231,
+        "created_at": 1624302823,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 232,
+        "created_at": 1624302826
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 233,
+        "created_at": 1624302830
+      },
+      {
+        "type": "buy_company",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 234,
+        "created_at": 1624302840,
+        "company": "ACC",
+        "price": 40
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 235,
+        "created_at": 1624303587,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624303587,
+            "corporations": []
+          }
+        ],
+        "hex": "H4",
+        "tile": "15-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 236,
+        "created_at": 1624303589
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 237,
+        "created_at": 1624303601,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ]
+            ],
+            "hexes": [
+              "G7",
+              "H6"
+            ],
+            "revenue": 90,
+            "revenue_str": "G7-H6"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "H6",
+                "I7",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6"
+            ],
+            "revenue": 100,
+            "revenue_str": "H6-J6"
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 140,
+            "revenue_str": "H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 238,
+        "created_at": 1624303602,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 239,
+        "created_at": 1624303605
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 240,
+        "created_at": 1624303608
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 241,
+        "created_at": 1624306661,
+        "shares": [
+          "B_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 242,
+        "created_at": 1624306678
+      },
+      {
+        "id": 243,
+        "type": "buy_shares",
+        "entity": 55,
+        "shares": [
+          "HSM_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 55,
+        "created_at": 1624308383
+      },
+      {
+        "id": 244,
+        "type": "undo",
+        "entity": 55,
+        "entity_type": "player",
+        "user": 55,
+        "created_at": 1624308393
+      },
+      {
+        "type": "sell_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 245,
+        "created_at": 1624308397,
+        "shares": [
+          "HSM_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 246,
+        "created_at": 1624308405,
+        "shares": [
+          "GCL_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 247,
+        "created_at": 1624308430,
+        "corporation": "Nord",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 248,
+        "created_at": 1624308435
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 249,
+        "created_at": 1624309689,
+        "shares": [
+          "GCL_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 250,
+        "created_at": 1624309695,
+        "corporation": "NBDS",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 251,
+        "created_at": 1624309699
+      },
+      {
+        "id": 252,
+        "type": "buy_shares",
+        "entity": 4301,
+        "shares": [
+          "HSM_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624350954
+      },
+      {
+        "id": 253,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624350962
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 254,
+        "created_at": 1624350965,
+        "shares": [
+          "HSM_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 255,
+        "created_at": 1624350973
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 256,
+        "created_at": 1624354051,
+        "shares": [
+          "Nord_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 257,
+        "created_at": 1624354053
+      },
+      {
+        "id": 258,
+        "type": "buy_shares",
+        "entity": 45,
+        "shares": [
+          "HSM_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624354842
+      },
+      {
+        "id": 259,
+        "type": "undo",
+        "entity": 45,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624354855
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 260,
+        "created_at": 1624354861,
+        "shares": [
+          "B_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 261,
+        "created_at": 1624354906,
+        "shares": [
+          "B_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 262,
+        "created_at": 1624354920
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 263,
+        "created_at": 1624357279
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 264,
+        "created_at": 1624357284
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 265,
+        "created_at": 1624362743
+      },
+      {
+        "id": 266,
+        "type": "buy_shares",
+        "entity": 45,
+        "shares": [
+          "NBDS_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624363575
+      },
+      {
+        "id": 267,
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4301,
+            "created_at": 1624363583,
+            "entity_type": "player"
+          }
+        ],
+        "user": 45,
+        "created_at": 1624363583
+      },
+      {
+        "id": 268,
+        "type": "undo",
+        "entity": 55,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624363596
+      },
+      {
+        "id": 269,
+        "type": "undo",
+        "entity": 45,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624363601
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 270,
+        "created_at": 1624363603,
+        "shares": [
+          "B_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 271,
+        "created_at": 1624363606,
+        "shares": [
+          "HSM_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 272,
+        "created_at": 1624363609,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624363609,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 273,
+        "created_at": 1624363617,
+        "corporation": "NBDS",
+        "until_condition": 3,
+        "from_market": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 274,
+        "created_at": 1624363917,
+        "shares": [
+          "HSM_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 275,
+        "created_at": 1624363926,
+        "shares": [
+          "GCL_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 276,
+        "created_at": 1624363929
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 277,
+        "created_at": 1624363943
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 278,
+        "created_at": 1624367736,
+        "shares": [
+          "B_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 279,
+        "created_at": 1624367785,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624367785,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 280,
+        "created_at": 1624368752,
+        "shares": [
+          "Nord_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 281,
+        "created_at": 1624368754,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624368754
+          }
+        ]
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 282,
+        "created_at": 1624368827,
+        "corporation": "NBDS",
+        "until_condition": 3,
+        "from_market": false
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 283,
+        "created_at": 1624369521,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624369521,
+            "shares": [
+              "NBDS_1"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624369521
+          },
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624369521
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 284,
+        "created_at": 1624369622,
+        "shares": [
+          "NBDS_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 285,
+        "created_at": 1624369625
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 286,
+        "created_at": 1624370687,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624370686,
+            "reason": "3 share(s) bought in NBDS, end condition met"
+          }
+        ],
+        "shares": [
+          "Nord_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 287,
+        "created_at": 1624370717,
+        "shares": [
+          "HSM_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 288,
+        "created_at": 1624370736,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624370736,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 289,
+        "created_at": 1624370741
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 290,
+        "created_at": 1624377177
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 291,
+        "created_at": 1624377181
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 292,
+        "created_at": 1624377412,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624377415
+          }
+        ]
+      },
+      {
+        "type": "place_token",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 293,
+        "created_at": 1624377524,
+        "city": "59-1-1",
+        "slot": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 294,
+        "created_at": 1624377529,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NBDS",
+            "entity_type": "corporation",
+            "created_at": 1624377528,
+            "corporations": []
+          }
+        ],
+        "hex": "D10",
+        "tile": "7-0",
+        "rotation": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 295,
+        "created_at": 1624377541,
+        "loan": 8
+      },
+      {
+        "type": "buy_train",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 296,
+        "created_at": 1624377597,
+        "train": "3'-0",
+        "price": 225,
+        "variant": "3'"
+      },
+      {
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 297,
+        "created_at": 1624377628
+      },
+      {
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 298,
+        "created_at": 1624377633
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 299,
+        "created_at": 1624377642,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624377641,
+            "corporations": []
+          }
+        ],
+        "hex": "E7",
+        "tile": "14-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 300,
+        "created_at": 1624377646,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D6",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E5"
+            ],
+            "revenue": 80,
+            "revenue_str": "D6-E5"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "E7",
+                "D6"
+              ]
+            ],
+            "hexes": [
+              "E7",
+              "D6"
+            ],
+            "revenue": 70,
+            "revenue_str": "E7-D6"
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F10",
+                "F8",
+                "E7"
+              ],
+              [
+                "E11",
+                "F10"
+              ]
+            ],
+            "hexes": [
+              "E7",
+              "F10",
+              "E11"
+            ],
+            "revenue": 80,
+            "revenue_str": "E7-F10-E11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 301,
+        "created_at": 1624377650,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 302,
+        "created_at": 1624377653,
+        "train": "4-0",
+        "price": 350,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 303,
+        "created_at": 1624377671
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 304,
+        "created_at": 1624377673
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 305,
+        "created_at": 1624377680
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 306,
+        "created_at": 1624380359,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624380362,
+            "corporations": []
+          }
+        ],
+        "hex": "I9",
+        "tile": "15-2",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 307,
+        "created_at": 1624380384,
+        "city": "15-0-0",
+        "slot": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 308,
+        "created_at": 1624380402,
+        "train": "4-1",
+        "price": 350,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 309,
+        "created_at": 1624380415
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 310,
+        "created_at": 1624380422
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 311,
+        "created_at": 1624380461,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624380464,
+            "corporations": []
+          }
+        ],
+        "hex": "G7",
+        "tile": "15-3",
+        "rotation": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 312,
+        "created_at": 1624380468,
+        "loan": 9
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 313,
+        "created_at": 1624380490
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 314,
+        "created_at": 1624380515,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 140,
+            "revenue_str": "H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 315,
+        "created_at": 1624380538,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 316,
+        "created_at": 1624380540
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 317,
+        "created_at": 1624380544
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 318,
+        "created_at": 1624381124,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624381125,
+            "corporations": []
+          }
+        ],
+        "hex": "H8",
+        "tile": "9-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 319,
+        "created_at": 1624381130
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 320,
+        "created_at": 1624381148,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3"
+            ],
+            "revenue": 130,
+            "revenue_str": "H6-J6-I3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 321,
+        "created_at": 1624381150,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 322,
+        "created_at": 1624381166,
+        "loan": 10
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 323,
+        "created_at": 1624381173
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 324,
+        "created_at": 1624381177
+      },
+      {
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 325,
+        "created_at": 1624381538,
+        "loan": 11
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 326,
+        "created_at": 1624381572,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624381575,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 327,
+        "created_at": 1624381575
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 328,
+        "created_at": 1624381578,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 140,
+            "revenue_str": "H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "id": 329,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624381580
+      },
+      {
+        "id": 330,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624381595
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 331,
+        "created_at": 1624381612,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 332,
+        "created_at": 1624381618
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 333,
+        "created_at": 1624381625
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 334,
+        "created_at": 1624396693,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NBDS",
+            "entity_type": "corporation",
+            "created_at": 1624396694,
+            "corporations": []
+          }
+        ],
+        "hex": "E9",
+        "tile": "8-4",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 335,
+        "created_at": 1624396694,
+        "city": "14-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 336,
+        "created_at": 1624396712,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "E7",
+                "D6"
+              ],
+              [
+                "E11",
+                "D10",
+                "E9",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E7",
+              "E11"
+            ],
+            "revenue": 110,
+            "revenue_str": "D6-E7-E11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 337,
+        "created_at": 1624396718,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 338,
+        "created_at": 1624396735
+      },
+      {
+        "id": 339,
+        "loan": 8,
+        "type": "payoff_loan",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624396763
+      },
+      {
+        "id": 340,
+        "type": "undo",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624396768
+      },
+      {
+        "type": "take_loan",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 341,
+        "created_at": 1624396801,
+        "loan": 12
+      },
+      {
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 342,
+        "created_at": 1624396802
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 343,
+        "created_at": 1624396840,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624396841,
+            "corporations": []
+          }
+        ],
+        "hex": "D6",
+        "tile": "120-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 344,
+        "created_at": 1624396910,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F10",
+                "F8",
+                "E7"
+              ],
+              [
+                "E11",
+                "F10"
+              ]
+            ],
+            "hexes": [
+              "E7",
+              "F10",
+              "E11"
+            ],
+            "revenue": 80,
+            "revenue_str": "E7-F10-E11"
+          },
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "D6",
+                "E5"
+              ],
+              [
+                "E7",
+                "D6"
+              ],
+              [
+                "E11",
+                "D10",
+                "E9",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "D6",
+              "E7",
+              "E11"
+            ],
+            "revenue": 170,
+            "revenue_str": "E5-D6-E7-E11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 345,
+        "created_at": 1624396919,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "E-SF",
+        "entity_type": "company",
+        "id": 346,
+        "created_at": 1624396941,
+        "hex": "B8",
+        "tile": "56-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 347,
+        "created_at": 1624396944
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 348,
+        "created_at": 1624396951
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 349,
+        "created_at": 1624401322,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624401323,
+            "corporations": []
+          }
+        ],
+        "hex": "J4",
+        "tile": "9-1",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 350,
+        "created_at": 1624401333,
+        "loan": 13
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 351,
+        "created_at": 1624401337
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 352,
+        "created_at": 1624401340,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3"
+            ],
+            "revenue": 130,
+            "revenue_str": "H6-J6-I3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 353,
+        "created_at": 1624401346,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 354,
+        "created_at": 1624401353
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 355,
+        "created_at": 1624401355
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 356,
+        "created_at": 1624428279,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624428278,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 357,
+        "created_at": 1624428298,
+        "loan": 14
+      },
+      {
+        "type": "place_token",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 358,
+        "created_at": 1624428301,
+        "city": "121-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 359,
+        "created_at": 1624428313,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 190,
+            "revenue_str": "H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 360,
+        "created_at": 1624428321,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 361,
+        "created_at": 1624428332
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 362,
+        "created_at": 1624428335
+      },
+      {
+        "id": 363,
+        "type": "sell_shares",
+        "entity": 4301,
+        "shares": [
+          "B_5"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624438559
+      },
+      {
+        "id": 364,
+        "type": "par",
+        "entity": 4301,
+        "corporation": "NFL",
+        "entity_type": "player",
+        "share_price": "80,2,4",
+        "user": 4301,
+        "created_at": 1624438582
+      },
+      {
+        "id": 365,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624438596
+      },
+      {
+        "id": 366,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624438604
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 367,
+        "created_at": 1624438610,
+        "shares": [
+          "GCL_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 368,
+        "created_at": 1624438612,
+        "shares": [
+          "B_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 369,
+        "created_at": 1624438619,
+        "corporation": "NFL",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 370,
+        "created_at": 1624438628
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 371,
+        "created_at": 1624469892,
+        "shares": [
+          "B_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 372,
+        "created_at": 1624469915
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 373,
+        "created_at": 1624474360,
+        "shares": [
+          "GCL_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 374,
+        "created_at": 1624474363
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 375,
+        "created_at": 1624524016,
+        "shares": [
+          "NFL_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 376,
+        "created_at": 1624524023
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 377,
+        "created_at": 1624524280
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 378,
+        "created_at": 1624530583,
+        "shares": [
+          "GCL_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 379,
+        "created_at": 1624530599,
+        "shares": [
+          "HSM_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 380,
+        "created_at": 1624530669
+      },
+      {
+        "id": 381,
+        "type": "buy_shares",
+        "entity": 4301,
+        "shares": [
+          "HSM_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624533903
+      },
+      {
+        "id": 382,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624533908
+      },
+      {
+        "id": 383,
+        "type": "buy_shares",
+        "entity": 4301,
+        "shares": [
+          "HSM_2"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624533910
+      },
+      {
+        "id": 384,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624533918
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 385,
+        "created_at": 1624533945,
+        "shares": [
+          "NFL_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 386,
+        "created_at": 1624533947
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 387,
+        "created_at": 1624543113,
+        "shares": [
+          "GCL_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 388,
+        "created_at": 1624543129
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 389,
+        "created_at": 1624543716,
+        "shares": [
+          "NBDS_3"
+        ],
+        "percent": 10
+      },
+      {
+        "id": 390,
+        "type": "undo",
+        "entity": 45,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624543757
+      },
+      {
+        "id": 391,
+        "type": "redo",
+        "entity": 45,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624543760
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 392,
+        "created_at": 1624543772
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 393,
+        "created_at": 1624544523
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 394,
+        "created_at": 1624545274,
+        "shares": [
+          "Nord_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 395,
+        "created_at": 1624545290
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 396,
+        "created_at": 1624546127
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 397,
+        "created_at": 1624546131
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 398,
+        "created_at": 1624554965
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 399,
+        "created_at": 1624555573
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 400,
+        "created_at": 1624558649,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NBDS",
+            "entity_type": "corporation",
+            "created_at": 1624558648,
+            "corporations": []
+          }
+        ],
+        "hex": "E9",
+        "tile": "23-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 401,
+        "created_at": 1624558653,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "E7",
+                "D6"
+              ],
+              [
+                "E11",
+                "D10",
+                "E9",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E7",
+              "E11"
+            ],
+            "revenue": 130,
+            "revenue_str": "D6-E7-E11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 402,
+        "created_at": 1624558675,
+        "kind": "payout"
+      },
+      {
+        "id": 403,
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624558681
+      },
+      {
+        "id": 404,
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624558700
+      },
+      {
+        "id": 405,
+        "type": "undo",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624558721
+      },
+      {
+        "id": 406,
+        "type": "undo",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624558757
+      },
+      {
+        "type": "take_loan",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 407,
+        "created_at": 1624558765,
+        "loan": 15
+      },
+      {
+        "type": "buy_train",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 408,
+        "created_at": 1624558794,
+        "train": "3-0",
+        "price": 435
+      },
+      {
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 409,
+        "created_at": 1624558799
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 410,
+        "created_at": 1624569445,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1624569447,
+            "corporations": []
+          }
+        ],
+        "hex": "B10",
+        "tile": "5-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 411,
+        "created_at": 1624569479
+      },
+      {
+        "type": "buy_train",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 412,
+        "created_at": 1624569481,
+        "train": "4'-0",
+        "price": 350,
+        "variant": "4'"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 413,
+        "created_at": 1624569483
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 414,
+        "created_at": 1624569485
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 415,
+        "created_at": 1624569603,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624569602,
+            "corporations": []
+          }
+        ],
+        "hex": "D10",
+        "tile": "29-0",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 416,
+        "created_at": 1624569609,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "D6",
+                "E5"
+              ],
+              [
+                "E7",
+                "D6"
+              ],
+              [
+                "E11",
+                "D10",
+                "E9",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "D6",
+              "E7",
+              "E11"
+            ],
+            "revenue": 170,
+            "revenue_str": "E5-D6-E7-E11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 417,
+        "created_at": 1624569611,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 418,
+        "created_at": 1624569617,
+        "train": "5-0",
+        "price": 550,
+        "variant": "5"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 419,
+        "created_at": 1624569636
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 420,
+        "created_at": 1624569701,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624569702,
+            "corporations": []
+          }
+        ],
+        "hex": "J6",
+        "tile": "63-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 421,
+        "created_at": 1624569709
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 422,
+        "created_at": 1624569715,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3"
+            ],
+            "revenue": 140,
+            "revenue_str": "H6-J6-I3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 423,
+        "created_at": 1624569717,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 424,
+        "created_at": 1624569721,
+        "loan": 16
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 425,
+        "created_at": 1624569729
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 426,
+        "created_at": 1624569732
+      },
+      {
+        "id": 427,
+        "hex": "H6",
+        "tile": "126-0",
+        "type": "lay_tile",
+        "entity": "B",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "created_at": 1624610587,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 55,
+        "created_at": 1624610582
+      },
+      {
+        "id": 428,
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624610611
+      },
+      {
+        "id": 429,
+        "type": "run_routes",
+        "entity": "B",
+        "routes": [
+          {
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "train": "3-1",
+            "revenue": 170,
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "revenue_str": "H6-H4-G1"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624610619
+      },
+      {
+        "id": 430,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624610708
+      },
+      {
+        "id": 431,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624610725
+      },
+      {
+        "id": 432,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624610733
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 433,
+        "created_at": 1624610738,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624610743,
+            "corporations": []
+          }
+        ],
+        "hex": "F8",
+        "tile": "19-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 434,
+        "created_at": 1624610744
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 435,
+        "created_at": 1624610754,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 160,
+            "revenue_str": "H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 436,
+        "created_at": 1624610762,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 437,
+        "created_at": 1624610774
+      },
+      {
+        "id": 438,
+        "loan": 1,
+        "type": "payoff_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624610776
+      },
+      {
+        "id": 439,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624610787
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 440,
+        "created_at": 1624610792
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 441,
+        "created_at": 1624610825,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624610829,
+            "corporations": []
+          }
+        ],
+        "hex": "E11",
+        "tile": "66-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 442,
+        "created_at": 1624610833,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 230,
+            "revenue_str": "H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 443,
+        "created_at": 1624610846,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 444,
+        "created_at": 1624610849,
+        "loan": 17
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 445,
+        "created_at": 1624610853
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 446,
+        "created_at": 1624610856
+      },
+      {
+        "id": 447,
+        "hex": "E5",
+        "tile": "64-0",
+        "type": "lay_tile",
+        "entity": "NBDS",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NBDS",
+            "created_at": 1624622224,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1624622225
+      },
+      {
+        "id": 448,
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622320
+      },
+      {
+        "id": 449,
+        "type": "run_routes",
+        "entity": "NBDS",
+        "routes": [
+          {
+            "hexes": [
+              "E5",
+              "E7",
+              "D6"
+            ],
+            "train": "3'-0",
+            "revenue": 140,
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "D6",
+                "E7"
+              ]
+            ],
+            "revenue_str": "E5-E7-D6"
+          },
+          {
+            "hexes": [
+              "H6",
+              "G7",
+              "E11"
+            ],
+            "train": "3-0",
+            "revenue": 130,
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ],
+              [
+                "E11",
+                "D10",
+                "E9",
+                "F8",
+                "G7"
+              ]
+            ],
+            "revenue_str": "H6-G7-E11"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622343
+      },
+      {
+        "id": 450,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622358
+      },
+      {
+        "id": 451,
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622383
+      },
+      {
+        "id": 452,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 446,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622392
+      },
+      {
+        "id": 453,
+        "hex": "D6",
+        "tile": "122-0",
+        "type": "lay_tile",
+        "entity": "NBDS",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NBDS",
+            "created_at": 1624622399,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1624622400
+      },
+      {
+        "id": 454,
+        "loan": 18,
+        "type": "take_loan",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622409
+      },
+      {
+        "id": 455,
+        "type": "undo",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622422
+      },
+      {
+        "id": 456,
+        "type": "undo",
+        "entity": "NBDS",
+        "action_id": 446,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622445
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 457,
+        "created_at": 1624622451,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NBDS",
+            "entity_type": "corporation",
+            "created_at": 1624622450,
+            "corporations": []
+          }
+        ],
+        "hex": "E5",
+        "tile": "64-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 458,
+        "created_at": 1624622455
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 459,
+        "created_at": 1624622489,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "E7",
+                "D6"
+              ],
+              [
+                "E7",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "E7",
+              "E5"
+            ],
+            "revenue": 140,
+            "revenue_str": "D6-E7-E5"
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "H6",
+                "G7"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "G7",
+              "H6"
+            ],
+            "revenue": 130,
+            "revenue_str": "E11-G7-H6"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 460,
+        "created_at": 1624622490,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 461,
+        "created_at": 1624622509
+      },
+      {
+        "id": 462,
+        "hex": "D6",
+        "tile": "122-0",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1624622530,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1624622531
+      },
+      {
+        "id": 463,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 461,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624622576
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 464,
+        "created_at": 1624622582,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624622581,
+            "corporations": []
+          }
+        ],
+        "hex": "F8",
+        "tile": "46-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 465,
+        "created_at": 1624622615,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "E5",
+                "E3"
+              ],
+              [
+                "D6",
+                "E5"
+              ],
+              [
+                "E7",
+                "D6"
+              ]
+            ],
+            "hexes": [
+              "E3",
+              "E5",
+              "D6",
+              "E7"
+            ],
+            "revenue": 200,
+            "revenue_str": "E3-E5-D6-E7"
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "J6"
+              ],
+              [
+                "G7",
+                "H8",
+                "I9"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "E5",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "J6",
+              "I9",
+              "G7",
+              "E7",
+              "E5"
+            ],
+            "revenue": 180,
+            "revenue_str": "J6-I9-G7-E7-E5"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 466,
+        "created_at": 1624622628,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 467,
+        "created_at": 1624622642
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 468,
+        "created_at": 1624629586,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624629588,
+            "corporations": []
+          }
+        ],
+        "hex": "I3",
+        "tile": "127-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 469,
+        "created_at": 1624629592
+      },
+      {
+        "type": "take_loan",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 470,
+        "created_at": 1624629595,
+        "loan": 18
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 471,
+        "created_at": 1624629598,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3"
+            ],
+            "revenue": 150,
+            "revenue_str": "H6-J6-I3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 472,
+        "created_at": 1624629600,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 473,
+        "created_at": 1624629647
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 474,
+        "created_at": 1624629653
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 475,
+        "created_at": 1624631270,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624631269,
+            "corporations": [
+              "B"
+            ]
+          }
+        ],
+        "hex": "H10",
+        "tile": "59-1",
+        "rotation": 0
+      },
+      {
+        "id": 476,
+        "city": "15-3-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624631308
+      },
+      {
+        "id": 477,
+        "loan": 19,
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624631310
+      },
+      {
+        "id": 478,
+        "type": "run_routes",
+        "entity": "B",
+        "routes": [
+          {
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "train": "3-1",
+            "revenue": 160,
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "revenue_str": "H6-H4-G1"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624631314
+      },
+      {
+        "id": 479,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624631328
+      },
+      {
+        "id": 480,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624631333
+      },
+      {
+        "id": 481,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624631337
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 482,
+        "created_at": 1624631339
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 483,
+        "created_at": 1624631348,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H4",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 160,
+            "revenue_str": "H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 484,
+        "created_at": 1624631353,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 485,
+        "created_at": 1624631362,
+        "loan": 19
+      },
+      {
+        "type": "buy_train",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 486,
+        "created_at": 1624631364,
+        "train": "5'-0",
+        "price": 550,
+        "variant": "5'"
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 487,
+        "created_at": 1624631366
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 488,
+        "created_at": 1624631390,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624631390,
+            "corporations": []
+          }
+        ],
+        "hex": "H6",
+        "tile": "126-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 489,
+        "created_at": 1624631393,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 250,
+            "revenue_str": "H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 490,
+        "created_at": 1624631406,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 491,
+        "created_at": 1624631411,
+        "loan": 20
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 492,
+        "created_at": 1624631418
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 493,
+        "created_at": 1624631421
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 494,
+        "created_at": 1624631914,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1624631916,
+            "corporations": [
+              "NFL"
+            ]
+          }
+        ],
+        "hex": "C7",
+        "tile": "9-2",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 495,
+        "created_at": 1624631915,
+        "city": "120-0-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 496,
+        "created_at": 1624631922,
+        "routes": [
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A9",
+                "B10"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "B8",
+              "B10",
+              "A9"
+            ],
+            "revenue": 100,
+            "revenue_str": "D6-B8-B10-A9"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 497,
+        "created_at": 1624631924,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 498,
+        "created_at": 1624631930
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 499,
+        "created_at": 1624631933
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 500,
+        "created_at": 1624632833,
+        "shares": [
+          "NBDS_1",
+          "NBDS_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 501,
+        "created_at": 1624632867,
+        "shares": [
+          "Nord_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 502,
+        "created_at": 1624632873
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 503,
+        "created_at": 1624632886,
+        "corporation": "Nord",
+        "until_condition": 3,
+        "from_market": false
+      },
+      {
+        "id": 504,
+        "type": "buy_shares",
+        "entity": 4301,
+        "shares": [
+          "HSM_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624634063
+      },
+      {
+        "id": 505,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624634068
+      },
+      {
+        "id": 506,
+        "type": "buy_shares",
+        "entity": 4301,
+        "shares": [
+          "HSM_2"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624634123
+      },
+      {
+        "id": 507,
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624634125
+      },
+      {
+        "id": 508,
+        "type": "undo",
+        "entity": 55,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624634138
+      },
+      {
+        "id": 509,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 4301,
+        "created_at": 1624634147
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 510,
+        "created_at": 1624634162,
+        "shares": [
+          "NFL_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 511,
+        "created_at": 1624634169
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 512,
+        "created_at": 1624635614,
+        "shares": [
+          "Nord_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 513,
+        "created_at": 1624635646,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624635646,
+            "shares": [
+              "Nord_6"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624635646
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 514,
+        "created_at": 1624637073,
+        "shares": [
+          "NFL_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 515,
+        "created_at": 1624637075
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 516,
+        "created_at": 1624637914,
+        "shares": [
+          "Nord_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 517,
+        "created_at": 1624637917,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624637917,
+            "shares": [
+              "Nord_8"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624637917
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 518,
+        "created_at": 1624639577,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624639576
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 519,
+        "created_at": 1624645436,
+        "shares": [
+          "HSM_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 520,
+        "created_at": 1624645439,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624645443,
+            "reason": "3 share(s) bought in Nord, end condition met"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 521,
+        "created_at": 1624653553,
+        "shares": [
+          "NFL_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 522,
+        "created_at": 1624653556,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624653557
+          }
+        ]
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 523,
+        "created_at": 1624653566,
+        "corporation": "NFL",
+        "until_condition": 4,
+        "from_market": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 524,
+        "created_at": 1624654811,
+        "shares": [
+          "NBDS_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 525,
+        "created_at": 1624654822,
+        "shares": [
+          "HSM_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 526,
+        "created_at": 1624654823,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624654827,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 527,
+        "created_at": 1624656314,
+        "shares": [
+          "NFL_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 528,
+        "created_at": 1624656320,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624656321,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 529,
+        "created_at": 1624656327,
+        "corporation": "NFL",
+        "until_condition": 4,
+        "from_market": false
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 530,
+        "created_at": 1624663939
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 531,
+        "created_at": 1624691147,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624691146,
+            "shares": [
+              "NFL_7"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624691146
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 532,
+        "created_at": 1624702382
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 533,
+        "created_at": 1624715928,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624715927,
+            "shares": [
+              "NFL_8"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624715927
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 534,
+        "created_at": 1624721440
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 535,
+        "created_at": 1624778253
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 536,
+        "created_at": 1624779555
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 537,
+        "created_at": 1624779595,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624779593,
+            "corporations": []
+          }
+        ],
+        "hex": "E7",
+        "tile": "63-1",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 538,
+        "created_at": 1624779632,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "E5",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "G7",
+              "E7",
+              "E5"
+            ],
+            "revenue": 180,
+            "revenue_str": "H6-G7-E7-E5"
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 260,
+            "revenue_str": "E11-E7-D6-E5-E3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 539,
+        "created_at": 1624779806,
+        "kind": "payout"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 540,
+        "created_at": 1624779807,
+        "loan": 0
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 541,
+        "created_at": 1624779810,
+        "loan": 3
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 542,
+        "created_at": 1624779886
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 543,
+        "created_at": 1624786014,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GCL",
+            "entity_type": "corporation",
+            "created_at": 1624786014,
+            "corporations": []
+          }
+        ],
+        "hex": "H10",
+        "tile": "65-0",
+        "rotation": 0
+      },
+      {
+        "id": 544,
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786040
+      },
+      {
+        "id": 545,
+        "type": "run_routes",
+        "entity": "GCL",
+        "routes": [
+          {
+            "hexes": [
+              "H6",
+              "J6",
+              "I3"
+            ],
+            "train": "3-2",
+            "revenue": 160,
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ]
+            ],
+            "revenue_str": "H6-J6-I3"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786058
+      },
+      {
+        "id": 546,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786061
+      },
+      {
+        "id": 547,
+        "type": "buy_train",
+        "price": 91,
+        "train": "4'-0",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786188
+      },
+      {
+        "id": 548,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786226
+      },
+      {
+        "id": 549,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786231
+      },
+      {
+        "id": 550,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786236
+      },
+      {
+        "id": 551,
+        "type": "undo",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624786242
+      },
+      {
+        "type": "place_token",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 552,
+        "created_at": 1624786250,
+        "city": "63-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 553,
+        "created_at": 1624786274,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3"
+            ],
+            "revenue": 160,
+            "revenue_str": "H6-J6-I3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 554,
+        "created_at": 1624786276,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 555,
+        "created_at": 1624786284,
+        "train": "4'-0",
+        "price": 91
+      },
+      {
+        "type": "pass",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 556,
+        "created_at": 1624786360
+      },
+      {
+        "id": 557,
+        "hex": "G5",
+        "tile": "8-5",
+        "type": "lay_tile",
+        "entity": "B",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "created_at": 1624786939,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 55,
+        "created_at": 1624786941
+      },
+      {
+        "id": 558,
+        "type": "undo",
+        "entity": "B",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624786953
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 559,
+        "created_at": 1624786969,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "B",
+            "entity_type": "corporation",
+            "created_at": 1624786967,
+            "corporations": []
+          }
+        ],
+        "hex": "G5",
+        "tile": "7-1",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 560,
+        "created_at": 1624787021,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H6",
+                "I7",
+                "J6"
+              ],
+              [
+                "H4",
+                "H6"
+              ]
+            ],
+            "hexes": [
+              "J6",
+              "H6",
+              "H4"
+            ],
+            "revenue": 150,
+            "revenue_str": "J6-H6-H4"
+          },
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "H4",
+                "G5",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "G7",
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 250,
+            "revenue_str": "E11-G7-H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 561,
+        "created_at": 1624787030,
+        "kind": "payout"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 562,
+        "created_at": 1624787033,
+        "loan": 1
+      },
+      {
+        "type": "pass",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 563,
+        "created_at": 1624787036
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 564,
+        "created_at": 1624787078,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624787076,
+            "corporations": []
+          }
+        ],
+        "hex": "H8",
+        "tile": "24-0",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 565,
+        "created_at": 1624787087,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 250,
+            "revenue_str": "H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 566,
+        "created_at": 1624787092,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 567,
+        "created_at": 1624787154,
+        "train": "6-0",
+        "price": 700,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 568,
+        "created_at": 1624787158
+      },
+      {
+        "type": "merge",
+        "entity": "B",
+        "entity_type": "corporation",
+        "id": 569,
+        "created_at": 1624787201,
+        "corporation": "B"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 570,
+        "created_at": 1624787253
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 571,
+        "created_at": 1624787655
+      },
+      {
+        "type": "merge",
+        "entity": "NBDS",
+        "entity_type": "corporation",
+        "id": 572,
+        "created_at": 1624787660,
+        "corporation": "NBDS"
+      },
+      {
+        "id": 573,
+        "type": "merge",
+        "entity": "GCL",
+        "corporation": "GCL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624788375
+      },
+      {
+        "id": 574,
+        "type": "undo",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624788399
+      },
+      {
+        "type": "merge",
+        "entity": "GCL",
+        "entity_type": "corporation",
+        "id": 575,
+        "created_at": 1624788414,
+        "corporation": "GCL"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 576,
+        "created_at": 1624795315
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 577,
+        "created_at": 1624796904,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1624796904,
+            "corporations": []
+          }
+        ],
+        "hex": "D6",
+        "tile": "122-0",
+        "rotation": 3
+      },
+      {
+        "type": "buy_train",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 578,
+        "created_at": 1624796907,
+        "train": "6-1",
+        "price": 700,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 579,
+        "created_at": 1624796910
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 580,
+        "created_at": 1624796962,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624796960,
+            "corporations": []
+          }
+        ],
+        "hex": "G7",
+        "tile": "125-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 581,
+        "created_at": 1624796971,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "E5",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "G7",
+              "E7",
+              "E5"
+            ],
+            "revenue": 190,
+            "revenue_str": "H6-G7-E7-E5"
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-E7-D6-E5-E3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 582,
+        "created_at": 1624797015,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 583,
+        "created_at": 1624797112,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624797110,
+            "corporations": []
+          }
+        ],
+        "hex": "D10",
+        "tile": "39-0",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 584,
+        "created_at": 1624797153,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 250,
+            "revenue_str": "H6-J6-I3-J2"
+          },
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "I9",
+                "H8",
+                "H6"
+              ],
+              [
+                "H10",
+                "I9"
+              ],
+              [
+                "H12",
+                "H10"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "G7",
+              "H6",
+              "I9",
+              "H10",
+              "H12"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-G7-H6-I9-H10-H12"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 585,
+        "created_at": 1624797157,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 586,
+        "created_at": 1624797251,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "entity_type": "corporation",
+            "created_at": 1624797249,
+            "corporations": []
+          }
+        ],
+        "hex": "I9",
+        "tile": "125-1",
+        "rotation": 4
+      },
+      {
+        "type": "place_token",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 587,
+        "created_at": 1624797253,
+        "city": "65-0-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 588,
+        "created_at": 1624797285,
+        "routes": [
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "I9",
+                "H10"
+              ],
+              [
+                "J6",
+                "I7",
+                "I9"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H10",
+              "I9",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 310,
+            "revenue_str": "H10-I9-J6-I3-J2"
+          },
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "H6",
+                "H8",
+                "I9"
+              ],
+              [
+                "H4",
+                "G5",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "I9",
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 220,
+            "revenue_str": "I9-H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 589,
+        "created_at": 1624797304,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 590,
+        "created_at": 1624797319
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 591,
+        "created_at": 1624798066,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1624798067,
+            "corporations": []
+          }
+        ],
+        "hex": "B10",
+        "tile": "14-1",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 592,
+        "created_at": 1624798076,
+        "routes": [
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A9",
+                "B10"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "B8",
+              "B10",
+              "A9"
+            ],
+            "revenue": 130,
+            "revenue_str": "D6-B8-B10-A9"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 593,
+        "created_at": 1624798077,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 594,
+        "created_at": 1624798079
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 595,
+        "created_at": 1624798159,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624798157,
+            "corporations": []
+          }
+        ],
+        "hex": "E9",
+        "tile": "41-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 596,
+        "created_at": 1624798177,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "E5",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "G7",
+              "E7",
+              "E5"
+            ],
+            "revenue": 190,
+            "revenue_str": "H6-G7-E7-E5"
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-E7-D6-E5-E3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 597,
+        "created_at": 1624798205,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 598,
+        "created_at": 1624798385,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624798384,
+            "corporations": []
+          }
+        ],
+        "hex": "D8",
+        "tile": "9-3",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 599,
+        "created_at": 1624798458,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 250,
+            "revenue_str": "H6-J6-I3-J2"
+          },
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "D6",
+                "C7",
+                "B8"
+              ],
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "D8",
+                "D6"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "I9",
+                "H8",
+                "H6"
+              ],
+              [
+                "H10",
+                "I9"
+              ]
+            ],
+            "hexes": [
+              "B8",
+              "D6",
+              "G7",
+              "H6",
+              "I9",
+              "H10"
+            ],
+            "revenue": 280,
+            "revenue_str": "B8-D6-G7-H6-I9-H10"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 600,
+        "created_at": 1624798463,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 601,
+        "created_at": 1624798495,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "entity_type": "corporation",
+            "created_at": 1624798493,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 602,
+        "created_at": 1624798555
+      },
+      {
+        "type": "run_routes",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 603,
+        "created_at": 1624798605,
+        "routes": [
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "I9",
+                "H10"
+              ],
+              [
+                "J6",
+                "I7",
+                "I9"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H10",
+              "I9",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 310,
+            "revenue_str": "H10-I9-J6-I3-J2"
+          },
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "H6",
+                "H8",
+                "I9"
+              ],
+              [
+                "H4",
+                "G5",
+                "H6"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "I9",
+              "H6",
+              "H4",
+              "G1"
+            ],
+            "revenue": 220,
+            "revenue_str": "I9-H6-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 604,
+        "created_at": 1624798610,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 605,
+        "created_at": 1624798628
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 606,
+        "created_at": 1624819082,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1624819084,
+            "corporations": []
+          }
+        ],
+        "hex": "B10",
+        "tile": "63-2",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 607,
+        "created_at": 1624819091,
+        "routes": [
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A9",
+                "B10"
+              ],
+              [
+                "A9",
+                "B8"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "D6",
+              "B8",
+              "B10",
+              "A9",
+              "B8"
+            ],
+            "revenue": 200,
+            "revenue_str": "E11-D6-B8-B10-A9-B8"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 608,
+        "created_at": 1624819092,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 609,
+        "created_at": 1624819093
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 610,
+        "created_at": 1624819150,
+        "shares": [
+          "MESS_1"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 611,
+        "created_at": 1624819155
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 612,
+        "created_at": 1624823573,
+        "shares": [
+          "MESS_2"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 613,
+        "created_at": 1624823598
+      },
+      {
+        "id": 614,
+        "type": "sell_shares",
+        "entity": 45,
+        "shares": [
+          "NFL_5",
+          "NFL_6",
+          "NFL_7",
+          "NFL_8"
+        ],
+        "percent": 40,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624824328
+      },
+      {
+        "id": 615,
+        "type": "buy_shares",
+        "entity": 45,
+        "shares": [
+          "Nord_2"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624824336
+      },
+      {
+        "id": 616,
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624824341
+      },
+      {
+        "id": 617,
+        "type": "undo",
+        "entity": 4301,
+        "action_id": 613,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624824357
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 618,
+        "created_at": 1624824385,
+        "shares": [
+          "NFL_5",
+          "NFL_6"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 619,
+        "created_at": 1624824395,
+        "shares": [
+          "Nord_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 620,
+        "created_at": 1624824398
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 621,
+        "created_at": 1624824418,
+        "corporation": "MESS",
+        "until_condition": 5,
+        "from_market": true
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 622,
+        "created_at": 1624879418,
+        "shares": [
+          "MESS_3"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 623,
+        "created_at": 1624879422
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 624,
+        "created_at": 1624959914,
+        "shares": [
+          "MESS_4"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 625,
+        "created_at": 1624959946,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624959944,
+            "shares": [
+              "MESS_20"
+            ],
+            "percent": 5
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624959944
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 626,
+        "created_at": 1624967680,
+        "shares": [
+          "MESS_5"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 627,
+        "created_at": 1624967688
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 628,
+        "created_at": 1624967692
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 629,
+        "created_at": 1624968452,
+        "shares": [
+          "MESS_6"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 630,
+        "created_at": 1624968458,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624968457,
+            "shares": [
+              "MESS_21"
+            ],
+            "percent": 5
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624968457
+          },
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624968457
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 631,
+        "created_at": 1624968464,
+        "shares": [
+          "MESS_7"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 632,
+        "created_at": 1624968473,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624968472,
+            "shares": [
+              "MESS_22"
+            ],
+            "percent": 5
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624968472
+          },
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624968472
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 633,
+        "created_at": 1624968477,
+        "shares": [
+          "MESS_8"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 634,
+        "created_at": 1624968479
+      },
+      {
+        "id": 635,
+        "type": "sell_shares",
+        "entity": 45,
+        "shares": [
+          "NFL_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "shares": [
+              "MESS_23"
+            ],
+            "percent": 5,
+            "created_at": 1624968766,
+            "entity_type": "player"
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "created_at": 1624968766,
+            "entity_type": "player"
+          },
+          {
+            "type": "program_disable",
+            "entity": 4301,
+            "reason": "Shares were sold",
+            "created_at": 1624968766,
+            "entity_type": "player"
+          }
+        ],
+        "user": 45,
+        "created_at": 1624968767
+      },
+      {
+        "id": 636,
+        "type": "undo",
+        "entity": 4301,
+        "entity_type": "player",
+        "user": 45,
+        "created_at": 1624968808
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 637,
+        "created_at": 1624968821,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624968820,
+            "shares": [
+              "MESS_23"
+            ],
+            "percent": 5
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624968820
+          },
+          {
+            "type": "program_disable",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624968820,
+            "reason": "Shares were sold"
+          }
+        ],
+        "shares": [
+          "Nord_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_disable",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 638,
+        "created_at": 1624968835,
+        "reason": "user"
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 639,
+        "created_at": 1624968879,
+        "corporation": "MESS",
+        "until_condition": 6,
+        "from_market": true
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 640,
+        "created_at": 1624968961
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 641,
+        "created_at": 1624968964
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 642,
+        "created_at": 1624969368,
+        "shares": [
+          "MESS_24"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 643,
+        "created_at": 1624969478,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624969478,
+            "shares": [
+              "MESS_25"
+            ],
+            "percent": 5
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1624969478
+          },
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624969478
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 644,
+        "created_at": 1624969489,
+        "shares": [
+          "HSM_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 645,
+        "created_at": 1624969492
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 646,
+        "created_at": 1624969708,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1624969707
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 647,
+        "created_at": 1624969720
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 648,
+        "created_at": 1624971329
+      },
+      {
+        "id": 649,
+        "hex": "B12",
+        "tile": "8-5",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1624972307,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1624972308
+      },
+      {
+        "id": 650,
+        "type": "run_routes",
+        "entity": "HSM",
+        "routes": [
+          {
+            "hexes": [
+              "H6",
+              "G7",
+              "E7",
+              "E5"
+            ],
+            "train": "4-0",
+            "revenue": 190,
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "E5",
+                "E7"
+              ]
+            ],
+            "revenue_str": "H6-G7-E7-E5"
+          },
+          {
+            "hexes": [
+              "E11",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "train": "5-0",
+            "revenue": 280,
+            "connections": [
+              [
+                "E7",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "revenue_str": "E11-E7-D6-E5-E3"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624972318
+      },
+      {
+        "id": 651,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624972320
+      },
+      {
+        "id": 652,
+        "type": "buy_train",
+        "price": 650,
+        "train": "8-0",
+        "entity": "HSM",
+        "variant": "8",
+        "exchange": "4-0",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624972324
+      },
+      {
+        "id": 653,
+        "type": "undo",
+        "entity": "MESS",
+        "action_id": 648,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1624972372
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 654,
+        "created_at": 1624972378,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1624972377,
+            "corporations": []
+          }
+        ],
+        "hex": "B8",
+        "tile": "15-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 655,
+        "created_at": 1624972400,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "G7",
+                "H6"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "E5",
+                "E7"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "G7",
+              "E7",
+              "E5"
+            ],
+            "revenue": 190,
+            "revenue_str": "H6-G7-E7-E5"
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E9",
+                "D10",
+                "E11"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-E7-D6-E5-E3"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 656,
+        "created_at": 1624972402,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 657,
+        "created_at": 1624972404,
+        "train": "8-0",
+        "price": 650,
+        "variant": "8",
+        "exchange": "4-0"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 658,
+        "created_at": 1624982378,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "entity_type": "corporation",
+            "created_at": 1624982376,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 659,
+        "created_at": 1624982380
+      },
+      {
+        "type": "run_routes",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 660,
+        "created_at": 1624982432,
+        "routes": [
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "I9",
+                "H10"
+              ],
+              [
+                "J6",
+                "I7",
+                "I9"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "H10",
+              "I9",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 310,
+            "revenue_str": "H10-I9-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 661,
+        "created_at": 1624982461,
+        "kind": "withhold"
+      },
+      {
+        "id": 662,
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624982463
+      },
+      {
+        "id": 663,
+        "hex": "H4",
+        "tile": "63-3",
+        "type": "lay_tile",
+        "entity": "Nord",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "created_at": 1624982473,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 55,
+        "created_at": 1624982475
+      },
+      {
+        "id": 664,
+        "type": "run_routes",
+        "entity": "Nord",
+        "routes": [
+          {
+            "hexes": [
+              "D6",
+              "G7",
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "train": "6-0",
+            "revenue": 370,
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "D8",
+                "D6"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "revenue_str": "D6-G7-H6-J6-I3-J2"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624982513
+      },
+      {
+        "id": 665,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624982515
+      },
+      {
+        "id": 666,
+        "type": "undo",
+        "entity": "Nord",
+        "action_id": 661,
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1624982557
+      },
+      {
+        "type": "buy_train",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 667,
+        "created_at": 1624985367,
+        "train": "8-1",
+        "price": 650,
+        "variant": "8",
+        "exchange": "5'-0"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 668,
+        "created_at": 1624985378
+      },
+      {
+        "type": "lay_tile",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 669,
+        "created_at": 1624985418,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1624985416,
+            "corporations": []
+          }
+        ],
+        "hex": "H4",
+        "tile": "63-3",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 670,
+        "created_at": 1624985454,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "D8",
+                "D6"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "G7",
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 370,
+            "revenue_str": "D6-G7-H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 671,
+        "created_at": 1624985455,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 672,
+        "created_at": 1624985462
+      },
+      {
+        "id": 673,
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "created_at": 1624997354,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 4301,
+        "created_at": 1624997355
+      },
+      {
+        "id": 674,
+        "type": "undo",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "user": 4301,
+        "created_at": 1624997378
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 675,
+        "created_at": 1624997385,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1624997384,
+            "corporations": []
+          }
+        ],
+        "hex": "B12",
+        "tile": "8-5",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 676,
+        "created_at": 1624997401,
+        "routes": [
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B8",
+                "A9"
+              ],
+              [
+                "A9",
+                "B10"
+              ],
+              [
+                "B10",
+                "B12",
+                "A13"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "D6",
+              "B8",
+              "A9",
+              "B10",
+              "A13"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-D6-B8-A9-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 677,
+        "created_at": 1624997403,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 678,
+        "created_at": 1624997410
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 679,
+        "created_at": 1625001599,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1625001598,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 680,
+        "created_at": 1625001602,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "D8",
+                "D6"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "G7",
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 370,
+            "revenue_str": "D6-G7-H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 681,
+        "created_at": 1625001604,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 682,
+        "created_at": 1625001616
+      },
+      {
+        "id": 683,
+        "hex": "D8",
+        "tile": "26-0",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1625001775,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1625001777
+      },
+      {
+        "id": 684,
+        "type": "run_routes",
+        "entity": "HSM",
+        "routes": [
+          {
+            "hexes": [
+              "E5",
+              "E7",
+              "G7",
+              "I9",
+              "H10"
+            ],
+            "train": "5-0",
+            "revenue": 220,
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "G7",
+                "F8",
+                "E9",
+                "E7"
+              ],
+              [
+                "I9",
+                "H8",
+                "G7"
+              ],
+              [
+                "H10",
+                "I9"
+              ]
+            ],
+            "revenue_str": "E5-E7-G7-I9-H10"
+          },
+          {
+            "hexes": [
+              "E3",
+              "E5",
+              "D6",
+              "E7",
+              "D6",
+              "B8",
+              "B10",
+              "A13"
+            ],
+            "train": "8-0",
+            "revenue": 450,
+            "connections": [
+              [
+                "E5",
+                "E3"
+              ],
+              [
+                "D6",
+                "E5"
+              ],
+              [
+                "E7",
+                "D6"
+              ],
+              [
+                "D6",
+                "D8",
+                "E7"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A13",
+                "B12",
+                "B10"
+              ]
+            ],
+            "revenue_str": "E3-E5-D6-E7-D6-B8-B10-A13"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625001877
+      },
+      {
+        "id": 685,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625001880
+      },
+      {
+        "id": 686,
+        "type": "undo",
+        "entity": "MESS",
+        "action_id": 682,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625001945
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 687,
+        "created_at": 1625001953,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1625001951,
+            "corporations": []
+          }
+        ],
+        "hex": "I7",
+        "tile": "40-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 688,
+        "created_at": 1625001994,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 280,
+            "revenue_str": "E5-E7-D6-E5-E3"
+          },
+          {
+            "train": "8-0",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "H6"
+              ],
+              [
+                "G7",
+                "H8",
+                "I9"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E9",
+                "E7"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A13",
+                "B12",
+                "B10"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "I9",
+              "G7",
+              "E7",
+              "D6",
+              "B8",
+              "B10",
+              "A13"
+            ],
+            "revenue": 400,
+            "revenue_str": "H6-I9-G7-E7-D6-B8-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 689,
+        "created_at": 1625002009,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 690,
+        "created_at": 1625035508,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "entity_type": "corporation",
+            "created_at": 1625035506,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 691,
+        "created_at": 1625035539,
+        "routes": [
+          {
+            "train": "8-1",
+            "connections": [
+              [
+                "H10",
+                "H12"
+              ],
+              [
+                "I9",
+                "H10"
+              ],
+              [
+                "H6",
+                "H8",
+                "I9"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "H4",
+                "I3"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H12",
+              "H10",
+              "I9",
+              "H6",
+              "J6",
+              "I3",
+              "H4",
+              "G1"
+            ],
+            "revenue": 520,
+            "revenue_str": "H12-H10-I9-H6-J6-I3-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 692,
+        "created_at": 1625035543,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 693,
+        "created_at": 1625035552
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 694,
+        "created_at": 1625043518,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1625043519,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 695,
+        "created_at": 1625043520,
+        "routes": [
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B8",
+                "A9"
+              ],
+              [
+                "A9",
+                "B10"
+              ],
+              [
+                "B10",
+                "B12",
+                "A13"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "D6",
+              "B8",
+              "A9",
+              "B10",
+              "A13"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-D6-B8-A9-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 696,
+        "created_at": 1625043521,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 697,
+        "created_at": 1625043523
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 698,
+        "created_at": 1625046381,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1625046379,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 699,
+        "created_at": 1625046385,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "D8",
+                "D6"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "G7",
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 370,
+            "revenue_str": "D6-G7-H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 700,
+        "created_at": 1625046387,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 701,
+        "created_at": 1625046391
+      },
+      {
+        "id": 702,
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1625048719,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1625048719
+      },
+      {
+        "id": 703,
+        "type": "run_routes",
+        "entity": "HSM",
+        "routes": [
+          {
+            "hexes": [
+              "E5",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "train": "5-0",
+            "revenue": 280,
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "revenue_str": "E5-E7-D6-E5-E3"
+          },
+          {
+            "hexes": [
+              "H6",
+              "I9",
+              "G7",
+              "E7",
+              "D6",
+              "B8",
+              "B10",
+              "A13"
+            ],
+            "train": "8-0",
+            "revenue": 400,
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "H6"
+              ],
+              [
+                "G7",
+                "H8",
+                "I9"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E9",
+                "E7"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A13",
+                "B12",
+                "B10"
+              ]
+            ],
+            "revenue_str": "H6-I9-G7-E7-D6-B8-B10-A13"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048736
+      },
+      {
+        "id": 704,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048755
+      },
+      {
+        "id": 705,
+        "type": "undo",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048784
+      },
+      {
+        "id": 706,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048806
+      },
+      {
+        "id": 707,
+        "type": "buy_train",
+        "price": 650,
+        "train": "8-2",
+        "entity": "HSM",
+        "variant": "8",
+        "exchange": "5-0",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048809
+      },
+      {
+        "id": 708,
+        "type": "undo",
+        "entity": "MESS",
+        "action_id": 701,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048819
+      },
+      {
+        "id": 709,
+        "hex": "D12",
+        "tile": "8-6",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1625048823,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1625048823
+      },
+      {
+        "id": 710,
+        "type": "undo",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048846
+      },
+      {
+        "id": 711,
+        "hex": "D8",
+        "tile": "20-0",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1625048850,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1625048849
+      },
+      {
+        "id": 712,
+        "type": "undo",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048871
+      },
+      {
+        "id": 713,
+        "hex": "G9",
+        "tile": "8-6",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1625048880,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1625048880
+      },
+      {
+        "id": 714,
+        "type": "run_routes",
+        "entity": "HSM",
+        "routes": [
+          {
+            "hexes": [
+              "E5",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "train": "5-0",
+            "revenue": 280,
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "revenue_str": "E5-E7-D6-E5-E3"
+          },
+          {
+            "hexes": [
+              "H6",
+              "I9",
+              "G7",
+              "E7",
+              "D6",
+              "B8",
+              "B10",
+              "A13"
+            ],
+            "train": "8-0",
+            "revenue": 400,
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "H6"
+              ],
+              [
+                "G7",
+                "H8",
+                "I9"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E9",
+                "E7"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A13",
+                "B12",
+                "B10"
+              ]
+            ],
+            "revenue_str": "H6-I9-G7-E7-D6-B8-B10-A13"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048897
+      },
+      {
+        "id": 715,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048898
+      },
+      {
+        "id": 716,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 701,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048925
+      },
+      {
+        "id": 717,
+        "hex": "D8",
+        "tile": "20-0",
+        "type": "lay_tile",
+        "entity": "HSM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "created_at": 1625048931,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 45,
+        "created_at": 1625048931
+      },
+      {
+        "id": 718,
+        "type": "undo",
+        "entity": "HSM",
+        "action_id": 701,
+        "entity_type": "corporation",
+        "user": 45,
+        "created_at": 1625048956
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 719,
+        "created_at": 1625048969,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1625048969,
+            "corporations": []
+          }
+        ],
+        "hex": "G9",
+        "tile": "8-6",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 720,
+        "created_at": 1625048971,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 280,
+            "revenue_str": "E5-E7-D6-E5-E3"
+          },
+          {
+            "train": "8-0",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "H6"
+              ],
+              [
+                "G7",
+                "H8",
+                "I9"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E9",
+                "E7"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A13",
+                "B12",
+                "B10"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "I9",
+              "G7",
+              "E7",
+              "D6",
+              "B8",
+              "B10",
+              "A13"
+            ],
+            "revenue": 400,
+            "revenue_str": "H6-I9-G7-E7-D6-B8-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 721,
+        "created_at": 1625048973,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 722,
+        "created_at": 1625053252,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "entity_type": "corporation",
+            "created_at": 1625053250,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 723,
+        "created_at": 1625053255,
+        "routes": [
+          {
+            "train": "8-1",
+            "connections": [
+              [
+                "H10",
+                "H12"
+              ],
+              [
+                "I9",
+                "H10"
+              ],
+              [
+                "H6",
+                "H8",
+                "I9"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "H4",
+                "I3"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H12",
+              "H10",
+              "I9",
+              "H6",
+              "J6",
+              "I3",
+              "H4",
+              "G1"
+            ],
+            "revenue": 520,
+            "revenue_str": "H12-H10-I9-H6-J6-I3-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 724,
+        "created_at": 1625053257,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 725,
+        "created_at": 1625053260
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 726,
+        "created_at": 1625055994,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1625055995,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 727,
+        "created_at": 1625055996,
+        "routes": [
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B8",
+                "A9"
+              ],
+              [
+                "A9",
+                "B10"
+              ],
+              [
+                "B10",
+                "B12",
+                "A13"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "D6",
+              "B8",
+              "A9",
+              "B10",
+              "A13"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-D6-B8-A9-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 728,
+        "created_at": 1625055997,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 729,
+        "created_at": 1625055998
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 730,
+        "created_at": 1625056051
+      },
+      {
+        "type": "sell_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 731,
+        "created_at": 1625058199,
+        "shares": [
+          "MESS_28",
+          "MESS_20",
+          "MESS_21",
+          "MESS_22",
+          "MESS_23",
+          "MESS_25"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 732,
+        "created_at": 1625058227,
+        "shares": [
+          "Nord_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 733,
+        "created_at": 1625058229,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1625058228,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 734,
+        "created_at": 1625058283,
+        "corporation": "NFL",
+        "until_condition": 4,
+        "from_market": true
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 735,
+        "created_at": 1625061030
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 736,
+        "created_at": 1625061068
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 737,
+        "created_at": 1625071587,
+        "shares": [
+          "MESS_28"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 738,
+        "created_at": 1625071597,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1625071596,
+            "shares": [
+              "NFL_5"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1625071596
+          },
+          {
+            "type": "pass",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1625071596
+          }
+        ]
+      },
+      {
+        "type": "sell_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 739,
+        "created_at": 1625071628,
+        "shares": [
+          "HSM_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 740,
+        "created_at": 1625071636,
+        "shares": [
+          "NFL_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 741,
+        "created_at": 1625071660
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 742,
+        "created_at": 1625079170,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4301,
+            "entity_type": "player",
+            "created_at": 1625079168,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 743,
+        "created_at": 1625080020
+      },
+      {
+        "type": "sell_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 744,
+        "created_at": 1625080237,
+        "shares": [
+          "NFL_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 745,
+        "created_at": 1625080910,
+        "shares": [
+          "MESS_20"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 746,
+        "created_at": 1625080919,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 45,
+            "entity_type": "player",
+            "created_at": 1625080918,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 747,
+        "created_at": 1625081001,
+        "shares": [
+          "NFL_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 748,
+        "created_at": 1625081025
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 749,
+        "created_at": 1625082773
+      },
+      {
+        "type": "buy_shares",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 750,
+        "created_at": 1625083001,
+        "shares": [
+          "MESS_21"
+        ],
+        "percent": 5
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 751,
+        "created_at": 1625083026
+      },
+      {
+        "type": "pass",
+        "entity": 45,
+        "entity_type": "player",
+        "id": 752,
+        "created_at": 1625085062
+      },
+      {
+        "type": "pass",
+        "entity": 4301,
+        "entity_type": "player",
+        "id": 753,
+        "created_at": 1625138340
+      },
+      {
+        "type": "pass",
+        "entity": 55,
+        "entity_type": "player",
+        "id": 754,
+        "created_at": 1625140521
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 755,
+        "created_at": 1625140526,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1625140525,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 756,
+        "created_at": 1625140529,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "D8",
+                "D6"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "G7",
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 370,
+            "revenue_str": "D6-G7-H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 757,
+        "created_at": 1625140531,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 758,
+        "created_at": 1625140533
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 759,
+        "created_at": 1625141150,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1625141148,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 760,
+        "created_at": 1625141152,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 280,
+            "revenue_str": "E5-E7-D6-E5-E3"
+          },
+          {
+            "train": "8-0",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "H6"
+              ],
+              [
+                "G7",
+                "H8",
+                "I9"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E9",
+                "E7"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A13",
+                "B12",
+                "B10"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "I9",
+              "G7",
+              "E7",
+              "D6",
+              "B8",
+              "B10",
+              "A13"
+            ],
+            "revenue": 400,
+            "revenue_str": "H6-I9-G7-E7-D6-B8-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 761,
+        "created_at": 1625141154,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 762,
+        "created_at": 1625141230,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "entity_type": "corporation",
+            "created_at": 1625141229,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 763,
+        "created_at": 1625141235,
+        "routes": [
+          {
+            "train": "8-1",
+            "connections": [
+              [
+                "H10",
+                "H12"
+              ],
+              [
+                "I9",
+                "H10"
+              ],
+              [
+                "H6",
+                "H8",
+                "I9"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "H4",
+                "I3"
+              ],
+              [
+                "G1",
+                "G3",
+                "H4"
+              ]
+            ],
+            "hexes": [
+              "H12",
+              "H10",
+              "I9",
+              "H6",
+              "J6",
+              "I3",
+              "H4",
+              "G1"
+            ],
+            "revenue": 520,
+            "revenue_str": "H12-H10-I9-H6-J6-I3-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 764,
+        "created_at": 1625141238,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 765,
+        "created_at": 1625141240
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 766,
+        "created_at": 1625146126,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "NFL",
+            "entity_type": "corporation",
+            "created_at": 1625146124,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 767,
+        "created_at": 1625146127,
+        "routes": [
+          {
+            "train": "6-1",
+            "connections": [
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B8",
+                "A9"
+              ],
+              [
+                "A9",
+                "B10"
+              ],
+              [
+                "B10",
+                "B12",
+                "A13"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "D6",
+              "B8",
+              "A9",
+              "B10",
+              "A13"
+            ],
+            "revenue": 280,
+            "revenue_str": "E11-D6-B8-A9-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 768,
+        "created_at": 1625146128,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 769,
+        "created_at": 1625146129
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 770,
+        "created_at": 1625146685,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "Nord",
+            "entity_type": "corporation",
+            "created_at": 1625146683,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 771,
+        "created_at": 1625146687,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "G7",
+                "F8",
+                "E9",
+                "D10",
+                "D8",
+                "D6"
+              ],
+              [
+                "H6",
+                "G7"
+              ],
+              [
+                "J6",
+                "I7",
+                "H6"
+              ],
+              [
+                "I3",
+                "I5",
+                "J6"
+              ],
+              [
+                "J2",
+                "I3"
+              ]
+            ],
+            "hexes": [
+              "D6",
+              "G7",
+              "H6",
+              "J6",
+              "I3",
+              "J2"
+            ],
+            "revenue": 370,
+            "revenue_str": "D6-G7-H6-J6-I3-J2"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 772,
+        "created_at": 1625146689,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "Nord",
+        "entity_type": "corporation",
+        "id": 773,
+        "created_at": 1625146691
+      },
+      {
+        "type": "pass",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 774,
+        "created_at": 1625149572,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "HSM",
+            "entity_type": "corporation",
+            "created_at": 1625149570,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 775,
+        "created_at": 1625149574,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "E7",
+                "E5"
+              ],
+              [
+                "D6",
+                "E7"
+              ],
+              [
+                "E5",
+                "D6"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "E7",
+              "D6",
+              "E5",
+              "E3"
+            ],
+            "revenue": 280,
+            "revenue_str": "E5-E7-D6-E5-E3"
+          },
+          {
+            "train": "8-0",
+            "connections": [
+              [
+                "I9",
+                "I7",
+                "H6"
+              ],
+              [
+                "G7",
+                "H8",
+                "I9"
+              ],
+              [
+                "E7",
+                "F8",
+                "G7"
+              ],
+              [
+                "D6",
+                "D8",
+                "D10",
+                "E9",
+                "E7"
+              ],
+              [
+                "B8",
+                "C7",
+                "D6"
+              ],
+              [
+                "B10",
+                "B8"
+              ],
+              [
+                "A13",
+                "B12",
+                "B10"
+              ]
+            ],
+            "hexes": [
+              "H6",
+              "I9",
+              "G7",
+              "E7",
+              "D6",
+              "B8",
+              "B10",
+              "A13"
+            ],
+            "revenue": 400,
+            "revenue_str": "H6-I9-G7-E7-D6-B8-B10-A13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HSM",
+        "entity_type": "corporation",
+        "id": 776,
+        "created_at": 1625149576,
+        "kind": "payout"
+      },
+      {
+        "id": 777,
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "created_at": 1625161157,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 55,
+        "created_at": 1625161158
+      },
+      {
+        "id": 778,
+        "type": "undo",
+        "entity": "MESS",
+        "action_id": 776,
+        "entity_type": "corporation",
+        "user": 55,
+        "created_at": 1625161420
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 779,
+        "created_at": 1625161425,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "MESS",
+            "entity_type": "corporation",
+            "created_at": 1625161424,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 780,
+        "created_at": 1625227196
+      },
+      {
+        "type": "run_routes",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 781,
+        "created_at": 1625227291,
+        "routes": [
+          {
+            "train": "8-1",
+            "connections": [
+              [
+                "H12",
+                "H10"
+              ],
+              [
+                "H10",
+                "I9"
+              ],
+              [
+                "I9",
+                "H8",
+                "H6"
+              ],
+              [
+                "H6",
+                "I7",
+                "J6"
+              ],
+              [
+                "J6",
+                "I5",
+                "I3"
+              ],
+              [
+                "I3",
+                "H4"
+              ],
+              [
+                "H4",
+                "G3",
+                "G1"
+              ]
+            ],
+            "hexes": [
+              "H12",
+              "H10",
+              "I9",
+              "H6",
+              "J6",
+              "I3",
+              "H4",
+              "G1"
+            ],
+            "revenue": 520,
+            "revenue_str": "H12-H10-I9-H6-J6-I3-H4-G1"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 782,
+        "created_at": 1625227293,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MESS",
+        "entity_type": "corporation",
+        "id": 783,
+        "created_at": 1625227295
+      },
+      {
+        "type": "end_game",
+        "entity": "NFL",
+        "entity_type": "corporation",
+        "id": 784,
+        "created_at": 1625227300
+      }
+    ],
+    "id": "hs_hrhdxdgz_46207",
+    "description": "Cloned from game 46207",
+    "user": {
+      "id": 0,
+      "name": "You"
+    },
+    "players": [
+      {
+        "id": 45,
+        "name": "Ticketautomat"
+      },
+      {
+        "id": 4301,
+        "name": "Daniel_1"
+      },
+      {
+        "id": 55,
+        "name": "kodemaniak"
+      }
+    ],
+    "max_players": 3,
+    "title": "1836Jr56",
+    "settings": {
+      "seed": 1851634023,
+      "unlisted": true,
+      "auto_routing": true,
+      "player_order": null,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "turn": 10,
+    "round": "Operating Round",
+    "acting": [
+      4301
+    ],
+    "result": {
+      "Ticketautomat": 7682,
+      "kodemaniak": 7667,
+      "Daniel_1": 2979
+    },
+    "loaded": true,
+    "created_at": "2021-07-02",
+    "updated_at": 1625227300,
+    "mode": "hotseat"
+  }


### PR DESCRIPTION
Fixes #5906 

It also displays the dividends for 20 share corps as fractional since the per-share dividends are friendly to the player anyways
![image](https://user-images.githubusercontent.com/2993555/124309653-106b0500-db39-11eb-9718-7bb76283064d.png)
![image](https://user-images.githubusercontent.com/2993555/124309701-1d87f400-db39-11eb-8f1b-08a6a594b2d1.png)
