### PR TITLE
18EU New corporations fund all shares in Phase 5+

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -265,6 +265,17 @@ module Engine
           super
         end
 
+        def float_corporation(corporation)
+          super
+
+          return unless @phase.status.include?('normal_formation')
+
+          bundle = Engine::ShareBundle.new(corporation.treasury_shares)
+          @bank.spend(bundle.price, corporation)
+          @share_pool.transfer_shares(bundle, @share_pool)
+          @log << "#{corporation.name} places remaining shares on the Market for #{format_currency(bundle.price)}"
+        end
+
         def all_free_hexes(corporation)
           hexes.select do |hex|
             hex.tile.cities.any? { |city| city.tokenable?(corporation, free: true) }


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/792

If a Corporation is started, but does not float, prior to Phase 5, and subsequently floats in Phase 5, the five unsold shares are monetized in accordance with the rules below: the last five shares in the Treasury are placed in the Pool and the Corporation receives an additional five times its Starting Value. In effect the Corporation will start with full capitalization, as if it had started in Phase 5, except for the monies received for exchange shares.