### PR TITLE
[18Ireland] Mark 1H' as no_local to prevent running just a single city.

### DIFF
--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -122,6 +122,7 @@ module Engine
             price: 40,
             rusts_on: '8H',
             reserved: true,
+            no_local: true,
           },
           {
             name: '4H',


### PR DESCRIPTION
(1-distance trains are tagged as local by default.)

fixes #6196