### PR TITLE
Allow rendering of striped tiles by adding a Stripes part

### DIFF
--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -10,6 +10,12 @@ module Lib
     Y_T = -87
     Y_B = 87
 
+    # 3 stripes, the outer stripes *must* overlap the corner of the hex
+    # so 3 x STRIPE_WIDTH < X_M_R < 5 x STRIPE_WIDTH < X_R
+
+    # 10 < STRIPE_WIDTH < 16.67
+    STRIPE_WIDTH = 16
+
     POINTS = "#{X_R},#{Y_M} #{X_M_R},#{Y_B} #{X_M_L},#{Y_B} #{X_L},#{Y_M} #{X_M_L},#{Y_T} #{X_M_R},#{Y_T}"
 
     EDGE_PATHS = [
@@ -20,6 +26,32 @@ module Lib
       "M #{X_M_R},#{Y_T} L #{X_R},#{Y_M}",
       "M #{X_R},#{Y_M} L #{X_M_R}, #{Y_B}",
     ].freeze
+
+    INTERSECT = Y_T + ((5 * STRIPE_WIDTH - X_M_R).to_f * Y_T.to_f / (X_M_R - X_R).to_f).to_i
+    # 3 lists of points
+    STRIPE_POINTS = [
+      [[-1 * STRIPE_WIDTH, Y_T], [STRIPE_WIDTH, Y_T], [STRIPE_WIDTH, -1 * Y_T], [-1 * STRIPE_WIDTH, -1 * Y_T]],
+      [
+        [3 * STRIPE_WIDTH, Y_T],
+        [X_M_R, Y_T],
+        [5 * STRIPE_WIDTH, INTERSECT],
+        [5 * STRIPE_WIDTH, -1 * INTERSECT],
+        [X_M_R, -1 * Y_T],
+        [3 * STRIPE_WIDTH, -1 * Y_T],
+      ],
+      [
+        [-3 * STRIPE_WIDTH, Y_T],
+        [-1 * X_M_R, Y_T],
+        [-5 * STRIPE_WIDTH, INTERSECT],
+        [-5 * STRIPE_WIDTH, -1 * INTERSECT],
+        [-1 * X_M_R, -1 * Y_T],
+        [-3 * STRIPE_WIDTH, -1 * Y_T],
+      ],
+    ].freeze
+
+    def self.stripe_points
+      STRIPE_POINTS.map { |points| points.map { |point| point.join(',') }.join(' ') }
+    end
 
     COLOR = {
       white: '#EAE0C8',

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -78,6 +78,16 @@ module View
         end
         children << hex_highlight if @highlight
 
+        if (color = @tile&.stripes&.color)
+          Lib::Hex.stripe_points.each do |stripe|
+            attrs = {
+              fill: Lib::Hex::COLOR[color],
+              points: stripe,
+            }
+            children << h(:polygon, attrs: attrs)
+          end
+        end
+
         if @tile
           children << h(
             Tile,

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -105,6 +105,10 @@ module Engine
         false
       end
 
+      def stripes?
+        false
+      end
+
       def partition?
         false
       end

--- a/lib/engine/part/stripes.rb
+++ b/lib/engine/part/stripes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Part
+    class Stripes < Base
+      attr_reader :color
+
+      def initialize(color)
+        @color = color
+      end
+
+      def stripes?
+        true
+      end
+    end
+  end
+end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -18,7 +18,7 @@ module Engine
                   :name, :opposite, :reservations, :upgrades, :color
     attr_reader :borders, :cities, :edges, :junction, :nodes, :labels,
                 :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
-                :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :hidden
+                :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :stripes, :hidden
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -29,8 +29,22 @@ module Engine
         color = :yellow
       elsif (code = GREEN[name])
         color = :green
+      elsif (code = GREENBROWN[name])
+        color = :green
+        code = if code.size.positive?
+                 'stripes=color:brown;' + code
+               else
+                 'stripes=color:brown'
+               end
       elsif (code = BROWN[name])
         color = :brown
+      elsif (code = BROWNGRAY[name])
+        color = :brown
+        code = if code.size.positive?
+                 'stripes=color:gray;' + code
+               else
+                 'stripes=color:gray'
+               end
       elsif (code = GRAY[name])
         color = :gray
       elsif (code = RED[name])
@@ -151,6 +165,8 @@ module Engine
         Part::Partition.new(params['a'], params['b'], params['type'], params['restrict'])
       when 'frame'
         Part::Frame.new(params['color'], params['color2'])
+      when 'stripes'
+        Part::Stripes.new(params['color'])
       end
     end
 
@@ -184,6 +200,7 @@ module Engine
       @stops = nil
       @edges = nil
       @frame = nil
+      @stripes = nil
       @junction = nil
       @icons = []
       @location_name = location_name
@@ -532,6 +549,8 @@ module Engine
           @partitions << part
         elsif part.frame?
           @frame = part
+        elsif part.stripes?
+          @stripes = part
         else
           raise "Part #{part} not separated."
         end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2993555/126793422-d8329d67-18c4-40ac-96ad-391de7d2859d.png)
This does not do any rules enforcement as to what they mean however. Tagging @volker18xxdev as they were working on 1829 and filed a bug for visibility and functionality of these tiles