### PR TITLE
Allow setting the seed manually when creating a game (api only)

### DIFF
--- a/routes/game.rb
+++ b/routes/game.rb
@@ -171,7 +171,7 @@ class Api
             description: r['description'],
             max_players: r['max_players'],
             settings: {
-              seed: Random.new_seed % 2**31,
+              seed: (r['seed'] || Random.new_seed) % 2**31,
               player_order: r['player_order'],
               unlisted: r['unlisted'],
               optional_rules: r['optional_rules'],


### PR DESCRIPTION
We want to use this to have the same setup for everyone in the 18Zoo tournament