### PR TITLE
show obsoleted trains on spreadsheet tab

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -476,7 +476,7 @@ module View
           h('td.padded_number', @game.format_currency(corporation.cash)),
           *treasury,
           h('td.padded_number', order_props, operating_order),
-          h(:td, corporation.trains.map(&:name).join(', ')),
+          h(:td, corporation.trains.map { |t| t.obsolete ? "(#{t.name})" : t.name }.join(', ')),
           h(:td, @game.token_string(corporation)),
           *extra,
           render_companies(corporation),


### PR DESCRIPTION
This shows obsoleted trains on the spreadsheet in parens, same way they are shown on the corp cards

![Screenshot 2021-11-03 9 01 19 AM](https://user-images.githubusercontent.com/1711810/140097550-ad79da46-ea0c-45da-a71d-c20120d1c5dd.png)

![Screenshot 2021-11-03 9 03 00 AM](https://user-images.githubusercontent.com/1711810/140097477-ebce37f9-4c06-487b-882d-b911d1779688.png)
)
