### PR TITLE
[18CZ] List the default train variant before other variants

### DIFF
--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -46,7 +46,8 @@ module Engine
         discount: @discount,
       }
 
-      variants << @variant
+      # Primary variant should be at the head of the list.
+      variants.unshift(@variant)
       @variants = variants.group_by { |h| h[:name] }.transform_values(&:first)
     end
 


### PR DESCRIPTION
Currently the default variant is listed last, which is generally odd, and particularly unhelpful in 18CZ where the variants appear gradually.

fixes #6160

This change will apply to all games with variant trains, e.g. 1822, 1846, 1862.