### PR TITLE
18SJ: Fix side effects for E trains

### DIFF
--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -1602,13 +1602,10 @@ module Engine
 
           # Check if a stop (excluding start and stop) does not allow pass-through
           # due to temporary passable SJ token
-          passthrough = stops.dup
-          passthrough.shift
-          passthrough.pop
-          passthrough.each do |s|
+          stops[1...-1].each do |s|
             next if !s.city? || s.tokened_by?(route.train.owner)
 
-            raise GameError, 'Cannot passthrough blocked city' if s.tokens.all? { |t| t&.corporation }
+            raise GameError, "Cannot passthrough blocked city in #{s.hex.name}" if s.tokens.all? { |t| t&.corporation }
           end
         end
       end

--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -1079,6 +1079,7 @@ module Engine
         end
 
         def revenue_for(route, stops)
+          ensure_route_does_not_passthrough_blocked_city(route, stops)
           revenue = super
 
           icons = visited_icons(stops)
@@ -1594,6 +1595,21 @@ module Engine
           # Two player variant will add a third player during setup but we need
           # to handle setup of cash and cert limit so that it includes the bot.
           two_player_variant ? 3 : @players.size
+        end
+
+        def ensure_route_does_not_passthrough_blocked_city(route, stops)
+          return if stops.size < 3 || !owns_electric_train?(route.train.owner) || route.train.name == 'E'
+
+          # Check if a stop (excluding start and stop) does not allow pass-through
+          # due to temporary passable SJ token
+          passthrough = stops.dup
+          passthrough.shift
+          passthrough.pop
+          passthrough.each do |s|
+            next if !s.city? || s.tokened_by?(route.train.owner)
+
+            raise GameError, 'Cannot passthrough blocked city' if s.tokens.all? { |t| t&.corporation }
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_sj/step/route.rb
+++ b/lib/engine/game/g_18_sj/step/route.rb
@@ -8,12 +8,6 @@ module Engine
     module G18SJ
       module Step
         class Route < Engine::Step::Route
-          def setup
-            @game.make_sj_tokens_passable_for_electric_trains(current_entity)
-
-            super
-          end
-
           def actions(entity)
             return [] unless can_run_trains?(actual_entity(entity))
 

--- a/lib/engine/game/g_18_sj/step/token.rb
+++ b/lib/engine/game/g_18_sj/step/token.rb
@@ -11,6 +11,11 @@ module Engine
             token.price = 0 if @game.bot_corporation?(entity)
             super(entity, city, token)
           end
+
+          def pass!
+            @game.make_sj_tokens_passable_for_electric_trains(current_entity)
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
Contains two fixes:
- Making SJ tokens passable is now done after the token step
  so that current entity cannot affect track or token through
  a blocked city, even if SJ token is there.
- If current entity makes a non-E route it cannot pass through
  a blocked city, even if SJ token is there.

Fixes #6676