### PR TITLE
1873 draft auto pass

### DIFF
--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -319,8 +319,8 @@ module View
       def enable_share_pass(form)
         settings = params(form)
 
-        unconditional = settings['unconditional']
-        indefinite = settings['indefinite']
+        unconditional = settings['sr_unconditional']
+        indefinite = settings['sr_indefinite']
 
         process_action(
           Engine::Action::ProgramSharePass.new(
@@ -344,11 +344,11 @@ module View
                       [h(:a, { attrs: { href: AUTO_ACTIONS_WIKI, target: '_blank' } },
                          'Please read this for more details when it will deactivate')])
         children << render_checkbox('Pass even if other players do actions that may impact you.',
-                                    'unconditional',
+                                    'sr_unconditional',
                                     form,
                                     !!settings&.unconditional)
         children << render_checkbox('Continue passing in future SR as well.',
-                                    'indefinite',
+                                    'sr_indefinite',
                                     form,
                                     !!settings&.indefinite)
 
@@ -362,10 +362,10 @@ module View
       def enable_independent_mines(form)
         settings = params(form)
 
-        skip_track = settings['skip_track']
-        skip_buy = settings['skip_buy']
-        skip_close = settings['skip_close']
-        indefinite = settings['indefinite']
+        skip_track = settings['im_skip_track']
+        skip_buy = settings['im_skip_buy']
+        skip_close = settings['im_skip_close']
+        indefinite = settings['im_indefinite']
 
         process_action(
           Engine::Action::ProgramIndependentMines.new(
@@ -401,12 +401,12 @@ module View
                       ' It will also deactivate itself when a mine has negative income.')
 
         children << h(:div, [
-          render_checkbox('Skip track lay', 'skip_track', form, settings ? settings.skip_track : true),
-          render_checkbox('Skip switchers', 'skip_buy', form, settings ? settings.skip_buy : true),
-          render_checkbox('Skip close mine', 'skip_close', form, settings ? settings.skip_close : true),
+          render_checkbox('Skip track lay', 'im_skip_track', form, settings ? settings.skip_track : true),
+          render_checkbox('Skip switchers', 'im_skip_buy', form, settings ? settings.skip_buy : true),
+          render_checkbox('Skip close mine', 'im_skip_close', form, settings ? settings.skip_close : true),
         ])
         children << h(:div, [
-          render_checkbox('Indefinite (normally stops after one OR set)', 'indefinite', form, settings&.indefinite),
+          render_checkbox('Indefinite (normally stops after one OR set)', 'im_indefinite', form, settings&.indefinite),
         ])
 
         subchildren = [render_button(settings ? 'Update' : 'Enable') { enable_independent_mines(form) }]

--- a/lib/engine/action/program_harzbahn_draft_pass.rb
+++ b/lib/engine/action/program_harzbahn_draft_pass.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+require_relative 'program_enable'
+
+module Engine
+  module Action
+    class ProgramHarzbahnDraftPass < ProgramEnable
+      attr_reader :until_premium, :unconditional
+
+      def initialize(entity, until_premium:, unconditional:)
+        super(entity)
+        @until_premium = until_premium
+        @unconditional = unconditional
+      end
+
+      def self.h_to_args(h, _game)
+        {
+          until_premium: h['until_premium'],
+          unconditional: h['unconditional'],
+        }
+      end
+
+      def args_to_h
+        {
+          'until_premium' => @until_premium,
+          'unconditional' => @unconditional,
+        }
+      end
+
+      def to_s
+        until_premium = @until_premium ? ", until premium #{@until_premium}" : ''
+        unconditionally = @unconditional ? ', unconditionally' : ''
+        "Pass in Draft#{until_premium}#{unconditionally}"
+      end
+
+      def disable?(game)
+        !game.round.auction?
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -3175,6 +3175,7 @@ module Engine
 
         def available_programmed_actions
           super + [
+            Action::ProgramHarzbahnDraftPass,
             Action::ProgramIndependentMines,
           ]
         end

--- a/lib/engine/round/auction.rb
+++ b/lib/engine/round/auction.rb
@@ -13,6 +13,10 @@ module Engine
         'ISR'
       end
 
+      def auction?
+        true
+      end
+
       def select_entities
         @game.players
       end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -184,6 +184,10 @@ module Engine
         false
       end
 
+      def auction?
+        false
+      end
+
       private
 
       def skip_steps

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -5,7 +5,14 @@ require_relative 'base'
 module Engine
   module Step
     class Program < Base
-      ACTIONS = %w[program_buy_shares program_independent_mines program_merger_pass program_share_pass program_disable].freeze
+      ACTIONS = %w[
+        program_buy_shares
+        program_independent_mines
+        program_merger_pass
+        program_harzbahn_draft_pass
+        program_share_pass
+        program_disable
+      ].freeze
 
       def actions(entity)
         return [] unless entity.player?
@@ -24,6 +31,10 @@ module Engine
       end
 
       def process_program_merger_pass(action)
+        process_program_enable(action)
+      end
+
+      def process_program_harzbahn_draft_pass(action)
         process_program_enable(action)
       end
 


### PR DESCRIPTION
Adds auto pass for the 1873 initial draft (the part where you buy a company or wait for the premium to drop).

Two related CLs attached:
* Add auction? method to round.
* Add prefixes to form fields in auto page to avoid collisions.