### PR TITLE
[18SJ] Add special 2 player variant

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -992,6 +992,10 @@ module Engine
         log_share_price(corporation, price) if self.class::SELL_MOVEMENT != :none
       end
 
+      def sold_out_increase?(_corporation)
+        self.class::SOLD_OUT_INCREASE
+      end
+
       def log_share_price(entity, from)
         to = entity.share_price.price
         return unless from != to

--- a/lib/engine/game/g_18_sj/meta.rb
+++ b/lib/engine/game/g_18_sj/meta.rb
@@ -25,6 +25,12 @@ module Engine
             short_name: 'The Oscarian Era',
             desc: 'Full cap only, sell even if not floated',
           },
+          {
+            sym: :two_player_variant,
+            short_name: 'A.W. Edelswärds 2 Player Variant',
+            desc: 'A.W. Edelswärd "bot" plays the 3rd player',
+            players: [2],
+          },
         ].freeze
       end
     end

--- a/lib/engine/game/g_18_sj/round/auction.rb
+++ b/lib/engine/game/g_18_sj/round/auction.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/auction'
+
+module Engine
+  module Game
+    module G18SJ
+      module Round
+        class Auction < Engine::Round::Auction
+          def select_entities
+            super.reject { |p| p == @game.edelsward }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_sj/round/requisitions.rb
+++ b/lib/engine/game/g_18_sj/round/requisitions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/choices'
+
+module Engine
+  module Game
+    module G18SJ
+      module Round
+        class Choices < Engine::Round::Choices
+          def select_entities
+            # The player of lowest worth is the chooser
+            [@game.operator_for_edelsward_requisition]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_sj/round/stock.rb
+++ b/lib/engine/game/g_18_sj/round/stock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/stock'
+
+module Engine
+  module Game
+    module G18SJ
+      module Round
+        class Stock < Engine::Round::Stock
+          def select_entities
+            super.reject { |p| p == @game.edelsward }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_sj/step/buy_company.rb
+++ b/lib/engine/game/g_18_sj/step/buy_company.rb
@@ -8,6 +8,12 @@ module Engine
     module G18SJ
       module Step
         class BuyCompany < Engine::Step::BuyCompany
+          def actions(entity)
+            return [] if entity.player == @game.edelsward
+
+            super
+          end
+
           def process_buy_company(action)
             return super unless action.company == @game.company_khj
 

--- a/lib/engine/game/g_18_sj/step/buy_train.rb
+++ b/lib/engine/game/g_18_sj/step/buy_train.rb
@@ -20,16 +20,6 @@ module Engine
 
           def do_after_buy_train_action(_action, _entity); end
 
-          def buyable_trains(entity)
-            if entity.player == @game.edelsward
-              result = @depot.depot_trains[0..1]
-              puts result.to_s
-              result
-            end
-
-            super
-          end
-
           def must_buy_train?(entity)
             return false if entity.player == @game.edelsward
 

--- a/lib/engine/game/g_18_sj/step/buy_train.rb
+++ b/lib/engine/game/g_18_sj/step/buy_train.rb
@@ -19,6 +19,28 @@ module Engine
           end
 
           def do_after_buy_train_action(_action, _entity); end
+
+          def buyable_trains(entity)
+            if entity.player == @game.edelsward
+              result = @depot.depot_trains[0..1]
+              puts result.to_s
+              result
+            end
+
+            super
+          end
+
+          def must_buy_train?(entity)
+            return false if entity.player == @game.edelsward
+
+            super
+          end
+
+          def can_entity_buy_train?(entity)
+            return false if entity.player == @game.edelsward
+
+            super
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_sj/step/requisition.rb
+++ b/lib/engine/game/g_18_sj/step/requisition.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G18SJ
+      module Step
+        class Requisition < Engine::Step::Base
+          ACTIONS = %w[choose].freeze
+
+          def setup
+            @choices = nil
+          end
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] if @game.requisition_turn == @game.turn || choices.empty?
+
+            ACTIONS
+          end
+
+          def help
+            "Select corporation that #{@game.edelsward.name} will start and requisit 100% of"
+          end
+
+          def choice_name
+            'Select unparred corporation'
+          end
+
+          def choices
+            return @choices if @choices
+
+            @choices = {}
+            @game.corporations
+              .reject(&:closed?)
+              .reject(&:minor?)
+              .reject(&:share_price)
+              .each do |c|
+                @choices[c.name] = c.full_name
+              end
+            @choices
+          end
+
+          def description
+            "Select #{@game.edelsward.name}'s next corporation"
+          end
+
+          def process_choose(action)
+            @game.requisit_corporation(action.choice)
+            @game.requisition_turn = @game.turn
+            pass!
+          end
+
+          def skip!
+            pass!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_sj/step/token.rb
+++ b/lib/engine/game/g_18_sj/step/token.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/token'
+
+module Engine
+  module Game
+    module G18SJ
+      module Step
+        class Token < Engine::Step::Token
+          def place_token(entity, city, token)
+            token.price = 0 if entity.player == @game.edelsward
+            super(entity, city, token)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_usa/round/stock.rb
+++ b/lib/engine/game/g_18_usa/round/stock.rb
@@ -10,7 +10,7 @@ module Engine
           def finish_round
             @game.corporations.select(&:floated?).sort.each do |corp|
               prev = corp.share_price.price
-              sold_out_stock_movement(corp) if sold_out?(corp) && @game.class::SOLD_OUT_INCREASE
+              sold_out_stock_movement(corp) if sold_out?(corp) && @game.sold_out_increase?(corp)
               shares_in_pool = corp.num_market_shares
               price_drops = shares_in_pool * 2
               price_drops.times { @game.stock_market.move_down(corp) }

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -66,7 +66,7 @@ module Engine
         corporations_to_move_price.sort.each do |corp|
           prev = corp.share_price.price
 
-          sold_out_stock_movement(corp) if sold_out?(corp) && @game.class::SOLD_OUT_INCREASE
+          sold_out_stock_movement(corp) if sold_out?(corp) && @game.sold_out_increase?(corp)
           pool_share_drop = @game.class::POOL_SHARE_DROP
           price_drops =
             if (pool_share_drop == :none) || (shares_in_pool = corp.num_market_shares).zero?


### PR DESCRIPTION
This 2 player variant adds a 3rd player, a bot, that is
partly automatic, and partly handled by the players, via
master mode. The bot is excluded from the value/result.

More details in the 18SJ rule book.