### PR TITLE
[18Rhl] 6 trains should be available on 5 train

### DIFF
--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -186,7 +186,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             num: 6,
             price: 600,
-            available_on: '3',
+            available_on: '5',
           },
           {
             name: '8',


### PR DESCRIPTION
fixes #6999

![image](https://user-images.githubusercontent.com/1711810/152695614-3c0de521-5b3a-44e8-91ed-3a6501a88614.png)
