### PR TITLE
Allow for colored borders; use it in 1836jr to make impassable borders blue

### DIFF
--- a/assets/app/view/game/part/borders.rb
+++ b/assets/app/view/game/part/borders.rb
@@ -54,6 +54,8 @@ module View
         }.freeze
 
         def color(border)
+          return setting_for(border.color) if border.color
+
           color =
             case border.type
             when :mountain
@@ -65,6 +67,10 @@ module View
             end
 
           setting_for(color)
+        end
+
+        def border_width(border)
+          border.type == :impassable ? '10' : '8'
         end
 
         def render_cost(border)
@@ -107,7 +113,7 @@ module View
             children << h(:line, attrs: {
                             **EDGES[border.edge],
                             stroke: color(border),
-                            'stroke-width': '8',
+                            'stroke-width': border_width(border),
                           })
             children << render_cost(border) if border.cost
           end

--- a/lib/engine/game/g_1836_jr30/game.rb
+++ b/lib/engine/game/g_1836_jr30/game.rb
@@ -393,16 +393,17 @@ module Engine
           gray: { ['A9'] => 'city=revenue:10;path=a:0,b:_0;path=a:_0,b:5' },
           white: {
             %w[A11 B12 C11 D12 E9 H8 I5 I7 K5 J4] => 'blank',
-            ['C7'] => 'border=edge:4,type:impassable',
-            ['C9'] => 'border=edge:1,type:impassable',
-            ['G3'] => 'border=edge:3,type:impassable',
-            ['G5'] => 'border=edge:2,type:impassable;border=edge:3,type:impassable',
+            ['C7'] => 'border=edge:4,type:impassable,color:blue',
+            ['C9'] => 'border=edge:1,type:impassable,color:blue',
+            ['G3'] => 'border=edge:3,type:impassable,color:blue',
+            ['G5'] => 'border=edge:2,type:impassable,color:blue;border=edge:3,type:impassable,color:blue',
             ['B8'] => 'town=revenue:0;town=revenue:0;upgrade=cost:80,terrain:water',
             %w[B10 E7 G7 H4 J6] => 'city=revenue:0',
             %w[D8 D10 F8 G9 G11] => 'upgrade=cost:40,terrain:water',
             ['F4'] =>
-            'town=revenue:0;upgrade=cost:40,terrain:water;border=edge:0,type:impassable;border=edge:5,type:impassable',
-            ['F6'] => 'upgrade=cost:80,terrain:water;border=edge:0,type:impassable',
+            'town=revenue:0;upgrade=cost:40,terrain:water;'\
+            'border=edge:0,type:impassable,color:blue;border=edge:5,type:impassable,color:blue',
+            ['F6'] => 'upgrade=cost:80,terrain:water;border=edge:0,type:impassable,color:blue',
             %w[F10 H2] => 'town=revenue:0',
             %w[I11 J10 J12 K7 K9] => 'upgrade=cost:60,terrain:mountain',
             ['I9'] => 'city=revenue:0;upgrade=cost:40,terrain:water',

--- a/lib/engine/game/g_1836_jr56/game.rb
+++ b/lib/engine/game/g_1836_jr56/game.rb
@@ -418,16 +418,17 @@ module Engine
           gray: { ['A9'] => 'city=revenue:10;path=a:0,b:_0;path=a:_0,b:5' },
           white: {
             %w[A11 B12 C11 D12 E9 H8 I5 I7 K5 J4] => 'blank',
-            ['C7'] => 'border=edge:4,type:impassable',
-            ['C9'] => 'border=edge:1,type:impassable',
-            ['G3'] => 'border=edge:3,type:impassable',
-            ['G5'] => 'border=edge:2,type:impassable;border=edge:3,type:impassable',
+            ['C7'] => 'border=edge:4,type:impassable,color:blue',
+            ['C9'] => 'border=edge:1,type:impassable,color:blue',
+            ['G3'] => 'border=edge:3,type:impassable,color:blue',
+            ['G5'] => 'border=edge:2,type:impassable,color:blue;border=edge:3,type:impassable,color:blue',
             ['B8'] => 'town=revenue:0;town=revenue:0;upgrade=cost:80,terrain:water',
             %w[B10 E7 G7 H4 J6] => 'city=revenue:0',
             %w[D8 D10 F8 G9 G11] => 'upgrade=cost:40,terrain:water',
             ['F4'] =>
-            'town=revenue:0;upgrade=cost:40,terrain:water;border=edge:0,type:impassable;border=edge:5,type:impassable',
-            ['F6'] => 'upgrade=cost:80,terrain:water;border=edge:0,type:impassable',
+            'town=revenue:0;upgrade=cost:40,terrain:water;'\
+            'border=edge:0,type:impassable,color:blue;border=edge:5,type:impassable,color:blue',
+            ['F6'] => 'upgrade=cost:80,terrain:water;border=edge:0,type:impassable,color:blue',
             %w[F10 H2] => 'town=revenue:0',
             %w[I11 J10 J12 K7 K9] => 'upgrade=cost:60,terrain:mountain',
             ['I9'] => 'city=revenue:0;upgrade=cost:40,terrain:water',
@@ -435,9 +436,9 @@ module Engine
             ['K11'] => 'town=revenue:0;town=revenue:0;upgrade=cost:60,terrain:mountain',
           },
           red: {
-            ['A13'] => 'offboard=revenue:yellow_40|brown_70;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1',
-            %w[E13 H12] => 'offboard=revenue:yellow_30|brown_50;path=a:1,b:_0,terminal:1',
-            ['K13'] => 'offboard=revenue:yellow_40|brown_70;path=a:1,b:_0,terminal:1;path=a:2,b:_0,terminal:1',
+            ['A13'] => 'offboard=revenue:yellow_40|brown_70;path=a:0,b:_0;path=a:1,b:_0',
+            %w[E13 H12] => 'offboard=revenue:yellow_30|brown_50;path=a:1,b:_0',
+            ['K13'] => 'offboard=revenue:yellow_40|brown_70;path=a:1,b:_0;path=a:2,b:_0',
           },
           yellow: {
             ['D6'] =>

--- a/lib/engine/part/border.rb
+++ b/lib/engine/part/border.rb
@@ -5,12 +5,13 @@ require_relative 'base'
 module Engine
   module Part
     class Border < Base
-      attr_reader :edge, :cost, :type
+      attr_reader :edge, :cost, :type, :color
 
-      def initialize(edge, type = nil, cost = nil)
+      def initialize(edge, type = nil, cost = nil, color = nil)
         @edge = edge.to_i
         @type = type&.to_sym
         @cost = cost&.to_i
+        @color = color&.to_sym
       end
 
       def border?

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -137,7 +137,7 @@ module Engine
       when 'upgrade'
         Part::Upgrade.new(params['cost'], params['terrain']&.split('|'), params['size'])
       when 'border'
-        Part::Border.new(params['edge'], params['type'], params['cost'])
+        Part::Border.new(params['edge'], params['type'], params['cost'], params['color'])
       when 'junction'
         junction = Part::Junction.new
         cache << junction

--- a/spec/lib/engine/games/config_spec.rb
+++ b/spec/lib/engine/games/config_spec.rb
@@ -40,6 +40,9 @@ module Engine
             expect(border.type).to eq(other_border.type),
                                    "Border types mismatch from:#{hex.name}:#{border.edge}"\
                                    " other:#{other_hex.name}:#{Hex.invert(border.edge)}"
+            expect(border.color).to eq(other_border.color),
+                                    "Border colors mismatch from:#{hex.name}:#{border.edge}"\
+                                    " other:#{other_hex.name}:#{Hex.invert(border.edge)}"
             expect(border.cost).to eq(other_border.cost),
                                    "Border costs mismatch from:#{hex.name}:#{border.edge}"\
                                    " other:#{other_hex.name}:#{Hex.invert(border.edge)}"


### PR DESCRIPTION
I also made impassable borders slightly thicker to make them look different from passable borders. We may want to emphasize the difference a little more in a future PR

Fixes #3269 
(I think I have different colors set up on my local v 18xx.games hence the difference in shades of blue)
before
![image](https://user-images.githubusercontent.com/2993555/126714220-cbd59609-4234-480e-8a57-32995c816cf6.png)

after
![image](https://user-images.githubusercontent.com/2993555/126714187-465e0f11-6717-47d6-8d54-8fb0da38fbba.png)
