### PR TITLE
only show bank when relevant

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -70,7 +70,7 @@ module View
             children << h(BuyCompanyFromOtherPlayer, game: @game)
           end
           children << render_bank
-          children << h(StockMarket, game: @game, show_bank: false)
+          children << h(StockMarket, game: @game, show_bank: true)
 
           h(:div, children)
         end
@@ -378,7 +378,6 @@ module View
               marginBottom: '1rem',
             },
           }
-          children << h(Bank, game: @game)
           children << h(TrainSchedule, game: @game)
           h(:div, props, children)
         end


### PR DESCRIPTION

The `undefined` element is no longer rendered if the bank is infinite, as in CZ
![image](https://user-images.githubusercontent.com/1711810/152256090-5b5f8a8d-c0bd-486f-9970-e409734043dd.png)

Games with a bank such as 46 still have it rendered
![Screenshot 2022-02-02 3 37 47 PM](https://user-images.githubusercontent.com/1711810/152256152-974a40f8-2cf4-4a36-ac87-6381e9b0e588.png)


