### PR TITLE
Fixes Trains selection for autorouting

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -18,8 +18,7 @@ module Engine
       connections = {}
 
       nodes = @game.graph.connected_nodes(corporation).keys.sort_by do |node|
-        revenue = corporation
-          .runnable_trains
+        revenue = @game.route_trains(corporation)
           .map { |train| node.route_revenue(@game.phase, train) }
           .max
         [


### PR DESCRIPTION
closes #5863 

for 18cz this fixes the issue with taking a not runnable train into account.

since the default implementation is entity.runnable_trains it should not change  most of the games and only improve the behaviour