### PR TITLE
Add dashed border for extra tokens to more clearly differentiate them

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -63,6 +63,11 @@ module View
             radius -= 3
             token_attrs[:stroke] = 'white'
             token_attrs[:'stroke-width'] = '3px'
+          elsif @extra_token
+            radius -= 3
+            token_attrs[:stroke] = 'black'
+            token_attrs[:'stroke-width'] = '3px'
+            token_attrs[:'stroke-dasharray'] = '4'
           end
 
           children = [h(:circle, attrs: token_attrs)]


### PR DESCRIPTION
Since #5940 was logged, making the extra tokens more easily differentiated is important. I looked at some of the other filters available and none of them looked like they would be great (although the inverse filter could be potentially useful at some point) 

Instead I'm opting for putting a dashed border around the token to differentiate it from other tokens that live inside the "normal" slots of the city
![image](https://user-images.githubusercontent.com/2993555/125459596-00f7c8fd-6dd3-4098-9eaa-8a6f41dd3114.png)

Tokens that DO occupy slots look the same as usual
![image](https://user-images.githubusercontent.com/2993555/125490750-a1e9fec4-7679-4187-ba06-4621eee48738.png)
