### PR TITLE
18VA: Don't scrap trains on bankruptcy

### DIFF
--- a/lib/engine/game/g_18_va/game.rb
+++ b/lib/engine/game/g_18_va/game.rb
@@ -553,6 +553,7 @@ module Engine
         SELL_AFTER = :operate
         EBUY_OTHER_VALUE = true
         EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = true
+        CLOSED_CORP_TRAINS_REMOVED = false
         ONLY_HIGHEST_BID_COMMITTED = true
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
         CERT_LIMIT_COUNTS_BANKRUPTED = true

--- a/lib/engine/game/g_18_va/step/bankrupt.rb
+++ b/lib/engine/game/g_18_va/step/bankrupt.rb
@@ -65,6 +65,7 @@ module Engine
 
             corps_to_close.keys.each { |c| @game.close_corporation(c) }
 
+            player.spend(player.cash, @game.bank) if player.cash.positive?
             @game.declare_bankrupt(player)
           end
         end


### PR DESCRIPTION
Fixes #6062 

Also fixes a bankrupt player holding onto cash if they didn't have a corporation to hand off to another player