### PR TITLE
18EU - Only exchange connected minor

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -991,6 +991,13 @@ module Engine
 
           all_minor_hexes(corporation)
         end
+
+        def exchange_corporations(exchange_ability)
+          return super if !exchange_ability.owner.minor? || @loading
+
+          parts = graph.connected_nodes(exchange_ability.owner).keys
+          parts.select(&:city?).flat_map { |c| c.tokens.compact.map(&:corporation) }
+        end
       end
     end
   end


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/792

A corporation must be connected to the minor in order for it to be eligible for exchange.

Map:

<img width="493" alt="Screen Shot 2021-08-07 at 10 26 02 PM" src="https://user-images.githubusercontent.com/15675400/128637161-83370f13-6a96-4430-8768-9be9c9b15ce5.png">

Before:

<img width="375" alt="Screen Shot 2021-08-07 at 10 26 48 PM" src="https://user-images.githubusercontent.com/15675400/128637163-f23f13d2-53fe-4e61-a251-0358837ee51a.png">

After (active player owns 13 but not 15):

<img width="404" alt="Screen Shot 2021-08-07 at 10 25 56 PM" src="https://user-images.githubusercontent.com/15675400/128637169-17044bb1-d89e-4971-8ff9-aa69947d34e8.png">
