### PR TITLE
show double share in player holdings

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -222,7 +222,8 @@ module View
         children << h('td.center', td_props, [h(:div, div_props, [h(:img, logo_props)])]) unless @hide_logo
 
         president_marker = corporation.president?(@player) ? '*' : ''
-        children << h(:td, td_props, corporation.name + president_marker)
+        double_marker = shares.any?(&:double_cert) ? ' d' : ''
+        children << h(:td, td_props, corporation.name + president_marker + double_marker)
         children << h('td.right', td_props, "#{shares.sum(&:percent)}%")
         h('tr.row', children)
       end


### PR DESCRIPTION
This adds a ` d` after the company symbol, if the player owns a double share of that company

Note the space between company symbol and the `d`, to separate it from the company symbol

If a player owns 30% or more of a company, it will still show that part of their ownership is a double share
(similar to how presidencies work)

This can stack with presidency, if a game allows that

![Screenshot 2021-07-07 3 53 47 PM](https://user-images.githubusercontent.com/1711810/124839331-742c6e00-df3d-11eb-9d82-dadd79d48d8e.png)
![Screenshot 2021-07-07 3 53 40 PM](https://user-images.githubusercontent.com/1711810/124839333-74c50480-df3d-11eb-97a6-835d63c13a89.png)

![Screenshot 2021-07-07 3 52 40 PM](https://user-images.githubusercontent.com/1711810/124839372-86a6a780-df3d-11eb-8b37-ae04d057be0e.png)
![Screenshot 2021-07-07 3 52 48 PM](https://user-images.githubusercontent.com/1711810/124839383-8c03f200-df3d-11eb-9f81-dc989ae28dbe.png)


closes #5809 