### PR TITLE
1870: Fixes all the multi-label punches for tile lays

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -799,7 +799,7 @@ module Engine
           return false if to.name == '171K' && from.hex.name != 'B11'
           return false if to.name == '172L' && from.hex.name != 'C18'
           return false if to.name == '63' && (from.hex.name == 'B11' || from.hex.name == 'C18')
-          return true if (from.color == :green && to.name == '170') && (from.hex.name == 'B11' || from.hex.name == 'C18')
+          return %w[B11 C18 N17 J3 J5].include?(from.hex.name) if from.color == :green && to.name == '170'
 
           super
         end

--- a/lib/engine/game/g_1870/step/special_track.rb
+++ b/lib/engine/game/g_1870/step/special_track.rb
@@ -17,8 +17,6 @@ module Engine
             extra_cost = owner == @game.ssw_corporation && home ? -20 : 0
             lay_tile(action, spender: spender, extra_cost: extra_cost)
 
-            action.tile.label = 'P' if action.tile.hex.id == 'C18'
-
             # Record any track laid after the dividend step
             if owner&.corporation? && (operating_info = owner.operating_history[[@game.turn, @round.round_num]])
               operating_info.laid_hexes = @round.laid_hexes

--- a/lib/engine/game/g_1870/step/track.rb
+++ b/lib/engine/game/g_1870/step/track.rb
@@ -22,10 +22,18 @@ module Engine
 
             super
 
-            return unless old_tile.label.to_s == 'P'
-
             old_tile.label = nil if %i[yellow green].include?(old_tile.color)
-            action.tile.label = 'P' if %i[yellow green].include?(action.tile.color)
+            old_tile.label = 'P' if old_tile.id == '170'
+
+            return if action.tile.color == 'gray'
+
+            if action.tile.hex.id == 'B11'
+              action.tile.label = 'K P'
+            elsif action.tile.hex.id == 'C18'
+              action.tile.label = 'P L'
+            elsif %i[J3 J5 N17].include?(action.tile.hex.id)
+              action.tile.label = 'P'
+            end
           end
         end
       end

--- a/lib/engine/game/g_1870/step/track.rb
+++ b/lib/engine/game/g_1870/step/track.rb
@@ -31,7 +31,7 @@ module Engine
               action.tile.label = 'K P'
             elsif action.tile.hex.id == 'C18'
               action.tile.label = 'P L'
-            elsif %i[J3 J5 N17].include?(action.tile.hex.id)
+            elsif %w[J3 J5 N17].include?(action.tile.hex.id)
               action.tile.label = 'P'
             end
           end


### PR DESCRIPTION
This deliberately doesn't use multiple labels because the pointy
weights don't currently render multiple labels for cities like a 14.

Fixes https://github.com/tobymao/18xx/issues/6704