### PR TITLE
refactor check_connected to not use node.select

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1160,9 +1160,9 @@ module Engine
         end
       end
 
-      def check_connected(route, _token)
-        corporation = route.corporation
-        return if route.ordered_paths.each_cons(2).all? { |pair| pair[0].connects_to?(pair[1], corporation) }
+      def check_connected(route, token_city)
+        corporation = token_city ? route.corporation : nil
+        return if route.ordered_paths.each_cons(2).all? { |a, b| a.connects_to?(b, corporation) }
 
         raise GameError, 'Route is not connected'
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1160,10 +1160,9 @@ module Engine
         end
       end
 
-      def check_connected(route, token)
-        paths_ = route.paths.uniq
-
-        return if token.select(paths_, corporation: route.corporation).size == paths_.size
+      def check_connected(route, _token)
+        corporation = route.corporation
+        return if route.ordered_paths.each_cons(2).all? { |pair| pair[0].connects_to?(pair[1], corporation) }
 
         raise GameError, 'Route is not connected'
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1160,8 +1160,7 @@ module Engine
         end
       end
 
-      def check_connected(route, token_city)
-        corporation = token_city ? route.corporation : nil
+      def check_connected(route, corporation)
         return if route.ordered_paths.each_cons(2).all? { |a, b| a.connects_to?(b, corporation) }
 
         raise GameError, 'Route is not connected'

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -1105,11 +1105,7 @@ module Engine
           # no need if distance is 2, avoids dealing with double-header route missing a token
           return if route.train.distance == 2
 
-          paths_ = route.paths.uniq
-
-          return if token.select(paths_, corporation: route.corporation).size == paths_.size
-
-          raise GameError, 'Route is not connected'
+          super
         end
 
         def compute_stops(route)

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -1101,7 +1101,7 @@ module Engine
           raise NoToken, 'Route must contain token' if !token && !double_header?(route)
         end
 
-        def check_connected(route, token)
+        def check_connected(route, corporation)
           # no need if distance is 2, avoids dealing with double-header route missing a token
           return if route.train.distance == 2
 

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -814,8 +814,8 @@ module Engine
           base_revenue
         end
 
-        def check_connected(route, token)
-          return if route.corporation.type == :city
+        def check_connected(route, corporation)
+          return if corporation.type == :city
 
           super
         end

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1558,25 +1558,7 @@ module Engine
           visits[1..-2].any? { |node| node.city? && custom_blocks?(node, corporation) }
         end
 
-        # change all bankrupt flipped tokens to neutral
-        def flipped_to_neutral
-          @bankrupt_corps.each do |corp|
-            corp.tokens.each do |token|
-              token.type = :neutral if token.status == :flipped
-            end
-          end
-        end
-
-        # change all bankrupt neutral tokens to flipped
-        def neutral_to_flipped
-          @bankrupt_corps.each do |corp|
-            corp.tokens.each do |token|
-              token.type = :normal if token.status == :flipped
-            end
-          end
-        end
-
-        def check_connected(route, token)
+        def check_connected(route, _token)
           visits = route.visited_stops
           blocked = nil
 
@@ -1590,16 +1572,10 @@ module Engine
             end
           end
 
-          paths_ = route.paths.uniq
-          token = blocked if blocked
-
-          flipped_to_neutral
-          if token.select(paths_, corporation: route.corporation).size != paths_.size
-            neutral_to_flipped
+          # no need to check whether cities are tokened out because of the above
+          unless route.ordered_paths.each_cons(2).all? { |pair| pair[0].connects_to?(pair[1], nil) }
             raise GameError, 'Route is not connected'
           end
-
-          neutral_to_flipped
 
           return unless blocked && route.routes.any? { |r| r != route && tokened_out?(r) }
 

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1558,12 +1558,11 @@ module Engine
           visits[1..-2].any? { |node| node.city? && custom_blocks?(node, corporation) }
         end
 
-        def check_connected(route, _token)
+        def check_connected(route, corporation)
           visits = route.visited_stops
           blocked = nil
 
           if visits.size > 2
-            corporation = route.corporation
             visits[1..-2].each do |node|
               next if !node.city? || !custom_blocks?(node, corporation)
               raise GameError, 'Route can only bypass one tokened-out city' if blocked

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1573,9 +1573,7 @@ module Engine
           end
 
           # no need to check whether cities are tokened out because of the above
-          unless route.ordered_paths.each_cons(2).all? { |pair| pair[0].connects_to?(pair[1], nil) }
-            raise GameError, 'Route is not connected'
-          end
+          super(route, nil)
 
           return unless blocked && route.routes.any? { |r| r != route && tokened_out?(r) }
 

--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -664,8 +664,8 @@ module Engine
           national_corporation?(entity) || entity.trains.any? { |t| local_train?(t) } || super
         end
 
-        def check_connected(route, token)
-          return if national_corporation?(route.corporation)
+        def check_connected(route, corporation)
+          return if national_corporation?(corporation)
 
           super
         end

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -1653,7 +1653,7 @@ module Engine
           route.visited_stops
         end
 
-        def check_connected(route, token)
+        def check_connected(route, corporation)
           # special case: don't check on concession route(s)
           con_route = @corporation_info[train_owner(route.train)][:concession_routes].any? do |c_r|
             (route.connection_hexes.flatten & c_r).size == c_r.size

--- a/lib/engine/game/g_1888/step/special_track.rb
+++ b/lib/engine/game/g_1888/step/special_track.rb
@@ -27,37 +27,6 @@ module Engine
 
             tile.rotation.zero?
           end
-
-          # needed to deal with non-plain track connections
-          #
-          def check_connect(_action, ability)
-            return if @game.loading
-            return if ability.type == :teleport
-            return unless ability.connect
-            return if ability.hexes.size < 2
-            return if !ability.start_count || ability.start_count < 2 || ability.start_count == ability.count
-
-            all_paths = ability.laid_hexes.flat_map do |hex_id|
-              @game.hex_by_id(hex_id).tile.paths
-            end.uniq
-
-            visited_hexes = [ability.laid_hexes[0]]
-            new_hexes = [ability.laid_hexes[0]]
-            until new_hexes.empty?
-              added_hexes = []
-              new_hexes.each do |hex_id|
-                new_hex_paths = @game.hex_by_id(hex_id).tile.paths
-                new_hex_paths.each do |path|
-                  walked_hexes = path.select(all_paths).map { |p| p.hex.id }.sort.uniq
-                  added_hexes.concat(walked_hexes - visited_hexes)
-                end
-              end
-              new_hexes = added_hexes.sort.uniq
-              visited_hexes.concat(new_hexes).sort!
-            end
-
-            raise GameError, 'Paths must be connected' if ability.laid_hexes.size != visited_hexes.size
-          end
         end
       end
     end

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -810,7 +810,7 @@ module Engine
           end
         end
 
-        def check_connected(route, token)
+        def check_connected(route, corporation)
           return if route.train.name == 'Convert'
 
           super

--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -347,7 +347,7 @@ module Engine
           super
         end
 
-        def check_connected(route, token)
+        def check_connected(route, corporation)
           return if pullman?(route.train)
 
           super

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -754,7 +754,7 @@ module Engine
           end
 
           # no need to check whether tokened out because of the above
-          return if route.ordered_paths.each_cons(2).all? { |pair| pair[0].connects_to?(pair[1], nil) }
+          super(route, nil)
 
           raise GameError, 'Route is not connected'
         end

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -753,10 +753,8 @@ module Engine
             end
           end
 
-          paths_ = route.paths.uniq
-          token = blocked if blocked
-
-          return if token.select(paths_, corporation: route.corporation).size == paths_.size
+          # no need to check whether tokened out because of the above
+          return if route.ordered_paths.each_cons(2).all? { |pair| pair[0].connects_to?(pair[1], nil) }
 
           raise GameError, 'Route is not connected'
         end

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -737,14 +737,13 @@ module Engine
               (RURAL_TILES & [visits.first.tile.name, visits.last.tile.name]).empty?
         end
 
-        def check_connected(route, token)
+        def check_connected(route, corporation)
           return super unless @round.train_upgrade_assignments[route.train]&.any? { |upgrade| upgrade['id'] == '/' }
 
           visits = route.visited_stops
           blocked = nil
 
           if visits.size > 2
-            corporation = route.corporation
             visits[1..-2].each do |node|
               next if !node.city? || !node.blocks?(corporation)
               raise GameError, 'Route can only bypass one tokened-out city' if blocked

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -748,7 +748,7 @@ module Engine
           raise GameError, 'Route cannot use holes as terminal more than once' if hole_used_twice
         end
 
-        def check_connected(route, _token)
+        def check_connected(route, corporation)
           blocked = nil
           blocked_by = nil
           train_with_sugar = nil
@@ -758,7 +758,6 @@ module Engine
 
             next unless visits.size > 2
 
-            corporation = route.corporation
             visits[1..-2].each do |node|
               next if !node.city? || !node.blocks?(corporation)
               raise GameError, 'Route is not connected' unless route.train.owner.assigned?(wings.id)

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -26,20 +26,9 @@ module Engine
         false
       end
 
-      def select(paths, corporation: nil)
-        on = paths.to_h { |p| [p, 0] }
-
-        walk(on: on, corporation: corporation) do |path|
-          on[path] = 1 if on[path]
-        end
-
-        on.keys.select { |p| on[p] == 1 }
-      end
-
       # Explore the paths and nodes reachable from this node
       #
       # visited: a hashset of visited Nodes
-      # on: see Path::Walk
       # corporation: If set don't walk on adjacent nodes which are blocked for the passed corporation
       # visited_paths: a hashset of visited Paths
       # counter: a hash tracking edges and junctions to avoid reuse
@@ -49,7 +38,6 @@ module Engine
       # This method recursively bubbles up yielded values from nested Node::Walk and Path::Walk calls
       def walk(
         visited: {},
-        on: nil,
         corporation: nil,
         visited_paths: {},
         skip_paths: nil,
@@ -70,7 +58,6 @@ module Engine
             visited: visited_paths,
             skip_paths: skip_paths,
             counter: counter,
-            on: on,
             tile_type: tile_type,
           ) do |path, vp, ct|
             ret = yield path, vp, visited
@@ -84,7 +71,6 @@ module Engine
               next_node.walk(
                 visited: visited,
                 counter: ct,
-                on: on,
                 corporation: corporation,
                 visited_paths: vp,
                 skip_track: skip_track,

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -104,21 +104,28 @@ module Engine
         end
       end
 
-      def select(paths)
-        on = paths.to_h { |p| [p, 0] }
-
-        walk(on: on) do |path|
-          on[path] = 1 if on[path]
+      def connects_to?(other, corporation)
+        [@a, @b].each do |part|
+          if part.edge?
+            edge = part.num
+            if (neighbor = hex.neighbors[edge])
+              np_edge = hex.invert(edge)
+              return true if neighbor == other.hex && other.edges.find { |e| e.num == np_edge }
+            end
+          elsif part.junction?
+            return true if other.junction == part
+          elsif other.nodes.include?(part) && !part.blocks?(corporation)
+            return true
+          end
         end
 
-        on.keys.select { |p| on[p] == 1 }
+        false
       end
 
       # skip: An exit to ignore. Useful to prevent ping-ponging between adjacent hexes.
       # jskip: An junction to ignore. May be useful on complex tiles
       # visited: a hashset of visited Paths. Used to avoid repeating track segments.
       # counter: a hash tracking edges and junctions to avoid reuse
-      # on: A set of Paths mapping to 1 or 0. When `on` is set. Usage is currently limited to `select` in path & node
       # skip_track: If passed, don't walk on track of that type (ie: :broad track for 1873)
       # tile_type: if :lawson don't undo visited paths
       def walk(
@@ -127,7 +134,6 @@ module Engine
         visited: {},
         skip_paths: nil,
         counter: Hash.new(0),
-        on: nil,
         tile_type: :normal,
         skip_track: nil,
         &block
@@ -144,9 +150,7 @@ module Engine
 
         if @junction && @junction != jskip
           @junction.paths.each do |jp|
-            next if on && !on[jp]
-
-            jp.walk(jskip: @junction, visited: visited, counter: counter, on: on, tile_type: tile_type, &block)
+            jp.walk(jskip: @junction, visited: visited, counter: counter, tile_type: tile_type, &block)
           end
         end
 
@@ -160,11 +164,10 @@ module Engine
           np_edge = hex.invert(edge)
 
           neighbor.paths[np_edge].each do |np|
-            next if on && !on[np]
             next unless lane_match?(@exit_lanes[edge], np.exit_lanes[np_edge])
             next if !@ignore_gauge_walk && !tracks_match?(np, dual_ok: true)
 
-            np.walk(skip: np_edge, visited: visited, counter: counter, on: on, skip_track: skip_track,
+            np.walk(skip: np_edge, visited: visited, counter: counter, skip_track: skip_track,
                     tile_type: tile_type, &block)
           end
 

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -110,7 +110,7 @@ module Engine
             edge = part.num
             if (neighbor = hex.neighbors[edge])
               np_edge = hex.invert(edge)
-              return true if neighbor == other.hex && other.edges.find { |e| e.num == np_edge }
+              return true if neighbor == other.hex && other.edges.any? { |e| e.num == np_edge }
             end
           elsif part.junction?
             return true if other.junction == part

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -266,8 +266,8 @@ module Engine
       @game.check_overlap(@routes)
     end
 
-    def check_connected!(token)
-      @check_connected ||= @game.check_connected(self, token) || true
+    def check_connected!
+      @check_connected ||= @game.check_connected(self, corporation) || true
     end
 
     def ordered_paths
@@ -321,7 +321,7 @@ module Engine
           check_cycles!
           check_distance!(visited)
           check_overlap!
-          check_connected!(token)
+          check_connected!
 
           @game.revenue_for(self, stops)
         end


### PR DESCRIPTION
Fixes #6157 

Completely removes Node::select and Path::select methods
Removes "on" parameter from Node::walk and Path::walk
Refactors Step::SpecialTrack to avoid Path::select