### PR TITLE
Fix end game message

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2273,7 +2273,11 @@ module Engine
                        when :current_or
                          " : Game Ends at conclusion of this OR (#{turn}.#{@round.round_num})"
                        when :full_or
-                         " : Game Ends at conclusion of #{round_end.short_name} #{turn}.#{operating_rounds}"
+                         if @round.is_a?(Round::Operating)
+                           " : Game Ends at conclusion of #{round_end.short_name} #{turn}.#{operating_rounds}"
+                         else
+                           " : Game Ends at conclusion of #{round_end.short_name} #{turn}.#{@phase.operating_rounds}"
+                         end
                        when :one_more_full_or_set
                          " : Game Ends at conclusion of #{round_end.short_name}"\
                          " #{@final_turn}.#{final_operating_rounds}"

--- a/lib/engine/game/g_1862/step/track.rb
+++ b/lib/engine/game/g_1862/step/track.rb
@@ -31,6 +31,8 @@ module Engine
           end
 
           def update_tile_lists(tile, old_tile)
+            raise GameError, 'tile already laid' unless @game.tiles.include(tile)
+
             @game.tiles.delete(tile)
             @game.tiles << old_tile unless old_tile.preprinted
 

--- a/lib/engine/game/g_1862/step/track.rb
+++ b/lib/engine/game/g_1862/step/track.rb
@@ -31,7 +31,7 @@ module Engine
           end
 
           def update_tile_lists(tile, old_tile)
-            raise GameError, 'tile already laid' unless @game.tiles.include(tile)
+            raise GameError, 'tile already laid' unless @game.tiles.include?(tile)
 
             @game.tiles.delete(tile)
             @game.tiles << old_tile unless old_tile.preprinted


### PR DESCRIPTION
Fixes #6515 (not just 1862-specific)
Add sanity check to tile lay actions for 1862.

This will likely require some 1862 games to be pinned.