### PR TITLE
[18NewEngland] Ability to sell shares during emergency money raising. Fixes #6746

### DIFF
--- a/lib/engine/game/g_18_new_england/step/buy_train.rb
+++ b/lib/engine/game/g_18_new_england/step/buy_train.rb
@@ -10,12 +10,13 @@ module Engine
           def actions(entity)
             return [] unless can_entity_buy_train?(entity)
 
-            return ['sell_shares'] if entity == current_entity.owner
+            return ['sell_shares'] if entity == current_entity.owner && president_may_contribute?(current_entity)
 
             return [] if entity != current_entity
-            return %w[sell_shares buy_train] if entity.type != :minor && president_may_contribute?(entity)
-            return %w[pass sell_shares buy_train] if entity.type == :minor && president_may_contribute?(entity)
-            return %w[buy_train pass] if can_buy_train?(entity)
+
+            # minor companies can be closed when forced to buy trains (closure is processed as pass action)
+            return %w[buy_train] if entity.type != :minor && must_buy_train?(entity)
+            return %w[pass buy_train] if can_buy_train?(entity)
 
             []
           end

--- a/lib/engine/game/g_18_new_england/step/buy_train.rb
+++ b/lib/engine/game/g_18_new_england/step/buy_train.rb
@@ -10,6 +10,8 @@ module Engine
           def actions(entity)
             return [] unless can_entity_buy_train?(entity)
 
+            return ['sell_shares'] if entity == current_entity.owner
+
             return [] if entity != current_entity
             return %w[sell_shares buy_train] if entity.type != :minor && president_may_contribute?(entity)
             return %w[pass sell_shares buy_train] if entity.type == :minor && president_may_contribute?(entity)


### PR DESCRIPTION
Fix for #6746 

Based on existing logic in https://github.com/tobymao/18xx/blob/1c27d4ca9ea41e8f55bc0b53b65de394a54d82af/lib/engine/game/g_18_eu/step/buy_train.rb#L12-L21

and
https://github.com/tobymao/18xx/blob/1c27d4ca9ea41e8f55bc0b53b65de394a54d82af/lib/engine/game/g_1846/step/buy_train.rb#L13-L15

I think the first one is correct, because in 18NewEngland issuing shares is a separate phase and cannot be done during emergency money raising.

I tested it locally in the hotseat mode and it works the way I would expect.
