### PR TITLE
invite link should use window location host

### DIFF
--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -188,7 +188,7 @@ module View
 
       invite_url = url(@gdata)
       flash = lambda do
-        `navigator.clipboard.writeText((window.location + invite_url).replace('//game', '/game'))`
+        `navigator.clipboard.writeText((window.location.host + invite_url).replace('//game', '/game'))`
         store(:flash_opts, { message: msg, color: 'lightgreen' }, skip: false)
       end
       render_link(invite_url, flash, 'Invite')


### PR DESCRIPTION
The invite link should use window.location.host so that the appended invite_url is not continuously added to the end of the url.
https://github.com/tobymao/18xx/issues/6640