### PR TITLE
[18Rhl] Three minor fixes

### DIFF
--- a/lib/engine/game/g_18_rhl/step/dividend.rb
+++ b/lib/engine/game/g_18_rhl/step/dividend.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+
+module Engine
+  module Game
+    module G18Rhl
+      module Step
+        class Dividend < Engine::Step::Dividend
+          def share_price_change(entity, revenue = 0)
+            return { share_direction: :left, share_times: 1 } unless revenue.positive?
+
+            if revenue >= entity.share_price.price
+              { share_direction: :right, share_times: 1 }
+            else
+              {}
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Avoid repeated home location tokening for CCE
2. Disallows 8 train routes if not RGE terminus or use non-RGE offboard
3. Requires at least price revenue for increase stock price