### PR TITLE
1848 Trains as variants and 2E Buy Rules

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -264,6 +264,7 @@ module Engine
             distance: 2,
             price: 200,
             num: 6,
+            available_on: '5',
           },
         ].freeze
 

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -509,7 +509,7 @@ module Engine
             Engine::Step::Route,
             Engine::Step::Dividend,
             Engine::Step::DiscardTrain,
-            Engine::Step::BuyTrain,
+            G1848::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
         end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -196,31 +196,76 @@ module Engine
                     operating_rounds: 3,
                   }].freeze
 
-        TRAINS = [{ name: '2', distance: 2, price: 100, rusts_on: '4', num: 6 },
-                  { name: '2+', distance: 2, price: 120, rusts_on: '4', num: 6 },
-                  { name: '3', distance: 3, price: 200, rusts_on: '6', num: 5 },
-                  { name: '3+', distance: 3, price: 230, rusts_on: '6', num: 5 },
-                  { name: '4', distance: 4, price: 300, rusts_on: '8', num: 4 },
-                  { name: '4+', distance: 4, price: 340, rusts_on: '8', num: 4 },
-                  {
-                    name: '5',
-                    distance: 5,
-                    price: 500,
-                    num: 3,
-                    events: [{ 'type' => 'close_companies' }],
-                  },
-                  { name: '5+', distance: 5, price: 550, num: 3 },
-                  { name: '6', distance: 6, price: 600, num: 2 },
-                  { name: '6+', distance: 6, price: 660, num: 2 },
-                  {
-                    name: 'D',
-                    distance: 999,
-                    price: 1100,
-                    num: 6,
-                    discount: { '4' => 300, '5' => 300, '6' => 300 },
-                  },
-                  { name: '8', distance: 8, price: 800, num: 6 },
-                  { name: '2E', distance: 2, price: 200, num: 6 }].freeze
+        TRAINS = [
+          {
+            name: '2',
+            distance: 2,
+            price: 100,
+            rusts_on: '4',
+            num: 6,
+            variants: [
+              { name: '2+', price: 120 },
+            ],
+          },
+          {
+            name: '3',
+            distance: 3,
+            price: 200,
+            rusts_on: '6',
+            num: 5,
+            variants: [
+              { name: '3+', distance: 3, price: 230 },
+            ],
+          },
+          {
+            name: '4',
+            distance: 4,
+            price: 300,
+            rusts_on: '8',
+            num: 4,
+            variants: [
+              { name: '4+', distance: 4, price: 340 },
+            ],
+          },
+          {
+            name: '5',
+            distance: 5,
+            price: 500,
+            num: 3,
+            events: [{ 'type' => 'close_companies' }],
+            variants: [
+              { name: '5+', distance: 5, price: 550 },
+],
+          },
+          {
+            name: '6',
+            distance: 6,
+            price: 600,
+            num: 2,
+            variants: [
+              { name: '6+', distance: 6, price: 660 },
+            ],
+          },
+          {
+            name: 'D',
+            distance: 999,
+            price: 1100,
+            num: 6,
+            discount: { '4' => 300, '5' => 300, '6' => 300 },
+          },
+          {
+            name: '8',
+            distance: 8,
+            price: 800,
+            num: 6,
+          },
+          {
+            name: '2E',
+            distance: 2,
+            price: 200,
+            num: 6,
+          },
+        ].freeze
 
         COMPANIES = [
           {

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -562,6 +562,13 @@ module Engine
             c.trains.count { |t| !t.obsolete && t.name != '2E' } > train_limit(c)
           end
         end
+
+        def must_buy_train?(entity)
+          # 2E does not count as compulsory train purchase
+          entity.trains.reject { |t| t.name == '2E' }.empty? &&
+            !depot.depot_trains.empty? &&
+             (self.class::MUST_BUY_TRAIN == :route && @graph.route_info(entity)&.dig(:route_train_purchase))
+        end
       end
     end
   end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -555,6 +555,13 @@ module Engine
             city.place_token(entity, home_token, free: true, check_tokenable: false, cheater: slot)
           end
         end
+
+        def crowded_corps
+          # 2E does not create a crowded corp
+          @crowded_corps ||= (minors + corporations).select do |c|
+            c.trains.count { |t| !t.obsolete && t.name != '2E' } > train_limit(c)
+          end
+        end
       end
     end
   end

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -15,6 +15,10 @@ module Engine
 
             super.reject { |t| t.name == '2E' }
           end
+
+          def room?(entity)
+            entity.trains.count { |t| t.name != '2E' } < @game.train_limit(entity)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def buyable_trains(entity)
+            # Cannot buy 2E if one is already owned
+            owns_2e = entity.trains.any? { |t| t.name == '2E' }
+            return super unless owns_2e
+
+            super.reject { |t| t.name == '2E' }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See issue #2548 (@benjaminxscott - if you want to update some of those tasks)

- Can buy current Train or Plus-Train now, rather than all train, then all plus-trains, then the next train.
- 2E available when you buy first 5, doesn't count against train limit, doesn't count for compulsory purchase, can only buy 1. Transfers are not yet prevented.

Trains are formatted that takes up more space, but copied the 1846 styling with its variants (and then changed remaining lines for consistency). I hope that's OK.