### PR TITLE
18Texas - Add private company powers, revise map

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -140,10 +140,11 @@ module View
             # If there's a choice of tokens of different types show the selector, otherwise just place
             next_tokens = step.available_tokens(entity)
             if next_tokens.size == 1 && actions.include?('place_token')
+              token_owner = step.respond_to?(:token_owner) && step.token_owner(@selected_company || @game.current_entity)
               action = Engine::Action::PlaceToken.new(
                 @selected_company || @game.current_entity,
                 city: @city,
-                tokener: @selected_company&.owned_by_player? ? @game.current_entity : nil,
+                tokener: @selected_company&.owned_by_player? ? @game.current_entity : token_owner,
                 slot: cheater || @slot_index,
                 token_type: next_tokens[0].type,
               )

--- a/assets/app/view/game/token_selector.rb
+++ b/assets/app/view/game/token_selector.rb
@@ -22,14 +22,17 @@ module View
         @size = @token_size / 2
         @distance = @token_size
 
-        tokens = @game.current_entity.tokens_by_type
+        step = @game.active_step
+        tokener = step.respond_to?(:token_owner) && step.token_owner(@game.current_entity)
+        tokens = tokener ? tokener.tokens_by_type : @game.current_entity.tokens_by_type
         tokens = list_coordinates(tokens, @distance, @size).map do |token, left, bottom|
           click = lambda do
             action = Engine::Action::PlaceToken.new(
               @game.current_entity,
               city: @tile_selector.city,
               slot: @tile_selector.slot_index,
-              token_type: token.type
+              token_type: token.type,
+              tokener: tokener,
             )
             process_action(action)
           end

--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -42,6 +42,7 @@ These attributes may be set for all ability types
       used with `close` abilities
     - `owning_corp_or_turn`: usable at any point during the owning corporation's OR turn
     - `owning_player_or_turn`: usable at any point during any of the owning player's OR turns
+    - `owning_player_track`: usable during track step during any of the owning player's OR turns
     - `owning_player_sr_turn`: usable at any point during any of the owning player's
     SR turns
     - `or_between_turns`: usable at the start of any corporation's OR turn,

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2549,6 +2549,8 @@ module Engine
             @round.operating? && @round.current_operator == ability.corporation
           when 'owning_player_or_turn'
             @round.operating? && @round.current_operator.player == ability.player
+          when 'owning_player_track'
+            @round.operating? && @round.current_operator.player == ability.player && current_step.is_a?(Step::Track)
           when 'owning_player_sr_turn'
             @round.stock? && @round.current_entity == ability.player
           when 'or_between_turns'

--- a/lib/engine/game/g_18_texas/entities.rb
+++ b/lib/engine/game/g_18_texas/entities.rb
@@ -37,7 +37,6 @@ module Engine
                         {
                           type: 'teleport',
                           when: 'owning_player_or_turn',
-                          reachable: false,
                           owner_type: 'player',
                           tiles: ['511'],
                           hexes: ['I14'],
@@ -80,7 +79,6 @@ module Engine
 
                         {
                           type: 'teleport',
-                          reachable: false,
                           when: 'owning_player_or_turn',
                           owner_type: 'player',
                           tiles: ['511'],

--- a/lib/engine/game/g_18_texas/entities.rb
+++ b/lib/engine/game/g_18_texas/entities.rb
@@ -14,7 +14,7 @@ module Engine
             name: 'Buffalo Bayou, Brazos and Colorado Railway Company',
             value: 50,
             revenue: 10,
-            desc: 'Blocks hex J13 until Phase 5. The owning president may place a #8 or #9 tile in this hex as an extra tile lay during the track laying step of a corporation for which they are president.',
+            desc: 'Extra Tile Lay. Blocks hex J13 until Phase 5. The owning president may place a #8 or #9 tile in this hex as an extra tile lay during the track laying step of a corporation for which they are president.',
             sym: 'BBBCRC',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J13'] },
                         {
@@ -31,7 +31,7 @@ module Engine
             name: 'Galveston and Red River Railway Company',
             value: 80,
             revenue: 20,
-            desc: 'The owning president may place a tile in hex I14 (Houston). The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action and the corporation must pay the terrain cost. The corporation may then immediately place a station token there.',
+            desc: 'Teleport to Houston. The owning president may place a tile in hex I14. The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action and the corporation must pay the terrain cost. The corporation may then immediately place a station token there.',
             sym: 'GRRRC',
             abilities: [
                         {
@@ -54,7 +54,7 @@ module Engine
             value: 210,
             revenue: 30,
             min_players: 4,
-            desc: 'Blocks hexes D13 and E12 until Phase 5. The owning president may place #8 and #9 tiles in these hexes as an extra tile lay during the track laying step of a corporation for which they are president. The tiles must connect to each other.',
+            desc: 'Extra Tile Lay. Blocks hexes D13 and E12 until Phase 5. The owning president may place #8 and #9 tiles in these hexes as an extra tile lay during the track laying step of a corporation for which they are president. The tiles must connect to each other.',
             sym: 'IGN',
             abilities: [{ type: 'shares', shares: 'match_share' },
                         { type: 'blocks_hexes', owner_type: 'player', hexes: %w[D13 E12] },
@@ -73,7 +73,7 @@ module Engine
             revenue: 40,
             min_players: 5,
             sym: 'NOPR',
-            desc: 'The owning president may place a tile in hex J5 (San Antonio). The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action. The corporation may then immediately place a station token there.',
+            desc: 'Teleport to San Antonio. The owning president may place a tile in hex J5. The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action. The corporation may then immediately place a station token there.',
 
             abilities: [{ type: 'shares', shares: 'match_share' },
 

--- a/lib/engine/game/g_18_texas/entities.rb
+++ b/lib/engine/game/g_18_texas/entities.rb
@@ -14,7 +14,7 @@ module Engine
             name: 'Buffalo Bayou, Brazos and Colorado Railway Company',
             value: 50,
             revenue: 10,
-            desc: 'No special ability',
+            desc: 'Blocks hex J13 until Phase 5. The owning president may place a #8 or #9 tile in this hex as an extra tile lay during the track laying step of a corporation for which they are president.',
             sym: 'BBBCRC',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J13'] },
                         {
@@ -31,7 +31,7 @@ module Engine
             name: 'Galveston and Red River Railway Company',
             value: 80,
             revenue: 20,
-            desc: 'The owning corporation may place a tile in hex I14. The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action and the corporation must pay the terrain cost. The corporation may then immediately place a station token there.',
+            desc: 'The owning president may place a tile in hex I14 (Houston). The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action and the corporation must pay the terrain cost. The corporation may then immediately place a station token there.',
             sym: 'GRRRC',
             abilities: [
                         {
@@ -55,6 +55,7 @@ module Engine
             value: 210,
             revenue: 30,
             min_players: 4,
+            desc: 'Blocks hexes D13 and E12 until Phase 5. The owning president may place #8 and #9 tiles in these hexes as an extra tile lay during the track laying step of a corporation for which they are president. The tiles must connect to each other.',
             sym: 'IGN',
             abilities: [{ type: 'shares', shares: 'match_share' },
                         { type: 'blocks_hexes', owner_type: 'player', hexes: %w[D13 E12] },
@@ -73,7 +74,7 @@ module Engine
             revenue: 40,
             min_players: 5,
             sym: 'NOPR',
-            desc: 'The owning corporation may place a tile in hex J5. The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action and the corporation must pay the terrain cost. The corporation may then immediately place a station token there.',
+            desc: 'The owning president may place a tile in hex J5 (San Antonio). The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action. The corporation may then immediately place a station token there.',
 
             abilities: [{ type: 'shares', shares: 'match_share' },
 

--- a/lib/engine/game/g_18_texas/entities.rb
+++ b/lib/engine/game/g_18_texas/entities.rb
@@ -19,7 +19,7 @@ module Engine
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J13'] },
                         {
                           type: 'tile_lay',
-                          when: 'owning_player_or_turn',
+                          when: 'owning_player_track',
                           owner_type: 'player',
                           hexes: ['J13'],
                           tiles: %w[8 9],
@@ -36,7 +36,7 @@ module Engine
             abilities: [
                         {
                           type: 'teleport',
-                          when: 'owning_player_or_turn',
+                          when: 'owning_player_track',
                           owner_type: 'player',
                           tiles: ['511'],
                           hexes: ['I14'],
@@ -60,7 +60,7 @@ module Engine
                         { type: 'blocks_hexes', owner_type: 'player', hexes: %w[D13 E12] },
                         {
                           type: 'tile_lay',
-                          when: 'owning_player_or_turn',
+                          when: 'owning_player_track',
                           owner_type: 'player',
                           hexes: %w[D13 E12],
                           tiles: %w[8 9],
@@ -79,7 +79,7 @@ module Engine
 
                         {
                           type: 'teleport',
-                          when: 'owning_player_or_turn',
+                          when: 'owning_player_track',
                           owner_type: 'player',
                           tiles: ['511'],
                           hexes: ['J5'],

--- a/lib/engine/game/g_18_texas/entities.rb
+++ b/lib/engine/game/g_18_texas/entities.rb
@@ -7,43 +7,87 @@ module Engine
   module Game
     module G18Texas
       module Entities
+        # rubocop:disable Layout/LineLength
+
         COMPANIES = [
           {
             name: 'Buffalo Bayou, Brazos and Colorado Railway Company',
             value: 50,
             revenue: 10,
             desc: 'No special ability',
-            sym: 'A',
+            sym: 'BBBCRC',
+            abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J13'] },
+                        {
+                          type: 'tile_lay',
+                          when: 'owning_player_or_turn',
+                          owner_type: 'player',
+                          hexes: ['J13'],
+                          tiles: %w[8 9],
+                          count: 1,
+                        }],
+
           },
           {
             name: 'Galveston and Red River Railway Company',
             value: 80,
             revenue: 20,
-            desc: 'No special ability',
-            sym: 'B',
-          },          {
+            desc: 'The owning corporation may place a tile in hex I14. The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action and the corporation must pay the terrain cost. The corporation may then immediately place a station token there.',
+            sym: 'GRRRC',
+            abilities: [
+                        {
+                          type: 'teleport',
+                          when: 'owning_player_or_turn',
+                          reachable: false,
+                          owner_type: 'player',
+                          tiles: ['511'],
+                          hexes: ['I14'],
+                        },
+                       ],
+          },
+          {
             name: 'Jay Gould',
             value: 200,
             revenue: 5,
             abilities: [{ type: 'shares', shares: 'random_president' }],
-            sym: 'C',
-          },          {
+            sym: 'JG',
+          }, {
             name: 'International–Great Northern',
             value: 210,
             revenue: 30,
-            abilities: [{ type: 'shares', shares: 'match_share' }],
             min_players: 4,
-            sym: 'D',
-          },          {
+            sym: 'IGN',
+            abilities: [{ type: 'shares', shares: 'match_share' },
+                        { type: 'blocks_hexes', owner_type: 'player', hexes: %w[D13 E12] },
+                        {
+                          type: 'tile_lay',
+                          when: 'owning_player_or_turn',
+                          owner_type: 'player',
+                          hexes: %w[D13 E12],
+                          tiles: %w[8 9],
+                          count: 2,
+                        }],
+          },
+          {
             name: 'New Orleans Pacific Railroad',
             value: 240,
             revenue: 40,
-
-            abilities: [{ type: 'shares', shares: 'match_share' }],
             min_players: 5,
-            sym: 'E',
+            sym: 'NOPR',
+            desc: 'The owning corporation may place a tile in hex J5. The corporation does not need to have a route to this hex. The tile placed counts as the corporation’s tile lay action and the corporation must pay the terrain cost. The corporation may then immediately place a station token there.',
+
+            abilities: [{ type: 'shares', shares: 'match_share' },
+
+                        {
+                          type: 'teleport',
+                          reachable: false,
+                          when: 'owning_player_or_turn',
+                          owner_type: 'player',
+                          tiles: ['511'],
+                          hexes: ['J5'],
+                        }],
           }
         ].freeze
+        # rubocop:enable Layout/LineLength
 
         CORPORATIONS = [
          {

--- a/lib/engine/game/g_18_texas/game.rb
+++ b/lib/engine/game/g_18_texas/game.rb
@@ -180,6 +180,8 @@ module Engine
         def operating_round(round_num)
           Engine::Round::Operating.new(self, [
             Engine::Step::Bankrupt,
+            Engine::Step::SpecialTrack,
+            Engine::Step::SpecialToken,
             Engine::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,

--- a/lib/engine/game/g_18_texas/map.rb
+++ b/lib/engine/game/g_18_texas/map.rb
@@ -90,6 +90,7 @@ module Engine
           'M8' => 'Corpus Christi',
           'N1' => 'Monterrey',
         }.freeze
+        # rubocop:disable Layout/LineLength
 
         HEXES = {
           white: {
@@ -193,7 +194,7 @@ module Engine
               ] => 'city=revenue:0;label=Y',
           },
           red: {
-            ['A12'] => 'offboard=revenue:yellow_20|brown_40;path=a:0,b:_0;path=a:5,b:_0',
+            ['A12'] => 'offboard=revenue:yellow_20|brown_40;path=a:0,b:_0',
             ['A18'] => 'offboard=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:5,b:_0',
             ['D1'] => 'offboard=revenue:yellow_50|brown_80;path=a:5,b:_0',
             %w[D19 H19] => 'offboard=revenue:yellow_30|brown_50;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0',
@@ -205,10 +206,11 @@ module Engine
             ['M8'] => 'town=revenue:yellow_20|brown_40;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0',
           },
           yellow: {
-            ['D9'] => 'city=revenue:30;city=revenue:30;label=Y;path=a:1,b:_0;path=a:_0,b:_1;path=a:_1,b:3',
-            ['I14'] => 'city=revenue:30;label=Y;path=a:1,b:_0;path=a:5,b:_0',
+            ['D9'] => 'city=revenue:10;city=revenue:20;label=Y;path=a:1,b:_0;path=a:_0,b:_1;path=a:_1,b:3;upgrade=cost:60,terrain:water',
+            ['I14'] => 'city=revenue:30;label=Y;path=a:1,b:_0;path=a:5,b:_0;upgrade=cost:60,terrain:water',
           },
         }.freeze
+        # rubocop:enable Layout/LineLength
 
         LAYOUT = :pointy
       end

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -82,7 +82,6 @@ module Engine
 
       def available_tokens(entity)
         ability = ability(entity)
-
         return super unless ability&.type == :token && ability.extra_action
 
         [Engine::Token.new(entity.owner)]

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -82,6 +82,7 @@ module Engine
 
       def available_tokens(entity)
         ability = ability(entity)
+
         return super unless ability&.type == :token && ability.extra_action
 
         [Engine::Token.new(entity.owner)]

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -33,7 +33,7 @@ module Engine
       end
 
       def round_state
-        state = @round.respond_to?(:teleported) ? {} : { teleported: nil }
+        state = @round.respond_to?(:teleported) ? {} : { teleported: nil, teleport_tokener: nil }
         state.merge(super)
       end
 
@@ -86,6 +86,7 @@ module Engine
           company.remove_ability(ability)
         else
           @round.teleported = company
+          @round.teleport_tokener = tokener
         end
       end
 

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -144,6 +144,7 @@ module Engine
           '%current_step%',
           'owning_corp_or_turn',
           'owning_player_or_turn',
+          'owning_player_track',
           'or_between_turns',
           'stock_round',
         ]


### PR DESCRIPTION
Company powers are activated during owning president's turn so new owning_player_track timing is added.

@roseundy provided code to perform a teleport action when a player owns the private company