### PR TITLE
[1849] add note that last share is a double

### DIFF
--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -236,6 +236,10 @@ module Engine
           'Treasury'
         end
 
+        def status_str(_corp)
+          'Last Share is 20% Cert'
+        end
+
         def sms_hexes
           SMS_HEXES
         end


### PR DESCRIPTION
Proposal to add a note on each corp using the `status_str` method to denote that the last share of each corp is a double

This makes this mechanic more apparent to players

Checking with @perwestling @scottredracecar first

Presumably this would apply to other games, like 1893

![Screenshot 2021-07-07 3 52 40 PM](https://user-images.githubusercontent.com/1711810/124839303-65de5200-df3d-11eb-8714-5cdfa6f585c1.png)

Related to #5809