### PR TITLE
1825: better handling of options

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -17,6 +17,7 @@ module View
     needs :selected_variant, default: nil, store: true
     needs :title, default: nil
     needs :production, default: nil
+    needs :optional_rules, default: [], store: true
 
     def render_content
       @label_style = { display: 'block' }
@@ -136,8 +137,8 @@ module View
       ]
 
       @game_variants = selected_game.game_variants
-      @visible_optional_rules = selected_game_or_variant::OPTIONAL_RULES
-      inputs << render_optional if !@game_variants.empty? || !@visible_optional_rules.empty?
+      @visible_optional_rules = selected_game_or_variant::OPTIONAL_RULES.reject { |rule| filtered_rule?(rule) }
+      inputs << render_optional if !@game_variants.empty? || !selected_game_or_variant::OPTIONAL_RULES.empty?
 
       div_props = {}
       div_props[:style] = { display: 'none' } if @mode == :json
@@ -152,9 +153,19 @@ module View
     end
 
     def uncheck_optional_rules
-      @visible_optional_rules&.each do |o_r|
-        Native(@inputs[o_r[:sym]]).elm&.checked = false
+      selected_game_or_variant::OPTIONAL_RULES.each do |o_r|
+        Native(@inputs[o_r[:sym]])&.elm&.checked = false
       end
+    end
+
+    def sync_rules
+      selected_game_or_variant::OPTIONAL_RULES.each do |o_r|
+        Native(@inputs[o_r[:sym]])&.elm&.checked = @optional_rules.include?(o_r[:sym])
+      end
+    end
+
+    def sync_rule(sym)
+      Native(@inputs[sym])&.elm&.checked = @optional_rules.include?(sym)
     end
 
     def toggle_game_variant(sym)
@@ -171,13 +182,30 @@ module View
       end
     end
 
+    def uncheck_mutex(sym)
+      return if selected_game_or_variant::MUTEX_RULES.empty?
+
+      selected_game_or_variant::MUTEX_RULES.each do |set|
+        next unless set.include?(sym)
+
+        set.each do |s|
+          next if s == sym
+
+          @optional_rules.delete(s)
+          sync_rule(s)
+        end
+      end
+    end
+
     def toggle_optional_rule(sym)
       lambda do
         if (@optional_rules ||= []).include?(sym)
           @optional_rules.delete(sym)
         else
           @optional_rules << sym
+          uncheck_mutex(sym)
         end
+        update_options
       end
     end
 
@@ -199,13 +227,13 @@ module View
         )])
       end
 
-      optional_rules = @visible_optional_rules.map do |o_r|
+      optional_rules = selected_game_or_variant::OPTIONAL_RULES.map do |o_r|
         label_text = "#{o_r[:short_name]}: #{o_r[:desc]}"
         h(:li, [render_input(
           label_text,
           type: 'checkbox',
           id: o_r[:sym],
-          attrs: { value: o_r[:sym] },
+          attrs: { value: o_r[:sym], disabled: !@visible_optional_rules.find { |vo_r| vo_r[:sym] == o_r[:sym] } },
           on: { input: toggle_optional_rule(o_r[:sym]) },
         )])
       end
@@ -218,10 +246,23 @@ module View
         },
       }
 
-      h(:div, [
+      info = selected_game_or_variant.respond_to?(:check_options) &&
+        selected_game_or_variant.check_options(@optional_rules, @num_players)
+
+      if info
+        h(:div, [
+          h(:label, 'Game Variants / Optional Rules'),
+          h(:ul, ul_props, [*game_variants, *optional_rules]),
+          h(:h4, 'Option Info/Errors'),
+          h(:div, info),
+          h(:br),
+        ])
+      else
+        h(:div, [
           h(:label, 'Game Variants / Optional Rules'),
           h(:ul, ul_props, [*game_variants, *optional_rules]),
         ])
+      end
     end
 
     def render_upload_button
@@ -363,6 +404,10 @@ module View
       @selected_variant ? @selected_variant[:meta] : selected_game
     end
 
+    def filtered_rule?(rule)
+      rule[:players] && !rule[:players].include?(@num_players)
+    end
+
     def update_inputs
       title = selected_game_or_variant.title
 
@@ -383,10 +428,22 @@ module View
       `window.history.replaceState(window.history.state, null, '?title=' + encodeURIComponent(#{title}))`
       root.store_app_route
 
-      visible_rules = selected_game::OPTIONAL_RULES.reject do |rule|
-        rule[:players] && !rule[:players].include?(@num_players)
+      visible_rules = []
+      selected_game::OPTIONAL_RULES.each do |rule|
+        if filtered_rule?(rule)
+          @optional_rules.delete(rule[:sym])
+        else
+          visible_rules << rule
+        end
       end
+      sync_rules
+
+      store(:optional_rules, @optional_rules, skip: true)
       store(:visible_optional_rules, visible_rules)
+    end
+
+    def update_options
+      store(:optional_rules, @optional_rules)
     end
   end
 end

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -54,6 +54,14 @@ module View
       acting.include?(player['id'] || player['name'])
     end
 
+    def lookup_min(game)
+      min_p, _max_p = game::PLAYER_RANGE
+      return min_p unless game.respond_to?(:min_players)
+
+      optional_rules = @gdata.dig('settings', 'optional_rules') || []
+      game.min_players(optional_rules, @gdata['max_players']) || min_p
+    end
+
     def render_header
       buttons = []
 
@@ -87,7 +95,7 @@ module View
       end
 
       game = Engine.meta_by_title(@gdata['title'])
-      @min_p, _max_p = game::PLAYER_RANGE
+      @min_p = lookup_min(game)
 
       can_start = owner? && new? && players.size >= @min_p
       buttons << render_button('Start', -> { start_game(@gdata) }) if can_start

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -119,6 +119,118 @@ module Engine
             desc: 'Do not increase bank size based on number of minors and kits',
           },
         ].freeze
+
+        MUTEX_RULES = [
+          %i[unit_1 unit_2 unit_3 unit_12 unit_23 unit_123],
+          %i[big_bank strict_bank],
+        ].freeze
+
+        def self.check_options(options, num_players)
+          optional_rules = (options || []).map(&:to_sym)
+
+          return if optional_rules.empty? && !num_players
+
+          if optional_rules.empty?
+            case num_players
+            when 2
+              return 'No Unit(s) selected. Will use Unit 3 based on player count'
+            when 3
+              return 'No Unit(s) selected. Will use Unit 2 based on player count'
+            when 4, 5
+              return 'No Unit(s) selected. Will use Unit 1 based on player count'
+            when 6, 7
+              return 'No Unit(s) selected. Will use Units 1+2 based on player count'
+            when 8
+              return 'No Unit(s) selected. Will use Units 1+2+3 based on player count'
+            else
+              return 'No Unit(s) selected. Will use Units 1+2+3 and R1+R2+R3 based on player count'
+            end
+          end
+
+          units = {}
+          kits = {}
+          regionals = {}
+
+          units[1] = true if optional_rules.include?(:unit_1)
+          units[1] = true if optional_rules.include?(:unit_12)
+          units[1] = true if optional_rules.include?(:unit_123)
+
+          units[2] = true if optional_rules.include?(:unit_2)
+          units[2] = true if optional_rules.include?(:unit_12)
+          units[2] = true if optional_rules.include?(:unit_23)
+          units[2] = true if optional_rules.include?(:unit_123)
+
+          units[3] = true if optional_rules.include?(:unit_3)
+          units[3] = true if optional_rules.include?(:unit_23)
+          units[3] = true if optional_rules.include?(:unit_123)
+
+          kits[1] = true if optional_rules.include?(:k1)
+          kits[2] = true if optional_rules.include?(:k2)
+          kits[3] = true if optional_rules.include?(:k3)
+          kits[5] = true if optional_rules.include?(:k5)
+          kits[6] = true if optional_rules.include?(:k6)
+          kits[7] = true if optional_rules.include?(:k7)
+
+          regionals[1] = true if optional_rules.include?(:r1)
+          regionals[2] = true if optional_rules.include?(:r2)
+          regionals[3] = true if optional_rules.include?(:r3)
+
+          if !units[1] && !units[2] && !units[3] && !optional_rules.empty?
+            return 'Must select at least one Unit if using other options'
+          end
+          return 'Cannot combine Units 1 and 3 without Unit 2' if units[1] && !units[2] && units[3]
+          return 'Cannot add Regionals without Unit 1' if !regionals.keys.empty? && !units[1]
+          return 'Cannot add K5 without Unit 2' if kits[5] && !units[2]
+          return 'Cannot add K7 without Unit 1' if kits[7] && !units[1]
+          return 'K2 not supported with just Unit 3' if kits[2] && !units[1] && !units[2] && units[3]
+          return 'K2 not supported without K3' if kits[2] && !kits[3]
+          return 'Cannot use extra Unit 3 trains without Unit 3' if !units[3] && optional_rules.include?(:u3p)
+          return 'Cannot use K1 or K6 with D1' if (kits[1] || kits[6]) && optional_rules.include?(:d1)
+          return 'Cannot use both bank options' if optional_rules.include?(:big_bank) && optional_rules.include?(:strict_bank)
+
+          nil
+        end
+
+        def self.min_players(optional_rules, num_players)
+          optional_rules = (optional_rules || []).map(&:to_sym)
+
+          if optional_rules.empty?
+            return unless num_players
+
+            case num_players
+            when 2, 3, 4, 5
+              return 2
+            when 6, 7
+              return 3
+            else
+              return 4
+            end
+          end
+
+          units = {}
+
+          units[1] = true if optional_rules.include?(:unit_1)
+          units[1] = true if optional_rules.include?(:unit_12)
+          units[1] = true if optional_rules.include?(:unit_123)
+
+          units[2] = true if optional_rules.include?(:unit_2)
+          units[2] = true if optional_rules.include?(:unit_12)
+          units[2] = true if optional_rules.include?(:unit_23)
+          units[2] = true if optional_rules.include?(:unit_123)
+
+          units[3] = true if optional_rules.include?(:unit_3)
+          units[3] = true if optional_rules.include?(:unit_23)
+          units[3] = true if optional_rules.include?(:unit_123)
+
+          case units.keys.sort.map(&:to_s).join
+          when '1', '2', '3'
+            2
+          when '12', '23'
+            3
+          else # all units
+            4
+          end
+        end
       end
     end
   end

--- a/lib/engine/game/meta.rb
+++ b/lib/engine/game/meta.rb
@@ -29,6 +29,7 @@ module Engine
       # full game class
       PLAYER_RANGE = nil
       OPTIONAL_RULES = [].freeze
+      MUTEX_RULES = [].freeze
 
       def self.included(klass)
         klass.extend(ClassMethods)


### PR DESCRIPTION
The modifies the create_game view to add optional rule sanity checking, and mutually exclusive options (essentially radio buttons).
It also changes the way optional rules are "hidden" based on player count - instead of removing them, it changes the checkboxes to disabled. It also fixes issues the code had when options became hidden to due player count

This also modifies the game_card view to dynamically determine the minimum number of players bases on optional rules

Finally, the meta for 1825 is modified to take advantage of these changes.