### PR TITLE
[1822] Extra route check

### DIFF
--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -418,10 +418,9 @@ module Engine
           city_node = @game.hex_by_id(@connection_hexes[0][1]).tile.nodes.find do |n|
             @game.city_tokened_by?(n, corporation)
           end
-          return add_single_node_connection(city_node)
-        else
-          @connection_hexes.clear
+          return add_single_node_connection(city_node) if city_node
         end
+        @connection_hexes.clear
       end
 
       possibilities = @connection_hexes.map do |hex_ids|


### PR DESCRIPTION
[1822] Extra route check

- Added an extra check to see that a local train have a valid route of 1 hex.

fixes #6753

This shouldnt break any games.