### PR TITLE
Adds an announcement of multi-jumps,

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1056,12 +1056,22 @@ module Engine
         self.class::SOLD_OUT_INCREASE
       end
 
-      def log_share_price(entity, from)
+      def log_share_price(entity, from, steps = nil)
         to = entity.share_price.price
         return unless from != to
 
+        jumps = ''
+        if steps
+          steps = share_jumps(steps)
+          jumps = " (#{steps} steps)" unless steps < 2
+        end
+
         @log << "#{entity.name}'s share price changes from #{format_currency(from)} "\
-                "to #{format_currency(to)}"
+                "to #{format_currency(to)}#{jumps}"
+      end
+
+      def share_jumps(steps)
+        steps
       end
 
       def can_run_route?(entity)

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1392,6 +1392,12 @@ module Engine
           end
         end
 
+        def share_jumps(steps)
+          return steps / 2 if steps > 1
+
+          steps
+        end
+
         def selling_movement?(corporation)
           corporation.operated? && !@no_price_drop_on_sale
         end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1209,6 +1209,12 @@ module Engine
           end
         end
 
+        def share_jumps(steps)
+          return steps / 2 if steps > 1
+
+          steps
+        end
+
         def selling_movement?(corporation)
           corporation.floated? && !@lner
         end

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -155,6 +155,7 @@ module Engine
 
         prev = entity.share_price.price
 
+        right_times = 0
         Array(payout[:share_times]).zip(Array(payout[:share_direction])).each do |share_times, direction|
           share_times.times do
             case direction
@@ -162,6 +163,7 @@ module Engine
               @game.stock_market.move_left(entity)
             when :right
               @game.stock_market.move_right(entity)
+              right_times += 1
             when :up
               @game.stock_market.move_up(entity)
             when :down
@@ -169,7 +171,7 @@ module Engine
             end
           end
         end
-        @game.log_share_price(entity, prev)
+        @game.log_share_price(entity, prev, right_times)
       end
 
       def routes


### PR DESCRIPTION
Ads a specific fix for 1860 and 1862 which have folded flat markets, all other games don't need a fix.

multi-step share price increases now look like this:  IOW's share price changes from £68 to £100 (4 steps)
single steps are unchanged.