### PR TITLE
Revert 18CO EMR change

### DIFF
--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1495,7 +1495,7 @@ module Engine
         end
 
         def emergency_issuable_bundles(entity)
-          [issuable_shares(entity).find { |bundle| bundle.price + entity.cash >= @depot.min_depot_price }]
+          issuable_shares(entity)
         end
 
         def issuable_shares(entity)


### PR DESCRIPTION
This logic is incomplete. There are times when a player should be able to issue fewer shares than is required to buy a train, example when they can't issue enough to afford the cheapest train. Will need to rethink this.