### PR TITLE
18CZ: Highlight trains a corp cannot run

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -325,6 +325,10 @@ module Engine
           @timeline.append("Next set of Operating Rounds will have #{OR_SETS[@turn - 1]} ORs")
         end
 
+        def able_to_operate?(entity, _train, name)
+          TRAINS_FOR_CORPORATIONS[name] == entity.type
+        end
+
         def par_prices(corp)
           par_nodes = stock_market.par_prices
           available_par_prices = PAR_RANGE[corp.type]


### PR DESCRIPTION
This should help prevent the trap of people buying a `4e` when they want a `3E` ;)
![image](https://user-images.githubusercontent.com/2993555/125873292-634a2643-f0ff-4c5d-80ea-d0e7a72e1eb7.png)
![image](https://user-images.githubusercontent.com/2993555/125873303-d62683bb-4528-4ba7-8ee9-a4cef5b67bce.png)
