### PR TITLE
Fix two bugs related to 18Rhl

### DIFF
--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -496,7 +496,7 @@ module Engine
         '469' => 'path=a:0,b:1,track:narrow',
       }.freeze
 
-      COLORS = %i[white yellow green brown gray blue greenbrown browngray none red purple].freeze
+      COLORS = %i[white yellow green brown gray blue greenbrown browngray none red purple orange].freeze
     end
   end
 end

--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -680,7 +680,7 @@ module Engine
                 type: 'tile_lay',
                 owner_type: 'player',
                 hexes: %w[D13 E12 E14 F11 F13 G12 G14 H13 I12 I14 J13 K2 K12],
-                tiles: %w[1 2 3 4 5 6 7 8 9 23 24 25 30 55 57 58 69 930 934 937],
+                tiles: %w[1 2 3 4 5 6 7 8 9 23 24 25 30 55 56 57 58 69 930 934 937],
                 free: true,
                 reachable: false,
                 count: 1,
@@ -898,6 +898,10 @@ module Engine
 
         def konzession_essen_osterath
           @konzession_essen_osterath ||= company_by_id('KEO')
+        end
+
+        def seilzuganlage
+          @seilzuganlage ||= company_by_id('Szl')
         end
 
         def trajektanstalt

--- a/lib/engine/game/g_18_rhl/step/special_track.rb
+++ b/lib/engine/game/g_18_rhl/step/special_track.rb
@@ -39,6 +39,19 @@ module Engine
             # the normal one.
             @game.start_trajektanstalt_teleport if action.entity == @game.trajektanstalt
           end
+
+          # Private 3 (Sailzuganlage) has all possible tiles, that can be played in all
+          # hexes with mountain terrain, as candidates. The general code will let through
+          # hexes that are not allowed, so we need to remove illegal upgrades.
+          def potential_tiles(entity, hex)
+            return [] unless (tile_ability = abilities(entity))
+
+            candidates = super
+            return candidates if candidates.empty? || tile_ability.owner != @game.seilzuganlage
+
+            potentials = @game.all_potential_upgrades(hex.tile).map(&:name)
+            candidates.select { |t| @game.upgrades_to?(hex.tile, t) && potentials.include?(t.name) }
+          end
         end
       end
     end


### PR DESCRIPTION
1. Orange need to be put into COLORS so that sort of tiles work.
   (So far only 18Rhl uses orange for any tile, but it is general.)
2. Fix private No 3 (Seilzuganlage) so that only allowed tiles can
   be used in the selected hex.