### PR TITLE
1825: receivership and halts

### DIFF
--- a/lib/engine/distance_graph.rb
+++ b/lib/engine/distance_graph.rb
@@ -69,12 +69,14 @@ module Engine
       merge_distance(node_distances, node, distance)
       return if corporation && node.blocks?(corporation)
 
+      count = node.visit_cost.positive? ? 1 : 0
+
       if !@separate_node_types
-        distance[:node] += 1
+        distance[:node] += count
       elsif node.city?
-        distance[:city] += 1
+        distance[:city] += count
       elsif node.town? && !node.halt?
-        distance[:town] += 1
+        distance[:town] += count
       end
 
       node.paths.each do |node_path|
@@ -104,11 +106,11 @@ module Engine
       end
 
       if !@separate_node_types
-        distance[:node] -= 1
+        distance[:node] -= count
       elsif node.city?
-        distance[:city] -= 1
+        distance[:city] -= count
       elsif node.town? && !node.halt?
-        distance[:town] -= 1
+        distance[:town] -= count
       end
     end
 

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -261,7 +261,12 @@ module Engine
             'color' => 'green',
             'code' => 'city=revenue:30,loc:0;city=revenue:30,loc:3;path=a:5,b:_0;path=a:2,b:_1;label=OO',
           },
-          '11' => 1,
+          '11' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:10,visit_cost:0;path=a:0,b:2;path=a:2,b:_0;path=a:_0,b:4;path=a:0,b:4;label=HALT',
+          },
           '13' => 1,
           '14' => 1,
           '23' => 1,
@@ -309,7 +314,12 @@ module Engine
         R3_TILES = {
           '8' => 1,
           '9' => 2,
-          '11' => 1,
+          '11' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:10,visit_cost:0;path=a:0,b:2;path=a:2,b:_0;path=a:_0,b:4;path=a:0,b:4;label=HALT',
+          },
           '14' => 1,
         }.freeze
 
@@ -365,7 +375,7 @@ module Engine
 
               gtiles[k] += v
             else
-              gtiles[k] = v
+              gtiles[k] = v.dup
             end
           end
         end

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -15,7 +15,7 @@ module Engine
         GAME_LOCATION = 'United Kingdom'
         GAME_RULES_URL = 'http://google.com'
 
-        PLAYER_RANGE = [2, 8].freeze
+        PLAYER_RANGE = [2, 9].freeze
         OPTIONAL_RULES = [
           {
             sym: :unit_1,

--- a/lib/engine/game/g_1825/round/operating.rb
+++ b/lib/engine/game/g_1825/round/operating.rb
@@ -14,9 +14,9 @@ module Engine
             entity.trains.each { |train| train.operated = false }
             actor = @game.acting_for_entity(entity)
             if actor == entity.owner
-              @log << "#{actor} operates #{entity.name}" unless finished?
+              @log << "#{actor.name} operates #{entity.name}" unless finished?
             else
-              @log << "#{actor} selected to operate #{entity.name} (in Receivership)" unless finished?
+              @log << "#{actor.name} selected to operate #{entity.name} (in Receivership)" unless finished?
             end
             @game.place_home_token(entity) if @home_token_timing == :operate || @game.minor_deferred_token?(entity)
             skip_steps

--- a/lib/engine/game/g_1825/round/operating.rb
+++ b/lib/engine/game/g_1825/round/operating.rb
@@ -12,7 +12,12 @@ module Engine
             @current_operator = entity
             @current_operator_acted = false
             entity.trains.each { |train| train.operated = false }
-            @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
+            actor = @game.acting_for_entity(entity)
+            if actor == entity.owner
+              @log << "#{actor} operates #{entity.name}" unless finished?
+            else
+              @log << "#{actor} selected to operate #{entity.name} (in Receivership)" unless finished?
+            end
             @game.place_home_token(entity) if @home_token_timing == :operate || @game.minor_deferred_token?(entity)
             skip_steps
             next_entity! if finished?

--- a/lib/engine/game/g_1825/step/buy_train.rb
+++ b/lib/engine/game/g_1825/step/buy_train.rb
@@ -7,6 +7,12 @@ module Engine
     module G1825
       module Step
         class BuyTrain < Engine::Step::BuyTrain
+          def actions(entity)
+            return [] if entity.corporation? && entity.receivership?
+
+            super
+          end
+
           def buyable_trains(entity)
             depot_trains = @depot.depot_trains
             other_trains = @depot.other_trains(entity)
@@ -23,6 +29,32 @@ module Engine
 
           def must_buy_train?(_entity)
             false
+          end
+
+          def skip!
+            if current_entity.corporation? && current_entity.receivership? && !@game.silent_receivership?(current_entity)
+              return receivership_buy(current_entity)
+            end
+
+            super
+          end
+
+          def receivership_buy(entity)
+            @passed = true
+            train = @depot.depot_trains.first
+            if entity.cash >= train.price && @game.can_run_route?(entity) && room?(entity)
+              @log << "#{entity.name} is in Receivership and must buy a train"
+
+              buy_train_action(
+                Engine::Action::BuyTrain.new(
+                  entity,
+                  train: train,
+                  price: train.price
+                )
+              )
+            else
+              log_skip(entity)
+            end
           end
         end
       end

--- a/lib/engine/game/g_1825/step/dividend.rb
+++ b/lib/engine/game/g_1825/step/dividend.rb
@@ -23,6 +23,50 @@ module Engine
               OperatingInfo.new(skip_routes, @game.actions.last, @game.routes_revenue(skip_routes), @round.laid_hexes)
           end
 
+          def dividend_options(entity)
+            revenue = @game.routes_revenue(routes) - @round.receivership_loan
+            dividend_types.map do |type|
+              payout = send(type, entity, revenue)
+              payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
+              [type, payout.merge(share_price_change(entity, revenue - payout[:corporation]))]
+            end.to_h
+          end
+
+          def process_dividend(action)
+            entity = action.entity
+            revenue = @game.routes_revenue(routes)
+            if @round.receivership_loan.positive?
+              @log << "Revenue of #{@game.format_currency(revenue)} is reduced by "\
+                      "#{@game.format_currency(@round.receivership_loan)} to offset track, token, and/or lease costs"
+              revenue -= @round.receivership_loan
+            end
+            kind = action.kind.to_sym
+            payout = dividend_options(entity)[kind]
+
+            rust_obsolete_trains!(entity)
+
+            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
+              routes,
+              action,
+              revenue,
+              @round.laid_hexes
+            )
+
+            entity.trains.each { |train| train.operated = true }
+
+            @round.receivership_loan = 0
+            @round.routes = []
+
+            log_run_payout(entity, kind, revenue, action, payout)
+
+            payout_corporation(payout[:corporation], entity)
+
+            payout_shares(entity, revenue - payout[:corporation]) if payout[:per_share].positive?
+            change_share_price(entity, payout)
+
+            pass!
+          end
+
           def corporation_dividends(_entity, _per_share)
             0
           end

--- a/lib/engine/game/g_1825/step/route.rb
+++ b/lib/engine/game/g_1825/step/route.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/route'
+
+module Engine
+  module Game
+    module G1825
+      module Step
+        class Route < Engine::Step::Route
+          LEASE_COST = 10
+
+          def actions(entity)
+            return [] if !entity.operator? || (entity.runnable_trains.empty? && !entity.receivership?)
+            return [] unless @game.can_run_route?(entity)
+
+            return ACTIONS + %w[special_buy] if entity.receivership? && !@round.leased_train
+
+            ACTIONS
+          end
+
+          def setup
+            @round.leased_train = nil
+            super
+          end
+
+          def round_state
+            super.merge(
+              {
+                leased_train: nil,
+              }
+            )
+          end
+
+          def help
+            return super unless current_entity.receivership?
+
+            loan_msg = if @round.receivership_loan.positive?
+                         " #{current_entity.name} has spent #{@game.format_currency(@round.receivership_loan)} "\
+                           'on track, tokens and/or a leased train that must be repaid out of the route '\
+                           ' revenue. In the event that the revenue will not cover this cost, you must UNDO '\
+                           'the moves that cannot be afforded.'
+                       else
+                         ''
+                       end
+
+            "#{current_entity.name} is in receivership (it has no president). "\
+              "#{@game.acting_for_entity(current_entity).name} has been selected to run its trains."\
+              "#{loan_msg}"
+          end
+
+          def process_run_routes(action)
+            revenue = @game.routes_revenue(action.routes)
+
+            if revenue < @round.receivership_loan
+              raise GameError, "Revenue of #{revenue} insufficent to cover #{@round.receivership_loan} in costs"
+            end
+
+            super
+          end
+
+          def buyable_items(entity)
+            return [] unless entity.receivership?
+            return [] if @round.leased_train
+
+            train = @game.depot.upcoming.first
+            [Item.new(description: "Lease #{train.name} train from bank", cost: LEASE_COST)]
+          end
+
+          def process_special_buy(action)
+            train = @game.depot.upcoming.first
+            entity = action.entity
+            @round.leased_train = train
+
+            if entity.cash >= LEASE_COST
+              entity.spend(LEASE_COST, @game.bank)
+            else
+              diff = LEASE_COST - entity.cash
+              entity.spend(entity.cash, @game.bank) if entity.cash.positive?
+              @round.receivership_loan += diff
+            end
+            @log << "#{entity.name} leases #{train.name} for #{@game.format_currency(LEASE_COST)}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add all of the receivership rules, except for dealing with the "imaginary 9th share" when buying the president's cert.
Implemented halt functionality

Common files:
* Engine::DistanceGraph - will now ignore nodes that have a 0 visit_cost.