### PR TITLE
18EU Final Exchange

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -18,7 +18,7 @@ module Engine
         include G18EU::Trains
         include CitiesPlusTownsRouteDistanceStr
 
-        attr_accessor :corporations_operated
+        attr_accessor :corporations_operated, :minor_exchange, :minor_exchange_priority
 
         EBUY_OTHER_VALUE = true # allow ebuying other corp trains for up to face
         EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = true # if ebuying from depot, must buy cheapest train
@@ -94,7 +94,7 @@ module Engine
         end
 
         def init_round
-          Round::Auction.new(self, [G18EU::Step::ModifiedDutchAuction])
+          Engine::Round::Auction.new(self, [G18EU::Step::ModifiedDutchAuction])
         end
 
         def exchange_for_partial_presidency?
@@ -102,7 +102,7 @@ module Engine
         end
 
         def operating_round(round_num)
-          Round::Operating.new(self, [
+          Engine::Round::Operating.new(self, [
             G18EU::Step::Bankrupt,
             G18EU::Step::Track,
             Engine::Step::Token,
@@ -116,7 +116,7 @@ module Engine
         end
 
         def stock_round
-          Round::Stock.new(self, [
+          Engine::Round::Stock.new(self, [
             Engine::Step::DiscardTrain,
             G18EU::Step::HomeToken,
             G18EU::Step::ReplaceToken,
@@ -125,9 +125,11 @@ module Engine
         end
 
         def new_minor_exchange_round
-          # TODO: Implement Minor Exchange Round
-          @minor_exchange = :done
-          new_stock_round
+          @log << '-- Minor Company Final Exchange --'
+          G18EU::Round::FinalExchange.new(self, [
+            G18EU::Step::ReplaceToken,
+            G18EU::Step::FinalExchange,
+          ])
         end
 
         # I don't like duplicating all of this just to add the minor exchange round, but
@@ -135,11 +137,13 @@ module Engine
         def next_round!
           @round =
             case @round
-            when Round::Stock
+            when G18EU::Round::FinalExchange
+              new_stock_round
+            when Engine::Round::Stock
               @operating_rounds = @phase.operating_rounds
               reorder_players
               new_operating_round
-            when Round::Operating
+            when Engine::Round::Operating
               if @round.round_num < @operating_rounds
                 or_round_finished
                 new_operating_round(@round.round_num + 1)
@@ -183,6 +187,7 @@ module Engine
           @log << '-- Event: Minor Exchange occurs before next Stock Round --'
 
           @minor_exchange = :triggered
+          @minor_exchange_priority = @round.current_operator.owner
         end
 
         def player_card_minors(player)
@@ -309,15 +314,17 @@ module Engine
         def exchange_corporations(exchange_ability)
           return super if !exchange_ability.owner.minor? || @loading
 
-          parts = graph.connected_nodes(exchange_ability.owner).keys
-          connected = parts.select(&:city?).flat_map { |c| c.tokens.compact.map(&:corporation) }
+          minor_tile = exchange_ability&.owner&.tokens&.first&.city&.tile
+          return [] unless minor_tile
 
-          minor_tile = exchange_ability.owner.tokens.first.city.tile
+          parts = graph.connected_nodes(exchange_ability.owner).keys
+          connected = parts.select(&:city?).flat_map { |city| city.tokens.compact.map(&:corporation) }
+
           colocated = corporations.select do |c|
             c.tokens.any? { |t| t.city&.tile == minor_tile }
           end
 
-          (connected + colocated).uniq
+          (connected + colocated).uniq.reject(&:minor?)
         end
 
         def after_par(corporation)
@@ -398,6 +405,19 @@ module Engine
 
         def can_go_bankrupt?(player, corporation)
           total_emr_buying_power(player, corporation) < min_depot_price(corporation)
+        end
+
+        def maybe_remove_duplicate_token!(tile)
+          tile.cities.each do |city|
+            prev = nil
+            city.tokens.compact.sort_by { |t| t.corporation.name }.each do |token|
+              if prev&.corporation == token.corporation
+                prev.remove!
+                @log << "#{token.corporation.name} redundant token removed from #{tile.hex.name}"
+              end
+              prev = token
+            end
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_eu/round/final_exchange.rb
+++ b/lib/engine/game/g_18_eu/round/final_exchange.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/stock'
+
+module Engine
+  module Game
+    module G18EU
+      module Round
+        class FinalExchange < Engine::Round::Stock
+          def initialize(game, steps, **opts)
+            super
+
+            @entity_index = @game.players.index(@game.minor_exchange_priority)
+            @game.minor_exchange = :in_progress
+          end
+
+          def self.short_name
+            'FER'
+          end
+
+          def name
+            'Minor Company Final Exchange Round'
+          end
+
+          def setup
+            start_entity
+          end
+
+          def select_entities
+            @game.players.reject(&:bankrupt)
+          end
+
+          def finished?
+            super || @game.minors.empty? || @game.minor_exchange == :done
+          end
+
+          private
+
+          def finish_round
+            @game.minor_exchange = :done
+            @entity_index = 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_eu/step/final_exchange.rb
+++ b/lib/engine/game/g_18_eu/step/final_exchange.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative 'minor_exchange'
+
+module Engine
+  module Game
+    module G18EU
+      module Step
+        class FinalExchange < Engine::Step::Base
+          include MinorExchange
+
+          def actions(entity)
+            return [] unless @round.players_history[entity].empty?
+
+            actions = []
+            actions << 'pass' if can_pass?(entity)
+            actions << 'buy_shares' if can_merge?(entity)
+
+            actions
+          end
+
+          def description
+            'Exchange Connected Minors for a Share'
+          end
+
+          def log_pass(entity)
+            @log << "#{entity.name} passes"
+          end
+
+          def log_skip(entity)
+            @log << "#{entity.name} has no valid actions and passes"
+          end
+
+          def pass_description
+            'Discard Minor(s)'
+          end
+
+          def round_state
+            {
+              pending_acquisition: nil,
+              players_history: Hash.new { |h2, k2| h2[k2] = [] },
+            }
+          end
+
+          def setup
+            @round.players_history[current_entity].clear
+          end
+
+          def process_buy_shares(action)
+            entity = action.entity
+            exchange_minor(entity, action.bundle)
+            @round.players_history[entity.player] << action
+          end
+
+          def process_pass(_action)
+            @game.minors.dup.each do |minor|
+              next unless minor&.owner == current_entity
+
+              merge_minor!(minor, nil, @game.bank)
+            end
+
+            super
+          end
+
+          def exchange_minor(minor, bundle)
+            corporation = bundle.corporation
+            source = bundle.owner
+            unless can_gain?(minor.owner, bundle, exchange: true)
+              raise GameError, "#{minor.name} cannot be exchanged for #{corporation.name}"
+            end
+
+            exchange_share(minor, corporation, source)
+            merge_minor!(minor, corporation, source)
+          end
+
+          def can_merge?(entity)
+            entity.minor? || @game.owns_any_minor?(entity)
+          end
+
+          def can_pass?(entity)
+            owned = @game.minors.select { |minor| minor.owner == entity }
+            return false if owned.empty?
+
+            owned.all? { |minor| can_discard?(minor) }
+          end
+
+          def can_discard?(minor)
+            ability = @game.abilities(minor, :exchange)
+            connected = @game.exchange_corporations(ability)
+            return true if connected.empty?
+
+            connected.any? { |c| !exchange?(c) }
+          end
+
+          def exchange?(corporation)
+            corporation.available_share || @game.share_pool.shares_by_corporation[corporation]&.first
+          end
+
+          def can_gain?(_entity, bundle, exchange: false)
+            return false unless exchange
+
+            bundle.corporation.ipoed
+          end
+
+          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true)
+            raise GameError, "Cannot buy a share of #{shares&.corporation&.name}" unless exchange
+
+            @game.share_pool.buy_shares(entity,
+                                        shares,
+                                        exchange: exchange,
+                                        swap: swap,
+                                        allow_president_change: allow_president_change)
+          end
+
+          def can_buy?(_entity, _bundle)
+            false
+          end
+
+          def can_buy_multiple?(_entity, _corporation, _owner)
+            false
+          end
+
+          def can_sell_any?(_entity)
+            false
+          end
+
+          def can_ipo_any?(_entity)
+            false
+          end
+
+          def purchasable_companies(_entity)
+            []
+          end
+
+          def ipo_type(_entity)
+            :par
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_eu/step/minor_exchange.rb
+++ b/lib/engine/game/g_18_eu/step/minor_exchange.rb
@@ -24,12 +24,15 @@ module Engine
         end
 
         def maybe_remove_token(minor, corporation)
+          return unless corporation
           return minor.tokens.first.remove! unless corporation.tokens.first&.used
 
           @round.pending_acquisition = { minor: minor, corporation: corporation }
         end
 
         def exchange_share(minor, corporation, source)
+          return unless corporation
+
           @game.log << "#{minor.owner.name} exchanges #{minor.name} for a "\
                        "10% share of #{corporation.name}"
 

--- a/lib/engine/game/g_18_eu/step/replace_token.rb
+++ b/lib/engine/game/g_18_eu/step/replace_token.rb
@@ -30,6 +30,8 @@ module Engine
           end
 
           def active_entities
+            return [] unless pending_acquisition
+
             [pending_corporation.owner]
           end
 
@@ -87,6 +89,7 @@ module Engine
             action.city.exchange_token(new_token)
 
             @game.log << "#{pending_corporation.name} replaces #{pending_minor.name} token on #{action.city.hex.name}"
+            @game.maybe_remove_duplicate_token!(action.city.tile)
 
             close!(pending_minor)
           end

--- a/lib/engine/game/g_18_eu/step/track.rb
+++ b/lib/engine/game/g_18_eu/step/track.rb
@@ -21,16 +21,7 @@ module Engine
 
             return if old_tile.cities.size == 1 || tile.color != :brown
 
-            tile.cities.each do |city|
-              prev = nil
-              city.tokens.compact.sort_by { |t| t.corporation.name }.each do |token|
-                if prev&.corporation == token.corporation
-                  prev.remove!
-                  @game.log << "#{token.corporation.name} redundant token removed from #{tile.hex.name}"
-                end
-                prev = token
-              end
-            end
+            @game.maybe_remove_duplicate_token!(tile)
           end
         end
       end


### PR DESCRIPTION
From: https://github.com/tobymao/18xx/issues/792

Occurs once per game immediately before the first SR after Phase 5

Begins with the president that bought the train that started Phase 5, then round the table, PD doesn’t move

On their turn, player choose minor to dispose, If connected (or colocated) must merge, including merging into a corporation with no stock available, which is the same result as discarding

Pres decides to accept or decline token. It is allowed to have stations in same hex, but not the same city.

May go over 60% but then must sell at first selling opportunity

These mergers may cause a corp to float (uncommon), and then it is capitalized as in post-phase 5 floatation.

---

General view
<img width="631" alt="Screen Shot 2022-02-06 at 2 47 40 PM" src="https://user-images.githubusercontent.com/15675400/152702735-7057ddbe-4d92-4d7f-94c4-02ebc01c8650.png">

Going over 60%, selling down in SR
<img width="1055" alt="Screen Shot 2022-02-06 at 2 23 13 PM" src="https://user-images.githubusercontent.com/15675400/152702742-95754ea5-6bae-4350-b47e-d9a45f3de8e0.png">

