### PR TITLE
Fix 1856 not allowing dits to downgrade

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -294,6 +294,10 @@ module Engine
 
       VARIABLE_FLOAT_PERCENTAGES = false
 
+      # Setting this to true is neccessary but insufficent to allow downgrading town tiles into plain track
+      # See 1856 for an example
+      ALLOW_REMOVING_TOWNS = false
+
       CACHABLE = [
         %i[players player],
         %i[corporations corporation],

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -730,6 +730,7 @@ module Engine
         SELL_MOVEMENT = :down_per_10
 
         HOME_TOKEN_TIMING = :operate
+        ALLOW_REMOVING_TOWNS = true
 
         RIGHT_COST = 50
 

--- a/lib/engine/game/g_1856/step/track.rb
+++ b/lib/engine/game/g_1856/step/track.rb
@@ -7,6 +7,41 @@ module Engine
     module G1856
       module Step
         class Track < Engine::Step::Track
+          def check_track_restrictions!(entity, old_tile, new_tile)
+            return if @game.loading || !entity.operator?
+
+            graph = @game.graph_for_entity(entity)
+
+            # Don't check that towns are preserved
+
+            old_paths = old_tile.paths
+            changed_city = false
+            used_new_track = old_paths.empty?
+
+            new_tile.paths.each do |np|
+              next unless graph.connected_paths(entity)[np]
+
+              op = old_paths.find { |path| np <= path }
+              used_new_track = true unless op
+              old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
+              new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
+              changed_city = true unless old_revenues == new_revenues
+            end
+
+            case @game.class::TRACK_RESTRICTION
+            when :permissive
+              true
+            when :city_permissive
+              raise GameError, 'Must be city tile or use new track' if new_tile.cities.none? && !used_new_track
+            when :restrictive
+              raise GameError, 'Must use new track' unless used_new_track
+            when :semi_restrictive
+              raise GameError, 'Must use new track or change city value' if !used_new_track && !changed_city
+            else
+              raise
+            end
+          end
+
           def legal_tile_rotation?(entity, hex, tile)
             old_paths = hex.tile.paths
             old_ctedges = hex.tile.city_town_edges

--- a/lib/engine/game/g_1856/step/track.rb
+++ b/lib/engine/game/g_1856/step/track.rb
@@ -7,41 +7,6 @@ module Engine
     module G1856
       module Step
         class Track < Engine::Step::Track
-          def check_track_restrictions!(entity, old_tile, new_tile)
-            return if @game.loading || !entity.operator?
-
-            graph = @game.graph_for_entity(entity)
-
-            # Don't check that towns are preserved
-
-            old_paths = old_tile.paths
-            changed_city = false
-            used_new_track = old_paths.empty?
-
-            new_tile.paths.each do |np|
-              next unless graph.connected_paths(entity)[np]
-
-              op = old_paths.find { |path| np <= path }
-              used_new_track = true unless op
-              old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
-              new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
-              changed_city = true unless old_revenues == new_revenues
-            end
-
-            case @game.class::TRACK_RESTRICTION
-            when :permissive
-              true
-            when :city_permissive
-              raise GameError, 'Must be city tile or use new track' if new_tile.cities.none? && !used_new_track
-            when :restrictive
-              raise GameError, 'Must use new track' unless used_new_track
-            when :semi_restrictive
-              raise GameError, 'Must use new track or change city value' if !used_new_track && !changed_city
-            else
-              raise
-            end
-          end
-
           def legal_tile_rotation?(entity, hex, tile)
             old_paths = hex.tile.paths
             old_ctedges = hex.tile.city_town_edges

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -283,9 +283,10 @@ module Engine
 
         graph = @game.graph_for_entity(entity)
 
-        raise GameError, 'New track must override old one' if old_tile.city_towns.any? do |old_city|
-          new_tile.city_towns.none? { |new_city| (old_city.exits - new_city.exits).empty? }
-        end
+        raise GameError, 'New track must override old one' if !@game.class::ALLOW_REMOVING_TOWNS &&
+            old_tile.city_towns.any? do |old_city|
+              new_tile.city_towns.none? { |new_city| (old_city.exits - new_city.exits).empty? }
+            end
 
         old_paths = old_tile.paths
         changed_city = false

--- a/spec/fixtures/1856/README.md
+++ b/spec/fixtures/1856/README.md
@@ -22,3 +22,6 @@ hotseat002: (needs replacement)
 
  hotseat006:
  * False Presidency game end
+
+ hotseat007:
+ * based off of #45471 - dit downgrade

--- a/spec/fixtures/1856/hotseat007.json
+++ b/spec/fixtures/1856/hotseat007.json
@@ -1,0 +1,11430 @@
+{
+    "status": "finished",
+    "actions": [
+      {
+        "type": "message",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 1,
+        "created_at": 1623161447,
+        "message": "Hi everyone - have fun! My first time playing this one on the site. Are there any alpha bugs to be aware of? "
+      },
+      {
+        "type": "bid",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 2,
+        "created_at": 1623161623,
+        "company": "GLSC",
+        "price": 75
+      },
+      {
+        "type": "bid",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 3,
+        "created_at": 1623164448,
+        "company": "GLSC",
+        "price": 80
+      },
+      {
+        "type": "bid",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 4,
+        "created_at": 1623164522,
+        "company": "NFSBC",
+        "price": 105
+      },
+      {
+        "type": "bid",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 5,
+        "created_at": 1623171495,
+        "company": "WSRC",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 6,
+        "created_at": 1623171531,
+        "company": "TCC",
+        "price": 55
+      },
+      {
+        "type": "message",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 7,
+        "created_at": 1623171585,
+        "message": "Not that I’ve seen so far, playing 4 games of 56 right now and not seeing anything unstable yet"
+      },
+      {
+        "type": "bid",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 8,
+        "created_at": 1623175073,
+        "company": "FT",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 9,
+        "created_at": 1623175076,
+        "company": "GLSC",
+        "price": 85
+      },
+      {
+        "type": "bid",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 10,
+        "created_at": 1623177822,
+        "company": "GLSC",
+        "price": 90
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 11,
+        "created_at": 1623177906
+      },
+      {
+        "type": "bid",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 12,
+        "created_at": 1623177947,
+        "company": "SCFTC",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 13,
+        "created_at": 1623195009
+      },
+      {
+        "type": "par",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 14,
+        "created_at": 1623213489,
+        "corporation": "LPS",
+        "share_price": "80,2,4"
+      },
+      {
+        "type": "par",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 15,
+        "created_at": 1623216960,
+        "corporation": "GW",
+        "share_price": "80,2,4"
+      },
+      {
+        "type": "par",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 16,
+        "created_at": 1623237247,
+        "corporation": "GT",
+        "share_price": "80,2,4"
+      },
+      {
+        "id": 17,
+        "type": "buy_shares",
+        "entity": 40,
+        "shares": [
+          "GW_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 40,
+        "created_at": 1623246175
+      },
+      {
+        "id": 18,
+        "type": "undo",
+        "entity": 405,
+        "entity_type": "player",
+        "user": 40,
+        "created_at": 1623246178
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 19,
+        "created_at": 1623246326
+      },
+      {
+        "type": "par",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 20,
+        "created_at": 1623252468,
+        "corporation": "CPR",
+        "share_price": "65,5,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 21,
+        "created_at": 1623253938,
+        "shares": [
+          "LPS_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 22,
+        "created_at": 1623256074,
+        "shares": [
+          "GW_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 23,
+        "created_at": 1623257540,
+        "shares": [
+          "GT_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 24,
+        "created_at": 1623257943
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 25,
+        "created_at": 1623257947
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 26,
+        "created_at": 1623258181,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1623258182
+          }
+        ],
+        "shares": [
+          "CPR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 27,
+        "created_at": 1623261602,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1623261601,
+            "corporations": []
+          }
+        ],
+        "hex": "C14",
+        "tile": "5-0",
+        "rotation": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 28,
+        "created_at": 1623261612,
+        "train": "2-0",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 29,
+        "created_at": 1623261613,
+        "train": "2-1",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 30,
+        "created_at": 1623261629
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 31,
+        "created_at": 1623263164,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1623263164,
+            "corporations": []
+          }
+        ],
+        "hex": "G14",
+        "tile": "8-0",
+        "rotation": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 32,
+        "created_at": 1623263174,
+        "train": "2-2",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 33,
+        "created_at": 1623263176,
+        "train": "2-3",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 34,
+        "created_at": 1623263178
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 35,
+        "created_at": 1623263180
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 36,
+        "created_at": 1623265794,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1623265793,
+            "corporations": []
+          }
+        ],
+        "hex": "P9",
+        "tile": "6-0",
+        "rotation": 5
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 37,
+        "created_at": 1623265812,
+        "train": "2-4",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 38,
+        "created_at": 1623265824,
+        "train": "2'-0",
+        "price": 100,
+        "variant": "2'"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 39,
+        "created_at": 1623265831
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 40,
+        "created_at": 1623265835
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 41,
+        "created_at": 1623266064,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1623266064,
+            "corporations": []
+          }
+        ],
+        "hex": "M6",
+        "tile": "58-0",
+        "rotation": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 42,
+        "created_at": 1623266084,
+        "loan": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 43,
+        "created_at": 1623266090,
+        "train": "3-0",
+        "price": 225,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 44,
+        "created_at": 1623266112
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 45,
+        "created_at": 1623266124
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 46,
+        "created_at": 1623266132
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 47,
+        "created_at": 1623266332
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 48,
+        "created_at": 1623269790
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 49,
+        "created_at": 1623271679
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 50,
+        "created_at": 1623324015,
+        "shares": [
+          "CPR_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 51,
+        "created_at": 1623325524
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 52,
+        "created_at": 1623326696
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 53,
+        "created_at": 1623335710
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 54,
+        "created_at": 1623335808
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 55,
+        "created_at": 1623337071,
+        "shares": [
+          "LPS_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 56,
+        "created_at": 1623337073
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 57,
+        "created_at": 1623352920
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 58,
+        "created_at": 1623355576
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 59,
+        "created_at": 1623356394
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 60,
+        "created_at": 1623357310
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 61,
+        "created_at": 1623398881
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 62,
+        "created_at": 1623400183,
+        "hex": "B15",
+        "tile": "7-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 63,
+        "created_at": 1623400187,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1623400188,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 64,
+        "created_at": 1623400200,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "C14",
+                "B15",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14"
+            ],
+            "revenue": 50,
+            "revenue_str": "B13-C14"
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14"
+            ],
+            "revenue": 50,
+            "revenue_str": "B13-C14"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 65,
+        "created_at": 1623400220,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 66,
+        "created_at": 1623400225
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 67,
+        "created_at": 1623400354
+      },
+      {
+        "type": "buy_company",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 68,
+        "created_at": 1623400611,
+        "company": "WSRC",
+        "price": 80
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 69,
+        "created_at": 1623400667
+      },
+      {
+        "type": "take_loan",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 70,
+        "created_at": 1623407075,
+        "loan": 1
+      },
+      {
+        "type": "buy_company",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 71,
+        "created_at": 1623407085,
+        "company": "TCC",
+        "price": 100
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 72,
+        "created_at": 1623407098,
+        "hex": "G12",
+        "tile": "6-1",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TCC",
+        "entity_type": "company",
+        "id": 73,
+        "created_at": 1623407123,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1623407123,
+            "corporations": []
+          }
+        ],
+        "hex": "H11",
+        "tile": "58-1",
+        "rotation": 5
+      },
+      {
+        "type": "place_token",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 74,
+        "created_at": 1623407129,
+        "city": "6-1-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 75,
+        "created_at": 1623407146,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "G12",
+              "F15"
+            ],
+            "revenue": 50,
+            "revenue_str": "G12-F15"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "G12",
+                "H11"
+              ]
+            ],
+            "hexes": [
+              "H11",
+              "G12"
+            ],
+            "revenue": 30,
+            "revenue_str": "H11-G12"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 76,
+        "created_at": 1623407148,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 77,
+        "created_at": 1623407157
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 78,
+        "created_at": 1623411436,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1623411435,
+            "corporations": []
+          }
+        ],
+        "hex": "O10",
+        "tile": "9-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 79,
+        "created_at": 1623411469
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 80,
+        "created_at": 1623411484,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9"
+            ],
+            "revenue": 40,
+            "revenue_str": "Q10-P9"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "P9"
+            ],
+            "revenue": 50,
+            "revenue_str": "N11-P9"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 81,
+        "created_at": 1623411486,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 82,
+        "created_at": 1623411503,
+        "loan": 2
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 83,
+        "created_at": 1623411529
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 84,
+        "created_at": 1623411531
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 85,
+        "created_at": 1623411536
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 86,
+        "created_at": 1623413708,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1623413706,
+            "corporations": []
+          }
+        ],
+        "hex": "N7",
+        "tile": "8-1",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 87,
+        "created_at": 1623413730,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "M4",
+                "M6"
+              ]
+            ],
+            "hexes": [
+              "M6",
+              "M4"
+            ],
+            "revenue": 40,
+            "revenue_str": "M6-M4"
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 88,
+        "created_at": 1623413733,
+        "loan": 3
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 89,
+        "created_at": 1623413736,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 90,
+        "created_at": 1623413740
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 91,
+        "created_at": 1623413766
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 92,
+        "created_at": 1623413770
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 93,
+        "created_at": 1623418841,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1623418842,
+            "corporations": []
+          }
+        ],
+        "hex": "C14",
+        "tile": "14-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 94,
+        "created_at": 1623418850,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "C14",
+                "B15",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "B13"
+            ],
+            "revenue": 60,
+            "revenue_str": "C14-B13"
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "B13"
+            ],
+            "revenue": 60,
+            "revenue_str": "C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 95,
+        "created_at": 1623418854,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 96,
+        "created_at": 1623418875
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 97,
+        "created_at": 1623418880
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 98,
+        "created_at": 1623418943
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 99,
+        "created_at": 1623420190,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1623420189,
+            "corporations": []
+          }
+        ],
+        "hex": "G12",
+        "tile": "14-1",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 100,
+        "created_at": 1623420195,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "G12"
+            ],
+            "revenue": 60,
+            "revenue_str": "F15-G12"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "G12",
+                "H11"
+              ]
+            ],
+            "hexes": [
+              "G12",
+              "H11"
+            ],
+            "revenue": 40,
+            "revenue_str": "G12-H11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 101,
+        "created_at": 1623420199,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 102,
+        "created_at": 1623420201
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 103,
+        "created_at": 1623420206
+      },
+      {
+        "id": 104,
+        "hex": "P9",
+        "tile": "14-2",
+        "type": "lay_tile",
+        "entity": "GT",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "created_at": 1623420414,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 7422,
+        "created_at": 1623420415
+      },
+      {
+        "id": 105,
+        "loan": 4,
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420422
+      },
+      {
+        "id": 106,
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420425
+      },
+      {
+        "id": 107,
+        "type": "run_routes",
+        "entity": "GT",
+        "routes": [
+          {
+            "hexes": [
+              "P9",
+              "Q10"
+            ],
+            "train": "2-4",
+            "revenue": 50,
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ]
+            ],
+            "revenue_str": "P9-Q10"
+          },
+          {
+            "hexes": [
+              "P9",
+              "N11"
+            ],
+            "train": "2'-0",
+            "revenue": 60,
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "revenue_str": "P9-N11"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420427
+      },
+      {
+        "id": 108,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420429
+      },
+      {
+        "id": 109,
+        "type": "undo",
+        "entity": "GT",
+        "action_id": 103,
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420439
+      },
+      {
+        "id": 110,
+        "loan": 4,
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420448
+      },
+      {
+        "id": 111,
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "created_at": 1623420452,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 7422,
+        "created_at": 1623420453
+      },
+      {
+        "id": 112,
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420454
+      },
+      {
+        "id": 113,
+        "type": "run_routes",
+        "entity": "GT",
+        "routes": [
+          {
+            "hexes": [
+              "P9",
+              "Q10"
+            ],
+            "train": "2-4",
+            "revenue": 40,
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ]
+            ],
+            "revenue_str": "P9-Q10"
+          },
+          {
+            "hexes": [
+              "P9",
+              "N11"
+            ],
+            "train": "2'-0",
+            "revenue": 50,
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "revenue_str": "P9-N11"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420456
+      },
+      {
+        "id": 114,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420458
+      },
+      {
+        "id": 115,
+        "type": "undo",
+        "entity": "GT",
+        "action_id": 103,
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420475
+      },
+      {
+        "id": 116,
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "created_at": 1623420480,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 7422,
+        "created_at": 1623420481
+      },
+      {
+        "id": 117,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623420486
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 118,
+        "created_at": 1623420492,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1623420491,
+            "corporations": []
+          }
+        ],
+        "hex": "P9",
+        "tile": "14-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 119,
+        "created_at": 1623420495
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 120,
+        "created_at": 1623420501,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ]
+            ],
+            "hexes": [
+              "P9",
+              "Q10"
+            ],
+            "revenue": 50,
+            "revenue_str": "P9-Q10"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "P9",
+              "N11"
+            ],
+            "revenue": 60,
+            "revenue_str": "P9-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 121,
+        "created_at": 1623420506,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 122,
+        "created_at": 1623420508,
+        "train": "3-1",
+        "price": 225,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 123,
+        "created_at": 1623420517
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 124,
+        "created_at": 1623420520
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 125,
+        "created_at": 1623420523
+      },
+      {
+        "id": 126,
+        "hex": "N9",
+        "tile": "4-0",
+        "type": "lay_tile",
+        "entity": "CPR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "created_at": 1623424836,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 405,
+        "created_at": 1623424837
+      },
+      {
+        "id": 127,
+        "type": "undo",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "user": 405,
+        "created_at": 1623424892
+      },
+      {
+        "id": 128,
+        "hex": "N7",
+        "tile": "23-0",
+        "type": "lay_tile",
+        "entity": "CPR",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "created_at": 1623424899,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 405,
+        "created_at": 1623424900
+      },
+      {
+        "id": 129,
+        "type": "undo",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "user": 405,
+        "created_at": 1623424921
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 130,
+        "created_at": 1623424929,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1623424929,
+            "corporations": []
+          }
+        ],
+        "hex": "N9",
+        "tile": "4-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 131,
+        "created_at": 1623424944,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "M6",
+                "N7",
+                "N9"
+              ],
+              [
+                "M4",
+                "M6"
+              ]
+            ],
+            "hexes": [
+              "N9",
+              "M6",
+              "M4"
+            ],
+            "revenue": 50,
+            "revenue_str": "N9-M6-M4"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 132,
+        "created_at": 1623424945,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 133,
+        "created_at": 1623424960,
+        "loan": 4
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 134,
+        "created_at": 1623424967
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 135,
+        "created_at": 1623424969
+      },
+      {
+        "type": "buy_company",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 136,
+        "created_at": 1623424992,
+        "company": "NFSBC",
+        "price": 200
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 137,
+        "created_at": 1623425056
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 138,
+        "created_at": 1623425070,
+        "shares": [
+          "CPR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 139,
+        "created_at": 1623425113
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 140,
+        "created_at": 1623426011,
+        "shares": [
+          "LPS_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 141,
+        "created_at": 1623426018
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 142,
+        "created_at": 1623426231,
+        "shares": [
+          "GW_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 143,
+        "created_at": 1623426243
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 144,
+        "created_at": 1623426590,
+        "shares": [
+          "LPS_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 145,
+        "created_at": 1623426592
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 146,
+        "created_at": 1623568223,
+        "shares": [
+          "GW_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 147,
+        "created_at": 1623568254
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 148,
+        "created_at": 1623585527,
+        "shares": [
+          "CPR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 149,
+        "created_at": 1623585540
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 150,
+        "created_at": 1623588473,
+        "shares": [
+          "CPR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 151,
+        "created_at": 1623588483
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 152,
+        "created_at": 1623591140,
+        "shares": [
+          "GW_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 153,
+        "created_at": 1623591144
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 154,
+        "created_at": 1623591571
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 155,
+        "created_at": 1623657671
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 156,
+        "created_at": 1623664758,
+        "shares": [
+          "CPR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 157,
+        "created_at": 1623664781
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 158,
+        "created_at": 1623664839
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 159,
+        "created_at": 1623668997
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 160,
+        "created_at": 1623675094
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 161,
+        "created_at": 1623677134
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 162,
+        "created_at": 1623683624,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 163,
+        "created_at": 1623683630
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 164,
+        "created_at": 1623683826
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 165,
+        "created_at": 1623690234
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 166,
+        "created_at": 1623693660
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 167,
+        "created_at": 1623739544
+      },
+      {
+        "type": "sell_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 168,
+        "created_at": 1623747467,
+        "shares": [
+          "CPR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 169,
+        "created_at": 1623747509,
+        "shares": [
+          "LPS_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 170,
+        "created_at": 1623748388
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 171,
+        "created_at": 1623767937
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 172,
+        "created_at": 1623768659
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 173,
+        "created_at": 1623768717
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 174,
+        "created_at": 1623772948
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 175,
+        "created_at": 1623773034,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1623773033,
+            "corporations": []
+          }
+        ],
+        "hex": "D13",
+        "tile": "8-2",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 176,
+        "created_at": 1623773039,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "C14",
+                "B15",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "B13"
+            ],
+            "revenue": 60,
+            "revenue_str": "C14-B13"
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "B13"
+            ],
+            "revenue": 60,
+            "revenue_str": "C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 177,
+        "created_at": 1623773042,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 178,
+        "created_at": 1623773044,
+        "train": "3-2",
+        "price": 225,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 179,
+        "created_at": 1623773056
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 180,
+        "created_at": 1623780332
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 181,
+        "created_at": 1623780416
+      },
+      {
+        "type": "take_loan",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 182,
+        "created_at": 1623781180,
+        "loan": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 183,
+        "created_at": 1623781193,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1623781193,
+            "corporations": []
+          }
+        ],
+        "hex": "G10",
+        "tile": "8-3",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 184,
+        "created_at": 1623781208,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "G12"
+            ],
+            "revenue": 60,
+            "revenue_str": "F15-G12"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12"
+            ],
+            "revenue": 60,
+            "revenue_str": "F9-G12"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 185,
+        "created_at": 1623781214,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 186,
+        "created_at": 1623781217,
+        "train": "3-3",
+        "price": 225,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 187,
+        "created_at": 1623781220
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 188,
+        "created_at": 1623781223
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 189,
+        "created_at": 1623781226
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 190,
+        "created_at": 1623781668,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1623781667,
+            "corporations": [
+              "CPR"
+            ]
+          }
+        ],
+        "hex": "N11",
+        "tile": "120-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 191,
+        "created_at": 1623781702
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 192,
+        "created_at": 1623781730,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "P9",
+              "Q8"
+            ],
+            "revenue": 50,
+            "revenue_str": "P9-Q8"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "Q10",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "P9",
+              "Q10"
+            ],
+            "revenue": 50,
+            "revenue_str": "P9-Q10"
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "N11",
+                "N9"
+              ],
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "N9",
+              "N11",
+              "P9"
+            ],
+            "revenue": 100,
+            "revenue_str": "N9-N11-P9"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 193,
+        "created_at": 1623781733,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 194,
+        "created_at": 1623781743
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 195,
+        "created_at": 1623781759
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 196,
+        "created_at": 1623781762
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 197,
+        "created_at": 1623784172,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1623784172,
+            "corporations": []
+          }
+        ],
+        "hex": "N7",
+        "tile": "23-0",
+        "rotation": 2
+      },
+      {
+        "type": "place_token",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 198,
+        "created_at": 1623784217,
+        "city": "120-0-1",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 199,
+        "created_at": 1623784236,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 110,
+            "revenue_str": "Q10-P9-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 200,
+        "created_at": 1623784238,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 201,
+        "created_at": 1623784240
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 202,
+        "created_at": 1623784242
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 203,
+        "created_at": 1623784269
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 204,
+        "created_at": 1623785088,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1623785088,
+            "corporations": []
+          }
+        ],
+        "hex": "F15",
+        "tile": "121-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 205,
+        "created_at": 1623785102,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "G12"
+            ],
+            "revenue": 80,
+            "revenue_str": "F15-G12"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ]
+            ],
+            "hexes": [
+              "G12",
+              "F9"
+            ],
+            "revenue": 60,
+            "revenue_str": "G12-F9"
+          },
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "G12",
+                "H11"
+              ]
+            ],
+            "hexes": [
+              "H11",
+              "G12"
+            ],
+            "revenue": 40,
+            "revenue_str": "H11-G12"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 206,
+        "created_at": 1623785105,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 207,
+        "created_at": 1623785109
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 208,
+        "created_at": 1623785189
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 209,
+        "created_at": 1623785193
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 210,
+        "created_at": 1623786500,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1623786500,
+            "corporations": []
+          }
+        ],
+        "hex": "E14",
+        "tile": "9-1",
+        "rotation": 2
+      },
+      {
+        "type": "place_token",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 211,
+        "created_at": 1623786519,
+        "city": "121-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 212,
+        "created_at": 1623786577,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "C14",
+                "B15",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "B13"
+            ],
+            "revenue": 60,
+            "revenue_str": "C14-B13"
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "G12",
+              "F15"
+            ],
+            "revenue": 80,
+            "revenue_str": "G12-F15"
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ],
+              [
+                "F15",
+                "E14",
+                "D13",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14",
+              "F15"
+            ],
+            "revenue": 110,
+            "revenue_str": "B13-C14-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 213,
+        "created_at": 1623786580,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 214,
+        "created_at": 1623786590
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 215,
+        "created_at": 1623786597
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 216,
+        "created_at": 1623791308
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 217,
+        "created_at": 1623793947,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1623793946,
+            "corporations": []
+          }
+        ],
+        "hex": "O8",
+        "tile": "9-2",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 218,
+        "created_at": 1623793998,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q8",
+              "P9"
+            ],
+            "revenue": 50,
+            "revenue_str": "Q8-P9"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "P9"
+            ],
+            "revenue": 90,
+            "revenue_str": "N11-P9"
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "M6",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "M6"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "M6",
+              "P9"
+            ],
+            "revenue": 70,
+            "revenue_str": "M4-M6-P9"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 219,
+        "created_at": 1623794001,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 220,
+        "created_at": 1623794007
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 221,
+        "created_at": 1623794009
+      },
+      {
+        "type": "buy_company",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 222,
+        "created_at": 1623794021,
+        "company": "FT",
+        "price": 40
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 223,
+        "created_at": 1623794024
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 224,
+        "created_at": 1623835660,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1623835659,
+            "corporations": []
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 225,
+        "created_at": 1623835662,
+        "loan": 6
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 226,
+        "created_at": 1623835667
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 227,
+        "created_at": 1623835670,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 110,
+            "revenue_str": "Q10-P9-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 228,
+        "created_at": 1623835671,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 229,
+        "created_at": 1623835673
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 230,
+        "created_at": 1623835676
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 231,
+        "created_at": 1623835686
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 232,
+        "created_at": 1623836186,
+        "shares": [
+          "GW_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 233,
+        "created_at": 1623836208
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 234,
+        "created_at": 1623851063,
+        "shares": [
+          "GW_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 235,
+        "created_at": 1623851070,
+        "shares": [
+          "GW_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 236,
+        "created_at": 1623851079
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 237,
+        "created_at": 1623855899,
+        "shares": [
+          "GT_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 238,
+        "created_at": 1623855909
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 239,
+        "created_at": 1623867176,
+        "shares": [
+          "GW_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 240,
+        "created_at": 1623867268,
+        "shares": [
+          "GW_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 241,
+        "created_at": 1623867302
+      },
+      {
+        "type": "sell_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 242,
+        "created_at": 1623869158,
+        "shares": [
+          "LPS_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 243,
+        "created_at": 1623869169,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 244,
+        "created_at": 1623869209,
+        "corporation": "CV",
+        "share_price": "80,2,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 245,
+        "created_at": 1623870360,
+        "shares": [
+          "CPR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 246,
+        "created_at": 1623870367
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 247,
+        "created_at": 1623874604,
+        "shares": [
+          "LPS_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 248,
+        "created_at": 1623874607
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 249,
+        "created_at": 1623875076,
+        "shares": [
+          "GW_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 250,
+        "created_at": 1623875091
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 251,
+        "created_at": 1623876939,
+        "shares": [
+          "CPR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 252,
+        "created_at": 1623876951
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 253,
+        "created_at": 1623918736,
+        "shares": [
+          "CV_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 254,
+        "created_at": 1623919413
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 255,
+        "created_at": 1623920914,
+        "shares": [
+          "GW_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 256,
+        "created_at": 1623920918,
+        "shares": [
+          "LPS_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 257,
+        "created_at": 1623934571,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 258,
+        "created_at": 1623934581
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 259,
+        "created_at": 1623937022
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 260,
+        "created_at": 1623937525,
+        "shares": [
+          "GT_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 261,
+        "created_at": 1623937539
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 262,
+        "created_at": 1623937557
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 263,
+        "created_at": 1623942548,
+        "shares": [
+          "CV_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 264,
+        "created_at": 1623942551
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 265,
+        "created_at": 1623943474
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 266,
+        "created_at": 1623943866
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 267,
+        "created_at": 1623944882,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1623944880
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 268,
+        "created_at": 1623946203
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 269,
+        "created_at": 1623946317,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1623946317,
+            "corporations": []
+          }
+        ],
+        "hex": "D15",
+        "tile": "7-1",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 270,
+        "created_at": 1623946327,
+        "loan": 7
+      },
+      {
+        "type": "place_token",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 271,
+        "created_at": 1623946331,
+        "city": "14-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 272,
+        "created_at": 1623946364,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "G12"
+            ],
+            "revenue": 80,
+            "revenue_str": "F15-G12"
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ]
+            ],
+            "hexes": [
+              "G12",
+              "F9"
+            ],
+            "revenue": 60,
+            "revenue_str": "G12-F9"
+          },
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "C14",
+                "B15",
+                "B13"
+              ],
+              [
+                "F15",
+                "E14",
+                "D13",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14",
+              "F15"
+            ],
+            "revenue": 110,
+            "revenue_str": "B13-C14-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 273,
+        "created_at": 1623946367,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 274,
+        "created_at": 1623946409
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 275,
+        "created_at": 1623946416
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 276,
+        "created_at": 1623946422
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 277,
+        "created_at": 1623962619,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1623962619,
+            "corporations": [
+              "LPS"
+            ]
+          }
+        ],
+        "hex": "F17",
+        "tile": "5-1",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 278,
+        "created_at": 1623962666,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "C14",
+                "B15",
+                "B13"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "B13"
+            ],
+            "revenue": 60,
+            "revenue_str": "C14-B13"
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "G12"
+            ],
+            "revenue": 80,
+            "revenue_str": "F15-G12"
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ],
+              [
+                "F15",
+                "E14",
+                "D13",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14",
+              "F15"
+            ],
+            "revenue": 110,
+            "revenue_str": "B13-C14-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 279,
+        "created_at": 1623962679,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 280,
+        "created_at": 1623962685,
+        "train": "3'-0",
+        "price": 225,
+        "variant": "3'"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 281,
+        "created_at": 1623962693
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 282,
+        "created_at": 1623962702
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 283,
+        "created_at": 1623967603,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1623967603,
+            "corporations": []
+          }
+        ],
+        "hex": "M4",
+        "tile": "121-1",
+        "rotation": 2
+      },
+      {
+        "id": 284,
+        "cost": 50,
+        "type": "special_buy",
+        "entity": "GT",
+        "description": "Bridge Token",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623967616
+      },
+      {
+        "id": 285,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623967630
+      },
+      {
+        "id": 286,
+        "cost": 50,
+        "type": "special_buy",
+        "entity": "GT",
+        "description": "Bridge Token",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623967644
+      },
+      {
+        "id": 287,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1623967657
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 288,
+        "created_at": 1623967662
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 289,
+        "created_at": 1623967709,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q8",
+              "P9"
+            ],
+            "revenue": 50,
+            "revenue_str": "Q8-P9"
+          },
+          {
+            "train": "2'-0",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "P9",
+              "N11"
+            ],
+            "revenue": 90,
+            "revenue_str": "P9-N11"
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "M6",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "M6"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "M6",
+              "P9"
+            ],
+            "revenue": 90,
+            "revenue_str": "M4-M6-P9"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 290,
+        "created_at": 1623967713,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 291,
+        "created_at": 1623967767,
+        "loan": 8
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 292,
+        "created_at": 1623967777
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 293,
+        "created_at": 1623967780
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 294,
+        "created_at": 1623967785
+      },
+      {
+        "type": "take_loan",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 295,
+        "created_at": 1624001368,
+        "loan": 9
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 296,
+        "created_at": 1624001378,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1624001377,
+            "corporations": []
+          }
+        ],
+        "hex": "M12",
+        "tile": "9-3",
+        "rotation": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 297,
+        "created_at": 1624001388,
+        "train": "4-0",
+        "price": 350,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 298,
+        "created_at": 1624001462
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 299,
+        "created_at": 1624001482
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 300,
+        "created_at": 1624001488
+      },
+      {
+        "type": "take_loan",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 301,
+        "created_at": 1624001499,
+        "loan": 10
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 302,
+        "created_at": 1624001549,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1624001547,
+            "corporations": []
+          }
+        ],
+        "hex": "N3",
+        "tile": "57-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 303,
+        "created_at": 1624001602
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 304,
+        "created_at": 1624001622,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 110,
+            "revenue_str": "Q10-P9-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 305,
+        "created_at": 1624001624,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 306,
+        "created_at": 1624001628,
+        "train": "4-1",
+        "price": 350,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 307,
+        "created_at": 1624001649
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 308,
+        "created_at": 1624001652
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 309,
+        "created_at": 1624001656
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 310,
+        "created_at": 1624007492,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1624007491,
+            "corporations": []
+          }
+        ],
+        "hex": "C16",
+        "tile": "9-4",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 311,
+        "created_at": 1624007509
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 312,
+        "created_at": 1624007527,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "F15",
+                "E14",
+                "D13",
+                "C14"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "F15",
+              "G12"
+            ],
+            "revenue": 110,
+            "revenue_str": "C14-F15-G12"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 313,
+        "created_at": 1624007530,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 314,
+        "created_at": 1624007534
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 315,
+        "created_at": 1624007537
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 316,
+        "created_at": 1624007540
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 317,
+        "created_at": 1624008953,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1624008953,
+            "corporations": []
+          }
+        ],
+        "hex": "E16",
+        "tile": "8-4",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 318,
+        "created_at": 1624008981,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ],
+              [
+                "F15",
+                "E14",
+                "D13",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14",
+              "F15"
+            ],
+            "revenue": 110,
+            "revenue_str": "B13-C14-F15"
+          },
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15"
+            ],
+            "revenue": 110,
+            "revenue_str": "F9-G12-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 319,
+        "created_at": 1624008986,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 320,
+        "created_at": 1624008996
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 321,
+        "created_at": 1624009019
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 322,
+        "created_at": 1624009023
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 323,
+        "created_at": 1624017986,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1624017984,
+            "corporations": []
+          }
+        ],
+        "hex": "L3",
+        "tile": "7-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 324,
+        "created_at": 1624017991
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 325,
+        "created_at": 1624018012,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ],
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "P9",
+              "Q8"
+            ],
+            "revenue": 110,
+            "revenue_str": "N11-P9-Q8"
+          }
+        ]
+      },
+      {
+        "id": 326,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1624018017
+      },
+      {
+        "id": 327,
+        "loan": 11,
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1624018024
+      },
+      {
+        "id": 328,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1624018034
+      },
+      {
+        "id": 329,
+        "type": "undo",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1624018036
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 330,
+        "created_at": 1624018040,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 331,
+        "created_at": 1624018042,
+        "loan": 11
+      },
+      {
+        "type": "buy_train",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 332,
+        "created_at": 1624018044,
+        "train": "4-2",
+        "price": 350,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 333,
+        "created_at": 1624018049
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 334,
+        "created_at": 1624018052
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 335,
+        "created_at": 1624018764,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1624018763,
+            "corporations": []
+          }
+        ],
+        "hex": "N3",
+        "tile": "14-3",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 336,
+        "created_at": 1624018772,
+        "loan": 12
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 337,
+        "created_at": 1624018774
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 338,
+        "created_at": 1624018841,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "N3",
+                "O2"
+              ],
+              [
+                "M4",
+                "N3"
+              ]
+            ],
+            "hexes": [
+              "O2",
+              "N3",
+              "M4"
+            ],
+            "revenue": 100,
+            "revenue_str": "O2-N3-M4"
+          },
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ],
+              [
+                "M6",
+                "N7",
+                "O8",
+                "P9"
+              ],
+              [
+                "M4",
+                "M6"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "P9",
+              "M6",
+              "M4"
+            ],
+            "revenue": 150,
+            "revenue_str": "N11-P9-M6-M4"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 339,
+        "created_at": 1624018843,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 340,
+        "created_at": 1624018853
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 341,
+        "created_at": 1624018856
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 342,
+        "created_at": 1624018863
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 343,
+        "created_at": 1624018875,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1624018874,
+            "corporations": []
+          }
+        ],
+        "hex": "L13",
+        "tile": "57-1",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 344,
+        "created_at": 1624018886,
+        "city": "57-1-0",
+        "slot": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 345,
+        "created_at": 1624018901,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "N11",
+                "M12",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "L13",
+              "N11"
+            ],
+            "revenue": 80,
+            "revenue_str": "L13-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 346,
+        "created_at": 1624018902,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 347,
+        "created_at": 1624019023,
+        "train": "3-0",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 348,
+        "created_at": 1624019037
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 349,
+        "created_at": 1624019041
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 350,
+        "created_at": 1624019064
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 351,
+        "created_at": 1624019234,
+        "shares": [
+          "CPR_5",
+          "CPR_7"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "par",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 352,
+        "created_at": 1624019251,
+        "corporation": "CA",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 353,
+        "created_at": 1624022740,
+        "shares": [
+          "LPS_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 354,
+        "created_at": 1624022748,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 355,
+        "created_at": 1624022817,
+        "corporation": "WGB",
+        "share_price": "90,1,4"
+      },
+      {
+        "id": 356,
+        "type": "buy_shares",
+        "entity": 7422,
+        "shares": [
+          "GT_5"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 7422,
+        "created_at": 1624024344
+      },
+      {
+        "id": 357,
+        "type": "undo",
+        "entity": 7422,
+        "entity_type": "player",
+        "user": 7422,
+        "created_at": 1624024359
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 358,
+        "created_at": 1624024388,
+        "shares": [
+          "LPS_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 359,
+        "created_at": 1624024393
+      },
+      {
+        "type": "sell_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 360,
+        "created_at": 1624273516,
+        "shares": [
+          "CPR_2",
+          "CPR_8"
+        ],
+        "percent": 20
+      },
+      {
+        "id": 361,
+        "type": "buy_shares",
+        "entity": 40,
+        "shares": [
+          "GW_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 40,
+        "created_at": 1624273549
+      },
+      {
+        "id": 362,
+        "type": "undo",
+        "entity": 405,
+        "entity_type": "player",
+        "user": 40,
+        "created_at": 1624273552
+      },
+      {
+        "type": "sell_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 363,
+        "created_at": 1624273554,
+        "shares": [
+          "GW_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 364,
+        "created_at": 1624273608,
+        "corporation": "THB",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 365,
+        "created_at": 1624282657,
+        "shares": [
+          "CV_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 366,
+        "created_at": 1624282719
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 367,
+        "created_at": 1624283233,
+        "shares": [
+          "CA_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 368,
+        "created_at": 1624283270
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 369,
+        "created_at": 1624284215,
+        "shares": [
+          "WGB_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 370,
+        "created_at": 1624284223
+      },
+      {
+        "id": 371,
+        "type": "buy_shares",
+        "entity": 7422,
+        "shares": [
+          "GT_5"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 7422,
+        "created_at": 1624284331
+      },
+      {
+        "id": 372,
+        "type": "undo",
+        "entity": 7422,
+        "entity_type": "player",
+        "user": 7422,
+        "created_at": 1624284335
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 373,
+        "created_at": 1624284367,
+        "shares": [
+          "CPR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 374,
+        "created_at": 1624284370
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 375,
+        "created_at": 1624297910,
+        "shares": [
+          "THB_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 376,
+        "created_at": 1624297925,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1624297924
+          }
+        ],
+        "corporation": "THB",
+        "until_condition": 5,
+        "from_market": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 377,
+        "created_at": 1624301747,
+        "shares": [
+          "CV_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 378,
+        "created_at": 1624301782
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 379,
+        "created_at": 1624302309,
+        "shares": [
+          "CA_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 380,
+        "created_at": 1624302315
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 381,
+        "created_at": 1624302937,
+        "shares": [
+          "WGB_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 382,
+        "created_at": 1624302940
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 383,
+        "created_at": 1624304832,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1624304831,
+            "shares": [
+              "THB_2"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1624304831
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 384,
+        "created_at": 1624306505,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 385,
+        "created_at": 1624306510
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 386,
+        "created_at": 1624337765,
+        "shares": [
+          "LPS_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 387,
+        "created_at": 1624337826
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 388,
+        "created_at": 1624338126,
+        "shares": [
+          "WGB_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 389,
+        "created_at": 1624338131
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 390,
+        "created_at": 1624366310,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1624366310,
+            "shares": [
+              "THB_3"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1624366310
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 391,
+        "created_at": 1624366846
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 392,
+        "created_at": 1624367475
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 393,
+        "created_at": 1624367917
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 394,
+        "created_at": 1624367941
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 395,
+        "created_at": 1624390372
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 396,
+        "created_at": 1624390444,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "created_at": 1624390443,
+            "corporations": []
+          }
+        ],
+        "hex": "D17",
+        "tile": "57-2",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 397,
+        "created_at": 1624390447,
+        "city": "5-1-0",
+        "slot": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 398,
+        "created_at": 1624390562,
+        "train": "3'-0",
+        "price": 294
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 399,
+        "created_at": 1624390582
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 400,
+        "created_at": 1624390593
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 401,
+        "created_at": 1624390634
+      },
+      {
+        "id": 402,
+        "hex": "L15",
+        "tile": "59-0",
+        "type": "lay_tile",
+        "entity": "THB",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624392127
+      },
+      {
+        "id": 403,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624392137
+      },
+      {
+        "type": "lay_tile",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 404,
+        "created_at": 1624392146,
+        "hex": "L15",
+        "tile": "59-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 405,
+        "created_at": 1624392147,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "entity_type": "corporation",
+            "created_at": 1624392147,
+            "corporations": []
+          }
+        ],
+        "city": "59-0-1",
+        "slot": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 406,
+        "created_at": 1624392154,
+        "train": "4'-0",
+        "price": 350,
+        "variant": "4'"
+      },
+      {
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 407,
+        "created_at": 1624392170,
+        "loan": 13
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 408,
+        "created_at": 1624392172
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 409,
+        "created_at": 1624392182
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 410,
+        "created_at": 1624392186
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 411,
+        "created_at": 1624392647,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1624392647,
+            "corporations": []
+          }
+        ],
+        "hex": "O4",
+        "tile": "8-5",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 412,
+        "created_at": 1624392661
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 413,
+        "created_at": 1624392681,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ],
+              [
+                "M6",
+                "N7",
+                "O8",
+                "P9"
+              ],
+              [
+                "M4",
+                "M6"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "P9",
+              "M6",
+              "M4"
+            ],
+            "revenue": 150,
+            "revenue_str": "N11-P9-M6-M4"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 414,
+        "created_at": 1624392683,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 415,
+        "created_at": 1624392754,
+        "train": "3-0",
+        "price": 402
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 416,
+        "created_at": 1624392781
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 417,
+        "created_at": 1624392783
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 418,
+        "created_at": 1624393011,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1624393010,
+            "corporations": []
+          }
+        ],
+        "hex": "B17",
+        "tile": "8-6",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 419,
+        "created_at": 1624393128,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ],
+              [
+                "F15",
+                "E14",
+                "D13",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14",
+              "F15"
+            ],
+            "revenue": 110,
+            "revenue_str": "B13-C14-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 420,
+        "created_at": 1624393131,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 421,
+        "created_at": 1624393152
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 422,
+        "created_at": 1624393160,
+        "loan": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 423,
+        "created_at": 1624393214
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 424,
+        "created_at": 1624393245,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1624393244,
+            "corporations": []
+          }
+        ],
+        "hex": "F17",
+        "tile": "15-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 425,
+        "created_at": 1624393276,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C14",
+                "B13"
+              ],
+              [
+                "F15",
+                "E14",
+                "D13",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "B13",
+              "C14",
+              "F15"
+            ],
+            "revenue": 110,
+            "revenue_str": "B13-C14-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 426,
+        "created_at": 1624393286,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 427,
+        "created_at": 1624393291,
+        "train": "5-0",
+        "price": 550,
+        "variant": "5"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 428,
+        "created_at": 1624393300
+      },
+      {
+        "id": 429,
+        "hex": "J11",
+        "tile": "57-3",
+        "type": "lay_tile",
+        "entity": "WGB",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "WGB",
+            "created_at": 1624393902,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 4473,
+        "created_at": 1624393903
+      },
+      {
+        "id": 430,
+        "type": "undo",
+        "entity": "WGB",
+        "action_id": 428,
+        "entity_type": "corporation",
+        "user": 4473,
+        "created_at": 1624393935
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 431,
+        "created_at": 1624393954,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "created_at": 1624393953,
+            "corporations": []
+          }
+        ],
+        "hex": "J11",
+        "tile": "5-0",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 432,
+        "created_at": 1624393961,
+        "loan": 14
+      },
+      {
+        "type": "buy_train",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 433,
+        "created_at": 1624393975,
+        "train": "3-3",
+        "price": 540
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 434,
+        "created_at": 1624393993
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 435,
+        "created_at": 1624396326,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1624396326,
+            "corporations": []
+          }
+        ],
+        "hex": "N11",
+        "tile": "122-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 436,
+        "created_at": 1624396335,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "N11",
+                "M12",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "L13"
+            ],
+            "revenue": 100,
+            "revenue_str": "N11-L13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 437,
+        "created_at": 1624396338,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 438,
+        "created_at": 1624396345
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 439,
+        "created_at": 1624396352
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 440,
+        "created_at": 1624397786,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1624397786,
+            "corporations": []
+          }
+        ],
+        "hex": "L5",
+        "tile": "9-5",
+        "rotation": 0
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 441,
+        "created_at": 1624397793,
+        "loan": 15
+      },
+      {
+        "type": "place_token",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 442,
+        "created_at": 1624397801,
+        "city": "122-0-1",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 443,
+        "created_at": 1624397872,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 140,
+            "revenue_str": "Q10-P9-N11"
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "M6",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "M6"
+              ],
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "M6",
+              "P9",
+              "Q8"
+            ],
+            "revenue": 120,
+            "revenue_str": "M4-M6-P9-Q8"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 444,
+        "created_at": 1624397880,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 445,
+        "created_at": 1624397899
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 446,
+        "created_at": 1624398607,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1624398607,
+            "corporations": [
+              "GW"
+            ]
+          }
+        ],
+        "hex": "B19",
+        "tile": "6-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 447,
+        "created_at": 1624398617
+      },
+      {
+        "type": "buy_train",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 448,
+        "created_at": 1624398626,
+        "train": "5-1",
+        "price": 550,
+        "variant": "5"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 449,
+        "created_at": 1624398692
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 450,
+        "created_at": 1624398695,
+        "loan": 5
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 451,
+        "created_at": 1624398696,
+        "loan": 7
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 452,
+        "created_at": 1624398703
+      },
+      {
+        "id": 453,
+        "hex": "G16",
+        "tile": "9-6",
+        "type": "lay_tile",
+        "entity": "LPS",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "created_at": 1624423940,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 2729,
+        "created_at": 1624423940
+      },
+      {
+        "id": 454,
+        "type": "undo",
+        "entity": "LPS",
+        "action_id": 452,
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624424025
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 455,
+        "created_at": 1624424051,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1624424051,
+            "corporations": []
+          }
+        ],
+        "hex": "D17",
+        "tile": "15-1",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 456,
+        "created_at": 1624424105,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "F17",
+                "F15"
+              ],
+              [
+                "F17",
+                "E16",
+                "D17"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "F17",
+              "D17"
+            ],
+            "revenue": 110,
+            "revenue_str": "F15-F17-D17"
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "B13",
+                "B15",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15",
+              "C14",
+              "B13"
+            ],
+            "revenue": 210,
+            "revenue_str": "F9-G12-F15-C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 457,
+        "created_at": 1624424113,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 458,
+        "created_at": 1624424120
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 459,
+        "created_at": 1624432962,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1624432960,
+            "corporations": []
+          }
+        ],
+        "hex": "L13",
+        "tile": "15-2",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 460,
+        "created_at": 1624432975,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "N11",
+                "M12",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "L13"
+            ],
+            "revenue": 110,
+            "revenue_str": "N11-L13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 461,
+        "created_at": 1624432977,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 462,
+        "created_at": 1624432986
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 463,
+        "created_at": 1624432992
+      },
+      {
+        "type": "take_loan",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 464,
+        "created_at": 1624440863,
+        "loan": 16
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 465,
+        "created_at": 1624441096,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "created_at": 1624441096,
+            "corporations": []
+          }
+        ],
+        "hex": "G16",
+        "tile": "9-6",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 466,
+        "created_at": 1624441660,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "F17",
+                "F15"
+              ],
+              [
+                "D17",
+                "E16",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "F17",
+              "D17"
+            ],
+            "revenue": 110,
+            "revenue_str": "F15-F17-D17"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 467,
+        "created_at": 1624441665,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 468,
+        "created_at": 1624441698
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 469,
+        "created_at": 1624441738
+      },
+      {
+        "type": "lay_tile",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 470,
+        "created_at": 1624446445,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "entity_type": "corporation",
+            "created_at": 1624446444,
+            "corporations": []
+          }
+        ],
+        "hex": "K14",
+        "tile": "7-3",
+        "rotation": 4
+      },
+      {
+        "type": "place_token",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 471,
+        "created_at": 1624451324,
+        "city": "15-2-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 472,
+        "created_at": 1624451341,
+        "routes": [
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "L13",
+                "M12",
+                "N11"
+              ],
+              [
+                "L15",
+                "K14",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "L13",
+              "L15"
+            ],
+            "revenue": 150,
+            "revenue_str": "N11-L13-L15"
+          }
+        ]
+      },
+      {
+        "id": 473,
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624451346
+      },
+      {
+        "id": 474,
+        "loan": 17,
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624451349
+      },
+      {
+        "id": 475,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624451364
+      },
+      {
+        "id": 476,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624451428
+      },
+      {
+        "id": 477,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624451430
+      },
+      {
+        "id": 478,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624451470
+      },
+      {
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 479,
+        "created_at": 1624451472,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 480,
+        "created_at": 1624451478,
+        "loan": 17
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 481,
+        "created_at": 1624451481
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 482,
+        "created_at": 1624451488
+      },
+      {
+        "id": 483,
+        "hex": "O8",
+        "tile": "23-1",
+        "type": "lay_tile",
+        "entity": "CPR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "created_at": 1624456353,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 405,
+        "created_at": 1624456353
+      },
+      {
+        "id": 484,
+        "type": "undo",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "user": 405,
+        "created_at": 1624456391
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 485,
+        "created_at": 1624456398,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1624456398,
+            "corporations": []
+          }
+        ],
+        "hex": "N7",
+        "tile": "45-0",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 486,
+        "created_at": 1624456746,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "N9",
+                "N11"
+              ],
+              [
+                "M6",
+                "N7",
+                "N9"
+              ],
+              [
+                "M4",
+                "M6"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "N9",
+              "M6",
+              "M4"
+            ],
+            "revenue": 150,
+            "revenue_str": "N11-N9-M6-M4"
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "P9",
+                "Q8"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q8",
+              "P9",
+              "N11"
+            ],
+            "revenue": 140,
+            "revenue_str": "Q8-P9-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 487,
+        "created_at": 1624456748,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 488,
+        "created_at": 1624456798
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 489,
+        "created_at": 1624457197,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1624457196,
+            "corporations": []
+          }
+        ],
+        "hex": "L7",
+        "tile": "8-7",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 490,
+        "created_at": 1624457213
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 491,
+        "created_at": 1624457222,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 140,
+            "revenue_str": "Q10-P9-N11"
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "M6",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "M6"
+              ],
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "M6",
+              "P9",
+              "Q8"
+            ],
+            "revenue": 120,
+            "revenue_str": "M4-M6-P9-Q8"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 492,
+        "created_at": 1624457236,
+        "kind": "withhold"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 493,
+        "created_at": 1624457239,
+        "loan": 2
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 494,
+        "created_at": 1624457242,
+        "loan": 8
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 495,
+        "created_at": 1624457246
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 496,
+        "created_at": 1624458859,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "created_at": 1624458859,
+            "corporations": []
+          }
+        ],
+        "hex": "I12",
+        "tile": "59-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 497,
+        "created_at": 1624458874
+      },
+      {
+        "type": "take_loan",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 498,
+        "created_at": 1624458878,
+        "loan": 18
+      },
+      {
+        "type": "run_routes",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 499,
+        "created_at": 1624458884,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "J11",
+                "I12"
+              ]
+            ],
+            "hexes": [
+              "I12",
+              "J11"
+            ],
+            "revenue": 60,
+            "revenue_str": "I12-J11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 500,
+        "created_at": 1624458886,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 501,
+        "created_at": 1624458896
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 502,
+        "created_at": 1624458898
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 503,
+        "created_at": 1624460367,
+        "shares": [
+          "LPS_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 504,
+        "created_at": 1624460374
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 505,
+        "created_at": 1624460625,
+        "shares": [
+          "CA_1",
+          "CA_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "par",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 506,
+        "created_at": 1624460630,
+        "corporation": "BBG",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 507,
+        "created_at": 1624464615,
+        "shares": [
+          "CPR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 508,
+        "created_at": 1624464622
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 509,
+        "created_at": 1624464760,
+        "shares": [
+          "CV_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 510,
+        "created_at": 1624464764
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 511,
+        "created_at": 1624546169,
+        "shares": [
+          "THB_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 512,
+        "created_at": 1624546172
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 513,
+        "created_at": 1624568050,
+        "shares": [
+          "GT_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 514,
+        "created_at": 1624568056
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 515,
+        "created_at": 1624595295,
+        "shares": [
+          "BBG_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 516,
+        "created_at": 1624595323
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 517,
+        "created_at": 1624596648
+      },
+      {
+        "id": 518,
+        "type": "buy_shares",
+        "entity": 7422,
+        "shares": [
+          "GT_6"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 7422,
+        "created_at": 1624596919
+      },
+      {
+        "id": 519,
+        "type": "undo",
+        "entity": 7422,
+        "entity_type": "player",
+        "user": 7422,
+        "created_at": 1624596924
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 520,
+        "created_at": 1624596974,
+        "shares": [
+          "GW_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 521,
+        "created_at": 1624596983
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 522,
+        "created_at": 1624604805,
+        "shares": [
+          "GW_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 523,
+        "created_at": 1624604820
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 524,
+        "created_at": 1624614015,
+        "shares": [
+          "GW_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 525,
+        "created_at": 1624614022
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 526,
+        "created_at": 1624615445,
+        "shares": [
+          "BBG_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 527,
+        "created_at": 1624615460
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 528,
+        "created_at": 1624623801
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 529,
+        "created_at": 1624627177,
+        "shares": [
+          "GT_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 530,
+        "created_at": 1624627180
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 531,
+        "created_at": 1624661312
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 532,
+        "created_at": 1624661319
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 533,
+        "created_at": 1624725052
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 534,
+        "created_at": 1624725496,
+        "shares": [
+          "BBG_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 535,
+        "created_at": 1624725502
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 536,
+        "created_at": 1624726692,
+        "shares": [
+          "WGB_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 537,
+        "created_at": 1624726697,
+        "shares": [
+          "GW_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 538,
+        "created_at": 1624736629,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 40,
+            "entity_type": "player",
+            "created_at": 1624736628,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 539,
+        "created_at": 1624771582
+      },
+      {
+        "type": "sell_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 540,
+        "created_at": 1624828846,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 541,
+        "created_at": 1624828876
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 542,
+        "created_at": 1624853734
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 543,
+        "created_at": 1624855358
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 544,
+        "created_at": 1624887883
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 545,
+        "created_at": 1624887900
+      },
+      {
+        "type": "sell_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 546,
+        "created_at": 1624888178,
+        "shares": [
+          "GT_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 547,
+        "created_at": 1624888181,
+        "shares": [
+          "CPR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 548,
+        "created_at": 1624888222
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 549,
+        "created_at": 1624888890
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 550,
+        "created_at": 1624901156
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 551,
+        "created_at": 1624901380
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 552,
+        "created_at": 1624901386
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 553,
+        "created_at": 1624904750
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 554,
+        "created_at": 1624905645,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1624905644,
+            "corporations": []
+          }
+        ],
+        "hex": "F15",
+        "tile": "126-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 555,
+        "created_at": 1624905670,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "F17",
+                "F15"
+              ],
+              [
+                "F17",
+                "E16",
+                "D17"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "F17",
+              "D17"
+            ],
+            "revenue": 120,
+            "revenue_str": "F15-F17-D17"
+          },
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "B13",
+                "B15",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15",
+              "C14",
+              "B13"
+            ],
+            "revenue": 220,
+            "revenue_str": "F9-G12-F15-C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 556,
+        "created_at": 1624905673,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 557,
+        "created_at": 1624905678
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 558,
+        "created_at": 1624906296,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1624906295,
+            "corporations": [
+              "WGB"
+            ]
+          }
+        ],
+        "hex": "I12",
+        "tile": "67-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 559,
+        "created_at": 1624906334
+      },
+      {
+        "type": "special_buy",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 560,
+        "created_at": 1624906364,
+        "description": "Tunnel Token",
+        "cost": 50
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 561,
+        "created_at": 1624906380,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "B13",
+                "B15",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15",
+              "C14",
+              "B13"
+            ],
+            "revenue": 230,
+            "revenue_str": "F9-G12-F15-C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 562,
+        "created_at": 1624906385,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 563,
+        "created_at": 1624906391
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 564,
+        "created_at": 1624906398
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 565,
+        "created_at": 1624906611,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1624906610,
+            "corporations": []
+          }
+        ],
+        "hex": "L13",
+        "tile": "125-0",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 566,
+        "created_at": 1624906645,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "L13",
+                "K14",
+                "L15"
+              ],
+              [
+                "N11",
+                "M12",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "L15",
+              "L13",
+              "N11"
+            ],
+            "revenue": 160,
+            "revenue_str": "L15-L13-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 567,
+        "created_at": 1624906647,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 568,
+        "created_at": 1624906687,
+        "train": "3-0",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 569,
+        "created_at": 1624906691
+      },
+      {
+        "id": 570,
+        "hex": "L15",
+        "tile": "66-0",
+        "type": "lay_tile",
+        "entity": "THB",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "created_at": 1624908616,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 40,
+        "created_at": 1624908617
+      },
+      {
+        "id": 571,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624908643
+      },
+      {
+        "id": 572,
+        "hex": "K12",
+        "tile": "9-7",
+        "type": "lay_tile",
+        "entity": "THB",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "created_at": 1624908653,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 40,
+        "created_at": 1624908654
+      },
+      {
+        "id": 573,
+        "type": "run_routes",
+        "entity": "THB",
+        "routes": [
+          {
+            "hexes": [
+              "N11",
+              "L13",
+              "L15"
+            ],
+            "train": "4'-0",
+            "revenue": 160,
+            "connections": [
+              [
+                "L13",
+                "M12",
+                "N11"
+              ],
+              [
+                "L15",
+                "K14",
+                "L13"
+              ]
+            ],
+            "revenue_str": "N11-L13-L15"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624908661
+      },
+      {
+        "id": 574,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624908663
+      },
+      {
+        "id": 575,
+        "loan": 19,
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624908666
+      },
+      {
+        "id": 576,
+        "type": "undo",
+        "entity": "THB",
+        "action_id": 569,
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624908707
+      },
+      {
+        "id": 577,
+        "hex": "M10",
+        "tile": "56-0",
+        "type": "lay_tile",
+        "entity": "THB",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "created_at": 1624908754,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 40,
+        "created_at": 1624908755
+      },
+      {
+        "id": 578,
+        "type": "run_routes",
+        "entity": "THB",
+        "routes": [
+          {
+            "hexes": [
+              "M10",
+              "N11",
+              "L13",
+              "L15"
+            ],
+            "train": "4'-0",
+            "revenue": 170,
+            "connections": [
+              [
+                "N11",
+                "M10"
+              ],
+              [
+                "L13",
+                "M12",
+                "N11"
+              ],
+              [
+                "L15",
+                "K14",
+                "L13"
+              ]
+            ],
+            "revenue_str": "M10-N11-L13-L15"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624908764
+      },
+      {
+        "id": 579,
+        "type": "undo",
+        "entity": "THB",
+        "action_id": 569,
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624908782
+      },
+      {
+        "type": "lay_tile",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 580,
+        "created_at": 1624908801,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "entity_type": "corporation",
+            "created_at": 1624908800,
+            "corporations": []
+          }
+        ],
+        "hex": "L15",
+        "tile": "66-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 581,
+        "created_at": 1624908810,
+        "routes": [
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "L13",
+                "M12",
+                "N11"
+              ],
+              [
+                "L15",
+                "K14",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "L13",
+              "L15"
+            ],
+            "revenue": 170,
+            "revenue_str": "N11-L13-L15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 582,
+        "created_at": 1624908856,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 583,
+        "created_at": 1624908861,
+        "loan": 19
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 584,
+        "created_at": 1624908977
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 585,
+        "created_at": 1624908980
+      },
+      {
+        "type": "take_loan",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 586,
+        "created_at": 1624909153,
+        "loan": 20
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 587,
+        "created_at": 1624909211,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "created_at": 1624909212,
+            "corporations": []
+          }
+        ],
+        "hex": "J15",
+        "tile": "5-1",
+        "rotation": 1
+      },
+      {
+        "id": 588,
+        "type": "buy_train",
+        "price": 1,
+        "train": "5-0",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624909256
+      },
+      {
+        "id": 589,
+        "type": "undo",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624909373
+      },
+      {
+        "type": "buy_train",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 590,
+        "created_at": 1624909705,
+        "train": "5'-0",
+        "price": 550,
+        "variant": "5'"
+      },
+      {
+        "type": "buy_train",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 591,
+        "created_at": 1624909726,
+        "train": "3-2",
+        "price": 10
+      },
+      {
+        "type": "pass",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 592,
+        "created_at": 1624909767
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 593,
+        "created_at": 1624909981,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1624909980,
+            "corporations": []
+          }
+        ],
+        "hex": "O6",
+        "tile": "8-8",
+        "rotation": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 594,
+        "created_at": 1624910000,
+        "loan": 21
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 595,
+        "created_at": 1624910003
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 596,
+        "created_at": 1624910021,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ],
+              [
+                "N3",
+                "O4",
+                "O6",
+                "N7",
+                "O8",
+                "P9"
+              ],
+              [
+                "M4",
+                "N3"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "P9",
+              "N3",
+              "M4"
+            ],
+            "revenue": 190,
+            "revenue_str": "N11-P9-N3-M4"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 597,
+        "created_at": 1624910051,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 598,
+        "created_at": 1624910080,
+        "train": "3-0",
+        "price": 313
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 599,
+        "created_at": 1624910109
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 600,
+        "created_at": 1624910408,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "created_at": 1624910409,
+            "corporations": [
+              "CA"
+            ]
+          }
+        ],
+        "hex": "H15",
+        "tile": "6-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 601,
+        "created_at": 1624910425
+      },
+      {
+        "type": "run_routes",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 602,
+        "created_at": 1624910429,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "F17",
+                "F15"
+              ],
+              [
+                "D17",
+                "E16",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "F17",
+              "D17"
+            ],
+            "revenue": 120,
+            "revenue_str": "F15-F17-D17"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 603,
+        "created_at": 1624910436,
+        "kind": "payout"
+      },
+      {
+        "id": 604,
+        "type": "buy_train",
+        "price": 30,
+        "train": "3-2",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624910478
+      },
+      {
+        "id": 605,
+        "type": "undo",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624910490
+      },
+      {
+        "type": "buy_train",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 606,
+        "created_at": 1624910507,
+        "train": "5'-0",
+        "price": 30
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 607,
+        "created_at": 1624910512,
+        "loan": 16
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 608,
+        "created_at": 1624910540
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 609,
+        "created_at": 1624913746,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "created_at": 1624913745,
+            "corporations": []
+          }
+        ],
+        "hex": "J11",
+        "tile": "15-3",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 610,
+        "created_at": 1624913762,
+        "city": "14-1-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 611,
+        "created_at": 1624913784,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15"
+            ],
+            "revenue": 140,
+            "revenue_str": "F9-G12-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 612,
+        "created_at": 1624913788,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 613,
+        "created_at": 1624913792,
+        "loan": 22
+      },
+      {
+        "type": "special_buy",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 614,
+        "created_at": 1624913794,
+        "description": "Tunnel Token",
+        "cost": 50
+      },
+      {
+        "type": "special_buy",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 615,
+        "created_at": 1624913797,
+        "description": "Bridge Token",
+        "cost": 50
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 616,
+        "created_at": 1624913803
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 617,
+        "created_at": 1624913806
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 618,
+        "created_at": 1624916165,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1624916164,
+            "corporations": [
+              "GT"
+            ]
+          }
+        ],
+        "hex": "K8",
+        "tile": "57-3",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 619,
+        "created_at": 1624916208
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 620,
+        "created_at": 1624916339,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 140,
+            "revenue_str": "Q10-P9-N11"
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "N3",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "O6",
+                "O4",
+                "N3"
+              ],
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "N3",
+              "P9",
+              "Q8"
+            ],
+            "revenue": 140,
+            "revenue_str": "M4-N3-P9-Q8"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 621,
+        "created_at": 1624916351,
+        "kind": "payout"
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 622,
+        "created_at": 1624916354,
+        "loan": 11
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 623,
+        "created_at": 1624916356,
+        "loan": 15
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 624,
+        "created_at": 1624916369
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 625,
+        "created_at": 1624916712,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1624916713,
+            "corporations": []
+          }
+        ],
+        "hex": "C16",
+        "tile": "23-1",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 626,
+        "created_at": 1624916770,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "F17",
+                "E16",
+                "D17"
+              ],
+              [
+                "F15",
+                "F17"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "B13",
+                "B15",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "D17",
+              "F17",
+              "F15",
+              "C14",
+              "B13"
+            ],
+            "revenue": 200,
+            "revenue_str": "D17-F17-F15-C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 627,
+        "created_at": 1624916772,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 628,
+        "created_at": 1624916777
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 629,
+        "created_at": 1624916781
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 630,
+        "created_at": 1624922096,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1624922096,
+            "corporations": []
+          }
+        ],
+        "hex": "C14",
+        "tile": "125-1",
+        "rotation": 3
+      },
+      {
+        "id": 631,
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "user": 4473,
+        "created_at": 1624922103
+      },
+      {
+        "id": 632,
+        "type": "undo",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "user": 4473,
+        "created_at": 1624922125
+      },
+      {
+        "type": "place_token",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 633,
+        "created_at": 1624922133,
+        "city": "15-3-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 634,
+        "created_at": 1624922138,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "B13",
+                "B15",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15",
+              "C14",
+              "B13"
+            ],
+            "revenue": 240,
+            "revenue_str": "F9-G12-F15-C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 635,
+        "created_at": 1624922141,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 636,
+        "created_at": 1624922144
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 637,
+        "created_at": 1624922169
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 638,
+        "created_at": 1624951665,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1624951661,
+            "corporations": []
+          }
+        ],
+        "hex": "K14",
+        "tile": "27-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 639,
+        "created_at": 1624951670
+      },
+      {
+        "type": "run_routes",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 640,
+        "created_at": 1624951686,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "L13",
+                "K14",
+                "L15"
+              ],
+              [
+                "N11",
+                "M12",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "L15",
+              "L13",
+              "N11"
+            ],
+            "revenue": 170,
+            "revenue_str": "L15-L13-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 641,
+        "created_at": 1624951688,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 642,
+        "created_at": 1624951715
+      },
+      {
+        "id": 643,
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "user": 405,
+        "created_at": 1624951718
+      },
+      {
+        "id": 644,
+        "type": "undo",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "user": 405,
+        "created_at": 1624951729
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 645,
+        "created_at": 1624951735,
+        "loan": 9
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 646,
+        "created_at": 1624951746
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 647,
+        "created_at": 1624952220,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "created_at": 1624952221,
+            "corporations": []
+          }
+        ],
+        "hex": "I16",
+        "tile": "8-9",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 648,
+        "created_at": 1624952243
+      },
+      {
+        "type": "run_routes",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 649,
+        "created_at": 1624952295,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "H15",
+                "I16",
+                "J15"
+              ],
+              [
+                "F17",
+                "G16",
+                "H15"
+              ]
+            ],
+            "hexes": [
+              "J15",
+              "H15",
+              "F17"
+            ],
+            "revenue": 70,
+            "revenue_str": "J15-H15-F17"
+          },
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "B19",
+                "A20"
+              ],
+              [
+                "D17",
+                "C16",
+                "B17",
+                "B19"
+              ],
+              [
+                "F17",
+                "E16",
+                "D17"
+              ],
+              [
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "A20",
+              "B19",
+              "D17",
+              "F17",
+              "F15"
+            ],
+            "revenue": 190,
+            "revenue_str": "A20-B19-D17-F17-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 650,
+        "created_at": 1624952297,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 651,
+        "created_at": 1624952306
+      },
+      {
+        "type": "take_loan",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 652,
+        "created_at": 1624975858,
+        "loan": 23
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 653,
+        "created_at": 1624975867,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "created_at": 1624975867,
+            "corporations": []
+          }
+        ],
+        "hex": "K10",
+        "tile": "8-10",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 654,
+        "created_at": 1624975879,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15"
+            ],
+            "revenue": 140,
+            "revenue_str": "F9-G12-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 655,
+        "created_at": 1624975881,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 656,
+        "created_at": 1624975886
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 657,
+        "created_at": 1624975889
+      },
+      {
+        "type": "lay_tile",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 658,
+        "created_at": 1624978499,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "entity_type": "corporation",
+            "created_at": 1624978498,
+            "corporations": [
+              "THB"
+            ]
+          }
+        ],
+        "hex": "L11",
+        "tile": "8-11",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 659,
+        "created_at": 1624978615,
+        "routes": [
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "L13",
+                "M12",
+                "N11"
+              ],
+              [
+                "L15",
+                "K14",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "L13",
+              "L15"
+            ],
+            "revenue": 170,
+            "revenue_str": "N11-L13-L15"
+          }
+        ]
+      },
+      {
+        "id": 660,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978619
+      },
+      {
+        "id": 661,
+        "loan": 24,
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978623
+      },
+      {
+        "id": 662,
+        "type": "buy_train",
+        "price": 700,
+        "train": "6-0",
+        "entity": "THB",
+        "variant": "6",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978625
+      },
+      {
+        "id": 663,
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978682
+      },
+      {
+        "id": 664,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978743
+      },
+      {
+        "id": 665,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978757
+      },
+      {
+        "id": 666,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978768
+      },
+      {
+        "id": 667,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978789
+      },
+      {
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 668,
+        "created_at": 1624978799,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 669,
+        "created_at": 1624978830
+      },
+      {
+        "type": "payoff_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 670,
+        "created_at": 1624978877,
+        "loan": 13
+      },
+      {
+        "id": 671,
+        "loan": 17,
+        "type": "payoff_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978879
+      },
+      {
+        "id": 672,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1624978890
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 673,
+        "created_at": 1624978912
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 674,
+        "created_at": 1624979131,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "created_at": 1624979129,
+            "corporations": []
+          }
+        ],
+        "hex": "F17",
+        "tile": "125-2",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 675,
+        "created_at": 1624979136,
+        "city": "125-2-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 676,
+        "created_at": 1624979158,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "F17",
+                "E16",
+                "D17"
+              ],
+              [
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "D17",
+              "F17",
+              "F15"
+            ],
+            "revenue": 130,
+            "revenue_str": "D17-F17-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 677,
+        "created_at": 1624979164,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 678,
+        "created_at": 1624979180
+      },
+      {
+        "type": "pass",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 679,
+        "created_at": 1624979184
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 680,
+        "created_at": 1624988686,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1624988687,
+            "corporations": []
+          }
+        ],
+        "hex": "P9",
+        "tile": "125-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 681,
+        "created_at": 1624988699
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 682,
+        "created_at": 1624988742,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "N3",
+                "M4"
+              ],
+              [
+                "N9",
+                "N7",
+                "O6",
+                "O4",
+                "N3"
+              ],
+              [
+                "N11",
+                "N9"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "N3",
+              "N9",
+              "N11"
+            ],
+            "revenue": 170,
+            "revenue_str": "M4-N3-N9-N11"
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "P9",
+                "Q8"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q8",
+              "P9",
+              "N11"
+            ],
+            "revenue": 150,
+            "revenue_str": "Q8-P9-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 683,
+        "created_at": 1624988743,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 684,
+        "created_at": 1624988755
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 685,
+        "created_at": 1624990145,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1624990144,
+            "corporations": []
+          }
+        ],
+        "hex": "K8",
+        "tile": "14-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 686,
+        "created_at": 1624990158,
+        "city": "14-0-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 687,
+        "created_at": 1624990178,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 150,
+            "revenue_str": "Q10-P9-N11"
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "N3",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "O6",
+                "O4",
+                "N3"
+              ],
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "N3",
+              "P9",
+              "Q8"
+            ],
+            "revenue": 150,
+            "revenue_str": "M4-N3-P9-Q8"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 688,
+        "created_at": 1624990196,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 689,
+        "created_at": 1624990198,
+        "loan": 24
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 690,
+        "created_at": 1624990206
+      },
+      {
+        "id": 691,
+        "hex": "E16",
+        "tile": "23-2",
+        "type": "lay_tile",
+        "entity": "LPS",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "created_at": 1624990273,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 2729,
+        "created_at": 1624990273
+      },
+      {
+        "id": 692,
+        "type": "undo",
+        "entity": "LPS",
+        "action_id": 690,
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624990369
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 693,
+        "created_at": 1624990409,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1624990409,
+            "corporations": []
+          }
+        ],
+        "hex": "B19",
+        "tile": "14-2",
+        "rotation": 0
+      },
+      {
+        "id": 694,
+        "cost": 50,
+        "type": "special_buy",
+        "entity": "LPS",
+        "description": "Tunnel Token",
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624990492
+      },
+      {
+        "id": 695,
+        "type": "undo",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "user": 2729,
+        "created_at": 1624990521
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 696,
+        "created_at": 1624990559,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "F15",
+                "F17"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "C14",
+                "D15",
+                "C16",
+                "B17",
+                "B19"
+              ],
+              [
+                "B19",
+                "A20"
+              ]
+            ],
+            "hexes": [
+              "F17",
+              "F15",
+              "C14",
+              "B19",
+              "A20"
+            ],
+            "revenue": 220,
+            "revenue_str": "F17-F15-C14-B19-A20"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 697,
+        "created_at": 1624990562,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 698,
+        "created_at": 1624990574
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 699,
+        "created_at": 1624990578
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 700,
+        "created_at": 1624991008,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1624991007,
+            "corporations": []
+          }
+        ],
+        "hex": "G12",
+        "tile": "63-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 701,
+        "created_at": 1624991032,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "B13",
+                "B15",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15",
+              "C14",
+              "B13"
+            ],
+            "revenue": 250,
+            "revenue_str": "F9-G12-F15-C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 702,
+        "created_at": 1624991036,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 703,
+        "created_at": 1624991039
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 704,
+        "created_at": 1624991042
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 705,
+        "created_at": 1624995483,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1624995484,
+            "corporations": []
+          }
+        ],
+        "hex": "J15",
+        "tile": "14-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 706,
+        "created_at": 1624995591
+      },
+      {
+        "type": "run_routes",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 707,
+        "created_at": 1624995599,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "L13",
+                "K14",
+                "L15"
+              ],
+              [
+                "N11",
+                "M12",
+                "L13"
+              ]
+            ],
+            "hexes": [
+              "L15",
+              "L13",
+              "N11"
+            ],
+            "revenue": 170,
+            "revenue_str": "L15-L13-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 708,
+        "created_at": 1624995601,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 709,
+        "created_at": 1624995613
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 710,
+        "created_at": 1624995619
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 711,
+        "created_at": 1624995738,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "created_at": 1624995738,
+            "corporations": []
+          }
+        ],
+        "hex": "D17",
+        "tile": "63-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 712,
+        "created_at": 1624995766
+      },
+      {
+        "type": "run_routes",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 713,
+        "created_at": 1624995810,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "H15",
+                "I16",
+                "J15"
+              ],
+              [
+                "F17",
+                "G16",
+                "H15"
+              ]
+            ],
+            "hexes": [
+              "J15",
+              "H15",
+              "F17"
+            ],
+            "revenue": 90,
+            "revenue_str": "J15-H15-F17"
+          },
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "B19",
+                "A20"
+              ],
+              [
+                "D17",
+                "C16",
+                "B17",
+                "B19"
+              ],
+              [
+                "F17",
+                "E16",
+                "D17"
+              ],
+              [
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "A20",
+              "B19",
+              "D17",
+              "F17",
+              "F15"
+            ],
+            "revenue": 220,
+            "revenue_str": "A20-B19-D17-F17-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 714,
+        "created_at": 1624995814,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 715,
+        "created_at": 1624995824
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 716,
+        "created_at": 1625005160,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "created_at": 1625005160,
+            "corporations": []
+          }
+        ],
+        "hex": "L11",
+        "tile": "23-2",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 717,
+        "created_at": 1625005169,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15"
+            ],
+            "revenue": 150,
+            "revenue_str": "F9-G12-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 718,
+        "created_at": 1625005170,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 719,
+        "created_at": 1625005174
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 720,
+        "created_at": 1625005179
+      },
+      {
+        "type": "lay_tile",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 721,
+        "created_at": 1625046898,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "entity_type": "corporation",
+            "created_at": 1625046897,
+            "corporations": []
+          }
+        ],
+        "hex": "K16",
+        "tile": "3-0",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 722,
+        "created_at": 1625046920,
+        "routes": [
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "L13",
+                "M12",
+                "N11"
+              ],
+              [
+                "L15",
+                "K14",
+                "L13"
+              ],
+              [
+                "L15",
+                "K16"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "L13",
+              "L15",
+              "K16"
+            ],
+            "revenue": 180,
+            "revenue_str": "N11-L13-L15-K16"
+          }
+        ]
+      },
+      {
+        "id": 723,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625046950
+      },
+      {
+        "id": 724,
+        "loan": 25,
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625046952
+      },
+      {
+        "id": 725,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625046967
+      },
+      {
+        "id": 726,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625046972
+      },
+      {
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 727,
+        "created_at": 1625046974,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 728,
+        "created_at": 1625046979
+      },
+      {
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 729,
+        "created_at": 1625047034,
+        "loan": 25
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 730,
+        "created_at": 1625047036
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 731,
+        "created_at": 1625047556,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "created_at": 1625047558,
+            "corporations": []
+          }
+        ],
+        "hex": "D15",
+        "tile": "28-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 732,
+        "created_at": 1625047571
+      },
+      {
+        "type": "run_routes",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 733,
+        "created_at": 1625047580,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "F17",
+                "E16",
+                "D17"
+              ],
+              [
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "D17",
+              "F17",
+              "F15"
+            ],
+            "revenue": 140,
+            "revenue_str": "D17-F17-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 734,
+        "created_at": 1625047582,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 735,
+        "created_at": 1625047677
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 736,
+        "created_at": 1625058250,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "created_at": 1625058250,
+            "corporations": []
+          }
+        ],
+        "hex": "K10",
+        "tile": "19-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 737,
+        "created_at": 1625058334
+      },
+      {
+        "type": "run_routes",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 738,
+        "created_at": 1625058344,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "N3",
+                "M4"
+              ],
+              [
+                "N9",
+                "N7",
+                "O6",
+                "O4",
+                "N3"
+              ],
+              [
+                "N11",
+                "N9"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "N3",
+              "N9",
+              "N11"
+            ],
+            "revenue": 170,
+            "revenue_str": "M4-N3-N9-N11"
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "P9",
+                "Q8"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "Q8",
+              "P9",
+              "N11"
+            ],
+            "revenue": 150,
+            "revenue_str": "Q8-P9-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 739,
+        "created_at": 1625058345,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 740,
+        "created_at": 1625058355
+      },
+      {
+        "id": 741,
+        "hex": "J9",
+        "tile": "4-1",
+        "type": "lay_tile",
+        "entity": "GT",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "created_at": 1625059118,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 7422,
+        "created_at": 1625059120
+      },
+      {
+        "id": 742,
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1625059124
+      },
+      {
+        "id": 743,
+        "type": "undo",
+        "entity": "GT",
+        "action_id": 740,
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1625059142
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 744,
+        "created_at": 1625059148,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1625059146,
+            "corporations": []
+          }
+        ],
+        "hex": "M4",
+        "tile": "127-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 745,
+        "created_at": 1625059155
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 746,
+        "created_at": 1625059176,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "P9",
+                "Q10"
+              ],
+              [
+                "P9",
+                "O10",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "Q10",
+              "P9",
+              "N11"
+            ],
+            "revenue": 150,
+            "revenue_str": "Q10-P9-N11"
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "N3",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "O6",
+                "O4",
+                "N3"
+              ],
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "hexes": [
+              "M4",
+              "N3",
+              "P9",
+              "Q8"
+            ],
+            "revenue": 160,
+            "revenue_str": "M4-N3-P9-Q8"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 747,
+        "created_at": 1625059181,
+        "kind": "payout"
+      },
+      {
+        "type": "take_loan",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 748,
+        "created_at": 1625059209,
+        "loan": 26
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 749,
+        "created_at": 1625059229
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 750,
+        "created_at": 1625059940,
+        "shares": [
+          "CA_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 751,
+        "created_at": 1625059980
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 752,
+        "created_at": 1625061517,
+        "shares": [
+          "CV_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 753,
+        "created_at": 1625061527
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 754,
+        "created_at": 1625062453,
+        "shares": [
+          "CA_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 755,
+        "created_at": 1625062456
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 756,
+        "created_at": 1625077504,
+        "shares": [
+          "CV_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 757,
+        "created_at": 1625077531
+      },
+      {
+        "type": "buy_shares",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 758,
+        "created_at": 1625078223,
+        "shares": [
+          "CA_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 759,
+        "created_at": 1625078229
+      },
+      {
+        "id": 760,
+        "type": "buy_shares",
+        "entity": 2729,
+        "shares": [
+          "CA_5"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "user": 2729,
+        "created_at": 1625078293
+      },
+      {
+        "id": 761,
+        "type": "undo",
+        "entity": 2729,
+        "entity_type": "player",
+        "user": 2729,
+        "created_at": 1625078327
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 762,
+        "created_at": 1625078331,
+        "shares": [
+          "CV_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 763,
+        "created_at": 1625078430
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 764,
+        "created_at": 1625083236,
+        "shares": [
+          "CPR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 765,
+        "created_at": 1625083241,
+        "corporation": "TGB",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 766,
+        "created_at": 1625083315,
+        "shares": [
+          "GT_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 767,
+        "created_at": 1625083320
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 768,
+        "created_at": 1625209412,
+        "shares": [
+          "CA_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 769,
+        "created_at": 1625209421
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 770,
+        "created_at": 1625213181
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 771,
+        "created_at": 1625213668,
+        "shares": [
+          "BBG_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 772,
+        "created_at": 1625213681
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 773,
+        "created_at": 1625228740,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1625228739,
+            "shares": [
+              "TGB_1"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1625228739
+          }
+        ],
+        "corporation": "TGB",
+        "until_condition": "float",
+        "from_market": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 774,
+        "created_at": 1625257820,
+        "shares": [
+          "CA_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 775,
+        "created_at": 1625257824
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 776,
+        "created_at": 1625330871,
+        "shares": [
+          "GT_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 777,
+        "created_at": 1625330879
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 778,
+        "created_at": 1625398229
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 779,
+        "created_at": 1625398597,
+        "shares": [
+          "BBG_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 780,
+        "created_at": 1625398608,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1625398606,
+            "reason": "Shares were sold"
+          }
+        ],
+        "shares": [
+          "CA_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 781,
+        "created_at": 1625410135,
+        "shares": [
+          "TGB_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 782,
+        "created_at": 1625410169
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 783,
+        "created_at": 1625426500
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 784,
+        "created_at": 1625428167,
+        "shares": [
+          "CA_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 785,
+        "created_at": 1625428180
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 786,
+        "created_at": 1625428453
+      },
+      {
+        "type": "sell_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 787,
+        "created_at": 1625428615,
+        "shares": [
+          "CV_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 788,
+        "created_at": 1625428628,
+        "shares": [
+          "CA_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 789,
+        "created_at": 1625459570,
+        "shares": [
+          "TGB_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 790,
+        "created_at": 1625459574
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 791,
+        "created_at": 1625486711
+      },
+      {
+        "type": "buy_shares",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 792,
+        "created_at": 1625486826,
+        "shares": [
+          "CV_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 793,
+        "created_at": 1625486828
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 794,
+        "created_at": 1625489213
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 795,
+        "created_at": 1625492165
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 796,
+        "created_at": 1625496087,
+        "shares": [
+          "CV_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 797,
+        "created_at": 1625496091,
+        "shares": [
+          "TGB_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 7422,
+        "entity_type": "player",
+        "id": 798,
+        "created_at": 1625533828
+      },
+      {
+        "type": "pass",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 799,
+        "created_at": 1625554379
+      },
+      {
+        "type": "pass",
+        "entity": 405,
+        "entity_type": "player",
+        "id": 800,
+        "created_at": 1625561949
+      },
+      {
+        "type": "pass",
+        "entity": 2729,
+        "entity_type": "player",
+        "id": 801,
+        "created_at": 1625562023
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 802,
+        "created_at": 1625576737
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 803,
+        "created_at": 1625583977,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1625583975,
+            "corporations": []
+          }
+        ],
+        "hex": "C18",
+        "tile": "9-7",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 804,
+        "created_at": 1625583988,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "F15",
+                "F17"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "C14",
+                "D15",
+                "C16",
+                "B17",
+                "B19"
+              ],
+              [
+                "B19",
+                "A20"
+              ]
+            ],
+            "hexes": [
+              "F17",
+              "F15",
+              "C14",
+              "B19",
+              "A20"
+            ],
+            "revenue": 220,
+            "revenue_str": "F17-F15-C14-B19-A20"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 805,
+        "created_at": 1625583992,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 806,
+        "created_at": 1625583995
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 807,
+        "created_at": 1625584015
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 808,
+        "created_at": 1625588048,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1625588047,
+            "corporations": []
+          }
+        ],
+        "hex": "M12",
+        "tile": "23-3",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 809,
+        "created_at": 1625588058,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "G12",
+                "G10",
+                "F9"
+              ],
+              [
+                "F15",
+                "G14",
+                "G12"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "B13",
+                "B15",
+                "C14"
+              ]
+            ],
+            "hexes": [
+              "F9",
+              "G12",
+              "F15",
+              "C14",
+              "B13"
+            ],
+            "revenue": 250,
+            "revenue_str": "F9-G12-F15-C14-B13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 810,
+        "created_at": 1625588061,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 811,
+        "created_at": 1625588064
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 812,
+        "created_at": 1625588068
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 813,
+        "created_at": 1625588420,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "created_at": 1625588419,
+            "corporations": []
+          }
+        ],
+        "hex": "H15",
+        "tile": "15-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 814,
+        "created_at": 1625588445
+      },
+      {
+        "type": "run_routes",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 815,
+        "created_at": 1625588543,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "H15",
+                "I16",
+                "J15"
+              ],
+              [
+                "F17",
+                "G16",
+                "H15"
+              ]
+            ],
+            "hexes": [
+              "J15",
+              "H15",
+              "F17"
+            ],
+            "revenue": 100,
+            "revenue_str": "J15-H15-F17"
+          },
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "B19",
+                "A20"
+              ],
+              [
+                "D17",
+                "C16",
+                "B17",
+                "B19"
+              ],
+              [
+                "F17",
+                "E16",
+                "D17"
+              ],
+              [
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "A20",
+              "B19",
+              "D17",
+              "F17",
+              "F15"
+            ],
+            "revenue": 220,
+            "revenue_str": "A20-B19-D17-F17-F15"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 816,
+        "created_at": 1625588546,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 817,
+        "created_at": 1625588550
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 818,
+        "created_at": 1625589417,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1625589416,
+            "corporations": []
+          }
+        ],
+        "hex": "M10",
+        "tile": "2-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 819,
+        "created_at": 1625589442
+      },
+      {
+        "type": "run_routes",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 820,
+        "created_at": 1625589461,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "L13",
+                "K14",
+                "L15"
+              ],
+              [
+                "N11",
+                "M12",
+                "L13"
+              ],
+              [
+                "N11",
+                "M10"
+              ]
+            ],
+            "hexes": [
+              "L15",
+              "L13",
+              "N11",
+              "M10"
+            ],
+            "revenue": 180,
+            "revenue_str": "L15-L13-N11-M10"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 821,
+        "created_at": 1625589465,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 822,
+        "created_at": 1625589639,
+        "train": "4-1",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 823,
+        "created_at": 1625589658
+      },
+      {
+        "type": "lay_tile",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 824,
+        "created_at": 1625591876,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "created_at": 1625591876,
+            "corporations": []
+          }
+        ],
+        "hex": "J11",
+        "tile": "63-2",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 825,
+        "created_at": 1625591906,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "J11",
+                "I12"
+              ],
+              [
+                "J11",
+                "K10",
+                "L11",
+                "M12",
+                "N11"
+              ]
+            ],
+            "hexes": [
+              "I12",
+              "J11",
+              "N11"
+            ],
+            "revenue": 170,
+            "revenue_str": "I12-J11-N11"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 826,
+        "created_at": 1625591911,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 827,
+        "created_at": 1625591915
+      },
+      {
+        "type": "pass",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 828,
+        "created_at": 1625591920
+      },
+      {
+        "type": "lay_tile",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 829,
+        "created_at": 1625593282,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "THB",
+            "entity_type": "corporation",
+            "created_at": 1625593281,
+            "corporations": []
+          }
+        ],
+        "hex": "L17",
+        "tile": "7-4",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 830,
+        "created_at": 1625593343,
+        "routes": [
+          {
+            "train": "4'-0",
+            "connections": [
+              [
+                "L13",
+                "M12",
+                "N11"
+              ],
+              [
+                "L15",
+                "K14",
+                "L13"
+              ],
+              [
+                "L15",
+                "K16"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "L13",
+              "L15",
+              "K16"
+            ],
+            "revenue": 180,
+            "revenue_str": "N11-L13-L15-K16"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 831,
+        "created_at": 1625593348,
+        "kind": "withhold"
+      },
+      {
+        "type": "take_loan",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 832,
+        "created_at": 1625593353,
+        "loan": 27
+      },
+      {
+        "id": 833,
+        "type": "buy_train",
+        "price": 700,
+        "train": "6-0",
+        "entity": "THB",
+        "variant": "6",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593355
+      },
+      {
+        "id": 834,
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593394
+      },
+      {
+        "id": 835,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593498
+      },
+      {
+        "id": 836,
+        "type": "redo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593503
+      },
+      {
+        "id": 837,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593531
+      },
+      {
+        "id": 838,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593538
+      },
+      {
+        "id": 839,
+        "type": "undo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593545
+      },
+      {
+        "id": 840,
+        "type": "redo",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625593565
+      },
+      {
+        "type": "buy_train",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 841,
+        "created_at": 1625593574,
+        "train": "6-0",
+        "price": 700,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 842,
+        "created_at": 1625593581
+      },
+      {
+        "type": "merge",
+        "entity": "THB",
+        "entity_type": "corporation",
+        "id": 843,
+        "created_at": 1625593583,
+        "corporation": "THB"
+      },
+      {
+        "type": "merge",
+        "entity": "CPR",
+        "entity_type": "corporation",
+        "id": 844,
+        "created_at": 1625595801,
+        "corporation": "CPR"
+      },
+      {
+        "type": "merge",
+        "entity": "WGB",
+        "entity_type": "corporation",
+        "id": 845,
+        "created_at": 1625596825,
+        "corporation": "WGB"
+      },
+      {
+        "type": "discard_train",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 846,
+        "created_at": 1625597835,
+        "train": "4'-0"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 847,
+        "created_at": 1625598316,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "created_at": 1625598314,
+            "corporations": []
+          }
+        ],
+        "hex": "H15",
+        "tile": "63-3",
+        "rotation": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 848,
+        "created_at": 1625598639,
+        "train": "5'-0",
+        "price": 447
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TGB",
+        "entity_type": "corporation",
+        "id": 849,
+        "created_at": 1625601130,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "TGB",
+            "entity_type": "corporation",
+            "created_at": 1625601129,
+            "corporations": []
+          }
+        ],
+        "hex": "K10",
+        "tile": "46-0",
+        "rotation": 3
+      },
+      {
+        "type": "place_token",
+        "entity": "TGB",
+        "entity_type": "corporation",
+        "id": 850,
+        "created_at": 1625601134,
+        "city": "127-0-0",
+        "slot": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "TGB",
+        "entity_type": "corporation",
+        "id": 851,
+        "created_at": 1625601225,
+        "train": "6-1",
+        "price": 700,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "TGB",
+        "entity_type": "corporation",
+        "id": 852,
+        "created_at": 1625601230
+      },
+      {
+        "id": 853,
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "created_at": 1625608350,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 7422,
+        "created_at": 1625608351
+      },
+      {
+        "id": 854,
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1625608352
+      },
+      {
+        "id": 855,
+        "type": "run_routes",
+        "entity": "GT",
+        "routes": [
+          {
+            "hexes": [
+              "M4",
+              "N3",
+              "P9",
+              "Q8"
+            ],
+            "train": "4-2",
+            "revenue": 160,
+            "connections": [
+              [
+                "N3",
+                "M4"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "O6",
+                "O4",
+                "N3"
+              ],
+              [
+                "Q8",
+                "P9"
+              ]
+            ],
+            "revenue_str": "M4-N3-P9-Q8"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1625608421
+      },
+      {
+        "id": 856,
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1625608424
+      },
+      {
+        "id": 857,
+        "type": "undo",
+        "entity": "GT",
+        "action_id": 852,
+        "entity_type": "corporation",
+        "user": 7422,
+        "created_at": 1625608442
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 858,
+        "created_at": 1625608453,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GT",
+            "entity_type": "corporation",
+            "created_at": 1625608452,
+            "corporations": []
+          }
+        ],
+        "hex": "N11",
+        "tile": "124-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 859,
+        "created_at": 1625608517
+      },
+      {
+        "type": "run_routes",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 860,
+        "created_at": 1625608531,
+        "routes": [
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "P9",
+                "O10",
+                "N11"
+              ],
+              [
+                "N3",
+                "O4",
+                "O6",
+                "N7",
+                "O8",
+                "P9"
+              ],
+              [
+                "M4",
+                "N3"
+              ]
+            ],
+            "hexes": [
+              "N11",
+              "P9",
+              "N3",
+              "M4"
+            ],
+            "revenue": 230,
+            "revenue_str": "N11-P9-N3-M4"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 861,
+        "created_at": 1625608532,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GT",
+        "entity_type": "corporation",
+        "id": 862,
+        "created_at": 1625608536
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 863,
+        "created_at": 1625630525,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "LPS",
+            "entity_type": "corporation",
+            "created_at": 1625630523,
+            "corporations": []
+          }
+        ],
+        "hex": "G14",
+        "tile": "25-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 864,
+        "created_at": 1625630546,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "F15",
+                "F17"
+              ],
+              [
+                "C14",
+                "D13",
+                "E14",
+                "F15"
+              ],
+              [
+                "C14",
+                "D15",
+                "C16",
+                "B17",
+                "B19"
+              ],
+              [
+                "B19",
+                "A20"
+              ]
+            ],
+            "hexes": [
+              "F17",
+              "F15",
+              "C14",
+              "B19",
+              "A20"
+            ],
+            "revenue": 220,
+            "revenue_str": "F17-F15-C14-B19-A20"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 865,
+        "created_at": 1625630553,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LPS",
+        "entity_type": "corporation",
+        "id": 866,
+        "created_at": 1625630567
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 867,
+        "created_at": 1625630795,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "GW",
+            "entity_type": "corporation",
+            "created_at": 1625630794,
+            "corporations": []
+          }
+        ],
+        "hex": "I10",
+        "tile": "9-8",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 868,
+        "created_at": 1625630856,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "J11",
+                "I12"
+              ],
+              [
+                "N11",
+                "M12",
+                "L11",
+                "K10",
+                "J11"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ],
+              [
+                "P9",
+                "Q8"
+              ]
+            ],
+            "hexes": [
+              "I12",
+              "J11",
+              "N11",
+              "P9",
+              "Q8"
+            ],
+            "revenue": 260,
+            "revenue_str": "I12-J11-N11-P9-Q8"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 869,
+        "created_at": 1625630859,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GW",
+        "entity_type": "corporation",
+        "id": 870,
+        "created_at": 1625630866
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 871,
+        "created_at": 1625630946,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "created_at": 1625630945,
+            "corporations": [
+              "CV"
+            ]
+          }
+        ],
+        "hex": "I14",
+        "tile": "69-0",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 872,
+        "created_at": 1625630958,
+        "city": "14-1-0",
+        "slot": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 873,
+        "created_at": 1625630994,
+        "train": "D-0",
+        "price": 1100,
+        "variant": "D"
+      },
+      {
+        "type": "pass",
+        "entity": "CA",
+        "entity_type": "corporation",
+        "id": 874,
+        "created_at": 1625631000
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 875,
+        "created_at": 1625645842,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "created_at": 1625645840,
+            "corporations": []
+          }
+        ],
+        "hex": "L15",
+        "tile": "123-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 876,
+        "created_at": 1625645851
+      },
+      {
+        "type": "buy_train",
+        "entity": "CV",
+        "entity_type": "corporation",
+        "id": 877,
+        "created_at": 1625645863,
+        "train": "D-1",
+        "price": 1100,
+        "variant": "D"
+      },
+      {
+        "id": 878,
+        "hex": "K16",
+        "tile": "5-0",
+        "type": "lay_tile",
+        "entity": "CGR",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CGR",
+            "created_at": 1625646473,
+            "entity_type": "corporation",
+            "corporations": []
+          }
+        ],
+        "user": 40,
+        "created_at": 1625646475
+      },
+      {
+        "id": 879,
+        "type": "undo",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625646486
+      },
+      {
+        "type": "message",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 880,
+        "created_at": 1625650010,
+        "message": "submitted a bug report as i can't currently 'bulldoze' the towns that i'd like to (H11 or K16)"
+      },
+      {
+        "type": "message",
+        "entity": 40,
+        "entity_type": "player",
+        "id": 881,
+        "created_at": 1625650023,
+        "message": "not sure it matters much to my position though so let's crack on! "
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 882,
+        "created_at": 1625650079,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CGR",
+            "entity_type": "corporation",
+            "created_at": 1625650078,
+            "corporations": []
+          }
+        ],
+        "hex": "O4",
+        "tile": "24-0",
+        "rotation": 0
+      },
+      {
+        "id": 883,
+        "city": "67-0-1",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625650136
+      },
+      {
+        "id": 884,
+        "type": "run_routes",
+        "entity": "CGR",
+        "routes": [
+          {
+            "hexes": [
+              "L15",
+              "L13",
+              "N11",
+              "P9",
+              "N3",
+              "M4"
+            ],
+            "train": "6-0",
+            "revenue": 330,
+            "connections": [
+              [
+                "L13",
+                "L15"
+              ],
+              [
+                "N11",
+                "M12",
+                "L13"
+              ],
+              [
+                "N11",
+                "O10",
+                "P9"
+              ],
+              [
+                "P9",
+                "O8",
+                "N7",
+                "O6",
+                "O4",
+                "N3"
+              ],
+              [
+                "N3",
+                "M4"
+              ]
+            ],
+            "revenue_str": "L15-L13-N11-P9-N3-M4"
+          }
+        ],
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625650206
+      },
+      {
+        "id": 885,
+        "type": "undo",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625650215
+      },
+      {
+        "id": 886,
+        "type": "undo",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "user": 40,
+        "created_at": 1625650219
+      },
+      {
+        "type": "place_token",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 887,
+        "created_at": 1625650220,
+        "city": "125-3-0",
+        "slot": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 888,
+        "created_at": 1625650258,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "L13",
+                "L15"
+              ],
+              [
+                "N11",
+                "M12",
+                "L13"
+              ],
+              [
+                "P9",
+                "O10",
+                "N11"
+              ],
+              [
+                "N3",
+                "O4",
+                "O6",
+                "N7",
+                "O8",
+                "P9"
+              ],
+              [
+                "M4",
+                "N3"
+              ]
+            ],
+            "hexes": [
+              "L15",
+              "L13",
+              "N11",
+              "P9",
+              "N3",
+              "M4"
+            ],
+            "revenue": 330,
+            "revenue_str": "L15-L13-N11-P9-N3-M4"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 889,
+        "created_at": 1625650312,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 890,
+        "created_at": 1625650364
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 891,
+        "created_at": 1625650489,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "created_at": 1625650488,
+            "corporations": []
+          }
+        ],
+        "hex": "K14",
+        "tile": "41-0",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 892,
+        "created_at": 1625650512,
+        "routes": [
+          {
+            "train": "5'-0",
+            "connections": [
+              [
+                "H15",
+                "G14",
+                "F15"
+              ],
+              [
+                "J15",
+                "I16",
+                "H15"
+              ],
+              [
+                "L15",
+                "K14",
+                "J15"
+              ],
+              [
+                "L13",
+                "L15"
+              ]
+            ],
+            "hexes": [
+              "F15",
+              "H15",
+              "J15",
+              "L15",
+              "L13"
+            ],
+            "revenue": 230,
+            "revenue_str": "F15-H15-J15-L15-L13"
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 893,
+        "created_at": 1625650515,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 894,
+        "created_at": 1625650518
+      },
+      {
+        "type": "undo",
+        "entity": "TGB",
+        "entity_type": "corporation",
+        "id": 895,
+        "created_at": 1625660213,
+        "action_id": 890
+      },
+      {
+        "type": "undo",
+        "entity": "BBG",
+        "entity_type": "corporation",
+        "id": 896,
+        "created_at": 1625660219,
+        "action_id": 877
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 897,
+        "created_at": 1625660247,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CGR",
+            "entity_type": "corporation",
+            "created_at": 1625660247,
+            "corporations": []
+          }
+        ],
+        "hex": "K16",
+        "tile": "5-0",
+        "rotation": 4
+      },
+      {
+        "type": "undo",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 898,
+        "created_at": 1625660342
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 899,
+        "created_at": 1625660765,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CGR",
+            "entity_type": "corporation",
+            "created_at": 1625660765,
+            "corporations": []
+          }
+        ],
+        "hex": "K16",
+        "tile": "7-5",
+        "rotation": 4
+      },
+      {
+        "type": "undo",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 900,
+        "created_at": 1625660767
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 901,
+        "created_at": 1625660773,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "CGR",
+            "entity_type": "corporation",
+            "created_at": 1625660773,
+            "corporations": []
+          }
+        ],
+        "hex": "M10",
+        "tile": "15-0",
+        "rotation": 2
+      },
+      {
+        "type": "end_game",
+        "entity": "CGR",
+        "entity_type": "corporation",
+        "id": 902,
+        "created_at": 1625661640
+      }
+    ],
+    "id": "hs_feckuvdr_45471",
+    "players": [
+      {
+        "id": 7422,
+        "name": "lukas4"
+      },
+      {
+        "id": 40,
+        "name": "thomb"
+      },
+      {
+        "id": 405,
+        "name": "marco4884"
+      },
+      {
+        "id": 2729,
+        "name": "rr1"
+      },
+      {
+        "id": 4473,
+        "name": "Corian09"
+      }
+    ],
+    "title": "1856",
+    "description": "Cloned from game 45471",
+    "max_players": 5,
+    "user": {
+      "id": 0,
+      "name": "You"
+    },
+    "settings": {
+      "seed": 2145792340,
+      "unlisted": false,
+      "auto_routing": true,
+      "player_order": null,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "turn": 7,
+    "round": "Operating Round",
+    "acting": [
+      40
+    ],
+    "result": {
+      "rr1": 3223,
+      "Corian09": 2690,
+      "lukas4": 2654,
+      "marco4884": 2555,
+      "thomb": 1692
+    },
+    "loaded": true,
+    "created_at": "2021-07-07",
+    "updated_at": 1625661640,
+    "mode": "hotseat"
+  }


### PR DESCRIPTION
A check was recently added to `tracker.rb` that makes sures that towns aren't removed during tile upgrades which of course prevents us from replacing town tiles with plain track tiles. Instead of altering the base code with flags I just copied it over into 1856's Track and removed the check
Fixes #5959 