### PR TITLE
18Carolinas: buy_power step/view; phases; support for power in UI

### DIFF
--- a/assets/app/view/game/buy_power.rb
+++ b/assets/app/view/game/buy_power.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+require 'view/game/emergency_money'
+require 'view/game/alternate_corporations'
+
+module View
+  module Game
+    class BuyPower < Snabberb::Component
+      include Actionable
+      include EmergencyMoney
+      include Lib::Settings
+      needs :corporation, default: nil
+
+      def render_president_contributions
+        player = @corporation.owner
+
+        children = []
+
+        verb = @must_buy_power ? 'must' : 'may'
+
+        cash_needed = @step.ebuy_cash_needed(@corporation)
+        cash = @corporation.cash + player.cash
+        share_funds_required = cash_needed - cash
+        share_funds_allowed = share_funds_required
+        share_funds_possible = @game.liquidity(player, emergency: true) - player.cash
+
+        if cash_needed > @corporation.cash
+          children << h(:div, "#{player.name} #{verb} contribute "\
+                              "#{@game.format_currency(cash_needed - @corporation.cash)} "\
+                              "for #{@corporation.name} to afford minimum train power.")
+        end
+
+        children << h(:div, "#{player.name} has #{@game.format_currency(player.cash)} in cash.")
+
+        if @step.can_ebuy_sell_shares?(@corporation)
+          if share_funds_allowed.positive?
+            children << h(:div, "#{player.name} has #{@game.format_currency(share_funds_possible)} "\
+                                'in sellable shares.')
+          end
+
+          if share_funds_required.positive?
+            children << h(:div, "#{player.name} #{verb} sell shares to raise at least "\
+                                "#{@game.format_currency(share_funds_required)}.")
+          end
+        end
+
+        if @must_buy_power &&
+           share_funds_possible < share_funds_required &&
+           @game.can_go_bankrupt?(player, @corporation)
+          children << h(:div, "#{player.name} does not have enough liquidity to "\
+                              "contribute towards #{@corporation.name} buying the minimum train "\
+                              "power. #{player.name} must declare bankruptcy.")
+        end
+
+        children.concat(render_emergency_money_raising(player)) if share_funds_allowed.positive?
+
+        children
+      end
+
+      def render
+        @step = @game.round.active_step
+        @corporation ||= @step.current_entity
+
+        @depot = @game.depot
+
+        children = []
+
+        @must_buy_power = @step.must_buy_power?(@corporation)
+
+        if @step.can_buy_power?(@corporation) || @must_buy_power
+          if @must_buy_power
+            children << h(:div, "#{@corporation.name} must buy train power "\
+                          "(at least #{@step.min_power_needed(@corporation)})")
+          end
+          children << h(:h3, 'Select Amount of Train Power to Buy')
+          children << h(:div, render_buy(@corporation))
+        end
+
+        children << render_chart
+        children << h(:div, "#{@corporation.name} has #{@game.format_currency(@corporation.cash)}.")
+        children << h(:div, "Power Progress: #{@game.power_progress}")
+        children << h(:div, "Current/Next power cost: #{@game.format_currency(@game.current_power_cost)} / "\
+                      "#{@game.format_currency(@game.next_power_cost)}")
+
+        if (@must_buy_train && @step.ebuy_president_can_contribute?(@corporation)) ||
+           @step.president_may_contribute?(@corporation)
+          children.concat(render_president_contributions)
+        end
+
+        props = {
+          style: {
+            display: 'grid',
+            rowGap: '0.5rem',
+            marginBottom: '1rem',
+          },
+        }
+
+        h('div#buy_trains', props, children)
+      end
+
+      def render_buy(corporation)
+        min, max = @step.power_minmax(corporation)
+        input = h(
+          'input.no_margin',
+          style: {
+            height: '1.2rem',
+            width: '3rem',
+            padding: '0 0 0 0.2rem',
+          },
+          attrs: {
+            type: 'number',
+            min: min,
+            max: max,
+            value: min,
+            size: 2,
+          }
+        )
+
+        buy_power = lambda do
+          amount = input.JS['elm'].JS['value'].to_i
+          process_action(Engine::Action::BuyPower.new(
+            corporation,
+            power: amount,
+          ))
+        end
+
+        [input,
+         h('button.no_margin', { on: { click: buy_power } }, 'Buy Power')]
+      end
+
+      def render_chart
+        header, *chart = @step.chart(@corporation)
+
+        rows = chart.map do |r|
+          h(:tr, [
+            h(:td, r[0]),
+            h(:td, r[1]),
+          ])
+        end
+
+        table_props = {
+          style: {
+            margin: '0.5rem 0',
+            textAlign: 'left',
+          },
+        }
+
+        h(:table, table_props, [
+          h(:thead, [
+            h(:tr, [
+              h(:th, header[0]),
+              h(:th, header[1]),
+            ]),
+          ]),
+          h(:tbody, rows),
+        ])
+      end
+    end
+  end
+end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -235,15 +235,7 @@ module View
       end
 
       def render_trains
-        trains = (@corporation.system? ? @corporation.shells : [@corporation]).map do |c|
-          if c.trains.empty?
-            'None'
-          else
-            c.trains.map { |t| t.obsolete ? "(#{t.name})" : t.name }.join(' ')
-          end
-        end
-
-        render_header_segment(trains, 'Trains')
+        render_header_segment(@game.trains_str(@corporation), 'Trains')
       end
 
       def render_header_segment(values, key)

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -326,13 +326,15 @@ module View
           },
         }
 
+        max = @game.class::MAX_PROGRESS
+
         [
           h(:h3, 'Power Progress'),
           h(:div, { style: { overflowX: 'auto' } }, [
             h(:table, [
               h(:tbody, [
-                h(:tr, props, Array.new(15) { |p| h(:td, p + 1) }),
-                h(:tr, props, Array.new(15) { |p| h(:td, @game.power_progress == (p + 1) ? '↑' : '') }),
+                h(:tr, props, Array.new(max) { |p| h(:td, p + 1) }),
+                h(:tr, props, Array.new(max) { |p| h(:td, @game.power_progress == (p + 1) ? '↑' : '') }),
               ]),
             ]),
           ]),

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -47,6 +47,9 @@ module View
           if @current_actions.include?('buy_train')
             left << h(IssueShares) if @current_actions.include?('sell_shares')
             left << h(BuyTrains)
+          elsif @current_actions.include?('buy_power')
+            left << h(IssueShares) if @current_actions.include?('sell_shares')
+            left << h(BuyPower)
           elsif @current_actions.include?('borrow_train')
             left << h(BorrowTrain)
           elsif @current_actions.include?('sell_shares') && entity.player?

--- a/lib/engine/action/buy_power.rb
+++ b/lib/engine/action/buy_power.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class BuyPower < Base
+      attr_reader :power
+
+      def initialize(entity, power:)
+        super(entity)
+        @power = power
+      end
+
+      def self.h_to_args(h, _game)
+        {
+          power: h['power'],
+        }
+      end
+
+      def args_to_h
+        {
+          'power' => @power,
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2593,6 +2593,28 @@ module Engine
       def operation_round_name
         self.class::OPERATING_ROUND_NAME
       end
+
+      def trains_str(corporation)
+        (corporation.system? ? corporation.shells : [corporation]).map do |c|
+          if c.trains.empty?
+            'None'
+          else
+            c.trains.map { |t| t.obsolete ? "(#{t.name})" : t.name }.join(' ')
+          end
+        end
+      end
+
+      def on_train_header
+        'On Train'
+      end
+
+      def train_limit_header
+        'Train Limit'
+      end
+
+      def train_power?
+        false
+      end
     end
   end
 end

--- a/lib/engine/game/g_18_carolinas/step/buy_power.rb
+++ b/lib/engine/game/g_18_carolinas/step/buy_power.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/emergency_money'
+
+module Engine
+  module Game
+    module G18Carolinas
+      module Step
+        class BuyPower < Engine::Step::Base
+          include Engine::Step::EmergencyMoney
+
+          def actions(entity)
+            return ['sell_shares'] if entity == current_entity&.owner
+            return [] if entity != current_entity
+            return %w[sell_shares buy_power] if president_may_contribute?(entity)
+            return %w[buy_power pass] if can_buy_power?(entity)
+
+            []
+          end
+
+          def description
+            'Buy Train Power'
+          end
+
+          def pass_description
+            'Skip (Power)'
+          end
+
+          def can_buy_power?(entity)
+            return false unless @game.corporation_power[entity] < @game.class::MAX_TRAIN
+
+            entity.cash >= if @game.power_progress < @game.class::MAX_PROGRESS
+                             @game.current_power_cost
+                           else
+                             @game.next_power_cost
+                           end
+          end
+
+          def min_train
+            @game.min_train
+          end
+
+          def check_spend(entity, delta)
+            unless must_buy_power?(entity)
+              raise GameError, 'Power too large' if delta > power_minmax(entity).last
+              raise GameError, 'Cannot afford power' if cash_needed(entity, delta) > entity.cash
+
+              return
+            end
+
+            return unless cash_needed(entity, delta) > entity.cash
+
+            if ebuy_power_needed(entity) != delta
+              raise GameError, 'Must buy exactly minimum required power during emergency buy'
+            end
+
+            return unless ebuy_cash_needed(entity) > entity.cash + entity.owner.cash
+
+            raise GameError, 'Not enough funds raised for emergency buy'
+          end
+
+          def process_buy_power(action)
+            delta = action.power
+            entity = action.entity
+
+            check_spend(entity, delta)
+            cost = cash_needed(entity, delta)
+            ebuy = false
+
+            raise GameError, 'Power purchased is too large' if delta > @game.class::MAX_TRAIN
+            raise GameError, 'Power purchased is too small' unless delta.positive?
+
+            if must_buy_power?(entity) && cost > entity.cash
+              # emergency buy
+              ebuy = true
+              cost = ebuy_cash_needed(entity) - entity.cash
+              remaining = cost - entity.cash
+              player = entity.owner
+              player.spend(remaining, entity)
+              @log << "#{player.name} contributes #{@game.format_currency(remaining)}"
+            end
+
+            @log << "#{entity.name} buys #{delta} power for #{@game.format_currency(cost)}"
+
+            @game.buy_power(entity, delta, cost, ebuy: ebuy)
+
+            pass!
+          end
+
+          def must_buy_power?(entity)
+            @game.must_buy_power?(entity)
+          end
+
+          # So I don't have to create a new IssueShares view...
+          def must_buy_train?(entity)
+            must_buy_power?(entity)
+          end
+
+          def president_may_contribute?(entity)
+            must_buy_power?(entity)
+          end
+
+          def ebuy_president_can_contribute?(corporation)
+            corporation.cash < min_cash_needed(corporation)
+          end
+
+          def can_ebuy_sell_shares?(_entity)
+            @game.class::EBUY_CAN_SELL_SHARES
+          end
+
+          def min_cash_needed(corporation)
+            return 0 unless @game.must_buy_power?(corporation)
+
+            diff = @game.min_train - @game.current_corporation_power(corporation)
+            if diff + @game.power_progress > @game.class::MAX_PROGRESS
+              (@game.class::MIN_TRAIN[@game.next_phase_name] -
+               (@game.current_corporation_power(corporation) / 3).to_i) * @game.next_power_cost
+            else
+              diff * @game.current_power_cost
+            end
+          end
+
+          def min_power_needed(corporation)
+            return 0 unless @game.must_buy_power?(corporation)
+
+            diff = @game.min_train - @game.current_corporation_power(corporation)
+            if diff + @game.power_progress > @game.class::MAX_PROGRESS
+              diff = @game.class::MIN_TRAIN[@game.next_phase_name] -
+                (@game.current_corporation_power(corporation) / 3).to_i
+            end
+            diff
+          end
+
+          # ebuy doesn't affect progress track, but is twice as expensive
+          def ebuy_cash_needed(corporation)
+            return 0 unless @game.corporation_power[corporation] < @game.class::MIN_TRAIN[@game.phase.name]
+
+            diff = @game.min_train - @game.corporation_power[corporation]
+            diff * @game.class::POWER_COST[@game.phase.name] * 2
+          end
+
+          def ebuy_power_needed(corporation)
+            return 0 unless @game.corporation_power[corporation] < @game.class::MIN_TRAIN[@game.phase.name]
+
+            @game.min_train - @game.corporation_power[corporation]
+          end
+
+          def cash_needed(_corporation, delta_power)
+            if delta_power + @game.power_progress > @game.class::MAX_PROGRESS
+              delta_power * @game.class::POWER_COST[@game.next_phase_name]
+            else
+              delta_power * @game.class::POWER_COST[@game.phase.name]
+            end
+          end
+
+          def power_minmax(corporation)
+            min = [min_power_needed(corporation), 1].max
+            max = min
+            max_possible = @game.class::MAX_TRAIN - @game.current_corporation_power(corporation)
+            max_possible.times do |p|
+              break unless corporation.cash >= cash_needed(corporation, p + 1)
+
+              max = [max, p + 1].max
+            end
+            [min, max]
+          end
+
+          def available_cash(entity)
+            return current_entity.cash if entity == current_entity
+
+            entity.cash + current_entity.cash
+          end
+
+          def needed_cash(entity)
+            ebuy_cash_needed(entity)
+          end
+
+          def chart(entity)
+            lines = []
+            lines << %w[Power Cost]
+            if @game.must_buy_power?(entity)
+              lines << [min_power_needed(entity), @game.format_currency(min_cash_needed(entity))]
+            else
+              max_possible = @game.class::MAX_TRAIN - @game.current_corporation_power(entity)
+              max_possible.times do |p|
+                break unless entity.cash >= (cash = cash_needed(entity, p + 1))
+
+                lines << [p + 1, @game.format_currency(cash)]
+              end
+            end
+            lines
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replace buy_trains step/action/view with buy_power step/action/view
Add train power and power progress support to game_info and corporation cards

Common file changes:
UI::Round::Operating - support for buy_power
UI::GameInfo - support for power progress, more generic phase info
UI::Corporation - support for train power
Engine::Game::Base - default methods to support above UI changes

Spreadsheet tab still needs more work.

### New buy_power view:
![buy_power](https://user-images.githubusercontent.com/8494213/124393503-13403400-dcb8-11eb-9e99-a1c23e6dc5fa.png)

### game_info with power progress and phases:
![power_phases](https://user-images.githubusercontent.com/8494213/124393529-2a7f2180-dcb8-11eb-9df1-2d5f121a63d9.png)

### spreadsheet with power progress from game_info:
![spreadsheet_progress](https://user-images.githubusercontent.com/8494213/124393540-3965d400-dcb8-11eb-8b81-0eab5874f47d.png)
