### PR TITLE
Fixed sorting for numbers

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -337,7 +337,11 @@ module View
           else
             case @spreadsheet_sort_by
             when :id
-              corporation.id
+              if /^\d+$/.match?(corporation.id)
+                [2, corporation.id.to_i]
+              else
+                [1, corporation.id]
+              end
             when :ipo_shares
               num_shares_of(@game.separate_treasury? ? @game.bank : corporation, corporation)
             when :market_shares


### PR DESCRIPTION
closes #6405

this should also fix sorting in 1822 etc.

No idea how to solve that without regex and no `corporation.id.to_i.to_s == corporation.id`