### PR TITLE
[18CZ, others] add priv. company size to name

### DIFF
--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -64,7 +64,7 @@ module View
           props[:class] = { active: true } if @selected_company == company
 
           company_name = company.name.truncate(company.owner.name.size < 5 ? 32 : 19)
-          company_name = "#{@game.company_size_str(company)} #{company_name}" if @game.respond_to?(:company_size_str)
+          company_name = "[#{@game.company_size_str(company)}] #{company_name}" if @game.respond_to?(:company_size_str)
 
           owner_name = company.owner.name.truncate
 

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -138,9 +138,12 @@ module View
                           @game.format_currency(@company.revenue)
                         end
 
+          company_name_str = @game.respond_to?(:company_size) ? "[#{@game.company_size(@company)}] " : ''
+          company_name_str += @company.name
+
           children = [
             h(:div, { style: header_style }, header_text),
-            h(:div, @company.name),
+            h(:div, company_name_str),
             h(:div, { style: description_style }, @company.desc),
             h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
             h(:div, { style: revenue_style }, "Revenue: #{revenue_str}"),
@@ -180,9 +183,9 @@ module View
       end
 
       def render_company_on_card(company)
-        title_str = @game.respond_to?(:company_size) ? "#{@game.company_size(company)} company: " : ''
+        title_str = @game.respond_to?(:company_size) ? "[#{@game.company_size(company)}] company: " : ''
         title_str += company.name
-        company_name_str = @game.respond_to?(:company_size_str) ? "#{@game.company_size_str(company)} " : ''
+        company_name_str = @game.respond_to?(:company_size_str) ? "[#{@game.company_size_str(company)}] " : ''
         company_name_str += company.name
 
         extra = []


### PR DESCRIPTION
1 - add size to the company name on card
2 - add brackets around first initial of size (shown on player card and ability usage)

Totally open for input

1 --
![Screenshot 2021-07-09 1 20 11 PM](https://user-images.githubusercontent.com/1711810/125132167-ce057300-e0b8-11eb-99dc-c7fd4cadf18c.png)


2 --
![Screenshot 2021-07-09 1 20 22 PM](https://user-images.githubusercontent.com/1711810/125132165-cd6cdc80-e0b8-11eb-9cab-549eaf6ef2bc.png)

@Zwergenpunk 
closes #5984