### PR TITLE
18Mag: fix dividend input size

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -144,7 +144,7 @@ module View
                     min: 0,
                     max: max,
                     type: 'number',
-                    size: max.to_s.size,
+                    size: max.to_s.size + 2,
                     step: @step.variable_input_step,
                   })
 


### PR DESCRIPTION
Fixes #6752 

This actually changes UI::Dividend, but only 18Mag and 1840 use the method with the fix