### PR TITLE
1862: ignore normal track restrictions when adding a dit to a tile

### DIFF
--- a/lib/engine/game/g_1862/step/track.rb
+++ b/lib/engine/game/g_1862/step/track.rb
@@ -30,6 +30,10 @@ module Engine
             to.color != :yellow || to.label.to_s == 'N'
           end
 
+          def check_track_restrictions!(entity, old_tile, new_tile)
+            super unless @game.adding_town?(old_tile, new_tile)
+          end
+
           def update_tile_lists(tile, old_tile)
             raise GameError, 'tile already laid' unless @game.tiles.include?(tile)
 


### PR DESCRIPTION
Fixes #6976 

No pins needed.