### PR TITLE
allow labels to be on right side

### DIFF
--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -181,7 +181,7 @@ module View
             if @tile.cities.one? && (@tile.cities.first.slots > 1)
               [P_LEFT_CORNER[layout]]
             else
-              [SINGLE_CITY_ONE_SLOT[layout], SINGLE_CITY_ONE_SLOT_RIGHT[layout]]
+              [SINGLE_CITY_ONE_SLOT[layout], SINGLE_CITY_ONE_SLOT_RIGHT[layout], P_RIGHT_CORNER[layout]]
             end
           elsif @tile.city_towns.size > 1 && layout == :flat
             MULTI_CITY_LOCATIONS


### PR DESCRIPTION
closes #6129

This does result in some other labeled cities changing, see examples below

## Takamatsu

before:
![Screenshot 2021-07-28 1 03 14 PM](https://user-images.githubusercontent.com/1711810/127418266-6c854936-d2e2-4769-a75b-a506c706c092.png)

after:
![Screenshot 2021-07-28 6 29 53 PM](https://user-images.githubusercontent.com/1711810/127417941-c4e45eb4-2d98-4ace-882d-b3949e0450e3.png)


## Kotohira
before:
![image](https://user-images.githubusercontent.com/1711810/127418381-11d372c8-c928-41ff-8357-384d01cd40fe.png)

after:
![after_koto](https://user-images.githubusercontent.com/1711810/127418319-b6fcc1ad-e211-40ac-ab12-b377e95084aa.png)

## Cleveland

Note that IMO this better / more consistent, since Toledo's LSL `icon` is similarly under the city slot already

before:
![before_cleve](https://user-images.githubusercontent.com/1711810/127418297-9debb1d0-43d2-4c29-8ba2-8609dc6ceb80.png)

after:
![after_cleve](https://user-images.githubusercontent.com/1711810/127418296-b2aa0a0d-ca42-4c35-8a7d-7e3f4dbf89b7.png)
