### PR TITLE
18NewEngland - ISR, SR fixes. First pass OR steps

### DIFF
--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -47,7 +47,11 @@ module View
 
           flags += " / #{@game.total_shares_to_float(@corporation, share_price.price)}" if @game.class::VARIABLE_FLOAT_PERCENTAGES
 
-          text = "#{@game.par_price_str(share_price)} (#{purchasable_shares}#{flags})"
+          text = if @corporation.presidents_percent < 100
+                   "#{@game.par_price_str(share_price)} (#{purchasable_shares}#{flags})"
+                 else
+                   @game.par_price_str(share_price)
+                 end
           h('button.small.par_price', props, text)
         end
 

--- a/lib/engine/game/g_18_new_england/entities.rb
+++ b/lib/engine/game/g_18_new_england/entities.rb
@@ -293,6 +293,13 @@ module Engine
             color: 'green',
             tokens: [0],
           },
+          {
+            sym: 'C',
+            name: 'Closed Dummy',
+            logo: '18_new_england/CLOSED',
+            color: 'black',
+            tokens: [0],
+          },
         ].freeze
       end
     end

--- a/lib/engine/game/g_18_new_england/game.rb
+++ b/lib/engine/game/g_18_new_england/game.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'meta'
 require_relative '../base'
+require_relative 'meta'
 require_relative 'entities'
 require_relative 'map'
 
@@ -41,7 +41,32 @@ module Engine
         CAPITALIZATION = :incremental
         MUST_SELL_IN_BLOCKS = false
 
+        TOP_MINOR_ROW = 0
+        BOTTOM_MINOR_ROW = 1
+        MAJOR_ROW = 2
         MARKET = [
+          [
+            '', '', '',
+            '50r',
+            '55r',
+            '60r',
+            '65r',
+            '70r',
+            '80r',
+            '90r',
+            '100r'
+          ],
+          [
+            '', '', '',
+            '50r',
+            '55r',
+            '60r',
+            '65r',
+            '70r',
+            '80r',
+            '90r',
+            '100r'
+          ],
           %w[35
              40
              45
@@ -72,51 +97,60 @@ module Engine
              500e],
            ].freeze
 
+        MARKET_TEXT = {
+          par: 'Par value',
+          no_cert_limit: 'Corporation shares do not count towards cert limit',
+          unlimited: 'Corporation shares can be held above 60%',
+          multiple_buy: 'Can buy more than one share in the corporation per turn',
+          close: 'Corporation closes',
+          endgame: 'End game trigger',
+          liquidation: 'Liquidation',
+          repar: 'Minor company value',
+          ignore_one_sale: 'Ignore first share sold when moving price',
+        }.freeze
+
         PHASES = [
           {
             name: '2',
-            train_limit: '4',
+            train_limit: { minor: 2, major: 4 },
             tiles: %i[yellow],
             operating_rounds: 2,
           },
           {
             name: '3',
             on: '3',
-            train_limit: 4,
+            train_limit: { minor: 2, major: 4 },
             tiles: %i[yellow green],
             operating_rounds: 2,
           },
           {
             name: '4',
             on: '4',
-            train_limit: 3,
+            train_limit: { minor: 1, major: 3 },
             tiles: %i[yellow green],
             operating_rounds: 2,
           },
           {
             name: '5',
             on: '5E',
-            train_limit: 3,
+            train_limit: { minor: 1, major: 3 },
             tiles: %i[yellow green brown],
             operating_rounds: 2,
           },
           {
             name: '6',
             on: '6E',
-            train_limit: 2,
+            train_limit: { minor: 1, major: 2 },
             tiles: %i[yellow green brown],
             operating_rounds: 2,
           },
           {
             name: '8',
             on: '8E',
-            train_limit: 2,
+            train_limit: { minor: 1, major: 2 },
             tiles: %i[yellow green brown gray],
             operating_rounds: 2,
           },
-          #    status: ['can_buy_companies'],
-          #    status: %w[can_buy_companies export_train],
-          #    status: %w[can_buy_companies export_train],
         ].freeze
 
         TRAINS = [
@@ -165,9 +199,12 @@ module Engine
         MUST_BUY_TRAIN = :always # mostly true, needs custom code
         SELL_MOVEMENT = :down_block_pres
         SELL_BUY_ORDER = :sell_buy
+        GAME_END_CHECK = { stock_market: :current_or, bankrupt: :immediate, bank: :full_or }.freeze
+        BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
         YELLOW_PRICES = [50, 55, 60, 65, 70].freeze
         GREEN_PRICES = [80, 90, 100].freeze
+        NUM_START_MINORS = 10
 
         # Two lays or one upgrade
         TILE_LAYS = [
@@ -175,19 +212,27 @@ module Engine
           { lay: true, upgrade: :not_if_upgraded },
         ].freeze
 
+        # one lay or one upgrade
+        MINOR_TILE_LAYS = [
+          { lay: true, upgrade: true },
+        ].freeze
+
         def setup
+          # pick initial 10 minors
+          #
+          @starting_minors = @corporations.select { |c| c.type == :minor }.sort_by { rand }.take(NUM_START_MINORS)
+
           # add yellow and green minor placeholders to stock market
           #
           @yellow_dummy = @minors.find { |d| d.name == 'Y' }
           @green_dummy = @minors.find { |d| d.name == 'G' }
+          @closed_dummy = @minors.find { |d| d.name == 'C' }
 
           minor_yellow_prices.each do |p|
-            p.corporations << @yellow_dummy
             p.corporations << @yellow_dummy
           end
 
           minor_green_prices.each do |p|
-            p.corporations << @green_dummy
             p.corporations << @green_dummy
           end
 
@@ -197,9 +242,10 @@ module Engine
           @log << '-- First Stock Round --'
         end
 
-        def lookup_price(p)
-          @stock_market.market[0].size.times do |i|
-            return @stock_market.share_price(0, i) if @stock_market.share_price(0, i).price == p
+        def lookup_minor_price(p, row)
+          @stock_market.market[row].size.times do |i|
+            next unless @stock_market.share_price(row, i)
+            return @stock_market.share_price(row, i) if @stock_market.share_price(row, i).price == p
           end
         end
 
@@ -218,6 +264,20 @@ module Engine
           ])
         end
 
+        def operating_round(round_num)
+          Engine::Round::Operating.new(self, [
+            Engine::Step::Bankrupt,
+            G18NewEngland::Step::RedeemShares,
+            G18NewEngland::Step::Track,
+            Engine::Step::Token,
+            Engine::Step::Route,
+            G18NewEngland::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            G18NewEngland::Step::BuyTrain,
+            G18NewEngland::Step::IssueShares,
+          ], round_num: round_num)
+        end
+
         def init_round_finished
           @reserved = {}
         end
@@ -230,11 +290,11 @@ module Engine
               @operating_rounds = @phase.operating_rounds
               reorder_players(:most_cash, log_player_order: true)
               new_operating_round
-            when Round::Stock
+            when Engine::Round::Stock
               @operating_rounds = @phase.operating_rounds
               reorder_players
               new_operating_round
-            when Round::Operating
+            when Engine::Round::Operating
               if @round.round_num < @operating_rounds
                 or_round_finished
                 new_operating_round(@round.round_num + 1)
@@ -254,7 +314,7 @@ module Engine
           index = price.corporations.find_index(@yellow_dummy) || price.corporations.find_index(@green_dummy)
           price.corporations.delete_at(index) if index
 
-          @minor_prices[price] += 1
+          @minor_prices[price.price] += 1
         end
 
         def place_home_token(corporation)
@@ -274,12 +334,16 @@ module Engine
 
         def minor_yellow_prices
           @minor_yellow_prices ||=
-            YELLOW_PRICES.map { |p| lookup_price(p) }
+            (YELLOW_PRICES.map do |p|
+               [lookup_minor_price(p, TOP_MINOR_ROW), lookup_minor_price(p, BOTTOM_MINOR_ROW)]
+             end).flatten
         end
 
         def minor_green_prices
           @minor_green_prices ||=
-            GREEN_PRICES.map { |p| lookup_price(p) }
+            (GREEN_PRICES.map do |p|
+               [lookup_minor_price(p, TOP_MINOR_ROW), lookup_minor_price(p, BOTTOM_MINOR_ROW)]
+             end).flatten
         end
 
         def share_prices
@@ -287,17 +351,25 @@ module Engine
         end
 
         def available_minor_prices
-          available = @minor_yellow_prices.reject { |p| @minor_prices[p] > 1 }
-          available.concat(@minor_green_prices.reject { |p| @minor_prices[p] > 1 }) if @phase.available?('3')
+          available = @minor_yellow_prices.reject { |p| @minor_prices[p.price] > 1 }
+          available.concat(@minor_green_prices.reject { |p| @minor_prices[p.price] > 1 }) if @phase.available?('3')
           available
         end
 
-        def status_str(corp)
-          return unless corp.type == :minor
-          return "Minor Company, Price = #{format_currency(corp.share_price.price)}" if corp.share_price
-          return "Reserved by #{@reserved[corp].name}" if @reserved[corp]
+        def available_minor_par_prices
+          available = @minor_yellow_prices.select { |p| p.corporations.include?(@yellow_dummy) }
+          return available unless @phase.available?('3')
 
-          'Minor Company'
+          available + minor_green_prices.select { |p| p.corporations.include?(@green_dummy) }
+        end
+
+        def status_array(corp)
+          return unless corp.type == :minor
+          return [['Minor Company'], ["Value: #{format_currency(corp.share_price.price)}"]] if corp.share_price
+          return [["Reserved by #{@reserved[corp].name}", 'bold']] if @reserved[corp]
+          return [['Minor Company']] if @starting_minors.include?(corp) || @phase.available?('3')
+
+          [['Minor Company - Not Available', 'bold']]
         end
 
         def corporation_show_shares?(corp)
@@ -305,13 +377,12 @@ module Engine
         end
 
         def operating_order
-          mins, majs = @corporations.reject(&:minor?).select(&:floated?).partition(&:type)
-          mins.sort + majs.sort
+          @corporations.reject(&:minor?).select(&:floated?).sort
         end
 
         def bank_sort(corporations)
           mins, majs = corporations.reject(&:minor?).partition(&:type)
-          majs.sort_by(&:name) + mins.sort_by(&:name)
+          mins.sort_by(&:name) + majs.sort_by(&:name)
         end
 
         def player_sort(entities)
@@ -337,6 +408,76 @@ module Engine
 
         def form_button_text(corp)
           "Reserve #{corp.name}"
+        end
+
+        def tile_lays(entity)
+          return self.class::TILE_LAYS unless entity.type == :minor
+
+          MINOR_TILE_LAYS
+        end
+
+        def upgrades_to?(from, to, special = false, selected_company: nil)
+          # handle special-case upgrades
+          return true if force_upgrade?(from, to)
+
+          super
+        end
+
+        def force_upgrade?(from, to)
+          return false unless from.preprinted
+          return false unless (list = PREPRINTED_UPGRADES[from.hex.coordinates])
+
+          list.include?(to.name)
+        end
+
+        def stock_round_corporations
+          @corporations.select do |c|
+            c.ipoed || (c.type == :minor && (@phase.available?('3') || @starting_minors.include?(c)))
+          end
+        end
+
+        def can_go_bankrupt?(_player, corporation)
+          corporation.type != :minor && super
+        end
+
+        def redeemaable_shares(entity)
+          return [] unless entity.corporation? && entity.type != :minor
+
+          bundles_for_corporation(share_pool, entity)
+            .reject { |bundle| entity.cash < bundle.price }
+        end
+
+        def issuable_shares(entity)
+          return [] unless entity.corporation? && entity.type != :minor
+          return [] unless round.steps.find { |step| step.instance_of?(G18NewEngland::Step::RedeemShares) }.active?
+
+          num_shares = entity.num_player_shares - entity.num_market_shares
+          bundles = bundles_for_corporation(entity, entity)
+          share_price = stock_market.find_share_price(entity, :left).price
+
+          bundles
+            .each { |bundle| bundle.share_price = share_price }
+            .reject { |bundle| bundle.num_shares > num_shares }
+        end
+
+        def par_price_str(share_price)
+          case share_price.coordinates.first
+          when MAJOR_ROW
+            format_currency(share_price.price)
+          when TOP_MINOR_ROW
+            "#{format_currency(share_price.price)}⇧"
+          else
+            "#{format_currency(share_price.price)}⇩"
+          end
+        end
+
+        def close_corporation(corporation, quiet: false)
+          share_price = corporation.share_price
+          minor = corporation.type == :minor
+          super
+          return unless minor
+
+          share_price.corporations << @closed_dummy
         end
       end
     end

--- a/lib/engine/game/g_18_new_england/game.rb
+++ b/lib/engine/game/g_18_new_england/game.rb
@@ -334,16 +334,16 @@ module Engine
 
         def minor_yellow_prices
           @minor_yellow_prices ||=
-            (YELLOW_PRICES.map do |p|
-               [lookup_minor_price(p, TOP_MINOR_ROW), lookup_minor_price(p, BOTTOM_MINOR_ROW)]
-             end).flatten
+            YELLOW_PRICES.flat_map do |p|
+              [lookup_minor_price(p, TOP_MINOR_ROW), lookup_minor_price(p, BOTTOM_MINOR_ROW)]
+            end
         end
 
         def minor_green_prices
           @minor_green_prices ||=
-            (GREEN_PRICES.map do |p|
-               [lookup_minor_price(p, TOP_MINOR_ROW), lookup_minor_price(p, BOTTOM_MINOR_ROW)]
-             end).flatten
+            GREEN_PRICES.flat_map do |p|
+              [lookup_minor_price(p, TOP_MINOR_ROW), lookup_minor_price(p, BOTTOM_MINOR_ROW)]
+            end
         end
 
         def share_prices

--- a/lib/engine/game/g_18_new_england/map.rb
+++ b/lib/engine/game/g_18_new_england/map.rb
@@ -49,6 +49,69 @@ module Engine
           '611' => 3,
           '216' => 2,
           '911' => 4,
+          'X1' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:50;city=revenue:50;path=a:1,b:_0;path=a:_0,b:3;'\
+                      'path=a:4,b:_1;path=a:_1,b:5;label=B',
+          },
+          'X2' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_0;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5;label=H',
+          },
+          'X3' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40;city=revenue:40;city=revenue:40;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_1;path=a:3,b:_1;path=a:_2,b:4;path=a:_2,b:5;label=NH',
+          },
+          'X4' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:70,slots:2;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_0;path=a:_0,b:3;path=a:_0,b:4;label=B',
+          },
+          'X5' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:50,slots:2;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_0;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5;label=H',
+          },
+          'X6' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:50,slots:2;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_0;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5;label=NH',
+          },
+          'X7' =>
+          {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:100,slots:2;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_0;path=a:_0,b:3;path=a:_0,b:4;label=B',
+          },
+          'X8' =>
+          {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:50,slots:2;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_0;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5;label=H',
+          },
+          'X9' =>
+          {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:60,slots:2;path=a:_0,b:0;path=a:_0,b:1;'\
+                      'path=a:2,b:_0;path=a:_0,b:3;path=a:_0,b:4;path=a:_0,b:5;label=NH',
+          },
         }.freeze
 
         LOCATION_NAMES = {
@@ -91,7 +154,6 @@ module Engine
 
         PREPRINTED_UPGRADES = {
           'L7' => %w[6],
-          'M4' => %w[3],
           'K4' => %w[14 15 619],
           'G8' => %w[14 15 619],
         }.freeze

--- a/lib/engine/game/g_18_new_england/round/first_stock.rb
+++ b/lib/engine/game/g_18_new_england/round/first_stock.rb
@@ -26,6 +26,11 @@ module Engine
               @entity_index = @entity_index.send(plus_or_minus, 1) % @entities.size
             end
           end
+
+          # only exit first stock round on consecutive passes
+          def finished?
+            @game.finished || @pass_order.size == @game.players.size
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_new_england/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_new_england/step/buy_sell_par_shares.rb
@@ -8,11 +8,26 @@ module Engine
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
           def visible_corporations
-            @game.corporations.select { |c| c.type == :minor || c.ipoed }
+            @game.stock_round_corporations
           end
 
           def get_par_prices(entity, _corp)
-            @game.available_minor_prices.select { |p| p.price * 2 <= entity.cash }
+            @game.available_minor_par_prices.select { |p| p.price * 2 <= entity.cash }
+          end
+
+          def can_ipo_any?(entity)
+            !bought? && @game.corporations.any? do |c|
+              if c.type == :minor
+                @game.can_par?(c, entity) && can_par_minor?(entity, c.shares.first&.to_bundle)
+              else
+                @game.can_par?(c, entity) && can_buy?(entity, c.shares.first&.to_bundle)
+              end
+            end
+          end
+
+          def can_par_minor?(entity, bundle)
+            @game.available_minor_prices.any? { |p| 2 * p.price <= entity.cash } &&
+              can_gain?(entity, bundle)
           end
         end
       end

--- a/lib/engine/game/g_18_new_england/step/buy_train.rb
+++ b/lib/engine/game/g_18_new_england/step/buy_train.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G18NewEngland
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def actions(entity)
+            # 1846 and a few others minors can't buy trains
+            return [] unless can_entity_buy_train?(entity)
+
+            return [] if entity != current_entity
+            return %w[sell_shares buy_train] if entity.type != :minor && president_may_contribute?(entity)
+            return %w[pass sell_shares buy_train] if entity.type == :minor && president_may_contribute?(entity)
+            return %w[buy_train pass] if can_buy_train?(entity)
+
+            []
+          end
+
+          def pass_description
+            if current_entity.trains.empty? && current_entity.type == :minor
+              "Close #{current_entity.name}"
+            else
+              @acted ? 'Done (Trains)' : 'Skip (Trains)'
+            end
+          end
+
+          def process_pass(action)
+            entity = action.entity
+            return super unless entity.trains.empty? && entity.type == :minor
+
+            @game.close_corporation(entity)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_new_england/step/dividend.rb
+++ b/lib/engine/game/g_18_new_england/step/dividend.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+require_relative '../../../step/minor_half_pay'
+
+module Engine
+  module Game
+    module G18NewEngland
+      module Step
+        class Dividend < Engine::Step::Dividend
+          include Engine::Step::HalfPay
+          include Engine::Step::MinorHalfPay
+          DIVIDEND_TYPES = %i[payout half withhold].freeze
+
+          def share_price_change(entity, revenue = 0)
+            return {} if entity.type == :minor
+
+            price = entity.share_price.price
+
+            if revenue.zero?
+              { share_direction: :left, share_times: 1 }
+            elsif revenue < price
+              {}
+            elsif revenue >= price && revenue < 2 * price
+              { share_direction: :right, share_times: 1 }
+            else
+              { share_direction: :right, share_times: 2 }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_new_england/step/issue_shares.rb
+++ b/lib/engine/game/g_18_new_england/step/issue_shares.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/issue_shares'
+
+module Engine
+  module Game
+    module G18NewEngland
+      module Step
+        class IssueShares < Engine::Step::IssueShares
+          def description
+            'Issue Shares'
+          end
+
+          def pass_description
+            'Skip (Issue)'
+          end
+
+          def redeemable_shares(_entity)
+            []
+          end
+
+          def issuable_shares(entity)
+            return [] if @round.redeemed
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_new_england/step/redeem_shares.rb
+++ b/lib/engine/game/g_18_new_england/step/redeem_shares.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/issue_shares'
+
+module Engine
+  module Game
+    module G18NewEngland
+      module Step
+        class RedeemShares < Engine::Step::IssueShares
+          def issuable_shares(_entity)
+            []
+          end
+
+          def description
+            'Redeem Shares'
+          end
+
+          def pass_description
+            'Skip (Redeem)'
+          end
+
+          def process_buy_shares(action)
+            @round.redeemed = true
+            super
+          end
+
+          def blocks?
+            false
+          end
+
+          def setup
+            @round.redeemed = nil
+            super
+          end
+
+          def round_state
+            super.merge(
+              {
+                redeemed: nil,
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_new_england/step/track.rb
+++ b/lib/engine/game/g_18_new_england/step/track.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G18NewEngland
+      module Step
+        class Track < Engine::Step::Track
+          def upgradeable_tiles(entity, ui_hex)
+            tiles = super
+            # don't allow 611 to be laid if 63 is a possibility
+            #
+            tiles.reject! { |t| t.name == '611' } if tiles.any? { |t| t.name == '63' }
+            tiles
+          end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            return super unless @game.force_upgrade?(hex.tile, tile)
+
+            # make sure new tile connects to same exits as old tile
+            old_exits = hex.tile.exits
+            new_exits = tile.exits
+
+            new_exits.all? { |edge| hex.neighbors[edge] } &&
+              !(new_exits & hex_neighbors(entity, hex)).empty? &&
+              old_exits.all? { |ex| new_exits.include?(ex) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_new_england_north/entities.rb
+++ b/lib/engine/game/g_18_new_england_north/entities.rb
@@ -289,21 +289,28 @@ module Engine
         ].freeze
 
         MINORS = [
-   {
-     sym: 'Y',
-     name: 'Yellow Dummy',
-     logo: '18_new_england/YELLOW',
-     color: 'yellow',
-     tokens: [0],
-   },
-   {
-     sym: 'G',
-     name: 'Green Dummy',
-     logo: '18_new_england/GREEN',
-     color: 'green',
-     tokens: [0],
-   },
- ].freeze
+          {
+            sym: 'Y',
+            name: 'Yellow Dummy',
+            logo: '18_new_england/YELLOW',
+            color: 'yellow',
+            tokens: [0],
+          },
+          {
+            sym: 'G',
+            name: 'Green Dummy',
+            logo: '18_new_england/GREEN',
+            color: 'green',
+            tokens: [0],
+          },
+          {
+            sym: 'C',
+            name: 'Closed Dummy',
+            logo: '18_new_england/CLOSED',
+            color: 'black',
+            tokens: [0],
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_18_new_england_north/game.rb
+++ b/lib/engine/game/g_18_new_england_north/game.rb
@@ -13,111 +13,9 @@ module Engine
         include G18NewEnglandNorth::Entities
         include G18NewEnglandNorth::Map
 
-        register_colors(black: '#16190e',
-                        blue: '#0189d1',
-                        brown: '#7b352a',
-                        gray: '#7c7b8c',
-                        green: '#3c7b5c',
-                        olive: '#808000',
-                        lightGreen: '#009a54ff',
-                        lightBlue: '#4cb5d2',
-                        lightishBlue: '#0097df',
-                        teal: '#009595',
-                        orange: '#d75500',
-                        magenta: '#d30869',
-                        purple: '#772282',
-                        red: '#ef4223',
-                        rose: '#b7274c',
-                        coral: '#f3716d',
-                        white: '#fff36b',
-                        navy: '#000080',
-                        cream: '#fffdd0',
-                        yellow: '#ffdea8')
-
-        CURRENCY_FORMAT_STR = '$%d'
         BANK_CASH = 6_000
         CERT_LIMIT = { 2 => 16, 3 => 12, 4 => 10 }.freeze
         STARTING_CASH = { 2 => 520, 3 => 400, 4 => 280 }.freeze
-        CAPITALIZATION = :incremental
-        MUST_SELL_IN_BLOCKS = false
-
-        MARKET = [
-          %w[35
-             40
-             45
-             50
-             55
-             60
-             65
-             70
-             80
-             90
-             100p
-             110p
-             120p
-             130p
-             145p
-             160p
-             180p
-             200p
-             220
-             240
-             260
-             280
-             310
-             340
-             380
-             420
-             460
-             500],
-           ].freeze
-
-        PHASES = [
-          {
-            name: '2',
-            train_limit: '4',
-            tiles: %i[yellow],
-            operating_rounds: 2,
-          },
-          {
-            name: '3',
-            on: '3',
-            train_limit: 4,
-            tiles: %i[yellow green],
-            operating_rounds: 2,
-          },
-          {
-            name: '4',
-            on: '4',
-            train_limit: 3,
-            tiles: %i[yellow green],
-            operating_rounds: 2,
-          },
-          {
-            name: '5',
-            on: '5E',
-            train_limit: 3,
-            tiles: %i[yellow green brown],
-            operating_rounds: 2,
-          },
-          {
-            name: '6',
-            on: '6E',
-            train_limit: 2,
-            tiles: %i[yellow green brown],
-            operating_rounds: 2,
-          },
-          {
-            name: '8',
-            on: '8E',
-            train_limit: 2,
-            tiles: %i[yellow green brown gray],
-            operating_rounds: 2,
-          },
-          #    status: ['can_buy_companies'],
-          #    status: %w[can_buy_companies export_train],
-          #    status: %w[can_buy_companies export_train],
-        ].freeze
 
         TRAINS = [
           {
@@ -159,17 +57,6 @@ module Engine
             price: 800,
             num: 20,
           },
-        ].freeze
-
-        HOME_TOKEN_TIMING = :float
-        MUST_BUY_TRAIN = :always # mostly true, needs custom code
-        SELL_MOVEMENT = :down_block_pres
-        SELL_BUY_ORDER = :sell_buy
-
-        # Two lays or one upgrade
-        TILE_LAYS = [
-          { lay: true, upgrade: true },
-          { lay: true, upgrade: :not_if_upgraded },
         ].freeze
       end
     end

--- a/public/logos/18_new_england/CLOSED.svg
+++ b/public/logos/18_new_england/CLOSED.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 8 8"
+   id="svg4"
+   sodipodi:docname="CLOSED.svg"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="105.5"
+     inkscape:cx="3.92891"
+     inkscape:cy="3.9478673"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <ellipse
+     cx="4"
+     cy="4"
+     rx="3.556"
+     ry="3.5555999"
+     fill="none"
+     stroke="#71bf44"
+     stroke-width="0.88889"
+     id="ellipse2"
+     style="stroke:#000000;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 1.5148388,6.4740744 C 6.477501,1.4923038 6.477501,1.4923038 6.477501,1.4923038 l 0.00414,-0.00414"
+     id="path1168" />
+</svg>

--- a/public/logos/18_new_england/CLOSED.svg
+++ b/public/logos/18_new_england/CLOSED.svg
@@ -1,5 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
- <ellipse cx="4" cy="4" rx="3.556" ry="3.5556" fill="none" stroke="#000" stroke-width=".88889"/>
- <path d="m1.5148 6.4741c4.9627-4.9818 4.9627-4.9818 4.9627-4.9818l0.00414-0.00414" fill="none" stroke="#000" stroke-width="1px"/>
-</svg>
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><ellipse cx="4" cy="4" rx="3.556" ry="3.5556" fill="none" stroke="#000" stroke-width=".88889"/><path d="m1.5148 6.4741c4.9627-4.9818 4.9627-4.9818 4.9627-4.9818l0.00414-0.00414" fill="none" stroke="#000" stroke-width="1px"/></svg>

--- a/public/logos/18_new_england/CLOSED.svg
+++ b/public/logos/18_new_england/CLOSED.svg
@@ -1,46 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   version="1.1"
-   viewBox="0 0 8 8"
-   id="svg4"
-   sodipodi:docname="CLOSED.svg"
-   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs8" />
-  <sodipodi:namedview
-     id="namedview6"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="105.5"
-     inkscape:cx="3.92891"
-     inkscape:cy="3.9478673"
-     inkscape:window-width="1848"
-     inkscape:window-height="1016"
-     inkscape:window-x="72"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4" />
-  <ellipse
-     cx="4"
-     cy="4"
-     rx="3.556"
-     ry="3.5555999"
-     fill="none"
-     stroke="#71bf44"
-     stroke-width="0.88889"
-     id="ellipse2"
-     style="stroke:#000000;stroke-opacity:1" />
-  <path
-     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="M 1.5148388,6.4740744 C 6.477501,1.4923038 6.477501,1.4923038 6.477501,1.4923038 l 0.00414,-0.00414"
-     id="path1168" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
+ <ellipse cx="4" cy="4" rx="3.556" ry="3.5556" fill="none" stroke="#000" stroke-width=".88889"/>
+ <path d="m1.5148 6.4741c4.9627-4.9818 4.9627-4.9818 4.9627-4.9818l0.00414-0.00414" fill="none" stroke="#000" stroke-width="1px"/>
 </svg>


### PR DESCRIPTION
* Fix issues with ISR (consecutive passing and snake order)
* Make market 2D to allow choice of top or bottom minor share value
* Tile upgrade rules for pre-printed track
* Tile 63 vs 611 rule
* 1/2 dividends
* minor train buying rules
* minor liquidation
* share redemption and issuing (not tested)

Common file change:
* UI:par - don't print parenthetical info on par values for companies that have 100% president shares