### PR TITLE
Include variant titles (e.g. 1822NRS) in game title filter options.

### DIFF
--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -23,7 +23,7 @@ module View
     def render_title(url_search_params)
       selected_title = url_search_params['title']
       game_options = [h(:option, { attrs: { value: '' } }, '(All titles)')]
-      Engine::VISIBLE_GAMES.map(&:title).sort.each do |title|
+      Engine::VISIBLE_GAMES_WITH_VARIANTS.map(&:title).sort.each do |title|
         # Don't use game::GAME_DROPDOWN_TITLE since it's not what is displayed in game cards.
         game_options << h(:option, { attrs: { value: title, selected: title == selected_title } }, title)
       end

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -23,8 +23,11 @@ module Engine
 
   GAME_METAS = GAME_META_BY_TITLE.values
 
-  VISIBLE_GAMES = GAME_METAS.select do |game_meta|
-    !game_meta::GAME_IS_VARIANT_OF && %i[alpha beta production].include?(game_meta::DEV_STAGE)
+  VISIBLE_GAMES_WITH_VARIANTS = GAME_METAS.select do |game_meta|
+    %i[alpha beta production].include?(game_meta::DEV_STAGE)
+  end
+  VISIBLE_GAMES = VISIBLE_GAMES_WITH_VARIANTS.reject do |game_meta|
+    game_meta::GAME_IS_VARIANT_OF
   end
 
   def self.game_by_title(title)


### PR DESCRIPTION
Fixes #6573