### PR TITLE
[1893] Support auto buy until float (fixes #5794)

### DIFF
--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -341,6 +341,12 @@ module Engine
           def sell_price(company)
             company.value
           end
+
+          # Override this to let auto buy always buy from market
+          # as there are no shares in IPO after parring
+          def from_market?(_program)
+            true
+          end
         end
       end
     end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -413,7 +413,7 @@ module Engine
                                                reason: "#{program.until_condition} share(s) bought in "\
                                                "#{corporation.name}, end condition met")]
           end
-          shares_by_percent = if program.from_market
+          shares_by_percent = if from_market?(program)
                                 source = 'market'
                                 @game.share_pool.shares_by_corporation[corporation]
                               else
@@ -446,6 +446,10 @@ module Engine
           # Buy-then-Sell games need the pass.
           [Action::Pass.new(entity)]
         end
+      end
+
+      def from_market?(program)
+        program.from_market
       end
     end
   end


### PR DESCRIPTION
As shares in 1893 are moved from IPO to market when parred,
we need to change the check in general code that checks if auto
order was for market or IPO. "Buy until float" has IPO as source.
So the check is extracted to a method, which 1893 can override,
so that "auto buy until float" always buys from market.