### PR TITLE
Fix 5905 - 18CO EMR Bundles

### DIFF
--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1495,7 +1495,7 @@ module Engine
         end
 
         def emergency_issuable_bundles(entity)
-          issuable_shares(entity)
+          [issuable_shares(entity).find { |bundle| bundle.price + entity.cash >= @depot.min_depot_price }]
         end
 
         def issuable_shares(entity)


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/5909

This changes limits the EMR bundles to only one option - the bundle that will allow buying the cheapest train. Before: Bundles worth more would trigger a "Cannot Sell Bundle" error, and thus were useless to show in the display. Smaller bundles were useless because the player would just have to keep issuing anyway.

Why Pins? - Games where a player issued one share multiple times will fail as that bundle no longer exists. I don't know how often if ever that occurred but its a distinct possibility.

Before:

<img width="303" alt="Screen Shot 2021-08-02 at 12 27 47 PM" src="https://user-images.githubusercontent.com/15675400/127907096-947c5193-f615-43a5-bbc0-892d855f672a.png">

After:

<img width="409" alt="Screen Shot 2021-08-02 at 10 58 07 AM" src="https://user-images.githubusercontent.com/15675400/127907034-e5292144-465b-4322-8530-5898346d2d8d.png">
