### PR TITLE
[1856] genericize spreadsheet view 'floated' => 'will operate'

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -389,7 +389,7 @@ module View
       end
 
       def render_corporation(corporation, operating_order, current_round)
-        return '' if @hide_not_floated && !corporation.floated?
+        return '' if @hide_not_floated && !@game.operating_order.include?(corporation)
 
         border_style = "1px solid #{color_for(:font2)}"
 
@@ -403,7 +403,7 @@ module View
 
         tr_props = tr_default_props
         market_props = { style: { borderRight: border_style } }
-        if !corporation.floated?
+        if !@game.operating_order.include?(corporation)
           tr_props[:style][:opacity] = '0.5'
         elsif corporation.share_price&.highlight? &&
           (color = StockMarket::COLOR_MAP[@game.class::STOCKMARKET_COLORS[corporation.share_price.type]])


### PR DESCRIPTION
56 has a concept where the company is not "floated" but is able to operate in the next round:

This changes the "show floated companies" view to include those "will operate" companies as well

![Screenshot 2021-08-18 11 47 47 AM](https://user-images.githubusercontent.com/1711810/129956176-99fbf7fc-0f77-44ea-8bd5-6eef709debde.png)


No change for other games, such as 46:
![Screenshot 2021-08-18 11 57 25 AM](https://user-images.githubusercontent.com/1711810/129956175-4a1835f4-e20d-4f23-834e-5f5fe462f837.png)