### PR TITLE
1848 Enable K Yellow Tiles

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -451,7 +451,7 @@ module Engine
             Engine::Step::Bankrupt,
             Engine::Step::Exchange,
             Engine::Step::BuyCompany,
-            Engine::Step::Track,
+            G1848::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,
             Engine::Step::Dividend,
@@ -459,6 +459,12 @@ module Engine
             Engine::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
+        end
+
+        def upgrades_to?(from, to, _special = false, selected_company: nil)
+          return %w[5 6 57].include?(to.name) if (from.hex.tile.label.to_s == 'K') && (from.hex.tile.color == 'white')
+
+          super
         end
       end
     end

--- a/lib/engine/game/g_1848/step/track.rb
+++ b/lib/engine/game/g_1848/step/track.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+require_relative 'tracker'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class Track < Engine::Step::Track
+          include Engine::Game::G1848::Tracker
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/tracker.rb
+++ b/lib/engine/game/g_1848/step/tracker.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/tracker'
+
+module Engine
+  module Game
+    module G1848
+      module Tracker
+        include Engine::Step::Tracker
+
+        def lay_tile_action(action)
+          # Yellow cities on K tiles need the K label added
+          add_k = action.hex.tile.label.to_s == 'K'
+          super
+          action.hex.tile.label = 'K' if add_k
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Normal yellow city tiles are used in 1848 for K tiles (with a K token in
the physical copy) which then upgrade to tiles labelled with a K.