### PR TITLE
[18NY] Bug fixes from designer feedback

### DIFF
--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -80,7 +80,7 @@ module Engine
             'You can only assign one tram to a line'
           end
 
-          def check_for_cheapest_train(entity, train); end
+          def check_for_cheapest_train(train); end
         end
       end
     end

--- a/lib/engine/game/g_18_cz/step/buy_train.rb
+++ b/lib/engine/game/g_18_cz/step/buy_train.rb
@@ -81,7 +81,7 @@ module Engine
             false
           end
 
-          def check_for_cheapest_train(entity, train); end
+          def check_for_cheapest_train(train); end
 
           def cheapest_train_price(corporation)
             cheapest_train = @depot.min_depot_train.variants.values.find do |item|

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -679,9 +679,7 @@ module Engine
         def claim_connection_bonus(entity, hex)
           @log << "#{entity.name} claims the connection bonus at #{hex.name} (#{hex.location_name})"
           hex.remove_assignment!('connection_bonus')
-          if hex.tile.color == 'red'
-            @offboard_bonus_locations.delete(@offboard_bonus_locations.find { |loc| loc.include?(hex) })
-          end
+          @offboard_bonus_locations.delete(@offboard_bonus_locations.find { |loc| loc.include?(hex) }) if hex.tile.color == 'red'
 
           if (ability = abilities(entity, :connection_bonus))
             ability.bonus_revenue += 10

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -582,7 +582,10 @@ module Engine
 
         def route_distance(route)
           # Count hex edges
-          route.chains.sum { |conn| conn[:paths].each_cons(2).sum { |a, b| a.hex == b.hex ? 0 : 1 } }
+          distance = route.chains.sum { |conn| conn[:paths].each_cons(2).sum { |a, b| a.hex == b.hex ? 0 : 1 } }
+          # Springfield is considered one hex
+          distance -= 1 if route.all_hexes.include?(hex_by_id('E25'))
+          distance
         end
 
         def route_distance_str(route)

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -606,7 +606,7 @@ module Engine
           return [] unless stops.any? { |stop| stop.tokened_by?(route.corporation) }
 
           if fivede_runs_stations_and_offboards_only?
-            stops.select! { |stop| stop.tokened_by?(route.corporation) || stop.type == 'offboard' }
+            stops.select! { |stop| stop.tokened_by?(route.corporation) || stop.tile.color == 'red' }
           end
           stops = stops.combination(5).map { |s| [s, revenue_for(route, s)] }.max_by(&:last).first if stops.size > 5
           stops
@@ -657,7 +657,7 @@ module Engine
         def potential_route_connection_bonus_hexes(route, stops: nil)
           stops ||= route.stops
           stops.map do |stop|
-            if !stop.hex.tile.offboards.empty?
+            if stop.hex.tile.color == 'red'
               offboard_connection_bonus_hex(route, stop)
             elsif stop.hex.assigned?('connection_bonus')
               stop.hex
@@ -679,7 +679,7 @@ module Engine
         def claim_connection_bonus(entity, hex)
           @log << "#{entity.name} claims the connection bonus at #{hex.name} (#{hex.location_name})"
           hex.remove_assignment!('connection_bonus')
-          unless hex.tile.offboards.empty?
+          if hex.tile.color == 'red'
             @offboard_bonus_locations.delete(@offboard_bonus_locations.find { |loc| loc.include?(hex) })
           end
 

--- a/lib/engine/game/g_18_ny/meta.rb
+++ b/lib/engine/game/g_18_ny/meta.rb
@@ -20,7 +20,7 @@ module Engine
         OPTIONAL_RULES = [
           {
             sym: :fivede,
-            short_name: '5DE Only Scores Stations and Offboards',
+            short_name: '5DE only scores stations and offboards',
             desc: '5DE trains may only score stationed cities and offboard hexes',
           },
         ].freeze

--- a/lib/engine/game/g_18_ny/step/buy_train.rb
+++ b/lib/engine/game/g_18_ny/step/buy_train.rb
@@ -13,15 +13,11 @@ module Engine
             return actions unless entity.corporation?
             return [] if entity.receivership?
 
-            actions << 'buy_train' if !actions.include?('buy_train') && must_buy_train?(entity)
+            actions << 'buy_train' if must_buy_train?(entity)
             actions << 'scrap_train' unless scrappable_trains(entity).empty?
             actions << 'take_loan' if can_take_loan?(entity)
-            actions << 'pass' if !actions.empty? && !actions.include?('pass') && !must_buy_train?(entity)
-            actions
-          end
-
-          def buying_power(entity)
-            super + scrappable_trains(entity).sum { |train| @game.salvage_value(train) }
+            actions << 'pass' if !actions.empty? && !must_buy_train?(entity)
+            actions.uniq
           end
 
           def ebuy_president_can_contribute?(corporation)
@@ -52,16 +48,27 @@ module Engine
             entity.cash >= @game.depot.min_depot_price
           end
 
+          def ebuy_offer_only_cheapest_depot_train?
+            @loan_taken
+          end
+
           def setup
             super
             @train_salvaged = false
+            @loan_taken = false
           end
 
           def issuable_shares(entity)
             # Issue is part of emergency buy
             return [] unless ebuy_president_can_contribute?(entity)
 
-            super.select { |bundle| selling_minimum_shares?(bundle) }
+            super
+          end
+
+          def selling_minimum_shares?(bundle)
+            return true if bundle.owner&.corporation?
+
+            super
           end
 
           def spend_minmax(entity, train)
@@ -75,8 +82,16 @@ module Engine
             scrappable_trains(entity).empty?
           end
 
+          def process_buy_train(action)
+            train = action.train
+            check_for_cheapest_train(train) if train.from_depot? && @loan_taken
+
+            super
+          end
+
           def process_take_loan(action)
             @game.take_loan(action.entity)
+            @loan_taken = true
           end
 
           def process_scrap_train(action)

--- a/lib/engine/game/g_18_ny/step/track.rb
+++ b/lib/engine/game/g_18_ny/step/track.rb
@@ -20,7 +20,8 @@ module Engine
             # Only need to make sure exits stay consistent for town to city upgrade
             old_tile = hex.tile
             if @game.town_to_city_upgrade?(old_tile, tile)
-              return old_tile.paths.all? { |old| tile.paths.any? { |new| old.exits == new.exits } }
+              return old_tile.paths.all? { |old| tile.paths.any? { |new| old.exits == new.exits } } &&
+                     !(tile.exits & hex_neighbors(entity, hex)).empty?
             end
 
             super

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -61,7 +61,7 @@ module Engine
 
         remaining = price - buying_power(entity)
         if remaining.positive? && president_may_contribute?(entity, action.shell)
-          check_for_cheapest_train(entity, train)
+          check_for_cheapest_train(train)
 
           raise GameError, 'Cannot contribute funds when exchanging' if exchange
           raise GameError, 'Cannot buy for more than cost' if price > train.price
@@ -123,12 +123,16 @@ module Engine
         entity.cash + current_entity.cash
       end
 
+      def ebuy_offer_only_cheapest_depot_train?
+        @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST
+      end
+
       def buyable_trains(entity)
         depot_trains = @depot.depot_trains
         other_trains = @game.class::ALLOW_TRAIN_BUY_FROM_OTHERS ? @depot.other_trains(entity) : []
 
         if entity.cash < @depot.min_depot_price
-          depot_trains = [@depot.min_depot_train] if @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST
+          depot_trains = [@depot.min_depot_train] if ebuy_offer_only_cheapest_depot_train?
 
           if @game.class::EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN
             # Don't alter the depot train list
@@ -214,15 +218,13 @@ module Engine
         false
       end
 
-      def check_for_cheapest_train(entity, train)
+      def check_for_cheapest_train(train)
         cheapest = @depot.min_depot_train
         cheapest_names = names_of_cheapest_variants(cheapest)
         raise GameError, "Cannot purchase #{train.name} train: cheaper train available (#{cheapest_names.first})" if
           !cheapest_names.include?(train.name) &&
           @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST &&
           (!@game.class::EBUY_OTHER_VALUE || train.from_depot?)
-
-        raise GameError, 'Cannot contribute funds when affordable trains exist' if cheapest.price <= entity.cash
       end
 
       def names_of_cheapest_variants(train)


### PR DESCRIPTION
- Player is not restricted to buying the cheapest train when emergency issuing; however, they become restricted the moment they contribute player cash or take loans.
- Offboard logic wasn't working for offboard areas that were cities, so use color instead
- Springfield's 2 hexes should act like one when calculating train distance
- Minor clean-up

I removed a check that didn't make sense. Whether the entity has more money than the cheapest train or not is irrelevant to is it the cheapest train. It broke 18NY, where a loan can put you over the cost, but is still considered emergency fund raising.