### PR TITLE
Move prototypes to prototype-production

### DIFF
--- a/lib/engine/game/g_1817_de/meta.rb
+++ b/lib/engine/game/g_1817_de/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :production
         PROTOTYPE = true
         DEPENDS_ON = '1817'
 

--- a/lib/engine/game/g_1877/meta.rb
+++ b/lib/engine/game/g_1877/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :production
         PROTOTYPE = true
         DEPENDS_ON = '1817'
 

--- a/lib/engine/game/g_18_texas/meta.rb
+++ b/lib/engine/game/g_18_texas/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :production
         PROTOTYPE = true
 
         GAME_LOCATION = 'Texas, United States'


### PR DESCRIPTION
1877
18DE
18Texas

Rules may change for these, but the prototype warning is sufficient, no need for extra warnings for alpha.