### PR TITLE
Add option to automatically switch auto-buy to auto-pass when done.

### DIFF
--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -155,6 +155,7 @@ module View
         settings = params(form)
 
         corporation = @game.corporation_by_id(settings['corporation'])
+        auto_pass_after = settings['auto_pass_after']
 
         if settings['float']
           until_condition = 'float'
@@ -172,7 +173,8 @@ module View
             sender,
             corporation: corporation,
             until_condition: until_condition,
-            from_market: from_market
+            from_market: from_market,
+            auto_pass_after: auto_pass_after,
           )
         )
       end
@@ -302,6 +304,10 @@ module View
                                             checked,
                                             corp_settings)
           end
+          children << render_checkbox('Switch to auto-pass after successful completion.',
+                                      'auto_pass_after',
+                                      form,
+                                      !!settings&.auto_pass_after)
           subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_buy_shares(form) }]
           subchildren << render_disable(settings) if settings
           children << h(:div, subchildren)

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -5,6 +5,7 @@ require_relative '../helper/type'
 module Engine
   module Action
     class Base
+      include Comparable
       include Helper::Type
 
       attr_reader :entity
@@ -76,9 +77,9 @@ module Engine
         false
       end
 
-      def happened_before?(other)
+      def <=>(other)
         # some actions are generated internally and don't have an id, fall back to timestamp.
-        id && other.id ? (id < other.id) : (Time.at(created_at) < Time.at(other.created_at))
+        id && other.id ? (id <=> other.id) : (Time.at(created_at) <=> Time.at(other.created_at))
       end
     end
   end

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -75,6 +75,11 @@ module Engine
       def free?
         false
       end
+
+      def happened_before?(other)
+        # some actions are generated internally and don't have an id, fall back to timestamp.
+        id && other.id ? (id < other.id) : (Time.at(created_at) < Time.at(other.created_at))
+      end
     end
   end
 end

--- a/lib/engine/action/program_buy_shares.rb
+++ b/lib/engine/action/program_buy_shares.rb
@@ -6,14 +6,15 @@ require_relative 'program_enable'
 module Engine
   module Action
     class ProgramBuyShares < ProgramEnable
-      attr_reader :corporation, :until_condition, :from_market
+      attr_reader :corporation, :until_condition, :from_market, :auto_pass_after
 
-      def initialize(entity, corporation:, until_condition:, from_market: false)
+      def initialize(entity, corporation:, until_condition:, from_market: false, auto_pass_after: false)
         super(entity)
         @corporation = corporation
         # Either float, or number of shares the player should have to exit the condition.
         @until_condition = until_condition
         @from_market = from_market
+        @auto_pass_after = auto_pass_after
       end
 
       def self.h_to_args(h, game)
@@ -21,11 +22,17 @@ module Engine
           corporation: game.corporation_by_id(h['corporation']),
           until_condition: h['until_condition'],
           from_market: h['from_market'],
+          auto_pass_after: h['auto_pass_after'],
         }
       end
 
       def args_to_h
-        { 'corporation' => @corporation.id, 'until_condition' => @until_condition, from_market: @from_market }
+        {
+          'corporation' => @corporation.id,
+          'until_condition' => @until_condition,
+          'from_market' => @from_market,
+          'auto_pass_after' => @auto_pass_after,
+        }
       end
 
       def self.description

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -390,7 +390,7 @@ module Engine
           corporations.each do |corporation, actions|
             actions.each do |action|
               # ignore shenanigans that happened before the program was enabled
-              next if action.happened_before?(program)
+              next if action < program
 
               reason = action_is_shenanigan?(entity, other_entity, action, corporation, share_to_buy)
               return reason if reason


### PR DESCRIPTION
The switch only happens if the auto-buy program completes successfully, not if it gets interrupted by shenanigans or inability to buy the specified shares.

Fixes #6483