### PR TITLE
[1893] Add possibility to purchase EVA from other player

### DIFF
--- a/lib/engine/game/g_1893/buy_company.rb
+++ b/lib/engine/game/g_1893/buy_company.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../step/buy_company'
+
+module Engine
+  module Game
+    module G1893
+      module Step
+        class BuyCompany < Engine::Step::BuyCompany
+          def actions(entity)
+            return ['buy_company'] if purchasable_companies(entity).any?
+
+            []
+          end
+
+          def process_buy_company(action)
+            buyer = spender(action.entity)
+            company = action.company
+            company.min_price = 1
+            company.max_price = buyer.cash
+
+            buy_company(buyer, company, action.price, company.owner)
+          end
+
+          def purchasable_companies(entity = nil)
+            entity ||= @game.current_entity
+            @game.purchasable_companies(spender(entity))
+          end
+
+          # Who should pay for bought company? (Assuming company is EVA)
+          def spender(entity)
+            return unless entity
+
+            entity.player? ? entity : entity.player
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -584,7 +584,7 @@ module Engine
           },
           {
             sym: 'EVA',
-            name: 'Eisenbahnverkehrsmittel Aktiengesellschaft',
+            name: 'EVA (Eisenbahnverkehrsmittel Aktiengesellschaft)',
             value: 150,
             revenue: 30,
             desc: 'Leaves the game after the purchase of the first 6-train. This private cannot be sold to '\
@@ -739,6 +739,14 @@ module Engine
           end
         end
 
+        # EVA can be bought from other player
+        def purchasable_companies(entity)
+          return [] if eva.closed? || eva.owner == @bank
+          return [eva] if eva.owner != entity
+
+          []
+        end
+
         # Show minors in spreadsheet
         def all_corporations
           @minors + @corporations
@@ -859,6 +867,7 @@ module Engine
             Engine::Step::Bankrupt,
             Engine::Step::DiscardTrain,
             Engine::Step::HomeToken,
+            G1893::Step::BuyCompany,
             G1893::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,

--- a/lib/engine/game/g_1893/step/buy_minor.rb
+++ b/lib/engine/game/g_1893/step/buy_minor.rb
@@ -26,7 +26,7 @@ module BuyMinor
   end
 
   def draft_company(company, player)
-    @game.bank.companies&.delete(company)
+    company.owner.companies&.delete(company)
     company.owner = player
     player.companies << company
   end

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -22,6 +22,10 @@ module Engine
             return [] if first_sr_passed?(entity)
 
             result = super
+            # This happens if a player can buy EVA from other player,
+            # but nothing else - ignore that case and just skip player
+            result = [] if result == %w[buy_company pass]
+
             result.concat(FIRST_SR_ACTIONS) if can_buy_company?(entity)
             result.concat(EXCHANGE_ACTIONS) if can_exchange?(entity)
             result.concat(SELL_COMPANY_ACTIONS) if can_sell_any_companies?(entity)
@@ -346,6 +350,11 @@ module Engine
           # as there are no shares in IPO after parring
           def from_market?(_program)
             true
+          end
+
+          def purchasable_companies(entity = nil)
+            entity ||= @game.current_entity
+            @game.purchasable_companies(entity)
           end
         end
       end

--- a/lib/engine/step/buy_company.rb
+++ b/lib/engine/step/buy_company.rb
@@ -45,6 +45,11 @@ module Engine
         company = action.company
         price = action.price
         owner = company.owner
+
+        buy_company(entity, company, price, owner)
+      end
+
+      def buy_company(entity, company, price, owner)
         raise GameError, "Cannot buy #{company.name} from #{owner.name}" unless @game.company_sellable(company)
 
         min = company.min_price


### PR DESCRIPTION
This commit makes it possible for the active player to purchase
the EVA company (for any amount - upto cash limit) at two times:
- During the stock round (is not counted as an action)
- During train purchase step

The purchaser is the active player, not the minor/corporation.
The purchaser pay.

Note! The rules does allow for buy/sell at any time, and this
would also be regarded as an action, for determination of first
player, but this implementation is a simplication that should
be good enough to at least give the players an option to buy EVA.