### PR TITLE
Better 1822 shenanigans

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -515,6 +515,7 @@ module Engine
         setup_optional_rules
         log_optional_rules
         setup
+        @round.setup
 
         initialize_actions(actions, at_action: at_action)
 

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1121,9 +1121,8 @@ module Engine
           # Randomize and setup the companies
           setup_companies
 
-          # Setup the fist bidboxes
+          # Actual bidbox setup happens in the stock round.
           @bidbox_minors_cache = []
-          setup_bidboxes
 
           # Setup exchange token abilities for all corporations
           setup_exchange_tokens

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -10,8 +10,6 @@ module Engine
         class BuySellParShares < Engine::Step::BuySellParShares
           include BidboxAuction
 
-          attr_accessor :bidders, :bid_actions
-
           def actions(entity)
             return ['choose_ability'] unless choices_ability(entity).empty?
             return [] unless entity == current_entity
@@ -121,6 +119,8 @@ module Engine
           end
 
           def pass!
+            # This should only be updated at the end of the round, not after each bid.
+            @round.update_stored_winning_bids(current_entity)
             store_bids!
             super
           end
@@ -214,8 +214,6 @@ module Engine
             super
 
             @bid_actions = 0
-            @bidders = @round.bidders || Hash.new { |h, k| h[k] = [] }
-            @bid_exceeded = @round.bid_exceeded || Hash.new { |h, k| h[k] = [] }
             @bids = @round.bids if @round.bids
             # Set initial value of @bids on the round if there's none.
             @round.bids = @bids unless @round.bids
@@ -233,21 +231,18 @@ module Engine
           end
 
           def store_bids!
-            @round.bidders = @bidders
             @round.bids = @bids
-            @bid_exceeded[current_entity].clear
-            @round.bid_exceeded = @bid_exceeded
-          end
-
-          def should_stop_applying_program(entity, program, share_to_buy)
-            return "No longer winning bids on #{@bid_exceeded[entity].map(&:id).join(',')}" unless @bid_exceeded[entity].empty?
-
-            super
           end
 
           def action_is_shenanigan?(entity, other_entity, action, corporation, share_to_buy)
-            # Bid is done in should_stop_applying_program
-            return if action.is_a?(Action::Bid)
+            if action.is_a?(Action::Bid)
+              stored_winning_bids = @round.stored_winning_bids(entity)
+              # The parameter is named corporation, but it can be a minor or company as well.
+              return "No longer winning bid on #{corporation.id}" if stored_winning_bids.include?(corporation)
+
+              # Any other bid is fine (probably).
+              return
+            end
 
             # Off shore cannot cause presidency shift, ignore
             return if action.is_a?(Action::Choose) && action.entity.id == @game.class::COMPANY_OSTH
@@ -258,16 +253,12 @@ module Engine
           protected
 
           def add_bid(action)
+            super
+
             company = action.company
             price = action.price
             entity = action.entity
 
-            winning_bid = highest_bid(company)
-            # Mark the previous highest bid as no longer winning
-            @bid_exceeded[winning_bid.entity] << company if winning_bid
-
-            super
-            @bidders[company] |= [entity]
             track_action(action, bid_target(action))
 
             @log << "#{entity.name} bids #{@game.format_currency(price)} for #{company.name}"

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -209,6 +209,7 @@ module Engine
           end
 
           def setup
+            # This sets the initial value of @bids
             setup_auction
             super
 
@@ -216,6 +217,8 @@ module Engine
             @bidders = @round.bidders || Hash.new { |h, k| h[k] = [] }
             @bid_exceeded = @round.bid_exceeded || Hash.new { |h, k| h[k] = [] }
             @bids = @round.bids if @round.bids
+            # Set initial value of @bids on the round if there's none.
+            @round.bids = @bids unless @round.bids
           end
 
           def bidding_tokens(player)

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -373,9 +373,8 @@ module Engine
           # Initialize the stock round choice for P7
           @p7_choice = nil
 
-          # Setup the fist bidboxes
+          # Actual bidbox setup happens in the stock round.
           @bidbox_minors_cache = []
-          setup_bidboxes
 
           # Setup exchange token abilities for all corporations
           setup_exchange_tokens

--- a/lib/engine/round/draft.rb
+++ b/lib/engine/round/draft.rb
@@ -26,11 +26,6 @@ module Engine
         @reverse_order ? @game.players.reverse : @game.players
       end
 
-      def setup
-        @steps.each(&:unpass!)
-        @steps.each(&:setup)
-      end
-
       def next_entity_index!
         @entities.rotate! if @rotating_order && @entity_index == (@entities.size - 1)
         return super unless @snake_order

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -22,7 +22,8 @@ module Engine
       end
 
       def setup
-        start_entity
+        skip_steps
+        next_entity! unless active_step
       end
 
       def after_process(_action)

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -34,6 +34,7 @@ module Engine
       def process_program_enable(action)
         @game.player_log(action.entity, "Enabled programmed action '#{action}'")
         @game.programmed_actions[action.entity] = action
+        @round.player_enabled_program(action.entity) if @round.respond_to?(:player_enabled_program)
       end
 
       def process_program_disable(action)

--- a/spec/fixtures/1822/hs_lxemeslq_30797.json
+++ b/spec/fixtures/1822/hs_lxemeslq_30797.json
@@ -2713,7 +2713,7 @@
           "entity": 671,
           "entity_type": "player",
           "created_at": 1615652117,
-          "reason": "No longer winning bids on P1"
+          "reason": "No longer winning bid on P1"
         }
       ]
     },
@@ -2820,7 +2820,7 @@
           "entity": 671,
           "entity_type": "player",
           "created_at": 1615652525,
-          "reason": "No longer winning bids on P1"
+          "reason": "No longer winning bid on P1"
         }
       ]
     },


### PR DESCRIPTION
Convert 1822 shenanigans checking to use action_is_shenanigan? only.

This fixes the problem where being outbid and then setting an auto action still results in the auto action being cancelled.

Fixes #6626

Has two associated clean-up commits. The first one makes setup get called properly on the initial round of a game, the second cleans up 1822 a bit to make the main change (the third commit) more focused.