### PR TITLE
18EU Remove redundant tokens after upgrade

### DIFF
--- a/lib/engine/game/g_18_eu/step/track.rb
+++ b/lib/engine/game/g_18_eu/step/track.rb
@@ -15,6 +15,23 @@ module Engine
 
             super
           end
+
+          def update_token!(_action, _entity, tile, old_tile)
+            super
+
+            return if old_tile.cities.size == 1 || tile.color != :brown
+
+            tile.cities.each do |city|
+              prev = nil
+              city.tokens.compact.sort_by { |t| t.corporation.name }.each do |token|
+                if prev&.corporation == token.corporation
+                  prev.remove!
+                  @game.log << "#{token.corporation.name} redundant token removed from #{tile.hex.name}"
+                end
+                prev = token
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/792

"These additional station tokens may be retained as long as they are in non-contiguous City circles: that is, until these cities are upgraded using the brown tiles designated for the purpose. When this occurs, any tokens beyond one in either Berlin or Vienna are removed from the map and returned to the Corporation for reuse: any tokens beyond one in each of “northern” and “southern” Paris are likewise removed from the map and returned to the Corporation for reuse."

<img width="501" alt="Screen Shot 2022-02-01 at 12 21 01 AM" src="https://user-images.githubusercontent.com/15675400/152001899-94de6136-c8c4-4e4f-9fe8-c09efdd452e3.png">

<img width="715" alt="Screen Shot 2022-02-01 at 12 21 11 AM" src="https://user-images.githubusercontent.com/15675400/152001902-6afc3e2d-a8aa-40f0-bc29-d6b628627087.png">
