### PR TITLE
Add fix_existing_users to import_game.

### DIFF
--- a/import_game.rb
+++ b/import_game.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'argon2'
 require 'net/http'
 require 'uri'
 
@@ -35,7 +36,7 @@ def import_game(game_id)
       id: player_id,
       name: name,
       email: "#{name}@example.com",
-      password: name,
+      password: 'password',
       settings: {
         notifications: 'none',
         webhook: nil,
@@ -95,4 +96,8 @@ def import_game(game_id)
   end
 
   game.id
+end
+
+def fix_existing_users
+  DB[:users].update(password: Argon2::Password.create('password'))
 end


### PR DESCRIPTION
The new method sets the password for all users to 'password', to make it possible to interact with imported games when the user already exists (likely from a database dump).

Also changes the password used for imported users to 'password'.