### PR TITLE
18EU Mountain Upgrade

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -814,7 +814,7 @@ module Engine
         def operating_round(round_num)
           Round::Operating.new(self, [
             G18EU::Step::Bankrupt,
-            Engine::Step::Track,
+            G18EU::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,
             G18EU::Step::Dividend,

--- a/lib/engine/game/g_18_eu/step/track.rb
+++ b/lib/engine/game/g_18_eu/step/track.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/track'
+require_relative '../../../part/upgrade'
 
 module Engine
   module Game
@@ -10,7 +11,7 @@ module Engine
           include Engine::Step::Tracker
 
           def process_lay_tile(action)
-            # TODO: Mountain to Rough change
+            action.tile.upgrades << Part::Upgrade.new(60, ['mountain'], nil) if action.hex.tile.upgrades.sum(&:cost) == 120
 
             super
           end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/792

In 18EU, 120 cost mountains turn into 60 cost rough after a tile is laid on them. In the physical game, there are double sided tokens to represent this.

Note: I can't help but feel like I might be missing the easier/cleaner way to implement this.

Before Tile Lay, the hex SE of Basil is 120 cost:

<img width="201" alt="Screen Shot 2021-08-25 at 7 10 47 AM" src="https://user-images.githubusercontent.com/15675400/130796795-e7a87be9-044d-4555-87df-ff98eb530655.png">

Ater Tile Lay, the hex SE of Basil is 60 cost:

<img width="266" alt="Screen Shot 2021-08-25 at 7 10 36 AM" src="https://user-images.githubusercontent.com/15675400/130796865-54655991-5ea3-4f83-9ed4-bd11f22428b6.png">
