### PR TITLE
18Carolinas: more rule changes

### DIFF
--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -247,7 +247,7 @@ module Engine
         CAPITALIZATION = :full
         MUST_SELL_IN_BLOCKS = false
         MARKET_SHARE_LIMIT = 100
-        SELL_BUY_ORDER = :sell_buy_sell
+        SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :first
         PRESIDENT_SALES_TO_MARKET = true
         HOME_TOKEN_TIMING = :operating_round

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -585,30 +585,8 @@ module Engine
         end
 
         def vote_and_convert
-          # count track types and see whether there are more pure standard
-          # or southern track tiles
-          standard_count = 0
-          southern_count = 0
-          @hexes.each do |hex|
-            broad = hex.tile.paths.any? { |path| path.track == :broad }
-            narrow = hex.tile.paths.any? { |path| path.track == :narrow }
-            standard_count += 1 if broad && !narrow
-            southern_count += 1 if !broad && narrow
-          end
-          @final_gauge = if standard_count > southern_count
-                           :broad
-                         elsif standard_count < southern_count
-                           :narrow
-                         else
-                           # tie breaker: Northern or Southern company
-                           SOUTH_CORPORATIONS.include?(current_entity.name) ? :narrow : :broad
-                         end
-
-          @log << if @final_gauge == :broad
-                    'More Standard track than Southern. Can now only upgrade to Standard track'
-                  else
-                    'More Southern track than Standard. Can now only upgrade to Southern track'
-                  end
+          @final_gauge = :broad
+          @log << 'Standard gauge is now the dominant gauge. Can now only upgrade to Standard track'
 
           @all_tiles.each { |t| t.ignore_gauge_compare = true }
           @_tiles.values.each { |t| t.ignore_gauge_compare = true }

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -41,7 +41,7 @@ module Engine
         }.freeze
 
         MARKET = [
-          %w[0
+          %w[0c
              10
              20
              30
@@ -247,7 +247,7 @@ module Engine
         CAPITALIZATION = :full
         MUST_SELL_IN_BLOCKS = false
         MARKET_SHARE_LIMIT = 100
-        SELL_BUY_ORDER = :sell_buy
+        SELL_BUY_ORDER = :sell_buy_sell
         SELL_AFTER = :first
         PRESIDENT_SALES_TO_MARKET = true
         HOME_TOKEN_TIMING = :operating_round
@@ -305,57 +305,6 @@ module Engine
         C8_HEXES = %w[G19 J12].freeze
         C8_ROTATION = 5
 
-        def init_tile_groups
-          [
-            %w[1n 1s],
-            %w[2n 2s],
-            %w[3n 3s],
-            %w[4n 4s],
-            %w[5 5s],
-            %w[6 6s],
-            %w[7 7s],
-            %w[8 8s],
-            %w[9 9s],
-            %w[55n 55s],
-            %w[56n 56s],
-            %w[57 57s],
-            %w[58n 58s],
-            %w[C1 C2],
-            %w[C3 C4],
-            %w[12 12s],
-            %w[13 13s],
-            %w[14 14s],
-            %w[15 15s],
-            %w[16 16s],
-            %w[19 19s],
-            %w[20 20s],
-            %w[23 23s],
-            %w[24 24s],
-            %w[25 25s],
-            %w[26 26s],
-            %w[27 27s],
-            %w[28 28s],
-            %w[29 29s],
-            %w[87n 87s],
-            %w[88n 88s],
-            %w[C5 C6],
-            %w[38 38s],
-            %w[39 39s],
-            %w[40 40s],
-            %w[41 41s],
-            %w[42 42s],
-            %w[43 43s],
-            %w[44 44s],
-            %w[45 45s],
-            %w[46 46s],
-            %w[47 47s],
-            %w[70 70s],
-            %w[C7 C7s],
-            %w[C8 C8s],
-            %w[C9 C9s],
-          ]
-        end
-
         def update_opposites
           by_name = @tiles.group_by(&:name)
           @tile_groups.each do |grp|
@@ -378,7 +327,7 @@ module Engine
         end
 
         def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
+          SharePool.new(self, allow_president_sale: self.class::PRESIDENT_SALES_TO_MARKET)
         end
 
         def setup
@@ -532,7 +481,16 @@ module Engine
           # handle C tiles specially
           return false if from.label.to_s == 'C' && to.color == :yellow && from.cities.size != to.cities.size
 
+          # handle special-case upgrades
+          return true if force_dit_upgrade?(from, to)
+
           super
+        end
+
+        def force_dit_upgrade?(from, to)
+          return false unless (list = DIT_UPGRADES[from.name])
+
+          list.include?(to.name)
         end
 
         def update_tile_lists!(tile, old_tile)
@@ -842,12 +800,21 @@ module Engine
         end
 
         def check_distance(route, visits)
+          super
+          raise GameError, 'Route cannot begin/end in a town' if visits.first.town? || visits.last.town?
+
           if route.train.name == 'Convert'
             raise GameError, 'Route must be specified' if visits.empty?
-            raise GameError, 'Route cannot begin/end in a town' if visits.first.town? || visits.last.town?
+
+            return
           end
 
-          super
+          node_hexes = {}
+          visits.each do |node|
+            raise GameError, 'Cannot visit multiple towns/cities in same hex' if node_hexes[node.hex]
+
+            node_hexes[node.hex] = true
+          end
         end
 
         def check_connected(route, token)

--- a/lib/engine/game/g_18_carolinas/map.rb
+++ b/lib/engine/game/g_18_carolinas/map.rb
@@ -86,25 +86,25 @@ module Engine
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:1,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
           },
           '2s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:2,track:narrow',
+            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:2,track:narrow',
           },
           '3s' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
+            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
           },
           '4s' =>
           {
             'count' => 3,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
+            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
           },
           '5s' =>
           {
@@ -140,13 +140,13 @@ module Engine
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
           },
           '56s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:3,track:narrow',
+            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:3,track:narrow',
           },
           '57s' =>
           {
@@ -158,7 +158,7 @@ module Engine
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
+            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
           },
           'C1' =>
           {
@@ -272,13 +272,13 @@ module Engine
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
+            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
           },
           '88s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
           },
           'C5' =>
           {
@@ -507,7 +507,7 @@ module Engine
             ] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_80;path=a:5,b:_0,track:dual',
             %w[
             A23
-            ] => 'offboard=revenue:yellow_40|green_50|brown_60|gray_80;path=a:0,b:_0,track:dual',
+            ] => 'offboard=revenue:yellow_40|green_50|brown_60|gray_80;path=a:0,b:_0',
             %w[
             G1
             ] => 'offboard=revenue:yellow_40|green_60|brown_80|gray_100;path=a:4,b:_0,track:dual',

--- a/lib/engine/game/g_18_carolinas/map.rb
+++ b/lib/engine/game/g_18_carolinas/map.rb
@@ -292,83 +292,11 @@ module Engine
             'color' => 'green',
             'code' => 'city=revenue:50,slots:2;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
           },
-          '38s' =>
-          {
-            'count' => 4,
-            'color' => 'brown',
-            'code' => 'city=revenue:40,slots:2;path=a:0,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
-          },
-          '39s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:2,track:narrow;path=a:0,b:1,track:narrow;path=a:1,b:2,track:narrow',
-          },
-          '40s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:2,track:narrow;path=a:2,b:4,track:narrow;path=a:0,b:4,track:narrow',
-          },
-          '41s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:1,track:narrow;path=a:1,b:3,track:narrow',
-          },
-          '42s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:3,b:5,track:narrow;path=a:0,b:5,track:narrow',
-          },
-          '43s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:0,b:2,track:narrow;path=a:1,b:3,track:narrow;path=a:1,b:2,track:narrow',
-          },
-          '44s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:1,b:4,track:narrow;path=a:0,b:1,track:narrow;path=a:3,b:4,track:narrow',
-          },
-          '45s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:2,b:4,track:narrow;path=a:0,b:4,track:narrow;path=a:2,b:3,track:narrow',
-          },
-          '46s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:2,b:4,track:narrow;path=a:3,b:4,track:narrow;path=a:0,b:2,track:narrow',
-          },
-          '47s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:3,track:narrow;path=a:1,b:4,track:narrow;path=a:1,b:3,track:narrow;path=a:0,b:4,track:narrow',
-          },
-          '70s' =>
-          {
-            'count' => 1,
-            'color' => 'brown',
-            'code' => 'path=a:0,b:1,track:narrow;path=a:0,b:2,track:narrow;path=a:1,b:3,track:narrow;path=a:2,b:3,track:narrow',
-          },
           'C7' =>
           {
             'count' => 2,
             'color' => 'brown',
             'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=C',
-          },
-          'C7s' =>
-          {
-            'count' => 2,
-            'color' => 'brown',
-            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
           },
           'C8' =>
           {
@@ -376,37 +304,25 @@ module Engine
             'color' => 'brown',
             'code' => 'city=revenue:60,slots:2;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
           },
-          'C8s' =>
-          {
-            'count' => 2,
-            'color' => 'brown',
-            'code' => 'city=revenue:60,slots:2;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;label=C',
-          },
           'C9' =>
           {
             'count' => 2,
             'color' => 'gray',
             'code' => 'city=revenue:70,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=C',
           },
-          'C9s' =>
-          {
-            'count' => 2,
-            'color' => 'gray',
-            'code' => 'city=revenue:70,slots:3;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;label=C',
-          },
         }.freeze
         # rubocop:enable Layout/LineLength
 
         DIT_UPGRADES = {
-          # yellow double-dit to green K or X city
-          '1' => ['14'],
-          '1s' => ['14s'],
-          '2' => ['15'],
-          '2s' => ['15s'],
-          '55' => ['14'],
-          '55s' => ['14s'],
-          '56' => ['15'],
-          '56s' => ['15s'],
+          # yellow double-dit to green single-dit or K or X city
+          '1' => %w[14 88],
+          '1s' => %w[14s 88s],
+          '2' => %w[15 87],
+          '2s' => %w[15s 87s],
+          '55' => %w[14 88],
+          '55s' => %w[14s 88s],
+          '56' => %w[15 87],
+          '56s' => %w[15s 87s],
           # yellow single-dit to green city
           '3' => %w[12 14 15],
           '3s' => %w[12s 14s 15s],
@@ -450,20 +366,20 @@ module Engine
             %w[87 87s],
             %w[88 88s],
             %w[C5 C6],
-            %w[38 38s],
-            %w[39 39s],
-            %w[40 40s],
-            %w[41 41s],
-            %w[42 42s],
-            %w[43 43s],
-            %w[44 44s],
-            %w[45 45s],
-            %w[46 46s],
-            %w[47 47s],
-            %w[70 70s],
-            %w[C7 C7s],
-            %w[C8 C8s],
-            %w[C9 C9s],
+            %w[38],
+            %w[39],
+            %w[40],
+            %w[41],
+            %w[42],
+            %w[43],
+            %w[44],
+            %w[45],
+            %w[46],
+            %w[47],
+            %w[70],
+            %w[C7],
+            %w[C8],
+            %w[C9],
           ]
         end
 

--- a/lib/engine/game/g_18_carolinas/map.rb
+++ b/lib/engine/game/g_18_carolinas/map.rb
@@ -496,7 +496,6 @@ module Engine
             E13
             E17
             E19
-            E21
             E23
             F16
             F18

--- a/lib/engine/game/g_18_carolinas/map.rb
+++ b/lib/engine/game/g_18_carolinas/map.rb
@@ -19,12 +19,12 @@ module Engine
           'D4' => 'Asheville',
           'C9' => 'Statesville',
           'D10' => 'Charlotte',
-          'D12' => 'Concord',
           'D8' => 'Gastonia',
           'E15' => 'Fayetteville',
           'E5' => 'Greenville',
           'E7' => 'Spartanburg & Gaffney',
           'E9' => 'Rock Hill',
+          'E21' => 'New Bern',
           'F20' => 'Jacksonville',
           'G1' => 'Atlanta',
           'G11' => 'Camden',
@@ -42,12 +42,21 @@ module Engine
 
         # rubocop:disable Layout/LineLength
         TILES = {
+          '1' => 1,
+          '2' => 1,
+          '3' => 2,
+          '4' => 3,
           '5' => 4,
           '6' => 4,
           '7' => 3,
           '8' => 13,
           '9' => 10,
+          '55' => 1,
+          '56' => 1,
           '57' => 4,
+          '58' => 2,
+          '87' => 2,
+          '88' => 2,
           '12' => 3,
           '13' => 8,
           '14' => 3,
@@ -73,83 +82,29 @@ module Engine
           '46' => 1,
           '47' => 1,
           '70' => 1,
-          '1n' =>
-          {
-            'count' => 1,
-            'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0;path=a:_0,b:3;path=a:0,b:_1;path=a:_1,b:4',
-          },
-          '2n' =>
-          {
-            'count' => 1,
-            'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:2',
-          },
-          '3n' =>
-          {
-            'count' => 2,
-            'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0;path=a:_0,b:1',
-          },
-          '4n' =>
-          {
-            'count' => 3,
-            'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0;path=a:_0,b:3',
-          },
-          '55n' =>
-          {
-            'count' => 1,
-            'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:4',
-          },
-          '56n' =>
-          {
-            'count' => 1,
-            'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0;path=a:_0,b:2;path=a:1,b:_1;path=a:_1,b:3',
-          },
-          '58n' =>
-          {
-            'count' => 2,
-            'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0;path=a:_0,b:2',
-          },
-          '87n' =>
-          {
-            'count' => 2,
-            'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0',
-          },
-          '88n' =>
-          {
-            'count' => 2,
-            'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0',
-          },
           '1s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:1,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:1,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
           },
           '2s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:2,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:2,track:narrow',
           },
           '3s' =>
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
           },
           '4s' =>
           {
             'count' => 3,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',
           },
           '5s' =>
           {
@@ -185,13 +140,13 @@ module Engine
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
           },
           '56s' =>
           {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:3,track:narrow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow;path=a:1,b:_1,track:narrow;path=a:_1,b:3,track:narrow',
           },
           '57s' =>
           {
@@ -203,7 +158,7 @@ module Engine
           {
             'count' => 2,
             'color' => 'yellow',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
           },
           'C1' =>
           {
@@ -317,13 +272,13 @@ module Engine
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow',
           },
           '88s' =>
           {
             'count' => 2,
             'color' => 'green',
-            'code' => 'town=revenue:20;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+            'code' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
           },
           'C5' =>
           {
@@ -442,6 +397,76 @@ module Engine
         }.freeze
         # rubocop:enable Layout/LineLength
 
+        DIT_UPGRADES = {
+          # yellow double-dit to green K or X city
+          '1' => ['14'],
+          '1s' => ['14s'],
+          '2' => ['15'],
+          '2s' => ['15s'],
+          '55' => ['14'],
+          '55s' => ['14s'],
+          '56' => ['15'],
+          '56s' => ['15s'],
+          # yellow single-dit to green city
+          '3' => %w[12 14 15],
+          '3s' => %w[12s 14s 15s],
+          '4' => %w[14 15],
+          '4s' => %w[14s 15s],
+          '58' => %w[12 13 14 15],
+          '58s' => %w[12s 13s 14s 15s],
+        }.freeze
+
+        def init_tile_groups
+          [
+            %w[1 1s],
+            %w[2 2s],
+            %w[3 3s],
+            %w[4 4s],
+            %w[5 5s],
+            %w[6 6s],
+            %w[7 7s],
+            %w[8 8s],
+            %w[9 9s],
+            %w[55 55s],
+            %w[56 56s],
+            %w[57 57s],
+            %w[58 58s],
+            %w[C1 C2],
+            %w[C3 C4],
+            %w[12 12s],
+            %w[13 13s],
+            %w[14 14s],
+            %w[15 15s],
+            %w[16 16s],
+            %w[19 19s],
+            %w[20 20s],
+            %w[23 23s],
+            %w[24 24s],
+            %w[25 25s],
+            %w[26 26s],
+            %w[27 27s],
+            %w[28 28s],
+            %w[29 29s],
+            %w[87 87s],
+            %w[88 88s],
+            %w[C5 C6],
+            %w[38 38s],
+            %w[39 39s],
+            %w[40 40s],
+            %w[41 41s],
+            %w[42 42s],
+            %w[43 43s],
+            %w[44 44s],
+            %w[45 45s],
+            %w[46 46s],
+            %w[47 47s],
+            %w[70 70s],
+            %w[C7 C7s],
+            %w[C8 C8s],
+            %w[C9 C9s],
+          ]
+        end
+
         NORTH_COLOR = '#00a651'
         SOUTH_COLOR = '#fdba12'
 
@@ -458,10 +483,10 @@ module Engine
             B22
             C5
             C7
-            C11
             C19
             C23
             D6
+            D12
             D14
             D16
             D18
@@ -530,8 +555,8 @@ module Engine
             D8
             B20
             C13
-            C21
             E15
+            F20
             ] => "city=revenue:0;frame=color:#{NORTH_COLOR}",
             %w[
             E9
@@ -542,8 +567,9 @@ module Engine
             ] => "city=revenue:0;frame=color:#{SOUTH_COLOR}",
             %w[
             C9
-            D12
-            F20
+            C11
+            C21
+            E21
             ] => "town=revenue:0;frame=color:#{NORTH_COLOR}",
             %w[
             G11
@@ -566,7 +592,7 @@ module Engine
             ] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_80;path=a:5,b:_0,track:dual',
             %w[
             A23
-            ] => 'offboard=revenue:yellow_40|green_50|brown_60|gray_80;path=a:0,b:_0',
+            ] => 'offboard=revenue:yellow_40|green_50|brown_60|gray_80;path=a:0,b:_0,track:dual',
             %w[
             G1
             ] => 'offboard=revenue:yellow_40|green_60|brown_80|gray_100;path=a:4,b:_0,track:dual',
@@ -574,10 +600,7 @@ module Engine
           gray: {
             %w[
             I17
-            ] => 'offboard=revenue:0,visit_cost:99;path=a:1,b:_0,terminal:1;path=a:2,b:_0,terminal:1',
-            %w[
-            A19
-            ] => 'offboard=revenue:0,visit_cost:99;path=a:5,b:_0,terminal:1',
+            ] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0,terminal:1',
             %w[
             B4
             ] => 'path=a:0,b:4,track:narrow',

--- a/lib/engine/game/g_18_carolinas/step/buy_power.rb
+++ b/lib/engine/game/g_18_carolinas/step/buy_power.rb
@@ -56,7 +56,7 @@ module Engine
 
           def pass_description
             if @game.must_buy_power?(current_entity)
-              'Skip (to Emergency Buy)'
+              'Skip (to Forced Power Purchase)'
             else
               'Skip (Power)'
             end

--- a/lib/engine/game/g_18_carolinas/step/track.rb
+++ b/lib/engine/game/g_18_carolinas/step/track.rb
@@ -54,6 +54,44 @@ module Engine
             @log << 'Switching to Track Conversion Mode'
             pass!
           end
+
+          def end_subset?(this, other)
+            return true if (this.city? || this.town?) && (other.city? || other.town?)
+
+            this <= other
+          end
+
+          # this is basically the path '<=' method except towns and cities match
+          # both this and other are paths
+          def path_subset?(this, other)
+            other_ends = other.ends
+            this.ends.all? do |t|
+              other_ends.any? do |o|
+                end_subset?(t, o)
+              end
+            end && (this.ignore_gauge_compare || this.tracks_match?(other))
+          end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            return super unless @game.force_dit_upgrade?(hex.tile, tile)
+
+            # basically a simplified version of the super except with a modified path check to allow dits to upgrade to cities
+            return false unless @game.legal_tile_rotation?(entity, hex, tile)
+
+            old_paths = hex.tile.paths
+            old_ctedges = hex.tile.city_town_edges
+
+            new_paths = tile.paths
+            new_exits = tile.exits
+            new_ctedges = tile.city_town_edges
+            multi_city_upgrade = new_ctedges.size > 1 && old_ctedges.size > 1
+
+            new_exits.all? { |edge| hex.neighbors[edge] } &&
+              !(new_exits & hex_neighbors(entity, hex)).empty? &&
+              # substituted path check:
+              old_paths.all? { |path| new_paths.any? { |p| path_subset?(p, path) } } &&
+              (!multi_city_upgrade || old_ctedges.all? { |oldct| new_ctedges.one? { |newct| (oldct & newct) == oldct } })
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #6216 

Also removes "voting" (and double-sided brown and gray tiles).
Also checks to make sure extending track is done in existing gauge.

Most existing games will need to be archived.