### PR TITLE
Make merger pass to_s dynamic based on phases recorded.

### DIFF
--- a/lib/engine/action/program_merger_pass.rb
+++ b/lib/engine/action/program_merger_pass.rb
@@ -33,11 +33,12 @@ module Engine
       end
 
       def to_s
-        corp_names = @corporations_by_round&.transform_values { |corps| corps.map(&:name).join(', ') }
-        ar_corps = corp_names&.dig('AR') || 'none'
-        mr_corps = corp_names&.dig('MR') || 'none'
+        phases = @corporations_by_round&.map do |phase, corps|
+          corps_str = corps && !corps.empty? ? corps.map(&:name).join(', ') : 'none'
+          "#{phase} (#{corps_str})"
+        end&.join(' and ')
         suffix = @options&.include?('disable_others') ? ', unless someone else acts' : ''
-        "Pass in AR (#{ar_corps}) and MR (#{mr_corps})#{suffix}"
+        "Pass on mergers in #{phases}#{suffix}"
       end
 
       def disable?(game)


### PR DESCRIPTION
Original impl always displayed values for AR and MR, but some titles use merger pass with a different phase set. E.g. in 1861 there's only the MR and no AR.

Makes the description use the phases recorded in @corporations_by_round instead of hardcoding AR/MR.

1861 example:
-- Programmed action 'Pass on mergers in MR (KK, MV)' removed due to round change

#4891