### PR TITLE
18Carolinas: modify phases, add "voting" for final track

### DIFF
--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -177,7 +177,7 @@ module Engine
             name: '3',
             train_limit: 2,
             tiles: %w[yellow],
-            operating_rounds: 2,
+            operating_rounds: 1,
           },
           {
             name: '4',
@@ -189,14 +189,14 @@ module Engine
             name: '5',
             train_limit: 3,
             tiles: %w[yellow green],
-            operating_rounds: 3,
-            status: ['track_conversion'],
+            operating_rounds: 2,
           },
           {
             name: '6',
             train_limit: 4,
             tiles: %w[yellow green brown],
             operating_rounds: 3,
+            status: ['track_conversion'],
           },
           {
             name: '7',
@@ -217,6 +217,8 @@ module Engine
             operating_rounds: 3,
           },
         ].freeze
+
+        CONVERT_PHASE = '6'
 
         PAR_BY_LAYER = {
           1 => 90,
@@ -621,8 +623,10 @@ module Engine
             @log << "#{corp.name} loses #{loss} power (to #{@corporation_power[corp]})" if loss.positive?
           end
 
-          return unless @phase.name == '5'
+          vote_and_convert if @phase.name == CONVERT_PHASE
+        end
 
+        def vote_and_convert
           # count track types and see whether there are more pure standard
           # or southern track tiles
           standard_count = 0

--- a/lib/engine/game/g_18_carolinas/map.rb
+++ b/lib/engine/game/g_18_carolinas/map.rb
@@ -86,25 +86,25 @@ module Engine
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:1,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
           },
           '2s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:2,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:2,track:narrow',
           },
           '3s' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
           },
           '4s' =>
           {
             'count' => 3,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
           },
           '5s' =>
           {
@@ -140,13 +140,13 @@ module Engine
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
           },
           '56s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:3,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:3,track:narrow',
           },
           '57s' =>
           {
@@ -158,7 +158,7 @@ module Engine
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
           },
           'C1' =>
           {
@@ -272,13 +272,13 @@ module Engine
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
           },
           '88s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
           },
           'C5' =>
           {
@@ -292,11 +292,83 @@ module Engine
             'color' => 'green',
             'code' => 'city=revenue:50,slots:2;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
           },
+          '38s' =>
+          {
+            'count' => 4,
+            'color' => 'brown',
+            'code' => 'city=revenue:40,slots:2;path=a:0,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          '39s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:2,track:narrow;path=a:0,b:1,track:narrow;path=a:1,b:2,track:narrow',
+          },
+          '40s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:2,track:narrow;path=a:2,b:4,track:narrow;path=a:0,b:4,track:narrow',
+          },
+          '41s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:1,track:narrow;path=a:1,b:3,track:narrow',
+          },
+          '42s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:3,track:narrow;path=a:3,b:5,track:narrow;path=a:0,b:5,track:narrow',
+          },
+          '43s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:2,track:narrow;path=a:1,b:3,track:narrow;path=a:1,b:2,track:narrow',
+          },
+          '44s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:3,track:narrow;path=a:1,b:4,track:narrow;path=a:0,b:1,track:narrow;path=a:3,b:4,track:narrow',
+          },
+          '45s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:3,track:narrow;path=a:2,b:4,track:narrow;path=a:0,b:4,track:narrow;path=a:2,b:3,track:narrow',
+          },
+          '46s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:3,track:narrow;path=a:2,b:4,track:narrow;path=a:3,b:4,track:narrow;path=a:0,b:2,track:narrow',
+          },
+          '47s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:3,track:narrow;path=a:1,b:4,track:narrow;path=a:1,b:3,track:narrow;path=a:0,b:4,track:narrow',
+          },
+          '70s' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'path=a:0,b:1,track:narrow;path=a:0,b:2,track:narrow;path=a:1,b:3,track:narrow;path=a:2,b:3,track:narrow',
+          },
           'C7' =>
           {
             'count' => 2,
             'color' => 'brown',
             'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=C',
+          },
+          'C7s' =>
+          {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
           },
           'C8' =>
           {
@@ -304,11 +376,23 @@ module Engine
             'color' => 'brown',
             'code' => 'city=revenue:60,slots:2;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
           },
+          'C8s' =>
+          {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:2;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;label=C',
+          },
           'C9' =>
           {
             'count' => 2,
             'color' => 'gray',
             'code' => 'city=revenue:70,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=C',
+          },
+          'C9s' =>
+          {
+            'count' => 2,
+            'color' => 'gray',
+            'code' => 'city=revenue:70,slots:3;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
           },
         }.freeze
         # rubocop:enable Layout/LineLength

--- a/lib/engine/game/g_18_carolinas/step/convert_track.rb
+++ b/lib/engine/game/g_18_carolinas/step/convert_track.rb
@@ -40,8 +40,9 @@ module Engine
 
           def process_run_routes(action)
             hexes = action.routes[0].connection_hexes.flatten.uniq.map { |h| @game.hex_by_id(h) }
-            hexes_to_flip = hexes.select { |h| h.tile.paths.any? { |p| p.track != :broad } }
-            raise GameError, 'No tiles with Southern Track submitted' if hexes_to_flip.empty?
+            hexes_to_flip = hexes.select { |h| h.tile.paths.any? { |p| p.track != @game.final_gauge } }
+            target_track = @game.final_gauge == :broad ? 'Southern' : 'Standard'
+            raise GameError, "No tiles with #{target_track} Track submitted" if hexes_to_flip.empty?
 
             hexes_to_flip.each { |h| @game.flip_tile!(h) }
             pass!

--- a/lib/engine/game/g_18_carolinas/step/track.rb
+++ b/lib/engine/game/g_18_carolinas/step/track.rb
@@ -19,7 +19,7 @@ module Engine
           end
 
           def conversion_available?
-            @game.phase.available?('5') && @round.num_laid_track.zero?
+            @game.final_gauge && @round.num_laid_track.zero?
           end
 
           def round_state


### PR DESCRIPTION
Changes from the designer (Scott):
* Phase 3 is only Yellow tiles, and only 1 OR
* Phase 5 is only Yellow and Green tiles, and only 2 ORs
* Track conversion now begins at the start of Phase 6, and now involves a "voting" mechanism where the number of pure Southern track tiles and pure Standard (Northern) track tiles are compared. The majority becomes the dominant track gauge for the remainder of the game
* All tiles are now double-sided, with Standard track on one side and Southern on the other.

This is a substantial change which will invalidate most games in progress.