### PR TITLE
18Carolinas: updated EMR code; bug fixes

### DIFF
--- a/assets/app/view/game/buy_power.rb
+++ b/assets/app/view/game/buy_power.rb
@@ -70,8 +70,8 @@ module View
 
         if @step.can_buy_power?(@corporation) || @must_buy_power
           if @must_buy_power
-            children << h(:div, "#{@corporation.name} must buy train power "\
-                                "(at least #{@step.min_power_needed(@corporation)})")
+            children << h(:div, "#{@corporation.name} must buy "\
+                                "#{@step.ebuy_power_needed(@corporation)} train power ")
           end
           children << h(:h3, 'Select Amount of Train Power to Buy')
           children << h(:div, render_buy(@corporation))

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -250,11 +250,15 @@ module Engine
 
     def ignore_gauge_walk=(val)
       @paths.each { |p| p.ignore_gauge_walk = val }
+      @nodes.each(&:clear!)
+      @junction&.clear!
       @_paths = nil
     end
 
     def ignore_gauge_compare=(val)
       @paths.each { |p| p.ignore_gauge_compare = val }
+      @nodes.each(&:clear!)
+      @junction&.clear!
       @_paths = nil
     end
 


### PR DESCRIPTION
Updated buy_power step to implement correct rules for EMR.
Fixed an issue with update_route_trains not saving trains correctly
Fixed an issue with setting ignore_gauge_* in Tile where I forgot to clear path caches in Node and Junction.
Fixed an issue with reusing trains where I forgot to clear the "operated" flag when shuffling trains around.