### PR TITLE
Handle internal actions with no action id in shenanigans check.

### DIFF
--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -388,7 +388,8 @@ module Engine
           corporations.each do |corporation, actions|
             actions.each do |action|
               # ignore shenanigans that happened before the program was enabled
-              next if action.id < program.id
+              # some actions are generated internally and don't have an id, use timestamp instead.
+              next if action.id ? (action.id < program.id) : (Time.at(action.created_at) < Time.at(program.created_at))
 
               reason = action_is_shenanigan?(entity, other_entity, action, corporation, share_to_buy)
               return reason if reason


### PR DESCRIPTION
Example of internal action is winning a bid in 1817.

https://github.com/tobymao/18xx/blob/master/lib/engine/game/g_1817/step/buy_sell_par_shares.rb#L364
```
action = Action::Par.new(entity, corporation: corporation, share_price: share_price)
process_par(action)
```

This action never passes through game/base process_action, so it never gets an id assigned. It does get tracked by track_action, however, so the shenanigans code needs to be able to process it.