### PR TITLE
21Moon: SRs and CRs

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -113,11 +113,15 @@ module View
           corp_shares.group_by(&:percent).values.map(&:first).sort_by(&:percent).reverse.map do |share|
             next unless @step.can_buy?(@current_entity, share.to_bundle)
 
+            button_prefix = 'Buy'
+            button_prefix = @step.corporate_buy_text(share) if @step.respond_to?(:corporate_buy_text)
+
             h(Button::BuyShare,
               share: share,
               entity: @current_entity,
               percentages_available: @ipo_shares.size,
-              source: share.corporation.name)
+              source: share.corporation.name,
+              prefix: button_prefix)
           end
         end
       end

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -356,7 +356,7 @@ module View
 
         player_rows = entities_rows(@game.players)
 
-        other_corp_rows = entities_rows(@game.corporations.reject { |c| c == @corporation })
+        other_corp_rows = entities_rows(@game.corporations.reject { |c| c == @corporation && !c.treasury_as_holding })
 
         num_ipo_shares = share_number_str(@corporation.num_ipo_shares - @corporation.num_ipo_reserved_shares)
         if @game.respond_to?(:reissued?) && @game.reissued?(@corporation) && !num_ipo_shares.empty?
@@ -377,7 +377,7 @@ module View
           ])
         end
 
-        if !num_treasury_shares.empty? && !@corporation.ipo_is_treasury?
+        if !num_treasury_shares.empty? && !@corporation.ipo_is_treasury? && !@corporation.treasury_as_holding
           pool_rows << h('tr.ipo', [
             h('td.left', 'Treasury'),
             h('td.right', shares_props, num_treasury_shares),
@@ -445,7 +445,7 @@ module View
 
       def render_owned_other_shares
         shares = @corporation
-          .shares_by_corporation.reject { |c, s| s.empty? || c == @corporation }
+          .shares_by_corporation.reject { |c, s| s.empty? || (c == @corporation && !@corporation.treasury_as_holding) }
           .sort_by { |c, s| [s.sum(&:percent), c.president?(@corporation) ? 1 : 0, c.name] }
           .reverse
           .map { |c, s| render_owned_other_corp(c, s) }

--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -26,7 +26,7 @@ module Engine
                   :type, :floatable, :original_par_price, :reservation_color, :min_price, :ipo_owner,
                   :always_market_price
     attr_reader :companies, :name, :full_name, :fraction_shares, :id, :needs_token_to_par,
-                :presidents_share, :price_multiplier
+                :presidents_share, :price_multiplier, :treasury_as_holding
     attr_writer :par_price, :share_price
 
     SHARES = ([20] + Array.new(8, 10)).freeze
@@ -77,6 +77,7 @@ module Engine
       @reservation_color = opts[:reservation_color]
       @price_percent = opts[:price_percent] || @second_share&.percent || (@presidents_share.percent / 2)
       @price_multiplier = (@second_share&.percent || (@presidents_share.percent / 2)) / @price_percent
+      @treasury_as_holding = opts[:treasury_as_holding] || false
 
       init_abilities(opts[:abilities])
       init_operator(opts)
@@ -145,7 +146,7 @@ module Engine
     end
 
     def num_treasury_shares
-      num_shares_of(self)
+      @treasury_as_holding ? 0 : num_shares_of(self)
     end
 
     def num_player_shares
@@ -175,11 +176,11 @@ module Engine
     end
 
     def corporate_share_holders
-      share_holders.select { |s_h, _| s_h.corporation? && s_h != self }
+      share_holders.select { |s_h, _| s_h.corporation? && (s_h != self || @treasury_as_holding) }
     end
 
     def corporate_shares
-      shares.reject { |share| share.corporation == self }
+      shares.reject { |share| share.corporation == self && !@treasury_as_holding }
     end
 
     def ipo_shares
@@ -187,7 +188,7 @@ module Engine
     end
 
     def treasury_shares
-      shares.select { |share| share.corporation == self }
+      shares.select { |share| share.corporation == self && !@treasury_as_holding }
     end
 
     def president?(player)

--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -101,6 +101,7 @@ module Engine
             tokens: [0, 25, 50, 75],
             float_percent: 50,
             max_ownership_percent: 50,
+            always_market_price: true,
           },
           {
             sym: 'ME',
@@ -112,6 +113,7 @@ module Engine
             tokens: [0, 25, 50, 75],
             float_percent: 50,
             max_ownership_percent: 50,
+            always_market_price: true,
           },
           {
             sym: 'MA',
@@ -123,6 +125,7 @@ module Engine
             tokens: [0, 25, 50, 75],
             float_percent: 50,
             max_ownership_percent: 50,
+            always_market_price: true,
           },
           {
             sym: 'DSE',
@@ -133,6 +136,7 @@ module Engine
             tokens: [0, 25, 50, 75],
             float_percent: 50,
             max_ownership_percent: 50,
+            always_market_price: true,
           },
           {
             sym: 'SM',
@@ -144,16 +148,18 @@ module Engine
             tokens: [0, 25, 50, 75],
             float_percent: 50,
             max_ownership_percent: 50,
+            always_market_price: true,
           },
           {
-            sym: 'I',
+            sym: 'IC',
             name: 'Intergalactic Corporation',
-            logo: '21Moon/I',
+            logo: '21Moon/IC',
             coordinates: 'I11',
             color: 'purple',
             tokens: [0, 25, 50, 75],
             float_percent: 50,
             max_ownership_percent: 50,
+            always_market_price: true,
           },
           {
             sym: 'LP',
@@ -161,9 +167,11 @@ module Engine
             logo: '21Moon/LP',
             coordinates: 'K9',
             color: 'violet',
+            text_color: 'black',
             tokens: [0, 25, 50, 75],
             float_percent: 50,
             max_ownership_percent: 50,
+            always_market_price: true,
           },
         ].freeze
       end

--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -102,6 +102,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 50,
             always_market_price: true,
+            treasury_as_holding: true,
           },
           {
             sym: 'ME',
@@ -114,6 +115,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 50,
             always_market_price: true,
+            treasury_as_holding: true,
           },
           {
             sym: 'MA',
@@ -126,6 +128,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 50,
             always_market_price: true,
+            treasury_as_holding: true,
           },
           {
             sym: 'DSE',
@@ -137,6 +140,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 50,
             always_market_price: true,
+            treasury_as_holding: true,
           },
           {
             sym: 'SM',
@@ -149,6 +153,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 50,
             always_market_price: true,
+            treasury_as_holding: true,
           },
           {
             sym: 'IC',
@@ -160,6 +165,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 50,
             always_market_price: true,
+            treasury_as_holding: true,
           },
           {
             sym: 'LP',
@@ -172,6 +178,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 50,
             always_market_price: true,
+            treasury_as_holding: true,
           },
         ].freeze
       end

--- a/lib/engine/game/g_21_moon/round/corporate.rb
+++ b/lib/engine/game/g_21_moon/round/corporate.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G21Moon
+      module Round
+        class Corporate < Engine::Round::Stock
+          def self.short_name
+            'CR'
+          end
+
+          def name
+            'Corporate Round'
+          end
+
+          def select_entities
+            @game.corporations.reject(&:closed?).select(&:ipoed).sort.reverse
+          end
+
+          def setup
+            start_operating unless @entities.empty?
+          end
+
+          def next_entity!
+            return if @entity_index == @entities.size - 1
+
+            next_entity_index!
+            reorder_entities!
+
+            @steps.each(&:unpass!)
+            @steps.each(&:setup)
+            start_operating
+          end
+
+          def start_operating
+            entity = @entities[@entity_index]
+            @current_operator = entity
+            @current_operator_acted = false
+            @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
+            skip_steps
+            next_entity! if finished?
+          end
+
+          def reorder_entities!
+            remaining = @entities[@entity_index..-1].sort.reverse
+            @entities[@entity_index..-1] = remaining
+          end
+
+          def finished?
+            !active_step
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_21_moon/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_21_moon/step/buy_sell_par_shares.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G21Moon
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          def actions(entity)
+            return ['sell_shares'] if entity&.corporation? && entity&.owner == current_entity && can_ipo_issue?(entity)
+            return [] if @issued
+
+            super
+          end
+
+          def can_ipo_any?(entity)
+            !bought? && @game.corporations.any? do |c|
+              @game.can_par?(c, entity) && can_buy?(entity, c.ipo_shares.first&.to_bundle)
+            end
+          end
+
+          def can_buy_any?(entity)
+            (can_buy_any_from_market?(entity) || can_buy_any_from_ipo?(entity))
+          end
+
+          def can_buy_any_from_ipo?(entity)
+            @game.corporations.each do |corporation|
+              next unless corporation.ipoed
+              return true if can_buy_shares?(entity, corporation.ipo_shares)
+            end
+
+            false
+          end
+
+          def can_ipo_issue?(corp)
+            corp&.corporation? && corp&.ipoed && @round.parred[corp] && !@round.issued[corp] && !bought? && !sold?
+          end
+
+          def parred_this_round?(corp)
+            @round.players_history[corp.owner][corp].include?(Action::Par)
+          end
+
+          def process_par(action)
+            super
+
+            @round.parred[action.corporation] = true
+          end
+
+          def process_sell_shares(action)
+            return issue_shares(action.entity, action.bundle) if action.entity.corporation?
+
+            super
+          end
+
+          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true)
+            corp = shares.corporation
+            if shares.owner == corp.ipo_owner
+              # IPO shares pay corporation
+              @game.share_pool.buy_shares(entity,
+                                          shares,
+                                          exchange: exchange,
+                                          swap: swap,
+                                          allow_president_change: allow_president_change)
+              price = corp.share_price.price * shares.num_shares
+              @game.bank.spend(price, corp)
+            else
+              super
+            end
+          end
+
+          def issue_shares(corp, bundle)
+            floated = corp.floated?
+
+            @log << "#{corp.name} issues #{share_str(bundle)} of #{corp.name} to the market"\
+                    " and receives #{@game.format_currency(bundle.price)}"
+            @game.share_pool.transfer_shares(bundle,
+                                             @game.share_pool,
+                                             spender: @game.bank,
+                                             receiver: corp)
+
+            @game.float_corporation(corp) if corp.floatable && floated != corp.floated?
+
+            @issued = true
+            @round.issued[corp] = true
+            @round.current_actions << :issue
+          end
+
+          def share_str(bundle)
+            num_shares = bundle.num_shares
+            return "a #{bundle.percent}% IPO share" if num_shares == 1
+
+            "#{num_shares} IPO shares"
+          end
+
+          # can only issue up to number of shares president has
+          def issuable_shares(entity)
+            return [] if bought? || sold?
+
+            shares = @game.bundles_for_corporation(@game.bank, entity) # IPO shares are in bank
+            shares.reject { |bundle| bundle.num_shares > entity.owner.num_shares_of(entity) }
+          end
+
+          def setup
+            @issued = false
+            super
+          end
+
+          def round_state
+            super.merge(
+              {
+                parred: {},
+                issued: {},
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_21_moon/step/corporate_buy_sell_shares.rb
+++ b/lib/engine/game/g_21_moon/step/corporate_buy_sell_shares.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G21Moon
+      module Step
+        class CorporateBuySellShares < Engine::Step::BuySellParShares
+          def redeemable_shares(_corp)
+            []
+          end
+
+          def can_sell_any?(entity)
+            can_issue?(entity) || super
+          end
+
+          def can_issue?(entity)
+            !bought? && entity.num_ipo_shares.positive? && max_issuable(entity).positive?
+          end
+
+          def issuable_shares(corp)
+            shares = @game.bundles_for_corporation(corp.ipo_owner, corp) # only IPO shares
+            shares.reject { |bundle| bundle.num_shares > max_issuable(corp) }
+          end
+
+          def max_issuable(corp)
+            num_p_shares = @game.players.sum { |p| p.num_shares_of(corp) }
+            num_c_shares = @game.corporations.sum { |p| p.num_shares_of(corp) }
+            num_m_shares = @game.share_pool.num_shares_of(corp)
+
+            [num_p_shares + num_c_shares - num_m_shares, @game.class::MARKET_SHARE_LIMIT - num_m_shares].min
+          end
+
+          def can_buy?(entity, bundle)
+            return unless bundle
+            # can't buy from own IPO
+            return if entity == bundle.corporation && bundle.owner == bundle.corporation.ipo_owner
+            # can't buy from other corporations
+            return if bundle.owner.corporation?
+
+            super
+          end
+
+          # FIXME: move to common location
+          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true)
+            corp = shares.corporation
+            if shares.owner == corp.ipo_owner
+              # IPO shares pay corporation
+              @game.share_pool.buy_shares(entity,
+                                          shares,
+                                          exchange: exchange,
+                                          swap: swap,
+                                          allow_president_change: allow_president_change)
+              price = corp.share_price.price * shares.num_shares
+              @game.bank.spend(price, corp)
+            else
+              super
+            end
+          end
+
+          def process_buy_shares(action)
+            @round.bought_from_ipo = true if action.bundle.owner.corporation?
+            buy_shares(action.entity, action.bundle, swap: action.swap, allow_president_change: false)
+            track_action(action, action.bundle.corporation)
+          end
+
+          def process_sell_shares(action)
+            if action.entity == action.bundle.corporation && action.bundle.owner == action.bundle.corporation.ipo_owner
+              return issue_shares(action)
+            end
+
+            super
+          end
+
+          def issue_shares(action)
+            corp = action.entity
+            bundle = action.bundle
+            floated = corp.floated?
+            price = corp.share_price.price
+
+            @log << "#{corp.name} issues #{share_str(bundle)} of #{corp.name} to the market"\
+                    " and receives #{@game.format_currency(bundle.price)}"
+            @game.share_pool.transfer_shares(bundle,
+                                             @game.share_pool,
+                                             spender: @game.bank,
+                                             receiver: corp)
+            @game.stock_market.move_down(corp) if floated
+            @game.log_share_price(corp, price)
+            @game.float_corporation(corp) if corp.floatable && floated != corp.floated?
+
+            track_action(action, corp)
+          end
+
+          def share_str(bundle)
+            num_shares = bundle.num_shares
+            return "a #{bundle.percent}% IPO share" if num_shares == 1
+
+            "#{num_shares} IPO shares"
+          end
+
+          def can_ipo_any?(_entity)
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_21_moon/step/trade_stock.rb
+++ b/lib/engine/game/g_21_moon/step/trade_stock.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G21Moon
+      module Step
+        class TradeStock < Engine::Step::Base
+          def actions(entity)
+            return [] unless entity == pending_entity
+
+            %w[choose]
+          end
+
+          def active_entities
+            [pending_entity]
+          end
+
+          def round_state
+            super.merge(
+              {
+                pending_trades: [],
+              }
+            )
+          end
+
+          def active?
+            pending_entity
+          end
+
+          def current_entity
+            pending_entity
+          end
+
+          def pending_entity
+            pending_trade[:entity]
+          end
+
+          def pending_bundle
+            pending_trade[:bundle]
+          end
+
+          def pending_trade
+            @round.pending_trades&.first || {}
+          end
+
+          def description
+            "Pick share to trade for #{pending_bundle.corporation.name}"
+          end
+
+          def choice_available?(entity)
+            entity == pending_entity
+          end
+
+          def choice_name
+            "Share to trade for a share of #{pending_bundle.corporation.name}"
+          end
+
+          def choices
+            available_shares(pending_entity, pending_bundle).to_h do |s|
+              [s.corporation.name, s.corporation.name]
+            end
+          end
+
+          def available_shares(entity, trade_bundle)
+            @game.corporations.map do |corp|
+              next if corp == trade_bundle.corporation
+
+              share = entity.shares_of(corp)
+                .select { |s| can_dump?(entity, s) }.min_by(&:percent)
+              next unless share
+
+              share
+            end.compact
+          end
+
+          def can_sell?(entity, bundle)
+            return unless bundle
+            return true unless bundle.presidents_share
+
+            sh = bundle.corporation.player_share_holders
+            (sh.reject { |k, _| k == entity }.values.max || 0) >= bundle.presidents_share.percent
+          end
+
+          def can_dump?(entity, share)
+            return true unless share.president
+
+            sh = share.corporation.player_share_holders
+            (sh.reject { |k, _| k == entity }.values.max || 0) >= share.percent
+          end
+
+          def ipo_type(_entity)
+            :par
+          end
+
+          def process_choose(action)
+            # do the trade as two separate actions
+            player = pending_entity
+            incoming = pending_bundle
+            trader = incoming.owner
+            outgoing = @game.sellable_bundles(player, @game.corporation_by_id(action.choice)).first
+
+            @log << "#{player.name} trades a share of #{outgoing.corporation.name} for a share of "\
+                    "#{incoming.corporation.name} with #{trader.name}"
+
+            @game.share_pool.buy_shares(player, incoming, exchange: true, exchance_price: :free)
+
+            # the other direction has to be broken into pieces because of a possible president change
+            # we also have to prevent the corporation from becoming president
+            #
+            outgoing.share_price = 0
+            @game.share_pool.sell_shares(outgoing, silent: true)
+
+            new_outgoing = @game.share_pool.shares_of(outgoing.corporation).first
+            @game.share_pool.buy_shares(trader, new_outgoing,
+                                        exchange: true, exchance_price: :free, allow_president_change: false)
+
+            @round.pending_trades.shift
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -120,7 +120,11 @@ module Engine
           !(@game.class::MUST_SELL_IN_BLOCKS && @round.players_sold[entity][corporation] == :now) &&
           can_sell_order? &&
           @game.share_pool.fit_in_bank?(bundle) &&
-          bundle.can_dump?(entity)
+          can_dump?(entity, bundle)
+      end
+
+      def can_dump?(entity, bundle)
+        bundle.can_dump?(entity)
       end
 
       def can_sell_order?

--- a/public/logos/21Moon/DSE.svg
+++ b/public/logos/21Moon/DSE.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.0999999" fill="#ffffff" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">DSE</text></svg>

--- a/public/logos/21Moon/IC.svg
+++ b/public/logos/21Moon/IC.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="purple"/><text x="4" y="5.0999999" fill="#ffffff" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">IC</text></svg>

--- a/public/logos/21Moon/LP.svg
+++ b/public/logos/21Moon/LP.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="violet"/><text x="4" y="5.0999999" fill="#000000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">LP</text></svg>

--- a/public/logos/21Moon/MA.svg
+++ b/public/logos/21Moon/MA.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="skyblue"/><text x="4" y="5.0999999" fill="#000000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">MA</text></svg>

--- a/public/logos/21Moon/ME.svg
+++ b/public/logos/21Moon/ME.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="gray"/><text x="4" y="5.0999999" fill="#000000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">ME</text></svg>

--- a/public/logos/21Moon/MV.svg
+++ b/public/logos/21Moon/MV.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="brown"/><text x="4" y="5.0999999" fill="#ffffff" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">MV</text></svg>

--- a/public/logos/21Moon/SM.svg
+++ b/public/logos/21Moon/SM.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg"><circle cx="4" cy="4" r="4" fill="tan"/><text x="4" y="5.0999999" fill="#000000" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">SM</text></svg>


### PR DESCRIPTION
Common code changes:

* UI::BuySellShares - allow custom button names when selling corporate shares
* UI::Corporation - handle treasury_as_holding
* Engine::Corporation - add treasury_as_holding option to treat all corporate-held shares the same
* Engine::Step::BuySellParShares - allow overriding of can_dump? method