### PR TITLE
Add "Auto pass" button in stock rounds.

### DIFF
--- a/assets/app/view/game/pass.rb
+++ b/assets/app/view/game/pass.rb
@@ -11,7 +11,10 @@ module View
 
       def render
         children = []
-        children << h(PassButton, before_process_pass: @before_process_pass) if @actions.include?('pass')
+        if @actions.include?('pass')
+          children << h(PassButton, before_process_pass: @before_process_pass)
+          children << h(PassAutoButton) if @game.round.stock? && @game.active_players_id.index(@user['id'])
+        end
         h(:div, children.compact)
       end
     end

--- a/assets/app/view/game/pass_auto_button.rb
+++ b/assets/app/view/game/pass_auto_button.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+
+module View
+  module Game
+    class PassAutoButton < Snabberb::Component
+      include Actionable
+
+      def render
+        props = {
+          on: {
+            click: lambda do
+              process_action(Engine::Action::ProgramSharePass.new(@game.current_entity))
+            end,
+          },
+        }
+
+        h(:button, props, 'Auto pass')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The button enables the auto pass in stock round program, same as the auto tab, but more accessible. The motivation is half to encourage more use of auto pass and half to make it less annoying when auto pass keeps getting cancelled over and over because someone sells and buys and sells and buys...

Only displayed for the active player, only in stock around, and does not show up in hotseat games.

![autopass](https://user-images.githubusercontent.com/37312691/144235602-81ce93fd-fad0-4bde-abe9-79df061a0a84.png)