### PR TITLE
1825: minors and regional kits

### DIFF
--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -73,7 +73,7 @@ module Engine
 
       GREEN = {
         '10' => 'city=revenue:30;city=revenue:30;path=a:0,b:_0;path=a:3,b:_1',
-        '11' => 'town=revenue:10;path=a:0,b:_0;path=a:_0,b:2;path=a:2,b:_0;path=a:_0,b:4;path=a:0,b:_0;path=a:_0,b:4;label=HALT',
+        '11' => 'town=revenue:10;path=a:0,b:2;path=a:2,b:_0;path=a:_0,b:4;path=a:0,b:4;label=HALT',
         '12' => 'city=revenue:30;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0',
         '13' => 'city=revenue:30;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0',
         '14' => 'city=revenue:30,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0',
@@ -94,7 +94,7 @@ module Engine
         '29' => 'path=a:0,b:2;path=a:0,b:1',
         '30' => 'path=a:0,b:4;path=a:0,b:1',
         '31' => 'path=a:0,b:2;path=a:0,b:5',
-        '52' => 'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:2,b:_1;label=OO',
+        '52' => 'city=revenue:40,loc:5;city=revenue:40,loc:3;path=a:0,b:_0;path=a:2,b:_1;label=OO',
         '53' => 'city=revenue:50;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=B',
         '54' => 'city=revenue:60,loc:0.5;city=revenue:60,loc:2.5;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3;label=NY',
         '59' => 'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:2,b:_1;label=OO',
@@ -292,7 +292,7 @@ module Engine
 
       BROWN = {
         '32' => 'city=revenue:70;city=revenue:70;city=revenue:70;city=revenue:70;city=revenue:70;city=revenue:70;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;label=L',
-        '33' => 'city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;label=L',
+        '33' => 'city=revenue:50,loc:0;city=revenue:50,loc:2;city=revenue:50,loc:4;path=a:5,b:_0;path=a:3,b:_1;path=a:4,b:_2;label=L',
         '34' => 'city=revenue:50,loc:1.5;city=revenue:50,loc:4.5;city=revenue:50,loc:3;path=a:0,b:_2;path=a:_2,b:3;path=a:2,b:_0;path=a:4,b:_1;label=BGM',
         '35' => 'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:2;path=a:1,b:_1;path=a:_1,b:3',
         '36' => 'city=revenue:40;city=revenue:40;path=a:1,b:_0;path=a:_0,b:3;path=a:0,b:_1;path=a:_1,b:4',
@@ -310,9 +310,9 @@ module Engine
         '61' => 'city=revenue:60;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=B',
         '62' => 'city=revenue:80,slots:2;city=revenue:80,slots:2;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3;label=NY',
         '63' => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
-        '64' => 'city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:2;path=a:3,b:_1;path=a:_1,b:4;label=OO',
-        '65' => 'city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:4;path=a:2,b:_1;path=a:_1,b:3;label=OO',
-        '66' => 'city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:2;label=OO',
+        '64' => 'city=revenue:50;city=revenue:50,loc:3.5;path=a:0,b:_0;path=a:_0,b:2;path=a:3,b:_1;path=a:_1,b:4;label=OO',
+        '65' => 'city=revenue:50;city=revenue:50,loc:2.5;path=a:0,b:_0;path=a:_0,b:4;path=a:2,b:_1;path=a:_1,b:3;label=OO',
+        '66' => 'city=revenue:50;city=revenue:50,loc:1.5;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:2;label=OO',
         '67' => 'city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:2,b:_1;path=a:_1,b:4;label=OO',
         '68' => 'city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;path=a:1,b:_1;path=a:_1,b:4;label=OO',
         '70' => 'path=a:0,b:1;path=a:0,b:2;path=a:1,b:3;path=a:2,b:3',
@@ -434,7 +434,7 @@ module Engine
       }.freeze
 
       GRAY = {
-        '48' => 'city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100',
+        '48' => 'city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;label=L',
         '49' => 'city=revenue:70,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;label=L',
         '50' => 'city=revenue:70,loc:1.5;city=revenue:70,loc:3;city=revenue:70,loc:4.5;path=a:0,b:_1;path=a:_1,b:3;path=a:1,b:_0;path=a:_0,b:2;path=a:4,b:_2;path=a:_2,b:5;label=BGM',
         '51' => 'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
@@ -449,7 +449,7 @@ module Engine
         '131' => 'city=revenue:100,slots:4;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
         '134' => 'city=revenue:100,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;label=M',
         '136' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=KC;label=SL;label=MSP',
-        '167' => 'city=revenue:70;city=revenue:70;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3;path=a:4,b:_0;path=a:5,b:_1',
+        '167' => 'city=revenue:70;city=revenue:70;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3;path=a:4,b:_0;path=a:5,b:_1;label=OO',
         '171' => 'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
         '172' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
         '232' => 'city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=C',

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -26,7 +26,7 @@ module Engine
                   :type, :floatable, :original_par_price, :reservation_color, :min_price, :ipo_owner,
                   :always_market_price
     attr_reader :companies, :name, :full_name, :fraction_shares, :id, :needs_token_to_par,
-                :presidents_share
+                :presidents_share, :price_multiplier
     attr_writer :par_price, :share_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze
@@ -75,6 +75,8 @@ module Engine
       @type = opts[:type]&.to_sym
       @hide_shares = opts[:hide_shares] || false
       @reservation_color = opts[:reservation_color]
+      @price_percent = opts[:price_percent] || @second_share&.percent || @presidents_share.percent / 2
+      @price_multiplier = (@second_share&.percent || @presidents_share.percent / 2) / @price_percent
 
       init_abilities(opts[:abilities])
       init_operator(opts)

--- a/lib/engine/game/g_1825/entities.rb
+++ b/lib/engine/game/g_1825/entities.rb
@@ -95,6 +95,7 @@ module Engine
             sym: 'LNWR',
             name: 'London & North Western Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100, 100],
             coordinates: 'T16',
             city: 0,
@@ -107,6 +108,7 @@ module Engine
             sym: 'GWR',
             name: 'Great Western Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100, 100],
             coordinates: 'V14',
             city: 0,
@@ -119,17 +121,20 @@ module Engine
             sym: 'GER',
             name: 'Great Eastern Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'V20',
             city: 4,
             color: 'darkblue',
             text_color: 'white',
             reservation_color: nil,
+            abilities: [{ type: 'blocks_hexes', owner_type: nil, hexes: ['U23'] }],
           },
           {
             sym: 'LSWR',
             name: 'London & South Western Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'V20',
             city: 0,
@@ -142,6 +147,7 @@ module Engine
             sym: 'SECR',
             name: 'South Eastern & Chatham Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'W23',
             city: 0,
@@ -153,6 +159,7 @@ module Engine
             sym: 'LBSC',
             name: 'London Brighton & South Coast Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100],
             coordinates: 'X20',
             city: 0,
@@ -168,6 +175,7 @@ module Engine
             sym: 'LNWR',
             name: 'London & North Western Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'Q11',
             city: 0,
@@ -179,6 +187,7 @@ module Engine
             sym: 'MR',
             name: 'Midland Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'Q15',
             city: 0,
@@ -191,6 +200,7 @@ module Engine
             sym: 'NER',
             name: 'North Eastern Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'L14',
             city: 0,
@@ -202,6 +212,7 @@ module Engine
             sym: 'GCR',
             name: 'Great Central Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100],
             coordinates: 'O15',
             city: 0,
@@ -213,6 +224,7 @@ module Engine
             sym: 'GNR',
             name: 'Great Northern Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100],
             coordinates: 'O15',
             city: 1,
@@ -223,9 +235,10 @@ module Engine
             sym: 'L&YR',
             name: 'Lancashire & Yorkshire Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100],
             coordinates: 'O11',
-            city: 0,
+            city: 1,
             color: 'purple',
             reservation_color: nil,
             abilities: [{ type: 'blocks_hexes', owner_type: nil, hexes: ['N10'] }],
@@ -237,6 +250,7 @@ module Engine
             sym: 'CR',
             name: 'Caledonia Railway',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'G5',
             city: 2,
@@ -247,6 +261,7 @@ module Engine
             sym: 'NBR',
             name: 'North British Railway',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100, 100],
             coordinates: 'G5',
             city: 1,
@@ -257,6 +272,7 @@ module Engine
             sym: 'GSWR',
             name: 'Glasgow & South West Railway Company',
             capitalization: :full,
+            max_ownership_percent: 100,
             tokens: [0, 40, 100],
             coordinates: 'G5',
             city: 0,
@@ -270,6 +286,8 @@ module Engine
             capitalization: :incremental,
             float_percent: 40,
             shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
             tokens: [0],
             coordinates: 'B12',
             city: 0,
@@ -281,6 +299,8 @@ module Engine
             capitalization: :incremental,
             float_percent: 40,
             shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
             tokens: [0],
             coordinates: 'B8',
             city: 0,
@@ -292,9 +312,111 @@ module Engine
             capitalization: :incremental,
             float_percent: 40,
             shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
             tokens: [0],
             coordinates: 'K7',
             city: 0,
+            color: '#1b967a',
+          },
+        ].freeze
+
+        R1_CORPORATIONS = [
+          {
+            sym: 'Cam',
+            name: 'Cambrian Railway',
+            capitalization: :incremental,
+            float_percent: 40,
+            shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
+            tokens: [0],
+            coordinates: 'R8',
+            color: '#1b967a',
+            abilities: [{ type: 'blocks_hexes', owner_type: nil, hexes: ['R8'] }],
+          },
+          {
+            sym: 'TV',
+            name: 'Taff Vale Railway',
+            capitalization: :incremental,
+            float_percent: 40,
+            shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
+            tokens: [0],
+            coordinates: 'V8',
+            color: '#1b967a',
+          },
+        ].freeze
+
+        R2_CORPORATIONS = [
+          {
+            sym: 'S&DR',
+            name: 'Somerset & Dorset Railway',
+            capitalization: :incremental,
+            float_percent: 40,
+            shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
+            tokens: [0],
+            coordinates: 'W9',
+            color: '#1b967a',
+          },
+        ].freeze
+
+        R3_CORPORATIONS = [
+          {
+            sym: 'M&GN',
+            name: 'Midland & Great Northern Joint Railway',
+            capitalization: :incremental,
+            float_percent: 40,
+            shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
+            tokens: [0],
+            coordinates: 'Q23',
+            color: '#1b967a',
+          },
+        ].freeze
+
+        K5_CORPORATIONS = [
+          {
+            sym: 'FR',
+            name: 'Furness Railway',
+            capitalization: :incremental,
+            float_percent: 40,
+            shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
+            tokens: [0],
+            coordinates: 'M9',
+            color: '#1b967a',
+          },
+          {
+            sym: 'NS',
+            name: 'North Staffordshire Railway',
+            capitalization: :incremental,
+            float_percent: 40,
+            shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
+            tokens: [0],
+            coordinates: 'Q13',
+            color: '#1b967a',
+          },
+        ].freeze
+
+        K7_CORPORATIONS = [
+          {
+            sym: 'LT&S',
+            name: 'London, Tilbury & Southend Railway',
+            capitalization: :incremental,
+            float_percent: 40,
+            shares: [40, 20, 20, 20],
+            price_percent: 10,
+            max_ownership_percent: 100,
+            tokens: [0],
+            coordinates: 'V22',
             color: '#1b967a',
           },
         ].freeze
@@ -320,11 +442,11 @@ module Engine
           'GNoS' => '5',
           'HR' => 'U3',
           'M&C' => '3T',
-          'C' => 'U3',
+          'Cam' => 'U3',
           'FR' => '5',
           'LT&S' => '2+2',
           'M&GN' => '4T',
-          'NSR' => '3T',
+          'NS' => '3T',
           'S&DR' => '5',
           'TV' => '4T',
         }.freeze
@@ -338,7 +460,6 @@ module Engine
           comps
         end
 
-        # FIXME: R1, R2, R3, K5, K7
         def game_corporations
           corps = []
           corps.concat(UNIT1_CORPORATIONS) if @units[1]
@@ -351,7 +472,17 @@ module Engine
             lnwr[:coordinates] = %w[T16 Q11]
           end
           corps.concat(UNIT3_CORPORATIONS) if @units[3]
-          # FIXME: Modify GWR (Unit 1) if playing with R2
+          corps.concat(R1_CORPORATIONS) if @regionals[1]
+          # Modify GWR (Unit 1) if playing with R2
+          if @regionals[2]
+            corps.concat(R2_CORPORATIONS)
+            gwr = corps.find { |corp| corp[:sym] == 'GWR' }
+            gwr[:tokens] = [0, 0, 40, 100, 100, 100, 100]
+            gwr[:coordinates] = %w[V14 Y7]
+          end
+          corps.concat(R3_CORPORATIONS) if @regionals[3]
+          corps.concat(K5_CORPORATIONS) if @kits[5]
+          corps.concat(K7_CORPORATIONS) if @kits[7]
           corps
         end
       end

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -15,7 +15,7 @@ module Engine
         include Entities
         include Map
 
-        attr_reader :units, :distance_graph
+        attr_reader :units, :node_distance_graph, :city_distance_graph
 
         register_colors(black: '#37383a',
                         seRed: '#f72d2d',
@@ -130,7 +130,27 @@ module Engine
           },
         ].freeze
 
-        UNIT2_PHASES = [
+        UNIT2_PHASES_NO_K3 = [
+          {
+            name: '3a',
+            on: '6',
+            train_limit: 3,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+          },
+        ].freeze
+
+        UNIT3_PHASES_NO_K3 = [
+          {
+            name: '3b',
+            on: '7',
+            train_limit: 3,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+          },
+        ].freeze
+
+        PHASES_K3 = [
           {
             name: '4a',
             on: '6',
@@ -138,9 +158,6 @@ module Engine
             tiles: %i[yellow green brown gray],
             operating_rounds: 3,
           },
-        ].freeze
-
-        UNIT3_PHASES = [
           {
             name: '4b',
             on: '7',
@@ -152,24 +169,58 @@ module Engine
 
         def game_phases
           gphases = COMMON_PHASES.dup
-          gphases.concat(UNIT2_PHASES) if @units[2]
-          gphases.concat(UNIT3_PHASES) if @units[3]
+          gphases.concat(UNIT2_PHASES_NO_K3) if @units[2] && !@kits[3]
+          gphases.concat(UNIT3_PHASES_NO_K3) if @units[3] && !@kits[3]
+          gphases.concat(PHASES_K3) if @kits[3]
           gphases
         end
 
-        # FIXME: 3T/4T/2+2/4+4E definition and/or handling
-        ALL_TRAINS = {
+        ALL_TRAINS_NO_K3 = {
+          '2' => { distance: 2, price: 180, rusts_on: '5' },
+          '3' => { distance: 3, price: 300 },
+          '4' => { distance: 4, price: 430 },
+          '5' => { distance: 5, price: 550 },
+          '3T' => { distance: 3, price: 370, available_on: '5' },
+          'U3' => {
+            distance: [{ 'nodes' => ['city'], 'pay' => 3, 'visit' => 3 },
+                       { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
+            price: 410,
+            available_on: '5',
+          },
+          '6' => { distance: 7, price: 650 },
+          '4T' => { distance: 3, price: 480, available_on: '6' },
+          '2+2' => { distance: 2, price: 600, available_on: '6' },
+          '7' => { distance: 7, price: 720 },
+          '4+4E' => {
+            distance: [{ 'nodes' => ['city'], 'pay' => 4, 'visit' => 99 },
+                       { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
+            price: 830,
+            available_on: '7',
+          },
+        }.freeze
+
+        ALL_TRAINS_K3 = {
           '2' => { distance: 2, price: 180, rusts_on: '5' },
           '3' => { distance: 3, price: 300, rusts_on: '7' },
           '4' => { distance: 4, price: 430 },
           '5' => { distance: 5, price: 550 },
-          '3T' => { distance: 3, price: 370, available_on: '3' },
-          'U3' => { distance: 3, price: 410, available_on: '3' },
+          '3T' => { distance: 3, price: 370, available_on: '5' },
+          'U3' => {
+            distance: [{ 'nodes' => ['city'], 'pay' => 3, 'visit' => 3 },
+                       { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
+            price: 410,
+            available_on: '5',
+          },
+          '6' => { distance: 7, price: 650 },
           '4T' => { distance: 3, price: 480, available_on: '6' },
           '2+2' => { distance: 2, price: 600, available_on: '6' },
-          '6' => { distance: 7, price: 650 },
           '7' => { distance: 7, price: 720 },
-          '4+4E' => { distance: 4, price: 830, available_on: '7' },
+          '4+4E' => {
+            distance: [{ 'nodes' => ['city'], 'pay' => 4, 'visit' => 99 },
+                       { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
+            price: 830,
+            available_on: '7',
+          },
         }.freeze
 
         def build_train_list(thash)
@@ -177,31 +228,85 @@ module Engine
             new_hash = {}
             new_hash[:name] = t
             new_hash[:num] = thash[t]
-            new_hash.merge!(ALL_TRAINS[t])
+            new_hash.merge!(ALL_TRAINS_NO_K3[t]) unless @kits[3]
+            new_hash.merge!(ALL_TRAINS_K3[t]) if @kits[3]
+            new_hash
+          end
+        end
+
+        def add_train_list(tlist, thash)
+          thash.keys.each do |t|
+            if (item = tlist.find { |h| h[:name] == t })
+              item[:num] += thash[t]
+            else
+              new_hash = {}
+              new_hash[:name] = t
+              new_hash[:num] = thash[t]
+              new_hash.merge!(ALL_TRAINS_NO_K3[t]) unless @kits[3]
+              new_hash.merge!(ALL_TRAINS_K3[t]) if @kits[3]
+
+              tlist << new_hash
+            end
+          end
+        end
+
+        # throw out available_on specifiers if that train isn't in the list for this game
+        # this should only apply to minor trains
+        def fix_train_availables(tlist)
+          all_trains = tlist.map { |h| h[:name] }
+          tlist.each do |h|
+            h.delete(:available_on) if h[:available_on] && !all_trains.include?(h[:available_on])
           end
         end
 
         # FIXME: add option for additonal 3T/U3 for Unit 3
         # FIXME: add K2 trains
-        # FIXME: add K3 trains
         def game_trains
-          case @units.keys.sort.map(&:to_s).join
-          when '1'
-            build_train_list({ '2' => 6, '3' => 4, '4' => 3, '5' => 4 })
-          when '2'
-            build_train_list({ '2' => 5, '3' => 3, '4' => 2, '5' => 3, '6' => 2 })
-          when '3'
-            # extra 5/3T/U3 for minors
-            build_train_list({ '2' => 5, '3' => 3, '4' => 1, '5' => 3, '7' => 2, '3T' => 1, 'U3' => 1 })
-          when '12'
-            build_train_list({ '2' => 7, '3' => 6, '4' => 4, '5' => 5, '6' => 2 })
-          when '23'
-            # extra 5/3T/U3 for minors
-            build_train_list({ '2' => 5, '3' => 5, '4' => 4, '5' => 6, '6' => 2, '7' => 2, '3T' => 1, 'U3' => 1 })
-          else # all units
-            # extra 5/3T/U3 for minors
-            build_train_list({ '2' => 7, '3' => 6, '4' => 5, '5' => 6, '6' => 2, '7' => 2, '3T' => 1, 'U3' => 1 })
+          trains = case @units.keys.sort.map(&:to_s).join
+                   when '1'
+                     build_train_list({ '2' => 6, '3' => 4, '4' => 3, '5' => 4 })
+                   when '2'
+                     build_train_list({ '2' => 5, '3' => 3, '4' => 2, '5' => 3, '6' => 2 })
+                   when '3'
+                     # extra 5/3T/U3 for minors
+                     build_train_list({ '2' => 5, '3' => 3, '4' => 1, '5' => 3, '7' => 2, '3T' => 1, 'U3' => 1 })
+                   when '12'
+                     build_train_list({ '2' => 7, '3' => 6, '4' => 4, '5' => 5, '6' => 2 })
+                   when '23'
+                     # extra 5/3T/U3 for minors
+                     build_train_list({ '2' => 5, '3' => 5, '4' => 4, '5' => 6, '7' => 2, '3T' => 1, 'U3' => 1 })
+                   else # all units
+                     # extra 5/3T/U3 for minors
+                     build_train_list({ '2' => 7, '3' => 6, '4' => 5, '5' => 6, '6' => 2, '7' => 2, '3T' => 1, 'U3' => 1 })
+                   end
+          add_train_list(trains, { 'U3' => 1, '4T' => 1 }) if @regionals[1]
+          add_train_list(trains, { '5' => 1 }) if @regionals[2]
+          add_train_list(trains, { '4T' => 1 }) if @regionals[3]
+          add_train_list(trains, { '5' => -1, '6' => 3, '7' => 2 }) if @kits[3]
+          add_train_list(trains, { '3T' => 1, '5' => 1 }) if @kits[5]
+          add_train_list(trains, { '2+2' => 1 }) if @kits[7]
+
+          # handle K2
+          if @kits[2]
+            case @units.keys.sort.map(&:to_s).join
+            when '1', '2'
+              add_train_list(trains, { '3T' => 3, 'U3' => 1, '2+2' => 3, '4T' => 2, '4+4E' => 2 })
+              add_train_list(trains, { '3' => -1, '4' => -1 }) if @kits[3]
+            when '12'
+              add_train_list(trains, { '3T' => 4, 'U3' => 2, '2+2' => 3, '4T' => 2, '4+4E' => 2 })
+              add_train_list(trains, { '3' => -1, '4' => -1, '5' => -1 }) if @kits[3]
+            when '23'
+              add_train_list(trains, { '3T' => 4, 'U3' => 2, '2+2' => 3, '4T' => 2, '4+4E' => 2 })
+              add_train_list(trains, { '3' => -1, '5' => -1 }) if @kits[3]
+            when '123'
+              add_train_list(trains, { '3T' => 5, 'U3' => 3, '2+2' => 3, '4T' => 2, '4+4E' => 2 })
+              add_train_list(trains, { '3' => -1, '4' => -1, '5' => -1 }) if @kits[3]
+            end
           end
+
+          fix_train_availables(trains)
+
+          trains
         end
 
         CURRENCY_FORMAT_STR = '£%d'
@@ -211,12 +316,18 @@ module Engine
         SELL_BUY_ORDER = :sell_buy_sell
         SOLD_OUT_INCREASE = false
         PRESIDENT_SALES_TO_MARKET = true
+        MARKET_SHARE_LIMIT = 100
         HOME_TOKEN_TIMING = :operating_round
         BANK_CASH = 50_000
         COMPANY_SALE_FEE = 30
-        TRACK_RESTRICTION = :restrictive
+        TRACK_RESTRICTION = :station_restrictive
         TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
         GAME_END_CHECK = { bank: :current_or, stock_market: :immediate }.freeze
+        TRAIN_PRICE_MIN = 10
+
+        BANK_UNIT1 = 5000
+        BANK_UNIT2 = 5000
+        BANK_UNIT3 = 4000
 
         def init_optional_rules(optional_rules)
           optional_rules = (optional_rules || []).map(&:to_sym)
@@ -235,9 +346,12 @@ module Engine
             when 6, 7
               optional_rules << :unit_12
               @log << 'Using Units 1+2 based on player count'
-            when 8, 9
+            when 8
               optional_rules << :unit_123
               @log << 'Using Units 1+2+3 based on player count'
+            when 9
+              optional_rules.concat(%i[unit_123 r1 r2 r3])
+              @log << 'Using Units 1+2+3 and R1+R2+R3 based on player count'
             end
           end
 
@@ -259,6 +373,8 @@ module Engine
 
           # sanity check player count and illegal combination of options
           @units = {}
+          @kits = {}
+          @regionals = {}
 
           @units[1] = true if optional_rules.include?(:unit_1)
           @units[1] = true if optional_rules.include?(:unit_12)
@@ -273,9 +389,24 @@ module Engine
           @units[3] = true if optional_rules.include?(:unit_23)
           @units[3] = true if optional_rules.include?(:unit_123)
 
-          raise OptionError, 'Cannot combine Units 1 and 3 without Unit 2' if @units[1] && !@units[2] && @units[3]
+          @kits[1] = true if optional_rules.include?(:k1)
+          @kits[2] = true if optional_rules.include?(:k2)
+          @kits[3] = true if optional_rules.include?(:k3)
+          @kits[5] = true if optional_rules.include?(:k5)
+          @kits[6] = true if optional_rules.include?(:k6)
+          @kits[7] = true if optional_rules.include?(:k7)
 
-          # FIXME: update for regional kits when added
+          @regionals[1] = true if optional_rules.include?(:r1)
+          @regionals[2] = true if optional_rules.include?(:r2)
+          @regionals[3] = true if optional_rules.include?(:r3)
+
+          raise OptionError, 'Cannot combine Units 1 and 3 without Unit 2' if @units[1] && !@units[2] && @units[3]
+          raise OptionError, 'Cannot add Regionals without Unit 1' if !@regionals.keys.empty? && !@units[1]
+          raise OptionError, 'Cannot add K5 without Unit 2' if @kits[5] && !@units[2]
+          raise OptionError, 'Cannot add K7 without Unit 1' if @kits[7] && !@units[1]
+          raise OptionError, 'K2 not supported with just Unit 3' if @kits[2] && !@units[1] && !@units[2] && @units[3]
+          raise OptionError, 'K2 not supported without K3' if @kits[2] && !@kits[3]
+
           p_range = case @units.keys.sort.map(&:to_s).join
                     when '1'
                       [2, 5]
@@ -288,7 +419,7 @@ module Engine
                     when '23'
                       [3, 5]
                     else # all units
-                      [4, 8]
+                      @regionals.empty? ? [4, 8] : [4, 9]
                     end
           if p_range.first > @players.size || p_range.last < @players.size
             raise OptionError, 'Invalid option(s) for number of players'
@@ -297,22 +428,30 @@ module Engine
           optional_rules
         end
 
+        def calculate_bank_cash
+          bank_cash = 0
+          if @optional_rules.include?(:big_bank)
+            bank_cash += BANK_UNIT1 if @units[1]
+            bank_cash += BANK_UNIT2 if @units[2]
+            bank_cash += BANK_UNIT3 if @units[3]
+          else
+            bank_cash = BANK_UNIT1 if @units[1]
+            bank_cash = BANK_UNIT2 if @units[2] && bank_cash.zero?
+            bank_cash = BANK_UNIT3 if @units[3] && bank_cash.zero?
+          end
+
+          # add in minor and kit changes (Mike Hutton clarification)
+          unless @optional_rules.include?(:strict_bank)
+            bank_cash += 2000 if @kits[2]
+            bank_cash += 2000 if @kits[3]
+            bank_cash += 1000 * num_minors
+          end
+
+          bank_cash
+        end
+
         def bank_by_options
-          @bank_by_options ||=
-            case @units.keys.sort.map(&:to_s).join
-            when '1'
-              6_000
-            when '2'
-              5_000
-            when '3'
-              4_000
-            when '12'
-              11_000
-            when '23'
-              9_000
-            else # all units
-              15_000
-            end
+          @bank_by_options ||= calculate_bank_cash
         end
 
         def cash_by_options
@@ -332,21 +471,60 @@ module Engine
           end
         end
 
-        def certs_by_options
-          case @units.keys.sort.map(&:to_s).join
-          when '1'
-            { 2 => 24, 3 => 16, 4 => 12, 5 => 10 }
-          when '2'
-            { 2 => 24, 3 => 16, 4 => 12 }
-          when '3'
-            { 2 => 17 }
-          when '12'
-            { 3 => 31, 4 => 23, 5 => 19, 6 => 16, 7 => 14 }
-          when '23'
-            { 3 => 29, 4 => 23, 5 => 18 }
-          else # all units
-            { 4 => 33, 5 => 28, 6 => 23, 7 => 19, 8 => 17, 9 => 15 }
+        def num_minors
+          num_minors = 0
+          num_minors += 2 if @regionals[1]
+          num_minors += 1 if @regionals[2]
+          num_minors += 1 if @regionals[2]
+          num_minors += 2 if @kits[5]
+          num_minors += 1 if @kits[7]
+          num_minors
+        end
+
+        def adjust_certs(certs, chash)
+          chash.keys.each do |nplayers|
+            if certs[nplayers]
+              certs[nplayers] += chash[nplayers]
+            else
+              certs[nplayers] = chash[nplayers]
+            end
           end
+        end
+
+        def certs_by_options
+          certs = case @units.keys.sort.map(&:to_s).join
+                  when '1'
+                    { 2 => 24, 3 => 16, 4 => 12, 5 => 10 }
+                  when '2'
+                    { 2 => 24, 3 => 16, 4 => 12 }
+                  when '3'
+                    { 2 => 17 }
+                  when '12'
+                    { 3 => 31, 4 => 23, 5 => 19, 6 => 16, 7 => 14 }
+                  when '23'
+                    { 3 => 29, 4 => 23, 5 => 18 }
+                  else # all units
+                    { 4 => 33, 5 => 28, 6 => 23, 7 => 19, 8 => 17, 9 => 15 }
+                  end
+
+          case num_minors
+          when 1
+            adjust_certs(certs, { 2 => 1, 3 => 1, 4 => 1 })
+          when 2
+            adjust_certs(certs, { 2 => 2, 3 => 2, 4 => 1, 5 => 1, 6 => 1 })
+          when 3
+            adjust_certs(certs, { 2 => 3, 3 => 2, 4 => 2, 5 => 2, 6 => 1, 7 => 1, 8 => 1, 9 => 1 })
+          when 4
+            adjust_certs(certs, { 2 => 4, 3 => 3, 4 => 2, 5 => 2, 6 => 2, 7 => 2, 8 => 1, 9 => 1 })
+          when 5
+            adjust_certs(certs, { 2 => 5, 3 => 4, 4 => 3, 5 => 2, 6 => 2, 7 => 2, 8 => 2, 9 => 1 })
+          when 6
+            adjust_certs(certs, { 3 => 5, 4 => 3, 5 => 3, 6 => 3, 7 => 2, 8 => 2, 9 => 1 })
+          when 7
+            adjust_certs(certs, { 3 => 5, 4 => 4, 5 => 3, 6 => 3, 7 => 2, 8 => 2, 9 => 2 })
+          end
+
+          certs
         end
 
         def init_bank
@@ -378,7 +556,10 @@ module Engine
         end
 
         def setup
-          @distance_graph = DistanceGraph.new(self, separate_node_types: false)
+          @log << "Bank starts with #{format_currency(bank_by_options)}"
+
+          @node_distance_graph = DistanceGraph.new(self, separate_node_types: false)
+          @city_distance_graph = DistanceGraph.new(self, separate_node_types: true)
           @formed = []
           @highest_layer = 0
           @layer_by_corp = {}
@@ -389,8 +570,9 @@ module Engine
 
             @layer_by_corp[corp] = pars.index(PAR_BY_CORPORATION[corp.name]) + 1
           end
-
           @minor_trigger_layer = pars.include?(71) ? pars.index(71) + 2 : pars.index(76) + 2
+          @max_layers = @layer_by_corp.values.max
+          @max_layers = [@max_layers, @minor_trigger_layer].max if @units[3] || num_minors.positive?
 
           # Distribute privates
           # Rules call for randomizing privates, assigning to players then reordering players
@@ -421,11 +603,36 @@ module Engine
             end
           end
           @highest_layer = 1 if unbought_companies.empty?
+
+          # pull out minor trains from depot
+          @minor_trains = []
+          corporations.each do |minor|
+            next unless (name = REQUIRED_TRAIN[minor.name])
+
+            req_train = @depot.upcoming.find { |t| t.name == name }
+            raise GameError, "Unable to find train #{name} for minor #{minor.name}" unless req_train
+
+            req_train.buyable = false
+            req_train.reserved = true
+            @minor_trains << req_train
+            @depot.remove_train(req_train)
+          end
+        end
+
+        # cache all stock prices
+        def share_prices
+          stock_market.market.first
         end
 
         def upgrades_to?(from, to, special = false, selected_company: nil)
           # handle special-case upgrades
           return true if force_dit_upgrade?(from, to)
+
+          # deal with striped tiles
+          # 119 upgrades from yellow, but upgrades to gray
+          return false if (from.name == '119') && (to.color == :brown)
+          # 166 upgrades from green, but doesn't upgrade to gray
+          return false if (from.name == '166') && (to.color == :gray)
 
           super
         end
@@ -445,11 +652,11 @@ module Engine
         end
 
         def major?(corp)
-          corp.presidents_share.percent == 20
+          corp&.corporation? && corp.presidents_share.percent == 20
         end
 
         def minor?(corp)
-          corp.presidents_share.percent != 20
+          corp&.corporation? && corp.presidents_share.percent != 20
         end
 
         def minor_required_train(corp)
@@ -459,6 +666,7 @@ module Engine
           @depot.trains.find { |t| t.name == rtrain }
         end
 
+        # minor share price is for a 20% share
         def minor_par_prices(corp)
           price = minor_required_train(corp).price
           stock_market.market.first.select { |p| (p.price * 10) > price }.reject { |p| p.type == :endgame }
@@ -486,7 +694,11 @@ module Engine
           layers = @layer_by_corp.select do |corp, _layer|
             corp.num_ipo_shares.zero?
           end.values
-          layers.empty? ? 1 : [layers.max + 1, 4].min
+          layers.empty? ? 1 : [layers.max + 1, @max_layers].min
+        end
+
+        def minor_deferred_token?(entity)
+          minor?(entity) && !entity.tokens.first&.used
         end
 
         def init_round
@@ -503,17 +715,30 @@ module Engine
         end
 
         def operating_round(round_num)
-          Round::Operating.new(self, [
+          G1825::Round::Operating.new(self, [
+            Engine::Step::HomeToken,
             G1825::Step::TrackAndToken,
             Engine::Step::Route,
-            Engine::Step::Dividend,
+            G1825::Step::Dividend,
             Engine::Step::DiscardTrain,
             Engine::Step::BuyTrain,
           ], round_num: round_num)
         end
 
+        # Minors need to have a tile with cities and paths before they can lay
+        # their home token
+        def can_place_home_token?(entity)
+          return true unless minor?(entity)
+
+          home_hex = hex_by_id(entity.coordinates)
+          raise GameError, "can't find home hex for #{entity.name}" unless home_hex
+
+          !home_hex.tile.paths.empty? && !home_hex.tile.cities.empty?
+        end
+
         def place_home_token(corporation)
           return if corporation.tokens.first&.used
+          return unless can_place_home_token?(corporation)
           return super unless corporation.coordinates.is_a?(Array)
 
           corporation.coordinates.each do |coord|
@@ -526,6 +751,7 @@ module Engine
             @log << "#{corporation.name} places a token on #{hex.name}"
             city.place_token(corporation, token)
           end
+          @graph.clear
         end
 
         # Formation isn't flotation for minors
@@ -533,14 +759,23 @@ module Engine
           @formed.include?(corp)
         end
 
+        # For minors: not flotation, but when minor can purchase its required train
         def check_formation(corp)
           return if formed?(corp)
 
-          if major?(corp)
-            @formed << corp if corp.floated?
-          elsif corp.cash >= minor_required_train(corp).price
-            # note, not flotation, but when minor can purchase its required train
+          if major?(corp) && corp.floated?
             @formed << corp
+            @log << "#{corp.name} forms"
+          elsif minor?(corp) && corp.cash >= (r_train = minor_required_train(corp)).price
+            @formed << corp
+            @log << "Minor #{corp.name} forms"
+
+            # buy required train (no phase-change side-effects)
+            @minor_trains.delete(r_train)
+            corp.trains << r_train
+            r_train.owner = corp
+            corp.spend(r_train.price, @bank)
+            @log << "Minor #{corp.name} spends #{format_currency(r_train.price)} for required train (#{r_train.name})"
           end
         end
 
@@ -582,7 +817,7 @@ module Engine
         end
 
         def status_array(corp)
-          if @layer_by_corp[corp]
+          if major?(corp)
             layer_str = "Band #{@layer_by_corp[corp]}"
             layer_str += ' (N/A)' unless can_ipo?(corp)
 
@@ -597,8 +832,11 @@ module Engine
           end
 
           status = []
-          status << %w[Minor bold] unless @layer_by_corp[corp]
-          status << ["Required Train: #{minor_required_train(corp).name}"] if !@layer_by_corp[corp] && corp.trains.empty?
+          status << %w[Minor bold] unless major?(corp)
+          if minor?(corp) && !formed?(corp)
+            train = minor_required_train(corp)
+            status << ["Train: #{train.name} (#{format_currency(train.price)})"]
+          end
           status << [layer_str]
           status << [par_str] if par_str
           status << %w[Receivership bold] if corp.receivership?
@@ -606,11 +844,35 @@ module Engine
           status
         end
 
-        # FIXME: change after implementing trains with non-scalar distances
+        def node_distance(train)
+          return 0 if train.name == 'U3'
+
+          train.distance.is_a?(Numeric) ? train.distance : 99
+        end
+
         def biggest_train_distance(entity)
+          biggest_node_distance(entity)
+        end
+
+        def biggest_node_distance(entity)
           return 0 if entity.trains.empty?
 
-          entity.trains.map(&:distance).max
+          biggest = entity.trains.map { |t| node_distance(t) }.max
+          return 3 if biggest == 2 & entity.trains.count { |t| t.distance == 2 } > 1
+
+          biggest
+        end
+
+        def city_distance(train)
+          return 0 unless train.name == 'U3'
+
+          3
+        end
+
+        def biggest_city_distance(entity)
+          return 0 if entity.trains.empty?
+
+          entity.trains.map { |t| city_distance(t) }.max
         end
 
         def double_header_pair?(a, b)
@@ -737,6 +999,10 @@ module Engine
             ['≥ 3× stock value', '3 →'],
             ['≥ 4× stock value', '3 →'],
           ]
+        end
+
+        def must_buy_train?(_entity)
+          false
         end
       end
     end

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -82,6 +82,23 @@ module Engine
           'X22' => 'Hastings',
           'Y11' => 'Weymouth',
           'Y13' => 'Bournemouth',
+          # R1
+          'P4' => 'Holyhead',
+          'Q5' => 'Portmodoc',
+          'S5' => 'Aberystwyth',
+          'T2' => 'Fishguard',
+          'U1' => 'MilfordHaven',
+          'V6' => 'Swansea',
+          # R2
+          'X4' => 'Barnstaple',
+          'Y7' => 'Exeter',
+          'Z2' => 'Fowey',
+          'Z4' => 'Devonport & Plymouth',
+          'Z6' => 'Torquay',
+          'AA-1' => 'Penzance',
+          'AA1' => 'Falmouth',
+          # R3
+          'Q23' => 'Melton Constable',
         }.freeze
 
         UNIT1_TILES = {
@@ -98,7 +115,7 @@ module Engine
           '56' => 1,
           '12' => 2,
           '13' => 1,
-          '14' => 3,
+          '14' => 2,
           '15' => 2,
           '16' => 1,
           '19' => 1,
@@ -135,7 +152,7 @@ module Engine
           '4' => 1,
           '5' => 2,
           '6' => 2,
-          '7' => 2,
+          '7' => 3,
           '8' => 4,
           '9' => 4,
           '55' => 1,
@@ -179,7 +196,7 @@ module Engine
           '68' => 1,
           '49' => 1,
           '50' => 1,
-          '51' => 1,
+          '51' => 2,
         }.freeze
 
         UNIT3_TILES = {
@@ -230,7 +247,97 @@ module Engine
           '118' => 1,
         }.freeze
 
+        R1_TILES = {
+          '2' => 1,
+          '3' => 1,
+          '4' => 1,
+          '6' => 2,
+          '7' => 2,
+          '8' => 2,
+          '69' => 1,
+          '10' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30,loc:0;city=revenue:30,loc:3;path=a:5,b:_0;path=a:2,b:_1;label=OO',
+          },
+          '11' => 1,
+          '13' => 1,
+          '14' => 1,
+          '23' => 1,
+          '24' => 1,
+          '35' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:2;path=a:1,b:_1;path=a:_1,b:3;label=OO',
+          },
+          '37' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:40,loc:0;city=revenue:40,loc:3;path=a:2,b:_0;path=a:5,b:_1;path=a:2,b:5;label=OO',
+          },
+          '38' => 1,
+          '66' => 1,
+        }.freeze
+
+        R2_TILES = {
+          '3' => 1,
+          '58' => 1,
+          '115' => 1,
+          '10' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30,loc:0;city=revenue:30,loc:3;path=a:5,b:_0;path=a:2,b:_1;label=OO',
+          },
+          '35' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:2;path=a:1,b:_1;path=a:_1,b:3;label=OO',
+          },
+          '37' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:40,loc:0;city=revenue:40,loc:3;path=a:2,b:_0;path=a:5,b:_1;path=a:2,b:5;label=OO',
+          },
+        }.freeze
+
+        R3_TILES = {
+          '8' => 1,
+          '9' => 2,
+          '11' => 1,
+          '14' => 1,
+        }.freeze
+
+        K3_TILES = {
+          '48' => 1,
+          '49' => 1,
+          '50' => 2,
+          '51' => 3,
+          '60' => 2,
+          '166' => 4,
+          '167' => 4,
+          '168' =>
+          {
+            'count' => 2,
+            'color' => 'gray',
+            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=OO',
+          },
+        }.freeze
+
+        K5_TILES = {
+          '15' => 1,
+          '69' => 1,
+          '119' => 1,
+        }.freeze
+
         DIT_UPGRADES = {
+          # gentle curve to three curves with a halt
+          '8' => %w[11],
           # yellow double-dit to green K or X city
           '1' => %w[14],
           '2' => %w[15],
@@ -243,6 +350,8 @@ module Engine
           '3' => %w[12 14 15 119],
           '4' => %w[14 15 119],
           '58' => %w[12 13 14 15 119],
+          # HACK: for 119 (green/brown tile that upgrades to gray)
+          '119' => %w[51],
         }.freeze
 
         def append_game_tiles(gtiles, new_tiles)
@@ -250,7 +359,7 @@ module Engine
             if gtiles[k] && v.is_a?(Hash)
               raise GameError, "conflicting tile definitions for tile #{k}" unless gtiles[k].is_a?(Hash)
 
-              gtiles[k].count += v.count
+              gtiles[k]['count'] += v['count']
             elsif gtiles[k]
               raise GameError, "conflicting tile definitions for tile #{k}" if gtiles[k].is_a?(Hash)
 
@@ -266,6 +375,11 @@ module Engine
           append_game_tiles(gtiles, UNIT1_TILES) if @units[1]
           append_game_tiles(gtiles, UNIT2_TILES) if @units[2]
           append_game_tiles(gtiles, UNIT3_TILES) if @units[3]
+          append_game_tiles(gtiles, R1_TILES) if @regionals[1]
+          append_game_tiles(gtiles, R2_TILES) if @regionals[2]
+          append_game_tiles(gtiles, R3_TILES) if @regionals[3]
+          append_game_tiles(gtiles, K3_TILES) if @kits[3]
+          append_game_tiles(gtiles, K5_TILES) if @kits[5]
           gtiles
         end
 
@@ -338,6 +452,7 @@ module Engine
           },
           gray: {
             ['T16'] => 'city=revenue:10;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+            ['U25'] => 'city=revenue:20;path=a:1,b:_0',
             ['V14'] => 'city=revenue:10;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0',
             ['V22'] => 'city=revenue:20,loc:4;path=a:1,b:_0;path=a:1,b:3;path=a:0,b:5',
             ['W9'] => 'path=a:0,b:3;path=a:0,b:4;path=a:3,b:4',
@@ -391,7 +506,7 @@ module Engine
             ['M9'] => 'city=revenue:10;town=revenue:10;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_1;path=a:5,b:_1',
             ['O15'] => 'city=revenue:20,loc:0.5;city=revenue:20,loc:3.5;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1',
             ['P8'] => 'path=a:1,b:4;path=a:4,b:5;path=a:1,b:5',
-            ['Q11'] => 'city=revenue:10,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+            ['Q11'] => 'city=revenue:10;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
           },
         }.freeze
 
@@ -455,6 +570,60 @@ module Engine
           },
         }.freeze
 
+        R1_HEXES = {
+          white: {
+            %w[R6
+               T4
+               U3
+               U5] => '',
+            %w[Q7
+               S7
+               T6] => 'upgrade=cost:100,terrain:mountain',
+            ['P6'] => 'upgrade=cost:40,terrain:water',
+            %w[Q5
+               S5] => 'town=revenue:0',
+            ['U7'] => 'town=revenue:0;town=revenue:0',
+            %w[R8
+               T2] => 'city=revenue:0',
+          },
+          gray: {
+            ['P4'] => 'city=revenue:20;path=a:4,b:_0;path=a:5,b:_0',
+            ['U1'] => 'city=revenue:10;path=a:3,b:_0;path=a:4,b:_0',
+            ['V6'] => 'city=revenue:20;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+        }.freeze
+
+        R2_HEXES = {
+          white: {
+            %w[Y1
+               Y3
+               Z0] => '',
+            %w[X6
+               Y5] => 'upgrade=cost:100,terrain:mountain',
+            %w[X4
+               Z2
+               Z6
+               AA-1] => 'town=revenue:0',
+            %w[Y7
+               AA1] => 'city=revenue:0',
+          },
+          yellow: {
+            ['Z4'] => 'city=revenue:0;city=revenue:0;label=OO',
+          },
+          gray: {
+            ['W9'] => 'city=revenue:10,loc:4.5;path=a:0,b:3;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5',
+          },
+        }.freeze
+
+        R3_HEXES = {
+          white: {
+            ['Q25'] => '',
+          },
+          gray: {
+            ['Q23'] => 'city=revenue:10;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+          },
+        }.freeze
+
         UNIT1_OFFMAP_HEXES = {
           gray: {
             ['Q7'] => 'offboard=revenue:0,visit_cost:99;path=a:5,b:_0',
@@ -473,9 +642,6 @@ module Engine
             %w[S7
                U7] => 'offboard=revenue:0,visit_cost:99;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
             ['Y7'] => 'offboard=revenue:0,visit_cost:99;path=a:3,b:_0;path=a:4,b:_0',
-            ['Z8'] => 'offboard=revenue:0,visit_cost:99;path=a:3,b:_0',
-            ['Z10'] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0;path=a:3,b:_0',
-            ['Z12'] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0',
           },
         }.freeze
 
@@ -508,6 +674,13 @@ module Engine
                L12
                L14] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0;path=a:3,b:_0',
             ['L16'] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0',
+          },
+        }.freeze
+
+        R1_OFFMAP_HEXES = {
+          gray: {
+            ['P8'] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:1,b:_0',
+            ['Q9'] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0',
           },
         }.freeze
         # rubocop:enable Layout/LineLength
@@ -547,11 +720,15 @@ module Engine
 
         def game_hexes
           ghexes = {}
+          append_game_hexes(ghexes, R1_HEXES) if @regionals[1]
+          append_game_hexes(ghexes, R2_HEXES) if @regionals[2]
+          append_game_hexes(ghexes, R3_HEXES) if @regionals[3]
           append_game_hexes(ghexes, UNIT1_HEXES) if @units[1]
           append_game_hexes(ghexes, UNIT2_HEXES) if @units[2]
           append_game_hexes(ghexes, UNIT3_HEXES) if @units[3]
 
           # append_game_hexes will ignore "spike" hexes if they are already defined
+          append_game_hexes(ghexes, R1_OFFMAP_HEXES) if @regionals[1]
           append_game_hexes(ghexes, UNIT1_OFFMAP_HEXES) if @units[1]
           append_game_hexes(ghexes, UNIT2_OFFMAP_HEXES) if @units[2]
           append_game_hexes(ghexes, UNIT3_OFFMAP_HEXES) if @units[3]

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -47,6 +47,61 @@ module Engine
             short_name: 'Units 1+2+3',
             desc: '4-8 players',
           },
+          {
+            sym: :r1,
+            short_name: 'R1',
+            desc: 'Regional Kit 1 - Wales',
+          },
+          {
+            sym: :r2,
+            short_name: 'R2',
+            desc: 'Regional Kit 2 - South West England',
+          },
+          {
+            sym: :r3,
+            short_name: 'R3',
+            desc: 'Regional Kit 3 - North Norfolk',
+          },
+          {
+            sym: :k1,
+            short_name: 'K1',
+            desc: 'Extension Kit 1 - Suplementary Tiles',
+          },
+          {
+            sym: :k2,
+            short_name: 'K2',
+            desc: 'Extension Kit 2 - Advanced Trains',
+          },
+          {
+            sym: :k3,
+            short_name: 'K3',
+            desc: 'Extension Kit 3 - Phase Four',
+          },
+          {
+            sym: :k5,
+            short_name: 'K5',
+            desc: 'Extension Kit 5 - Minors for Unit 2',
+          },
+          {
+            sym: :k6,
+            short_name: 'K6',
+            desc: 'Extension Kit 6 - Advanced Tiles',
+          },
+          {
+            sym: :k7,
+            short_name: 'K7',
+            desc: 'Extension Kit 7 - London, Tilbury and Southend Railway',
+          },
+          {
+            sym: :big_bank,
+            short_name: 'BigBank',
+            desc: 'When combining units, add banks from each unit',
+          },
+          {
+            sym: :strict_bank,
+            short_name: 'StrictBank',
+            desc: 'Do not increase bank size based on number of minors and kits',
+          },
         ].freeze
       end
     end

--- a/lib/engine/game/g_1825/round/operating.rb
+++ b/lib/engine/game/g_1825/round/operating.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G1825
+      module Round
+        class Operating < Engine::Round::Operating
+          def start_operating
+            entity = @entities[@entity_index]
+            @current_operator = entity
+            @current_operator_acted = false
+            entity.trains.each { |train| train.operated = false }
+            @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
+            @game.place_home_token(entity) if @home_token_timing == :operate || @game.minor_deferred_token?(entity)
+            skip_steps
+            next_entity! if finished?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1825/step/buy_train.rb
+++ b/lib/engine/game/g_1825/step/buy_train.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1825
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def buyable_trains(entity)
+            depot_trains = @depot.depot_trains
+            other_trains = @depot.other_trains(entity)
+
+            depot_trains.reject! { |t| entity.cash < t.price }
+            other_trains = [] if entity.cash < @game.class::TRAIN_PRICE_MIN || entity.receivership?
+
+            depot_trains + other_trains
+          end
+
+          def spend_minmax(entity, _train)
+            [@game.class::TRAIN_PRICE_MIN, buying_power(entity)]
+          end
+
+          def must_buy_train?(_entity)
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1825/step/dividend.rb
+++ b/lib/engine/game/g_1825/step/dividend.rb
@@ -29,6 +29,7 @@ module Engine
 
           def share_price_change(entity, revenue)
             curr_price = entity.share_price.price
+
             if revenue.positive? && revenue <= curr_price / 2
               {}
             elsif revenue > curr_price / 2 && revenue < 2 * curr_price

--- a/lib/engine/game/g_1825/step/track_and_token.rb
+++ b/lib/engine/game/g_1825/step/track_and_token.rb
@@ -7,6 +7,27 @@ module Engine
     module G1825
       module Step
         class TrackAndToken < Engine::Step::TrackAndToken
+          def description
+            return 'Lay Home Track' if @game.minor_deferred_token?(current_entity)
+
+            'Place a Token or Lay Track'
+          end
+
+          # handle updating tile reservation if there is now only one tokenable city on tile
+          def update_tile_reservation(tile)
+            return unless tile.reservations.one?
+            return if tile.cities.empty?
+
+            corp = tile.reservations[0]
+            return unless tile.cities.count { |c| c.tokenable?(corp) } == 1
+
+            city = tile.cities.find { |c| c.tokenable?(corp) }
+            return unless (slot = city.get_slot(corp))
+
+            city.add_reservation!(corp, slot)
+            tile.reservations.delete(corp)
+          end
+
           # 1825: it is only an "upgrade" if the new tile replaces another laid tile
           def lay_tile_action(action, entity: nil, spender: nil)
             tile = action.tile
@@ -27,6 +48,11 @@ module Engine
             upgraded_track(old_tile, tile, action.hex)
             @round.num_laid_track += 1
             @round.laid_hexes << action.hex
+
+            update_tile_reservation(tile)
+
+            # handle deferred tile lay
+            @game.place_home_token(entity) if @game.minor_deferred_token?(entity) && @game.can_place_home_token?(entity)
 
             return unless (ability = @game.abilities(entity, :blocks_hexes))
 
@@ -84,30 +110,45 @@ module Engine
               (!multi_city_upgrade || old_ctedges.all? { |oldct| new_ctedges.one? { |newct| (oldct & newct) == oldct } })
           end
 
-          def reachable_node?(entity, node, max_distance)
-            return false if max_distance.zero?
+          def reachable_node?(entity, node, max_node_distance, max_city_distance)
+            if max_node_distance.positive?
+              node_distances = @game.node_distance_graph.node_distances(entity)
+              return false unless node_distances[node]
+              return true if node_distances[node][:node] < max_node_distance
+            end
 
-            node_distances = @game.distance_graph.node_distances(entity)
-            return false unless node_distances[node]
+            if max_city_distance.positive?
+              city_distances = @game.city_distance_graph.node_distances(entity)
+              return false unless city_distances[node]
+              return true if city_distances[node][:city] < max_city_distance
+            end
 
-            node_distances[node][:node] < max_distance
+            false
           end
 
           # 1825 rule: any upgraded station must be reachable with a train
           def check_track_restrictions!(entity, old_tile, new_tile)
             return if @game.loading || !entity.operator?
 
+            # allow a placement on home hex if minor home token hasn't been laid
+            # This should only apply to three of the minors (Cambrian, Taff Vale, North Staffordshire)
+            return if @game.minor_deferred_token?(entity) && new_tile.hex.id == entity.coordinates
+
             super
 
             return if old_tile.preprinted || new_tile.nodes.empty?
 
-            if (max_distance = @game.biggest_train_distance(entity)).zero?
-              raise GameError, 'Cannot upgrade a city/town without a train'
-            end
+            raise GameError, 'Cannot upgrade a city/town without a train' if entity.trains.empty?
 
-            @game.distance_graph.clear
+            # a 4+4E train can reach any tile on the network
+            return if (max_node_distance = @game.biggest_node_distance(entity)) == 99
+
+            max_city_distance = @game.biggest_city_distance(entity)
+
+            @game.node_distance_graph.clear
+            @game.city_distance_graph.clear
             new_tile.nodes.each do |node|
-              unless reachable_node?(entity, node, max_distance)
+              unless reachable_node?(entity, node, max_node_distance, max_city_distance)
                 raise GameError, 'Unable to reach city/town on upgraded tile with any train'
               end
             end
@@ -122,9 +163,18 @@ module Engine
           end
 
           def available_hex(entity, hex)
+            return true if @game.minor_deferred_token?(entity) && hex.id == entity.coordinates
             return true if can_lay_tile?(entity) && super
 
             tokenable_hex?(entity, hex)
+          end
+
+          def hex_neighbors(entity, hex)
+            return super if !@game.minor_deferred_token?(entity) || hex.id != entity.coordinates
+
+            neighbors = {}
+            hex.neighbors.each { |e, _| neighbors[e] = true }
+            neighbors.keys
           end
         end
       end

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -28,7 +28,7 @@ module Engine
       },
     }.freeze
 
-    LETTERS = ('A'..'Z').to_a
+    LETTERS = ('A'..'Z').to_a + ('AA'..'AZ').to_a
     NEGATIVE_LETTERS = [0] + ('a'..'z').to_a
 
     COORD_LETTER = /([A-Za-z]+)/.freeze

--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -43,7 +43,8 @@ module Engine
 
     def price_per_share
       share_price = @owner == corporation.ipo_owner ? corporation.par_price : corporation.share_price
-      share_price&.price || corporation.min_price
+      # annoyingly, this doesn't work: share_price&.price&.* corporation.multiplier (Opal bug?)
+      share_price&.price ? share_price.price * corporation.price_multiplier : corporation.min_price
     end
 
     def price

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -309,6 +309,8 @@ module Engine
           raise GameError, 'Must use new track' unless used_new_track
         when :semi_restrictive
           raise GameError, 'Must use new track or change city value' if !used_new_track && !changed_city
+        when :station_restrictive
+          raise GameError, 'Must use new track' if !used_new_track && !new_tile.nodes.empty?
         else
           raise
         end


### PR DESCRIPTION
Add dividend rules
Add train purchase rules
Add functionality for minors
Add Regional kits R1, R2, R2, K5 and K7 (corps, maps and tiles)
Certificate limits for minors
Rewrote bank cash calculation
More option validation

Common file edits:
* Engine::Corporation and Engine::Share - added support for calculating certificate prices when the price for a share is based on a 10% share, even for 5-share corporations where the smallest certificate is 20%
* Engine::Hex - added support for letter coordinates "AA" to "AZ"
* Step::Tracker - new track restriction type :station_restrictive to allow separate checking of tiles with nodes