### PR TITLE
1825/18EU Allow for a train that does not require a token.

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -231,8 +231,6 @@ module Engine
 
       ALLOW_TRAIN_BUY_FROM_OTHERS = true # Allows train buy from other corporations
 
-      MN_TRAIN_MUST_USE_TOKEN = true # when picking best M out of N stops, must one of the stops must be tokened
-
       # Default tile lay, one tile either upgrade or lay at zero cost
       # allows multiple lays, value must be either true, false or :not_if_upgraded
       TILE_LAYS = [{ lay: true, upgrade: true, cost: 0 }].freeze
@@ -1237,7 +1235,7 @@ module Engine
           stops, revenue = visits.combination(num_stops.to_i).map do |stops|
             # Make sure this set of stops is legal
             # 1) At least one stop must have a token (if enabled)
-            next if self.class::MN_TRAIN_MUST_USE_TOKEN && stops.none? { |stop| stop.tokened_by?(route.corporation) }
+            next if train.requires_token && stops.none? { |stop| stop.tokened_by?(route.corporation) }
 
             # 2) We can't ask for more revenue centers of a type than are allowed
             types_used = Array.new(distance.size, 0) # how many slots of each row are filled

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -350,7 +350,6 @@ module Engine
         TILE_LAYS = [{ lay: true, upgrade: true }, { lay: :not_if_upgraded, upgrade: false }].freeze
         GAME_END_CHECK = { bank: :current_or, stock_market: :immediate }.freeze
         TRAIN_PRICE_MIN = 10
-        MN_TRAIN_MUST_USE_TOKEN = false
         IMPASSABLE_HEX_COLORS = %i[blue sepia red].freeze
         TILE_200 = '200'
 
@@ -654,7 +653,7 @@ module Engine
 
           # pre-allocate dummy trains used for tile 200
           @pass_thru = {}
-          DUMMY_TRAINS.each { |train| @pass_thru[train[:name]] = Train.new(**train, index: 999) }
+          DUMMY_TRAINS.each { |train| @pass_thru[train[:name]] = Train.new(**train, requires_token: false, index: 999) }
         end
 
         # cache all stock prices

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -9,7 +9,7 @@ module Engine
 
     attr_accessor :obsolete, :operated, :events, :variants, :obsolete_on, :rusted, :rusts_on, :index, :name,
                   :distance, :reserved
-    attr_reader :available_on, :discount, :multiplier, :sym, :variant
+    attr_reader :available_on, :discount, :multiplier, :sym, :variant, :requires_token
     attr_writer :buyable
 
     def initialize(name:, distance:, price:, index: 0, **opts)
@@ -30,6 +30,7 @@ module Engine
       @operated = false
       @events = (opts[:events] || []).select { |e| @index == (e['when'] || 1) - 1 }
       @reserved = opts[:reserved] || false
+      @requires_token = opts[:requires_token].nil? ? true : opts[:requires_token]
       init_variants(opts[:variants])
     end
 


### PR DESCRIPTION
This need is shared between 1825 and 18EU, so I wanted to make the implementation more generic. The original implementation was tied to the train being an MN type, which did not apply to 18EU.

1825 Tested:

<img width="665" alt="Screen Shot 2022-01-31 at 10 43 32 AM" src="https://user-images.githubusercontent.com/15675400/151845340-9bbf89e6-49d6-45d7-8dc0-867a1997e05e.png">

