### PR TITLE
player notification info sentence in tools tab

### DIFF
--- a/assets/app/view/game/tools.rb
+++ b/assets/app/view/game/tools.rb
@@ -29,7 +29,7 @@ module View
 
       def player_notification
         h('div.margined', [
-          h(:label, "You can send any player a notification (via email/webhooks) by tagging them in game chat: @username"),
+          h(:label, 'Send any player a notification (via email/webhooks) by tagging them in game chat: @username'),
         ])
       end
 

--- a/assets/app/view/game/tools.rb
+++ b/assets/app/view/game/tools.rb
@@ -27,6 +27,12 @@ module View
         ])
       end
 
+      def player_notification
+        h('div.margined', [
+          h(:label, "You can send any player a notification (via email/webhooks) by tagging them in game chat: @username"),
+        ])
+      end
+
       def master_mode
         mode = @settings[:master_mode] || false
         toggle = lambda do
@@ -64,7 +70,7 @@ module View
       end
 
       def render_tools
-        children = [master_mode]
+        children = [player_notification, master_mode]
         children << end_game unless @game.finished
         children
       end


### PR DESCRIPTION
![Screenshot from 2021-08-10 09-32-57](https://user-images.githubusercontent.com/69309175/128876222-2fa34977-5a70-4c33-9506-109b4de00c2e.png)

For #5297

I thought for a while about the other suggestions but not sure they'd be better - default text in the input box wouldn't be needed after one or two appearances, and the button would create two disconnected ways to do the same thing.