### PR TITLE
Show all finished games on the home page

### DIFF
--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -16,16 +16,15 @@ module View
     needs :refreshing, default: nil, store: true
 
     def render
-      your_games, other_games = @games.partition { |game| user_in_game?(@user, game) || user_owns_game?(@user, game) }
+      your_games, other_games = @games.partition do |game|
+        user_in_game?(@user, game) && %w[new active].include?(game['status'])
+      end
 
       children = [
         render_header,
         h(Welcome, show_intro: your_games.size < 2),
         h(Chat, user: @user, connection: @connection),
       ]
-
-      # these will show up in the profile page
-      your_games.reject! { |game| %w[finished archived].include?(game['status']) }
 
       grouped = other_games.group_by { |game| game['status'] }
 


### PR DESCRIPTION
Currently games the logged-in user was part of are excluded from the home page. It makes sense to have a separate list of your own games on the profile page, but I don't see any reason we can't also show them on the home page. They're already being fetched and downloaded, just filtered out.

No changes to the profile page.