### PR TITLE
[18Mag] fix issue with string operations

### DIFF
--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -2,14 +2,12 @@
 
 require_relative 'meta'
 require_relative '../base'
-require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G18Mag
       class Game < Game::Base
         include_meta(G18Mag::Meta)
-        include CitiesPlusTownsRouteDistanceStr
 
         attr_reader :tile_groups, :unused_tiles, :sik, :skev, :ldsteg, :mavag, :raba, :snw, :gc, :terrain_tokens
 


### PR DESCRIPTION
closes #6095 

This removes the `CitiesPlusTownsRouteDistanceStr` function from the game script, which doesn't seem to break anything

This function was breaking games since it [causes the train distance string to be used as part of a math operation here](https://github.com/tobymao/18xx/blob/master/lib/engine/game/cities_plus_towns_route_distance_str.rb#L10)