### PR TITLE
Add detailed descriptions of auto actions in game log

### DIFF
--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -155,6 +155,7 @@ module View
         settings = params(form)
 
         corporation = @game.corporation_by_id(settings['corporation'])
+        auto_pass_after = settings['auto_pass_after']
 
         if settings['float']
           until_condition = 'float'
@@ -172,7 +173,8 @@ module View
             sender,
             corporation: corporation,
             until_condition: until_condition,
-            from_market: from_market
+            from_market: from_market,
+            auto_pass_after: auto_pass_after,
           )
         )
       end
@@ -302,6 +304,10 @@ module View
                                             checked,
                                             corp_settings)
           end
+          children << render_checkbox('Switch to auto-pass after successful completion.',
+                                      'auto_pass_after',
+                                      form,
+                                      !!settings&.auto_pass_after)
           subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_buy_shares(form) }]
           subchildren << render_disable(settings) if settings
           children << h(:div, subchildren)

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -5,6 +5,7 @@ require_relative '../helper/type'
 module Engine
   module Action
     class Base
+      include Comparable
       include Helper::Type
 
       attr_reader :entity
@@ -76,9 +77,9 @@ module Engine
         false
       end
 
-      def happened_before?(other)
+      def <=>(other)
         # some actions are generated internally and don't have an id, fall back to timestamp.
-        id && other.id ? (id < other.id) : (Time.at(created_at) < Time.at(other.created_at))
+        id && other.id ? (id <=> other.id) : (Time.at(created_at) <=> Time.at(other.created_at))
       end
     end
   end

--- a/lib/engine/action/base.rb
+++ b/lib/engine/action/base.rb
@@ -75,6 +75,11 @@ module Engine
       def free?
         false
       end
+
+      def happened_before?(other)
+        # some actions are generated internally and don't have an id, fall back to timestamp.
+        id && other.id ? (id < other.id) : (Time.at(created_at) < Time.at(other.created_at))
+      end
     end
   end
 end

--- a/lib/engine/action/program_buy_shares.rb
+++ b/lib/engine/action/program_buy_shares.rb
@@ -35,12 +35,11 @@ module Engine
         }
       end
 
-      def self.description
-        'Buy shares until condition is met'
-      end
-
-      def self.print_name
-        'Buy Shares'
+      def to_s
+        source = @from_market ? 'market' : 'IPO'
+        condition = @until_condition == 'float' ? 'floated' : "#{@until_condition} shares"
+        suffix = @auto_pass_after ? ', then auto pass' : ''
+        "Buy #{corporation.name} from #{source} until #{condition}#{suffix}"
       end
 
       def disable?(game)

--- a/lib/engine/action/program_buy_shares.rb
+++ b/lib/engine/action/program_buy_shares.rb
@@ -6,14 +6,15 @@ require_relative 'program_enable'
 module Engine
   module Action
     class ProgramBuyShares < ProgramEnable
-      attr_reader :corporation, :until_condition, :from_market
+      attr_reader :corporation, :until_condition, :from_market, :auto_pass_after
 
-      def initialize(entity, corporation:, until_condition:, from_market: false)
+      def initialize(entity, corporation:, until_condition:, from_market: false, auto_pass_after: false)
         super(entity)
         @corporation = corporation
         # Either float, or number of shares the player should have to exit the condition.
         @until_condition = until_condition
         @from_market = from_market
+        @auto_pass_after = auto_pass_after
       end
 
       def self.h_to_args(h, game)
@@ -21,11 +22,17 @@ module Engine
           corporation: game.corporation_by_id(h['corporation']),
           until_condition: h['until_condition'],
           from_market: h['from_market'],
+          auto_pass_after: h['auto_pass_after'],
         }
       end
 
       def args_to_h
-        { 'corporation' => @corporation.id, 'until_condition' => @until_condition, from_market: @from_market }
+        {
+          'corporation' => @corporation.id,
+          'until_condition' => @until_condition,
+          'from_market' => @from_market,
+          'auto_pass_after' => @auto_pass_after,
+        }
       end
 
       def self.description

--- a/lib/engine/action/program_independent_mines.rb
+++ b/lib/engine/action/program_independent_mines.rb
@@ -34,12 +34,14 @@ module Engine
         }
       end
 
-      def self.description
-        "Pass on independent mines until #{@indefinite ? 'turned off' : 'next SR'}"
-      end
-
-      def self.print_name
-        'Pass on independent mines'
+      def to_s
+        steps = []
+        steps << 'track' if @skip_track
+        steps << 'buy trains' if @skip_buy
+        steps << 'close' if @skip_close
+        steps << 'nothing?!' if steps.empty?
+        condition = @indefinite ? 'turned off' : 'next SR'
+        "Pass (#{steps.join(',')}) for independent mines until #{condition}"
       end
 
       def disable?(game)

--- a/lib/engine/action/program_merger_pass.rb
+++ b/lib/engine/action/program_merger_pass.rb
@@ -32,12 +32,12 @@ module Engine
         }
       end
 
-      def self.description
-        'Automatically Pass conversion/mergers/offering corporations in merger/acquisition rounds'
-      end
-
-      def self.print_name
-        'Pass in Mergers'
+      def to_s
+        corp_names = @corporations_by_round&.transform_values { |corps| corps.map(&:name).join(', ') }
+        ar_corps = corp_names&.fetch('AR') || 'none'
+        mr_corps = corp_names&.fetch('MR') || 'none'
+        suffix = @options&.include?('disable_others') ? ', unless someone else acts' : ''
+        "Pass in AR (#{ar_corps}) and MR (#{mr_corps})#{suffix}"
       end
 
       def disable?(game)

--- a/lib/engine/action/program_share_pass.rb
+++ b/lib/engine/action/program_share_pass.rb
@@ -10,11 +10,7 @@ module Engine
         super(entity)
       end
 
-      def self.description
-        'Pass in the Stock Round'
-      end
-
-      def self.print_name
+      def to_s
         'Pass in Stock Round'
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2191,7 +2191,7 @@ module Engine
       def check_programmed_actions
         @programmed_actions.reject! do |entity, action|
           if action&.disable?(self)
-            player_log(entity, 'Programmed action removed due to round change')
+            player_log(entity, "Programmed action '#{action}' removed due to round change")
             true
           end
         end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -390,7 +390,7 @@ module Engine
           corporations.each do |corporation, actions|
             actions.each do |action|
               # ignore shenanigans that happened before the program was enabled
-              next if action.happened_before?(program)
+              next if action < program
 
               reason = action_is_shenanigan?(entity, other_entity, action, corporation, share_to_buy)
               return reason if reason

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -32,13 +32,14 @@ module Engine
       end
 
       def process_program_enable(action)
-        @game.player_log(action.entity, "Enabled programmed action #{action.class.print_name}")
+        @game.player_log(action.entity, "Enabled programmed action '#{action}'")
         @game.programmed_actions[action.entity] = action
       end
 
       def process_program_disable(action)
-        @game.player_log(action.entity, "Disabled programmed action due to '#{action.reason}'") if action.reason
-        @game.programmed_actions.delete(action.entity)
+        program = @game.programmed_actions.delete(action.entity)
+        reason = action.reason || 'unknown reason'
+        @game.player_log(action.entity, "Disabled programmed action '#{program}' due to '#{reason}'")
       end
 
       def skip!; end


### PR DESCRIPTION
NB: The first two commits are from #6608

Implementation-wise, removes the unused description method and replaces the print_name method with a standard to_s returning detailed descriptions of the action. Also modifes the game log to include this description every time the program is enabled and disabled.

Example messages:
Enabled programmed action 'Buy SAL from IPO until floated'
Enabled programmed action 'Buy SAL from IPO until 3 shares'
Programmed action 'Buy SAL from IPO until 3 shares' removed due to round change
Enabled programmed action 'Pass in Stock Round'
Disabled programmed action 'Pass in Stock Round' due to 'Shares were sold'
Enabled programmed action 'Pass in AR (PW, R) and MR (PW, R)'

Fixes #4891