### PR TITLE
18EU Hamburg is Neutral

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -79,6 +79,20 @@ module Engine
 
           @minor_exchange = nil
           @corporations_operated = []
+
+          # Place neutral tokens in the off board cities
+          neutral = Corporation.new(
+            sym: 'N',
+            name: 'Neutral',
+            logo: 'open_city',
+            simple_logo: 'open_city.alt',
+            tokens: [0, 0],
+          )
+          neutral.owner = @bank
+
+          neutral.tokens.each { |token| token.type = :neutral }
+
+          city_by_id('G2-0-0').place_token(neutral, neutral.next_token)
         end
 
         # this could be a useful function in depot itself

--- a/lib/engine/game/g_18_eu/map.rb
+++ b/lib/engine/game/g_18_eu/map.rb
@@ -70,7 +70,7 @@ module Engine
             ['N5'] => 'offboard=revenue:yellow_20|brown_30;path=a:1,b:_0',
             ['A6'] => 'offboard=revenue:yellow_40|brown_70;path=a:0,b:_0;path=a:5,b:_0',
             ['G2'] =>
-                   'offboard=revenue:yellow_30|brown_50;path=a:1,b:_0;path=a:_0,b:5;'\
+                   'city=revenue:yellow_30|brown_50,loc:2;path=a:1,b:_0;path=a:_0,b:5;'\
                    'path=a:0,b:_0;path=a:_0,b:5;path=a:0,b:_0;path=a:_0,b:1',
             ['G22'] =>
                    'offboard=revenue:yellow_30|brown_50;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',


### PR DESCRIPTION
Found that the tile in the config was set to terminal. It should be an open city.

<img width="119" alt="Screen Shot 2022-02-06 at 2 40 33 PM" src="https://user-images.githubusercontent.com/15675400/152702495-4aff0e1b-e69b-46fe-9adc-bff2b7a95edb.png">


I've updated it with an implementation like 18GA.

Unfortunately, placing the city centered causes the name/values to overlap.

<img width="137" alt="Screen Shot 2022-02-06 at 2 37 24 PM" src="https://user-images.githubusercontent.com/15675400/152702402-f5a39547-fbd1-4081-995c-b88ac15ec333.png">
