### PR TITLE
Add rake action spec_parallel for running rspec in parallel.

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,5 @@
+-I assets/app/
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::SummaryLogger --out tmp/spec_summary.log
+--format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log

--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,6 @@ group :development do
 end
 
 group :test do
+  gem 'parallel_tests'
   gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       ast (>= 2.3.0)
       parser (~> 3.0, >= 3.0.3.2)
     parallel (1.21.0)
+    parallel_tests (3.7.3)
+      parallel
     parser (3.0.3.2)
       ast (~> 2.4.1)
     pg (1.2.3)
@@ -111,6 +113,7 @@ DEPENDENCIES
   mini_racer
   newrelic_rpm
   opal
+  parallel_tests
   pry-byebug
   rake
   redis
@@ -130,4 +133,4 @@ DEPENDENCIES
   unicorn-worker-killer
 
 BUNDLED WITH
-   2.2.15
+   2.3.0.dev

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 unless ENV['RACK_ENV'] == 'production'
+  require 'parallel_tests'
   require 'rspec/core/rake_task'
   require 'rubocop/rake_task'
 
@@ -10,7 +11,12 @@ unless ENV['RACK_ENV'] == 'production'
     task.requires << 'rubocop-performance'
   end
 
-  task default: %i[spec rubocop]
+  desc 'Run spec in parallel'
+  task :spec_parallel do
+    ParallelTests::CLI.new.run(['--type', 'rspec'])
+  end
+
+  task default: %i[spec_parallel rubocop]
 end
 
 # Migrate


### PR DESCRIPTION
Also set as the default rake action instead of regular spec.

Runtime on my machine (quad core) is reduced by 25-50%, depending on overall system load.

50% is the maximum possible speedup as there's a single spec that takes half the overall time, and parallel_tests won't split up individual specs. Splitting up the large specs (assets_spec and game_spec) is one option, investigating e.g. parallel_split_tests is another.