### PR TITLE
Don't disable auto actions for shenanigans that happened before the p…

### DIFF
--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -236,7 +236,7 @@ module Engine
             @round.bid_exceeded = @bid_exceeded
           end
 
-          def should_stop_applying_program(entity, share_to_buy)
+          def should_stop_applying_program(entity, program, share_to_buy)
             return "No longer winning bids on #{@bid_exceeded[entity].map(&:id).join(',')}" unless @bid_exceeded[entity].empty?
 
             super

--- a/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
@@ -64,7 +64,7 @@ module Engine
             @round.current_actions.count { |x| x.is_a?(Action::BuyShares) && x.bundle.corporation == corporation }
           end
 
-          def should_stop_applying_program(entity, share_to_buy)
+          def should_stop_applying_program(entity, program, share_to_buy)
             # The automatic program should stop if the 20% share is acquireable
             if !share_to_buy || !share_to_buy.last_cert
               @game.corporations.each do |corporation|

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -375,13 +375,16 @@ module Engine
         end
       end
 
-      def should_stop_applying_program(entity, share_to_buy)
+      def should_stop_applying_program(entity, program, share_to_buy)
         # check for shenanigans, returning the first failure reason it finds
         @round.players_history.each do |other_entity, corporations|
           next if other_entity == entity
 
           corporations.each do |corporation, actions|
             actions.each do |action|
+              # ignore shenanigans that happened before the program was enabled
+              next if action.id < program.id
+
               reason = action_is_shenanigan?(entity, other_entity, action, corporation, share_to_buy)
               return reason if reason
             end
@@ -401,7 +404,7 @@ module Engine
         return unless available_actions.include?('pass')
         return unless normal_pass?(entity)
 
-        reason = should_stop_applying_program(entity, nil) unless @game.actions.last == program
+        reason = should_stop_applying_program(entity, program, nil)
         return [Action::ProgramDisable.new(entity, reason: reason)] if reason
 
         [Action::Pass.new(entity)]
@@ -440,7 +443,7 @@ module Engine
 
           share = shares_by_percent.values.first.first
 
-          reason = should_stop_applying_program(entity, share) unless @game.actions.last == program
+          reason = should_stop_applying_program(entity, program, share)
           return [Action::ProgramDisable.new(entity, reason: reason)] if reason
 
           [Action::BuyShares.new(entity, shares: share)]


### PR DESCRIPTION
…rogram was enabled.

Fixes the case where someone e.g. sells shares, you enable auto-pass, and your auto-pass gets cancelled because there was shenanigans since your last turn.

Fixes #5215