### PR TITLE
Train limit change should affect minors as well

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1722,7 +1722,7 @@ module Engine
       end
 
       def crowded_corps
-        @crowded_corps ||= corporations.select do |c|
+        @crowded_corps ||= (minors + corporations).select do |c|
           trains = self.class::OBSOLETE_TRAINS_COUNT_FOR_LIMIT ? c.trains.size : c.trains.count { |t| !t.obsolete }
           trains > train_limit(c)
         end


### PR DESCRIPTION
Minor was excluded from crowded corps check, which meant that a title
like 1893, which have decreasing train limit for minors, would not
discard trains in a correct way.

Fixes #6509