### PR TITLE
Auto independent mines

### DIFF
--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -23,6 +23,7 @@ module View
         if @game.players.find { |p| p.name == @user&.dig('name') }
           types = {
             Engine::Action::ProgramBuyShares => ->(settings) { render_buy_shares(settings) },
+            Engine::Action::ProgramIndependentMines => ->(settings) { render_independent_mines(settings) },
             Engine::Action::ProgramMergerPass => ->(settings) { render_merger_pass(settings) },
             Engine::Action::ProgramSharePass => ->(settings) { render_share_pass(settings) },
           }.freeze
@@ -330,6 +331,46 @@ module View
                          'Please read this for more details when it will deactivate')])
 
         subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_share_pass }]
+        subchildren << render_disable(settings) if settings
+        children << h(:div, subchildren)
+
+        children
+      end
+
+      def enable_independent_mines(form)
+        settings = params(form)
+
+        indefinite = settings['indefinite']
+
+        process_action(
+          Engine::Action::ProgramIndependentMines.new(
+            sender,
+            indefinite: indefinite
+          )
+        )
+      end
+
+      def render_independent_mines(settings)
+        form = {}
+        text = 'Auto Independent Mines'
+        text += ' (Enabled)' if settings
+        children = [h(:h3, text)]
+        children << h(:p,
+                      'Automatically skip closing independent mines, and optionally also laying track.'\
+                      ' This will deactivate itself in the next SR, unless set to indefinite.'\
+                      ' It will also deactivate itself when a mine has negative income.')
+
+        indefinite = settings ? settings&.indefinite : false
+        children << h(:div, [render_input(
+          'Indefinite (normally stops after one OR set)',
+          id: 'indefinite',
+          type: 'checkbox',
+          inputs: form,
+          attrs: {
+            checked: indefinite,
+          })])
+
+        subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_independent_mines(form) }]
         subchildren << render_disable(settings) if settings
         children << h(:div, subchildren)
 

--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -340,13 +340,31 @@ module View
       def enable_independent_mines(form)
         settings = params(form)
 
+        skip_track = settings['skip_track']
+        skip_buy = settings['skip_buy']
+        skip_close = settings['skip_close']
         indefinite = settings['indefinite']
 
         process_action(
           Engine::Action::ProgramIndependentMines.new(
             sender,
+            skip_track: skip_track,
+            skip_buy: skip_buy,
+            skip_close: skip_close,
             indefinite: indefinite
           )
+        )
+      end
+
+      def render_checkbox(label, id, form, checked)
+        render_input(
+          label,
+          id: id,
+          type: 'checkbox',
+          inputs: form,
+          attrs: {
+            checked: checked,
+          }
         )
       end
 
@@ -356,19 +374,18 @@ module View
         text += ' (Enabled)' if settings
         children = [h(:h3, text)]
         children << h(:p,
-                      'Automatically skip closing independent mines, and optionally also laying track.'\
+                      'Automatically skip independent mine actions.'\
                       ' This will deactivate itself in the next SR, unless set to indefinite.'\
                       ' It will also deactivate itself when a mine has negative income.')
 
-        indefinite = settings ? settings&.indefinite : false
-        children << h(:div, [render_input(
-          'Indefinite (normally stops after one OR set)',
-          id: 'indefinite',
-          type: 'checkbox',
-          inputs: form,
-          attrs: {
-            checked: indefinite,
-          })])
+        children << h(:div, [
+          render_checkbox('Skip track lay', 'skip_track', form, settings ? settings.skip_track : true),
+          render_checkbox('Skip switchers', 'skip_buy', form, settings ? settings.skip_buy : true),
+          render_checkbox('Skip close mine', 'skip_close', form, settings ? settings.skip_close : true),
+        ])
+        children << h(:div, [
+          render_checkbox('Indefinite (normally stops after one OR set)', 'indefinite', form, settings&.indefinite),
+        ])
 
         subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_independent_mines(form) }]
         subchildren << render_disable(settings) if settings

--- a/lib/engine/action/program_independent_mines.rb
+++ b/lib/engine/action/program_independent_mines.rb
@@ -6,19 +6,32 @@ require_relative 'program_enable'
 module Engine
   module Action
     class ProgramIndependentMines < ProgramEnable
-      attr_reader :indefinite
+      attr_reader :indefinite, :skip_track, :skip_buy, :skip_close
 
-      def initialize(entity, indefinite:)
+      def initialize(entity, skip_track:, skip_buy:, skip_close:, indefinite:)
         super(entity)
+        @skip_track = skip_track
+        @skip_buy = skip_buy
+        @skip_close = skip_close
         @indefinite = indefinite
       end
 
       def self.h_to_args(h, _game)
-        { indefinite: h['indefinite'] }
+        {
+          skip_track: h['skip_track'],
+          skip_buy: h['skip_buy'],
+          skip_close: h['skip_close'],
+          indefinite: h['indefinite'],
+        }
       end
 
       def args_to_h
-        { 'indefinite' => @indefinite }
+        {
+          'skip_track' => @skip_track,
+          'skip_buy' => @skip_buy,
+          'skip_close' => @skip_close,
+          'indefinite' => @indefinite,
+        }
       end
 
       def self.description

--- a/lib/engine/action/program_independent_mines.rb
+++ b/lib/engine/action/program_independent_mines.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'program_enable'
+
+module Engine
+  module Action
+    class ProgramIndependentMines < ProgramEnable
+      attr_reader :indefinite
+
+      def initialize(entity, indefinite:)
+        super(entity)
+        @indefinite = indefinite
+      end
+
+      def self.h_to_args(h, _game)
+        { indefinite: h['indefinite'] }
+      end
+
+      def args_to_h
+        { 'indefinite' => @indefinite }
+      end
+
+      def self.description
+        "Pass on independent mines until #{@indefinite ? 'turned off' : 'next SR'}"
+      end
+
+      def self.print_name
+        'Pass on independent mines'
+      end
+
+      def disable?(game)
+        !game.round.operating? && !@indefinite
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -3171,6 +3171,12 @@ module Engine
             },
           ]
         end
+
+        def available_programmed_actions
+          super + [
+            Action::ProgramIndependentMines,
+          ]
+        end
       end
     end
   end

--- a/lib/engine/game/g_1873/step/buy_train.rb
+++ b/lib/engine/game/g_1873/step/buy_train.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/buy_train'
+require_relative '../../../step/programmer'
 
 module Engine
   module Game
     module G1873
       module Step
         class BuyTrain < Engine::Step::BuyTrain
+          include Engine::Step::Programmer
+
           def setup
             super
           end
@@ -344,6 +347,18 @@ module Engine
 
           def president_may_contribute?(_corporation, _active_shell)
             false
+          end
+
+          def auto_actions(entity)
+            programmed_auto_actions(entity)
+          end
+
+          def activate_program_independent_mines(entity, _program)
+            available_actions = actions(entity)
+            return unless available_actions.include?('pass')
+            return unless entity.minor?
+
+            [Action::Pass.new(entity)]
           end
         end
       end

--- a/lib/engine/game/g_1873/step/buy_train.rb
+++ b/lib/engine/game/g_1873/step/buy_train.rb
@@ -353,10 +353,11 @@ module Engine
             programmed_auto_actions(entity)
           end
 
-          def activate_program_independent_mines(entity, _program)
+          def activate_program_independent_mines(entity, program)
             available_actions = actions(entity)
             return unless available_actions.include?('pass')
             return unless entity.minor?
+            return unless program.skip_buy
 
             [Action::Pass.new(entity)]
           end

--- a/lib/engine/game/g_1873/step/convert.rb
+++ b/lib/engine/game/g_1873/step/convert.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/base'
+require_relative '../../../step/programmer'
 
 module Engine
   module Game
     module G1873
       module Step
         class Convert < Engine::Step::Base
+          include Engine::Step::Programmer
+
           def actions(entity)
             return [] if entity.minor? && !entity.owner
             return %w[convert pass] if can_convert?(entity)
@@ -58,6 +61,18 @@ module Engine
             end
 
             pass!
+          end
+
+          def auto_actions(entity)
+            programmed_auto_actions(entity)
+          end
+
+          def activate_program_independent_mines(entity, _program)
+            available_actions = actions(entity)
+            return unless available_actions.include?('pass')
+            return unless entity.minor?
+
+            [Action::Pass.new(entity)]
           end
         end
       end

--- a/lib/engine/game/g_1873/step/convert.rb
+++ b/lib/engine/game/g_1873/step/convert.rb
@@ -67,10 +67,11 @@ module Engine
             programmed_auto_actions(entity)
           end
 
-          def activate_program_independent_mines(entity, _program)
+          def activate_program_independent_mines(entity, program)
             available_actions = actions(entity)
             return unless available_actions.include?('pass')
             return unless entity.minor?
+            return unless program.skip_close
 
             [Action::Pass.new(entity)]
           end

--- a/lib/engine/game/g_1873/step/track.rb
+++ b/lib/engine/game/g_1873/step/track.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../../../step/programmer'
 require_relative '../../../step/track'
 
 module Engine
@@ -7,6 +8,8 @@ module Engine
     module G1873
       module Step
         class Track < Engine::Step::Track
+          include Engine::Step::Programmer
+
           def round_state
             {
               non_double_tile: false,
@@ -228,6 +231,18 @@ module Engine
             @log << "#{entity.name} had portions of concession route previously built"
             @log << "#{entity.name} pays remaining concession cost of #{@game.format_currency(total_cost)}"
             entity.spend(total_cost, @game.bank)
+          end
+
+          def auto_actions(entity)
+            programmed_auto_actions(entity)
+          end
+
+          def activate_program_independent_mines(entity, _program)
+            available_actions = actions(entity)
+            return unless available_actions.include?('pass')
+            return unless entity.minor?
+
+            [Action::Pass.new(entity)]
           end
         end
       end

--- a/lib/engine/game/g_1873/step/track.rb
+++ b/lib/engine/game/g_1873/step/track.rb
@@ -237,10 +237,11 @@ module Engine
             programmed_auto_actions(entity)
           end
 
-          def activate_program_independent_mines(entity, _program)
+          def activate_program_independent_mines(entity, program)
             available_actions = actions(entity)
             return unless available_actions.include?('pass')
             return unless entity.minor?
+            return unless program.skip_track
 
             [Action::Pass.new(entity)]
           end

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Engine
   module Step
     class Program < Base
-      ACTIONS = %w[program_buy_shares program_merger_pass program_share_pass program_disable].freeze
+      ACTIONS = %w[program_buy_shares program_independent_mines program_merger_pass program_share_pass program_disable].freeze
 
       def actions(entity)
         return [] unless entity.player?
@@ -16,6 +16,10 @@ module Engine
       def process_program_buy_shares(action)
         raise GameError, 'Until condition is unset' if !@game.loading && !action.until_condition
 
+        process_program_enable(action)
+      end
+
+      def process_program_independent_mines(action)
         process_program_enable(action)
       end
 


### PR DESCRIPTION
This adds an auto program for Harzbahn 1873 to automate independent mines, which currently are a big drag on game speed due to their large number and mostly trivial actions.

The first commit contains the program, the second commit extends the UI to allow disabling each of the three actions a mine can perform separately.

Code passed rake, but I'm a total beginner at ruby and github, so there's probably room for improvement still.