### PR TITLE
1893: Fixes for abilities and merge UI

### DIFF
--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -848,17 +848,17 @@ module Engine
         end
 
         def operating_round(round_num)
-          Engine::Round::Operating.new(self, [
-            Engine::Step::Bankrupt,
-            Engine::Step::DiscardTrain,
-            Engine::Step::HomeToken,
-            G1893::Step::BuyCompany,
-            G1893::Step::Track,
-            Engine::Step::Token,
-            Engine::Step::Route,
-            G1893::Step::Dividend,
-            G1893::Step::BuyTrain,
-          ], round_num: round_num)
+          G1893::Round::Operating.new(self, [
+          Engine::Step::Bankrupt,
+          Engine::Step::DiscardTrain,
+          Engine::Step::HomeToken,
+          G1893::Step::BuyCompany,
+          G1893::Step::Track,
+          Engine::Step::Token,
+          Engine::Step::Route,
+          G1893::Step::Dividend,
+          G1893::Step::BuyTrain,
+        ], round_num: round_num)
         end
 
         def new_merger_round(count)
@@ -1233,11 +1233,13 @@ module Engine
             move_share(president_share, new_president)
           end
 
-          # Give president the chance to discard any trains
-          @potential_discard_trains << mergable unless mergable.trains.empty?
-
           mergable.ipoed = true
-          @log << "#{mergable.name} have been completely founded and now floats"
+          @log << "-- #{mergable.name} have been completely founded and now floats"
+          return if mergable.trains.empty?
+
+          # Give president the chance to discard any trains
+          @potential_discard_trains << mergable
+          @log << "-- #{mergable.owner.name} will have to decide which trains #{mergable.name} should keep"
         end
 
         def shares_for_presidency_swap(shares, num_shares)

--- a/lib/engine/game/g_1893/round/operating.rb
+++ b/lib/engine/game/g_1893/round/operating.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G1893
+      module Round
+        class Operating < Engine::Round::Operating
+          def actions_for(entity)
+            # No actions available for companies during the OR
+            return [] if entity.company?
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Do not show any abilities in UI during ORs
2. Fix bug when passing prematurely during discard of trains
   (Pass was previously an option even though train limit exceeded)
3. Correct UI handling of merge (fixes #6624)