### PR TITLE
Autorouter fixes for 1860, 1862, 1873, 1849, plus probably more

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -58,25 +58,14 @@ module Engine
             chain = []
           end
 
-          assign_both = lambda do |a, b|
-            if a == last_left || b == last_right
-              left = b
-              right = a
-            else
-              left = a
-              right = b
-            end
-            complete.call
-          end
-
           assign = lambda do |a, b|
-            n = a || b
             if a && b
-              assign_both.call(a, b)
+              left, right = a == last_left || b == last_right ? [b, a] : [a, b]
+              complete.call
             elsif !left
-              left = n
+              left = a || b
             elsif !right
-              right = n
+              right = a || b
               complete.call
             end
           end

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -60,7 +60,13 @@ module Engine
 
           assign = lambda do |a, b|
             if a && b
-              left, right = a == last_left || b == last_right ? [b, a] : [a, b]
+              if a == last_left || b == last_right
+                left = b
+                right = a
+              else
+                left = a
+                right = b
+              end
               complete.call
             elsif !left
               left = a || b

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -58,15 +58,6 @@ module Engine
             chain = []
           end
 
-          assign = lambda do |n|
-            if !left
-              left = n
-            elsif !right
-              right = n
-              complete.call
-            end
-          end
-
           assign_both = lambda do |a, b|
             if a == last_left || b == last_right
               left = b
@@ -78,13 +69,23 @@ module Engine
             complete.call
           end
 
+          assign = lambda do |a, b|
+            n = a || b
+            if a && b
+              assign_both.call(a, b)
+            elsif !left
+              left = n
+            elsif !right
+              right = n
+              complete.call
+            end
+          end
+
           paths.each do |path|
             chain << path
             a, b = path.nodes
 
-            assign.call(a) if a && !b
-            assign.call(b) if b && !a
-            assign_both.call(a, b) if a && b
+            assign.call(a, b) if a || b
           end
 
           next if chains.empty?

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -95,11 +95,21 @@ module Engine
             train,
             connection_data: connection,
           )
+          #<roseundy
+          puts "train: #{train.id} trying route: #{route.hexes.map(&:id).join(',')}"
+          #roseundy>
           route.revenue
           train_routes[train] << route
         rescue GameError # rubocop:disable Lint/SuppressedException
         end
       end
+      #<roseundy
+      puts "train_routes:"
+      train_routes.each do |k, v|
+        puts "  Train: #{k.id}"
+        v.each { |r| puts "    Route: #{r.hexes.map(&:id).join(',')}" }
+      end
+      #roseundy>
       puts "Pruned paths to #{train_routes.map { |k, v| k.name + ':' + v.size.to_s }.join(', ')} in: #{Time.now - now}"
 
       static.each { |route| train_routes[route.train] = [route] }
@@ -109,6 +119,13 @@ module Engine
       end
 
       train_routes = train_routes.values.sort_by(&:size)
+
+      #<roseundy
+      puts "train_routes:"
+      train_routes.each do |v|
+        v.each { |r| puts "   Train: #{r.train.id} Route: #{r.hexes.map(&:id).join(',')}" }
+      end
+      #roseundy>
 
       combos = [[]]
       possibilities = []
@@ -129,6 +146,12 @@ module Engine
               puts "#{counter} / #{limit}"
               raise if Time.now - now > route_timeout
             end
+
+            #<roseundy
+            puts "trying combo:"
+            combo.each { |r| puts "   Train: #{r.train.id} Route: #{r.hexes.map(&:id).join(',')}" }
+            #roseundy>
+
             route.revenue
             possibilities << combo
             combo

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1683,7 +1683,6 @@ module Engine
         # all routes must intersect each other
         def check_intersection(routes)
           actual_routes = routes.reject { |r| r.chains.empty? }
-          return unless actual_routes
 
           # build a map of which routes intersect with each route
           intersects = Hash.new { |h, k| h[k] = [] }

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1670,7 +1670,6 @@ module Engine
           home_city = tokens.find { |c| c.hex == hex_by_id(corporation.coordinates) }
           found = false
           routes.each { |r| found ||= r.visited_stops.include?(home_city) } if home_city
-          puts 'At least one route must include home token' unless found
           raise GameError, 'At least one route must include home token' unless found
         end
 
@@ -1701,10 +1700,6 @@ module Engine
           visited = {}
           visit_route(0, intersects, visited)
 
-          if visited.size != actual_routes.size
-            puts "routes must intersect"
-            puts "routes: #{routes}"
-          end
           raise GameError, 'Routes must intersect with each other' if visited.size != actual_routes.size
         end
 
@@ -1724,7 +1719,6 @@ module Engine
             corporation = route.corporation
             visits[1..-2].each do |node|
               next if !node.city? || !custom_blocks?(node, corporation)
-              puts 'Route can only bypass one tokened-out city' if blocked
               raise GameError, 'Route can only bypass one tokened-out city' if blocked
 
               blocked = node
@@ -1734,13 +1728,11 @@ module Engine
           paths_ = route.paths.uniq
           token = blocked if blocked
           if custom_node_select(token, paths_, corporation: route.corporation).size != paths_.size
-            puts 'Route is not connected'
             raise GameError, 'Route is not connected'
           end
 
           return unless blocked && route.routes.any? { |r| r != route && tokened_out?(r) }
 
-          puts 'Only one train can bypass a tokened-out city'
           raise GameError, 'Only one train can bypass a tokened-out city'
         end
 
@@ -1756,9 +1748,6 @@ module Engine
                            [c_allowance - city_stops.size, 0].max
                          end
 
-          puts 'Route has too many cities/offboards' if city_stops.size > c_allowance
-          puts 'Route has too many towns' if town_stops.size > th_allowance && option_no_skip_towns?
-          puts 'Route cannot begin/end in a halt' if visits.first.halt? || visits.last.halt?
           raise GameError, 'Route has too many cities/offboards' if city_stops.size > c_allowance
           raise GameError, 'Route has too many towns' if town_stops.size > th_allowance && option_no_skip_towns?
           raise GameError, 'Route cannot begin/end in a halt' if visits.first.halt? || visits.last.halt?
@@ -1769,7 +1758,6 @@ module Engine
           last_hex = nil
           route.ordered_paths.each do |path|
             hex = path.hex
-            puts 'Route cannot re-enter a hex' if hex != last_hex && visited_hexes[hex]
             raise GameError, 'Route cannot re-enter a hex' if hex != last_hex && visited_hexes[hex]
 
             visited_hexes[hex] = true
@@ -1781,7 +1769,6 @@ module Engine
           check_hex_reentry(route)
           check_home_token(current_entity, route.routes) unless route.routes.empty?
           check_intersection(route.routes) unless route.routes.empty?
-          puts "skipping check_home_token and check_intersection" if route.routes.empty?
         end
 
         # must stop at all towns on route or must maximize revenue

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1349,6 +1349,8 @@ module Engine
 
         # Brute force it. Theoretical max combos is 729, but realistic max is order of magnitude lower
         def global_optimize(routes)
+          return [] if routes.empty?
+
           route_stops = routes.map { |r| revenue_stop_options(r) }
           possibilities = if routes.one?
                             route_stops[0].product
@@ -1368,8 +1370,9 @@ module Engine
         end
 
         def optimize_stops(route, _num_pay, _total_stops)
-          @global_stops ||= global_optimize(route.routes)
+          return [] if route.routes.empty?
 
+          @global_stops ||= global_optimize(route.routes)
           @global_stops[route.routes.index(route)]
         end
 
@@ -1530,6 +1533,8 @@ module Engine
         # - route intersection requirement
         # - freight track end-to-end requirements
         def check_overlap(routes)
+          return if routes.empty?
+
           check_home_token(current_entity, routes)
           check_intersection(routes)
           check_freight_intersections(routes)

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -1747,15 +1747,17 @@ module Engine
         end
 
         def check_other(route)
+          # make sure a single route doesn't visit cities in a given hex twice
+          check_hex_reentry(route)
+
+          return if route.routes.empty?
+
           # make sure routes from same supertrain intersect
           super_routes = route.routes.reject do |r|
             r.chains.empty? ||
               @supertrains[route.train] != @supertrains[r.train]
           end
           check_intersection(@supertrains[route.train], super_routes)
-
-          # make sure a single route doesn't visit cities in a given hex twice
-          check_hex_reentry(route)
 
           check_diesel_nodes(route) if diesel?(route.train)
 

--- a/lib/engine/part/revenue_center.rb
+++ b/lib/engine/part/revenue_center.rb
@@ -57,6 +57,7 @@ module Engine
         return (@revenue[:diesel]) if train.name.upcase == 'D' && @revenue[:diesel]
 
         phase.tiles.reverse_each { |color| return (@revenue[color]) if @revenue[color] }
+        1
       end
 
       def revenue_multiplier(train)
@@ -68,6 +69,8 @@ module Engine
         row = distance.index do |h|
           h['nodes'].include?(type)
         end
+        return base_multiplier unless row
+
         distance[row].fetch('multiplier', base_multiplier)
       end
 

--- a/lib/engine/part/revenue_center.rb
+++ b/lib/engine/part/revenue_center.rb
@@ -57,7 +57,7 @@ module Engine
         return (@revenue[:diesel]) if train.name.upcase == 'D' && @revenue[:diesel]
 
         phase.tiles.reverse_each { |color| return (@revenue[color]) if @revenue[color] }
-        1
+        0
       end
 
       def revenue_multiplier(train)

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -253,7 +253,7 @@ module Engine
       connection_data.each do |c|
         right = c[:right]
         cycles[c[:left]] = true
-        raise GameError, "Cannot use #{right.hex.name} twice" if cycles[right]
+        raise GameError, "Cannot use #{right.hex.name} (#{right.inspect}) twice" if cycles[right]
 
         cycles[right] = true
       end


### PR DESCRIPTION
Modified autorouter to handle intra-tile paths correctly (1860, 18Mex, 18Texas, 18MS).
Modified 1860, 1862 and 1873 to deal with the autorouter path pruning algorithm (i.e. skip them if route.routes is empty).
Modified Part::RevenuCenter to bail gracefully (needed for 1862 offboards with the autorouter).
Modifed Route to display more useful error information when checking chains.

Fixes #6100 