### PR TITLE
Make spreadsheet visibility options a bit more clear

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -389,7 +389,7 @@ module View
       end
 
       def render_corporation(corporation, operating_order, current_round)
-        return '' if @hide_not_floated && !corporation.floated?
+        return '' if @hide_not_floated && !@game.operating_order.include?(corporation)
 
         border_style = "1px solid #{color_for(:font2)}"
 
@@ -403,7 +403,7 @@ module View
 
         tr_props = tr_default_props
         market_props = { style: { borderRight: border_style } }
-        if !corporation.floated?
+        if !@game.operating_order.include?(corporation)
           tr_props[:style][:opacity] = '0.5'
         elsif corporation.share_price&.highlight? &&
           (color = StockMarket::COLOR_MAP[@game.class::STOCKMARKET_COLORS[corporation.share_price.type]])

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -295,7 +295,7 @@ module View
                 textDecoration: 'underline',
               },
             },
-            @hide_not_floated ? 'floated' : 'all'),
+            @hide_not_floated ? 'Show unfloated' : 'Hide unfloated'),
           ')',
          ])
       end


### PR DESCRIPTION
This makes the links that toggle "hide/show unfloated companies" a bit more obvious since they use an action verb instead of `all`

Default view:
![image](https://user-images.githubusercontent.com/1711810/129953274-5c18cca2-734b-4d08-88ab-8f7122707df0.png)

After toggling:
![Screenshot 2021-08-18 11 32 50 AM](https://user-images.githubusercontent.com/1711810/129953305-c4ce66d4-f1a9-429f-bc0f-8993b7e50bbc.png)
