### PR TITLE
[18Rhl] Update Priority Deal handling

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -169,7 +169,7 @@ module View
         }
 
         order = @game.next_sr_player_order
-        trs << render_priority_deal(priority_props) if order == :after_last_to_act &&
+        trs << render_priority_deal(priority_props) if @game.show_priority_deal_player?(order) &&
                                                        @player == @game.priority_deal_player
         trs << render_next_sr_position(priority_props) if %i[first_to_pass most_cash least_cash].include?(order) &&
                                                           @game.next_sr_position(@player)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2251,6 +2251,10 @@ module Engine
         @corporations.dup.each { |c| close_corporation(c) if c.share_price&.type == :close }
       end
 
+      def show_priority_deal_player?(order)
+        order == :after_last_to_act
+      end
+
       def priority_deal_player
         players = @players.reject(&:bankrupt)
 

--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -904,7 +904,9 @@ module Engine
         end
 
         def priority_deal_player
-          players_with_max_cash.size > 1 ? players_with_max_cash.first : super
+          return players_with_max_cash.first if @round.is_a?(Engine::Round::Stock) && players_with_max_cash.one?
+
+          super
         end
 
         def players_with_max_cash
@@ -912,7 +914,15 @@ module Engine
           @players.select { |p| p.cash == max_cash }
         end
 
+        def show_priority_deal_player?(_order)
+          true
+        end
+
         def reorder_players(_order = nil, log_player_order: false)
+          # Player order is the player with most cash (followed by seating order)
+          # and if multiple players have most cast, left of last to act (followed
+          # by seating order).
+
           max_cash_players = players_with_max_cash
           if max_cash_players.one?
             @players.rotate!(@players.index(max_cash_players.first))


### PR DESCRIPTION
Priority Deal is now shown continuously (in the SR) for the player
that has the most cash. (If two or more share this, the PD is shown
for the player after last to act.)