### PR TITLE
Add game details to webhook message

### DIFF
--- a/queue.rb
+++ b/queue.rb
@@ -29,7 +29,8 @@ MessageBus.subscribe '/turn' do |msg|
     next if (user.settings['webhook_user_id']&.strip || '') == ''
 
     begin
-      message = "<@#{user.settings['webhook_user_id']}> #{data['type']} #{data['game_url']}"
+      message = "<@#{user.settings['webhook_user_id']}> #{data['type']} in #{game.title} \"#{game.description}\" " \
+                "(#{game.round} #{game.turn})\n#{data['game_url']}"
       Hooks.send(user, message)
     rescue Exception => e # rubocop:disable Lint/RescueException
       puts e.backtrace


### PR DESCRIPTION
Fixes #5312 

Adds the game title, description, round and turn to the webhook message string. The result looks like:

```
@TestUser Your Turn in 1830 "Chat Test" (Stock Round 1)
http://localhost:9292/game/1
```

Styling suggestions welcome!