### PR TITLE
18EU Bankruptcy

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -25,6 +25,8 @@ module Engine
         MUST_BID_INCREMENT_MULTIPLE = true
         TOKENS_FEE = 100
 
+        GAME_END_CHECK = { bank: :full_or }.freeze # TODO: extreme edge case of one player remaining
+
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
             'minor_exchange' => [
               'Minor Exchange',

--- a/lib/engine/game/g_18_eu/step/bankrupt.rb
+++ b/lib/engine/game/g_18_eu/step/bankrupt.rb
@@ -7,7 +7,65 @@ module Engine
     module G18EU
       module Step
         class Bankrupt < Engine::Step::Bankrupt
-          # TODO: Implement removing player from game
+          def sell_bankrupt_shares(player, corporation)
+            super
+
+            transfer_remaining_shares(player)
+            fund_previous_corporation(player, corporation) unless corporation.presidents_share.owner == @game.share_pool
+            maybe_restart_ownerless_corporations
+          end
+
+          def transfer_remaining_shares(player)
+            player.shares.each do |share|
+              @game.share_pool.transfer_shares(share.to_bundle, @game.share_pool, price: 0, allow_president_change: true)
+            end
+          end
+
+          def fund_previous_corporation(player, corporation)
+            @game.log << "#{corporation.name} gains #{@game.format_currency(player.cash)} from former president."
+            player.spend(player.cash, corporation)
+          end
+
+          def maybe_restart_ownerless_corporations
+            @game.corporations.each do |c|
+              next unless c.ipoed
+              next unless c.presidents_share.owner == @game.share_pool
+
+              restart_corporation!(c)
+            end
+          end
+
+          def restart_corporation!(corporation)
+            @game.log << "#{corporation.name} has no president and is restarted with no compensation."
+
+            transferred = []
+            corporation.trains.dup.each do |train|
+              transferred << train
+              @game.depot.reclaim_train(train)
+            end
+
+            unless transferred.empty?
+              @game.log << "#{corporation.name} places #{transferred.map(&:name).join(', ')}"\
+                           " train#{transferred.one? ? '' : 's'} into the pool"
+            end
+
+            corporation.share_holders.keys.each do |sh|
+              next if sh == corporation
+
+              sh.shares_by_corporation[corporation].dup.each { |share| share.transfer(corporation) }
+            end
+
+            corporation.spend(corporation.cash, @game.bank) if corporation.cash.positive?
+            corporation.tokens.each(&:remove!)
+            corporation.share_price&.corporations&.delete(corporation)
+            corporation.share_price = nil
+            corporation.par_price = nil
+            corporation.ipoed = false
+            corporation.unfloat!
+            corporation.owner = nil
+
+            @game.bank.shares_by_corporation[corporation].sort_by!(&:id)
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_eu/step/minor_exchange.rb
+++ b/lib/engine/game/g_18_eu/step/minor_exchange.rb
@@ -56,7 +56,7 @@ module Engine
 
           transferred = []
           if destination == @game.depot
-            source.trains.each do |train|
+            source.trains.dup.each do |train|
               @game.depot.reclaim_train(train)
               transferred << train
             end

--- a/lib/engine/step/bankrupt.rb
+++ b/lib/engine/step/bankrupt.rb
@@ -35,6 +35,15 @@ module Engine
           raise GameError, msg
         end
 
+        sell_bankrupt_shares(player, corp)
+        @round.recalculate_order if @round.respond_to?(:recalculate_order)
+
+        player.spend(player.cash, @game.bank) if player.cash.positive?
+
+        @game.declare_bankrupt(player)
+      end
+
+      def sell_bankrupt_shares(player, _corp)
         @log << "-- #{player.name} goes bankrupt and sells remaining shares --"
 
         player.shares_by_corporation(sorted: true).each do |corporation, _|
@@ -47,11 +56,6 @@ module Engine
             @game.sell_shares_and_change_price(bundle)
           end
         end
-        @round.recalculate_order if @round.respond_to?(:recalculate_order)
-
-        player.spend(player.cash, @game.bank) if player.cash.positive?
-
-        @game.declare_bankrupt(player)
       end
     end
   end


### PR DESCRIPTION
From https://github.com/tobymao/18xx/issues/792

If, after selling all the stock he is legally permitted to sell, the President cannot raise sufficient cash to buy a train, he is bankrupt. His remaining holdings are placed in the Pool (for the purposes of this rule only, the Pool may contain more than fifty percent of a Corporation, and the stock price remains unchanged) and he is eliminated from the game. The Presidency of any of his controlled Corporations is transferred to the next eligible player. If no such player exists (i.e., if no player holds two shares of one of the affected Corporations), the Corporation is closed and all its shares are removed without compensation. Its station tokens are removed from the map and any trains it owns are placed in the Pool and become available for purchase. Its shares are returned to the Corporation Treasury, and it may subsequently reenter play as a new Corporation.

If the Presidency of the Corporation for which the bankrupt player was buying a train is transferred in this manner, its Treasury will contain the total amount raised by the now bankrupt President during his Emergency Money Raising. The new President must complete the Emergency Money Raising using his own resources and buy a train for the Corporation.