### PR TITLE
[1862, others] make inoperable trains gray while buying

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -232,7 +232,7 @@ module View
             end
             train_props = { style: {} }
             unless @game.able_to_operate?(corporation, train, name)
-              color = StockMarket::COLOR_MAP[:yellow]
+              color = StockMarket::COLOR_MAP[:gray]
               train_props[:style][:backgroundColor] = color
               train_props[:style][:color] = contrast_on(color)
             end
@@ -350,7 +350,7 @@ module View
 
             train_props = { style: {} }
             unless @game.able_to_operate?(corporation, group[0], name)
-              color = StockMarket::COLOR_MAP[:yellow]
+              color = StockMarket::COLOR_MAP[:gray]
               train_props[:style][:backgroundColor] = color
               train_props[:style][:color] = contrast_on(color)
             end


### PR DESCRIPTION
I like this suggestion from @dfannius

![Screenshot 2021-07-15 8 02 11 AM](https://user-images.githubusercontent.com/1711810/125810956-ab46752d-8be0-4ff8-9b7f-30fab93d498c.png)


related to #5966 