### PR TITLE
add error messages if unable to token

### DIFF
--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -127,26 +127,25 @@ module Engine
         if check_tokenable && !tokenable?(
             corporation, free: free, tokens: token, cheater: cheater, extra_slot: extra_slot, spender: spender
           )
-          raise GameError, "#{corporation.name} cannot lay token - has no tokens left" if @error == :no_tokens
 
-          if @error == :existing_token
+          case @error
+          when :no_tokens
+            raise GameError, "#{corporation.name} cannot lay token - has no tokens left"
+          when :existing_token
             raise GameError,
                   "#{corporation.name} cannot lay token - already has a token on #{tile.hex&.id}"
-          end
-          if @error == :blocked_reservation
+          when :blocked_reservation
             raise GameError,
                   "#{corporation.name} cannot lay token - remaining token slots are reserved on #{tile.hex&.id}"
-          end
-          if @error == :no_money
+          when :no_money
             raise GameError,
                   "#{corporation.name} cannot lay token - cannot afford token on #{tile.hex&.id}"
-          end
-          if @error == :no_slots
+          when :no_slots
             raise GameError,
                   "#{corporation.name} cannot lay token - no token slots available on #{tile.hex&.id}"
+          else
+            raise GameError, "#{corporation.name} cannot lay token on #{id} #{tile.hex&.id}"
           end
-
-          raise GameError, "#{corporation.name} cannot lay token on #{id} #{tile.hex&.id}"
         end
 
         exchange_token(token, cheater: cheater, extra_slot: extra_slot)

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -110,6 +110,28 @@ module Engine
         if check_tokenable && !tokenable?(
             corporation, free: free, tokens: token, cheater: cheater, extra_slot: extra_slot, spender: spender
           )
+          if tile.cities.any? do |c|
+               c.tokened_by?(token.corporation)
+             end
+            raise GameError,
+                  "#{corporation.name} cannot lay token - already has a token on #{tile.hex&.id}"
+          end
+
+          if tile.token_blocked_by_reservation?(corporation)
+            raise GameError,
+                  "#{corporation.name} cannot lay token - remaining token slots are reserved on #{tile.hex&.id}"
+          end
+          if !free && token.price > (spender || corporation).cash
+            raise GameError,
+                  "#{corporation.name} cannot lay token - cannot afford token on #{tile.hex&.id}"
+          end
+          unless extra_slot || get_slot(
+token.corporation, cheater: cheater
+)
+            raise GameError,
+                  "#{corporation.name} cannot lay token - no token slots available on #{tile.hex&.id}"
+          end
+
           raise GameError, "#{corporation.name} cannot lay token on #{id} #{tile.hex&.id}"
         end
 


### PR DESCRIPTION
closes #6530 

Tested with cases:
1 - IC attempts to token Terra Haute, which it can't afford
https://gist.github.com/benjaminxscott/4526e3d9603ea5d9df8218f254e5c2c5

2 - NYC attempts to token Erie, where it already has a token
https://gist.github.com/benjaminxscott/d94992f37484341daa179eb9c262112d

3 - GT attempts to token Erie, which has a reserved slot so it has no open slots
https://gist.github.com/benjaminxscott/14743b143adca8253140b918607a37d6