### PR TITLE
Fix earlier rubocop fix

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -61,7 +61,7 @@ module View
                                 "#{@game.format_currency(share_funds_allowed)}.")
           end
 
-          if @game.class :EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN
+          if @game.class::EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN
             children << h(:div, "#{player.name} may not sell more shares than is necessary "\
                                 'to buy the train that is purchased.')
           end


### PR DESCRIPTION
In assets/app/view/game/buy_trains.rb,
the line:
`if @game.class:EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN`
was changed to:
`if @game.class :EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN`
but this needs to be:
`if @game.class::EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN`