### PR TITLE
1849: treat double share atomically for EMR legality (fixes #5163)

### DIFF
--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -23,9 +23,11 @@ module Engine
       end
 
       def selling_minimum_shares?(bundle)
+        # True if next smaller bundle is insufficient
         seller = bundle.owner
-        total_cash = bundle.price + available_cash(seller)
-        total_cash < needed_cash(seller) + bundle.price_per_share
+        additional_cash_needed = needed_cash(seller) - available_cash(seller)
+        next_smaller_bundle_price = bundle.price - bundle.shares.map(&:price).min
+        next_smaller_bundle_price < additional_cash_needed
       end
 
       def sellable_bundle?(bundle)


### PR DESCRIPTION
I also refactored the math to make it more clear what the method is really checking, but the change in logic is effectively just replacing `bundle.price_per_share` to `bundle.shares.map(&:price).min`.