### PR TITLE
1856: Restore %d to 1856's default currency format

### DIFF
--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -33,7 +33,7 @@ module Engine
                         blue: '#0189d1',
                         brown: '#7b352a')
 
-        CURRENCY_FORMAT_STR = '$%f'
+        CURRENCY_FORMAT_STR = '$%d'
 
         BANK_CASH = 12_000
 


### PR DESCRIPTION
I missed this reverting this %f back to %d when I was trying to make currency say "$32" or "$9.5"
Fixes #5921 