### PR TITLE
1825: rendering fixes; K1, K6 and D1

### DIFF
--- a/assets/app/lib/hex.rb
+++ b/assets/app/lib/hex.rb
@@ -64,6 +64,7 @@ module Lib
       blue: '#35A7FF',
       purple: '#A79ECD',
       orange: '#FFA500',
+      sepia: '#6b4b35',
     }.freeze
 
     def self.points(scale: 1.0)

--- a/assets/app/view/game/part/town_location.rb
+++ b/assets/app/view/game/part/town_location.rb
@@ -210,7 +210,7 @@ module View
 
         # center two-exit town on the track if there isn't any more track on the tile
         def center_town?(tile, town)
-          town.exits.size == 2 && tile.exits.size == 2
+          town.exits.size == 2 && (tile.exits.size == 2 || tile.exits.size == 3)
         end
 
         # Returns an array of weights, location and rotations

--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -449,7 +449,7 @@ module Engine
         '131' => 'city=revenue:100,slots:4;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
         '134' => 'city=revenue:100,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;label=M',
         '136' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=KC;label=SL;label=MSP',
-        '167' => 'city=revenue:70;city=revenue:70;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3;path=a:4,b:_0;path=a:5,b:_1;label=OO',
+        '167' => 'city=revenue:70,loc:0.5;city=revenue:70,loc:2.5;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3;path=a:4,b:_0;path=a:5,b:_1;label=OO',
         '171' => 'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
         '172' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
         '232' => 'city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=C',
@@ -490,13 +490,17 @@ module Engine
         '1200' => 'city=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0',
       }.freeze
 
+      BROWNSEPIA = {
+        '200' => 'city=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+      }.freeze
+
       NONE = {
         '467' => 'path=a:0,b:3,track:narrow',
         '468' => 'path=a:0,b:2,track:narrow',
         '469' => 'path=a:0,b:1,track:narrow',
       }.freeze
 
-      COLORS = %i[white yellow green brown gray blue greenbrown browngray none red purple orange].freeze
+      COLORS = %i[white yellow green brown gray blue greenbrown browngray brownsepia none red purple orange].freeze
     end
   end
 end

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -305,6 +305,9 @@ module Engine
         TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
         GAME_END_CHECK = { bank: :current_or, stock_market: :immediate }.freeze
         TRAIN_PRICE_MIN = 10
+        IMPASSABLE_HEX_COLORS = %i[blue sepia red].freeze
+
+        TILE200_HEXES = %w[Q11 T16 V14].freeze
 
         BANK_UNIT1 = 5000
         BANK_UNIT2 = 5000
@@ -389,6 +392,7 @@ module Engine
           raise OptionError, 'K2 not supported with just Unit 3' if @kits[2] && !@units[1] && !@units[2] && @units[3]
           raise OptionError, 'K2 not supported without K3' if @kits[2] && !@kits[3]
           raise OptionError, 'Cannot use extra Unit 3 trains without Unit 3' if !@units[3] && optional_rules.include?(:u3p)
+          raise OptionError, 'Cannot use K1 or K6 with D1' if (@kits[1] || @kits[6]) && optional_rules.include?(:d1)
 
           p_range = case @units.keys.sort.map(&:to_s).join
                     when '1'
@@ -642,9 +646,13 @@ module Engine
 
           # deal with striped tiles
           # 119 upgrades from yellow, but upgrades to gray
-          return false if (from.name == '119') && (to.color == :brown)
-          # 166 upgrades from green, but doesn't upgrade to gray
-          return false if (from.name == '166') && (to.color == :gray)
+          return false if from.name == '119' && to.color == :brown
+          # 166 upgrades from green, but doesn't upgrade
+          return false if from.name == '166'
+          # 200 upgrades from pre-printed brown tiles on Crewe, Wolverton or Swindon, doesn't upgrade
+          return false if from.name == '200'
+          return false if to.name == '200' && from.color != :sepia
+          return true if to.name == '200' && TILE200_HEXES.include?(from.hex&.id)
 
           super
         end

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -101,6 +101,7 @@ module Engine
           'Q23' => 'Melton Constable',
         }.freeze
 
+        # rubocop:disable Layout/LineLength
         UNIT1_TILES = {
           '1' => 1,
           '2' => 1,
@@ -130,7 +131,12 @@ module Engine
           '52' => 2,
           '87' => 1,
           '88' => 1,
-          '32' => 1,
+          '32' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:70;city=revenue:70;city=revenue:70;city=revenue:70;city=revenue:70;city=revenue:70;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;label=LD',
+          },
           '34' => 1,
           '38' => 2,
           '41' => 1,
@@ -144,6 +150,7 @@ module Engine
           '67' => 1,
           '68' => 1,
         }.freeze
+        # rubocop:enable Layout/LineLength
 
         UNIT2_TILES = {
           '1' => 1,
@@ -323,8 +330,32 @@ module Engine
           '14' => 1,
         }.freeze
 
+        K1_TILES = {
+          '17' => 1,
+          '18' => 1,
+          '21' => 1,
+          '22' => 1,
+          '28' => 1,
+          '29' => 1,
+          '30' => 1,
+          '31' => 1,
+          '39' => 1,
+          '40' => 1,
+          '41' => 1,
+          '42' => 1,
+          '43' => 1,
+          '44' => 1,
+          '47' => 1,
+        }.freeze
+
+        # rubocop:disable Layout/LineLength
         K3_TILES = {
-          '48' => 1,
+          '48' =>
+          {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;city=revenue:100;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;label=LD',
+          },
           '49' => 1,
           '50' => 2,
           '51' => 3,
@@ -338,12 +369,100 @@ module Engine
             'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=OO',
           },
         }.freeze
+        # rubocop:enable Layout/LineLength
 
         K5_TILES = {
           '15' => 1,
           '69' => 1,
           '119' => 1,
         }.freeze
+
+        K6_TILES = {
+          '58' => 2,
+          '198' =>
+          {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:5,b:_0;path=a:2,b:_1;path=a:4,b:_1;label=OO',
+          },
+          '199' =>
+          {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_1;path=a:4,b:_1;label=OO',
+          },
+          '11' =>
+          {
+            'count' => 2,
+            'color' => 'green',
+            'code' => 'town=revenue:10,visit_cost:0;path=a:0,b:2;path=a:2,b:_0;path=a:_0,b:4;path=a:0,b:4;label=HALT',
+          },
+          '82' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'path=a:0,b:1;path=a:1,b:3;path=a:0,b:3',
+          },
+          '83' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'path=a:0,b:5;path=a:5,b:3;path=a:0,b:3',
+          },
+          '119' => 2,
+          '200' => 2,
+        }.freeze
+
+        # rubocop:disable Layout/LineLength
+        D1_TILES = {
+          '7' => 2,
+          '58' => 2,
+          '115' => 2,
+          '10' => 3,
+          '11' =>
+          {
+            'count' => 3,
+            'color' => 'green',
+            'code' => 'town=revenue:10,visit_cost:0;path=a:0,b:2;path=a:2,b:_0;path=a:_0,b:4;path=a:0,b:4;label=HALT',
+          },
+          '17' => 1,
+          '18' => 1,
+          '20' => 1,
+          '21' => 1,
+          '22' => 1,
+          '30' => 1,
+          '31' => 1,
+          '82' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'path=a:0,b:1;path=a:1,b:3;path=a:0,b:3',
+          },
+          '83' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'path=a:0,b:5;path=a:5,b:3;path=a:0,b:3',
+          },
+          '35' => 1,
+          '36' => 1,
+          '37' => 1,
+          '38' => 1,
+          '39' => 1,
+          '40' => 1,
+          '43' => 1,
+          '44' => 1,
+          '47' => 1,
+          '119' => 2,
+          '174' =>
+          {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'city=revenue:50,loc:0.5;city=revenue:50,loc:4.5;path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_1;path=a:5,b:_1;path=a:1,b:4;label=OO',
+          },
+          '200' => 2,
+        }.freeze
+        # rubocop:enable Layout/LineLength
 
         DIT_UPGRADES = {
           # gentle curve to three curves with a halt
@@ -388,8 +507,11 @@ module Engine
           append_game_tiles(gtiles, R1_TILES) if @regionals[1]
           append_game_tiles(gtiles, R2_TILES) if @regionals[2]
           append_game_tiles(gtiles, R3_TILES) if @regionals[3]
+          append_game_tiles(gtiles, K1_TILES) if @kits[1]
           append_game_tiles(gtiles, K3_TILES) if @kits[3]
           append_game_tiles(gtiles, K5_TILES) if @kits[5]
+          append_game_tiles(gtiles, K6_TILES) if @kits[6]
+          append_game_tiles(gtiles, D1_TILES) if @optional_rules.include?(:d1)
           gtiles
         end
 
@@ -458,9 +580,9 @@ module Engine
           green: {
             ['S13'] => 'city=revenue:40;city=revenue:40;city=revenue:40;path=a:1,b:_0;path=a:3,b:_1;path=a:5,b:_2;label=BGM',
             ['V10'] => 'city=revenue:30;path=a:0,b:_0;path=a:4,b:_0',
-            ['V20'] => 'city=revenue:50;city=revenue:50;city=revenue:50;city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;label=L',
+            ['V20'] => 'city=revenue:50;city=revenue:50;city=revenue:50;city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;label=LD',
           },
-          gray: {
+          sepia: {
             ['T16'] => 'city=revenue:10;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
             ['U25'] => 'city=revenue:20;path=a:1,b:_0',
             ['V14'] => 'city=revenue:10;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0',
@@ -512,7 +634,7 @@ module Engine
             ['O9'] => 'city=revenue:40;city=revenue:40;path=a:3,b:_0;path=a:5,b:_1;label=L',
             ['O11'] => 'city=revenue:40;city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:2,b:_1;path=a:4,b:_2;label=BGM',
           },
-          gray: {
+          sepia: {
             ['M9'] => 'city=revenue:10;town=revenue:10;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_1;path=a:5,b:_1',
             ['O15'] => 'city=revenue:20,loc:0.5;city=revenue:20,loc:3.5;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1',
             ['P8'] => 'path=a:1,b:4;path=a:4,b:5;path=a:1,b:5',
@@ -569,9 +691,9 @@ module Engine
           green: {
             ['G5'] => 'city=revenue:40;path=a:1,b:_0;city=revenue:40;path=a:3,b:_1;city=revenue:40;path=a:5,b:_2',
           },
-          gray: {
+          sepia: {
             ['B8'] => 'city=revenue:20,loc:5.5;path=a:0,b:_0;path=a:5,b:_0',
-            ['B12'] => 'city=revenue:30,loc:0;path=a:0,b:_0',
+            ['B12'] => 'city=revenue:30;path=a:0,b:_0',
             ['E1'] => 'city=revenue:20,loc:2.5;path=a:3,b:_0;path=a:4,b:_0',
             ['E7'] => 'city=revenue:10,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
             ['F2'] => 'town=revenue:10,loc:4;path=a:4,b:_0;town=revenue:10,loc:1;path=a:5,b:_1',
@@ -596,7 +718,7 @@ module Engine
             %w[R8
                T2] => 'city=revenue:0',
           },
-          gray: {
+          sepia: {
             ['P4'] => 'city=revenue:20;path=a:4,b:_0;path=a:5,b:_0',
             ['U1'] => 'city=revenue:10;path=a:3,b:_0;path=a:4,b:_0',
             ['V6'] => 'city=revenue:20;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
@@ -620,7 +742,7 @@ module Engine
           yellow: {
             ['Z4'] => 'city=revenue:0;city=revenue:0;label=OO',
           },
-          gray: {
+          sepia: {
             ['W9'] => 'city=revenue:10,loc:4.5;path=a:0,b:3;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5',
           },
         }.freeze
@@ -629,29 +751,29 @@ module Engine
           white: {
             ['Q25'] => '',
           },
-          gray: {
+          sepia: {
             ['Q23'] => 'city=revenue:10;path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0',
           },
         }.freeze
 
         UNIT1_OFFMAP_HEXES = {
           gray: {
-            ['Q7'] => 'offboard=revenue:0,visit_cost:99;path=a:5,b:_0',
-            %w[Q9
+            %w[Q7
+               Q9
                Q11
                Q13
                Q15
                Q17
                Q19
                Q23
-               Q25] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:5,b:_0',
-            %w[R6
+               Q25
+               R6
                T6
                V6
-               X6] => 'offboard=revenue:0,visit_cost:99;path=a:4,b:_0',
-            %w[S7
-               U7] => 'offboard=revenue:0,visit_cost:99;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
-            ['Y7'] => 'offboard=revenue:0,visit_cost:99;path=a:3,b:_0;path=a:4,b:_0',
+               X6
+               S7
+               U7
+               Y7] => '',
           },
         }.freeze
 
@@ -660,37 +782,37 @@ module Engine
             %w[K9
                K11
                K13
-               K15] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:5,b:_0',
-            ['Q7'] => 'offboard=revenue:0,visit_cost:99;path=a:4,b:_0',
-            ['R8'] => 'offboard=revenue:0,visit_cost:99;path=a:3,b:_0',
-            %w[R10
+               K15
+               Q7
+               R8
+               R10
                R12
                R14
                R16
-               R18] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0;path=a:3,b:_0',
-            ['R20'] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0',
+               R18
+               R20] => '',
           },
         }.freeze
 
         UNIT3_OFFMAP_HEXES = {
           gray: {
             %w[B6
-               C1] => 'offboard=revenue:0,visit_cost:99;path=a:5,b:_0',
-            %w[B10
-               C3] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:5,b:_0',
-            ['C5'] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0',
-            %w[L8
+               C1
+               B10
+               C3
+               C5
+               L8
                L10
                L12
-               L14] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0;path=a:3,b:_0',
-            ['L16'] => 'offboard=revenue:0,visit_cost:99;path=a:2,b:_0',
+               L14
+               L16] => '',
           },
         }.freeze
 
         R1_OFFMAP_HEXES = {
           gray: {
-            ['P8'] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:1,b:_0',
-            ['Q9'] => 'offboard=revenue:0,visit_cost:99;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0',
+            %w[P8
+               Q9] => '',
           },
         }.freeze
         # rubocop:enable Layout/LineLength
@@ -737,7 +859,7 @@ module Engine
           append_game_hexes(ghexes, UNIT2_HEXES) if @units[2]
           append_game_hexes(ghexes, UNIT3_HEXES) if @units[3]
 
-          # append_game_hexes will ignore "spike" hexes if they are already defined
+          # append_game_hexes will ignore offboard hexes if they are already defined
           append_game_hexes(ghexes, R1_OFFMAP_HEXES) if @regionals[1]
           append_game_hexes(ghexes, UNIT1_OFFMAP_HEXES) if @units[1]
           append_game_hexes(ghexes, UNIT2_OFFMAP_HEXES) if @units[2]

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -62,11 +62,11 @@ module Engine
             short_name: 'R3',
             desc: 'Regional Kit 3 - North Norfolk',
           },
-          # {
-          #  sym: :k1,
-          #  short_name: 'K1',
-          #  desc: 'Extension Kit 1 - Suplementary Tiles',
-          # },
+          {
+            sym: :k1,
+            short_name: 'K1',
+            desc: 'Extension Kit 1 - Suplementary Tiles',
+          },
           {
             sym: :k2,
             short_name: 'K2',
@@ -82,21 +82,21 @@ module Engine
             short_name: 'K5',
             desc: 'Extension Kit 5 - Minors for Unit 2',
           },
-          # {
-          #  sym: :k6,
-          #  short_name: 'K6',
-          #  desc: 'Extension Kit 6 - Advanced Tiles',
-          # },
+          {
+            sym: :k6,
+            short_name: 'K6',
+            desc: 'Extension Kit 6 - Advanced Tiles',
+          },
           {
             sym: :k7,
             short_name: 'K7',
             desc: 'Extension Kit 7 - London, Tilbury and Southend Railway',
           },
-          # {
-          #  sym: :d1,
-          #  short_name: 'K7',
-          #  desc: 'Extension Kit 7 - London, Tilbury and Southend Railway',
-          # },
+          {
+            sym: :d1,
+            short_name: 'D1',
+            desc: 'Development Kit 1 - Additional Tiles',
+          },
           {
             sym: :u3p,
             short_name: 'U3+',

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -51,6 +51,13 @@ module Engine
         color = :red
       elsif (code = BLUE[name])
         color = :blue
+      elsif (code = BROWNSEPIA[name])
+        color = :brown
+        code = if code.size.positive?
+                 'stripes=color:sepia;' + code
+               else
+                 'stripes=color:sepia'
+               end
       else
         raise Engine::GameError, "Tile '#{name}' not found"
       end


### PR DESCRIPTION
* Implement "Sepia" tiles to distinguish pre-printed non-upgradable track from gray tiles. A nice side-effect of this is that I no longer need stubs on the gray borders in order to lay track against them.
* Fix rendering of "Halt" tile 11
* Minor tile tweaks
* Implement final kits K1, K6 and D1

![sepia_map](https://user-images.githubusercontent.com/8494213/132261680-fed694ce-23d6-4999-a74d-e3cd1d4cbab3.png)


