### PR TITLE
1846 show draft to active player

### DIFF
--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -49,9 +49,11 @@ module View
         @valid_actors.any? { |actor| actor.id == @user['id'] }
       end
 
-      def process_action(action)
-        hotseat = @game_data[:mode] == :hotseat
+      def hotseat?
+        @game_data[:mode] == :hotseat
+      end
 
+      def process_action(action)
         if @game.exception
           msg = 'This game is broken and cannot accept any new actions. If '\
                 'this issue has not already been reported, please follow the '\
@@ -64,7 +66,7 @@ module View
             Press >| to navigate to the current game action.')
         end
 
-        if !hotseat &&
+        if !hotseat? &&
            !action.free? &&
            participant? &&
            !valid_actor?(action)
@@ -99,7 +101,7 @@ module View
           @game_data[:status] = 'active'
         end
 
-        if hotseat
+        if hotseat?
           @game_data[:turn] = game.turn
           @game_data[:round] = game.round.name
           @game_data[:acting] = game.active_players_id

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -25,7 +25,7 @@ module View
           @current_actions = @step.current_actions
 
           user_name = @user&.dig('name')
-          user_is_player = user_name && @game.players.map(&:name).include?(user_name)
+          user_is_player = !hotseat? && user_name && @game.players.map(&:name).include?(user_name)
           @user_is_current_player = user_is_player && @current_entity.name == user_name
           @block_show = user_is_player && !@user_is_current_player && !Lib::Storage[@game.id]&.dig('master_mode')
 

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -25,10 +25,9 @@ module View
           @current_actions = @step.current_actions
 
           user_name = @user&.dig('name')
-          @block_show = user_name &&
-            @game.players.map(&:name).include?(user_name) &&
-            @current_entity.name != user_name &&
-            !Lib::Storage[@game.id]&.dig('master_mode')
+          user_is_player = user_name && @game.players.map(&:name).include?(user_name)
+          @user_is_current_player = user_is_player && @current_entity.name == user_name
+          @block_show = user_is_player && !@user_is_current_player && !Lib::Storage[@game.id]&.dig('master_mode')
 
           store(:before_process_pass, -> { hide! }, skip: true) if @current_actions.include?('pass')
 
@@ -74,6 +73,7 @@ module View
         end
 
         def render_show_button
+          return nil if @user_is_current_player
           return nil if @step.visible? && @step.players_visible?
 
           toggle = lambda do
@@ -331,6 +331,8 @@ module View
         end
 
         def hidden?
+          return false if @user_is_current_player
+
           @block_show || @hidden
         end
 


### PR DESCRIPTION
Automatically show the draft / player info in non-hotseat games when the logged-in user is the active player.

Not automatically displayed to logged-out users in case they're a player with expired cookies, not automatically showing in hotseat since it'd reveal too much in actual hotseat play.

Also fix hotseat games where one of the players has the same name as the logged-in user. The old code would detect this as it being someone else's turn and require master mode.

Also factors out a hotseat? method in actionable for reuse.