### PR TITLE
Fix ability_right_time? (on_phase check)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2559,7 +2559,7 @@ module Engine
       def ability_right_time?(ability, time, on_phase, passive_ok, strict_time)
         return true unless @round
         return true if time == 'any' || ability.when?('any')
-        return (on_phase == ability.on_phase) || (on_phase == 'any') if on_phase
+        return (on_phase == ability.on_phase) || (on_phase == 'any') if ability.on_phase
         return false if ability.passive && !passive_ok
         return true if ability.passive && ability.when.empty?
 


### PR DESCRIPTION
I think I found an error. The way on_phase checking was handled resulted in such ability:

```
              {
                type: 'revenue_change',
                revenue: 0,
                on_phase: 'Brown',
                owner_type: 'corporation',
              },
```

triggering upon the sale of the company. Indeed the whole line was skipped since `on_phase` was `nil`.