### PR TITLE
[1893] fix par value names

### DIFF
--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -667,8 +667,8 @@ module Engine
 
         MARKET_TEXT = {
           par: 'Par values for non-merged corporations',
-          par_1: 'Par value for AGV',
-          par_2: 'Par value for HGK',
+          par_1: 'Par value for HGK',
+          par_2: 'Par value for AGV',
         }.freeze
 
         STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(


### PR DESCRIPTION
checked the rules and market on BGG which seems to indicate that the green box is meant to be AGV par price

![image](https://user-images.githubusercontent.com/1711810/141222004-e3fed001-6f12-4049-af64-51d83ca490bb.png)


closes #6500