### PR TITLE
Fix invalid font used when Lato does not have glyphs available

### DIFF
--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -1,5 +1,5 @@
 * {
-  font-family: Lato, sans;
+  font-family: Lato, sans-serif;
   word-spacing: 1px;
   line-height: 1.25;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Fixes the issue when Lato font does not have glyphs (e.g. with Cyrillic symbols on the screenshot). In this case a serif font is used, while a sans-serif was definitely meant to be.

![Screenshot 2021-12-15 at 11 21 27](https://user-images.githubusercontent.com/576786/146157226-2d819fb7-228f-461d-b8df-4efd4d27be2b.png)
