### PR TITLE
[1893] Some fixes

### DIFF
--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -496,7 +496,6 @@ module Engine
               type: 'minor',
               tokens: [0],
               logo: '1893/EKB',
-              simple_logo: '1893/EKB.alt',
               coordinates: 'T3',
               city: 0,
               color: :green,
@@ -516,7 +515,6 @@ module Engine
               type: 'minor',
               tokens: [0],
               logo: '1893/KFBE',
-              simple_logo: '1893/KFBE.alt',
               coordinates: 'L3',
               city: 0,
               color: :red,
@@ -527,7 +525,6 @@ module Engine
               type: 'minor',
               tokens: [0],
               logo: '1893/KSZ',
-              simple_logo: '1893/KSZ.alt',
               coordinates: 'P7',
               city: 0,
               color: :green,
@@ -538,7 +535,6 @@ module Engine
               type: 'minor',
               tokens: [0],
               logo: '1893/KBE',
-              simple_logo: '1893/KBE.alt',
               coordinates: 'O4',
               city: 0,
               color: :red,
@@ -549,7 +545,6 @@ module Engine
               type: 'minor',
               tokens: [0],
               logo: '1893/BKB',
-              simple_logo: '1893/BKB.alt',
               coordinates: 'I2',
               city: 0,
               color: :green,
@@ -868,11 +863,18 @@ module Engine
 
         def new_merger_round(count)
           @merger_count = count
-          @log << "-- Merge Round #{@turn}.#{@merger_count} (of 3) --"
+          @log << "-- #{round_description('Merger')} --"
           G1893::Round::Merger.new(self, [
             G1893::Step::PotentialDiscardTrainsAfterMerge,
             G1893::Step::Merger,
           ])
+        end
+
+        def round_description(name, _round_num = nil)
+          return super unless name == 'Merger'
+          return "Merger Round before Stock Round #{@turn + 1}" if @merger_count > 2
+
+          "Merger Round before Operating Round #{@turn}.#{@merger_count}"
         end
 
         def float_str(entity)
@@ -1405,7 +1407,7 @@ module Engine
             gray: {
               ['F1'] => 'town=revenue:10;path=a:4,b:_0;path=a:5,b:_0',
               ['F5'] => 'path=a:1,b:2;path=a:3,b:5',
-              ['T7'] => 'path=a:1,b:2;path=a:3,b:5;upgrade=cost:0,terrain:water',
+              ['T7'] => 'path=a:1,b:2;path=a:3,b:5',
               ['F9'] => 'path=a:2,b:0',
               ['H5'] => 'city=revenue:20;path=a:0,b:_0',
               ['H9'] => 'path=a:3,b:1',
@@ -1427,9 +1429,9 @@ module Engine
               ['L5'] => 'city=revenue:0;border=edge:5,type:impassable;upgrade=cost:40,terrain:water;label=K;'\
                         'border=edge:4,type:water,cost:0',
               ['M6'] => 'upgrade=cost:40,terrain:water;border=edge:2,type:impassable',
-              ['O6'] => 'city=revenue:0;upgrade=cost:0,terrain:water;border=edge:1,type:impassable;'\
+              ['O6'] => 'city=revenue:0;border=edge:1,type:impassable;'\
                         'border=edge:2,type:impassable',
-              ['Q6'] => 'upgrade=cost:0,terrain:water;border=edge:0,type:impassable;border=edge:1,type:impassable;'\
+              ['Q6'] => 'border=edge:0,type:impassable;border=edge:1,type:impassable;'\
                         'border=edge:2,type:impassable',
               ['S6'] => 'city=revenue:0;upgrade=cost:40,terrain:water;border=edge:3,type:impassable;'\
                         'border=edge:4,type:water,cost:0;label=BX',

--- a/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1893/step/buy_sell_par_shares.rb
@@ -206,7 +206,7 @@ module Engine
             @game.after_par(corporation)
             track_action(action, action.corporation, true)
 
-            @log << "Remaining 80% of #{corporation.name} are moved to market"
+            @log << "Remaining 80% of #{corporation.name} is moved to market"
             @game.move_buyable_shares_to_market(corporation)
             @par_rag = nil
           end

--- a/public/logos/1893/BKB.alt.svg
+++ b/public/logos/1893/BKB.alt.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">BKB</text></svg>

--- a/public/logos/1893/EKB.alt.svg
+++ b/public/logos/1893/EKB.alt.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">EKB</text></svg>

--- a/public/logos/1893/KBE.alt.svg
+++ b/public/logos/1893/KBE.alt.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="red"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">KBE</text></svg>

--- a/public/logos/1893/KFBE.alt.svg
+++ b/public/logos/1893/KFBE.alt.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="red"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">KFBE</text></svg>

--- a/public/logos/1893/KSZ.alt.svg
+++ b/public/logos/1893/KSZ.alt.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">KSZ</text></svg>


### PR DESCRIPTION
1. Improve description (in log and for round title in game info)
   for merger rounds. Now they state which is the next round
   (as the Merger Round 3.2 does not say that much).
   Fixes #6385

2. Remove terrain 0 for upgrade when it was just a cosmetic.
   The blue hex sides with cost 0 does have a game function so
   they remains.
   Fixes #6384

3. Fixed a log message for moving shares to market.
   Fixes #6383

4. Use same logos for minor 1-5 regardless if simplified or not
   Fixes #6382