### PR TITLE
Make it possible to show multiple double certificates

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -226,8 +226,8 @@ module View
         children << h('td.center', td_props, [h(:div, div_props, [h(:img, logo_props)])]) unless @hide_logo
 
         president_marker = corporation.president?(@player) ? '*' : ''
-        double_marker = shares.any?(&:double_cert) ? ' d' : ''
-        children << h(:td, td_props, corporation.name + president_marker + double_marker)
+        double_markers = 'd' * shares.count(&:double_cert)
+        children << h(:td, td_props, corporation.name + president_marker + double_markers)
         children << h('td.right', td_props, "#{shares.sum(&:percent)}%")
         h('tr.row', children)
       end


### PR DESCRIPTION
In e.g. 18Rhl there are two double certificates in corporation KKK.
With this commit if both certificates are in the same location
'dd' is shown. 'd' is used for single double certificate as before.

Here is how it looks like in 18Rhl - only KKK has double shares.

![image](https://user-images.githubusercontent.com/2631151/129797051-d178b916-fda8-413c-87ea-6f71bf0159b9.png)