### PR TITLE
1848 Enable COM Start and Home Rules

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -483,6 +483,10 @@ module Engine
           @sydney ||= hex_by_id('F17')
         end
 
+        def adelaide
+          @adelaide ||= hex_by_id('G6')
+        end
+
         def check_sydney_adelaide_connected
           return @sydney_adelaide_connected if @sydney_adelaide_connected
 
@@ -494,8 +498,16 @@ module Engine
 
         def place_home_token(entity)
           return super if entity.name != :COM
+          return unless @sydney_adelaide_connected
+          return if entity.tokens.first&.used
 
-          super if @sydney_adelaide_connected
+          # COM places home tokens... regardless as to whether there is space for them
+          [sydney, adelaide].each do |home_hex|
+            city = home_hex.tile.cities[0]
+            slot = city.available_slots.positive? ? 0 : city.slots
+            home_token = entity.tokens.find { |token| !token.used && token.price.zero? }
+            city.place_token(entity, home_token, free: true, check_tokenable: false, cheater: slot)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -7,6 +7,8 @@ module Engine
   module Game
     module G1848
       class Game < Game::Base
+        attr_reader :sydney_adelaide_connected
+
         include_meta(G1848::Meta)
 
         CURRENCY_FORMAT_STR = '£%d'
@@ -440,8 +442,13 @@ module Engine
 
         HOME_TOKEN_TIMING = :operate
 
+        def setup
+          super
+          @sydney_adelaide_connected = false
+        end
+
         def new_auction_round
-          Round::Auction.new(self, [
+          Engine::Round::Auction.new(self, [
             G1848::Step::DutchAuction,
           ])
         end
@@ -465,6 +472,30 @@ module Engine
           return %w[5 6 57].include?(to.name) if (from.hex.tile.label.to_s == 'K') && (from.hex.tile.color == 'white')
 
           super
+        end
+
+        def sar
+          # SAR is used for graph to find adelaide (to connect to sydney for starting COM)
+          @sar ||= @corporations.find { |corporation| corporation.name == 'SAR' }
+        end
+
+        def sydney
+          @sydney ||= hex_by_id('F17')
+        end
+
+        def check_sydney_adelaide_connected
+          return @sydney_adelaide_connected if @sydney_adelaide_connected
+
+          graph = Graph.new(self, home_as_token: true, no_blocking: true)
+          graph.compute(sar)
+          @sydney_adelaide_connected = graph.reachable_hexes(sar).include?(sydney)
+          @sydney_adelaide_connected
+        end
+
+        def place_home_token(entity)
+          return super if entity.name != :COM
+
+          super if @sydney_adelaide_connected
         end
       end
     end

--- a/lib/engine/game/g_1848/step/operating.rb
+++ b/lib/engine/game/g_1848/step/operating.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G1848
+      module Round
+        class Operating < Engine::Round::Operating
+          def skip_entity?(entity)
+            return super if entity.name != :COM
+
+            !@game.sydney_adelaide_connected
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/tracker.rb
+++ b/lib/engine/game/g_1848/step/tracker.rb
@@ -13,6 +13,11 @@ module Engine
           add_k = action.hex.tile.label.to_s == 'K'
           super
           action.hex.tile.label = 'K' if add_k
+
+          was_connected = @game.sydney_adelaide_connected
+          now_connected = @game.check_sydney_adelaide_connected
+
+          @log << 'Sydney and Adelaide are connected - COM may start operating' if !was_connected && now_connected
         end
       end
     end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -28,8 +28,12 @@ module Engine
         after_setup
       end
 
+      def any_to_act?
+        @entities.any? { |entity| !skip_entity?(entity) }
+      end
+
       def after_setup
-        start_operating unless @entities.empty?
+        start_operating if any_to_act?
       end
 
       def after_process(action)
@@ -68,6 +72,8 @@ module Engine
 
       def start_operating
         entity = @entities[@entity_index]
+        return next_entity! if skip_entity?(entity)
+
         @current_operator = entity
         @current_operator_acted = false
         entity.trains.each { |train| train.operated = false }
@@ -90,6 +96,10 @@ module Engine
 
       def operating?
         true
+      end
+
+      def finished?
+        super || !any_to_act?
       end
     end
   end


### PR DESCRIPTION
Includes a bug fix which could potentially (but probably hasn't) effected other games when the first company in an OR is skipped, or when all companies in an OR is skipped. See c2cae9a.