### PR TITLE
18EU Emergency Buy

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -20,6 +20,10 @@ module Engine
 
         attr_accessor :corporations_operated
 
+        EBUY_OTHER_VALUE = true # allow ebuying other corp trains for up to face
+        EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = true # if ebuying from depot, must buy cheapest train
+        EBUY_CAN_SELL_SHARES = true # true if a player can sell shares for ebuy
+
         HOME_TOKEN_TIMING = :par
         MIN_BID_INCREMENT = 5
         MUST_BID_INCREMENT_MULTIPLE = true
@@ -232,12 +236,8 @@ module Engine
           raise GameError, 'Cannot stop at Paris/Vienna/Berlin twice' if city_hexes.size != city_hexes.uniq.size
         end
 
-        def emergency_issuable_cash(corporation)
-          emergency_issuable_bundles(corporation).max_by(&:num_shares)&.price || 0
-        end
-
-        def emergency_issuable_bundles(entity)
-          issuable_shares(entity)
+        def emergency_issuable_bundles(_entity)
+          []
         end
 
         def issuable_shares(entity)
@@ -374,6 +374,28 @@ module Engine
             depot.reclaim_train(pullman)
             @log << "#{c.name} is forced to discard pullman train"
           end
+        end
+
+        def depot_trains(entity)
+          has_pullman = owns_pullman?(entity)
+          has_train = entity.trains.empty?
+          @depot.depot_trains.reject do |t|
+            pullman?(t) && (has_train || has_pullman)
+          end
+        end
+
+        def min_depot_train(entity)
+          depot_trains(entity).min_by(&:price)
+        end
+
+        def min_depot_price(entity)
+          return 0 unless (train = min_depot_train(entity))
+
+          train.variants.map { |_, v| v[:price] }.min
+        end
+
+        def can_go_bankrupt?(player, corporation)
+          total_emr_buying_power(player, corporation) < min_depot_price(corporation)
         end
       end
     end

--- a/lib/engine/game/g_18_eu/step/buy_train.rb
+++ b/lib/engine/game/g_18_eu/step/buy_train.rb
@@ -21,16 +21,32 @@ module Engine
           end
 
           def buyable_trains(entity)
-            trains = super
+            depot_trains = @game.depot_trains(entity)
 
-            trains.reject! do |t|
-              @game.pullman?(t) &&
-                (entity.trains.empty? ||
-                  @game.owns_pullman?(entity) ||
-                  t.owner.corporation?)
+            if entity.cash < @game.min_depot_price(entity) && ebuy_offer_only_cheapest_depot_train?
+              depot_trains = [@game.min_depot_train(entity)]
             end
 
-            trains
+            # if a player sold shares, they cannot buy over
+            other_trains = if @last_share_sold_price && entity.cash.zero?
+                             []
+                           else
+                             @depot.other_trains(entity).reject { |t| @game.pullman?(t) }
+                           end
+
+            depot_trains + other_trains
+          end
+
+          def cheapest_train_price(corporation)
+            @game.min_depot_price(corporation)
+          end
+
+          def check_for_cheapest_train(_train)
+            true
+          end
+
+          def needed_cash(_entity)
+            cheapest_train_price(current_entity)
           end
         end
       end


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/792

_If company is broke (0), may use president cash to buy up to face value, but not sell shares_

In addition, I found the Pullman was triggering the cheapest depot train for ebuying, which cannot be bought as the only train, shown here:

<img width="320" alt="Screen Shot 2022-02-03 at 3 17 52 PM" src="https://user-images.githubusercontent.com/15675400/152582190-17dd85cf-8e62-4360-88bb-bcbd6893fa3a.png">

----------

Presedential Contribution during Ebuy without shares sold.

<img width="653" alt="Screen Shot 2022-02-04 at 11 06 32 AM" src="https://user-images.githubusercontent.com/15675400/152582280-8e1b0945-292a-4f8b-b187-f8670b00cd7e.png">
<img width="381" alt="Screen Shot 2022-02-04 at 11 06 48 AM" src="https://user-images.githubusercontent.com/15675400/152582283-e3e8f1c0-c8d2-43cd-bebc-e771f3ff9e91.png">

----------

If the president sells shares, the corporation must buy the cheapest non-pullman.

<img width="480" alt="Screen Shot 2022-02-04 at 11 07 01 AM" src="https://user-images.githubusercontent.com/15675400/152582625-a58437d1-6261-48f6-aabc-3e01131522a4.png">

