### PR TITLE
Simplify receivership and trainless-company-shares behaviour to make it easier to use in multiple games

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2195,7 +2195,7 @@ module Engine
       end
 
       def init_share_pool
-        SharePool.new(self)
+        SharePool.new(self, allow_president_sale: self.class::PRESIDENT_SALES_TO_MARKET)
       end
 
       def connect_hexes

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -949,6 +949,8 @@ module Engine
       end
 
       def value_for_dumpable(player, corporation)
+        return value_for_sellable(player, corporation) if self.class::PRESIDENT_SALES_TO_MARKET
+
         max_bundle = bundles_for_corporation(player, corporation)
           .select { |bundle| bundle.can_dump?(player) && @share_pool&.fit_in_bank?(bundle) }
           .max_by(&:price)

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -584,10 +584,6 @@ module Engine
           certs_by_options[players.size]
         end
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
-        end
-
         def setup
           @log << "Bank starts with #{format_currency(bank_by_options)}"
 

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -900,10 +900,6 @@ module Engine
           Bank.new(20_000, log: @log, check: false)
         end
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
-        end
-
         def option_23p_map?
           @optional_rules&.include?(:two_player_map) || @optional_rules&.include?(:original_game)
         end

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1082,6 +1082,13 @@ module Engine
           @corporations.select { |c| c.floated? && !nationalized?(c) }.sort
         end
 
+        def liquidity(player)
+          without_companies = super
+          return without_companies unless turn > 1
+
+          without_companies + player.companies.sum { |c| c.value - COMPANY_SALE_FEE }
+        end
+
         def place_home_token(corporation)
           # will this break the game?
           return if sr_after_southern

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -2,6 +2,7 @@
 
 require_relative 'meta'
 require_relative '../base'
+require_relative '../trainless_shares_half_value'
 require_relative '../../distance_graph'
 
 module Engine
@@ -9,6 +10,7 @@ module Engine
     module G1860
       class Game < Game::Base
         include_meta(G1860::Meta)
+        include TrainlessSharesHalfValue
 
         attr_reader :nationalization, :sr_after_southern, :distance_graph
 
@@ -1076,22 +1078,6 @@ module Engine
           @bank.break! if !@nationalization && bank_cash.negative?
         end
 
-        def player_value(player)
-          player.cash +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.any? }.sum(&:price) +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.none? }
-            .sum { |s| (s.price / 2).to_i } + player.companies.sum(&:value)
-        end
-
-        def liquidity(player)
-          company_value = turn > 1 ? player.companies.sum { |c| c.value - COMPANY_SALE_FEE } : 0
-
-          player.cash +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.any? }.sum(&:price) +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.none? }
-            .sum { |s| (s.price / 2).to_i } + company_value
-        end
-
         def operating_order
           @corporations.select { |c| c.floated? && !nationalized?(c) }.sort
         end
@@ -1364,28 +1350,6 @@ module Engine
 
         def corporation_available?(entity)
           entity.corporation? && can_ipo?(entity)
-        end
-
-        def bundles_for_corporation(share_holder, corporation, shares: nil)
-          return [] unless corporation.ipoed
-
-          shares = (shares || share_holder.shares_of(corporation)).sort_by(&:price)
-
-          shares.flat_map.with_index do |share, index|
-            bundle = shares.take(index + 1)
-            percent = bundle.sum(&:percent)
-            bundles = [Engine::ShareBundle.new(bundle, percent)]
-            if share.president
-              normal_percent = corporation.share_percent
-              difference = corporation.presidents_percent - normal_percent
-              num_partial_bundles = difference / normal_percent
-              (1..num_partial_bundles).each do |n|
-                bundles.insert(0, Engine::ShareBundle.new(bundle, percent - (normal_percent * n)))
-              end
-            end
-            bundles.each { |b| b.share_price = (b.price_per_share / 2).to_i if corporation.trains.empty? }
-            bundles
-          end
         end
 
         def selling_movement?(corporation)

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -524,10 +524,6 @@ module Engine
           @max_tokens ||= @optional_rules&.include?(:eight_tokens) ? OPTIONAL_TOKENS : NORM_TOKENS
         end
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
-        end
-
         def init_companies(players)
           clist = super
 

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -326,10 +326,6 @@ module Engine
           end
         end
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: self.class::PRESIDENT_SALES_TO_MARKET)
-        end
-
         def setup
           @saved_tiles = @tiles.dup
 

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -255,10 +255,6 @@ module Engine
           },
         ].freeze
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
-        end
-
         def init_scenario(optional_rules)
           num_players = @players.size
           two_east_west = optional_rules.include?(:two_player_ew)

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -2,6 +2,7 @@
 
 require_relative '../base'
 require_relative '../cities_plus_towns_route_distance_str'
+require_relative '../trainless_shares_half_value'
 require_relative 'meta'
 require_relative 'entities'
 require_relative 'map'
@@ -16,6 +17,7 @@ module Engine
         include Entities
         include Map
         include Scenarios
+        include TrainlessSharesHalfValue
 
         GAME_END_CHECK = { final_train: :current_or, stock_market: :current_or }.freeze
 
@@ -431,41 +433,6 @@ module Engine
 
         def after_par(corporation)
           @lnwr_ipoed = true if corporation.id == 'LNWR'
-        end
-
-        def bundles_for_corporation(share_holder, corporation, shares: nil)
-          return [] unless corporation.ipoed
-
-          shares = (shares || share_holder.shares_of(corporation)).sort_by(&:price)
-
-          shares.flat_map.with_index do |share, index|
-            bundle = shares.take(index + 1)
-            percent = bundle.sum(&:percent)
-            bundles = [Engine::ShareBundle.new(bundle, percent)]
-            if share.president
-              normal_percent = corporation.share_percent
-              difference = corporation.presidents_percent - normal_percent
-              num_partial_bundles = difference / normal_percent
-              (1..num_partial_bundles).each do |n|
-                bundles.insert(0, Engine::ShareBundle.new(bundle, percent - (normal_percent * n)))
-              end
-            end
-            bundles.each { |b| b.share_price = (b.price_per_share / 2).to_i if corporation.trains.empty? }
-            bundles
-          end
-        end
-
-        def player_shares_value(player)
-          trainless_shares, train_shares = player.shares.partition { |s| s.corporation.trains.empty? }
-          train_shares.sum(&:price) + trainless_shares.sum { |s| (s.price / 2).to_i }
-        end
-
-        def player_value(player)
-          player.cash + player_shares_value(player) + player.companies.sum(&:value)
-        end
-
-        def liquidity(player)
-          player.cash + player_shares_value(player)
         end
 
         def float_corporation(corporation)

--- a/lib/engine/game/trainless_shares_half_value.rb
+++ b/lib/engine/game/trainless_shares_half_value.rb
@@ -26,16 +26,8 @@ module TrainlessSharesHalfValue
     end
   end
 
-  def player_shares_value(player)
-    trainless_shares, train_shares = player.shares.partition { |s| s.corporation.trains.empty? }
-    train_shares.sum(&:price) + trainless_shares.sum { |s| (s.price / 2).to_i }
-  end
-
   def player_value(player)
-    player.cash + player_shares_value(player) + player.companies.sum(&:value)
-  end
-
-  def liquidity(player)
-    player.cash + player_shares_value(player)
+    trainless_shares, train_shares = player.shares.partition { |s| s.corporation.trains.empty? }
+    player.cash + train_shares.sum(&:price) + trainless_shares.sum { |s| (s.price / 2).to_i } + player.companies.sum(&:value)
   end
 end

--- a/lib/engine/game/trainless_shares_half_value.rb
+++ b/lib/engine/game/trainless_shares_half_value.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#
+# This module makes the shares of companies without a train worth half the usual value
+#
+module TrainlessSharesHalfValue
+  def bundles_for_corporation(share_holder, corporation, shares: nil)
+    return [] unless corporation.ipoed
+
+    shares = (shares || share_holder.shares_of(corporation)).sort_by(&:price)
+
+    shares.flat_map.with_index do |share, index|
+      bundle = shares.take(index + 1)
+      percent = bundle.sum(&:percent)
+      bundles = [Engine::ShareBundle.new(bundle, percent)]
+      if share.president
+        normal_percent = corporation.share_percent
+        difference = corporation.presidents_percent - normal_percent
+        num_partial_bundles = difference / normal_percent
+        (1..num_partial_bundles).each do |n|
+          bundles.insert(0, Engine::ShareBundle.new(bundle, percent - (normal_percent * n)))
+        end
+      end
+      bundles.each { |b| b.share_price = (b.price_per_share / 2).to_i if corporation.trains.empty? }
+      bundles
+    end
+  end
+
+  def player_shares_value(player)
+    trainless_shares, train_shares = player.shares.partition { |s| s.corporation.trains.empty? }
+    train_shares.sum(&:price) + trainless_shares.sum { |s| (s.price / 2).to_i }
+  end
+
+  def player_value(player)
+    player.cash + player_shares_value(player) + player.companies.sum(&:value)
+  end
+
+  def liquidity(player)
+    player.cash + player_shares_value(player)
+  end
+end


### PR DESCRIPTION
- Make the base game's `init_share_pool` method use the `PRESIDENT_SALES_TO_MARKET` constant - therefore games no longer need to override both the constant and the method to enable presidencies to be sellable
- Move the shared behaviour of trainless corporation shares being worth 50% in 1860, 1862, and 18GB into a single module for improved maintainabillity