### PR TITLE
[1846] only output list of privates once

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -278,9 +278,9 @@ module Engine
               end
               place_second_token(corporation)
             end
-            @log << "Privates in the game: #{@companies.reject { |c| c.name.include?('Pass') }.map(&:name).join(', ')}"
-            @log << "Corporations in the game: #{@corporations.map(&:name).join(', ')}"
           end
+          @log << "Privates in the game: #{@companies.reject { |c| c.name.include?('Pass') }.map(&:name).join(', ')}"
+          @log << "Corporations in the game: #{@corporations.map(&:name).join(', ')}"
 
           @cert_limit = init_cert_limit
 


### PR DESCRIPTION
I accidentally put the output in the 'corp removal' loop, which fires twice in 2P

closes #5977 