### PR TITLE
1836jr56 uses 1856 SR rules

### DIFF
--- a/lib/engine/game/g_1836_jr56/game.rb
+++ b/lib/engine/game/g_1836_jr56/game.rb
@@ -540,6 +540,15 @@ module Engine
           national.add_ability(self.class::NATIONAL_FORCED_WITHHOLD_ABILITY)
         end
 
+        def stock_round
+          G1856::Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            G1856::Step::BuySellParShares,
+          ])
+        end
+
         def operating_round(round_num)
           G1856::Round::Operating.new(self, [
             G1856::Step::Bankrupt,


### PR DESCRIPTION
I noticed this while working on autoactions in 1856. This will require pinning some games most likely? It's also possible that nobody's really playing 1836jr56