### PR TITLE
18 usa privates batch2

### DIFF
--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -500,7 +500,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
+                hexes: COAL_HEXES,
                 tiles: %w[7coal 8coal 9coal],
                 free: false,
                 when: 'track',
@@ -533,7 +533,7 @@ module Engine
               },
               {
                 type: 'assign_hexes',
-                hexes: %w[C10 C17 D14 E15 E17 F20 G17],
+                hexes: BRIDGE_CITY_HEXES,
                 count: 1,
                 when: 'owning_corp_or_turn',
                 owner_type: 'corporation',
@@ -556,7 +556,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B12 G15 H4 I17 I21 I23 J14],
+                hexes: OIL_HEXES,
                 tiles: %w[7oil 8oil 9oil],
                 free: false,
                 when: 'track',
@@ -584,7 +584,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B10 C7 C19 D16 E5 E9 G21 H6],
+                hexes: IRON_HEXES,
                 tiles: %w[7iron10 8iron10 9iron10],
                 free: false,
                 when: 'track',
@@ -630,7 +630,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B12 G15 H4 I17 I21 I23 J14],
+                hexes: OIL_HEXES,
                 tiles: %w[7oil 8oil 9oil],
                 free: false,
                 when: 'track',
@@ -667,7 +667,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
+                hexes: COAL_HEXES,
                 tiles: %w[7coal 8coal 9coal],
                 free: false,
                 when: 'track',
@@ -699,7 +699,7 @@ module Engine
               },
               {
                 type: 'assign_hexes',
-                hexes: %w[C10 C17 D14 E15 E17 F20 G17],
+                hexes: BRIDGE_CITY_HEXES,
                 count: 2,
                 when: 'owning_corp_or_turn',
                 owner_type: 'corporation',
@@ -738,7 +738,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B10 C7 C19 D16 E5 E9 G21 H6],
+                hexes: IRON_HEXES,
                 tiles: %w[7iron10 8iron10 9iron10],
                 free: false,
                 when: 'track',
@@ -765,7 +765,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
+                hexes: COAL_HEXES,
                 tiles: %w[7coal 8coal 9coal],
                 free: false,
                 when: 'track',
@@ -1051,6 +1051,10 @@ module Engine
 
         LAYOUT = :pointy
 
+        OIL_HEXES = %w[B12 G15 H4 I17 I21 I23 J14].freeze
+        IRON_HEXES = %w[B10 C7 C19 D16 E5 E9 G21 H6].freeze
+        COAL_HEXES = %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24].freeze
+        BRIDGE_CITY_HEXES = %w[C10 C17 D14 E15 E17 F20 G17].freeze
         ASSIGNMENT_TOKENS = {
           'bridge' => '/icons/1817/bridge_token.svg',
         }.freeze
@@ -1219,7 +1223,7 @@ module Engine
           revenue += 10 * route.all_hexes.count { |hex| hex.tile.id.include?('coal') }
           revenue += 10 * route.all_hexes.count { |hex| hex.tile.id.include?('iron10') }
           revenue += 20 * route.all_hexes.count { |hex| hex.tile.id.include?('iron20') }
-          revenue += (increased_oil? ? 20 : 10) * route.all_hexes.count { |hex| hex.tile.id.include?('oil') }
+          revenue + (increased_oil? ? 20 : 10) * route.all_hexes.count { |hex| hex.tile.id.include?('oil') }
         end
 
         def increased_oil?

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -67,7 +67,7 @@ module Engine
           {
             'count' => 'unlimited',
             'color' => 'yellow',
-            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:1;path=a:_0,b:_0;label=⚒️',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:1;label=⚒️',
           },
           '8iron10' =>
           {
@@ -1053,7 +1053,6 @@ module Engine
 
         ASSIGNMENT_TOKENS = {
           'bridge' => '/icons/1817/bridge_token.svg',
-          'oil' => '/icons/1817/mine_token.svg',
         }.freeze
 
         SEED_MONEY = 200
@@ -1201,7 +1200,7 @@ module Engine
             G1817::Step::CashCrisis,
             G18USA::Step::Loan,
             G18USA::Step::SpecialTrack,
-            G1817::Step::Assign,
+            G18USA::Step::Assign,
             G18USA::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -45,6 +45,61 @@ module Engine
           '597' => 'unlimited',
           '611' => 'unlimited',
           '619' => 'unlimited',
+          # Could make fun oil tiles like coal and iron but then we'd need to make 12 tiles (3y + 4grn + 3b + 2gry)
+          '7coal' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:1;label=⛏️',
+          },
+          '8coal' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:2;label=⛏️',
+          },
+          '9coal' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:3;label=⛏️',
+          },
+          '7iron1' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:1;label=⚒️',
+          },
+          '8iron1' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:2;label=⚒️',
+          },
+          '9iron1' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:3;label=⚒️',
+          },
+          '7iron2' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'green',
+            'code' => 'offboard=revenue:20,hide:1;path=a:0,b:1;label=⚒️',
+          },
+          '8iron2' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'green',
+            'code' => 'offboard=revenue:20,hide:1;path=a:0,b:2;label=⚒️',
+          },
+          '9iron2' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'green',
+            'code' => 'offboard=revenue:20,hide:1;path=a:0,b:3;label=⚒️',
+          },
           'X01' =>
           {
             'count' => 'unlimited',
@@ -108,7 +163,7 @@ module Engine
             'color' => 'brown',
             'code' => 'city=revenue:70,slots:4;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=NY',
           },
-          X17: {
+          'X17' => {
             'count' => 'unlimited',
             'color' => 'gray',
             'code' => 'junction;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;',
@@ -119,7 +174,7 @@ module Engine
             'code' => 'city=revenue:80,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;'\
                       'path=a:5,b:_0;label=DFW',
           },
-          X19: {
+          'X19' => {
             'count' => 1,
             'color' => 'gray',
             'code' => 'city=revenue:90,slots:4;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=LA',
@@ -354,7 +409,7 @@ module Engine
             value: 30,
             revenue: 0,
             desc: 'Comes with one coal mine marker. When placing a yellow '\
-                  'tile in a mountain hex next to a revenue location, can place '\
+                  'tile in a coal hex pointing to a revenue location, can place '\
                   'token to avoid $15 terrain fee.  Marked yellow hexes cannot be '\
                   'upgraded.  Hexes pay $10 extra revenue and do not count as a '\
                   'stop.  May not start or end a route at a coal mine.',
@@ -363,9 +418,12 @@ module Engine
               {
                 type: 'tile_lay',
                 hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
-                tiles: %w[7 8 9],
+                tiles: %w[7coal 8coal 9coal],
                 free: false,
                 when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
                 owner_type: 'corporation',
                 count: 1,
               },
@@ -393,9 +451,111 @@ module Engine
               {
                 type: 'assign_hexes',
                 hexes: %w[C10 C17 D14 E15 E17 F20 G17],
-                count: 2,
+                count: 1,
                 when: 'owning_corp_or_turn',
                 owner_type: 'corporation',
+              },
+            ],
+            color: nil,
+          },
+          # P3
+          {
+            name: 'Reece Oil and Gas',
+            value: 30,
+            revenue: 0,
+            desc: 'Comes with one oil marker. When placing a yellow '\
+                  'tile in an oilfield hex pointing to a revenue location, can place '\
+                  'token.  Marked yellow hexes *can* be '\
+                  'upgraded.  Hexes pay $10 extra revenue and do not count as a '\
+                  'stop.  Hexes revenue bonus is upgraded automatically to $20 in phase 5. '\
+                  'May not start or end a route at an oilfield.',
+            sym: 'P3',
+            abilities: [
+              {
+                type: 'tile_lay',
+                hexes: %w[B12 C7 C19 D16 E5 E9 G21 H6],
+                tiles: %w[7 8 9],
+                free: false,
+                when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
+                owner_type: 'corporation',
+                count: 1,
+              },
+            ],
+            color: nil,
+          },
+          # P4
+          {
+            name: 'Hendrickson Iron',
+            value: 40,
+            revenue: 0,
+            desc: 'Comes with one ore marker. When placing a yellow '\
+                  'tile in a mining hex pointing to a revenue location, can place '\
+                  'token to avoid $15 terrain fee.  Marked yellow hexes cannot be '\
+                  'upgraded.  Hexes pay $10 extra revenue and do not count as a '\
+                  'stop.  A tile lay action may be used to increase the revenue bonus to $20 in phase 3. '\
+                  '  May not start or end a route at an iron mine.',
+            sym: 'P4',
+            abilities: [
+              {
+                type: 'tile_lay',
+                hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
+                tiles: %w[7iron1 8iron1 9iron1],
+                free: false,
+                when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
+                owner_type: 'corporation',
+                count: 1,
+              },
+            ],
+            color: nil,
+          },
+          # P5
+          {
+            name: 'Nobel\'s Blasting Powder',
+            value: 30,
+            revenue: 0,
+            desc: '$15 discount on mountains. No money is refunded if combined with the ability of another private that also '\
+            'negates the cost of difficult terrain',
+            sym: 'P5',
+            abilities: [
+              {
+                type: 'tile_discount',
+                discount: 15,
+                terrain: 'mountain',
+                owner_type: 'corporation',
+              },
+            ],
+            color: nil,
+          },
+          # P12
+          {
+            name: 'Standard Oil Co.',
+            value: 60,
+            revenue: 0,
+            desc: 'Comes with two oil markers. When placing a yellow '\
+                  'tile in an oilfield hex pointing to a revenue location, can place '\
+                  'token.  Marked yellow hexes *can* be '\
+                  'upgraded.  Hexes pay $10 extra revenue and do not count as a '\
+                  'stop.  Hexes revenue bonus is upgraded automatically to $20 in phase 5. '\
+                  'May not start or end a route at an oilfield.',
+            sym: 'P12',
+            abilities: [
+              {
+                type: 'tile_lay',
+                hexes: %w[B12 C7 C19 D16 E5 E9 G21 H6],
+                tiles: %w[7oil 8oil 9oil],
+                free: false,
+                when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
+                owner_type: 'corporation',
+                count: 1,
               },
             ],
             color: nil,
@@ -425,9 +585,12 @@ module Engine
               {
                 type: 'tile_lay',
                 hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
-                tiles: %w[7 8 9],
+                tiles: %w[7coal 8coal 9coal],
                 free: false,
                 when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
                 owner_type: 'corporation',
                 count: 2,
               },
@@ -477,6 +640,34 @@ module Engine
             ],
             color: nil,
           },
+          # P24
+          {
+            name: 'Anaconda Copper',
+            value: 90,
+            revenue: 0,
+            desc: 'Comes with two ore markers. When placing a yellow '\
+                  'tile in a mining hex pointing to a revenue location, can place '\
+                  'token to avoid $15 terrain fee.  Marked yellow hexes cannot be '\
+                  'upgraded.  Hexes pay $10 extra revenue and do not count as a '\
+                  'stop.  A tile lay action may be used to increase the revenue bonus to $20 in phase 3. '\
+                  '  May not start or end a route at an iron mine.',
+            sym: 'P24',
+            abilities: [
+              {
+                type: 'tile_lay',
+                hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
+                tiles: %w[7iron1 8iron1 9iron1],
+                free: false,
+                when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
+                owner_type: 'corporation',
+                count: 1,
+              },
+            ],
+            color: nil,
+          },
           # P28
           {
             name: 'Consolidation Coal Co.',
@@ -492,9 +683,12 @@ module Engine
               {
                 type: 'tile_lay',
                 hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
-                tiles: %w[7 8 9],
+                tiles: %w[7coal 8coal 9coal],
                 free: false,
                 when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
                 owner_type: 'corporation',
                 count: 3,
               },
@@ -774,8 +968,11 @@ module Engine
 
         LAYOUT = :pointy
 
-        PITTSBURGH_PRIVATE_NAME = 'DTC'
-        PITTSBURGH_PRIVATE_HEX = 'F14'
+        ASSIGNMENT_TOKENS = {
+          'bridge' => '/icons/1817/bridge_token.svg',
+          'oil' => '/icons/1817/mine_token.svg',
+        }.freeze
+
 
         SEED_MONEY = 200
         # Alphabetized. Not sure what official ordering is
@@ -823,7 +1020,7 @@ module Engine
 
         def optional_hexes
           offboard = OFFBOARD_VALUES.sort_by { rand }
-          plain_hexes = %w[B20 B26 C5 C11 C13 C15 D2 D4 D12 D22 E13 E27 F2 F6 F12 F14 G9 G13 G19 G25 H10 H12 H16
+          plain_hexes = %w[B20 B26 C5 C11 C13 C15 D2 D4 D12 D22 E13 F2 F6 F12 F14 G9 G13 G19 G25 H10 H12 H16
                            H24 H26]
           {
             red: {
@@ -846,6 +1043,7 @@ module Engine
                          "|gray_#{offboard[2][3]},groups:Mexico,hide:1;path=a:3,b:_0;border=edge:2",
             },
             white: {
+              %w[E27] => 'stub=edge:3',
               %w[E11 G3 H14 I15 H20 H22 F26 C29 D24] => 'city=revenue:0',
               %w[D6 E3 E7 G7 G11 H8 I13 I25 G27 E23] => 'city=revenue:0;icon=image:18_ms/coins',
               %w[C17 E15 E17 F20 G17 I19] => 'city=revenue:0;upgrade=cost:10,terrain:water;icon=image:18_usa/bridge',
@@ -858,7 +1056,8 @@ module Engine
               %w[D16 E5 H6] => 'icon=image:18_usa/mine',
               %w[G15 H4 I17 I21 I23 J14] => 'icon=image:18_usa/oil-derrick',
               %w[E19 F16] => 'icon=image:18_usa/coalcar',
-              %w[C9 D8 D10 D26 E25 F8 F10 F22 F24] => 'upgrade=cost:15,terrain:mountain;icon=image:18_usa/coalcar',
+              %w[C9 D8 D10 E25 F8 F10 F22 F24] => 'upgrade=cost:15,terrain:mountain;icon=image:18_usa/coalcar',
+              %w[D26] => 'upgrade=cost:15,terrain:mountain;icon=image:18_usa/coalcar;stub=edge:4',
               %w[B16 B18] => 'icon=image:18_usa/gnr',
               ['C19'] => 'icon=image:18_usa/gnr;icon=image:18_usa/mine',
               ['B10'] => 'icon=image:18_usa/gnr;icon=image:18_usa/coalcar;icon=image:18_usa/mine',
@@ -886,6 +1085,7 @@ module Engine
               ['D28'] => 'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:1,b:_1;path=a:3,b:_0;label=NY',
             },
             blue: {
+              ['F28'] => 'offboard=revenue:yellow_0,visit_cost:99;path=a:0,b:_0',
               %w[B24 C21] => '',
             },
           }
@@ -918,15 +1118,23 @@ module Engine
             G1817::Step::Bankrupt,
             G1817::Step::CashCrisis,
             G18USA::Step::Loan,
-            G1817::Step::SpecialTrack,
+            G18USA::Step::SpecialTrack,
             G1817::Step::Assign,
-            G1817::Step::Track,
+            G18USA::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,
             G18USA::Step::Dividend,
             Engine::Step::DiscardTrain,
             G1817::Step::BuyTrain,
           ], round_num: round_num)
+        end
+
+        def little_oil
+          @little_oil ||= company_by_id('P3')
+        end
+
+        def big_oil
+          @little_oil ||= company_by_id('P12qq')
         end
       end
     end

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -45,7 +45,6 @@ module Engine
           '597' => 'unlimited',
           '611' => 'unlimited',
           '619' => 'unlimited',
-          # Could make fun oil tiles like coal and iron but then we'd need to make 12 tiles (3y + 4grn + 3b + 2gry)
           '7coal' =>
           {
             'count' => 'unlimited',
@@ -64,41 +63,115 @@ module Engine
             'color' => 'yellow',
             'code' => 'offboard=revenue:10,hide:1;path=a:0,b:3;label=⛏️',
           },
-          '7iron1' =>
+          '7iron10' =>
           {
             'count' => 'unlimited',
             'color' => 'yellow',
-            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:1;label=⚒️',
+            'code' => 'offboard=revenue:10,hide:1;path=a:0,b:1;path=a:_0,b:_0;label=⚒️',
           },
-          '8iron1' =>
+          '8iron10' =>
           {
             'count' => 'unlimited',
             'color' => 'yellow',
             'code' => 'offboard=revenue:10,hide:1;path=a:0,b:2;label=⚒️',
           },
-          '9iron1' =>
+          '9iron10' =>
           {
             'count' => 'unlimited',
             'color' => 'yellow',
             'code' => 'offboard=revenue:10,hide:1;path=a:0,b:3;label=⚒️',
           },
-          '7iron2' =>
+          '7iron20' =>
           {
             'count' => 'unlimited',
             'color' => 'green',
             'code' => 'offboard=revenue:20,hide:1;path=a:0,b:1;label=⚒️',
           },
-          '8iron2' =>
+          '8iron20' =>
           {
             'count' => 'unlimited',
             'color' => 'green',
             'code' => 'offboard=revenue:20,hide:1;path=a:0,b:2;label=⚒️',
           },
-          '9iron2' =>
+          '9iron20' =>
           {
             'count' => 'unlimited',
             'color' => 'green',
             'code' => 'offboard=revenue:20,hide:1;path=a:0,b:3;label=⚒️',
+          },
+          '7oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:yellow_10|brown_20,hide:1;path=a:0,b:1;label=🛢️',
+          },
+          '8oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:yellow_10|brown_20,hide:1;path=a:0,b:2;label=🛢️',
+          },
+          '9oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'yellow',
+            'code' => 'offboard=revenue:yellow_10|brown_20,hide:1;path=a:0,b:3;label=🛢️',
+          },
+          '544oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'brown',
+            'code' => 'junction;offboard=revenue:20,hide:1;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=🛢️',
+          },
+          '545oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'brown',
+            'code' => 'junction;offboard=revenue:20,hide:1;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=🛢️',
+          },
+          '546oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'brown',
+            'code' => 'junction;offboard=revenue:20,hide:1;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=🛢️',
+          },
+          '80oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'green',
+            'code' => 'junction;offboard=revenue:yellow_10|brown_20,hide:1;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;label=🛢️',
+          },
+          '81oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'green',
+            'code' => 'junction;offboard=revenue:yellow_10|brown_20,hide:1;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=🛢️',
+          },
+          '82oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'green',
+            'code' => 'junction;offboard=revenue:yellow_10|brown_20,hide:1;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;label=🛢️',
+          },
+          '83oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'green',
+            'code' => 'junction;offboard=revenue:yellow_10|brown_20,hide:1;path=a:0,b:_0;path=a:5,b:_0;path=a:3,b:_0;label=🛢️',
+          },
+          '60oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'gray',
+            'code' => 'junction;offboard=revenue:20,hide:1;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=🛢️',
+          },
+          'X17oil' =>
+          {
+            'count' => 'unlimited',
+            'color' => 'gray',
+            'code' => 'junction;offboard=revenue:20,hide:1;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=🛢️',
           },
           'X01' =>
           {
@@ -473,8 +546,8 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B12 C7 C19 D16 E5 E9 G21 H6],
-                tiles: %w[7 8 9],
+                hexes: %w[B12 G15 H4 I17 I21 I23 J14],
+                tiles: %w[7oil 8oil 9oil],
                 free: false,
                 when: 'track',
                 discount: 15,
@@ -501,8 +574,8 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
-                tiles: %w[7iron1 8iron1 9iron1],
+                hexes: %w[B10 C7 C19 D16 E5 E9 G21 H6],
+                tiles: %w[7iron10 8iron10 9iron10],
                 free: false,
                 when: 'track',
                 discount: 15,
@@ -520,7 +593,7 @@ module Engine
             value: 30,
             revenue: 0,
             desc: '$15 discount on mountains. No money is refunded if combined with the ability of another private that also '\
-            'negates the cost of difficult terrain',
+                  'negates the cost of difficult terrain',
             sym: 'P5',
             abilities: [
               {
@@ -547,7 +620,7 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B12 C7 C19 D16 E5 E9 G21 H6],
+                hexes: %w[B12 G15 H4 I17 I21 I23 J14],
                 tiles: %w[7oil 8oil 9oil],
                 free: false,
                 when: 'track',
@@ -555,7 +628,7 @@ module Engine
                 consume_tile_lay: true,
                 closed_when_used_up: true,
                 owner_type: 'corporation',
-                count: 1,
+                count: 2,
               },
             ],
             color: nil,
@@ -655,8 +728,8 @@ module Engine
             abilities: [
               {
                 type: 'tile_lay',
-                hexes: %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24],
-                tiles: %w[7iron1 8iron1 9iron1],
+                hexes: %w[B10 C7 C19 D16 E5 E9 G21 H6],
+                tiles: %w[7iron10 8iron10 9iron10],
                 free: false,
                 when: 'track',
                 discount: 15,
@@ -973,7 +1046,6 @@ module Engine
           'oil' => '/icons/1817/mine_token.svg',
         }.freeze
 
-
         SEED_MONEY = 200
         # Alphabetized. Not sure what official ordering is
 
@@ -1127,14 +1199,6 @@ module Engine
             Engine::Step::DiscardTrain,
             G1817::Step::BuyTrain,
           ], round_num: round_num)
-        end
-
-        def little_oil
-          @little_oil ||= company_by_id('P3')
-        end
-
-        def big_oil
-          @little_oil ||= company_by_id('P12qq')
         end
       end
     end

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -485,6 +485,10 @@ module Engine
                     events: [{ 'type' => 'signal_end_game' }],
                   }].freeze
 
+        OIL_HEXES = %w[B12 G15 H4 I17 I21 I23 J14].freeze
+        IRON_HEXES = %w[B10 C7 C19 D16 E5 E9 G21 H6].freeze
+        COAL_HEXES = %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24].freeze
+        BRIDGE_CITY_HEXES = %w[C10 C17 D14 E15 E17 F20 G17].freeze
         COMPANIES = [
           # P1
           {
@@ -676,6 +680,47 @@ module Engine
                 closed_when_used_up: true,
                 owner_type: 'corporation',
                 count: 2,
+              },
+            ],
+            color: nil,
+          },
+          # P21
+          # TODO: Make it work as a combo with P27
+          {
+            name: 'Keystone Bridge Co.',
+            value: 80,
+            revenue: 0,
+            desc: 'Comes with one $10 bridge token that may be placed by the owning '\
+                  'corp in a city with $10 water cost, max one token '\
+                  'per city, regardless of connectivity.  Allows owning corp to '\
+                  'skip $10 river fee when placing track. '\
+                  'Also comes with one coal token and one ore token. (see rules on coal and ore) '\
+                  'You can only ever use one of these two; using one means you forfeit the other',
+            sym: 'P21',
+            abilities: [
+              {
+                type: 'tile_discount',
+                discount: 10,
+                terrain: 'water',
+                owner_type: 'corporation',
+              },
+              {
+                type: 'assign_hexes',
+                hexes: BRIDGE_CITY_HEXES,
+                count: 1,
+                when: 'owning_corp_or_turn',
+                owner_type: 'corporation',
+              },
+              {
+                type: 'tile_lay',
+                hexes: COAL_HEXES + IRON_HEXES,
+                tiles: %w[7coal 8coal 9coal 7iron10 8iron10 9iron10],
+                free: false,
+                when: 'track',
+                discount: 15,
+                consume_tile_lay: true,
+                owner_type: 'corporation',
+                count: 1,
               },
             ],
             color: nil,
@@ -1051,10 +1096,6 @@ module Engine
 
         LAYOUT = :pointy
 
-        OIL_HEXES = %w[B12 G15 H4 I17 I21 I23 J14].freeze
-        IRON_HEXES = %w[B10 C7 C19 D16 E5 E9 G21 H6].freeze
-        COAL_HEXES = %w[B6 B10 B12 C9 D8 D10 D26 E19 E25 F8 F10 F16 F22 F24].freeze
-        BRIDGE_CITY_HEXES = %w[C10 C17 D14 E15 E17 F20 G17].freeze
         ASSIGNMENT_TOKENS = {
           'bridge' => '/icons/1817/bridge_token.svg',
         }.freeze

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -521,8 +521,8 @@ module Engine
             revenue: 0,
             desc: 'Comes with one $10 bridge token that may be placed by the owning '\
                   'corp in a city with $10 water cost, max one token '\
-                  'per city, regardless of connectivity..  Allows owning corp to '\
-                  'skip $10 river fee when placing yellow tiles.',
+                  'per city, regardless of connectivity.  Allows owning corp to '\
+                  'skip $10 river fee when placing track.',
             sym: 'P2',
             abilities: [
               {
@@ -688,7 +688,7 @@ module Engine
             desc: 'Comes with two $10 bridge tokens that may be placed by the owning '\
                   'corp in a city with $10 water cost, max one token '\
                   'per city, regardless of connectivity..  Allows owning corp to '\
-                  'skip $10 river fee when placing yellow tiles.',
+                  'skip $10 river fee when placing track.',
             sym: 'P22',
             abilities: [
               {

--- a/lib/engine/game/g_18_usa/step/assign.rb
+++ b/lib/engine/game/g_18_usa/step/assign.rb
@@ -17,7 +17,7 @@ module Engine
             end
 
             case company.id
-            when 'P2', 'P22'
+            when 'P2', 'P22', 'P21'
               id = 'bridge'
               raise GameError, "Bridge already on #{target.name}" if target.assigned?(id)
 

--- a/lib/engine/game/g_18_usa/step/assign.rb
+++ b/lib/engine/game/g_18_usa/step/assign.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/assign'
+
+module Engine
+  module Game
+    module G18USA
+      module Step
+        class Assign < Engine::Step::Assign
+          def process_assign(action)
+            company = action.entity
+            target = action.target
+
+            unless (ability = @game.abilities(company, :assign_hexes))
+              raise GameError,
+                    "Could not assign #{company.name} to #{target.name}; :assign_hexes ability not found"
+            end
+
+            case company.id
+            when 'P2', 'P22'
+              id = 'bridge'
+              raise GameError, "Bridge already on #{target.name}" if target.assigned?(id)
+
+              target.assign!(id)
+              ability.use!
+              @log << "#{company.name} builds bridge on #{target.name}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_usa/step/dividend.rb
+++ b/lib/engine/game/g_18_usa/step/dividend.rb
@@ -22,7 +22,7 @@ module Engine
             times = 2 if revenue >= price * 1
             times = 3 if revenue >= price * 1.5
             times = 4 if revenue >= price * 2
-            if times.positive?
+            if times&.positive?
               { share_direction: :right, share_times: times }
             else
               {}

--- a/lib/engine/game/g_18_usa/step/special_track.rb
+++ b/lib/engine/game/g_18_usa/step/special_track.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/special_track'
+
+module Engine
+  module Game
+    module G18USA
+      module Step
+        class SpecialTrack < Engine::Step::SpecialTrack
+          def process_lay_tile(action)
+            return super unless [@game.little_oil.id, @game.big_oil.id].include?(action.entity.id)
+
+            tile = action.tile
+            owner = action.entity.owner
+
+            tile.hex.assign!('oil')
+            @game.log << "#{owner.name} adds oil to #{tile.hex.name}"
+          end
+
+          def hex_neighbors(entity, hex)
+            # See 1817 and reinsert pittsburgh check for handling metros
+
+            hexes = abilities(entity)&.hexes
+            return if hexes&.any? && !hexes&.include?(hex.id)
+
+            # When actually laying track entity will be the corp.
+            owner = entity.corporation? ? entity : entity.owner
+
+            @game.graph.connected_hexes(owner)[hex]
+          end
+
+          def potential_future_tiles(_entity, hex)
+            @game.tiles
+              .uniq(&:name)
+              .select { |t| @game.upgrades_to?(hex.tile, t) }
+          end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            # See 1817 and reinsert pittsburgh check for handling metros
+            super &&
+            tile.exits.any? do |exit|
+              neighbor = hex.neighbors[exit]
+              ntile = neighbor&.tile
+              next false unless ntile
+
+              # The neighbouring tile must have a city or offboard or town
+              # That neighbouring tile must either connect to an edge on the tile or
+              # potentially be updated in future.
+              # 1817 doesn't have any coal next to towns but 1817NA does and
+              #  Marc Voyer confirmed that coal should be able to connect to the gray pre-printed town
+              (ntile.cities&.any? || ntile.offboards&.any? || ntile.towns&.any?) &&
+              (ntile.exits.any? { |e| e == Hex.invert(exit) } || potential_future_tiles(entity, neighbor).any?)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_usa/step/special_track.rb
+++ b/lib/engine/game/g_18_usa/step/special_track.rb
@@ -31,7 +31,10 @@ module Engine
           end
 
           def legal_tile_rotation?(entity, hex, tile)
-            puts 'ltr?', tile.labels
+            # These are needed for the combo private (Keystone Bridge Co)
+            return false if tile.id.include?('iron') && !@game.class::IRON_HEXES.include?(hex.id)
+            return false if tile.id.include?('coal') && !@game.class::COAL_HEXES.include?(hex.id)
+
             # See 1817 and reinsert pittsburgh check for handling metros
             super &&
             tile.exits.any? do |exit|

--- a/lib/engine/game/g_18_usa/step/track.rb
+++ b/lib/engine/game/g_18_usa/step/track.rb
@@ -12,30 +12,7 @@ module Engine
           include Engine::Step::UpgradeTrackMaxExits
 
           def check_track_restrictions!(entity, old_tile, new_tile)
-            return if @game.loading || !entity.operator?
-
-            graph = @game.graph_for_entity(entity)
-
-            raise GameError, 'New track must override old one' if !@game.class::ALLOW_REMOVING_TOWNS &&
-                old_tile.city_towns.any? do |old_city|
-                  new_tile.city_towns.none? { |new_city| (old_city.exits - new_city.exits).empty? }
-                end
-
-            old_paths = old_tile.paths
-            changed_city = false
-            used_new_track = old_paths.empty?
-
-            new_tile.paths.each do |np|
-              next unless graph.connected_paths(entity)[np]
-
-              op = old_paths.find { |path| np <= path }
-              used_new_track = true unless op
-              old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
-              new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
-              changed_city = true unless old_revenues == new_revenues
-            end
-            return if used_new_track || changed_city || new_tile.id.include?('iron')
-            raise GameError, 'Must use new track or change city value' if !used_new_track && !changed_city
+            old_tile.name.include?('iron') && new_tile.name.include?('iron') ? true : super
           end
         end
       end

--- a/lib/engine/game/g_18_usa/step/track.rb
+++ b/lib/engine/game/g_18_usa/step/track.rb
@@ -10,6 +10,33 @@ module Engine
       module Step
         class Track < Engine::Step::Track
           include Engine::Step::UpgradeTrackMaxExits
+
+          def check_track_restrictions!(entity, old_tile, new_tile)
+            return if @game.loading || !entity.operator?
+
+            graph = @game.graph_for_entity(entity)
+
+            raise GameError, 'New track must override old one' if !@game.class::ALLOW_REMOVING_TOWNS &&
+                old_tile.city_towns.any? do |old_city|
+                  new_tile.city_towns.none? { |new_city| (old_city.exits - new_city.exits).empty? }
+                end
+
+            old_paths = old_tile.paths
+            changed_city = false
+            used_new_track = old_paths.empty?
+
+            new_tile.paths.each do |np|
+              next unless graph.connected_paths(entity)[np]
+
+              op = old_paths.find { |path| np <= path }
+              used_new_track = true unless op
+              old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
+              new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
+              changed_city = true unless old_revenues == new_revenues
+            end
+            return if used_new_track || changed_city || new_tile.id.include?('iron')
+            raise GameError, 'Must use new track or change city value' if !used_new_track && !changed_city
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_usa/step/track.rb
+++ b/lib/engine/game/g_18_usa/step/track.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/tracker'
+require_relative '../../../step/track'
+require_relative '../../../step/upgrade_track_max_exits'
+
+module Engine
+  module Game
+    module G18USA
+      module Step
+        class Track < Engine::Step::Track
+          include Engine::Step::UpgradeTrackMaxExits
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This batch is the bridge, oil, coal, and iron privates in 18USA

I made some special tiles for coal, oil, and iron in the game because the `tile_lay` ability was more natural to work with than `assign` when dealing with how the iron token "can be flipped with a tile upgrade action" in green phase and tiles with oil tokens can be upgraded and automatically update their revenue. 

![image](https://user-images.githubusercontent.com/2993555/126023005-af94bdba-af02-4b53-a905-eb9b2174c1a8.png)
![image](https://user-images.githubusercontent.com/2993555/126023034-45faf397-9cd5-4e39-8c96-14b4464f5483.png)
