### PR TITLE
Remove redundant explicit passing of needs.

### DIFF
--- a/assets/app/view/game/pass.rb
+++ b/assets/app/view/game/pass.rb
@@ -7,13 +7,12 @@ module View
   module Game
     class Pass < Snabberb::Component
       include Actionable
-      needs :before_process_pass, store: true
       needs :actions, default: []
 
       def render
         children = []
         if @actions.include?('pass')
-          children << h(PassButton, before_process_pass: @before_process_pass)
+          children << h(PassButton)
           children << h(PassAutoButton) if @game.round.stock? && @game.active_players_id.include?(@user&.dig('id'))
         end
         h(:div, children.compact)

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -16,7 +16,7 @@ module View
         needs :hidden, default: true, store: true
         needs :flash_opts, default: {}, store: true
         needs :user
-        needs :before_process_pass, store: true
+        needs :before_process_pass, default: -> {}, store: true
 
         def render
           @round = @game.round

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -15,7 +15,6 @@ module View
     needs :tile_selector, default: nil, store: true
     needs :user
     needs :connected, default: false, store: true
-    needs :before_process_pass, default: -> {}, store: true
     needs :scroll_pos, default: nil, store: true
     needs :chat_input, default: '', store: true
 
@@ -413,11 +412,10 @@ module View
         else
           h(Game::Round::Operating, game: @game)
         end
-      when Engine::Round::Draft
-        h(Game::Round::Auction, game: @game, user: @user, before_process_pass: @before_process_pass)
       when Engine::Round::Choices
         h(Game::Round::Choices, game: @game)
-      when Engine::Round::Auction
+      when Engine::Round::Auction,
+           Engine::Round::Draft
         h(Game::Round::Auction, game: @game, user: @user)
       when Engine::Round::Merger
         if !(%w[buy_train scrap_train reassign_trains] & current_entity_actions).empty?
@@ -438,7 +436,7 @@ module View
       children << h(Game::EntityOrder, round: @round)
       unless @game.finished
         children << h(Game::Abilities, user: @user, game: @game)
-        children << h(Game::Pass, before_process_pass: @before_process_pass, actions: current_entity_actions)
+        children << h(Game::Pass, actions: current_entity_actions)
         children << h(Game::Help, game: @game)
       end
       children << render_action


### PR DESCRIPTION
PassButton and Auction both use the same stored need, so there's no need to pass it explicitly from GamePage and Pass.