### PR TITLE
Don't kill the pittsburgh private in 1817 if it's owned by a player

### DIFF
--- a/lib/engine/game/g_1817/step/track.rb
+++ b/lib/engine/game/g_1817/step/track.rb
@@ -15,10 +15,10 @@ module Engine
 
             super
 
-            return unless action.hex.name == @game.class::PITTSBURGH_PRIVATE_HEX
+            psm = @game.company_by_id(@game.class::PITTSBURGH_PRIVATE_NAME)
+            return if action.hex.name != @game.class::PITTSBURGH_PRIVATE_HEX || psm.owned_by_player?
 
             # PSM loses it's special if something else goes on F13
-            psm = @game.company_by_id(@game.class::PITTSBURGH_PRIVATE_NAME)
             @game.log << "#{psm.name} closes as it can no longer be used"
             psm.close!
           end


### PR DESCRIPTION
Rules as written privates never close in 1817. This fixes #6087 (the other companies close upon use, which implies they aren't owned by a player)