### PR TITLE
Fix 5909 - remove 18CO EMR extra options

### DIFF
--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1495,7 +1495,9 @@ module Engine
         end
 
         def emergency_issuable_bundles(entity)
-          issuable_shares(entity)
+          eligible, remaining = issuable_shares(entity)
+            .partition { |bundle| bundle.price + entity.cash < @depot.min_depot_price }
+          eligible.concat(remaining.take(1))
         end
 
         def issuable_shares(entity)


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/5909

The return is "all bundles that do not allow buying any train, plus the one bundle that allows buying the cheapest train, if it exists."

I ran tests on this to ensure I did not wind up with unexpected nils.