### PR TITLE
display bank, train_schedule inline-block

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -375,13 +375,11 @@ module View
           children = []
           props = {
             style: {
-              display: 'flex',
-              flexDirection: 'row',
               marginBottom: '1rem',
             },
           }
-          children << h(:div, [h(Bank, game: @game)].compact)
-          children << h(:div, [h(TrainSchedule, game: @game)])
+          children << h(Bank, game: @game)
+          children << h(TrainSchedule, game: @game)
           h(:div, props, children)
         end
       end


### PR DESCRIPTION
This fixes a bug with my previous PR for issue #6650 which broke the layout in mobile.