### PR TITLE
18EU Cannot stop at Paris/Vienna/Berlin twice

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -221,6 +221,16 @@ module Engine
           str
         end
 
+        def check_other(route)
+          city_hexes = route.stops.map do |stop|
+            next unless stop.city?
+
+            stop.tile.hex
+          end.compact
+
+          raise GameError, 'Cannot stop at Paris/Vienna/Berlin twice' if city_hexes.size != city_hexes.uniq.size
+        end
+
         def emergency_issuable_cash(corporation)
           emergency_issuable_bundles(corporation).max_by(&:num_shares)&.price || 0
         end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/792

A train may not run more than once to the same City, Town, Port, or Off-Map Location, including separate City Circles in Paris, Berlin and Vienna.

Note: Default implementation already prevents "City, Town, Port, or Off-Map Location", it is only the separate circles that needs special handling.

<img width="425" alt="Screen Shot 2022-02-01 at 10 46 59 AM" src="https://user-images.githubusercontent.com/15675400/152023176-35bd8c8f-4150-4212-a997-e260299f6c81.png">


