### PR TITLE
[1893] Improve presentation of bonds

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -307,7 +307,7 @@ module View
             },
           }
 
-          @game.companies.select { |c| c.owner == @game.bank }.map do |company|
+          @game.buyable_bank_owned_companies.map do |company|
             children = []
             children << h(Company, company: company,
                                    bids: (@current_actions.include?('bid') ? @step.bids[company] : nil))

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -10,8 +10,8 @@ module Engine
     include Entity
     include Ownable
 
-    attr_accessor :desc, :max_price, :min_price, :revenue, :discount, :value
-    attr_reader :name, :sym, :min_auction_price, :treasury, :interval, :color, :text_color
+    attr_accessor :name, :desc, :max_price, :min_price, :revenue, :discount, :value
+    attr_reader :sym, :min_auction_price, :treasury, :interval, :color, :text_color
 
     def initialize(sym:, name:, value:, revenue: 0, desc: '', abilities: [], **opts)
       @sym = sym

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -832,6 +832,10 @@ module Engine
         end
       end
 
+      def buyable_bank_owned_companies
+        @companies.select { |c| !c.closed? && c.owner == @bank }
+      end
+
       def after_buy_company(player, company, _price)
         abilities(company, :shares) do |ability|
           ability.shares.each do |share|

--- a/lib/engine/game/g_1893/step/buy_minor.rb
+++ b/lib/engine/game/g_1893/step/buy_minor.rb
@@ -2,7 +2,6 @@
 
 module BuyMinor
   def draft_object(object, player, price, forced: false)
-    # TODO: Remove to_company when cleaning up
     company = @game.to_company(object)
 
     player.spend(price, @game.bank)

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -29,7 +29,6 @@ module Engine
             result.concat(FIRST_SR_ACTIONS) if can_buy_company?(entity)
             result.concat(EXCHANGE_ACTIONS) if can_exchange?(entity)
             result.concat(SELL_COMPANY_ACTIONS) if can_sell_any_companies?(entity)
-            # TODO: Next line to be removed - is to handle obsolete buy minor
             result.concat(BUY_MINOR_ACTIONS) if can_buy_company?(entity)
             result
           end
@@ -38,7 +37,7 @@ module Engine
             return false if first_sr_passed?(player) || @game.num_certs(player) >= @game.cert_limit
             return buyable_company?(player, company) if company
 
-            @game.buyable_companies.any? { |c| buyable_company?(player, c) }
+            @game.buyable_bank_owned_companies.any? { |c| buyable_company?(player, c) }
           end
 
           def buyable_company?(player, company)
@@ -118,6 +117,7 @@ module Engine
 
           def handle_buy_company(company, player, price)
             draft_object(company, player, price)
+            @game.set_bond_names! if @game.bond?(company)
             return unless @game.draftables.one?
 
             @game.corporations.each do |c|
@@ -127,7 +127,6 @@ module Engine
             end
           end
 
-          # TODO: Rmove this when code cleaned up
           def process_buy_corporation(action)
             company = action.minor
             player = action.entity
@@ -158,6 +157,7 @@ module Engine
             price = action.price
             raise GameError, "Cannot sell #{company.id}" unless can_sell_company?(company)
 
+            @game.set_bond_names! if @game.bond?(company)
             @log << "#{player.name} sells #{company.name} for #{@game.format_currency(price)} to the bank"
             @game.bank.spend(price, player)
             company.owner = @game.bank

--- a/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
+++ b/lib/engine/game/g_1893/step/starting_package_forced_auction.rb
@@ -125,7 +125,7 @@ module Engine
           def may_purchase?(entity)
             return false unless !!@auctioning
 
-            @game.buyable_companies.include?(entity)
+            @game.buyable_bank_owned_companies.include?(entity)
           end
 
           def may_choose?(_entity)

--- a/lib/engine/game/g_1893/step/starting_package_initial_auction.rb
+++ b/lib/engine/game/g_1893/step/starting_package_initial_auction.rb
@@ -33,7 +33,7 @@ module Engine
           end
 
           def available
-            @game.buyable_companies.reject { |c| @game.bond?(c) }
+            @game.buyable_bank_owned_companies.reject { |c| @game.bond?(c) }
           end
 
           def may_purchase?(entity)


### PR DESCRIPTION
Show only one bank owned bond in stock view.

Make name of bank owned bonds dynamic to show the number of
bonds bank own. The name of non-bank owned bonds always have
the same name.

Name of minor connected companies changed to make it less
confusing compared to bonds.

Some minor cleanups, including descriptions of minor connected
companies.

Small refactoring of general code:
  1. make it possible for 1893 to override which companies to show
     in the stock view.
  2. change name attribute of company to an accessor to make it
     possible for 1893 to use dynamic name of companies