### PR TITLE
[1860] Hide cert limit when there's no limit.

### DIFF
--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1107,6 +1107,10 @@ module Engine
           super
         end
 
+        def show_game_cert_limit?
+          !@no_price_drop_on_sale
+        end
+
         def event_fishbourne_to_bank!
           ffc = @companies.find { |c| c.sym == 'FFC' }
           ffc.owner = @bank


### PR DESCRIPTION
Uses the existing show_game_cert_limit? method to hide the cert limit when it disappears with the 8+4 train.

Before: x/999
After: x