### PR TITLE
Check for auto-buy completion before checking available actions.

### DIFF
--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -418,21 +418,21 @@ module Engine
       end
 
       def activate_program_buy_shares(entity, program)
-        available_actions = actions(entity)
         corporation = program.corporation
-        if available_actions.include?('buy_shares')
-          # check if end condition met
-          finished_reason = if program.until_condition == 'float'
-                              "#{corporation.name} is floated" if corporation.floated?
-                            elsif entity.num_shares_of(corporation, ceil: false) >= program.until_condition
-                              "#{program.until_condition} share(s) bought in #{corporation.name}, end condition met"
-                            end
-          if finished_reason
-            actions = [Action::ProgramDisable.new(entity, reason: finished_reason)]
-            actions << Action::ProgramSharePass.new(entity) if program.auto_pass_after
-            return actions
-          end
+        # check if end condition met
+        finished_reason = if program.until_condition == 'float'
+                            "#{corporation.name} is floated" if corporation.floated?
+                          elsif entity.num_shares_of(corporation, ceil: false) >= program.until_condition
+                            "#{program.until_condition} share(s) bought in #{corporation.name}, end condition met"
+                          end
+        if finished_reason
+          actions = [Action::ProgramDisable.new(entity, reason: finished_reason)]
+          actions << Action::ProgramSharePass.new(entity) if program.auto_pass_after
+          return actions
+        end
 
+        available_actions = actions(entity)
+        if available_actions.include?('buy_shares')
           shares_by_percent = if from_market?(program)
                                 source = 'market'
                                 @game.share_pool.shares_by_corporation[corporation]

--- a/spec/fixtures/1889/hs_lhglbbiz_17502.json
+++ b/spec/fixtures/1889/hs_lhglbbiz_17502.json
@@ -374,7 +374,8 @@
       "created_at": 1615311276,
       "corporation": "IR",
       "until_condition": 1,
-      "from_market": true
+      "from_market": true,
+      "auto_pass_after": true
     },
     {
       "type": "pass",
@@ -393,6 +394,21 @@
             "IR_4"
           ],
           "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 671,
+          "entity_type": "player",
+          "created_at": 1615311279,
+          "reason": "1 share(s) bought in IR, end condition met"
+        },
+        {
+          "type": "program_share_pass",
+          "entity": 671,
+          "entity_type": "player",
+          "indefinite": false,
+          "created_at": 1615311279,
+          "unconditional": false
         },
         {
           "type": "pass",
@@ -451,7 +467,7 @@
           "entity": 671,
           "entity_type": "player",
           "created_at": 1615311545,
-          "reason": "1 share(s) bought in IR, end condition met"
+          "reason": "LenaC bought on corporation TR and is unsecure"
         }
       ]
     },


### PR DESCRIPTION
Auto-buy programs would not mark themselves as complete if buy_shares was not an available action (a common scenario when spending all your money to float). Formerly only a nuisance, but with the option to transition to auto-pass it actually breaks that functionality. Easy fix, just check for completion before checking if buying is allowed.

This *will* change behavior for buy X shares programs in buy-sell titles. They would previously generate a pass action after the last buy and terminate on the next turn. Now they will terminate after the last buy and not generate a pass (unless conversion to auto-pass is enabled). This seems like an improvement since the option to auto-pass exists, and the default behavior has been aligned with buy until float.

I've fixed the one fixture that was affected by this. My understanding is that real games won't need patching because the generated pass action remains valid even if the code would no longer generate it.