### PR TITLE
UI: adjust size for number input forms for Firefox

### DIFF
--- a/assets/app/view/game/buy_company_from_other_player.rb
+++ b/assets/app/view/game/buy_company_from_other_player.rb
@@ -22,7 +22,7 @@ module View
                     type: 'number',
                     min: 1,
                     max: max,
-                    size: max,
+                    size: max.to_s.size + 2,
                   })
         children = [input]
         @game.round.active_step.purchasable_companies(@game.current_entity).each do |company|

--- a/assets/app/view/game/buy_power.rb
+++ b/assets/app/view/game/buy_power.rb
@@ -113,7 +113,7 @@ module View
             min: min,
             max: max,
             value: min,
-            size: 2,
+            size: max.to_s.size + 2,
           }
         )
 

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -265,7 +265,7 @@ module View
               min: 0,
               max: @step.warranty_max,
               value: 0,
-              size: 1,
+              size: @step.warranty_max.to_s.size + 2,
             }
           )
 
@@ -421,7 +421,7 @@ module View
             min: train.price,
             max: train.price,
             value: train.price,
-            size: 1,
+            size: train.price.to_s.size + 2,
           }
         else
           min, max = @step.spend_minmax(@corporation, train)
@@ -430,7 +430,7 @@ module View
             min: min,
             max: max,
             value: min,
-            size: @corporation.cash.to_s.size,
+            size: @corporation.cash.to_s.size + 2,
           }
         end
       end

--- a/assets/app/view/game/buy_value_input.rb
+++ b/assets/app/view/game/buy_value_input.rb
@@ -20,7 +20,7 @@ module View
                     type: 'number',
                     min: @min_value,
                     max: @max_value,
-                    size: @size,
+                    size: @size + 2,
                   })
 
         buy_click = lambda do

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -149,7 +149,7 @@ module View
                       min: @step.min_bid(company),
                       max: @step.max_bid(@current_entity, company),
                       type: 'number',
-                      size: @current_entity.cash.to_s.size,
+                      size: @current_entity.cash.to_s.size + 2,
                     })
 
           buttons = []
@@ -200,7 +200,7 @@ module View
                 min: @step.min_player_bid,
                 max: @step.max_player_bid(@current_entity),
                 type: 'number',
-                size: @current_entity.cash.to_s.size,
+                size: @current_entity.cash.to_s.size + 2,
               })
           h(:div, [
             input,
@@ -276,7 +276,7 @@ module View
                       min: @step.min_bid(minor),
                       max: @step.max_bid(@current_entity, minor),
                       type: 'number',
-                      size: @current_entity.cash.to_s.size,
+                      size: @current_entity.cash.to_s.size + 2,
                     })
 
           [


### PR DESCRIPTION
Completing what I started with #6752 

Also, the size field for BuyCompanyFromOtherPlayer was just plain wrong

As far as I can tell, these changes don't affect Chrome's rendering.