### PR TITLE
[18NY] Implement mergers

### DIFF
--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -191,7 +191,6 @@ module View
               store(:flash_opts, 'Select a corporation to merge with')
             end
           end
-          puts @selected_corporation
           h(:button, { attrs: { disabled: !@selected_corporation }, on: { click: merge } },
             @step.merge_name(@selected_corporation))
         end

--- a/assets/app/view/game/round/merger.rb
+++ b/assets/app/view/game/round/merger.rb
@@ -191,8 +191,9 @@ module View
               store(:flash_opts, 'Select a corporation to merge with')
             end
           end
-
-          h(:button, { on: { click: merge } }, @step.merge_name)
+          puts @selected_corporation
+          h(:button, { attrs: { disabled: !@selected_corporation }, on: { click: merge } },
+            @step.merge_name(@selected_corporation))
         end
       end
     end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -369,7 +369,7 @@ module View
         end
 
         def render_bid_input(company)
-          return [] unless @step.can_bid?(@current_entity, company)
+          return [] unless @step.respond_to?(:can_bid_company?) && @step.can_bid_company?(@current_entity, company)
 
           [h(Bid, entity: @current_entity, corporation: company)]
         end

--- a/lib/engine/game/g_1817/step/acquire.rb
+++ b/lib/engine/game/g_1817/step/acquire.rb
@@ -30,7 +30,7 @@ module Engine
             actions
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             'Acquire'
           end
 

--- a/lib/engine/game/g_1817/step/conversion.rb
+++ b/lib/engine/game/g_1817/step/conversion.rb
@@ -23,7 +23,7 @@ module Engine
             actions
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             'Merge'
           end
 

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -222,7 +222,7 @@ module Engine
             @game.bidding_token_per_player - (bids_for_player(player)&.size || 0)
           end
 
-          def can_bid?(entity, company)
+          def can_bid_company?(entity, company)
             return false unless num_certs_with_bids(entity) < @game.cert_limit
             return false if max_bid(entity, company) < min_bid(company) || highest_player_bid?(entity, company)
 

--- a/lib/engine/game/g_1822/step/minor_acquisition.rb
+++ b/lib/engine/game/g_1822/step/minor_acquisition.rb
@@ -56,7 +56,7 @@ module Engine
             'Acquire a minor'
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             'Acquire a minor'
           end
 

--- a/lib/engine/game/g_1840/step/acquisition_auction.rb
+++ b/lib/engine/game/g_1840/step/acquisition_auction.rb
@@ -126,7 +126,7 @@ module Engine
             @auctioning
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             'Select Tram for auction'
           end
 

--- a/lib/engine/game/g_1856/step/nationalization_payoff.rb
+++ b/lib/engine/game/g_1856/step/nationalization_payoff.rb
@@ -27,7 +27,7 @@ module Engine
             @game.national
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             "Merge into #{@game.national.name}"
           end
 

--- a/lib/engine/game/g_1862/step/acquire.rb
+++ b/lib/engine/game/g_1862/step/acquire.rb
@@ -7,7 +7,7 @@ module Engine
     module G1862
       module Step
         class Acquire < G1862::Step::Merge
-          def merge_name
+          def merge_name(_entity = nil)
             'Acquire'
           end
 

--- a/lib/engine/game/g_1862/step/merge.rb
+++ b/lib/engine/game/g_1862/step/merge.rb
@@ -28,7 +28,7 @@ module Engine
             super
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             'Merge'
           end
 

--- a/lib/engine/game/g_1867/step/merge.rb
+++ b/lib/engine/game/g_1867/step/merge.rb
@@ -37,7 +37,7 @@ module Engine
             super
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             return 'Convert' if @converting
             return 'Finish Merge' if @merge_major
 

--- a/lib/engine/game/g_1873/step/form.rb
+++ b/lib/engine/game/g_1873/step/form.rb
@@ -15,7 +15,7 @@ module Engine
             MERGE_ACTION
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             'Merge'
           end
 

--- a/lib/engine/game/g_18_ireland/step/merge.rb
+++ b/lib/engine/game/g_18_ireland/step/merge.rb
@@ -37,7 +37,7 @@ module Engine
             @round.vote_outcome == :for
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             return 'Choose new corporation' if finalize_merger?
             return 'Add to proposed merge' if @round.merging
 

--- a/lib/engine/game/g_18_mex/step/merge.rb
+++ b/lib/engine/game/g_18_mex/step/merge.rb
@@ -23,7 +23,7 @@ module Engine
             @game.ndm
           end
 
-          def merge_name
+          def merge_name(_entity = nil)
             "Merge #{mergee.name} into #{merge_target.name}"
           end
 

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -649,7 +649,7 @@ module Engine
           end
 
           multiplier = entity.owner == corporation.owner ? 1 : 3
-          corporation.share_price.price * multiplier * 10
+          corporation.share_price.price * multiplier * corporation.num_player_shares
         end
 
         def acquire_corporation(entity, corporation); end

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -595,6 +595,10 @@ module Engine
           entity.num_player_shares
         end
 
+        def loan_face_value
+          @loan_value
+        end
+
         def loan_value(entity = nil)
           @loan_value - (entity && interest_paid?(entity) ? interest_rate : 0)
         end

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -231,6 +231,7 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::SpecialBuyTrain,
             G18NY::Step::BuyTrain,
+            G18NY::Step::AcquireCorporation,
             [G18NY::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
         end
@@ -640,6 +641,18 @@ module Engine
           num_loans = maximum_loans(entity) - entity.loans.size
           entity.cash + (num_loans * loan_value(entity))
         end
+
+        def acquisition_cost(entity, corporation)
+          if corporation.type == :minor
+            multiplier = entity.owner == corporation.owner ? 2 : 5
+            return corporation.share_price.price * multiplier
+          end
+
+          multiplier = entity.owner == corporation.owner ? 1 : 3
+          corporation.share_price.price * multiplier * 10
+        end
+
+        def acquire_corporation(entity, corporation); end
       end
     end
   end

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -514,8 +514,8 @@ module Engine
           end
         end
 
-        def add_coal_token_ability(entity, _num_tokens)
-          entity.add_ability(G18NY::Ability::CoalRevenue.new(type: :coal_revenue, bonus_revenue: 10))
+        def add_coal_token_ability(entity, revenue: 10)
+          entity.add_ability(G18NY::Ability::CoalRevenue.new(type: :coal_revenue, bonus_revenue: revenue))
         end
 
         def coal_location_name(location)
@@ -647,16 +647,88 @@ module Engine
         end
 
         def acquisition_cost(entity, corporation)
-          if corporation.type == :minor
-            multiplier = entity.owner == corporation.owner ? 2 : 5
-            return corporation.share_price.price * multiplier
-          end
+          multiplier = acquisition_cost_multiplier(entity, corporation)
+          return corporation.share_price.price * multiplier if corporation.type == :minor
 
-          multiplier = entity.owner == corporation.owner ? 1 : 3
-          corporation.share_price.price * multiplier * corporation.num_player_shares
+          corporation.share_price.price * multiplier * (corporation.num_player_shares + corporation.num_market_shares)
         end
 
-        def acquire_corporation(entity, corporation); end
+        def acquisition_cost_multiplier(entity, corporation)
+          return entity.owner == corporation.owner ? 2 : 5 if corporation.type == :minor
+
+          entity.owner == corporation.owner ? 1 : 3
+        end
+
+        def acquire_corporation(entity, corporation)
+          acquisition_verb = entity.owner == corporation.owner ? 'merges with' : 'takes over'
+          @log << "-- #{entity.name} #{acquisition_verb} #{corporation.name} --"
+
+          # Pay for the acquisition
+          share_price = corporation.share_price.price
+          multiplier = acquisition_cost_multiplier(entity, corporation)
+          if corporation.type == :minor
+            cost = share_price * multiplier
+            @log << "#{entity.name} pays #{corporation.owner.name} #{format_currency(cost)}"
+            entity.spend(cost, corporation.owner)
+          else
+            corporation.share_holders.keys.each do |sh|
+              next if sh == corporation
+
+              cost = share_price * sh.num_shares_of(corporation) * multiplier
+              @log << "#{entity.name} pays #{sh.name} #{format_currency(cost)}"
+              entity.spend(share_price * sh.num_shares_of(corporation), sh)
+            end
+          end
+
+          # Combine assets
+          if corporation.cash.positive?
+            @log << "#{entity.name} acquires #{format_currency(corporation.cash)} from #{corporation.name}"
+            corporation.spend(corporation.cash, entity)
+          end
+
+          unless corporation.loans.empty?
+            num_to_payoff = [entity.cash / loan_face_value, corporation.loans.size].min
+            @log << "#{entity.name} pays off #{num_to_payoff} of #{corporation.name}'s loans"
+            entity.spend(num_to_payoff * loan_face_value, @bank)
+
+            if (remaining_loans = corporation.loans.size - num_to_payoff).positive?
+
+              @log << "#{entity.name} takes on #{remaining_loans} loan#{remaining_loans == 1 ? '' : 's'}" \
+                      " from #{corporation.name}"
+              @loans.concat(corporation.loans)
+              corporation.loans.clear
+
+              initial_sp = entity.share_price.price
+              remaining_loans.times do
+                loan = @loans.pop
+                entity.loans << loan
+                @stock_market.move_left(entity)
+              end
+              @log << "#{entity.name}'s share price changes from" \
+                      " #{format_currency(initial_sp)} to #{format_currency(entity.share_price.price)}"
+            end
+          end
+
+          unless corporation.trains.empty?
+            trains_str = corporation.trains.map(&:name).join(', ')
+            @log << "#{entity.name} acquires a #{trains_str} from #{corporation.name}"
+            corporation.trains.dup.each { |t| buy_train(entity, t, :free) }
+          end
+
+          if (revenue = coal_revenue(corporation)).positive?
+            @log << "#{entity.name} acquires #{format_currency(revenue)} in coal revenue from #{corporation.name}"
+
+            if (ability = abilities(entity, :coal_revenue))
+              ability.bonus_revenue += revenue
+            else
+              add_coal_token_ability(entity, revenue: revenue)
+            end
+          end
+
+          # TODO: Tokens have to be chosen
+
+          close_corporation(corporation, quiet: true)
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_ny/step/acquire_corporation.rb
+++ b/lib/engine/game/g_18_ny/step/acquire_corporation.rb
@@ -58,7 +58,7 @@ module Engine
 
             acquisition_cost = @game.acquisition_cost(entity, corporation)
             if (num_loans_over_the_limit = entity.loans.size + corporation.loans.size - @game.maximum_loans(entity)).positive?
-              acquistion_cost += num_loans_over_the_limit * @game.loan_face_value
+              acquisition_cost += num_loans_over_the_limit * @game.loan_face_value
             end
             return false if acquisition_cost > entity.cash
 

--- a/lib/engine/game/g_18_ny/step/acquire_corporation.rb
+++ b/lib/engine/game/g_18_ny/step/acquire_corporation.rb
@@ -18,8 +18,14 @@ module Engine
             return [Engine::Action::Pass.new(entity)] if acquisition_candidates(entity).empty?
           end
 
-          def merge_name
-            'Merge/Takeover'
+          def merge_name(entity = nil)
+            return 'Merge/Takeover' unless entity
+
+            "#{merge_type(entity)} (#{@game.format_currency(@game.acquisition_cost(current_entity, entity))})"
+          end
+
+          def merge_type(entity)
+            current_entity.owner == entity.owner ? 'Merge' : 'Takeover'
           end
 
           def merger_auto_pass_entity

--- a/lib/engine/game/g_18_ny/step/acquire_corporation.rb
+++ b/lib/engine/game/g_18_ny/step/acquire_corporation.rb
@@ -55,7 +55,7 @@ module Engine
           def can_acquire?(entity, corporation)
             return false if entity == corporation
             return false if corporation.closed? || !corporation.floated?
-            
+
             acquisition_cost = @game.acquisition_cost(entity, corporation)
             if (num_loans_over_the_limit = entity.loans.size + corporation.loans.size - @game.maximum_loans(entity)).positive?
               acquistion_cost += num_loans_over_the_limit * @game.loan_face_value

--- a/lib/engine/game/g_18_ny/step/acquire_corporation.rb
+++ b/lib/engine/game/g_18_ny/step/acquire_corporation.rb
@@ -58,7 +58,7 @@ module Engine
             
             acquisition_cost = @game.acquisition_cost(entity, corporation)
             if (num_loans_over_the_limit = entity.loans.size + corporation.loans.size - @game.maximum_loans(entity)).positive?
-              acquistion_cost += num_loans_over_the_limit * @game.initial_loan_value
+              acquistion_cost += num_loans_over_the_limit * @game.loan_face_value
             end
             return false if acquisition_cost > entity.cash
 

--- a/lib/engine/game/g_18_ny/step/acquire_corporation.rb
+++ b/lib/engine/game/g_18_ny/step/acquire_corporation.rb
@@ -55,7 +55,12 @@ module Engine
           def can_acquire?(entity, corporation)
             return false if entity == corporation
             return false if corporation.closed? || !corporation.floated?
-            return false if entity.cash < @game.acquisition_cost(entity, corporation)
+            
+            acquisition_cost = @game.acquisition_cost(entity, corporation)
+            if (num_loans_over_the_limit = entity.loans.size + corporation.loans.size - @game.maximum_loans(entity)).positive?
+              acquistion_cost += num_loans_over_the_limit * @game.initial_loan_value
+            end
+            return false if acquisition_cost > entity.cash
 
             corporation_tokened_cities = corporation.tokens.select(&:used).map(&:city)
             !(@game.graph.connected_nodes(entity).keys & corporation_tokened_cities).empty?

--- a/lib/engine/game/g_18_ny/step/acquire_corporation.rb
+++ b/lib/engine/game/g_18_ny/step/acquire_corporation.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G18NY
+      module Step
+        class AcquireCorporation < Engine::Step::Base
+          def actions(entity)
+            return [] if entity != current_entity
+            return [] unless entity.corporation?
+
+            %w[merge pass]
+          end
+
+          def auto_actions(entity)
+            return [Engine::Action::Pass.new(entity)] if acquisition_candidates(entity).empty?
+          end
+
+          def merge_name
+            'Merge/Takeover'
+          end
+
+          def merger_auto_pass_entity
+            current_entity
+          end
+
+          def description
+            'Mergers and Takeovers'
+          end
+
+          def process_merge(action)
+            entity = action.entity
+            corporation = action.corporation
+
+            raise GameError, 'Must select a company to merge or takeover' unless corporation
+            raise GameError, "Unable to merge or takeover #{corporation.name}" unless can_acquire?(entity, corporation)
+
+            @game.acquire_corporation(entity, corporation)
+          end
+
+          def mergeable_type(entity)
+            "Corporations that #{entity.name} can merge or takeover"
+          end
+
+          def mergeable(entity)
+            acquisition_candidates(entity)
+          end
+
+          def acquisition_candidates(entity)
+            @game.corporations.select { |c| can_acquire?(entity, c) }
+          end
+
+          def can_acquire?(entity, corporation)
+            return false if entity == corporation
+            return false if corporation.closed? || !corporation.floated?
+            return false if entity.cash < @game.acquisition_cost(entity, corporation)
+
+            corporation_tokened_cities = corporation.tokens.select(&:used).map(&:city)
+            !(@game.graph.connected_nodes(entity).keys & corporation_tokened_cities).empty?
+          end
+
+          def show_other_players
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_ny/step/bankrupt.rb
+++ b/lib/engine/game/g_18_ny/step/bankrupt.rb
@@ -28,9 +28,8 @@ module Engine
             end
 
             if player.companies.any?
-              # TODO: companies should be buyable
-              @log << "#{player.name}'s companies close: #{player.companies.map(&:sym).join(', ')}"
-              player.companies.dup.each(&:close!)
+              @log << "#{player.name}'s companies go to the bank: #{player.companies.map(&:sym).join(', ')}"
+              player.companies.each { |c| c.owner = @game.bank }
             end
 
             @log << "#{@game.format_currency(player.cash)} is transferred from "\

--- a/lib/engine/game/g_18_ny/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_ny/step/buy_sell_par_shares.rb
@@ -11,7 +11,7 @@ module Engine
           MAX_MINOR_PAR = 80
 
           def actions(entity)
-            return corporate_actions(entity) if !entity.player? && entity.owned_by?(current_entity)
+            return corporate_actions(entity) if entity.corporation? && entity.owned_by?(current_entity)
 
             super
           end

--- a/lib/engine/game/g_18_ny/step/buy_train.rb
+++ b/lib/engine/game/g_18_ny/step/buy_train.rb
@@ -58,8 +58,8 @@ module Engine
 
           def spend_minmax(entity, train)
             minmax = super
-            minmax.first = train.price if train.owner&.corporation? && !train.owner.loans.empty?
-            minmax.last = train.price unless entity.loans.empty?
+            minmax[0] = train.price if train.owner&.corporation? && !train.owner.loans.empty?
+            minmax[-1] = train.price unless entity.loans.empty?
             minmax
           end
 

--- a/lib/engine/game/g_18_ny/step/replace_tokens.rb
+++ b/lib/engine/game/g_18_ny/step/replace_tokens.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G18NY
+      module Step
+        class ReplaceTokens < Engine::Step::Base
+          REMOVE_TOKEN_ACTIONS = %w[remove_token pass].freeze
+
+          def description
+            'Replace Tokens'
+          end
+
+          def actions(entity)
+            return [] unless current_entity == entity
+
+            REMOVE_TOKEN_ACTIONS
+          end
+
+          def active?
+            corporation && acquired_corporation && remaining_tokens?
+          end
+
+          def active_entities
+            [corporation]
+          end
+
+          def round_state
+            {
+              acquisition_corporations: [],
+            }
+          end
+
+          def corporation
+            @round.acquisition_corporations[0]
+          end
+
+          def acquired_corporation
+            @round.acquisition_corporations[-1]
+          end
+
+          def remaining_tokens?
+            !corporation.tokens.reject(&:used).empty? && !acquired_corporation.tokens.select(&:used).empty?
+          end
+
+          def available_hex(entity, hex)
+            return false unless entity == corporation
+
+            hexes.include?(hex)
+          end
+
+          def hexes
+            acquired_corporation.tokens.select(&:used).map(&:hex)
+          end
+
+          def can_replace_token?(entity, token)
+            entity == current_entity && token.corporation == acquired_corporation
+          end
+
+          def process_remove_token(action)
+            entity = action.entity
+            city = action.city
+            token = city.tokens[action.slot]
+            hex = city.hex
+
+            raise GameError, "Cannot replace token in #{hex.name} (#{hex.location_name})" unless available_hex(entity, hex)
+
+            @log << "#{entity.name} replaces token in #{hex.name} (#{hex.location_name})"
+            token.swap!(entity.tokens.reject(&:used).first, check_tokenable: false)
+            @game.complete_acquisition(corporation, acquired_corporation) unless remaining_tokens?
+          end
+
+          def process_pass(action)
+            @game.complete_acquisition(corporation, acquired_corporation)
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_zoo/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_zoo/step/buy_sell_par_shares.rb
@@ -61,6 +61,10 @@ module Engine
             @log << "#{entity.name} declines to buy shares"
           end
 
+          def buyable_bank_owned_companies(_entity)
+            available_companies
+          end
+
           def available_companies
             return [] if bought?
 

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -22,7 +22,7 @@ module Engine
         actions = []
         actions << 'buy_shares' if can_buy_any?(entity)
         actions << 'par' if can_ipo_any?(entity)
-        actions << 'buy_company' unless purchasable_companies(entity).empty?
+        actions << 'buy_company' if !purchasable_companies(entity).empty? || !buyable_bank_owned_companies(entity).empty?
         actions << 'sell_shares' if can_sell_any?(entity)
 
         actions << 'pass' unless actions.empty?
@@ -261,6 +261,16 @@ module Engine
           !@game.phase.status.include?('can_buy_companies_from_other_players')
 
         @game.purchasable_companies(entity)
+      end
+
+      def buyable_bank_owned_companies(entity)
+        return [] unless entity.player?
+
+        @game.buyable_bank_owned_companies.select { |c| can_buy_company?(entity, c) }
+      end
+
+      def can_buy_company?(player, company)
+        @game.buyable_bank_owned_companies.include?(company) && player.cash >= company.value
       end
 
       def get_par_prices(entity, _corp)

--- a/public/logos/18_ny/1.svg
+++ b/public/logos/18_ny/1.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">1</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">1</text></svg>

--- a/public/logos/18_ny/10.svg
+++ b/public/logos/18_ny/10.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">10</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">10</text></svg>

--- a/public/logos/18_ny/11.svg
+++ b/public/logos/18_ny/11.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">11</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">11</text></svg>

--- a/public/logos/18_ny/2.svg
+++ b/public/logos/18_ny/2.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">2</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">2</text></svg>

--- a/public/logos/18_ny/3.svg
+++ b/public/logos/18_ny/3.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">3</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">3</text></svg>

--- a/public/logos/18_ny/4.svg
+++ b/public/logos/18_ny/4.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">4</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">4</text></svg>

--- a/public/logos/18_ny/5.svg
+++ b/public/logos/18_ny/5.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">5</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">5</text></svg>

--- a/public/logos/18_ny/6.svg
+++ b/public/logos/18_ny/6.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">6</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">6</text></svg>

--- a/public/logos/18_ny/7.svg
+++ b/public/logos/18_ny/7.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">7</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">7</text></svg>

--- a/public/logos/18_ny/8.svg
+++ b/public/logos/18_ny/8.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">8</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">8</text></svg>

--- a/public/logos/18_ny/9.svg
+++ b/public/logos/18_ny/9.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#fff"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial">9</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4"/><text x="4" y="5.8" text-anchor="middle" font-weight="700" font-size="5" font-family="Arial" fill="#fff">9</text></svg>


### PR DESCRIPTION
Also buying privates in the stock round and change minor tokens to black.

Common code changes
- Made the Merge button customizable based on which entity is selected. The button also appears disabled if nothing is selected.
- Added buy company for bank owned privates to base stock round. It was original subclassed by many games.
- Fixed 1822 assumption that if buy_company and bid actions are present, then companies are biddable. For 18NY the biddable entity is the minors (auction).

Tested against the entire database and UI was spot tested in affected games.