### PR TITLE
1882: Fix behaviour if NWR owner places token on NWR tile

### DIFF
--- a/lib/engine/game/g_1882/game.rb
+++ b/lib/engine/game/g_1882/game.rb
@@ -290,6 +290,7 @@ module Engine
                 price: 0,
                 teleport_price: 0,
                 when: 'owning_corp_or_turn',
+                special_only: true,
                 count: 1,
                 from_owner: true,
               },

--- a/lib/engine/game/g_1882/step/special_nwr.rb
+++ b/lib/engine/game/g_1882/step/special_nwr.rb
@@ -101,6 +101,7 @@ module Engine
               available_tokens(@entity)[0],
               connected: false,
               extra_action: true,
+              special_ability: @game.abilities(@entity, :token),
             )
             @destination = action.city.hex
 


### PR DESCRIPTION
If the NWR owner places a token on a NWR tile, the token they used
would cost zero, and then they wouldn't be able to use the NWR ability

fixes #5879