### PR TITLE
Prevent Safari treating chat input as username field

### DIFF
--- a/assets/app/view/chat.rb
+++ b/assets/app/view/chat.rb
@@ -42,6 +42,13 @@ module View
         end
       end
 
+      prevent_default = lambda do |event|
+        event = Native(event)
+        event.preventDefault
+      end
+
+      form_props = { on: { submit: prevent_default } }
+
       chatbar_props = {
         attrs: {
           autocomplete: 'off',
@@ -59,7 +66,7 @@ module View
         on: { keyup: enter },
       }
 
-      children << h('input#chatbar', chatbar_props) if @user
+      children << h(:form, form_props, [h('input#chatbar', chatbar_props)]) if @user
 
       props = {
         key: 'global_chat',


### PR DESCRIPTION
Attempts to fix #4656 again after recent occurrences.

Adds a form tag around the chat input on the home page. This appears to prevent Safari from detecting the input as part of a login form when certain keywords are in the chat log.

Steps to replicate:
- Use MacOS Safari to create an account, electing to save your password. (Thanks BrowserStack)
- Logout
- Login using the saved password.
- Enter a chat message with the string "username"
- Refresh the page
- Click on the chat input and observe the option to fill in the form with your username.

![Screenshot_20210821_040130](https://user-images.githubusercontent.com/105335/130315858-c4c617e5-5faf-47c0-81bc-e73c55ed71ad.png)

