### PR TITLE
Don't crash if stock.setup skips a player.

### DIFF
--- a/lib/engine/game/g_1822/round/stock.rb
+++ b/lib/engine/game/g_1822/round/stock.rb
@@ -10,10 +10,11 @@ module Engine
           attr_accessor :bids
 
           def setup
-            super
             @game.setup_bidboxes
             # Store bids the player was winning at the end of their turn.
             @stored_winning_bids = Hash.new { |h, k| h[k] = [] }
+            # Super attempts to skip players, must happen after setting up variables.
+            super
           end
 
           def player_enabled_program(entity)


### PR DESCRIPTION
The stock around setup method will skip players who have no legal actions. A skip translates into a pass action, and in 1822 that updates the winning bids, but the winning bids hash was not created before calling super.

Fix is creating the hash before calling super.