### PR TITLE
Prevent Safari using game chat as login form

### DIFF
--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -41,6 +41,11 @@ module View
           end
         end
 
+        prevent_default = lambda do |event|
+          event = Native(event)
+          event.preventDefault
+        end
+
         if participant?
           children << h(:div, {
                           style: {
@@ -55,18 +60,23 @@ module View
                   margin: 'auto 0',
                 },
               }, [@user['name'] + ':']),
-            h('input#chatbar',
-              attrs: {
-                autocomplete: 'off',
-                title: 'hotkey: c – esc to leave',
-                type: 'text',
-                value: @chat_input,
-              },
-              style: {
-                marginLeft: '0.5rem',
-                flex: '1',
-              },
-              on: { keyup: key_event }),
+            h(:form, {
+                style: { display: 'contents' },
+                on: { submit: prevent_default },
+              }, [
+              h('input#chatbar',
+                attrs: {
+                  autocomplete: 'off',
+                  title: 'hotkey: c – esc to leave',
+                  type: 'text',
+                  value: @chat_input,
+                },
+                style: {
+                  marginLeft: '0.5rem',
+                  flex: '1',
+                },
+                on: { keyup: key_event }),
+              ]),
             ])
         end
 


### PR DESCRIPTION
Fixes #4656 in the game chat in the same manner as #6252 

In this case the form tag interfered with the width of the input field, thus the need for the `display: contents` style.

Note that the game chat seems less prone to triggering the autocomplete depending on what other text is present, but it is still possible:
![Screenshot_20210821_043524](https://user-images.githubusercontent.com/105335/130397581-e02fac0f-55cd-40cc-a522-f91df0631cbb.png)
