### PR TITLE
18EU Red to Red Bonus

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -79,7 +79,7 @@ module Engine
         def add_optional_train(type)
           modified_trains = @depot.trains.select { |t| t.name == type }
           new_train = modified_trains.first.clone
-          new_train.index = modified_trains.length
+          new_train.index = modified_trains.size
           @depot.add_train(new_train)
         end
 
@@ -192,7 +192,7 @@ module Engine
         end
 
         def route_ends_red?(stops)
-          return false unless stops.length > 1
+          return false unless stops.size > 1
 
           stops.first.hex.tile.color == :red && stops.last.hex.tile.color == :red
         end


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/792

A train beginning and ending its route in different red hexes gains a bonus based on how many of the corporation's tokens it has run through, limited to a maximum by the phase.

<img width="704" alt="Screen Shot 2022-01-30 at 9 58 24 AM" src="https://user-images.githubusercontent.com/15675400/151709247-dc5a8bda-1f72-4cce-a61d-f317e7407c25.png">

On route selector:

<img width="629" alt="Screen Shot 2022-01-30 at 9 59 23 AM" src="https://user-images.githubusercontent.com/15675400/151709282-7ee3da69-cf7a-4df3-ab80-d9009e3209b5.png">


Resulting log:

<img width="698" alt="Screen Shot 2022-01-30 at 9 56 37 AM" src="https://user-images.githubusercontent.com/15675400/151709252-00d7e48d-5369-45f6-9686-bc67e0c3de2c.png">

