### PR TITLE
Add context of who is laying tile to logic to determine if tile upgrades are legal

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -82,7 +82,8 @@ module View
               h(TileConfirmation, zoom: map_zoom)
             else
               tiles = step.upgradeable_tiles(current_entity, @tile_selector.hex)
-              all_upgrades = @game.all_potential_upgrades(@tile_selector.hex.tile, selected_company: @selected_company)
+              all_upgrades = @game.all_potential_upgrades(@tile_selector.hex.tile, selected_company: @selected_company,
+                                                                                   laying_entity: current_entity)
 
               select_tiles = all_upgrades.map do |tile|
                 real_tile = tiles.find { |t| t.name == tile.name }

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1355,7 +1355,7 @@ module Engine
         self.class::TILE_LAYS
       end
 
-      def upgrades_to?(from, to, special = false, selected_company: nil)
+      def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
         # correct color progression?
         return false unless Engine::Tile::COLORS.index(to.color) == (Engine::Tile::COLORS.index(from.color) + 1)
 
@@ -2382,12 +2382,12 @@ module Engine
         @bank.cash
       end
 
-      def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+      def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
         colors = Array(@phase.phases.last[:tiles])
         @all_tiles
           .select { |t| colors.include?(t.color) }
           .uniq(&:name)
-          .select { |t| upgrades_to?(tile, t, selected_company: selected_company) }
+          .select { |t| upgrades_to?(tile, t, selected_company: selected_company, laying_entity: laying_entity) }
           .reject(&:blocks_lay)
       end
 

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -538,7 +538,7 @@ module Engine
 
         attr_accessor :bidding_token_per_player, :player_debts
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
           return upgrades unless tile_manifest
 
@@ -1231,7 +1231,7 @@ module Engine
           end
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Check the S hex and potential upgrades
           if self.class::UPGRADABLE_S_HEX_NAME == from.hex.name && from.color == :white
             return self.class::UPGRADABLE_S_YELLOW_CITY_TILE == to.name

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -1138,7 +1138,7 @@ module Engine
           @round.force_next_entity! if @round.current_entity == minor
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Virginia tunnel can only be upgraded to #4 tile
           return false if from.hex.id == VA_TUNNEL_HEX && to.name != '4'
 

--- a/lib/engine/game/g_1829/game.rb
+++ b/lib/engine/game/g_1829/game.rb
@@ -131,7 +131,7 @@ module Engine
 
         LAYOUT = :pointy
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           return GREEN_CITIES.include?(to.name) if YELLOW_TOWNS.include? from.hex.tile.name
           return BROWN_CITIES.include?(to.name) if GREEN_CITIES.include? from.hex.tile.name
           return GRAY_CITIES.include?(to.name) if BROWN_CITIES.include? from.hex.tile.name
@@ -139,7 +139,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           # upgrade for 1,2,3,4,55 in 12,13,14,15
           upgrades = super
           return upgrades unless tile_manifest

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -590,7 +590,7 @@ module Engine
           tile.frame&.color == '#ffa500'
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           if from.towns.empty? && from.cities.empty? && !to.towns.empty? && to.cities.empty? &&
             from.color == :white && to.color == :yellow
             return true

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -653,7 +653,7 @@ module Engine
           end
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           super && (from.hex.id != 'B14' || @messina_upgradeable)
         end
 

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1083,7 +1083,7 @@ module Engine
         # from: Tile - Tile to upgrade from
         # to: Tile - Tile to upgrade to
         # special - ???
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           return false if from.name == '470'
           # double dits upgrade to Green cities in gray
           return gray_phase? if to.name == '14' && %w[55 1].include?(from.name)
@@ -1127,7 +1127,7 @@ module Engine
         # tile: The tile to be upgraded
         # tile_manifest: true/false Is this being called from the tile manifest screen
         #
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
           return upgrades unless tile_manifest
 

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -927,7 +927,7 @@ module Engine
           to.towns.size == from.towns.size + 1
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           return true if adding_town?(from, to)
 
           super

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -1323,7 +1323,7 @@ module Engine
           entity.type == :national ? 'Nat’l' : entity.type.capitalize
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # O labelled tile upgrades to Ys until Grey
           return super unless self.class::HEX_WITH_O_LABEL.include?(from.hex.name)
 

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -544,11 +544,11 @@ module Engine
           @tiles.find { |t| t.name == "#{tile_name}B" && !t.hex }
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           @pending_boom_tile_lays[tile.hex] || super
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           hex = from.hex
           if @pending_boom_tile_lays[hex]
             from.name == to.name.downcase

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -795,7 +795,7 @@ module Engine
             end
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           return false if to.name == '171K' && from.hex.name != 'B11'
           return false if to.name == '172L' && from.hex.name != 'C18'
 

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -1373,7 +1373,7 @@ module Engine
             (from.name == '956' && LEGAL_956_DBL_UPGRADES.include?(to.name))
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           # correct color progression?
           if !(reserved_tiles[from.hex.id] && reserved_tiles[from.hex.id][:tile] == to) &&
             (Engine::Tile::COLORS.index(to.color) != (Engine::Tile::COLORS.index(from.color) + 1))

--- a/lib/engine/game/g_1888/game.rb
+++ b/lib/engine/game/g_1888/game.rb
@@ -198,7 +198,7 @@ module Engine
           @terracotta ||= company_by_id('TA')
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           if special && selected_company == yanda
             return ((from.hex.id == DALIAN_HEX && to.name == DALIAN_FERRY_TILE) ||
                     (from.hex.id == YANTAI_HEX && to.name == YANTAI_FERRY_TILE))

--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -1067,7 +1067,7 @@ module Engine
           (water_borders & tile.exits).empty?
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           if from.color == :yellow && from.hex.name == LEVERKUSEN_HEX_NAME
             # Leverkusen can upgrade double dits to one city
             return to.name == LEVERKUSEN_GREEN_TILE
@@ -1080,7 +1080,7 @@ module Engine
           raise GameError, "Cannot place a tile in #{from.hex.name} until green phase"
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false)
+        def all_potential_upgrades(tile, tile_manifest: false, laying_entity: nil)
           upgrades = super
           return upgrades if !tile_manifest || !LEVERKUSEN_YELLOW_TILES.include?(tile.name)
 

--- a/lib/engine/game/g_18_al/game.rb
+++ b/lib/engine/game/g_18_al/game.rb
@@ -625,7 +625,7 @@ module Engine
             .each { |hex| hex.tile.icons = [] }
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Lumber terminal cannot be upgraded
           return false if from.name == '445'
 
@@ -641,7 +641,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           # Lumber terminal cannot be upgraded
           return [] if tile.name == '445'
 

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -496,7 +496,7 @@ module Engine
           ], round_num: round_num)
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           from_standard = from.paths.any? { |p| p.track == :broad }
           from_southern = from.paths.any? { |p| p.track != :broad }
 

--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1355,7 +1355,7 @@ module Engine
           str
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           return true if special && from.hex.tile.color == :yellow && GREEN_CITY_TILES.include?(to.name)
 
           # Green towns can't be upgraded to brown cities unless the hex has the upgrade icon
@@ -1368,7 +1368,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
 
           return upgrades unless tile_manifest

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -521,7 +521,7 @@ module Engine
           end
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           return true if from.color == :white && to.color == :red
 
           return false unless from.paths_are_subset_of?(to.paths)

--- a/lib/engine/game/g_18_ga/game.rb
+++ b/lib/engine/game/g_18_ga/game.rb
@@ -541,7 +541,7 @@ module Engine
           super
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Augusta (D10) use standard tiles for yellow, and special tile for green
           return to.name == '453a' if from.color == :yellow && from.hex.name == 'D10'
 
@@ -557,7 +557,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
 
           return upgrades unless tile_manifest

--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -591,7 +591,7 @@ module Engine
           close_corporation(protect)
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           # The Irish Mail
           return true if special && from.color == :blue && to.color == :red
 

--- a/lib/engine/game/g_18_ka/game.rb
+++ b/lib/engine/game/g_18_ka/game.rb
@@ -1112,7 +1112,7 @@ module Engine
         # tile: The tile to be upgraded
         # tile_manifest: true/false Is this being called from the tile manifest screen
         #
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
           return upgrades unless tile_manifest
 
@@ -1128,7 +1128,7 @@ module Engine
         # from: Tile - Tile to upgrade from
         # to: Tile - Tile to upgrade to
         # special - ???
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           if EQUATOR_HEXES.include?(from.name) && @phase.tiles.include?(:green)
             return !farm_blocked? if to.name == farm_tile.name
             return !elevator_blocked? if to.name == elevator_tile.name

--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -358,7 +358,7 @@ module Engine
           end
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           # correct color progression?
           return false unless Engine::Tile::COLORS.index(to.color) == (Engine::Tile::COLORS.index(from.color) + 1)
 

--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -1124,7 +1124,7 @@ module Engine
           @merged_cities_to_select = []
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Copper Canyon cannot be upgraded
           return false if from.name == '470'
 
@@ -1136,7 +1136,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           # Copper Canyon cannot be upgraded
           return [] if tile.name == '470'
 

--- a/lib/engine/game/g_18_ms/game.rb
+++ b/lib/engine/game/g_18_ms/game.rb
@@ -390,7 +390,7 @@ module Engine
           end
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Only allow tile gray tile (446) in Montgomery (E11) or Birmingham (C9)
           return to.name == '446' if from.color == :brown && HEXES_FOR_GRAY_TILE.include?(from.hex.name)
 
@@ -400,7 +400,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
 
           return upgrades unless tile_manifest

--- a/lib/engine/game/g_18_neb/game.rb
+++ b/lib/engine/game/g_18_neb/game.rb
@@ -583,7 +583,7 @@ module Engine
           return to == '116' if from == :brown
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           case from.hex.name
           when OMAHA_HEX
             return omaha_upgrade(to.name, from.color)
@@ -606,7 +606,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
           return upgrades unless tile_manifest
 

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -291,7 +291,7 @@ module Engine
           @erie_canal_private.close!
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           return true if town_to_city_upgrade?(from, to)
 
           super

--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -1088,7 +1088,7 @@ module Engine
           place_free_token(cce, 'I10', 1, silent: false)
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Osterath cannot be upgraded
           return false if from.name == '935'
 
@@ -1133,7 +1133,7 @@ module Engine
           raise GameError, "Cannot place a tile in #{from.hex.name} until green phase"
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           # Osterath cannot be upgraded
           return [] if tile.name == '935'
 

--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -1263,7 +1263,7 @@ module Engine
           end
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # Handle upgrade to Stockholm gray tile
           return to.name == '131' if from.color == :brown && from.hex.name == 'G10'
           return false if to.name == '131'
@@ -1271,7 +1271,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
 
           return upgrades unless tile_manifest

--- a/lib/engine/game/g_18_tn/game.rb
+++ b/lib/engine/game/g_18_tn/game.rb
@@ -612,7 +612,7 @@ module Engine
           @lnr ||= company_by_id('LNR')
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # When upgrading from green to brown:
           #   If Memphis (H3), Chattanooga (H15), Nashville (F11)
           #   only brown P tile (#170) are allowed.
@@ -624,7 +624,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
 
           return upgrades unless tile_manifest

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -1542,7 +1542,7 @@ module Engine
         # from: Tile - Tile to upgrade from
         # to: Tile - Tile to upgrade to
         # special - ???
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           # TODO: Check if it's near a metropolis
           return true if @company_town_tiles.map(&:name).include?(to.name) && from.color == :white
           return @phase.tiles.include?(:brown) if @rhq_tiles.map(&:name).include?(to.name) &&
@@ -1555,7 +1555,7 @@ module Engine
         # tile: The tile to be upgraded
         # tile_manifest: true/false Is this being called from the tile manifest screen
         #
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
           return upgrades unless tile_manifest
 

--- a/lib/engine/game/g_18_va/game.rb
+++ b/lib/engine/game/g_18_va/game.rb
@@ -845,7 +845,7 @@ module Engine
           @share_pool.transfer_shares(bundle, @share_pool)
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
+        def upgrades_to?(from, to, _special = false, selected_company: nil, laying_entity: nil)
           return to.name == '170ric' if from.color == :green && from.hex.name == self.class::RIC_HEX
           return to.name == '170was' if from.color == :green && from.hex.name == self.class::WAS_HEX
           return to.name == '170' if from.color == :green && self.class::P_HEXES.include?(from.hex.name)
@@ -854,7 +854,7 @@ module Engine
           super
         end
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil, laying_entity: nil)
           upgrades = super
           return upgrades unless tile_manifest
 

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -428,7 +428,7 @@ module Engine
           Array.new(@round.bonus_tracks) { |_| { lay: true } } if @round.bonus_tracks.positive?
         end
 
-        def upgrades_to?(from, to, special = false, selected_company: nil)
+        def upgrades_to?(from, to, special = false, selected_company: nil, laying_entity: nil)
           return false if to.name == 'TI_455' && from.hex.coordinates != game_corporation_coordinates['TI']
           return false if to.name == 'GI_455' && from.hex.coordinates != game_corporation_coordinates['GI']
           return false if to.name == 'BB_455' && from.hex.coordinates != game_corporation_coordinates['BB']
@@ -1325,7 +1325,7 @@ module Engine
           rust_trains!(train_by_id('4J-0'), nil)
         end
 
-        def all_potential_upgrades(tile, tile_manifest: nil, selected_company: nil)
+        def all_potential_upgrades(tile, tile_manifest: nil, selected_company: nil, laying_entity: nil)
           if selected_company == rabbits
             return all_potential_upgrades_for_rabbits(tile, tile_manifest,
                                                       selected_company)

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -127,7 +127,7 @@ module Engine
           .compact
           .select do |t|
           @game.phase.tiles.include?(t.color) && @game.upgrades_to?(hex.tile, t, special,
-                                                                    selected_company: entity)
+                                                                    selected_company: entity, laying_entity: entity)
         end
       end
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -96,7 +96,8 @@ module Engine
 
         tile.rotate!(rotation)
 
-        unless @game.upgrades_to?(old_tile, tile, entity.company?, selected_company: entity.company? && entity || nil)
+        unless @game.upgrades_to?(old_tile, tile, entity.company?, selected_company: entity.company? && entity || nil,
+                                                                   laying_entity: entity)
           raise GameError, "#{old_tile.name} is not upgradeable to #{tile.name}"
         end
         if !@game.loading && !legal_tile_rotation?(entity, hex, tile)
@@ -314,12 +315,12 @@ module Engine
         end
       end
 
-      def potential_tiles(_entity, hex)
+      def potential_tiles(entity, hex)
         colors = @game.phase.tiles
         @game.tiles
           .select { |tile| colors.include?(tile.color) }
           .uniq(&:name)
-          .select { |t| @game.upgrades_to?(hex.tile, t) }
+          .select { |t| @game.upgrades_to?(hex.tile, t, laying_entity: entity) }
           .reject(&:blocks_lay)
       end
 


### PR DESCRIPTION
This is needed for my approach on handling 18USA's special tile rules - particularly that in phase 5 and beyond, on it's first turn a corporation may, as a bonus tile lay, lay or upgrade its home to brown (skipping intermediate tile lays).

To know if it's legal to lay the given brown tile the `all_potential_upgrades` and `upgrades_to?` methods need to know which corporation is trying to lay in the given hex