### PR TITLE
Add intra-tile paths to check_overlap

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1097,6 +1097,9 @@ module Engine
             if a.edge? && b.town? && (nedge = b.tile.preferred_city_town_edges[b]) && nedge != a.num
               check.call([path.hex, b, path.lanes[1][1]])
             end
+
+            # check intra-tile paths between nodes
+            check.call([path.hex, path]) if path.nodes.size > 1
           end
         end
       end

--- a/lib/engine/game/g_18_texas/game.rb
+++ b/lib/engine/game/g_18_texas/game.rb
@@ -533,6 +533,19 @@ module Engine
             [{ lay: true, upgrade: true, cost: 0 }]
           end
         end
+
+        def check_overlap(routes)
+          paths = {}
+          routes.each do |route|
+            route.paths.each do |path|
+              raise GameError, "Route cannot reuse track on #{path.hex.id}" if paths[path]
+
+              paths[path] = true
+            end
+          end
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_texas/game.rb
+++ b/lib/engine/game/g_18_texas/game.rb
@@ -533,19 +533,6 @@ module Engine
             [{ lay: true, upgrade: true, cost: 0 }]
           end
         end
-
-        def check_overlap(routes)
-          paths = {}
-          routes.each do |route|
-            route.paths.each do |path|
-              raise GameError, "Route cannot reuse track on #{path.hex.id}" if paths[path]
-
-              paths[path] = true
-            end
-          end
-
-          super
-        end
       end
     end
   end


### PR DESCRIPTION
Games with intra-tile paths can allow the autorouter to select routes with duplicate paths.