### PR TITLE
Make place_token and remove_token actions possible for non-blocking steps

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -117,38 +117,38 @@ module View
 
           step = @game.round.active_step(@selected_company)
           entity = @selected_company || step.current_entity
-          actions = step.actions(entity)
-          return if (%w[remove_token place_token] & actions).empty?
-          return if @token && !step.can_replace_token?(entity, @token) &&
+          remove_token_step = @game.round.step_for(entity, 'remove_token')
+          place_token_step = @game.round.step_for(entity, 'place_token')
+          return if !remove_token_step && !place_token_step
+          return if @token && !remove_token_step&.can_replace_token?(entity, @token) &&
                     !(cheater = @game.abilities(entity, :token)&.cheater) &&
                     !@game.abilities(entity, :token)&.extra_slot
 
           event.JS.stopPropagation
 
           # if remove_token and place_token is possible, remove should only be called when a token is available
-          if (actions.include?('remove_token') && !actions.include?('place_token')) ||
-            (actions.include?('remove_token') && @token)
+          if remove_token_step && (@token || !place_token_step)
             return unless @token
 
             action = Engine::Action::RemoveToken.new(
-              @selected_company || @game.current_entity,
+              entity,
               city: @city,
               slot: @slot_index
             )
             process_action(action)
           else
             # If there's a choice of tokens of different types show the selector, otherwise just place
-            next_tokens = step.available_tokens(entity)
-            if next_tokens.size == 1 && actions.include?('place_token')
-              token_owner = @game.token_owner(@selected_company || @game.current_entity)
+            next_tokens = place_token_step.available_tokens(entity)
+            if next_tokens.size == 1 && place_token_step
+              token_owner = @game.token_owner(entity)
               action = Engine::Action::PlaceToken.new(
-                @selected_company || @game.current_entity,
+                entity,
                 city: @city,
                 tokener: @selected_company&.owned_by_player? ? @game.current_entity : token_owner,
                 slot: cheater || @slot_index,
                 token_type: next_tokens[0].type,
               )
-              action.cost = step.token_cost_override(
+              action.cost = place_token_step.token_cost_override(
                 action.entity,
                 action.city,
                 action.slot,


### PR DESCRIPTION
Same technique as used for issue_shares for 1846. This will be used for 18NY, provided it doesn't cause any major issues with other games; however, it's hard to test as it's a view code change. It shouldn't affect games as they shouldn't have non-blocking steps, prior to the current blocking step, with the 'place_token" or 'remove_token' action as they wouldn't have been possible to use before this change. I did test with 1817 since it has a token selection at the corporation auction, a regular token placement, and remove tokens if over the limit after acquisition and they all worked as expected.

In general, I don't know why all view logic doesn't act like this. It would create a lot more flexibility for non-blocking steps, but one step at a time.

I've kept the PR as only this change, so in case I missed something and this does break games, it is easily revertable. 