### PR TITLE
[1893] Do not allow buy of company when cert limit reached

### DIFF
--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -35,7 +35,7 @@ module Engine
           end
 
           def can_buy_company?(player, company = nil)
-            return false if first_sr_passed?(player)
+            return false if first_sr_passed?(player) || @game.num_certs(player) >= @game.cert_limit
             return buyable_company?(player, company) if company
 
             @game.buyable_companies.any? { |c| buyable_company?(player, c) }


### PR DESCRIPTION
This probably only applies when trying to buy an AdSK bond late
in the game.

This might break games as it was previously possible to buy
AdSK bonds to exceed cert limit (although those had to be sold
to be allowed to pass in SR), so any games this break can be
pinned (or archived if finished).

I intend to set 1893 to beta when this PR is deployed.