### PR TITLE
[1822] pay to bank before floating company

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -633,7 +633,7 @@ module Engine
           # On acquired abilities
           on_acquired_train(company, entity) if self.class::PRIVATE_TRAINS.include?(company.id)
           on_aqcuired_remove_revenue(company) if self.class::PRIVATE_REMOVE_REVENUE.include?(company.id)
-          on_aqcuired_phase_revenue(company) if self.class::PRIVATE_PHASE_REVENUE.include?(company.id)
+          on_acquired_phase_revenue(company) if self.class::PRIVATE_PHASE_REVENUE.include?(company.id)
           on_aqcuired_midland_great_northern(company) if self.class::COMPANY_MGNR == company.id
         end
 
@@ -1715,7 +1715,7 @@ module Engine
           entity.tokens << Engine::Token.new(entity, price: self.class::TOKEN_PRICE)
         end
 
-        def on_aqcuired_phase_revenue(company)
+        def on_acquired_phase_revenue(company)
           revenue_player = @phase_revenue[company.id]
           @log << "#{company.owner.name} gains #{format_currency(revenue_player.cash)}"
           revenue_player.spend(revenue_player.cash, company.owner)


### PR DESCRIPTION
closes #5953

Works with sample game at issue

May archive / break games

Main bugfix is [player paying the bank before the bank pays to start the minor](https://github.com/tobymao/18xx/pull/6002/files#diff-6f471d381e596c4a0bbf760e2a864407e25b795b3b92366d07243f764397547dR116) which incorrectly breaks the bank as 1K+ gets paid out of the bank often in games

Minor bugfix is [player buying the presidency and then paying the difference later](https://github.com/tobymao/18xx/pull/6002/files#diff-6f471d381e596c4a0bbf760e2a864407e25b795b3b92366d07243f764397547dL98) instead of giving the player a temp loan, which could incorrectly break the bank theoretically