### PR TITLE
[18 Tokaido] disable pass-order variant for two players

### DIFF
--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -23,6 +23,7 @@ module Engine
           {
             sym: :pass_priority,
             short_name: 'Pass Priority',
+            players: [3, 4],
             desc: 'player order in stock round determined by order of passing in previous stock round',
           },
           {


### PR DESCRIPTION
There is literally no difference between the pass-order and default order with two players.
