### PR TITLE
18Rhl: Corrections of privates and map

### DIFF
--- a/lib/engine/game/g_18_rhl/entities.rb
+++ b/lib/engine/game/g_18_rhl/entities.rb
@@ -167,6 +167,7 @@ module Engine
                           special: true,
                           count: 1,
                           when: %w[owning_player_or_turn],
+                          consume_tile_lay: false,
                         }],
           },
           {
@@ -174,17 +175,14 @@ module Engine
             name: 'No. 2 Konzession Essen-Osterath',
             value: 30,
             revenue: 0,
-            desc: 'With the beginning of the green phase the special function can be used. As director of a '\
+            desc: 'With the beginning of the green phase this special function can be used. As director of a '\
                   'corporation the owner may lay the orange tile #935 on hex E8 regardless whether there is a tile '\
-                  'on that hex or not. Directly after the tile placement the operating corporation may place a '\
-                  'station token for free on that hex (the director must use the station token with the lowest '\
-                  'cost). If the corporation places this station token it is the only station token the corporation '\
-                  'may place in that Operating Round. When the corporation does not place the station token, any '\
-                  'other corporation may place a station marker on hex E8 according to the normal rules. If the '\
-                  'corporation places the station token in hex E8 during a later Operating Round it has to pay for '\
-                  'the station token. After the purchase of the first 5-train the tile #935 may no longer be laid. '\
-                  'After the placement of the station marker the corporation may not place a tile even when it has '\
-                  'not used its normal tile lay (placing a station token is always the step after the tile lay!).',
+                  'on that hex or not. Directly after this tile placement the operating corporation may directly '\
+                  'place a station token for free on that hex (the cheapest available token will be used. '\
+                  "This tile placement of is in addition to corporation's normal tile lay. There need not be a link "\
+                  "to the corporation's network. If the token is placed as part of this ability no further tile "\
+                  'lays or upgrades are allowed in this turn. After the purchase of the first 5-train the #935 tile '\
+                  'may no longer be laid.',
             abilities: [
               {
                 type: 'teleport',
@@ -193,6 +191,7 @@ module Engine
                 hexes: %w[E8],
                 count: 1,
                 when: %w[owning_player_or_turn],
+                free_tile_lay: true,
               },
             ],
           },
@@ -215,6 +214,7 @@ module Engine
                 reachable: false,
                 count: 1,
                 when: %w[owning_player_or_turn],
+                consume_tile_lay: false,
               },
             ],
           },
@@ -227,12 +227,10 @@ module Engine
                   'Köln / Düsseldorf / Duisburg for free. This tile placement is in addition to the '\
                   "corporation's normal tile lay. The corporation may place a station token there in the same OR "\
                   "by paying the appropriate costs. There need not be a link to the corporation's network. "\
-                  'If the station marker is not placed in the same Operating Round but later, the corporation '\
-                  'must have a track connection to that hex. After the placement of the station token the '\
-                  'corporation may not place a tile even when it has not used its normal tile lay (placing a '\
-                  'station marker is always the step after the tile lay!). Note! Token can only be used '\
-                  'together with the upgrade to green and not as a token-only action. If all applicable hexes '\
-                  'are green the special ability is no longer usable.',
+                  'If the token is placed as part of this ability no further tile lays or upgrades are '\
+                  'allowed in this turn. Note! Token can only be used together with the upgrade to green '\
+                  'and not as a token-only action. If no applicable hexes are yellow the special ability '\
+                  'is no longer usable.',
             abilities: [
               {
                 type: 'teleport',
@@ -241,6 +239,7 @@ module Engine
                 hexes: %w[D9 F9 I10],
                 count: 1,
                 when: %w[owning_player_or_turn],
+                free_tile_lay: true,
               },
             ],
           },
@@ -270,9 +269,9 @@ module Engine
               { type: 'close', when: 'par', corporation: 'RhE' },
             ],
             desc: 'The player who purchased this must immediately set the par value for the RhE. The par '\
-                  'can only be 70M, 75M or 80M. The money RhE receives for the presidency will be the winning'\
+                  'can only be 70M, 75M or 80M. The money RhE receives for the presidency will be the winning '\
                   'bid. Three 10% shares of the RhE will be placed in the Bank Pool. The Bank will delay paying '\
-                  'the par value of theese three 10% shares to the RhE treasury until there is a track link from '\
+                  'the par value of these three 10% shares to the RhE treasury until there is a track link from '\
                   'Köln to Aachen via Düren (cannot be blocked by non-RhE station tokens).',
           },
         ].freeze

--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -259,8 +259,8 @@ module Engine
           G18Rhl::Round::Operating.new(self, [
             G18Rhl::Step::Bankrupt,
             Engine::Step::HomeToken,
-            G18Rhl::Step::SpecialToken, # Must be before any track lay (due to private No. 4)
             G18Rhl::Step::SpecialTrack,
+            G18Rhl::Step::SpecialToken, # Must be before regular track lay (due to private No. 4)
             G18Rhl::Step::Track,
             G18Rhl::Step::RheBonusCheck,
             Engine::Step::Token,

--- a/lib/engine/game/g_18_rhl/map.rb
+++ b/lib/engine/game/g_18_rhl/map.rb
@@ -275,7 +275,7 @@ module Engine
         }.freeze
 
         LOCATION_NAMES = {
-          'A2' => 'Nimwegen',
+          'A4' => 'Nimwegen',
           'A6' => 'Arnheim',
           'A14' => 'Hamburg Münster',
           'B9' => 'Wesel',
@@ -378,7 +378,6 @@ module Engine
           end
           {
             red: {
-              ['A2'] => 'offboard=revenue:yellow_40|brown_60,hide:1,groups:NorthWest',
               ['A4'] => 'offboard=revenue:yellow_40|brown_60,groups:NorthWest;path=a:0,b:_0,terminal:1;'\
                         'border=edge:4,type:impassable,color:blue;icon=image:18_rhl/RGE',
               ['A6'] => 'offboard=revenue:yellow_40|brown_60,groups:NorthWest;path=a:5,b:_0,terminal:1;'\
@@ -391,11 +390,9 @@ module Engine
               ['D15'] => 'city=revenue:10;city=revenue:10;path=a:0,b:_0,terminal:1;path=a:1,b:_1,terminal:1;'\
                          'label=+10/link;icon=image:18_rhl/ERh',
               ['E2'] => 'city=revenue:yellow_20|brown_40;path=a:3,b:_0;path=a:5,b:_0',
-              ['G2'] => 'city=revenue:yellow_10|brown_20,groups:Roermond;path=a:4,b:_0,terminal:1',
-              ['H1'] => 'offboard=revenue:yellow_10|brown_20,hide:1,groups:Roermond;icon=image:18_rhl/ERh',
+              ['G2'] => 'city=revenue:yellow_10|brown_20,groups:Roermond;path=a:4,b:_0,terminal:1;icon=image:18_rhl/ERh',
               ['J1'] => 'offboard=revenue:yellow_10|brown_30;path=a:5,b:_0,terminal:1',
               ['L1'] => 'offboard=revenue:yellow_30|brown_60;path=a:3,b:_0,terminal:1',
-              %w[L3 L5 L7] => '',
               ['L9'] => 'town=revenue:10;path=a:2,b:_0;path=a:3,b:_0',
               ['L11'] => 'offboard=revenue:yellow_30|brown_70;border=edge:3,type:impassable,color:blue;'\
                          'border=edge:4,type:impassable,color:blue;path=a:2,b:_0;icon=image:18_rhl/RGE',
@@ -403,7 +400,7 @@ module Engine
                          'icon=image:18_rhl/RGE',
             },
             gray: {
-              %w[A8 A10 A12 B1 D1 F1] => '',
+              %w[A2 A8 A10 A12 B1 D1 F1 H1 L3 L5 L7] => '',
               %w[F15 H15] => 'path=a:0,b:2',
               ['I4'] => 'path=a:0,b:3',
               ['J15'] => 'city=revenue:yellow_20|brown_40,loc:1;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;'\

--- a/lib/engine/game/g_18_rhl/step/special_token.rb
+++ b/lib/engine/game/g_18_rhl/step/special_token.rb
@@ -16,6 +16,14 @@ module Engine
             @round.teleport_ability
           end
 
+          def adjust_token_price_ability!(entity, token, _hex, _city, special_ability: nil)
+            return super unless entity == @game.konzession_essen_osterath
+
+            # Need to override this as base implementation otherwise change token price to 0.
+            # In 18Rhl the full current price is paid for teleported token.
+            [token, special_ability]
+          end
+
           def process_place_token(action)
             return super unless @round.teleported
 
@@ -31,6 +39,7 @@ module Engine
               action.token,
               connected: false,
               special_ability: ability(entity),
+              spender: @game.current_entity,
             )
 
             teleport_complete

--- a/lib/engine/game/g_18_rhl/step/special_track.rb
+++ b/lib/engine/game/g_18_rhl/step/special_track.rb
@@ -11,13 +11,16 @@ module Engine
           include LayTileChecks
 
           def abilities(entity, **kwargs, &block)
-            return unless entity.company?
-            # Restrict private No2 and No4 to not be used in yellow phase
-            return if (@game.phase.name == '2') &&
-                     (entity == @game.konzession_essen_osterath ||
-                      entity == @game.trajektanstalt)
-            # Do not allow special tile lay after train buys (to avoid exploits)
-            return if @round.bought_trains.include?(@game.current_entity)
+            return if !entity.company? ||
+                      # Do not allow any tile lay if tokening has been used
+                      @round.tokened ||
+                      # Do not allow special tile lay after train buys (to avoid exploits)
+                      @round.bought_trains.include?(@game.current_entity) ||
+                      # Restrict private No2 and No4 (and No1 in Ratingen variant) to not be used in yellow phase
+                      (@game.phase.name == '2' &&
+                       (entity == @game.konzession_essen_osterath ||
+                        entity == @game.trajektanstalt ||
+                        entity == @game.angertalbahn))
 
             %i[tile_lay teleport].each do |type|
               ability = @game.abilities(
@@ -44,8 +47,19 @@ module Engine
             super
           end
 
+          def get_tile_lay(_entity)
+            # Base code caused a crash for 18Rhl so this solves it.
+            { lay: true, upgrade: true, cost: 0, upgrade_cost: 0, cannot_reuse_same_hex: false }
+          end
+
           def process_lay_tile(action)
+            if action.entity == @game.trajektanstalt && action.tile.color == :brown
+              # Private 4 can only be used to upgrade to green
+              raise GameError, "#{@game.trajektanstalt.name} cannot upgrade to brown tiles"
+            end
+
             ability = abilities(action.entity)
+
             super
 
             return unless ability.type == :teleport

--- a/lib/engine/game/g_18_rhl/step/track.rb
+++ b/lib/engine/game/g_18_rhl/step/track.rb
@@ -9,6 +9,13 @@ module Engine
       module Step
         class Track < Engine::Step::Track
           include LayTileChecks
+
+          def actions(entity)
+            # Do not allow any tile lay if tokening has been used
+            return [] if @round.tokened
+
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
P1 (Ratingen): Set attribute that using this does not consume regular
tile lay. Also, restrict so this P1 cannot be used during yellow phase.

P2: Bug fixes: Make tile lay free. Also fixed a crash.
    And updated description.

P3: Set attribute that using this does not consume regular
tile lay.

P4: Bug fixes: Make tile lay free, and token cost is not free.
    Also fixed a crash. And updated description. This fixes https://github.com/tobymao/18xx/issues/6948

P6: Correct description.

Finally, also do not allow any tile laying of any kind after
a tokening has taken place.

Also have transformed some unused red hexes to gray.