### PR TITLE
[18CZ] emit private size after purchase

### DIFF
--- a/lib/engine/game/g_18_cz/step/draft.rb
+++ b/lib/engine/game/g_18_cz/step/draft.rb
@@ -79,7 +79,7 @@ module Engine
 
             @companies.delete(company)
 
-            @log << "#{player.name} buys #{company.name} for #{@game.format_currency(price)}"
+            @log << "#{player.name} buys [#{@game.company_size(company)}] #{company.name} for #{@game.format_currency(price)}"
 
             entities.each(&:unpass!)
             @round.next_entity_index!


### PR DESCRIPTION

Output log now includes private size after purchase

![image](https://user-images.githubusercontent.com/1711810/133129610-e608fc1e-4f84-4a60-b0b2-38813517e1d1.png)
