### PR TITLE
1830+ PRR Home - Halt implementation method (preview)

### DIFF
--- a/lib/engine/game/g_1830_plus/game.rb
+++ b/lib/engine/game/g_1830_plus/game.rb
@@ -9,6 +9,8 @@ module Engine
     module G1830Plus
       class Game < G1830::Game
         include_meta(G1830Plus::Meta)
+        attr_reader :prr_graph
+
         CERT_LIMIT = { 2 => 32, 3 => 27, 4 => 20, 5 => 16, 6 => 14, 7 => 13 }.freeze
 
         STARTING_CASH = { 2 => 1200, 3 => 800, 4 => 600, 5 => 480, 6 => 400, 7 => 350 }.freeze
@@ -177,9 +179,7 @@ module Engine
           super
         end
 
-        def check_distance(route, visits)
-          distance = super
-
+        def check_distance(route, _visits)
           prr_halt_visits = route.stops.count(&:halt?)
           prr_token_visits = route.stops.count { |s| s.city? && s.tokened_by?(prr) }
           raise GameError, 'Only PRR may use PRR home halt' if prr_halt_visits.positive? && route.train.owner != prr
@@ -271,8 +271,8 @@ module Engine
             Engine::Step::SpecialToken,
             Engine::Step::BuyCompany,
             Engine::Step::HomeToken,
-            Engine::Step::Track,
-            Engine::Step::Token,
+            G1830Plus::Step::Track,
+            G1830Plus::Step::Token,
             Engine::Step::Route,
             Engine::Step::Dividend,
             Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_1830_plus/step/token.rb
+++ b/lib/engine/game/g_1830_plus/step/token.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/token'
+module Engine
+  module Game
+    module G1830Plus
+      module Step
+        class Token < Engine::Step::Token
+          def place_token(entity, city, token, connected: true, extra_action: false,
+                          special_ability: nil, check_tokenable: true, spender: nil)
+            super
+            @game.prr_graph.clear
+            @game.graph.clear
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1830_plus/step/track.rb
+++ b/lib/engine/game/g_1830_plus/step/track.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/track'
+module Engine
+  module Game
+    module G1830Plus
+      module Step
+        class Track < Engine::Step::Track
+          def lay_tile(action, extra_cost: 0, entity: nil, spender: nil)
+            super
+            @game.prr_graph.clear
+            @game.graph.clear
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/token.rb
+++ b/lib/engine/step/token.rb
@@ -25,7 +25,7 @@ module Engine
       end
 
       def available_hex(entity, hex)
-        @game.graph.reachable_hexes(entity)[hex]
+        @game.graph_for_entity(entity).reachable_hexes(entity)[hex]
       end
 
       def process_place_token(action)

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -21,7 +21,7 @@ module Engine
           !@round.tokened &&
           !(tokens = available_tokens(entity)).empty? &&
           min_token_price(tokens) <= buying_power(entity) &&
-          @game.graph.can_token?(entity)
+          @game.graph_for_entity(entity).can_token?(entity)
       end
 
       # This is called to see if the cost of a PlaceToken action should be overriden
@@ -92,7 +92,7 @@ module Engine
         end
 
         @round.tokened = true unless extra_action
-        @game.graph.clear
+        @game.graph_for_entity(entity).clear
       end
 
       def pay_token_cost(entity, cost)
@@ -137,7 +137,7 @@ module Engine
           end
 
           token.price = ability.teleport_price if ability.teleport_price
-          token.price = ability.price(token) if @game.graph.reachable_hexes(entity)[hex]
+          token.price = ability.price(token) if @game.graph_for_entity(entity).reachable_hexes(entity)[hex]
           return [token, ability]
         end
 
@@ -145,7 +145,7 @@ module Engine
       end
 
       def check_connected(entity, city, hex)
-        return if @game.loading || @game.graph.connected_nodes(entity)[city]
+        return if @game.loading || @game.graph_for_entity(entity).connected_nodes(entity)[city]
 
         city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
         raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"


### PR DESCRIPTION
I'm looking for feedback on this before I get too far on it

Autorouting looks like it works for PRR now and tokens work too

![image](https://user-images.githubusercontent.com/2993555/124755433-5e955500-def9-11eb-9df6-a31592b2eb2d.png)
After clicking the halt for the second train
![image](https://user-images.githubusercontent.com/2993555/124755576-8a183f80-def9-11eb-96c0-45a2f42f33ca.png)

Halts are automatically skipped for other corps and autorouting works as expected
![image](https://user-images.githubusercontent.com/2993555/124755670-a7e5a480-def9-11eb-9752-5649abc93a49.png)

I tried some prototypes of using a city (megaltoona?) connected to all the exits on Altoona, but it gets far too crowded on Altoona on brown tiles that aren't the 3 pointed triangle. Having four halts on a brown tile isn't nearly as crowded and it may be possible to make the halts slimmer and PRR themed later if I go down this path
