### PR TITLE
[1840] fix dit values on F8,F10

### DIFF
--- a/lib/engine/game/g_1840/map.rb
+++ b/lib/engine/game/g_1840/map.rb
@@ -299,9 +299,9 @@ module Engine
             %w[H30 C29] => 'town=revenue:10;path=a:1,b:_0;path=a:2,b:_0',
             ['F30'] => 'town=revenue:10;path=a:0,b:_0;path=a:1,b:_0',
             ['D28'] => 'town=revenue:20;path=a:0,b:_0;path=a:1,b:_0',
-            ['F8'] => 'town=revenue:20;path=a:0,b:_0;path=a:1,b:_0;town=revenue:20;path=a:2,b:_1;path=a:3,b:_1' \
+            ['F8'] => 'town=revenue:10;path=a:0,b:_0;path=a:1,b:_0;town=revenue:10;path=a:2,b:_1;path=a:3,b:_1' \
                       'border=edge:4',
-            ['F10'] => 'town=revenue:20;path=a:4,b:_0;path=a:5,b:_0;town=revenue:20;path=a:2,b:_1;path=a:3,b:_1' \
+            ['F10'] => 'town=revenue:10;path=a:4,b:_0;path=a:5,b:_0;town=revenue:10;path=a:2,b:_1;path=a:3,b:_1' \
                        'border=edge:1',
             ['A19'] => 'town=revenue:30;path=a:1,b:_0,track:narrow;path=a:5,b:_0,track:narrow',
             ['C7'] => 'city=revenue:30,slots:2;path=a:0,b:_0,track:narrow;path=a:4,b:_0,track:narrow;' \


### PR DESCRIPTION
I presume F8 and F10 need updated, instead of F7/F9 as noted in the issue (the latter are not on the map)

closes #6059 

![image](https://user-images.githubusercontent.com/1711810/126374801-b1df5e21-5794-4d87-a99f-97e7a02a30cf.png)
