### PR TITLE
[18CZ] fix EMR by implementing `company_sale_price` func

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1504,6 +1504,10 @@ module Engine
         entity.cash + (issuable_shares(entity).map(&:price).max || 0)
       end
 
+      def company_sale_price(_company)
+        raise NotImplementedError
+      end
+
       def two_player?
         @two_player ||= @players.size == 2
       end

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -788,6 +788,10 @@ module Engine
           COMPANY_REVENUE_TO_TYPE[company.revenue][0]
         end
 
+        def company_sale_price(company)
+          company.value
+        end
+
         def remove_ate_reservation
           hex = hex_by_id('B9')
           hex.tile.reservations.clear


### PR DESCRIPTION
closes #6078 

Issue caused with bugfix in 
https://github.com/tobymao/18xx/commit/a4b1a5f35f736f9640011a79a2377f53828a083c#diff-c424fe765fa42b21004cdcbd52a9601b7ff9351f061d04cacec49f40973a2bb1R42

Also add this function to base (throws NotImplemented) , so games with similar mechanics will throw an instructive error at lint-time