### PR TITLE
Add support for unconditional and/or indefinite auto pass

### DIFF
--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -320,11 +320,13 @@ module View
         settings = params(form)
 
         unconditional = settings['unconditional']
+        indefinite = settings['indefinite']
 
         process_action(
           Engine::Action::ProgramSharePass.new(
             sender,
             unconditional: unconditional,
+            indefinite: indefinite,
           )
         )
       end
@@ -345,6 +347,10 @@ module View
                                     'unconditional',
                                     form,
                                     !!settings&.unconditional)
+        children << render_checkbox('Indefinite: Continue passing in future SR as well.',
+                                    'indefinite',
+                                    form,
+                                    !!settings&.indefinite)
 
         subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_share_pass(form) }]
         subchildren << render_disable(settings) if settings

--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -316,15 +316,21 @@ module View
         children
       end
 
-      def enable_share_pass
+      def enable_share_pass(form)
+        settings = params(form)
+
+        unconditional = settings['unconditional']
+
         process_action(
           Engine::Action::ProgramSharePass.new(
-            sender
+            sender,
+            unconditional: unconditional,
           )
         )
       end
 
       def render_share_pass(settings)
+        form = {}
         text = 'Auto Pass in Stock Round'
         text += ' (Enabled)' if settings
         children = [h(:h3, text)]
@@ -335,8 +341,12 @@ module View
         children << h(:p,
                       [h(:a, { attrs: { href: AUTO_ACTIONS_WIKI, target: '_blank' } },
                          'Please read this for more details when it will deactivate')])
+        children << render_checkbox('Unconditional: Pass even if other players do actions that may impact you.',
+                                    'unconditional',
+                                    form,
+                                    !!settings&.unconditional)
 
-        subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_share_pass }]
+        subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_share_pass(form) }]
         subchildren << render_disable(settings) if settings
         children << h(:div, subchildren)
 

--- a/lib/engine/action/program_share_pass.rb
+++ b/lib/engine/action/program_share_pass.rb
@@ -6,28 +6,30 @@ require_relative 'program_enable'
 module Engine
   module Action
     class ProgramSharePass < ProgramEnable
-      attr_reader :unconditional
+      attr_reader :unconditional, :indefinite
 
-      def initialize(entity, unconditional: false)
+      def initialize(entity, unconditional: false, indefinite: false)
         super(entity)
         @unconditional = unconditional
+        @indefinite = indefinite
       end
 
       def self.h_to_args(h, _game)
-        { unconditional: h['unconditional'] }
+        { unconditional: h['unconditional'], indefinite: h['indefinite'] }
       end
 
       def args_to_h
-        { 'unconditional' => @unconditional }
+        { 'unconditional' => @unconditional, 'indefinite' => @indefinite }
       end
 
       def to_s
         unconditionally = @unconditional ? ', unconditionally' : ''
-        "Pass in Stock Round#{unconditionally}"
+        indefinitely = @indefinite ? ', indefinitely' : ''
+        "Pass in Stock Round#{unconditionally}#{indefinitely}"
       end
 
       def disable?(game)
-        !game.round.stock?
+        !game.round.stock? && !@indefinite
       end
     end
   end

--- a/lib/engine/action/program_share_pass.rb
+++ b/lib/engine/action/program_share_pass.rb
@@ -6,12 +6,24 @@ require_relative 'program_enable'
 module Engine
   module Action
     class ProgramSharePass < ProgramEnable
-      def initialize(entity)
+      attr_reader :unconditional
+
+      def initialize(entity, unconditional: false)
         super(entity)
+        @unconditional = unconditional
+      end
+
+      def self.h_to_args(h, _game)
+        { unconditional: h['unconditional'] }
+      end
+
+      def args_to_h
+        { 'unconditional' => @unconditional }
       end
 
       def to_s
-        'Pass in Stock Round'
+        unconditionally = @unconditional ? ', unconditionally' : ''
+        "Pass in Stock Round#{unconditionally}"
       end
 
       def disable?(game)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -411,7 +411,7 @@ module Engine
         return unless available_actions.include?('pass')
         return unless normal_pass?(entity)
 
-        reason = should_stop_applying_program(entity, program, nil)
+        reason = should_stop_applying_program(entity, program, nil) unless program.unconditional
         return [Action::ProgramDisable.new(entity, reason: reason)] if reason
 
         [Action::Pass.new(entity)]


### PR DESCRIPTION
 Add an option to make SR auto-pass unconditional. The option bypasses the entire should_stop_applying_program call tree in buy_sell_par_shares, which also stops calling into game-specific overrides of that method and/or action_is_shenanigan?.

Add an option to make SR auto-pass indefinite. This intended mainly for use where the game drags on beyond SR relevance, e.g. late 18CZ. Can also be used together with the unconditional option to essentially drop out of a game.