### PR TITLE
[1828] check that stock is in gray before trying to move up

### DIFF
--- a/lib/engine/game/g_1828/round/stock.rb
+++ b/lib/engine/game/g_1828/round/stock.rb
@@ -10,8 +10,8 @@ module Engine
           protected
 
           def sold_out_stock_movement(corp)
-            @game.stock_market.move_up(corp)
             @game.stock_market.move_up(corp) if corp.share_price.type == :unlimited
+            @game.stock_market.move_up(corp)
             @game.stock_market.move_up(corp) if corp.owner.num_shares_of(corp) >= 8
           end
 


### PR DESCRIPTION
So we don't miss out on a price movement, we first check whether the stock is in the "gray zone" - and then move it if so, before we attempt other movements for "sold out" and "80% owned by one player"

Given the example in the bug report, the companies now move three rows up as expected
```
MC's share price changes from $58 to $71
OSH's share price changes from $58 to $71
NW's share price changes from $55 to $68
```

fixes #5957 