### PR TITLE
[1893] Improve player order after drafting (fixes #6204)

### DIFF
--- a/lib/engine/game/g_1893/step/buy_minor.rb
+++ b/lib/engine/game/g_1893/step/buy_minor.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module BuyMinor
-  def draft_object(object, player, price, forced: false)
-    company = @game.to_company(object)
-
+  def draft_object(company, player, price, forced: false)
     player.spend(price, @game.bank)
     verb = forced ? 'is forced to buy' : 'buys'
     @log << "#{player.name} #{verb} \"#{company.name}\" for #{@game.format_currency(price)}"

--- a/lib/engine/game/g_1893/step/starting_package_initial_auction.rb
+++ b/lib/engine/game/g_1893/step/starting_package_initial_auction.rb
@@ -98,8 +98,7 @@ module Engine
             player = action.entity
             price = action.price
 
-            # TODO: Use only action.company when cleaning up code (this is to keep games that did not use proxy minors)
-            draft_object(@game.to_company(action.minor || action.company), player, price)
+            draft_object(action.company, player, price)
 
             action_finalized
           end
@@ -120,7 +119,9 @@ module Engine
           def action_finalized
             @round.next_entity_index!
             if finished?
-              @round.reset_entity_index!
+              # Do not call reset_entity_index, as we need to keep "left of last to act" entity
+              # (or first passer) as priority dealer for next draft/stock round.
+              @game.next_turn!
             else
               entity = entities[entity_index]
               return unless @game.passers_first_stock_round.include?(entity)

--- a/spec/fixtures/1893/46448.json
+++ b/spec/fixtures/1893/46448.json
@@ -56,7 +56,7 @@
       {
          "id":2,
          "type":"bid",
-         "minor":"KFBE",
+         "company":"KFBE",
          "price":200,
          "entity":1048,
          "entity_type":"player",
@@ -103,7 +103,7 @@
       {
          "id":7,
          "type":"bid",
-         "minor":"EKB",
+         "company":"EKB",
          "price":210,
          "entity":7785,
          "entity_type":"player",
@@ -113,7 +113,7 @@
       {
          "id":8,
          "type":"bid",
-         "minor":"KSZ",
+         "company":"KSZ",
          "price":100,
          "entity":3864,
          "entity_type":"player",
@@ -123,7 +123,7 @@
       {
          "id":9,
          "type":"bid",
-         "minor":"KBE",
+         "company":"KBE",
          "price":220,
          "entity":1048,
          "entity_type":"player",
@@ -151,7 +151,7 @@
       {
          "id":12,
          "type":"bid",
-         "minor":"BKB",
+         "company":"BKB",
          "price":190,
          "entity":5909,
          "entity_type":"player",


### PR DESCRIPTION
Also some clean up of drafted company.

This commit most likely break all 1893 games, so I suggest pinning
unfinished games, and archiving finished games.