### PR TITLE
18Texas - Define buying power to be equal to treasury (not including treasury shares)

### DIFF
--- a/lib/engine/game/g_18_texas/game.rb
+++ b/lib/engine/game/g_18_texas/game.rb
@@ -207,6 +207,10 @@ module Engine
             .select { |bundle| @share_pool.fit_in_bank?(bundle) }
         end
 
+        def buying_power(entity, **)
+          entity.cash
+        end
+
         def redeemable_shares(entity)
           return [] unless entity.corporation?
 


### PR DESCRIPTION
fixes #6244