### PR TITLE
Added module for M+N display of route length for games with friendly dits

### DIFF
--- a/lib/engine/game/cities_plus_towns_route_distance_str.rb
+++ b/lib/engine/game/cities_plus_towns_route_distance_str.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#
+# This module replaces the default route string of "total distance as an integer" with
+# one of the format M+N where N is the number of towns and M is everything else
+#
+module CitiesPlusTownsRouteDistanceStr
+  def route_distance_str(route)
+    towns = route.visited_stops.count(&:town?)
+    cities = route_distance(route) - towns
+    towns.positive? ? "#{cities}+#{towns}" : cities.to_s
+  end
+end

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -5,12 +5,14 @@ require_relative '../base'
 require_relative 'stock_market'
 require_relative 'system'
 require_relative 'shell'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G1828
       class Game < Game::Base
         include_meta(G1828::Meta)
+        include CitiesPlusTownsRouteDistanceStr
 
         register_colors(hanBlue: '#446CCF',
                         steelBlue: '#4682B4',

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -7,12 +7,14 @@ require_relative '../base'
 require_relative '../company_price_up_to_face'
 require_relative '../interest_on_loans'
 require_relative '../stubs_are_restricted'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G1867
       class Game < Game::Base
         include_meta(G1867::Meta)
+        include CitiesPlusTownsRouteDistanceStr
 
         register_colors(black: '#16190e',
                         blue: '#0189d1',

--- a/lib/engine/game/g_18_al/game.rb
+++ b/lib/engine/game/g_18_al/game.rb
@@ -3,11 +3,13 @@
 require_relative 'meta'
 require_relative '../base'
 require_relative '../company_price_50_to_150_percent'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G18AL
       class Game < Game::Base
+        include CitiesPlusTownsRouteDistanceStr
         include_meta(G18AL::Meta)
 
         CURRENCY_FORMAT_STR = '$%d'

--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -5,12 +5,14 @@ require_relative 'share_pool'
 require_relative 'stock_market'
 require_relative '../base'
 require_relative '../company_price_50_to_150_percent'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G18CO
       class Game < Game::Base
         include_meta(G18CO::Meta)
+        include CitiesPlusTownsRouteDistanceStr
 
         attr_accessor :presidents_choice
 

--- a/lib/engine/game/g_18_fl/game.rb
+++ b/lib/engine/game/g_18_fl/game.rb
@@ -3,12 +3,14 @@
 require_relative 'meta'
 require_relative '../base'
 require_relative 'round/operating'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G18FL
       class Game < Game::Base
         include_meta(G18FL::Meta)
+        include CitiesPlusTownsRouteDistanceStr
 
         register_colors(black: '#37383a',
                         orange: '#f48221',

--- a/lib/engine/game/g_18_ga/game.rb
+++ b/lib/engine/game/g_18_ga/game.rb
@@ -3,12 +3,14 @@
 require_relative 'meta'
 require_relative '../base'
 require_relative '../company_price_50_to_150_percent'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G18GA
       class Game < Game::Base
         include_meta(G18GA::Meta)
+        include CitiesPlusTownsRouteDistanceStr
 
         CURRENCY_FORMAT_STR = '$%d'
 

--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -2,12 +2,14 @@
 
 require_relative 'meta'
 require_relative '../base'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G18Mag
       class Game < Game::Base
         include_meta(G18Mag::Meta)
+        include CitiesPlusTownsRouteDistanceStr
 
         attr_reader :tile_groups, :unused_tiles, :sik, :skev, :ldsteg, :mavag, :raba, :snw, :gc, :terrain_tokens
 

--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -4,11 +4,13 @@ require_relative 'meta'
 require_relative 'share_pool'
 require_relative '../base'
 require_relative '../company_price_50_to_150_percent'
+require_relative '../cities_plus_towns_route_distance_str'
 module Engine
   module Game
     module G18MEX
       class Game < Game::Base
         include_meta(G18MEX::Meta)
+        include CitiesPlusTownsRouteDistanceStr
 
         attr_reader :merged_major
 

--- a/lib/engine/game/g_18_ms/game.rb
+++ b/lib/engine/game/g_18_ms/game.rb
@@ -5,12 +5,14 @@ require_relative 'map'
 require_relative 'meta'
 require_relative '../base'
 require_relative '../company_price_50_to_150_percent'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G18MS
       class Game < Game::Base
         include_meta(G18MS::Meta)
+        include CitiesPlusTownsRouteDistanceStr
         include Entities
         include Map
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2993555/126675868-387f917e-de01-4c84-b69b-4cfdbe68bdf1.png)
![image](https://user-images.githubusercontent.com/2993555/126675893-f5c0a929-6086-45f7-a37e-1ff4a42a5c2f.png)
![image](https://user-images.githubusercontent.com/2993555/126675929-f6c3a223-c7b0-48e0-8957-0a7b69bb5a79.png)
![image](https://user-images.githubusercontent.com/2993555/126675947-47cd9d55-55e4-4180-ad1f-9f353fefd64e.png)
Omits the "+N" if there are no towns
![image](https://user-images.githubusercontent.com/2993555/126676003-788d64ae-4123-431e-9385-2c4ac2b196e9.png)
Fixes #2170 