### PR TITLE
18NewEngland: Show separate IPO+Treasury shares in spreadsheet

### DIFF
--- a/lib/engine/game/g_18_new_england/game.rb
+++ b/lib/engine/game/g_18_new_england/game.rb
@@ -637,6 +637,10 @@ module Engine
           super + (multiplier < 2 ? '' : " (x#{multiplier})")
         end
 
+        def separate_treasury?
+          true
+        end
+
         def available_programmed_actions
           [Action::ProgramMergerPass, Action::ProgramBuyShares, Action::ProgramSharePass]
         end


### PR DESCRIPTION
Allow IPO and Treasury shares to be displayed in spreadsheet.