### PR TITLE
18ka tile locks

### DIFF
--- a/lib/engine/game/g_18_ka/game.rb
+++ b/lib/engine/game/g_18_ka/game.rb
@@ -446,6 +446,7 @@ module Engine
                   { name: '+4', distance: 0, price: 100, available_on: '6', num: 2 },
                   { name: '+5', distance: 0, price: 125, available_on: '8', num: 1 }].freeze
 
+        EQUATOR_HEXES = %w[C16 G16 I16].freeze
         COMPANIES = [
           {
             name: 'Platinum Credit Card',
@@ -469,7 +470,27 @@ module Engine
             desc: 'The owning corporation may place the Farm (F) tile on an equitorial hex as a bonus disconnected '\
                   'tile lay. In exchange for closing this private the corporation may token it for free',
             sym: 'C',
-            abilities: [],
+            abilities: [
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                free: false,
+                hexes: EQUATOR_HEXES,
+                tiles: %w[FARM1],
+                when: 'track',
+                count: 1,
+              },
+              {
+                type: 'token',
+                description: 'Token in the Farm tile for free',
+                hexes: EQUATOR_HEXES,
+                count: 1,
+                price: 0,
+                teleport_price: 0,
+                extra_action: true,
+                from_owner: true,
+              },
+            ],
           },
           {
             name: 'Bob\'s Better Bridges',
@@ -503,7 +524,27 @@ module Engine
             desc: 'The owning corporation may place the Capitol (C) tile on an equitorial hex as a bonus disconnected '\
                   'tile lay. In exchange for closing this private the corporation may token it for free',
             sym: 'G',
-            abilities: [],
+            abilities: [
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                free: false,
+                hexes: EQUATOR_HEXES,
+                tiles: %w[CAP1],
+                when: 'track',
+                count: 1,
+              },
+              {
+                type: 'token',
+                description: 'Token in the Captiol tile for free',
+                hexes: EQUATOR_HEXES,
+                count: 1,
+                price: 0,
+                teleport_price: 0,
+                extra_action: true,
+                from_owner: true,
+              },
+            ],
           },
           {
             name: 'Mole People',
@@ -521,7 +562,27 @@ module Engine
             desc: 'The owning corporation may place the Space Elevator (SE) tile on an equitorial hex as a bonus '\
                   'disconnected tile lay. In exchange for closing this private the corporation may token it for free',
             sym: 'I',
-            abilities: [],
+            abilities: [
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                free: false,
+                hexes: EQUATOR_HEXES,
+                tiles: %w[SE1],
+                when: 'track',
+                count: 1,
+              },
+              {
+                type: 'token',
+                description: 'Token in the Space Elevator tile for free',
+                hexes: EQUATOR_HEXES,
+                count: 1,
+                price: 0,
+                teleport_price: 0,
+                extra_action: true,
+                from_owner: true,
+              },
+            ],
           },
           {
             name: 'Protoype Maglev',
@@ -558,7 +619,6 @@ module Engine
           'RdP' => '/icons/1846/sc_token.svg',
         }.freeze
         PORT_HEXES = %w[A9 B8 B10 D6 E5 E11 F4 F10 G7 H2 H4 H6 H10 I3 I9 J6 J8 K11].freeze
-        EQUATOR_HEXES = %w[C16 G16 I16].freeze
         CORPORATIONS = [
           # Tier 1
           {
@@ -1000,7 +1060,7 @@ module Engine
             G1856::Step::Assign,
             G1856::Step::Loan,
             G1856::Step::SpecialTrack,
-            G1856::Step::SpecialToken,
+            G18KA::Step::SpecialToken,
             Engine::Step::BuyCompany,
             Engine::Step::HomeToken,
 

--- a/lib/engine/game/g_18_ka/step/special_token.rb
+++ b/lib/engine/game/g_18_ka/step/special_token.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/special_token'
+
+module Engine
+  module Game
+    module G18KA
+      module Step
+        class SpecialToken < Engine::Step::SpecialToken
+          def actions(entity)
+            return [] if entity.company? && entity.owner.player?
+
+            super
+          end
+
+          def process_place_token(action)
+            company = action.entity
+            hex = action.city.hex
+            case company.sym
+            when 'C'
+              raise GameError, "Must use #{company.name} ability on farm tile" unless hex.tile.labels.first.to_s == 'F'
+            when 'G'
+              raise GameError, "Must use #{company.name} ability on capitol tile" unless hex.tile.labels.first.to_s == 'C'
+            when 'I'
+              raise GameError, "Must use #{company.name} ability on space elevator tile" unless hex.tile.labels.first.to_s == 'SE'
+            end
+
+            super
+
+            # The farm / captiol / space elevator privates close immediately on token ability use
+            return unless %w[C G I].include?(company.sym)
+
+            @game.log << "#{company.name} closes"
+            company.close!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
May as well put in some work on 18KA
This implements the 3 tile locking privates. 9 more to go.
It doesn't implement the rule that 
```
If this private is closed in Phase 5 while owned by a player, the player immediately places the tile in
one of the Equatorial hexes. If multiple Equatorial privates are in player’s hands when they are closed
at the start of phase 5, this is resolved in clockwise order starting with the player that bought the 5 train
```
for each of the tile locking privates, but that's a stupid rule (the game setup is to randomly remove some of the privates at the start..) so I'll have to update the rules instead