### PR TITLE
1860: Displays the shortened trains in nationalization

### DIFF
--- a/lib/engine/game/g_1860/step/route.rb
+++ b/lib/engine/game/g_1860/step/route.rb
@@ -55,9 +55,10 @@ module Engine
             min_price.positive? && entity.cash >= min_price
           end
 
-          def train_name(entity, train)
+          def train_name(_entity, train)
             if @game.nationalization
-              "%s (%s)" % [train.name.split("+")[0], train.name]
+              short_train = train.name.split('+')[0]
+              "#{short_train} (#{train.name})"
             else
               train.name
             end

--- a/lib/engine/game/g_1860/step/route.rb
+++ b/lib/engine/game/g_1860/step/route.rb
@@ -55,6 +55,14 @@ module Engine
             min_price.positive? && entity.cash >= min_price
           end
 
+          def train_name(entity, train)
+            if @game.nationalization
+              "%s (%s)" % [train.name.split("+")[0], train.name]
+            else
+              train.name
+            end
+          end
+
           def process_run_routes(action)
             entity = action.entity
             @round.routes = action.routes


### PR DESCRIPTION
In the nationalization N+m trains run as N train only. This displays a hint for this in the nationalisation phase.

Fixes https://github.com/tobymao/18xx/issues/6961