### PR TITLE
[1873] Remove restart logic from corporation_available?

### DIFF
--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -896,8 +896,6 @@ module Engine
 
         def corporation_available?(entity)
           return false unless entity.corporation?
-          return true if entity == @mhe
-          return can_restart?(entity, @round.active_step.current_entity) if entity.receivership?
 
           entity.ipoed || can_par?(entity, @round.active_step.current_entity)
         end

--- a/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1873/step/buy_sell_par_shares.rb
@@ -31,7 +31,7 @@ module Engine
 
           def can_buy?(entity, bundle)
             corp = bundle.corporation
-            return if corp.receivership? && !@game.can_restart?(corp, entity)
+            return @game.can_restart?(corp, entity) if corp.receivership?
 
             super
           end


### PR DESCRIPTION
1873 is the only company that has corporation_available? return false after it has previously returned true, which seems counter to the general purpose of that method, and also doesn't get applied in many parts of the game since corporation_available? is assumed to be a UI convenience.

Also fixes a line that would return nil in a method that's supposed to return a boolean.