### PR TITLE
Fix 4817 - 18CO Starting Slot Late Game

### DIFF
--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1300,7 +1300,7 @@ module Engine
           return unless corporation.coordinates
 
           tile = hex_by_id(corporation.coordinates).tile
-          city = tile.cities[corporation.city || 0]
+          city = tile.cities[corporation.city || 0] || tile.cities[0]
           slot = city.get_slot(corporation)
           tile.add_reservation!(corporation, slot ? corporation.city : nil, slot)
           log << "#{corporation.name} reserves station on #{tile.hex.name}"\


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/4817

If the corporation's starting city has been removed as it was merged into a greater city ( see: Denver ) then get_slot would return nil. We need to check if that city still exists, and if not, use the 0 city.