### PR TITLE
18NewEngland: Express trains; Merger auto actions; playthrough fixes

### DIFF
--- a/lib/engine/game/g_18_new_england/entities.rb
+++ b/lib/engine/game/g_18_new_england/entities.rb
@@ -104,7 +104,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'BL',
@@ -119,7 +119,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'BP',
@@ -133,7 +133,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'CR',
@@ -147,7 +147,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'CV',
@@ -161,7 +161,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'ER',
@@ -175,7 +175,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'FRR',
@@ -188,7 +188,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'GR',
@@ -201,7 +201,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'HNH',
@@ -215,7 +215,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'HRR',
@@ -229,7 +229,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'NLN',
@@ -244,7 +244,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'NYNH',
@@ -258,7 +258,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'NYW',
@@ -271,7 +271,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'PE',
@@ -284,7 +284,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'WNR',
@@ -297,7 +297,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
         ].freeze
 

--- a/lib/engine/game/g_18_new_england/meta.rb
+++ b/lib/engine/game/g_18_new_england/meta.rb
@@ -14,6 +14,12 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18NewEngland'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://www.dropbox.com/s/x0dsehrxqr1tl6w/18Chesapeake_Rules.pdf'
+        GAME_VARIANTS = [
+          sym: :north,
+          name: '18NewEngland 2',
+          title: '18NewEngland 2: Northern States',
+          desc: 'smaller map and player count',
+        ].freeze
 
         PLAYER_RANGE = [3, 5].freeze
       end

--- a/lib/engine/game/g_18_new_england/step/bankrupt.rb
+++ b/lib/engine/game/g_18_new_england/step/bankrupt.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/bankrupt'
+
+module Engine
+  module Game
+    module G18NewEngland
+      module Step
+        class Bankrupt < Engine::Step::Bankrupt
+          def process_bankrupt(action)
+            corp = action.entity
+            player = corp.owner
+
+            unless @game.can_go_bankrupt?(player, corp)
+              buying_power = @game.format_currency(@game.total_emr_buying_power(player, corp))
+              price = @game.format_currency(@game.depot.min_depot_price)
+
+              msg = "Cannot go bankrupt. #{corp.name}'s cash plus #{player.name}'s cash and "\
+                    "sellable shares total #{buying_power}, and the cheapest train in the "\
+                    "Depot costs #{price}."
+              raise GameError, msg
+            end
+
+            player.spend(player.cash, @game.bank) if player.cash.positive?
+
+            @log << "-- #{player.name} goes bankrupt. Any companies with #{player.name} as director will close --"
+
+            @game.corporations.dup.each { |c| close_corporation(c) if c.owner == player }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_new_england/step/buy_train.rb
+++ b/lib/engine/game/g_18_new_england/step/buy_train.rb
@@ -8,7 +8,6 @@ module Engine
       module Step
         class BuyTrain < Engine::Step::BuyTrain
           def actions(entity)
-            # 1846 and a few others minors can't buy trains
             return [] unless can_entity_buy_train?(entity)
 
             return [] if entity != current_entity

--- a/lib/engine/game/g_18_new_england/step/issue_shares.rb
+++ b/lib/engine/game/g_18_new_england/step/issue_shares.rb
@@ -29,17 +29,28 @@ module Engine
             @round.issued = true
             corp = action.entity
             bundle = action.bundle
+            @log << "#{corp.name} issues #{share_str(bundle)} of #{corp.name} to the market"\
+                    " and receives #{@game.format_currency(bundle.price)}"
+            # @game.share_pool.sell_shares(bundle, silent: true)
+            @game.share_pool.transfer_shares(bundle,
+                                             @game.share_pool,
+                                             spender: @game.bank,
+                                             receiver: corp)
+            price = corp.share_price.price
+            action.bundle.num_shares.times { @game.stock_market.move_left(corp) }
+            @game.log_share_price(corp, price)
+          end
+
+          def share_str(bundle)
             ipo = if bundle.owner == @game.bank
                     'IPO '
                   else
                     ''
                   end
-            @log << "#{corp.name} issues a 10% #{ipo}share of #{corp.name} to market"\
-                    " and receives #{@game.format_currency(bundle.price)}"
-            @game.share_pool.sell_shares(bundle, silent: true)
-            price = corp.share_price.price
-            action.bundle.num_shares.times { @game.stock_market.move_left(corp) }
-            @game.log_share_price(corp, price)
+            num_shares = bundle.num_shares
+            return "a #{bundle.percent}% #{ipo}share" if num_shares == 1
+
+            "#{num_shares} #{ipo}shares"
           end
 
           def setup

--- a/lib/engine/game/g_18_new_england/step/merge.rb
+++ b/lib/engine/game/g_18_new_england/step/merge.rb
@@ -3,6 +3,7 @@
 require_relative '../../../step/base'
 require_relative '../../../token'
 require_relative '../../../step/token_merger'
+require_relative '../../../step/programmer_merger_pass'
 
 module Engine
   module Game
@@ -10,6 +11,7 @@ module Engine
       module Step
         class Merge < Engine::Step::Base
           include Engine::Step::TokenMerger
+          include Engine::Step::ProgrammerMergerPass
           CONVERT_PAR = 100
 
           def actions(entity)
@@ -32,6 +34,14 @@ module Engine
             return [Engine::Action::Pass.new(entity)] if mergeable_candidates(entity).empty?
 
             super
+          end
+
+          def others_acted?
+            !@round.converts.empty?
+          end
+
+          def merger_auto_pass_entity
+            current_entity unless @converting || @merging
           end
 
           def merge_name(_entity = nil)
@@ -98,6 +108,7 @@ module Engine
             # Replace the entity with the new one.
             @round.entities[@round.entity_index] = target
             @round.converted = target
+            @round.converts << target
             # New president is eligable to buy shares
             @round.share_dealing_players = [target.owner]
           end
@@ -137,6 +148,8 @@ module Engine
             end
 
             @round.converted = target
+            @round.converts << target
+            # New president is eligable to buy shares
             @round.share_dealing_players = [target.owner]
             @merging = nil
           end
@@ -219,6 +232,7 @@ module Engine
           def round_state
             {
               converted: nil,
+              converts: [],
               share_dealing_players: [],
               share_dealing_multiple: [],
             }

--- a/lib/engine/game/g_18_new_england_north/entities.rb
+++ b/lib/engine/game/g_18_new_england_north/entities.rb
@@ -107,7 +107,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
           {
             sym: 'MC',
@@ -121,7 +121,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -135,7 +135,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -149,7 +149,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
           },
 
           {
@@ -164,7 +164,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -178,7 +178,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -192,7 +192,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -206,7 +206,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -220,7 +220,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -234,7 +234,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -249,7 +249,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -263,7 +263,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -277,7 +277,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -292,7 +292,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
           {
@@ -306,7 +306,7 @@ module Engine
             max_ownership_percent: 100,
             shares: [100],
             type: 'minor',
-            capitalization: 'incremental',
+            capitalization: :incremental,
             reservation_color: nil,
           },
         ].freeze

--- a/lib/engine/game/g_18_new_england_north/map.rb
+++ b/lib/engine/game/g_18_new_england_north/map.rb
@@ -98,6 +98,8 @@ module Engine
           J5: 'Hartford',
         }.freeze
 
+        PREPRINTED_UPGRADES = {}.freeze
+
         HEXES = {
           white: {
             %w[

--- a/lib/engine/game/g_18_new_england_north/meta.rb
+++ b/lib/engine/game/g_18_new_england_north/meta.rb
@@ -1,20 +1,24 @@
 # frozen_string_literal: true
 
 require_relative '../meta'
+require_relative '../g_18_new_england/meta'
 
 module Engine
   module Game
     module G18NewEnglandNorth
       module Meta
         include Game::Meta
+        include G18NewEngland::Meta
 
         DEV_STAGE = :prealpha
         DEPENDS_ON = '18NewEngland'
 
-        GAME_DESIGNER = 'Scott Petersen'
+        GAME_ALIASES = ['18NewEngland 2'].freeze
+        GAME_IS_VARIANT_OF = G18NewEngland::Meta
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18NewEnglandNorth'
-        GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://github.com/tobymao/18xx/wiki/18NewEnglandNorth'
+        GAME_SUBTITLE = nil
+        GAME_TITLE = '18NewEngland 2: Northern States'
 
         PLAYER_RANGE = [2, 4].freeze
       end


### PR DESCRIPTION
* Add express train rules
* Player bankruptcy rules
* Add merger auto pass
* Make "18NewEngland 2" an option on 18NewEngland
* Add reservation highlighting for available minors on first stock round
* Fix ordering of par values for minors
* Numerous playthrough fixes
* Server-sourced bug fixes