### PR TITLE
[18NY] 5DE train

### DIFF
--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -426,6 +426,7 @@ module Engine
 
         def can_par?(corporation, _parrer)
           return false if corporation == nyc_corporation && !@nyc_formation_state
+          return false if @turn == 1 && corporation.type != :minor && corporation.id != 'D&H'
 
           super
         end

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -591,17 +591,15 @@ module Engine
         end
 
         def compute_stops(route)
-          if route.train.name == '5DE'
-            stops = route.visited_stops
-            return [] unless stops.any? { |stop| stop.tokened_by?(route.corporation) }
+          return super unless route.train.name == '5DE'
 
-            if fivede_runs_stations_and_offboards_only?
-              stops.select! { |stop| stop.tokened_by?(route.corporation) || stop.type == 'offboard' }
-            end
-            stops = stops.combination(5).map { |s| [s, revenue_for(route, s)] }.max_by(&:last).first if stops.size > 5
-          else
-            stops = super
+          stops = route.visited_stops
+          return [] unless stops.any? { |stop| stop.tokened_by?(route.corporation) }
+
+          if fivede_runs_stations_and_offboards_only?
+            stops.select! { |stop| stop.tokened_by?(route.corporation) || stop.type == 'offboard' }
           end
+          stops = stops.combination(5).map { |s| [s, revenue_for(route, s)] }.max_by(&:last).first if stops.size > 5
           stops
         end
 

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -211,6 +211,10 @@ module Engine
           @albany_hex ||= hex_by_id('F20')
         end
 
+        def fivede_runs_stations_and_offboards_only?
+          @fivede_optional_rule ||= @optional_rules.include?(:fivede)
+        end
+
         def active_minors
           operating_order.select { |c| c.type == :minor && c.floated? }
         end
@@ -581,8 +585,24 @@ module Engine
 
         def check_distance(route, _visits)
           limit = route.train.distance
+          limit = 99 if limit.is_a?(Array)
           distance = route_distance(route)
           raise GameError, "#{distance} is too many hex edges for #{route.train.name} train" if distance > limit
+        end
+
+        def compute_stops(route)
+          if route.train.name == '5DE'
+            stops = route.visited_stops
+            return [] unless stops.any? { |stop| stop.tokened_by?(route.corporation) }
+
+            if fivede_runs_stations_and_offboards_only?
+              stops.select! { |stop| stop.tokened_by?(route.corporation) || stop.type == 'offboard' }
+            end
+            stops = stops.combination(5).map { |s| [s, revenue_for(route, s)] }.max_by(&:last).first if stops.size > 5
+          else
+            stops = super
+          end
+          stops
         end
 
         def revenue_for(route, stops)
@@ -590,7 +610,9 @@ module Engine
         end
 
         def revenue_str(route)
-          str = super
+          stops = route.stops
+          stop_hexes = stops.map(&:hex)
+          str = route.hexes.map { |h| stop_hexes.include?(h) ? h&.name : "(#{h&.name})" }.join('-')
 
           if (num_bonuses = route.stops.count { |stop| stop.hex.assigned?(CONNECTION_BONUS_ICON) }).positive?
             str += " + #{num_bonuses} Connection Bonus#{num_bonuses == 1 ? '' : 'es'}"
@@ -732,7 +754,7 @@ module Engine
         def emergency_issuable_bundles(corp)
           bundles = bundles_for_corporation(corp, corp)
 
-          num_issuable_shares = [5 - corp.num_market_shares, corp.num_player_shares].min
+          num_issuable_shares = [5, corp.num_player_shares].min - corp.num_market_shares
           bundles.reject { |bundle| bundle.num_shares > num_issuable_shares }.sort_by(&:price)
         end
 

--- a/lib/engine/game/g_18_ny/meta.rb
+++ b/lib/engine/game/g_18_ny/meta.rb
@@ -17,6 +17,13 @@ module Engine
         GAME_TITLE = '18NY'
 
         PLAYER_RANGE = [2, 6].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :fivede,
+            short_name: '5DE Only Scores Stations and Offboards',
+            desc: '5DE trains may only score stationed cities and offboard hexes',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -28,7 +28,7 @@ module Engine
       @rusted = false
       @obsolete = false
       @operated = false
-      @events = (opts[:events] || []).select { |e| @index == (e[:when] || 1) - 1 }
+      @events = (opts[:events] || []).select { |e| @index == (e['when'] || 1) - 1 }
       @reserved = opts[:reserved] || false
       init_variants(opts[:variants])
     end


### PR DESCRIPTION
Fix route distance for diesels, show which stops the 5DE scores in the route str, 5DE only needs to run one of its stations, not score it, and add optional rule for 5DE to only run stations and offboards.

Now also includes the fix for the linked bug and a symbol vs string fix.