### PR TITLE
1825: add sepia to legal colors

### DIFF
--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -500,7 +500,7 @@ module Engine
         '469' => 'path=a:0,b:1,track:narrow',
       }.freeze
 
-      COLORS = %i[white yellow green brown gray blue greenbrown browngray brownsepia none red purple orange].freeze
+      COLORS = %i[white yellow green brown gray blue sepia greenbrown browngray brownsepia none red purple orange].freeze
     end
   end
 end


### PR DESCRIPTION
Forgot to add "sepia" to the list of legal colors. This prevented tile 200 from being placed.

No archiving needed.

Fixes #6441 