### PR TITLE
Added a check disabling pass when selling is required in 1817.

### DIFF
--- a/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
@@ -46,7 +46,9 @@ module Engine
               actions << 'short' if can_short_any?(entity)
               actions << 'bid' if max_bid(entity) >= self.class::MIN_BID
             end
-            actions << 'pass' if (actions.any? || any_corporate_actions?(entity)) && !actions.include?('pass')
+            if (actions.any? || any_corporate_actions?(entity)) && !actions.include?('pass') && !must_sell?(entity)
+              actions << 'pass'
+            end
             actions
           end
 


### PR DESCRIPTION
must_sell? appears to correctly check for possible sales using can_sell_any?
so the IPO share case seems to be covered.

NB: This change will break games where people have illegally passed. The example game in the bug actually has an earlier illegal pass as wel. 

Fixes https://github.com/tobymao/18xx/issues/6842