### PR TITLE
Fix being unable to create games that start with a stock around.

### DIFF
--- a/routes/game.rb
+++ b/routes/game.rb
@@ -178,7 +178,7 @@ class Api
               auto_routing: r['auto_routing'],
             },
             title: title,
-            round: Engine.game_by_title(title).new([]).round&.name,
+            round: 'Unstarted',
           }
 
           game = Game.create(params)


### PR DESCRIPTION
Use a fixed 'unstarted' value for round name when creating (unpopulated) games.

Trying to init the game before anyone joins breaks due to https://github.com/tobymao/18xx/commit/069b5b9952ad458a4af4d1ed79fe0efe241f71e9 adding a call to round.setup and the stock round setup logic calling code that eventually tries to operate based on the number of players (which is zero).

The round name is only rendered once the game is started, and the value is replaced at start time, so any dummy value should do fine here.

Improvements to round.setup are also possible (e.g. pass in an arg saying it's the initial round, so it avoids running unnecessary skipping logic), but this seems like the simplest fix.

Fixes #6657