### PR TITLE
Add "what's this?" tooltips for Auto Route in game card and create game views

### DIFF
--- a/assets/app/lib/whats_this.rb
+++ b/assets/app/lib/whats_this.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Lib
+  module WhatsThis
+    module AutoRoute
+      def auto_route_whats_this
+        h(Component,
+          tooltip: 'Allows players to request automatic route suggestions. Using them is optional.',
+          url: 'https://github.com/tobymao/18xx/wiki/Auto-Routing')
+      end
+    end
+
+    class Component < Snabberb::Component
+      needs :tooltip
+      needs :url
+
+      def render
+        h(:span,
+          {
+            style: {
+              'font-size' => '0.8rem',
+              'vertical-align' => 'super',
+            },
+          },
+          [
+            ' (',
+            h(:a,
+              {
+                attrs: {
+                  href: @url,
+                  title: @tooltip,
+                },
+                style: { 'text-decoration' => 'underline dotted' },
+              },
+              '?'),
+            ')',
+          ])
+      end
+    end
+  end
+end

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'game_manager'
+require 'lib/whats_this'
 require 'view/form'
 
 module View
   class CreateGame < Form
     include GameManager
+    include Lib::WhatsThis::AutoRoute
 
     needs :mode, default: :multi, store: true
     needs :num_players, default: 3, store: true
@@ -32,7 +34,7 @@ module View
         inputs << h(:label, { style: @label_style }, 'Game Options')
         inputs << render_input('Invite only game', id: 'unlisted', type: :checkbox,
                                                    container_style: { paddingLeft: '0.5rem' })
-        inputs << render_input('Auto Routing', id: 'auto_routing', type: :checkbox)
+        inputs << render_input('Auto Routing', id: 'auto_routing', type: :checkbox, siblings: [auto_route_whats_this])
         inputs << render_game_info
       when :hotseat
         inputs << h(:label, { style: @label_style }, 'Player Names')

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -42,7 +42,7 @@ module View
     end
 
     # rubocop:disable Layout/LineLength
-    def render_input(label, id:, placeholder: '', el: 'input', type: 'text', attrs: {}, on: {}, container_style: {}, label_style: {}, input_style: {}, children: [], inputs: nil)
+    def render_input(label, id:, placeholder: '', el: 'input', type: 'text', attrs: {}, on: {}, container_style: {}, label_style: {}, input_style: {}, children: [], siblings: [], inputs: nil)
       # rubocop:enable Layout/LineLength
       label_props = {
         style: {
@@ -73,7 +73,7 @@ module View
       h(
         'div.input-container',
         { style: { **container_style } },
-        children
+        children + siblings,
       )
     end
 

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -9,6 +9,7 @@ module View
   class GameCard < Snabberb::Component
     include GameManager
     include Lib::Settings
+    include Lib::WhatsThis::AutoRoute
 
     needs :user
     needs :gdata # can't conflict with game_data
@@ -234,7 +235,7 @@ module View
       children = [h(:div, [h(:strong, 'Id: '), @gdata['id'].to_s])]
       if @gdata['status'] == 'new'
         children << h(:div, [h(:i, 'Invite only game')]) if @gdata.dig('settings', 'unlisted')
-        children << h(:div, [h(:i, 'Auto Routing')]) if @gdata.dig('settings', 'auto_routing')
+        children << h(:div, [h(:i, ['Auto Routing', auto_route_whats_this])]) if @gdata.dig('settings', 'auto_routing')
       end
       children << h(:div, [h(:strong, 'Description: '), @gdata['description']]) unless @gdata['description'].empty?
 


### PR DESCRIPTION
This is intended to reduce unwarranted hesitancy towards Auto Route. People in chat have said they avoid joining / creating Auto Route games because they think it is mandatory, or doesn't allow manual routing.

Create game page:
![create_game](https://user-images.githubusercontent.com/37312691/149376785-28a4d761-01d7-406c-82ab-c51cbc6afc9b.png)

Game card:
![game_card](https://user-images.githubusercontent.com/37312691/149376800-8ef9a57c-04c0-4e33-8b10-0b816f257416.png)

Could be combined with (or replaced by) linking to a wiki page.

I was originally going to change the string "Auto Route" to something more descriptive, but I couldn't come up with a clear *and* concise replacement.