### PR TITLE
Fix auto-buy allowing to buy receivership shares without the buy option.

### DIFF
--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -896,8 +896,6 @@ module Engine
 
         def corporation_available?(entity)
           return false unless entity.corporation?
-          return true if entity == @mhe
-          return can_restart?(entity, @round.active_step.current_entity) if entity.receivership?
 
           entity.ipoed || can_par?(entity, @round.active_step.current_entity)
         end

--- a/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
@@ -29,6 +29,13 @@ module Engine
             end
           end
 
+          def can_buy?(entity, bundle)
+            corporation = bundle.corporation
+            return @game.can_restart?(corporation, entity) if corporation.receivership? && corporation != @game.mhe
+
+            super
+          end
+
           def can_buy_multiple?(entity, corporation, _owner)
             return unless corporation.corporation?
 


### PR DESCRIPTION
Works by moving the restart logic from corporation_available? to can_buy?.

1873 was the only company that had corporation_available? return false after it had previously returned true, which seems counter to the general purpose of that method, and also doesn't get applied in many parts of the game since corporation_available? is assumed to be a UI convenience.

By putting the logic in can_buy? instead it gets applied in the same place as corporation_available? (for showing buy buttons), but also applies to auto-buy and other parts of share buying.

New result on receivership auto-buy: 'Disabled programmed action 'Buy U from market until 2 shares' due to 'Cannot buy U from market''

Fixes #6861