### PR TITLE
[1817] update rules link

### DIFF
--- a/lib/engine/game/g_1817/meta.rb
+++ b/lib/engine/game/g_1817/meta.rb
@@ -14,7 +14,7 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817'
         GAME_LOCATION = 'NYSE, USA'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://drive.google.com/file/d/0B1SWz2pNe2eAbnI4NVhpQXV4V0k/view'
+        GAME_RULES_URL = 'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/1817_Rules_v1.0_-_5_March_2015.pdf'
 
         PLAYER_RANGE = [3, 12].freeze
         OPTIONAL_RULES = [


### PR DESCRIPTION
This cdn link is posted on [the AAG site](https://all-aboardgames.com/pages/rules), seems like that's the canonical one

closes #6371