### PR TITLE
[18Rhl] should be one fewer 2 train

### DIFF
--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -214,7 +214,7 @@ module Engine
         def num_trains(train)
           return train[:num] unless train[:name] == '2'
 
-          optional_2_train ? 8 : 7
+          optional_2_train ? 7 : 6
         end
 
         def optional_2_train

--- a/lib/engine/game/g_18_rhl/meta.rb
+++ b/lib/engine/game/g_18_rhl/meta.rb
@@ -22,7 +22,7 @@ module Engine
           {
             sym: :optional_2_train,
             short_name: 'Optional 2-Train',
-            desc: 'Add an 8th 2-train',
+            desc: 'Add a 7th 2-train',
           },
           {
             sym: :lower_starting_capital,


### PR DESCRIPTION
closes #6993

without optional 2train added:
![image](https://user-images.githubusercontent.com/1711810/152693139-2c9f8bf2-dba9-418c-ab3c-1554d0344539.png)
