### PR TITLE
In timing issues w/ 1856, if an incorrect pass gets given to Track, escrow does not get passed.

### DIFF
--- a/lib/engine/game/g_1856/step/escrow.rb
+++ b/lib/engine/game/g_1856/step/escrow.rb
@@ -20,6 +20,10 @@ module Engine
             ]
           end
 
+          def description
+            'Escrow Calculation - Undo if you see this'
+          end
+
           def actions(_entity)
             ACTIONS
           end


### PR DESCRIPTION
This provides a description for Escrow which notifies the user to undo. This is somewhat possible in 1856
because the game takes somewhat long (~2 seconds by the end of the game) to replay for an undo so a race
condition with the server is possible.

FIxes #6035 
This adds a description to a step so it will not need pins or archiving games.