### PR TITLE
Extra tokens are tied to !from_owner, not extra_action

### DIFF
--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -82,7 +82,7 @@ module Engine
 
       def available_tokens(entity)
         ability = ability(entity)
-        return [Engine::Token.new(entity.owner)] if ability&.type == :token && ability.extra_action
+        return [Engine::Token.new(entity.owner)] if ability&.type == :token && !ability.from_owner
 
         super(@game.token_owner(entity))
       end


### PR DESCRIPTION
This line was translated incorrectly in PR #4932. Following the call chain, the line determines if the place_token action is returned for the company and thus if it is shown in the UI or not. The bug would manifest as the company not being selectable in the UI when all the corporation's tokens are used, even if from_owner is false and would show in the UI when the corporation has no tokens, but extra_action is true.

Note: Tokener is correct, as long as the ability showed up in the UI, it would behave correctly.