### PR TITLE
18EU Fix Merging during Loading

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -326,7 +326,8 @@ module Engine
         end
 
         def exchange_corporations(exchange_ability)
-          return super if !exchange_ability.owner.minor? || @loading
+          return corporations if @loading
+          return super unless exchange_ability.owner.minor?
 
           minor_tile = exchange_ability&.owner&.tokens&.first&.city&.tile
           return [] unless minor_tile

--- a/lib/engine/game/g_18_eu/step/final_exchange.rb
+++ b/lib/engine/game/g_18_eu/step/final_exchange.rb
@@ -11,6 +11,7 @@ module Engine
           include MinorExchange
 
           def actions(entity)
+            return [] if entity.corporation?
             return [] unless @round.players_history[entity].empty?
 
             actions = []
@@ -86,6 +87,8 @@ module Engine
           end
 
           def can_discard?(minor)
+            return true if @game.loading
+
             ability = @game.abilities(minor, :exchange)
             connected = @game.exchange_corporations(ability)
             return true if connected.empty?


### PR DESCRIPTION
Fix https://github.com/tobymao/18xx/issues/7021

Connected minors are detected using pathing, which we avoid during loading. Instead of assuming no connected, we can safely assume the action was valid during original submission.