### PR TITLE
18Ireland - bids must be multiples of 5

### DIFF
--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -20,6 +20,8 @@ module Engine
         EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN = true
         EBUY_OTHER_VALUE = false
         CERT_LIMIT_COUNTS_BANKRUPTED = true
+        MUST_BID_INCREMENT_MULTIPLE = true
+        MIN_BID_INCREMENT = 5
 
         ASSIGNMENT_TOKENS = {
           'CDSPC' => '/icons/18_ireland/port_token.svg',


### PR DESCRIPTION
All bids (both in the private auction and when starting 5-share companies) must be multiple of £5 as per the rules: https://boardgamegeek.com/filepage/219076/18ireland-rules-mass-production-version.