### PR TITLE
[1866] Port Bonus

### DIFF
--- a/lib/engine/game/g_1866/map.rb
+++ b/lib/engine/game/g_1866/map.rb
@@ -379,6 +379,8 @@ module Engine
           'U1' => 'Murcia',
           'V18' => 'Palermo',
           'V20' => 'Catania',
+          'B11' => 'Port Token Bonus',
+          'U8' => 'Port Token Bonus',
         }.freeze
 
         HEXES = {
@@ -757,6 +759,12 @@ module Engine
               'path=a:1,b:4;border=edge:1;border=edge:4',
             ['T18'] =>
               'path=a:1,b:4;border=edge:1',
+
+            # Port bonus
+            %w[B11 U8] =>
+              'offboard=revenue:yellow_00|green_20|brown_30|gray_40;path=a:0,b:_0;'\
+              'offboard=revenue:yellow_00|green_20|brown_30|gray_40;path=a:5,b:_0;'\
+              'icon=image:1866/port,sticky:1',
           },
         }.freeze
       end

--- a/lib/engine/game/g_1866/step/dividend.rb
+++ b/lib/engine/game/g_1866/step/dividend.rb
@@ -61,7 +61,7 @@ module Engine
             price = entity.share_price.price
             times = 0
             times = 1 if revenue >= price || @game.major_national_corporation?(entity)
-            times = 2 if revenue >= price * 2 && !@game.national_corporation?(entity)
+            times = 2 if revenue >= price * 2 && @game.public_corporation?(entity)
             if times.positive?
               { share_direction: :right, share_times: times }
             else

--- a/lib/engine/game/g_1866/step/first_turn_housekeeping.rb
+++ b/lib/engine/game/g_1866/step/first_turn_housekeeping.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1866
+      module Step
+        class FirstTurnHousekeeping < Engine::Step::BuyTrain
+          def actions(entity)
+            if entity.corporation? && @game.public_corporation?(entity) && !entity.operated? &&
+              @game.local_train?(@game.depot.upcoming.first) && can_buy_train?(entity)
+              return %w[buy_train pass]
+            end
+
+            []
+          end
+
+          def buyable_trains(_entity)
+            # Clone the first available L train, this to remove the 2 train variant from it. Since a L train is the
+            # only train you are allowed to buy during the housekeeping
+            train = @game.depot.upcoming.first
+            l_train = Engine::Train.new(name: train.name, distance: train.distance, price: train.price)
+            l_train.owner = @game.depot
+            [l_train]
+          end
+
+          def description
+            'First Turn Housekeeping'
+          end
+
+          def process_buy_train(action)
+            # Make sure the corp buy the correct train with a 2 variant
+            new_action = Action::BuyTrain.new(
+              action.entity,
+              train: @game.depot.upcoming.first,
+              price: action.price,
+              variant: action.variant,
+            )
+
+            super(new_action)
+            pass!
+          end
+
+          def must_buy_train?(_entity)
+            false
+          end
+
+          def skip!
+            pass!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1866/step/token.rb
+++ b/lib/engine/game/g_1866/step/token.rb
@@ -7,10 +7,26 @@ module Engine
     module G1866
       module Step
         class Token < Engine::Step::Token
+          def available_hex(entity, hex)
+            return nil if @game.public_corporation?(entity) && !@game.hex_operating_rights?(entity, hex)
+
+            super
+          end
+
           def log_skip(entity)
             return if @game.national_corporation?(entity)
 
             @log << "#{entity.name} skips place a token"
+          end
+
+          def process_place_token(action)
+            entity = action.entity
+            hex = action.city.hex
+            if @game.public_corporation?(entity) && !@game.hex_operating_rights?(entity, hex)
+              raise GameError, 'Cannot place token without operating rights in the selected region'
+            end
+
+            super
           end
         end
       end

--- a/lib/engine/game/g_1866/step/track.rb
+++ b/lib/engine/game/g_1866/step/track.rb
@@ -7,6 +7,13 @@ module Engine
     module G1866
       module Step
         class Track < Engine::Step::Track
+          def available_hex(entity, hex)
+            return nil if @game.national_corporation?(entity) && !@game.hex_within_national_region?(entity, hex)
+            return nil if @game.public_corporation?(entity) && !@game.hex_operating_rights?(entity, hex)
+
+            super
+          end
+
           def can_lay_tile?(entity)
             action = get_tile_lay(entity)
             return false unless action
@@ -21,8 +28,8 @@ module Engine
             if @game.national_corporation?(entity) && !@game.hex_within_national_region?(entity, hex)
               raise GameError, 'Cannot lay or upgrade tiles outside the nationals region'
             end
-            if !@game.national_corporation?(entity) && !@game.hex_operating_rights?(entity, hex)
-              raise GameError, 'Cannot lay or upgrade tiles without operating rights in the correct region'
+            if @game.public_corporation?(entity) && !@game.hex_operating_rights?(entity, hex)
+              raise GameError, 'Cannot lay or upgrade tiles without operating rights in the selected region'
             end
 
             super


### PR DESCRIPTION
- Token must check operating rights
- Export L/2 trains after OR2
- Obsolete trains only runs for half
- You can run on the same double town hex, but you cant run to the same hex on London or Paris
- Implemented port bonus, and it should only work one time on each port per corporation