### PR TITLE
Simplify receivership and trainless corporation shares behaviour

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -949,6 +949,8 @@ module Engine
       end
 
       def value_for_dumpable(player, corporation)
+        return value_for_sellable(player, corporation) if self.class::PRESIDENT_SALES_TO_MARKET
+
         max_bundle = bundles_for_corporation(player, corporation)
           .select { |bundle| bundle.can_dump?(player) && @share_pool&.fit_in_bank?(bundle) }
           .max_by(&:price)
@@ -2195,7 +2197,7 @@ module Engine
       end
 
       def init_share_pool
-        SharePool.new(self)
+        SharePool.new(self, allow_president_sale: self.class::PRESIDENT_SALES_TO_MARKET)
       end
 
       def connect_hexes

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -584,10 +584,6 @@ module Engine
           certs_by_options[players.size]
         end
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
-        end
-
         def setup
           @log << "Bank starts with #{format_currency(bank_by_options)}"
 

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -2,6 +2,7 @@
 
 require_relative 'meta'
 require_relative '../base'
+require_relative '../trainless_shares_half_value'
 require_relative '../../distance_graph'
 
 module Engine
@@ -9,6 +10,7 @@ module Engine
     module G1860
       class Game < Game::Base
         include_meta(G1860::Meta)
+        include TrainlessSharesHalfValue
 
         attr_reader :nationalization, :sr_after_southern, :distance_graph
 
@@ -900,10 +902,6 @@ module Engine
           Bank.new(20_000, log: @log, check: false)
         end
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
-        end
-
         def option_23p_map?
           @optional_rules&.include?(:two_player_map) || @optional_rules&.include?(:original_game)
         end
@@ -1080,20 +1078,11 @@ module Engine
           @bank.break! if !@nationalization && bank_cash.negative?
         end
 
-        def player_value(player)
-          player.cash +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.any? }.sum(&:price) +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.none? }
-            .sum { |s| (s.price / 2).to_i } + player.companies.sum(&:value)
-        end
-
         def liquidity(player)
-          company_value = turn > 1 ? player.companies.sum { |c| c.value - COMPANY_SALE_FEE } : 0
+          without_companies = super
+          return without_companies unless turn > 1
 
-          player.cash +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.any? }.sum(&:price) +
-            player.shares.select { |s| s.corporation.ipoed & s.corporation.trains.none? }
-            .sum { |s| (s.price / 2).to_i } + company_value
+          without_companies + player.companies.sum { |c| c.value - COMPANY_SALE_FEE }
         end
 
         def operating_order
@@ -1368,28 +1357,6 @@ module Engine
 
         def corporation_available?(entity)
           entity.corporation? && can_ipo?(entity)
-        end
-
-        def bundles_for_corporation(share_holder, corporation, shares: nil)
-          return [] unless corporation.ipoed
-
-          shares = (shares || share_holder.shares_of(corporation)).sort_by(&:price)
-
-          shares.flat_map.with_index do |share, index|
-            bundle = shares.take(index + 1)
-            percent = bundle.sum(&:percent)
-            bundles = [Engine::ShareBundle.new(bundle, percent)]
-            if share.president
-              normal_percent = corporation.share_percent
-              difference = corporation.presidents_percent - normal_percent
-              num_partial_bundles = difference / normal_percent
-              (1..num_partial_bundles).each do |n|
-                bundles.insert(0, Engine::ShareBundle.new(bundle, percent - (normal_percent * n)))
-              end
-            end
-            bundles.each { |b| b.share_price = (b.price_per_share / 2).to_i if corporation.trains.empty? }
-            bundles
-          end
         end
 
         def selling_movement?(corporation)

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -2,6 +2,7 @@
 
 require_relative 'meta'
 require_relative '../base'
+require_relative '../trainless_shares_half_value'
 require_relative 'entities'
 require_relative 'map'
 require_relative 'round/parliament'
@@ -28,6 +29,7 @@ module Engine
         include_meta(G1862::Meta)
         include Entities
         include Map
+        include TrainlessSharesHalfValue
 
         attr_accessor :chartered, :base_tiles, :deferred_rust, :skip_round, :permits, :lner, :london_nodes
 
@@ -420,6 +422,7 @@ module Engine
         HOME_TOKEN_TIMING = :operate
         SELL_AFTER = :any_time
         SELL_BUY_ORDER = :sell_buy
+        PRESIDENT_SALES_TO_MARKET = true
         MARKET_SHARE_LIMIT = 100
         CERT_LIMIT_INCLUDES_PRIVATES = false
 
@@ -522,10 +525,6 @@ module Engine
 
         def max_tokens
           @max_tokens ||= @optional_rules&.include?(:eight_tokens) ? OPTIONAL_TOKENS : NORM_TOKENS
-        end
-
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
         end
 
         def init_companies(players)
@@ -1185,28 +1184,6 @@ module Engine
           return [] if shares.empty?
 
           [Engine::ShareBundle.new(shares)]
-        end
-
-        def bundles_for_corporation(share_holder, corporation, shares: nil)
-          return [] unless corporation.ipoed
-
-          shares = (shares || share_holder.shares_of(corporation)).sort_by(&:price)
-
-          shares.flat_map.with_index do |share, index|
-            bundle_shares = shares.take(index + 1)
-            percent = bundle_shares.sum(&:percent)
-            bundles = [Engine::ShareBundle.new(bundle_shares, percent)]
-            if share.president
-              normal_percent = corporation.share_percent
-              difference = corporation.presidents_percent - normal_percent
-              num_partial_bundles = difference / normal_percent
-              (1..num_partial_bundles).each do |n|
-                bundles.insert(0, Engine::ShareBundle.new(bundle_shares, percent - (normal_percent * n)))
-              end
-            end
-            bundles.each { |b| b.share_price = (b.price_per_share / 2).to_i if corporation.trains.empty? }
-            bundles
-          end
         end
 
         def selling_movement?(corporation)
@@ -2369,15 +2346,6 @@ module Engine
 
         def separate_treasury?
           true
-        end
-
-        def player_value(player)
-          halfprice_shares, reg_shares = player.shares.partition { |s| s.corporation.trains.empty? }
-          player.cash + reg_shares.sum(&:price) + halfprice_shares.sum { |s| (s.price / 2).to_i }
-        end
-
-        def liquidity(player)
-          player_value(player)
         end
 
         def decorate_marker(icon)

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -326,10 +326,6 @@ module Engine
           end
         end
 
-        def init_share_pool
-          SharePool.new(self, allow_president_sale: self.class::PRESIDENT_SALES_TO_MARKET)
-        end
-
         def setup
           @saved_tiles = @tiles.dup
 

--- a/lib/engine/game/trainless_shares_half_value.rb
+++ b/lib/engine/game/trainless_shares_half_value.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#
+# This module makes the shares of companies without a train worth half the usual value
+#
+module TrainlessSharesHalfValue
+  def bundles_for_corporation(share_holder, corporation, shares: nil)
+    return [] unless corporation.ipoed
+
+    shares = (shares || share_holder.shares_of(corporation)).sort_by(&:price)
+
+    shares.flat_map.with_index do |share, index|
+      bundle = shares.take(index + 1)
+      percent = bundle.sum(&:percent)
+      bundles = [Engine::ShareBundle.new(bundle, percent)]
+      if share.president
+        normal_percent = corporation.share_percent
+        difference = corporation.presidents_percent - normal_percent
+        num_partial_bundles = difference / normal_percent
+        (1..num_partial_bundles).each do |n|
+          bundles.insert(0, Engine::ShareBundle.new(bundle, percent - (normal_percent * n)))
+        end
+      end
+      bundles.each { |b| b.share_price = (b.price_per_share / 2).to_i if corporation.trains.empty? }
+      bundles
+    end
+  end
+
+  def player_value(player)
+    trainless_shares, train_shares = player.shares.partition { |s| s.corporation.trains.empty? }
+    player.cash + train_shares.sum(&:price) + trainless_shares.sum { |s| (s.price / 2).to_i } + player.companies.sum(&:value)
+  end
+end

--- a/spec/fixtures/1862/46925.json
+++ b/spec/fixtures/1862/46925.json
@@ -1,0 +1,10844 @@
+{
+    "id": 46925,
+    "description": "",
+    "user": {
+        "id": 665,
+        "name": "Krzysztof"
+    },
+    "players": [
+        {
+            "id": 7378,
+            "name": "gregos"
+        },
+        {
+            "id": 1864,
+            "name": "Galatolol"
+        },
+        {
+            "id": 665,
+            "name": "Krzysztof"
+        }
+    ],
+    "max_players": 4,
+    "title": "1862",
+    "settings": {
+        "seed": 1185551085,
+        "unlisted": true,
+        "auto_routing": false,
+        "player_order": null,
+        "optional_rules": []
+    },
+    "user_settings": null,
+    "status": "finished",
+    "turn": 6,
+    "round": "Operating Round",
+    "acting": [
+        7378,
+        1864,
+        665
+    ],
+    "result": {
+        "gregos": 14907,
+        "Galatolol": 17395,
+        "Krzysztof": 15159
+    },
+    "actions": [
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 1,
+            "created_at": 1624192654,
+            "corporation": "EUR",
+            "price": 0
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 2,
+            "created_at": 1624192672,
+            "corporation": "EUR",
+            "price": 5
+        },
+        {
+            "type": "bid",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 3,
+            "created_at": 1624192678,
+            "corporation": "EUR",
+            "price": 10
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 4,
+            "created_at": 1624192688,
+            "corporation": "EUR",
+            "price": 15
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 5,
+            "created_at": 1624192694,
+            "corporation": "EUR",
+            "price": 20
+        },
+        {
+            "type": "bid",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 6,
+            "created_at": 1624192699,
+            "corporation": "EUR",
+            "price": 25
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 7,
+            "created_at": 1624192702,
+            "corporation": "EUR",
+            "price": 30
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 8,
+            "created_at": 1624192704
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 9,
+            "created_at": 1624192733
+        },
+        {
+            "type": "par",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 10,
+            "created_at": 1624192763,
+            "corporation": "EUR",
+            "share_price": "62,0,16"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 11,
+            "created_at": 1624192765,
+            "shares": [
+                "EUR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 12,
+            "created_at": 1624192766,
+            "shares": [
+                "EUR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 13,
+            "created_at": 1624192848,
+            "corporation": "ECR",
+            "price": 5
+        },
+        {
+            "type": "bid",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 14,
+            "created_at": 1624192856,
+            "corporation": "ECR",
+            "price": 10
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 15,
+            "created_at": 1624192866
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 16,
+            "created_at": 1624192870,
+            "corporation": "ECR",
+            "price": 15
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 17,
+            "created_at": 1624192875
+        },
+        {
+            "type": "par",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 18,
+            "created_at": 1624192959,
+            "corporation": "ECR",
+            "share_price": "68,0,18"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 19,
+            "created_at": 1624192971,
+            "shares": [
+                "ECR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 20,
+            "created_at": 1624192972,
+            "shares": [
+                "ECR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "bid",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 21,
+            "created_at": 1624193006,
+            "corporation": "WVR",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 22,
+            "created_at": 1624193031
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 23,
+            "created_at": 1624193063
+        },
+        {
+            "type": "par",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 24,
+            "created_at": 1624193131,
+            "corporation": "WVR",
+            "share_price": "82,0,22"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 25,
+            "created_at": 1624193132,
+            "shares": [
+                "WVR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 26,
+            "created_at": 1624193135,
+            "shares": [
+                "WVR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 27,
+            "created_at": 1624193140
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 28,
+            "created_at": 1624193307,
+            "corporation": "ENR",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 29,
+            "created_at": 1624193316
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 30,
+            "created_at": 1624193319
+        },
+        {
+            "type": "par",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 31,
+            "created_at": 1624193335,
+            "corporation": "ENR",
+            "share_price": "68,0,18"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 32,
+            "created_at": 1624193337,
+            "shares": [
+                "ENR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 33,
+            "created_at": 1624193338,
+            "shares": [
+                "ENR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 34,
+            "created_at": 1624193343
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 35,
+            "created_at": 1624193391
+        },
+        {
+            "type": "par",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 36,
+            "created_at": 1624193505,
+            "corporation": "N&E",
+            "share_price": "74,0,20"
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 37,
+            "created_at": 1624193510
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 38,
+            "created_at": 1624193514
+        },
+        {
+            "type": "par",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 39,
+            "created_at": 1624193532,
+            "corporation": "Y&N",
+            "share_price": "54,0,12"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 40,
+            "created_at": 1624193539,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624193547,
+                    "reason": "Corporation Y&N parred"
+                }
+            ],
+            "shares": [
+                "N&E_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 41,
+            "created_at": 1624193580,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624193579
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 42,
+            "created_at": 1624193604,
+            "shares": [
+                "Y&N_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 43,
+            "created_at": 1624193608,
+            "shares": [
+                "N&E_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "choose",
+            "choice": 4,
+            "entity": 7378,
+            "entity_type": "player",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "created_at": 1624193629,
+                    "entity_type": "player"
+                }
+            ],
+            "id": 44,
+            "user": 7378,
+            "created_at": 1624193621,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "shares": [
+                "Y&N_2"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 45,
+            "user": 665,
+            "created_at": 1624193625,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 46,
+            "user": 7378,
+            "created_at": 1624193648,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 47,
+            "user": 7378,
+            "created_at": 1624193650,
+            "skip": true
+        },
+        {
+            "type": "choose",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 48,
+            "created_at": 1624193654,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624193662
+                }
+            ],
+            "choice": 3
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 49,
+            "created_at": 1624193659,
+            "shares": [
+                "Y&N_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "choose",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 50,
+            "created_at": 1624193662,
+            "choice": 3
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 51,
+            "created_at": 1624193670,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624193678
+                }
+            ],
+            "shares": [
+                "N&E_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 52,
+            "created_at": 1624193673,
+            "shares": [
+                "Y&N_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 53,
+            "created_at": 1624193678,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624193687
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 54,
+            "created_at": 1624193682,
+            "shares": [
+                "Y&N_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 55,
+            "created_at": 1624193696,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624193704
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 56,
+            "created_at": 1624193700,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WVR",
+                    "entity_type": "corporation",
+                    "created_at": 1624193688
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 57,
+            "created_at": 1624193713,
+            "hex": "G8",
+            "tile": "57-0",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 58,
+            "created_at": 1624193717,
+            "hex": "G10",
+            "tile": "8851-0",
+            "rotation": 3
+        },
+        {
+            "type": "buy_train",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 59,
+            "created_at": 1624193726,
+            "train": "A-0",
+            "price": 100,
+            "variant": "2E*",
+            "warranties": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 60,
+            "created_at": 1624193741,
+            "train": "A-1",
+            "price": 100,
+            "variant": "1F*",
+            "warranties": 2
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 61,
+            "created_at": 1624193750,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WVR",
+                    "entity_type": "corporation",
+                    "created_at": 1624193738
+                },
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624193738
+                }
+            ]
+        },
+        {
+            "hex": "B13",
+            "tile": "6-0",
+            "type": "lay_tile",
+            "entity": "N&E",
+            "rotation": 3,
+            "entity_type": "corporation",
+            "id": 62,
+            "user": 7378,
+            "created_at": 1624193780,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 63,
+            "user": 7378,
+            "created_at": 1624193805,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 64,
+            "created_at": 1624193823,
+            "hex": "B13",
+            "tile": "6-0",
+            "rotation": 3
+        },
+        {
+            "hex": "B11",
+            "tile": "8852-0",
+            "type": "lay_tile",
+            "entity": "N&E",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 65,
+            "user": 7378,
+            "created_at": 1624193844,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 66,
+            "user": 7378,
+            "created_at": 1624193867,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 67,
+            "created_at": 1624193924,
+            "hex": "B11",
+            "tile": "8852-0",
+            "rotation": 0
+        },
+        {
+            "type": "buy_train",
+            "price": 100,
+            "train": "A-2",
+            "entity": "N&E",
+            "variant": "1F*",
+            "warranties": 0,
+            "entity_type": "corporation",
+            "id": 68,
+            "user": 7378,
+            "created_at": 1624193932,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "created_at": 1624193944,
+                    "entity_type": "corporation"
+                },
+                {
+                    "type": "pass",
+                    "entity": "ECR",
+                    "created_at": 1624193944,
+                    "entity_type": "corporation"
+                }
+            ],
+            "id": 69,
+            "user": 7378,
+            "created_at": 1624193936,
+            "skip": true
+        },
+        {
+            "hex": "D13",
+            "tile": "57-1",
+            "type": "lay_tile",
+            "entity": "ECR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 70,
+            "user": 1864,
+            "created_at": 1624193941,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 71,
+            "user": 1864,
+            "created_at": 1624193944,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 72,
+            "user": 7378,
+            "created_at": 1624193951,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 73,
+            "user": 7378,
+            "created_at": 1624193955,
+            "skip": true
+        },
+        {
+            "type": "buy_train",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 74,
+            "created_at": 1624193967,
+            "train": "A-2",
+            "price": 100,
+            "variant": "1F*",
+            "warranties": 2
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 75,
+            "created_at": 1624193971,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624193979
+                },
+                {
+                    "type": "pass",
+                    "entity": "ECR",
+                    "entity_type": "corporation",
+                    "created_at": 1624193979
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 76,
+            "created_at": 1624193978,
+            "hex": "D13",
+            "tile": "6-1",
+            "rotation": 4
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 77,
+            "created_at": 1624193986
+        },
+        {
+            "type": "buy_train",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 78,
+            "created_at": 1624193988,
+            "train": "A-3",
+            "price": 100,
+            "variant": "1F*",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 79,
+            "created_at": 1624193995,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "ECR",
+                    "entity_type": "corporation",
+                    "created_at": 1624193995
+                },
+                {
+                    "type": "pass",
+                    "entity": "ENR",
+                    "entity_type": "corporation",
+                    "created_at": 1624193995
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 80,
+            "created_at": 1624194002,
+            "hex": "F3",
+            "tile": "5-0",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 81,
+            "created_at": 1624194005,
+            "hex": "E2",
+            "tile": "57-1",
+            "rotation": 2
+        },
+        {
+            "type": "place_token",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 82,
+            "created_at": 1624194014,
+            "city": "57-1-0",
+            "slot": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 83,
+            "created_at": 1624194020,
+            "train": "A-4",
+            "price": 100,
+            "variant": "1F*",
+            "warranties": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 84,
+            "created_at": 1624194021,
+            "train": "A-5",
+            "price": 100,
+            "variant": "1F*",
+            "warranties": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 85,
+            "created_at": 1624194022,
+            "train": "A-6",
+            "price": 100,
+            "variant": "1F*",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 86,
+            "created_at": 1624194032,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "ENR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194032
+                },
+                {
+                    "type": "pass",
+                    "entity": "EUR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194032
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 87,
+            "created_at": 1624194066,
+            "hex": "E12",
+            "tile": "790-0",
+            "rotation": 2
+        },
+        {
+            "type": "buy_train",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 88,
+            "created_at": 1624194071,
+            "train": "B-0",
+            "price": 200,
+            "variant": "2/3E",
+            "warranties": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 89,
+            "created_at": 1624194075,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "EUR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194083
+                },
+                {
+                    "type": "pass",
+                    "entity": "Y&N",
+                    "entity_type": "corporation",
+                    "created_at": 1624194083
+                }
+            ],
+            "train": "B-1",
+            "price": 200,
+            "variant": "2/3E",
+            "warranties": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 90,
+            "created_at": 1624194097,
+            "hex": "H5",
+            "tile": "202-0",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 91,
+            "created_at": 1624194105,
+            "hex": "H7",
+            "tile": "57-2",
+            "rotation": 0
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 92,
+            "created_at": 1624194117
+        },
+        {
+            "type": "buy_train",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 93,
+            "created_at": 1624194125,
+            "train": "B-2",
+            "price": 200,
+            "variant": "2F",
+            "warranties": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 94,
+            "created_at": 1624194129,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "Y&N",
+                    "entity_type": "corporation",
+                    "created_at": 1624194117
+                }
+            ],
+            "train": "A-1",
+            "price": 50
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 95,
+            "created_at": 1624194138
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 96,
+            "created_at": 1624194181,
+            "shares": [
+                "ENR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 97,
+            "created_at": 1624194189
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 98,
+            "created_at": 1624194190
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 99,
+            "created_at": 1624194194,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WVR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194194
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 100,
+            "created_at": 1624194205,
+            "hex": "F11",
+            "tile": "790-1",
+            "rotation": 1
+        },
+        {
+            "type": "place_token",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 101,
+            "created_at": 1624194209,
+            "city": "790-1-0",
+            "slot": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 102,
+            "created_at": 1624194220,
+            "routes": [
+                {
+                    "train": "A-0",
+                    "connections": [
+                        [
+                            "G10",
+                            "F11"
+                        ],
+                        [
+                            "G8",
+                            "G10"
+                        ]
+                    ],
+                    "hexes": [
+                        "F11",
+                        "G10",
+                        "G8"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "F11-G10-G8",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 103,
+            "created_at": 1624194223,
+            "kind": "hudson"
+        },
+        {
+            "type": "buy_train",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 104,
+            "created_at": 1624194234,
+            "train": "B-3",
+            "price": 200,
+            "variant": "2/3E",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 105,
+            "created_at": 1624194246,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WVR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194234
+                },
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624194234
+                }
+            ]
+        },
+        {
+            "hex": "B9",
+            "tile": "790-2",
+            "type": "lay_tile",
+            "entity": "N&E",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 106,
+            "user": 7378,
+            "created_at": 1624194252,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 107,
+            "user": 7378,
+            "created_at": 1624194258,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 108,
+            "created_at": 1624194261
+        },
+        {
+            "type": "place_token",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 109,
+            "created_at": 1624194263,
+            "city": "B15-0-3",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 110,
+            "created_at": 1624194272,
+            "routes": [
+                {
+                    "train": "A-2",
+                    "connections": [
+                        [
+                            "B13",
+                            "C14"
+                        ]
+                    ],
+                    "hexes": [
+                        "C14",
+                        "B13"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "C14-B13",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 111,
+            "created_at": 1624194274,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 112,
+            "created_at": 1624194280,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624194288
+                },
+                {
+                    "type": "pass",
+                    "entity": "ECR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194288
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 113,
+            "created_at": 1624194298
+        },
+        {
+            "type": "place_token",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 114,
+            "created_at": 1624194300,
+            "city": "D15-0-4",
+            "slot": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 115,
+            "created_at": 1624194312,
+            "routes": [
+                {
+                    "train": "A-3",
+                    "connections": [
+                        [
+                            "D13",
+                            "D15"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "D13"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "D15-D13",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 116,
+            "created_at": 1624194313,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 117,
+            "created_at": 1624194321,
+            "train": "B-4",
+            "price": 200,
+            "variant": "2F",
+            "warranties": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 118,
+            "created_at": 1624194322,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "ECR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194321
+                },
+                {
+                    "type": "pass",
+                    "entity": "ENR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194321
+                }
+            ],
+            "train": "B-5",
+            "price": 200,
+            "variant": "2F",
+            "warranties": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 119,
+            "created_at": 1624194334,
+            "hex": "F3",
+            "tile": "15-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 120,
+            "created_at": 1624194348,
+            "routes": [
+                {
+                    "train": "A-4",
+                    "connections": [
+                        [
+                            "F3",
+                            "F1"
+                        ]
+                    ],
+                    "hexes": [
+                        "F1",
+                        "F3"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "F1-F3",
+                    "subsidy": 0
+                },
+                {
+                    "train": "A-5",
+                    "connections": [
+                        [
+                            "F3",
+                            "E2"
+                        ]
+                    ],
+                    "hexes": [
+                        "E2",
+                        "F3"
+                    ],
+                    "revenue": 0,
+                    "revenue_str": "E2-F3",
+                    "subsidy": 0
+                },
+                {
+                    "train": "A-6",
+                    "connections": [
+                        [
+                            "E2",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "D1",
+                        "E2"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "D1-E2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 121,
+            "created_at": 1624194349,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 122,
+            "created_at": 1624194386,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "ENR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194385
+                },
+                {
+                    "type": "pass",
+                    "entity": "EUR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194385
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 123,
+            "created_at": 1624194394,
+            "hex": "F13",
+            "tile": "621-0",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 124,
+            "created_at": 1624194397,
+            "hex": "E10",
+            "tile": "8850-0",
+            "rotation": 0
+        },
+        {
+            "type": "place_token",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 125,
+            "created_at": 1624194402,
+            "city": "790-1-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 126,
+            "created_at": 1624194421,
+            "routes": [
+                {
+                    "train": "B-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "F13",
+                            "G14"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "F13",
+                        "G14"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "[E12]-F13-G14",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-1",
+                    "connections": [
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ]
+                    ],
+                    "hexes": [
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E10",
+                        "E12"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "[G8]-G10-F11-E10-E12",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "kind": "payout",
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 127,
+            "user": 7378,
+            "created_at": 1624194445,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "Y&N",
+                    "created_at": 1624194471,
+                    "entity_type": "corporation"
+                }
+            ],
+            "id": 128,
+            "user": 7378,
+            "created_at": 1624194462,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 129,
+            "user": 7378,
+            "created_at": 1624194478,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 130,
+            "user": 7378,
+            "created_at": 1624194481,
+            "skip": true
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 131,
+            "created_at": 1624194483,
+            "kind": "withhold"
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 132,
+            "created_at": 1624194489
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 133,
+            "created_at": 1624194491,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "Y&N",
+                    "entity_type": "corporation",
+                    "created_at": 1624194499
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 134,
+            "created_at": 1624194500,
+            "hex": "H5",
+            "tile": "792-0",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 135,
+            "created_at": 1624194513
+        },
+        {
+            "type": "run_routes",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 136,
+            "created_at": 1624194536,
+            "routes": [
+                {
+                    "train": "B-2",
+                    "connections": [
+                        [
+                            "H7",
+                            "H9"
+                        ],
+                        [
+                            "H5",
+                            "H7"
+                        ]
+                    ],
+                    "hexes": [
+                        "H9",
+                        "H7",
+                        "H5"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "H9-H7-H5",
+                    "subsidy": 0
+                },
+                {
+                    "train": "A-1",
+                    "connections": [
+                        [
+                            "I4",
+                            "H5"
+                        ]
+                    ],
+                    "hexes": [
+                        "H5",
+                        "I4"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "H5-I4",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 137,
+            "created_at": 1624194540,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 138,
+            "created_at": 1624194545,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "Y&N",
+                    "entity_type": "corporation",
+                    "created_at": 1624194533
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 139,
+            "created_at": 1624194549
+        },
+        {
+            "hex": "G6",
+            "tile": "8851-1",
+            "type": "lay_tile",
+            "entity": "WVR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 140,
+            "user": 665,
+            "created_at": 1624194568,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 141,
+            "user": 665,
+            "created_at": 1624194580,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 142,
+            "created_at": 1624194587,
+            "hex": "G12",
+            "tile": "57-3",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 143,
+            "created_at": 1624194612,
+            "hex": "G6",
+            "tile": "8851-1",
+            "rotation": 0
+        },
+        {
+            "type": "place_token",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 144,
+            "created_at": 1624194616,
+            "city": "790-0-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 145,
+            "created_at": 1624194635,
+            "routes": [
+                {
+                    "train": "A-0",
+                    "connections": [
+                        [
+                            "G10",
+                            "F11"
+                        ],
+                        [
+                            "G8",
+                            "G10"
+                        ]
+                    ],
+                    "hexes": [
+                        "F11",
+                        "G10",
+                        "G8"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "F11-G10-G8",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-3",
+                    "connections": [
+                        [
+                            "G12",
+                            "H13"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "H13",
+                        "G12",
+                        "F11"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "H13-G12-[F11]",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 146,
+            "created_at": 1624194638,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 147,
+            "created_at": 1624194648
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 148,
+            "created_at": 1624194651,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "ENR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194639
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 149,
+            "created_at": 1624194660,
+            "hex": "F5",
+            "tile": "790-2",
+            "rotation": 0
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 150,
+            "created_at": 1624194664
+        },
+        {
+            "type": "run_routes",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 151,
+            "created_at": 1624194677,
+            "routes": [
+                {
+                    "train": "A-4",
+                    "connections": [
+                        [
+                            "F3",
+                            "F1"
+                        ]
+                    ],
+                    "hexes": [
+                        "F3",
+                        "F1"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "F3-F1",
+                    "subsidy": 0
+                },
+                {
+                    "train": "A-5",
+                    "connections": [
+                        [
+                            "F3",
+                            "E2"
+                        ]
+                    ],
+                    "hexes": [
+                        "F3",
+                        "E2"
+                    ],
+                    "revenue": 0,
+                    "revenue_str": "F3-E2",
+                    "subsidy": 0
+                },
+                {
+                    "train": "A-6",
+                    "connections": [
+                        [
+                            "E2",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "E2",
+                        "D1"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "E2-D1",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 152,
+            "created_at": 1624194681,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 153,
+            "created_at": 1624194683,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "ENR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194683
+                },
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624194683
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 154,
+            "created_at": 1624194693,
+            "hex": "B9",
+            "tile": "790-3",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 155,
+            "created_at": 1624194702
+        },
+        {
+            "type": "run_routes",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 156,
+            "created_at": 1624194711,
+            "routes": [
+                {
+                    "train": "A-2",
+                    "connections": [
+                        [
+                            "B13",
+                            "C14"
+                        ]
+                    ],
+                    "hexes": [
+                        "B13",
+                        "C14"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "B13-C14",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 157,
+            "created_at": 1624194715,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 158,
+            "created_at": 1624194719,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624194727
+                },
+                {
+                    "type": "pass",
+                    "entity": "ECR",
+                    "entity_type": "corporation",
+                    "created_at": 1624194727
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 159,
+            "created_at": 1624194724,
+            "hex": "E12",
+            "tile": "791-0",
+            "rotation": 5
+        },
+        {
+            "type": "place_token",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 160,
+            "created_at": 1624194730,
+            "city": "621-0-0",
+            "slot": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 161,
+            "created_at": 1624194749,
+            "routes": [
+                {
+                    "train": "A-3",
+                    "connections": [
+                        [
+                            "D13",
+                            "D15"
+                        ]
+                    ],
+                    "hexes": [
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 160,
+                    "revenue_str": "D13-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-4",
+                    "connections": [
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ]
+                    ],
+                    "hexes": [
+                        "F13",
+                        "E12",
+                        "D13"
+                    ],
+                    "revenue": 0,
+                    "revenue_str": "F13-E12-D13",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-5",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "G14-F13",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 162,
+            "created_at": 1624194750,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 163,
+            "created_at": 1624194758
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 164,
+            "created_at": 1624194763
+        },
+        {
+            "type": "lay_tile",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 165,
+            "created_at": 1624194787,
+            "hex": "G8",
+            "tile": "619-0",
+            "rotation": 0
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 166,
+            "created_at": 1624194804
+        },
+        {
+            "type": "run_routes",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 167,
+            "created_at": 1624194810,
+            "routes": [
+                {
+                    "train": "B-2",
+                    "connections": [
+                        [
+                            "H7",
+                            "H9"
+                        ],
+                        [
+                            "H5",
+                            "H7"
+                        ]
+                    ],
+                    "hexes": [
+                        "H9",
+                        "H7",
+                        "H5"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "H9-H7-H5",
+                    "subsidy": 0
+                },
+                {
+                    "train": "A-1",
+                    "connections": [
+                        [
+                            "I4",
+                            "H5"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "I4-H5",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 168,
+            "created_at": 1624194817,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 169,
+            "created_at": 1624194821
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 170,
+            "created_at": 1624194824
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 171,
+            "created_at": 1624194833
+        },
+        {
+            "hex": "F13",
+            "tile": "793-0",
+            "type": "lay_tile",
+            "entity": "EUR",
+            "rotation": 5,
+            "entity_type": "corporation",
+            "id": 172,
+            "user": 7378,
+            "created_at": 1624194845,
+            "skip": true
+        },
+        {
+            "city": "793-0-0",
+            "slot": 1,
+            "type": "place_token",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 173,
+            "user": 7378,
+            "created_at": 1624194846,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 174,
+            "user": 7378,
+            "created_at": 1624194924,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 175,
+            "user": 7378,
+            "created_at": 1624194930,
+            "skip": true
+        },
+        {
+            "hex": "D11",
+            "tile": "57-4",
+            "type": "lay_tile",
+            "entity": "EUR",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 176,
+            "user": 7378,
+            "created_at": 1624194933,
+            "skip": true
+        },
+        {
+            "hex": "C10",
+            "tile": "57-5",
+            "type": "lay_tile",
+            "entity": "EUR",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 177,
+            "user": 7378,
+            "created_at": 1624194936,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 178,
+            "user": 7378,
+            "created_at": 1624194949,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 179,
+            "user": 7378,
+            "created_at": 1624194986,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 180,
+            "user": 7378,
+            "created_at": 1624194990,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 181,
+            "user": 7378,
+            "created_at": 1624194993,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 182,
+            "created_at": 1624194996,
+            "hex": "F13",
+            "tile": "793-0",
+            "rotation": 5
+        },
+        {
+            "city": "793-0-0",
+            "slot": 1,
+            "type": "place_token",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 183,
+            "user": 7378,
+            "created_at": 1624195009,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 184,
+            "user": 7378,
+            "created_at": 1624195031,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 185,
+            "created_at": 1624195035
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 186,
+            "created_at": 1624195037,
+            "routes": [
+                {
+                    "train": "B-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "F13",
+                            "G14"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "F13",
+                        "G14"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "[E12]-F13-G14",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-1",
+                    "connections": [
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ]
+                    ],
+                    "hexes": [
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E10",
+                        "E12"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "[G8]-G10-F11-E10-E12",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 187,
+            "created_at": 1624195039,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 188,
+            "created_at": 1624195041
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 189,
+            "created_at": 1624195045
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 190,
+            "created_at": 1624195058
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 191,
+            "created_at": 1624195080
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 192,
+            "created_at": 1624195125
+        },
+        {
+            "type": "par",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 193,
+            "created_at": 1624195255,
+            "corporation": "NGC",
+            "share_price": "58,0,14"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 194,
+            "created_at": 1624195298,
+            "shares": [
+                "ECR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "sell_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 195,
+            "created_at": 1624195316,
+            "shares": [
+                "ENR_1",
+                "ENR_2",
+                "ENR_3",
+                "ENR_0"
+            ],
+            "percent": 60
+        },
+        {
+            "type": "par",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 196,
+            "created_at": 1624195483,
+            "corporation": "WStI",
+            "share_price": "95,0,25"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 197,
+            "created_at": 1624195986,
+            "shares": [
+                "NGC_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 198,
+            "created_at": 1624196034,
+            "shares": [
+                "N&E_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 199,
+            "created_at": 1624196080,
+            "shares": [
+                "WStI_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 200,
+            "created_at": 1624196087,
+            "shares": [
+                "NGC_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "choose",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 201,
+            "created_at": 1624196089,
+            "choice": 3
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 202,
+            "created_at": 1624196131,
+            "shares": [
+                "EUR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 203,
+            "created_at": 1624196206,
+            "shares": [
+                "WStI_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "choose",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 204,
+            "created_at": 1624196230,
+            "choice": 2
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 205,
+            "created_at": 1624196243,
+            "shares": [
+                "NGC_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 206,
+            "created_at": 1624196251,
+            "shares": [
+                "NGC_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 207,
+            "created_at": 1624196271,
+            "shares": [
+                "ECR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 208,
+            "created_at": 1624196283,
+            "shares": [
+                "NGC_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 209,
+            "created_at": 1624196291
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 210,
+            "created_at": 1624196296,
+            "shares": [
+                "ECR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 211,
+            "created_at": 1624196311
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 212,
+            "created_at": 1624196313
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 213,
+            "created_at": 1624196317,
+            "shares": [
+                "ECR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 214,
+            "created_at": 1624196320
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 215,
+            "created_at": 1624196324
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 216,
+            "created_at": 1624196327,
+            "shares": [
+                "ECR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 217,
+            "created_at": 1624196329
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 218,
+            "created_at": 1624196333,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624196341
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 219,
+            "created_at": 1624196342,
+            "shares": [
+                "EUR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 220,
+            "created_at": 1624196349,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624196337
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 221,
+            "created_at": 1624196353,
+            "shares": [
+                "EUR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 222,
+            "user": 7378,
+            "created_at": 1624196357,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624196365
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 223,
+            "created_at": 1624196364,
+            "shares": [
+                "EUR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 224,
+            "user": 7378,
+            "created_at": 1624196366,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624196374
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 225,
+            "created_at": 1624196370,
+            "shares": [
+                "EUR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 226,
+            "user": 7378,
+            "created_at": 1624196374,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624196382
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 227,
+            "user": 7378,
+            "created_at": 1624196379,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WStI",
+                    "entity_type": "corporation",
+                    "created_at": 1624196387
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 228,
+            "created_at": 1624196391,
+            "hex": "B5",
+            "tile": "57-4",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 229,
+            "created_at": 1624196394,
+            "hex": "C4",
+            "tile": "202-1",
+            "rotation": 1
+        },
+        {
+            "type": "place_token",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 230,
+            "created_at": 1624196396,
+            "city": "202-1-0",
+            "slot": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 231,
+            "created_at": 1624196400,
+            "train": "C-0",
+            "price": 280,
+            "variant": "3F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 232,
+            "created_at": 1624196402,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WStI",
+                    "entity_type": "corporation",
+                    "created_at": 1624196402
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 233,
+            "created_at": 1624196433
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 234,
+            "created_at": 1624196446,
+            "hex": "F7",
+            "tile": "6-2",
+            "rotation": 5
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 235,
+            "created_at": 1624196450,
+            "hex": "E8",
+            "tile": "57-5",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 236,
+            "created_at": 1624196486,
+            "routes": [
+                {
+                    "train": "B-3",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "I4-H5-G6-[G8]",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 237,
+            "created_at": 1624196494,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 238,
+            "created_at": 1624196499
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 239,
+            "created_at": 1624196502
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 240,
+            "created_at": 1624196512
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 241,
+            "created_at": 1624196531,
+            "hex": "D13",
+            "tile": "15-1",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 242,
+            "created_at": 1624196548,
+            "routes": [
+                {
+                    "train": "B-4",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "E12-D13-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-5",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "G14-F13-E12",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 243,
+            "created_at": 1624196555,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 244,
+            "created_at": 1624196558,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624196558
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 245,
+            "created_at": 1624196579,
+            "hex": "B13",
+            "tile": "15-2",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 246,
+            "created_at": 1624196584
+        },
+        {
+            "type": "run_routes",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 247,
+            "created_at": 1624196587,
+            "routes": [
+                {
+                    "train": "A-2",
+                    "connections": [
+                        [
+                            "B13",
+                            "C14"
+                        ]
+                    ],
+                    "hexes": [
+                        "B13",
+                        "C14"
+                    ],
+                    "revenue": 180,
+                    "revenue_str": "B13-C14",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 248,
+            "created_at": 1624196591,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 249,
+            "created_at": 1624196593,
+            "train": "C-1",
+            "price": 280,
+            "variant": "3F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "N&E",
+            "entity_type": "corporation",
+            "id": 250,
+            "created_at": 1624196602,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "N&E",
+                    "entity_type": "corporation",
+                    "created_at": 1624196610
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 251,
+            "created_at": 1624196609
+        },
+        {
+            "type": "lay_tile",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 252,
+            "created_at": 1624196615,
+            "hex": "D9",
+            "tile": "621-1",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 253,
+            "created_at": 1624196642,
+            "hex": "C10",
+            "tile": "6-3",
+            "rotation": 4
+        },
+        {
+            "type": "place_token",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 254,
+            "created_at": 1624196665,
+            "city": "621-1-0",
+            "slot": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 255,
+            "created_at": 1624196671,
+            "routes": [
+                {
+                    "train": "B-2",
+                    "connections": [
+                        [
+                            "H7",
+                            "H9"
+                        ],
+                        [
+                            "H5",
+                            "H7"
+                        ]
+                    ],
+                    "hexes": [
+                        "H9",
+                        "H7",
+                        "H5"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "H9-H7-H5",
+                    "subsidy": 0
+                },
+                {
+                    "train": "A-1",
+                    "connections": [
+                        [
+                            "I4",
+                            "H5"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "I4-H5",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 256,
+            "created_at": 1624196673,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 257,
+            "created_at": 1624196687
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 258,
+            "created_at": 1624196690
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 259,
+            "created_at": 1624196695
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 260,
+            "created_at": 1624196703,
+            "hex": "D11",
+            "tile": "6-4",
+            "rotation": 5
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 261,
+            "created_at": 1624196707,
+            "hex": "C12",
+            "tile": "8852-1",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 262,
+            "created_at": 1624196721
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 263,
+            "created_at": 1624196751,
+            "routes": [
+                {
+                    "train": "B-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "F13",
+                            "G14"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "F13",
+                        "G14"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "[E12]-F13-G14",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-1",
+                    "connections": [
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ]
+                    ],
+                    "hexes": [
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E10",
+                        "E12"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "[G8]-G10-F11-E10-E12",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 264,
+            "created_at": 1624196766,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 265,
+            "created_at": 1624196773
+        },
+        {
+            "type": "merge",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 266,
+            "created_at": 1624196776,
+            "corporation": "N&E"
+        },
+        {
+            "type": "choose",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 267,
+            "created_at": 1624196780,
+            "choice": "first"
+        },
+        {
+            "type": "choose",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 268,
+            "created_at": 1624196786,
+            "choice": "redeem"
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 269,
+            "created_at": 1624196795
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 270,
+            "created_at": 1624196811,
+            "hex": "C12",
+            "tile": "20_1b-0",
+            "rotation": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 271,
+            "created_at": 1624196877,
+            "train": "C-2",
+            "price": 280,
+            "variant": "3E",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 272,
+            "created_at": 1624196880
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 273,
+            "created_at": 1624196884
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 274,
+            "created_at": 1624196939,
+            "hex": "F11",
+            "tile": "791-1",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 275,
+            "created_at": 1624196955
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 276,
+            "created_at": 1624197019,
+            "routes": [
+                {
+                    "train": "B-0",
+                    "connections": [
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ]
+                    ],
+                    "hexes": [
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E10",
+                        "E12"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "G8-G10-F11-E10-[E12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-1",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "E12-[D13]-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "C-1",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "E12",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "D13"
+                    ],
+                    "revenue": 190,
+                    "revenue_str": "G14-F13-E12-D13",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 277,
+            "created_at": 1624197022,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 278,
+            "created_at": 1624197038
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 279,
+            "created_at": 1624197040
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 280,
+            "created_at": 1624197047
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 281,
+            "created_at": 1624197061,
+            "hex": "D11",
+            "tile": "15-3",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 282,
+            "created_at": 1624197110,
+            "routes": [
+                {
+                    "train": "B-4",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "E12-D13-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-5",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "G14-F13-E12",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 283,
+            "created_at": 1624197112,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 284,
+            "created_at": 1624197116
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 285,
+            "created_at": 1624197130
+        },
+        {
+            "type": "lay_tile",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 286,
+            "created_at": 1624197229,
+            "hex": "D9",
+            "tile": "793-1",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 287,
+            "created_at": 1624197255
+        },
+        {
+            "type": "run_routes",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 288,
+            "created_at": 1624197267,
+            "routes": [
+                {
+                    "train": "B-2",
+                    "connections": [
+                        [
+                            "H7",
+                            "H9"
+                        ],
+                        [
+                            "H5",
+                            "H7"
+                        ]
+                    ],
+                    "hexes": [
+                        "H9",
+                        "H7",
+                        "H5"
+                    ],
+                    "revenue": 170,
+                    "revenue_str": "H9-H7-H5",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 289,
+            "created_at": 1624197269,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 290,
+            "created_at": 1624197278
+        },
+        {
+            "type": "pass",
+            "entity": "Y&N",
+            "entity_type": "corporation",
+            "id": 291,
+            "created_at": 1624197281
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 292,
+            "created_at": 1624197284
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 293,
+            "created_at": 1624197309,
+            "hex": "C10",
+            "tile": "619-1",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 294,
+            "created_at": 1624197328,
+            "routes": [
+                {
+                    "train": "B-3",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "I4-H5-G6-[G8]",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 295,
+            "created_at": 1624197330,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 296,
+            "created_at": 1624197335
+        },
+        {
+            "type": "pass",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 297,
+            "created_at": 1624197337,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WStI",
+                    "entity_type": "corporation",
+                    "created_at": 1624197325
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 298,
+            "created_at": 1624197359
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 299,
+            "created_at": 1624197364,
+            "routes": [
+                {
+                    "train": "C-0",
+                    "connections": [
+                        [
+                            "B5",
+                            "A6"
+                        ],
+                        [
+                            "C4",
+                            "B5"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "A6",
+                        "B5",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 240,
+                    "revenue_str": "A6-B5-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 300,
+            "created_at": 1624197368,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 301,
+            "created_at": 1624197378,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "WStI",
+                    "entity_type": "corporation",
+                    "created_at": 1624197377
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 302,
+            "created_at": 1624197386
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 303,
+            "created_at": 1624197392
+        },
+        {
+            "type": "place_token",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 304,
+            "created_at": 1624197395,
+            "city": "B15-0-3",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 305,
+            "created_at": 1624197408,
+            "routes": [
+                {
+                    "train": "C-2",
+                    "connections": [
+                        [
+                            "C10",
+                            "D9"
+                        ],
+                        [
+                            "C14",
+                            "C12",
+                            "C10"
+                        ]
+                    ],
+                    "hexes": [
+                        "D9",
+                        "C10",
+                        "C14"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "D9-C10-C14",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 306,
+            "created_at": 1624197412,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 307,
+            "created_at": 1624197418
+        },
+        {
+            "type": "merge",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 308,
+            "created_at": 1624197481,
+            "corporation": "Y&N"
+        },
+        {
+            "type": "choose",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 309,
+            "created_at": 1624197497,
+            "choice": "first"
+        },
+        {
+            "type": "choose",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 310,
+            "created_at": 1624197514,
+            "choice": "redeem"
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 311,
+            "created_at": 1624197541
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 312,
+            "created_at": 1624197555
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 313,
+            "created_at": 1624197566,
+            "corporation": "SVR",
+            "price": 0
+        },
+        {
+            "type": "bid",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 314,
+            "created_at": 1624197615,
+            "corporation": "SVR",
+            "price": 5
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 315,
+            "created_at": 1624197618,
+            "corporation": "SVR",
+            "price": 10
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 316,
+            "created_at": 1624197621,
+            "corporation": "SVR",
+            "price": 15
+        },
+        {
+            "type": "bid",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 317,
+            "created_at": 1624197624,
+            "corporation": "SVR",
+            "price": 20
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 318,
+            "created_at": 1624197628,
+            "corporation": "SVR",
+            "price": 25
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 319,
+            "created_at": 1624197629,
+            "corporation": "SVR",
+            "price": 30
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 320,
+            "created_at": 1624197632
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 321,
+            "created_at": 1624197672,
+            "corporation": "SVR",
+            "price": 35
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 322,
+            "created_at": 1624197716,
+            "corporation": "SVR",
+            "price": 40
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 323,
+            "created_at": 1624197755,
+            "corporation": "SVR",
+            "price": 50
+        },
+        {
+            "type": "bid",
+            "price": 55,
+            "entity": 1864,
+            "corporation": "SVR",
+            "entity_type": "player",
+            "id": 324,
+            "user": 1864,
+            "created_at": 1624197758,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 325,
+            "user": 1864,
+            "created_at": 1624197769,
+            "skip": true
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 326,
+            "created_at": 1624197772,
+            "corporation": "SVR",
+            "price": 60
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 327,
+            "created_at": 1624197838,
+            "corporation": "SVR",
+            "price": 65
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 328,
+            "created_at": 1624197841,
+            "corporation": "SVR",
+            "price": 70
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 329,
+            "created_at": 1624197845
+        },
+        {
+            "type": "par",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 330,
+            "created_at": 1624197852,
+            "corporation": "SVR",
+            "share_price": "100,0,26"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 331,
+            "created_at": 1624197854,
+            "shares": [
+                "SVR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 332,
+            "created_at": 1624197855,
+            "shares": [
+                "SVR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 333,
+            "created_at": 1624197871
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 334,
+            "created_at": 1624197980,
+            "corporation": "W&F",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 335,
+            "created_at": 1624198031
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 336,
+            "created_at": 1624198048
+        },
+        {
+            "type": "par",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 337,
+            "created_at": 1624198064,
+            "corporation": "W&F",
+            "share_price": "90,0,24"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 338,
+            "created_at": 1624198073,
+            "shares": [
+                "W&F_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 339,
+            "created_at": 1624198074,
+            "shares": [
+                "W&F_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 340,
+            "created_at": 1624198084
+        },
+        {
+            "type": "par",
+            "entity": 665,
+            "corporation": "ENR",
+            "entity_type": "player",
+            "share_price": "100,0,26",
+            "id": 341,
+            "user": 665,
+            "created_at": 1624198239,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "shares": [
+                "W&F_3"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 342,
+            "user": 7378,
+            "created_at": 1624198271,
+            "skip": true
+        },
+        {
+            "type": "sell_shares",
+            "entity": 1864,
+            "shares": [
+                "WStI_1",
+                "WStI_2",
+                "WStI_0"
+            ],
+            "percent": 50,
+            "entity_type": "player",
+            "id": 343,
+            "user": 1864,
+            "created_at": 1624198332,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "shares": [
+                "EUR_7"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 344,
+            "user": 1864,
+            "created_at": 1624198355,
+            "skip": true
+        },
+        {
+            "type": "sell_shares",
+            "entity": 665,
+            "shares": [
+                "WVR_1",
+                "WVR_2",
+                "WVR_0"
+            ],
+            "percent": 50,
+            "entity_type": "player",
+            "id": 345,
+            "user": 665,
+            "created_at": 1624198364,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "shares": [
+                "NGC_6"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 346,
+            "user": 665,
+            "created_at": 1624198382,
+            "skip": true
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "created_at": 1624198402,
+                    "entity_type": "player"
+                }
+            ],
+            "id": 347,
+            "user": 7378,
+            "created_at": 1624198394,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "shares": [
+                "NGC_7"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 348,
+            "user": 1864,
+            "created_at": 1624198409,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "shares": [
+                "ENR_1"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "created_at": 1624198415,
+                    "entity_type": "player"
+                }
+            ],
+            "id": 349,
+            "user": 665,
+            "created_at": 1624198427,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "shares": [
+                "SVR_3"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 350,
+            "user": 1864,
+            "created_at": 1624198436,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "shares": [
+                "ENR_2"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 351,
+            "user": 665,
+            "created_at": 1624198441,
+            "skip": true
+        },
+        {
+            "type": "choose",
+            "choice": 3,
+            "entity": 665,
+            "entity_type": "player",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "created_at": 1624198464,
+                    "entity_type": "player"
+                }
+            ],
+            "id": 352,
+            "user": 665,
+            "created_at": 1624198476,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "shares": [
+                "SVR_4"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 353,
+            "user": 1864,
+            "created_at": 1624198537,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "shares": [
+                "ENR_3"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "created_at": 1624198568,
+                    "entity_type": "player"
+                }
+            ],
+            "id": 354,
+            "user": 665,
+            "created_at": 1624198581,
+            "skip": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "shares": [
+                "SVR_5"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 355,
+            "user": 1864,
+            "created_at": 1624198586,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": 665,
+            "action_id": 341,
+            "entity_type": "player",
+            "id": 356,
+            "user": 7378,
+            "created_at": 1624198705,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 357,
+            "user": 7378,
+            "created_at": 1624198709,
+            "skip": true
+        },
+        {
+            "type": "par",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 358,
+            "created_at": 1624198730,
+            "corporation": "L&E",
+            "share_price": "100,0,26"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 359,
+            "created_at": 1624198736,
+            "shares": [
+                "W&F_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "sell_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 360,
+            "created_at": 1624198744,
+            "shares": [
+                "WStI_1",
+                "WStI_2",
+                "WStI_0"
+            ],
+            "percent": 50
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 361,
+            "created_at": 1624198753,
+            "shares": [
+                "EUR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 362,
+            "created_at": 1624198763
+        },
+        {
+            "type": "sell_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 363,
+            "created_at": 1624198765,
+            "shares": [
+                "WVR_1",
+                "WVR_2",
+                "WVR_0"
+            ],
+            "percent": 50
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 364,
+            "created_at": 1624198772,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198760,
+                    "reason": "Shares were sold"
+                }
+            ],
+            "shares": [
+                "NGC_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 365,
+            "user": 1864,
+            "created_at": 1624198780
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 366,
+            "created_at": 1624198782
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 367,
+            "created_at": 1624198782,
+            "shares": [
+                "NGC_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 368,
+            "created_at": 1624198789,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198777
+                }
+            ],
+            "shares": [
+                "L&E_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 369,
+            "created_at": 1624198795,
+            "shares": [
+                "SVR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 370,
+            "created_at": 1624198799,
+            "shares": [
+                "L&E_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "choose",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 371,
+            "created_at": 1624198801,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198789
+                }
+            ],
+            "choice": 3
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 372,
+            "created_at": 1624198806,
+            "shares": [
+                "SVR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 373,
+            "created_at": 1624198811,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198799
+                }
+            ],
+            "shares": [
+                "L&E_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 374,
+            "created_at": 1624198819,
+            "shares": [
+                "SVR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 375,
+            "created_at": 1624198855,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198843
+                }
+            ],
+            "shares": [
+                "SVR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 376,
+            "created_at": 1624198860,
+            "shares": [
+                "SVR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 377,
+            "created_at": 1624198892,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198880
+                }
+            ],
+            "shares": [
+                "L&E_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 378,
+            "created_at": 1624198900,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624198900
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 379,
+            "created_at": 1624198905,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198893
+                },
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624198893
+                }
+            ],
+            "shares": [
+                "L&E_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 380,
+            "created_at": 1624198908,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7378,
+                    "entity_type": "player",
+                    "created_at": 1624198896
+                },
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624198896
+                }
+            ],
+            "shares": [
+                "L&E_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 381,
+            "created_at": 1624198915
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 382,
+            "user": 7378,
+            "created_at": 1624198938,
+            "skip": true
+        },
+        {
+            "hex": "E14",
+            "tile": "8851-2",
+            "type": "lay_tile",
+            "entity": "EUR",
+            "rotation": 3,
+            "entity_type": "corporation",
+            "id": 383,
+            "user": 7378,
+            "created_at": 1624198949,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "action_id": 381,
+            "entity_type": "corporation",
+            "id": 384,
+            "user": 7378,
+            "created_at": 1624199007,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 385,
+            "created_at": 1624199009
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 386,
+            "created_at": 1624199014,
+            "hex": "C8",
+            "tile": "201-0",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 387,
+            "created_at": 1624199018,
+            "hex": "D7",
+            "tile": "8852-2",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 388,
+            "created_at": 1624199023
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 389,
+            "created_at": 1624199122,
+            "routes": [
+                {
+                    "train": "B-0",
+                    "connections": [
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ]
+                    ],
+                    "hexes": [
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E10",
+                        "E12"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "G8-G10-F11-E10-[E12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-1",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "E12-[D13]-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "C-1",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "E12",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "D13"
+                    ],
+                    "revenue": 190,
+                    "revenue_str": "G14-F13-E12-D13",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 390,
+            "created_at": 1624199147,
+            "kind": "withhold"
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 391,
+            "created_at": 1624199151
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 392,
+            "created_at": 1624199156
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 393,
+            "created_at": 1624199173
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 394,
+            "created_at": 1624199179,
+            "hex": "E10",
+            "tile": "18_1b-0",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 395,
+            "created_at": 1624199185,
+            "routes": [
+                {
+                    "train": "B-4",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "E12-D13-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-5",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "G14-F13-E12",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 396,
+            "created_at": 1624199187,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 397,
+            "created_at": 1624199190
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 398,
+            "created_at": 1624199196
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 399,
+            "created_at": 1624199210,
+            "hex": "B7",
+            "tile": "6-5",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 400,
+            "created_at": 1624199213,
+            "hex": "C6",
+            "tile": "6-6",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 401,
+            "created_at": 1624199235
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 402,
+            "created_at": 1624199274,
+            "routes": [
+                {
+                    "train": "C-2",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C10"
+                    ],
+                    "revenue": 170,
+                    "revenue_str": "A8-B9-C10",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-2",
+                    "connections": [
+                        [
+                            "C10",
+                            "C12",
+                            "C14"
+                        ]
+                    ],
+                    "hexes": [
+                        "C14",
+                        "C10"
+                    ],
+                    "revenue": 170,
+                    "revenue_str": "C14-C10",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 403,
+            "created_at": 1624199279,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 404,
+            "created_at": 1624199294
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 405,
+            "created_at": 1624199296
+        },
+        {
+            "type": "pass",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 406,
+            "created_at": 1624199368
+        },
+        {
+            "type": "lay_tile",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 407,
+            "created_at": 1624199384,
+            "hex": "F9",
+            "tile": "8852-3",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 408,
+            "created_at": 1624199389
+        },
+        {
+            "type": "pass",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 409,
+            "created_at": 1624199426
+        },
+        {
+            "type": "buy_train",
+            "price": 280,
+            "train": "C-3",
+            "entity": "SVR",
+            "variant": "3E",
+            "warranties": 0,
+            "entity_type": "corporation",
+            "id": 410,
+            "user": 1864,
+            "created_at": 1624199497,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 411,
+            "user": 1864,
+            "created_at": 1624199540,
+            "skip": true
+        },
+        {
+            "type": "redo",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 412,
+            "user": 1864,
+            "created_at": 1624199553,
+            "skip": true
+        },
+        {
+            "type": "buy_train",
+            "price": 360,
+            "train": "D-0",
+            "entity": "SVR",
+            "variant": "5F*",
+            "warranties": 0,
+            "entity_type": "corporation",
+            "id": 413,
+            "user": 1864,
+            "created_at": 1624199577,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 414,
+            "user": 1864,
+            "created_at": 1624199635,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 415,
+            "user": 1864,
+            "created_at": 1624199639,
+            "skip": true
+        },
+        {
+            "type": "buy_train",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 416,
+            "created_at": 1624199646,
+            "train": "C-3",
+            "price": 280,
+            "variant": "3E",
+            "warranties": 3
+        },
+        {
+            "type": "buy_train",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 417,
+            "created_at": 1624199662,
+            "train": "D-0",
+            "price": 360,
+            "variant": "5F*",
+            "warranties": 0
+        },
+        {
+            "type": "merge",
+            "entity": "SVR",
+            "corporation": "ECR",
+            "entity_type": "corporation",
+            "id": 418,
+            "user": 1864,
+            "created_at": 1624199668,
+            "skip": true
+        },
+        {
+            "type": "choose",
+            "choice": "last",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 419,
+            "user": 1864,
+            "created_at": 1624199753,
+            "skip": true
+        },
+        {
+            "type": "choose",
+            "choice": "redeem",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 420,
+            "user": 665,
+            "created_at": 1624199764,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 421,
+            "user": 1864,
+            "created_at": 1624199793,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 422,
+            "user": 7378,
+            "created_at": 1624199794,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 423,
+            "user": 7378,
+            "created_at": 1624199795,
+            "skip": true
+        },
+        {
+            "type": "redo",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 424,
+            "user": 7378,
+            "created_at": 1624199798,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 425,
+            "user": 7378,
+            "created_at": 1624199801,
+            "skip": true
+        },
+        {
+            "type": "merge",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 426,
+            "created_at": 1624199815,
+            "corporation": "ECR"
+        },
+        {
+            "type": "choose",
+            "entity": "SVR",
+            "entity_type": "corporation",
+            "id": 427,
+            "created_at": 1624199818,
+            "choice": "last"
+        },
+        {
+            "type": "choose",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 428,
+            "created_at": 1624199828,
+            "choice": "redeem"
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 429,
+            "created_at": 1624199844
+        },
+        {
+            "type": "lay_tile",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 430,
+            "created_at": 1624199897,
+            "hex": "C4",
+            "tile": "793-2",
+            "rotation": 0
+        },
+        {
+            "type": "place_token",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 431,
+            "created_at": 1624199899,
+            "city": "793-2-0",
+            "slot": 1
+        },
+        {
+            "type": "buy_train",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 432,
+            "created_at": 1624199906,
+            "train": "D-1",
+            "price": 360,
+            "variant": "5F*",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 433,
+            "created_at": 1624199912
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 434,
+            "created_at": 1624199914,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": "W&F",
+                    "entity_type": "corporation",
+                    "created_at": 1624199902
+                }
+            ]
+        },
+        {
+            "hex": "E4",
+            "tile": "6-7",
+            "type": "lay_tile",
+            "entity": "W&F",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 435,
+            "user": 7378,
+            "created_at": 1624199926,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "W&F",
+            "action_id": 434,
+            "entity_type": "corporation",
+            "id": 436,
+            "user": 7378,
+            "created_at": 1624199943,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 437,
+            "created_at": 1624199961,
+            "hex": "E4",
+            "tile": "6-7",
+            "rotation": 2
+        },
+        {
+            "hex": "D3",
+            "tile": "8850-1",
+            "type": "lay_tile",
+            "entity": "W&F",
+            "rotation": 5,
+            "entity_type": "corporation",
+            "id": 438,
+            "user": 7378,
+            "created_at": 1624199978,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 439,
+            "user": 7378,
+            "created_at": 1624199995,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 440,
+            "created_at": 1624199998,
+            "hex": "E6",
+            "tile": "8852-4",
+            "rotation": 1
+        },
+        {
+            "type": "place_token",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 441,
+            "created_at": 1624200026,
+            "city": "793-1-0",
+            "slot": 1
+        },
+        {
+            "type": "buy_train",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 442,
+            "created_at": 1624200032,
+            "train": "D-2",
+            "price": 360,
+            "variant": "4L*",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 443,
+            "created_at": 1624200036
+        },
+        {
+            "type": "pass",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 444,
+            "created_at": 1624200039
+        },
+        {
+            "type": "run_routes",
+            "entity": "WVR",
+            "entity_type": "corporation",
+            "id": 445,
+            "created_at": 1624200090,
+            "routes": [
+                {
+                    "train": "B-3",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "I4-H5-G6-[G8]",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "routes": [
+                {
+                    "hexes": [
+                        "A6",
+                        "B5",
+                        "C4",
+                        "C2"
+                    ],
+                    "train": "C-0",
+                    "revenue": 240,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "B5",
+                            "A6"
+                        ],
+                        [
+                            "C4",
+                            "B5"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "revenue_str": "A6-B5-C4-C2"
+                }
+            ],
+            "entity_type": "corporation",
+            "id": 446,
+            "user": 7378,
+            "created_at": 1624200095,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 447,
+            "user": 7378,
+            "created_at": 1624200102,
+            "skip": true
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 448,
+            "created_at": 1624200109,
+            "routes": [
+                {
+                    "train": "C-0",
+                    "connections": [
+                        [
+                            "B5",
+                            "A6"
+                        ],
+                        [
+                            "C4",
+                            "B5"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "A6",
+                        "B5",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 240,
+                    "revenue_str": "A6-B5-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 449,
+            "created_at": 1624200156
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 450,
+            "created_at": 1624200186,
+            "hex": "E12",
+            "tile": "794-0",
+            "rotation": 0
+        },
+        {
+            "type": "place_token",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 451,
+            "created_at": 1624200192,
+            "city": "793-0-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "routes": [
+                {
+                    "hexes": [
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E10",
+                        "E12"
+                    ],
+                    "train": "B-0",
+                    "revenue": 90,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ]
+                    ],
+                    "revenue_str": "G8-G10-F11-E10-[E12]"
+                },
+                {
+                    "hexes": [
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "train": "B-1",
+                    "revenue": 230,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "revenue_str": "E12-[D13]-D15"
+                },
+                {
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "D13"
+                    ],
+                    "train": "C-1",
+                    "revenue": 190,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "E12",
+                            "D13"
+                        ]
+                    ],
+                    "revenue_str": "G14-F13-E12-D13"
+                }
+            ],
+            "entity_type": "corporation",
+            "id": 452,
+            "user": 7378,
+            "created_at": 1624200199,
+            "skip": true
+        },
+        {
+            "kind": "payout",
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 453,
+            "user": 7378,
+            "created_at": 1624200202,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 454,
+            "user": 7378,
+            "created_at": 1624200249,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 455,
+            "user": 7378,
+            "created_at": 1624200253,
+            "skip": true
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 456,
+            "created_at": 1624200294,
+            "routes": [
+                {
+                    "train": "B-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "G14-F13-[E12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "B-1",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 180,
+                    "revenue_str": "[E12]-D13-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "C-1",
+                    "connections": [
+                        [
+                            "F11",
+                            "E12"
+                        ],
+                        [
+                            "G12",
+                            "F11"
+                        ],
+                        [
+                            "H13",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "E12",
+                        "F11",
+                        "G12",
+                        "H13"
+                    ],
+                    "revenue": 240,
+                    "revenue_str": "E12-F11-G12-H13",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 457,
+            "created_at": 1624200296,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 458,
+            "created_at": 1624200337,
+            "train": "E-0",
+            "price": 500,
+            "variant": "4/5E",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 459,
+            "created_at": 1624200421
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 460,
+            "created_at": 1624200423
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 461,
+            "created_at": 1624200426
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 462,
+            "created_at": 1624200431,
+            "hex": "G8",
+            "tile": "611-0",
+            "rotation": 0
+        },
+        {
+            "type": "place_token",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 463,
+            "created_at": 1624200432,
+            "city": "611-0-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 464,
+            "created_at": 1624200466,
+            "routes": [
+                {
+                    "train": "C-3",
+                    "connections": [
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ]
+                    ],
+                    "hexes": [
+                        "F13",
+                        "E12",
+                        "F11"
+                    ],
+                    "revenue": 190,
+                    "revenue_str": "F13-E12-F11",
+                    "subsidy": 0
+                },
+                {
+                    "train": "D-0",
+                    "connections": [
+                        [
+                            "G12",
+                            "H13"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "H13",
+                        "G12",
+                        "F11",
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "H13-G12-F11-E12-D13-D15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 465,
+            "created_at": 1624200467,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 466,
+            "created_at": 1624200562,
+            "train": "E-1",
+            "price": 500,
+            "variant": "4/5E",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 467,
+            "created_at": 1624200566
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 468,
+            "created_at": 1624200571
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 469,
+            "created_at": 1624200576
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 470,
+            "created_at": 1624200589,
+            "hex": "D11",
+            "tile": "611-1",
+            "rotation": 4
+        },
+        {
+            "type": "place_token",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 471,
+            "created_at": 1624200590,
+            "city": "611-1-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 472,
+            "created_at": 1624200626,
+            "routes": [
+                {
+                    "train": "C-2",
+                    "connections": [
+                        [
+                            "C10",
+                            "D9"
+                        ],
+                        [
+                            "C14",
+                            "C12",
+                            "C10"
+                        ]
+                    ],
+                    "hexes": [
+                        "D9",
+                        "C10",
+                        "C14"
+                    ],
+                    "revenue": 280,
+                    "revenue_str": "D9-C10-C14",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 473,
+            "created_at": 1624200630,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 474,
+            "created_at": 1624200656,
+            "train": "E-2",
+            "price": 500,
+            "variant": "6F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 475,
+            "created_at": 1624200662
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 476,
+            "created_at": 1624200664
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 477,
+            "created_at": 1624200667
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 478,
+            "created_at": 1624200685
+        },
+        {
+            "type": "place_token",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 479,
+            "created_at": 1624200693,
+            "city": "D15-0-4",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 480,
+            "created_at": 1624200714,
+            "routes": [
+                {
+                    "train": "D-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "C6",
+                            "B7"
+                        ],
+                        [
+                            "C4",
+                            "C6"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "B7",
+                        "C6",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 310,
+                    "revenue_str": "A8-B9-B7-C6-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "kind": "payout",
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 481,
+            "user": 665,
+            "created_at": 1624200716,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 482,
+            "user": 665,
+            "created_at": 1624200734,
+            "skip": true
+        },
+        {
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 483,
+            "created_at": 1624200737,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 484,
+            "created_at": 1624200745,
+            "train": "F-0",
+            "price": 600,
+            "variant": "7F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 485,
+            "created_at": 1624200759
+        },
+        {
+            "type": "pass",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 486,
+            "created_at": 1624200764
+        },
+        {
+            "type": "lay_tile",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 487,
+            "created_at": 1624200791,
+            "hex": "G4",
+            "tile": "8850-1",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 488,
+            "created_at": 1624200844
+        },
+        {
+            "type": "pass",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 489,
+            "created_at": 1624200848
+        },
+        {
+            "type": "run_routes",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 490,
+            "created_at": 1624200858,
+            "routes": [
+                {
+                    "train": "D-2",
+                    "connections": [
+                        [
+                            "D7",
+                            "C8"
+                        ],
+                        [
+                            "E6",
+                            "D7"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ],
+                        [
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "E4",
+                            "F3"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "D7",
+                        "E6",
+                        "F5",
+                        "F3",
+                        "E4"
+                    ],
+                    "revenue": 160,
+                    "revenue_str": "C8-D7-E6-F5-F3-E4",
+                    "subsidy": 60
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 491,
+            "created_at": 1624200864,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 492,
+            "created_at": 1624200868
+        },
+        {
+            "type": "pass",
+            "entity": "W&F",
+            "entity_type": "corporation",
+            "id": 493,
+            "created_at": 1624200870
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 494,
+            "created_at": 1624200931
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 495,
+            "created_at": 1624201071,
+            "corporation": "WStI",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 496,
+            "created_at": 1624201095
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 497,
+            "created_at": 1624201102,
+            "corporation": "WStI",
+            "price": 5
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 498,
+            "created_at": 1624201105,
+            "corporation": "WStI",
+            "price": 10
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 499,
+            "created_at": 1624201108,
+            "corporation": "WStI",
+            "price": 15
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 500,
+            "created_at": 1624201112,
+            "corporation": "WStI",
+            "price": 20
+        },
+        {
+            "type": "bid",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 501,
+            "created_at": 1624201124,
+            "corporation": "WStI",
+            "price": 50
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 502,
+            "created_at": 1624201148
+        },
+        {
+            "type": "par",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 503,
+            "created_at": 1624201155,
+            "corporation": "WStI",
+            "share_price": "100,0,26"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 504,
+            "created_at": 1624201157,
+            "shares": [
+                "WStI_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 505,
+            "created_at": 1624201159,
+            "shares": [
+                "WStI_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "bid",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 506,
+            "created_at": 1624201176,
+            "corporation": "ENR",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 507,
+            "created_at": 1624201187
+        },
+        {
+            "type": "par",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 508,
+            "created_at": 1624201194,
+            "corporation": "ENR",
+            "share_price": "100,0,26"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 509,
+            "created_at": 1624201195,
+            "shares": [
+                "ENR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 510,
+            "created_at": 1624201197,
+            "shares": [
+                "ENR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 511,
+            "created_at": 1624201203
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 512,
+            "created_at": 1624201231,
+            "shares": [
+                "L&E_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 513,
+            "created_at": 1624201264,
+            "shares": [
+                "ENR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 514,
+            "created_at": 1624201271
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 515,
+            "created_at": 1624201273,
+            "shares": [
+                "W&F_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "sell_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 516,
+            "created_at": 1624201380,
+            "shares": [
+                "W&F_1",
+                "W&F_2",
+                "W&F_3",
+                "W&F_0"
+            ],
+            "percent": 60
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 517,
+            "created_at": 1624201415,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624201423,
+                    "reason": "Shares were sold"
+                }
+            ],
+            "shares": [
+                "WStI_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 518,
+            "user": 7378,
+            "created_at": 1624201441
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 519,
+            "created_at": 1624201445
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 520,
+            "created_at": 1624201471,
+            "shares": [
+                "WStI_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 521,
+            "created_at": 1624201491,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624201499
+                }
+            ],
+            "shares": [
+                "WStI_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 522,
+            "created_at": 1624201499,
+            "shares": [
+                "ENR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 523,
+            "created_at": 1624201512,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624201521
+                }
+            ],
+            "shares": [
+                "WStI_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 524,
+            "created_at": 1624201516,
+            "shares": [
+                "WStI_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 525,
+            "created_at": 1624201527,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624201535
+                }
+            ],
+            "shares": [
+                "ENR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 526,
+            "created_at": 1624201534
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 527,
+            "created_at": 1624201540,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624201549
+                }
+            ],
+            "shares": [
+                "ENR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 528,
+            "created_at": 1624201544
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 529,
+            "created_at": 1624201548,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1864,
+                    "entity_type": "player",
+                    "created_at": 1624201556
+                }
+            ],
+            "shares": [
+                "ENR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 530,
+            "created_at": 1624201555
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 531,
+            "created_at": 1624201560
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 532,
+            "created_at": 1624201589
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 533,
+            "user": 7378,
+            "created_at": 1624201597,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 534,
+            "user": 7378,
+            "created_at": 1624201603,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 535,
+            "created_at": 1624201612,
+            "hex": "D13",
+            "tile": "611-2",
+            "rotation": 2
+        },
+        {
+            "type": "place_token",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 536,
+            "created_at": 1624201635,
+            "city": "611-2-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 537,
+            "created_at": 1624201661,
+            "routes": [
+                {
+                    "train": "E-0",
+                    "connections": [
+                        [
+                            "D13",
+                            "D15"
+                        ],
+                        [
+                            "E12",
+                            "D13"
+                        ],
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "F13",
+                            "G14"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "D13",
+                        "E12",
+                        "F13",
+                        "G14"
+                    ],
+                    "revenue": 460,
+                    "revenue_str": "D15-[D13]-E12-F13-G14",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 538,
+            "created_at": 1624201675,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 539,
+            "created_at": 1624201679,
+            "train": "F-1",
+            "price": 600,
+            "variant": "7F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 540,
+            "created_at": 1624201684
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 541,
+            "created_at": 1624201687
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 542,
+            "created_at": 1624201701
+        },
+        {
+            "hex": "C10",
+            "tile": "611-3",
+            "type": "lay_tile",
+            "entity": "NGC",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 543,
+            "user": 665,
+            "created_at": 1624201770,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 544,
+            "user": 665,
+            "created_at": 1624201779,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 545,
+            "user": 665,
+            "created_at": 1624201916,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 546,
+            "user": 665,
+            "created_at": 1624201921,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 547,
+            "created_at": 1624201931,
+            "hex": "F7",
+            "tile": "619-2",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 548,
+            "created_at": 1624201935
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 549,
+            "created_at": 1624201947,
+            "routes": [
+                {
+                    "train": "E-2",
+                    "connections": [
+                        [
+                            "F7",
+                            "F5"
+                        ],
+                        [
+                            "E8",
+                            "F7"
+                        ],
+                        [
+                            "D9",
+                            "E8"
+                        ],
+                        [
+                            "C10",
+                            "D9"
+                        ],
+                        [
+                            "C14",
+                            "C12",
+                            "C10"
+                        ]
+                    ],
+                    "hexes": [
+                        "F5",
+                        "F7",
+                        "E8",
+                        "D9",
+                        "C10",
+                        "C14"
+                    ],
+                    "revenue": 340,
+                    "revenue_str": "F5-F7-E8-D9-C10-C14",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 550,
+            "created_at": 1624201958,
+            "kind": "withhold"
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 551,
+            "created_at": 1624201963
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 552,
+            "user": 665,
+            "created_at": 1624201966,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 553,
+            "user": 665,
+            "created_at": 1624201981,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 554,
+            "created_at": 1624202012
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 555,
+            "created_at": 1624202018
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 556,
+            "created_at": 1624202067,
+            "hex": "F11",
+            "tile": "795-0",
+            "rotation": 3
+        },
+        {
+            "type": "place_token",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 557,
+            "created_at": 1624202068,
+            "city": "792-0-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 558,
+            "created_at": 1624202208,
+            "routes": [
+                {
+                    "train": "C-3",
+                    "connections": [
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ]
+                    ],
+                    "hexes": [
+                        "F13",
+                        "E12",
+                        "F11"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "F13-E12-F11",
+                    "subsidy": 0
+                },
+                {
+                    "train": "D-0",
+                    "connections": [
+                        [
+                            "G12",
+                            "H13"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "H13",
+                        "G12",
+                        "F11",
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "H13-G12-F11-E12-D13-D15",
+                    "subsidy": 0
+                },
+                {
+                    "train": "E-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "E12"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "A8-B9-C10-D11-[E12]",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 559,
+            "created_at": 1624202234,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 560,
+            "created_at": 1624202253,
+            "train": "G-0",
+            "price": 700,
+            "variant": "8F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 561,
+            "created_at": 1624202257
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 562,
+            "created_at": 1624202263
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 563,
+            "created_at": 1624202290,
+            "hex": "C4",
+            "tile": "796-0",
+            "rotation": 0
+        },
+        {
+            "type": "place_token",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 564,
+            "created_at": 1624202294,
+            "city": "796-0-0",
+            "slot": 1
+        },
+        {
+            "type": "buy_train",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 565,
+            "created_at": 1624202299,
+            "train": "H-0",
+            "price": 800,
+            "variant": "9F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 566,
+            "created_at": 1624202333
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 567,
+            "created_at": 1624202384
+        },
+        {
+            "hex": "F3",
+            "tile": "611-3",
+            "type": "lay_tile",
+            "entity": "ENR",
+            "rotation": 5,
+            "entity_type": "corporation",
+            "id": 568,
+            "user": 1864,
+            "created_at": 1624202391,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 569,
+            "user": 1864,
+            "created_at": 1624202408,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 570,
+            "created_at": 1624202418,
+            "hex": "C8",
+            "tile": "793-2",
+            "rotation": 4
+        },
+        {
+            "type": "place_token",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 571,
+            "created_at": 1624202433,
+            "city": "793-2-0",
+            "slot": 1
+        },
+        {
+            "type": "buy_train",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 572,
+            "created_at": 1624202445,
+            "train": "H-1",
+            "price": 800,
+            "variant": "9F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 573,
+            "created_at": 1624202447
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 574,
+            "created_at": 1624202454
+        },
+        {
+            "type": "lay_tile",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 575,
+            "created_at": 1624202466,
+            "hex": "B13",
+            "tile": "611-3",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 576,
+            "created_at": 1624202486,
+            "routes": [
+                {
+                    "train": "F-0",
+                    "connections": [
+                        [
+                            "B13",
+                            "B15"
+                        ],
+                        [
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B9",
+                            "B11"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "C6",
+                            "B7"
+                        ],
+                        [
+                            "C4",
+                            "C6"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "B15",
+                        "B13",
+                        "B11",
+                        "B9",
+                        "B7",
+                        "C6",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 480,
+                    "revenue_str": "B15-B13-B11-B9-B7-C6-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 577,
+            "created_at": 1624202489,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 578,
+            "created_at": 1624202493
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 579,
+            "created_at": 1624202495
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 580,
+            "user": 7378,
+            "created_at": 1624202514,
+            "skip": true
+        },
+        {
+            "hex": "E2",
+            "tile": "14-0",
+            "type": "lay_tile",
+            "entity": "EUR",
+            "rotation": 1,
+            "entity_type": "corporation",
+            "id": 581,
+            "user": 7378,
+            "created_at": 1624202571,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "EUR",
+            "action_id": 579,
+            "entity_type": "corporation",
+            "id": 582,
+            "user": 7378,
+            "created_at": 1624202591,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 583,
+            "created_at": 1624202593
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 584,
+            "created_at": 1624202633,
+            "hex": "H7",
+            "tile": "14-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 585,
+            "created_at": 1624202696,
+            "routes": [
+                {
+                    "train": "E-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "E10",
+                        "F11",
+                        "G12"
+                    ],
+                    "revenue": 340,
+                    "revenue_str": "G14-F13-E12-E10-F11-[G12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "F-1",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 500,
+                    "revenue_str": "I6-H7-G8-G10-F11-E12-D13-D15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 586,
+            "created_at": 1624202697,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 587,
+            "created_at": 1624202699
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 588,
+            "created_at": 1624202702
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 589,
+            "created_at": 1624202716
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 590,
+            "created_at": 1624202734,
+            "hex": "F5",
+            "tile": "791-2",
+            "rotation": 0
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 591,
+            "created_at": 1624202742
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 592,
+            "created_at": 1624202760,
+            "routes": [
+                {
+                    "train": "E-2",
+                    "connections": [
+                        [
+                            "F7",
+                            "F5"
+                        ],
+                        [
+                            "E8",
+                            "F7"
+                        ],
+                        [
+                            "D9",
+                            "E8"
+                        ],
+                        [
+                            "C10",
+                            "D9"
+                        ],
+                        [
+                            "C14",
+                            "C12",
+                            "C10"
+                        ]
+                    ],
+                    "hexes": [
+                        "F5",
+                        "F7",
+                        "E8",
+                        "D9",
+                        "C10",
+                        "C14"
+                    ],
+                    "revenue": 360,
+                    "revenue_str": "F5-F7-E8-D9-C10-C14",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 593,
+            "created_at": 1624202762,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 594,
+            "created_at": 1624202815,
+            "train": "H-2",
+            "price": 800,
+            "variant": "6E",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 595,
+            "created_at": 1624202818
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 596,
+            "created_at": 1624202838
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 597,
+            "created_at": 1624202877,
+            "hex": "F13",
+            "tile": "797-0",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 598,
+            "created_at": 1624202924,
+            "routes": [
+                {
+                    "train": "C-3",
+                    "connections": [
+                        [
+                            "E12",
+                            "F13"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ]
+                    ],
+                    "hexes": [
+                        "F13",
+                        "E12",
+                        "F11"
+                    ],
+                    "revenue": 220,
+                    "revenue_str": "F13-E12-F11",
+                    "subsidy": 0
+                },
+                {
+                    "train": "E-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "E12"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "A8-B9-C10-D11-[E12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "G-0",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "D13",
+                            "D11"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 530,
+                    "revenue_str": "I4-H5-G6-G8-F9-D11-D13-D15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 599,
+            "created_at": 1624202929,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 600,
+            "created_at": 1624202936,
+            "train": "H-3",
+            "price": 800,
+            "variant": "9F",
+            "warranties": 0
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 601,
+            "created_at": 1624202940
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 602,
+            "created_at": 1624202945
+        },
+        {
+            "type": "lay_tile",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 603,
+            "created_at": 1624203034,
+            "hex": "B7",
+            "tile": "15-4",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 604,
+            "created_at": 1624203043,
+            "routes": [
+                {
+                    "train": "F-0",
+                    "connections": [
+                        [
+                            "B13",
+                            "B15"
+                        ],
+                        [
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B9",
+                            "B11"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "C6",
+                            "B7"
+                        ],
+                        [
+                            "C4",
+                            "C6"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "B15",
+                        "B13",
+                        "B11",
+                        "B9",
+                        "B7",
+                        "C6",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 480,
+                    "revenue_str": "B15-B13-B11-B9-B7-C6-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 605,
+            "created_at": 1624203045,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 606,
+            "created_at": 1624203047
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 607,
+            "created_at": 1624203077
+        },
+        {
+            "hex": "D3",
+            "tile": "8851-2",
+            "type": "lay_tile",
+            "entity": "WStI",
+            "rotation": 1,
+            "entity_type": "corporation",
+            "id": 608,
+            "user": 7378,
+            "created_at": 1624203085,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 609,
+            "user": 7378,
+            "created_at": 1624203155,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 610,
+            "created_at": 1624203186,
+            "hex": "D3",
+            "tile": "8851-2",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 611,
+            "created_at": 1624203189
+        },
+        {
+            "type": "place_token",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 612,
+            "created_at": 1624203208,
+            "city": "15-0-0",
+            "slot": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 613,
+            "created_at": 1624203262,
+            "routes": [
+                {
+                    "train": "H-0",
+                    "connections": [
+                        [
+                            "F3",
+                            "F1"
+                        ],
+                        [
+                            "E4",
+                            "F3"
+                        ],
+                        [
+                            "D3",
+                            "E4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "B5",
+                            "C4"
+                        ],
+                        [
+                            "A6",
+                            "B5"
+                        ]
+                    ],
+                    "hexes": [
+                        "F1",
+                        "F3",
+                        "E4",
+                        "D3",
+                        "C4",
+                        "B5",
+                        "A6"
+                    ],
+                    "revenue": 360,
+                    "revenue_str": "F1-F3-E4-D3-C4-B5-A6",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 614,
+            "created_at": 1624203264,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 615,
+            "created_at": 1624203266
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 616,
+            "created_at": 1624203275
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 617,
+            "created_at": 1624203280,
+            "hex": "B9",
+            "tile": "791-3",
+            "rotation": 2
+        },
+        {
+            "type": "place_token",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 618,
+            "created_at": 1624203310,
+            "city": "791-2-0",
+            "slot": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 619,
+            "created_at": 1624203336,
+            "routes": [
+                {
+                    "train": "H-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C8",
+                            "B9"
+                        ],
+                        [
+                            "D7",
+                            "C8"
+                        ],
+                        [
+                            "E6",
+                            "D7"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ],
+                        [
+                            "F3",
+                            "F5"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C8",
+                        "D7",
+                        "E6",
+                        "F5",
+                        "F3"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "A8-B9-C8-D7-E6-F5-F3",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 620,
+            "created_at": 1624203339,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 621,
+            "created_at": 1624203344
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 622,
+            "created_at": 1624203349
+        },
+        {
+            "type": "lay_tile",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 623,
+            "created_at": 1624203368,
+            "hex": "E4",
+            "tile": "14-1",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 624,
+            "created_at": 1624203391,
+            "routes": [
+                {
+                    "train": "E-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "E10",
+                        "F11",
+                        "G12"
+                    ],
+                    "revenue": 350,
+                    "revenue_str": "G14-F13-E12-E10-F11-[G12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "F-1",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 500,
+                    "revenue_str": "I6-H7-G8-G10-F11-E12-D13-D15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 625,
+            "created_at": 1624203394,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 626,
+            "created_at": 1624203395
+        },
+        {
+            "type": "pass",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 627,
+            "created_at": 1624203397
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 628,
+            "user": 7378,
+            "created_at": 1624203412,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 629,
+            "user": 7378,
+            "created_at": 1624203418,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 630,
+            "created_at": 1624203428
+        },
+        {
+            "type": "lay_tile",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 631,
+            "created_at": 1624203552,
+            "hex": "C10",
+            "tile": "611-4",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 632,
+            "created_at": 1624203556,
+            "routes": [
+                {
+                    "train": "F-0",
+                    "connections": [
+                        [
+                            "B13",
+                            "B15"
+                        ],
+                        [
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B9",
+                            "B11"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "C6",
+                            "B7"
+                        ],
+                        [
+                            "C4",
+                            "C6"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "B15",
+                        "B13",
+                        "B11",
+                        "B9",
+                        "B7",
+                        "C6",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 480,
+                    "revenue_str": "B15-B13-B11-B9-B7-C6-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 633,
+            "created_at": 1624203558,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 634,
+            "created_at": 1624203561
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 635,
+            "created_at": 1624203562
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 636,
+            "created_at": 1624203576,
+            "hex": "E14",
+            "tile": "8851-3",
+            "rotation": 3
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 637,
+            "created_at": 1624203592
+        },
+        {
+            "type": "place_token",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 638,
+            "created_at": 1624203594,
+            "city": "57-3-0",
+            "slot": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 639,
+            "created_at": 1624203635,
+            "routes": [
+                {
+                    "train": "E-2",
+                    "connections": [
+                        [
+                            "E14",
+                            "D15"
+                        ],
+                        [
+                            "E12",
+                            "E14"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ],
+                        [
+                            "G12",
+                            "F11"
+                        ],
+                        [
+                            "H13",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "E14",
+                        "E12",
+                        "F11",
+                        "G12",
+                        "H13"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "D15-E14-E12-F11-G12-H13",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-2",
+                    "connections": [
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D11",
+                            "E12"
+                        ],
+                        [
+                            "C10",
+                            "D11"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "B9",
+                            "A8"
+                        ]
+                    ],
+                    "hexes": [
+                        "F11",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "A8"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "F11-E12-D11-C10-B9-A8",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 640,
+            "created_at": 1624203638,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 641,
+            "created_at": 1624203641
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 642,
+            "created_at": 1624203650
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 643,
+            "created_at": 1624203676,
+            "hex": "B5",
+            "tile": "619-3",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 644,
+            "created_at": 1624203693,
+            "routes": [
+                {
+                    "train": "H-0",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "F7",
+                            "G8"
+                        ],
+                        [
+                            "F5",
+                            "F7"
+                        ],
+                        [
+                            "E4",
+                            "F5"
+                        ],
+                        [
+                            "D3",
+                            "E4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "B5",
+                            "C4"
+                        ],
+                        [
+                            "A6",
+                            "B5"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "F7",
+                        "F5",
+                        "E4",
+                        "D3",
+                        "C4",
+                        "B5",
+                        "A6"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "I6-H7-G8-F7-F5-E4-D3-C4-B5-A6",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 645,
+            "created_at": 1624203695,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 646,
+            "created_at": 1624203697
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 647,
+            "created_at": 1624203703
+        },
+        {
+            "hex": "B9",
+            "tile": "794-1",
+            "type": "lay_tile",
+            "entity": "ECR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 648,
+            "user": 1864,
+            "created_at": 1624203713,
+            "skip": true
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "routes": [
+                {
+                    "hexes": [
+                        "C8",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "E12"
+                    ],
+                    "train": "E-1",
+                    "revenue": 250,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "B9",
+                            "C8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ]
+                    ],
+                    "revenue_str": "C8-B9-C10-[D11]-E12"
+                },
+                {
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "D13",
+                        "D15"
+                    ],
+                    "train": "G-0",
+                    "revenue": 530,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "D13",
+                            "D11"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "revenue_str": "I4-H5-G6-G8-F9-D11-D13-D15"
+                },
+                {
+                    "hexes": [
+                        "A10",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "F9",
+                        "G8",
+                        "H7"
+                    ],
+                    "train": "H-3",
+                    "revenue": 270,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "B9",
+                            "A10"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "F9",
+                            "E10",
+                            "D11"
+                        ],
+                        [
+                            "G8",
+                            "F9"
+                        ],
+                        [
+                            "H7",
+                            "G8"
+                        ]
+                    ],
+                    "revenue_str": "A10-B9-C10-D11-F9-G8-H7"
+                }
+            ],
+            "entity_type": "corporation",
+            "id": 649,
+            "user": 1864,
+            "created_at": 1624203799,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 650,
+            "user": 1864,
+            "created_at": 1624203832,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 651,
+            "user": 1864,
+            "created_at": 1624203876,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 652,
+            "created_at": 1624203882,
+            "hex": "B7",
+            "tile": "611-5",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "routes": [
+                {
+                    "hexes": [
+                        "D13",
+                        "E12",
+                        "F11",
+                        "G10",
+                        "G8",
+                        "G6",
+                        "H5"
+                    ],
+                    "train": "E-1",
+                    "revenue": 250,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "E12",
+                            "D13"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ],
+                        [
+                            "G10",
+                            "F11"
+                        ],
+                        [
+                            "G8",
+                            "G10"
+                        ],
+                        [
+                            "G6",
+                            "G8"
+                        ],
+                        [
+                            "H5",
+                            "G6"
+                        ]
+                    ],
+                    "revenue_str": "D13-E12-F11-G10-[G8]-G6-H5"
+                },
+                {
+                    "hexes": [
+                        "A6",
+                        "B7",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "E12",
+                        "F13",
+                        "F15"
+                    ],
+                    "train": "G-0",
+                    "revenue": 450,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "B7",
+                            "A6"
+                        ],
+                        [
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "F13",
+                            "F15"
+                        ]
+                    ],
+                    "revenue_str": "A6-B7-B9-C10-D11-E12-F13-F15"
+                },
+                {
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "C12",
+                        "B13",
+                        "B15"
+                    ],
+                    "train": "H-3",
+                    "revenue": 560,
+                    "subsidy": 0,
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "C12",
+                            "D11"
+                        ],
+                        [
+                            "B13",
+                            "C12"
+                        ],
+                        [
+                            "B15",
+                            "B13"
+                        ]
+                    ],
+                    "revenue_str": "I4-H5-G6-G8-F9-D11-C12-B13-B15"
+                }
+            ],
+            "entity_type": "corporation",
+            "id": 653,
+            "user": 1864,
+            "created_at": 1624203991,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 654,
+            "user": 1864,
+            "created_at": 1624204011,
+            "skip": true
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 655,
+            "created_at": 1624204117,
+            "routes": [
+                {
+                    "train": "E-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "D13",
+                            "D11"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "D13"
+                    ],
+                    "revenue": 260,
+                    "revenue_str": "A8-B9-C10-D11-[D13]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "G-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 450,
+                    "revenue_str": "G14-F13-E12-D11-C10-B9-B7-A6",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-3",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "C12",
+                            "D11"
+                        ],
+                        [
+                            "B13",
+                            "C12"
+                        ],
+                        [
+                            "B15",
+                            "B13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "C12",
+                        "B13",
+                        "B15"
+                    ],
+                    "revenue": 560,
+                    "revenue_str": "I4-H5-G6-G8-F9-D11-C12-B13-B15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 656,
+            "created_at": 1624204126,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 657,
+            "created_at": 1624204130
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 658,
+            "created_at": 1624204132
+        },
+        {
+            "type": "lay_tile",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 659,
+            "created_at": 1624204136,
+            "hex": "B9",
+            "tile": "794-1",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 660,
+            "created_at": 1624204186,
+            "routes": [
+                {
+                    "train": "H-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A10"
+                        ],
+                        [
+                            "C8",
+                            "B9"
+                        ],
+                        [
+                            "D7",
+                            "C8"
+                        ],
+                        [
+                            "E6",
+                            "D7"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ],
+                        [
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "F3",
+                            "F1"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B9",
+                        "C8",
+                        "D7",
+                        "E6",
+                        "F5",
+                        "F3",
+                        "F1"
+                    ],
+                    "revenue": 400,
+                    "revenue_str": "A10-B9-C8-D7-E6-F5-F3-F1",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 661,
+            "created_at": 1624204188,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 662,
+            "created_at": 1624204190
+        },
+        {
+            "type": "pass",
+            "entity": 1864,
+            "entity_type": "player",
+            "id": 663,
+            "created_at": 1624204199
+        },
+        {
+            "type": "pass",
+            "entity": 665,
+            "entity_type": "player",
+            "id": 664,
+            "created_at": 1624204209
+        },
+        {
+            "type": "pass",
+            "entity": 7378,
+            "entity_type": "player",
+            "id": 665,
+            "created_at": 1624204213
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 666,
+            "created_at": 1624204289,
+            "routes": [
+                {
+                    "train": "E-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "E10",
+                        "F11",
+                        "G12"
+                    ],
+                    "revenue": 350,
+                    "revenue_str": "G14-F13-E12-E10-F11-[G12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "F-1",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 500,
+                    "revenue_str": "I6-H7-G8-G10-F11-E12-D13-D15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 667,
+            "created_at": 1624204291,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 668,
+            "created_at": 1624204312,
+            "routes": [
+                {
+                    "train": "E-2",
+                    "connections": [
+                        [
+                            "E14",
+                            "D15"
+                        ],
+                        [
+                            "E12",
+                            "E14"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ],
+                        [
+                            "G12",
+                            "F11"
+                        ],
+                        [
+                            "H13",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "E14",
+                        "E12",
+                        "F11",
+                        "G12",
+                        "H13"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "D15-E14-E12-F11-G12-H13",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-2",
+                    "connections": [
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D11",
+                            "E12"
+                        ],
+                        [
+                            "C10",
+                            "D11"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "B9",
+                            "A8"
+                        ]
+                    ],
+                    "hexes": [
+                        "F11",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "A8"
+                    ],
+                    "revenue": 440,
+                    "revenue_str": "F11-E12-D11-C10-B9-A8",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 669,
+            "created_at": 1624204385,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 670,
+            "created_at": 1624204482,
+            "train": "H-4",
+            "price": 800,
+            "variant": "9F",
+            "warranties": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 671,
+            "created_at": 1624204487,
+            "routes": [
+                {
+                    "train": "F-0",
+                    "connections": [
+                        [
+                            "B13",
+                            "B15"
+                        ],
+                        [
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B9",
+                            "B11"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "C6",
+                            "B7"
+                        ],
+                        [
+                            "C4",
+                            "C6"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "B15",
+                        "B13",
+                        "B11",
+                        "B9",
+                        "B7",
+                        "C6",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 480,
+                    "revenue_str": "B15-B13-B11-B9-B7-C6-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 672,
+            "created_at": 1624204489,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 673,
+            "created_at": 1624204504,
+            "routes": [
+                {
+                    "train": "E-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "D13",
+                            "D11"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "D13"
+                    ],
+                    "revenue": 280,
+                    "revenue_str": "A8-B9-C10-D11-[D13]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "G-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 450,
+                    "revenue_str": "G14-F13-E12-D11-C10-B9-B7-A6",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-3",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "C12",
+                            "D11"
+                        ],
+                        [
+                            "B13",
+                            "C12"
+                        ],
+                        [
+                            "B15",
+                            "B13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "C12",
+                        "B13",
+                        "B15"
+                    ],
+                    "revenue": 560,
+                    "revenue_str": "I4-H5-G6-G8-F9-D11-C12-B13-B15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 674,
+            "created_at": 1624204505,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 675,
+            "created_at": 1624204513,
+            "routes": [
+                {
+                    "train": "H-0",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "F7",
+                            "G8"
+                        ],
+                        [
+                            "F5",
+                            "F7"
+                        ],
+                        [
+                            "E4",
+                            "F5"
+                        ],
+                        [
+                            "D3",
+                            "E4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "B5",
+                            "C4"
+                        ],
+                        [
+                            "A6",
+                            "B5"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "F7",
+                        "F5",
+                        "E4",
+                        "D3",
+                        "C4",
+                        "B5",
+                        "A6"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "I6-H7-G8-F7-F5-E4-D3-C4-B5-A6",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 676,
+            "created_at": 1624204515,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 677,
+            "created_at": 1624204522,
+            "routes": [
+                {
+                    "train": "H-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A10"
+                        ],
+                        [
+                            "C8",
+                            "B9"
+                        ],
+                        [
+                            "D7",
+                            "C8"
+                        ],
+                        [
+                            "E6",
+                            "D7"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ],
+                        [
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "F3",
+                            "F1"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B9",
+                        "C8",
+                        "D7",
+                        "E6",
+                        "F5",
+                        "F3",
+                        "F1"
+                    ],
+                    "revenue": 400,
+                    "revenue_str": "A10-B9-C8-D7-E6-F5-F3-F1",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 678,
+            "created_at": 1624204523,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 679,
+            "created_at": 1624204532,
+            "routes": [
+                {
+                    "train": "E-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "E10",
+                        "F11",
+                        "G12"
+                    ],
+                    "revenue": 350,
+                    "revenue_str": "G14-F13-E12-E10-F11-[G12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "F-1",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 500,
+                    "revenue_str": "I6-H7-G8-G10-F11-E12-D13-D15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 680,
+            "created_at": 1624204533,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 681,
+            "created_at": 1624204539,
+            "routes": [
+                {
+                    "train": "E-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "D13",
+                            "D11"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "D13"
+                    ],
+                    "revenue": 280,
+                    "revenue_str": "A8-B9-C10-D11-[D13]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "G-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 450,
+                    "revenue_str": "G14-F13-E12-D11-C10-B9-B7-A6",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-3",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "C12",
+                            "D11"
+                        ],
+                        [
+                            "B13",
+                            "C12"
+                        ],
+                        [
+                            "B15",
+                            "B13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "C12",
+                        "B13",
+                        "B15"
+                    ],
+                    "revenue": 560,
+                    "revenue_str": "I4-H5-G6-G8-F9-D11-C12-B13-B15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 682,
+            "created_at": 1624204540,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 683,
+            "created_at": 1624204557,
+            "routes": [
+                {
+                    "train": "F-0",
+                    "connections": [
+                        [
+                            "B13",
+                            "B15"
+                        ],
+                        [
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B9",
+                            "B11"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "C6",
+                            "B7"
+                        ],
+                        [
+                            "C4",
+                            "C6"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "B15",
+                        "B13",
+                        "B11",
+                        "B9",
+                        "B7",
+                        "C6",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 480,
+                    "revenue_str": "B15-B13-B11-B9-B7-C6-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 684,
+            "created_at": 1624204558,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 685,
+            "created_at": 1624204563,
+            "routes": [
+                {
+                    "train": "H-0",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "F7",
+                            "G8"
+                        ],
+                        [
+                            "F5",
+                            "F7"
+                        ],
+                        [
+                            "E4",
+                            "F5"
+                        ],
+                        [
+                            "D3",
+                            "E4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "B5",
+                            "C4"
+                        ],
+                        [
+                            "A6",
+                            "B5"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "F7",
+                        "F5",
+                        "E4",
+                        "D3",
+                        "C4",
+                        "B5",
+                        "A6"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "I6-H7-G8-F7-F5-E4-D3-C4-B5-A6",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 686,
+            "created_at": 1624204564,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 687,
+            "created_at": 1624204678,
+            "routes": [
+                {
+                    "train": "E-2",
+                    "connections": [
+                        [
+                            "E14",
+                            "D15"
+                        ],
+                        [
+                            "E12",
+                            "E14"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ],
+                        [
+                            "G12",
+                            "F11"
+                        ],
+                        [
+                            "H13",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "E14",
+                        "E12",
+                        "F11",
+                        "G12",
+                        "H13"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "D15-E14-E12-F11-G12-H13",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-2",
+                    "connections": [
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D11",
+                            "E12"
+                        ],
+                        [
+                            "C10",
+                            "D11"
+                        ],
+                        [
+                            "B9",
+                            "C10"
+                        ],
+                        [
+                            "A10",
+                            "B9"
+                        ]
+                    ],
+                    "hexes": [
+                        "F11",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "A10"
+                    ],
+                    "revenue": 440,
+                    "revenue_str": "F11-E12-D11-C10-B9-A10",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-4",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "C10",
+                            "D11"
+                        ],
+                        [
+                            "B9",
+                            "C10"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "A6",
+                            "B7"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "I6-H7-G8-F9-D11-C10-B9-B7-A6",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 688,
+            "created_at": 1624204679,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 689,
+            "created_at": 1624204707,
+            "routes": [
+                {
+                    "train": "H-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A10"
+                        ],
+                        [
+                            "C8",
+                            "B9"
+                        ],
+                        [
+                            "D7",
+                            "C8"
+                        ],
+                        [
+                            "E6",
+                            "D7"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ],
+                        [
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "F3",
+                            "F1"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B9",
+                        "C8",
+                        "D7",
+                        "E6",
+                        "F5",
+                        "F3",
+                        "F1"
+                    ],
+                    "revenue": 400,
+                    "revenue_str": "A10-B9-C8-D7-E6-F5-F3-F1",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 690,
+            "created_at": 1624204708,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 691,
+            "created_at": 1624204712,
+            "routes": [
+                {
+                    "train": "E-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "E10"
+                        ],
+                        [
+                            "E10",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "E10",
+                        "F11",
+                        "G12"
+                    ],
+                    "revenue": 350,
+                    "revenue_str": "G14-F13-E12-E10-F11-[G12]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "F-1",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "G10",
+                            "G8"
+                        ],
+                        [
+                            "F11",
+                            "G10"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "G10",
+                        "F11",
+                        "E12",
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 500,
+                    "revenue_str": "I6-H7-G8-G10-F11-E12-D13-D15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "EUR",
+            "entity_type": "corporation",
+            "id": 692,
+            "created_at": 1624204714,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 693,
+            "created_at": 1624204740,
+            "routes": [
+                {
+                    "train": "E-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A8"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "D13",
+                            "D11"
+                        ]
+                    ],
+                    "hexes": [
+                        "A8",
+                        "B9",
+                        "C10",
+                        "D11",
+                        "D13"
+                    ],
+                    "revenue": 280,
+                    "revenue_str": "A8-B9-C10-D11-[D13]",
+                    "subsidy": 0
+                },
+                {
+                    "train": "G-0",
+                    "connections": [
+                        [
+                            "F13",
+                            "G14"
+                        ],
+                        [
+                            "F13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "D11"
+                        ],
+                        [
+                            "D11",
+                            "C10"
+                        ],
+                        [
+                            "C10",
+                            "B9"
+                        ],
+                        [
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "G14",
+                        "F13",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 450,
+                    "revenue_str": "G14-F13-E12-D11-C10-B9-B7-A6",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-3",
+                    "connections": [
+                        [
+                            "H5",
+                            "I4"
+                        ],
+                        [
+                            "G6",
+                            "H5"
+                        ],
+                        [
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "C12",
+                            "D11"
+                        ],
+                        [
+                            "B13",
+                            "C12"
+                        ],
+                        [
+                            "B15",
+                            "B13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I4",
+                        "H5",
+                        "G6",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "C12",
+                        "B13",
+                        "B15"
+                    ],
+                    "revenue": 560,
+                    "revenue_str": "I4-H5-G6-G8-F9-D11-C12-B13-B15",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ECR",
+            "entity_type": "corporation",
+            "id": 694,
+            "created_at": 1624204744,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 695,
+            "created_at": 1624204751,
+            "routes": [
+                {
+                    "train": "E-2",
+                    "connections": [
+                        [
+                            "E14",
+                            "D15"
+                        ],
+                        [
+                            "E12",
+                            "E14"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ],
+                        [
+                            "G12",
+                            "F11"
+                        ],
+                        [
+                            "H13",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "E14",
+                        "E12",
+                        "F11",
+                        "G12",
+                        "H13"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "D15-E14-E12-F11-G12-H13",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-2",
+                    "connections": [
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "D11",
+                            "E12"
+                        ],
+                        [
+                            "C10",
+                            "D11"
+                        ],
+                        [
+                            "B9",
+                            "C10"
+                        ],
+                        [
+                            "A10",
+                            "B9"
+                        ]
+                    ],
+                    "hexes": [
+                        "F11",
+                        "E12",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "A10"
+                    ],
+                    "revenue": 440,
+                    "revenue_str": "F11-E12-D11-C10-B9-A10",
+                    "subsidy": 0
+                },
+                {
+                    "train": "H-4",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "F9",
+                            "G8"
+                        ],
+                        [
+                            "D11",
+                            "E10",
+                            "F9"
+                        ],
+                        [
+                            "C10",
+                            "D11"
+                        ],
+                        [
+                            "B9",
+                            "C10"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "A6",
+                            "B7"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "F9",
+                        "D11",
+                        "C10",
+                        "B9",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "I6-H7-G8-F9-D11-C10-B9-B7-A6",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NGC",
+            "entity_type": "corporation",
+            "id": 696,
+            "created_at": 1624204770,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 697,
+            "created_at": 1624204774,
+            "routes": [
+                {
+                    "train": "F-0",
+                    "connections": [
+                        [
+                            "B13",
+                            "B15"
+                        ],
+                        [
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B9",
+                            "B11"
+                        ],
+                        [
+                            "B7",
+                            "B9"
+                        ],
+                        [
+                            "C6",
+                            "B7"
+                        ],
+                        [
+                            "C4",
+                            "C6"
+                        ],
+                        [
+                            "C2",
+                            "C4"
+                        ]
+                    ],
+                    "hexes": [
+                        "B15",
+                        "B13",
+                        "B11",
+                        "B9",
+                        "B7",
+                        "C6",
+                        "C4",
+                        "C2"
+                    ],
+                    "revenue": 480,
+                    "revenue_str": "B15-B13-B11-B9-B7-C6-C4-C2",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "L&E",
+            "entity_type": "corporation",
+            "id": 698,
+            "created_at": 1624204775,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 699,
+            "created_at": 1624204782,
+            "routes": [
+                {
+                    "train": "H-0",
+                    "connections": [
+                        [
+                            "H7",
+                            "I6"
+                        ],
+                        [
+                            "G8",
+                            "H7"
+                        ],
+                        [
+                            "F7",
+                            "G8"
+                        ],
+                        [
+                            "F5",
+                            "F7"
+                        ],
+                        [
+                            "E4",
+                            "F5"
+                        ],
+                        [
+                            "D3",
+                            "E4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "B5",
+                            "C4"
+                        ],
+                        [
+                            "A6",
+                            "B5"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "H7",
+                        "G8",
+                        "F7",
+                        "F5",
+                        "E4",
+                        "D3",
+                        "C4",
+                        "B5",
+                        "A6"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "I6-H7-G8-F7-F5-E4-D3-C4-B5-A6",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "WStI",
+            "entity_type": "corporation",
+            "id": 700,
+            "created_at": 1624204784,
+            "kind": "payout"
+        },
+        {
+            "type": "run_routes",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 701,
+            "created_at": 1624204788,
+            "routes": [
+                {
+                    "train": "H-1",
+                    "connections": [
+                        [
+                            "B9",
+                            "A10"
+                        ],
+                        [
+                            "C8",
+                            "B9"
+                        ],
+                        [
+                            "D7",
+                            "C8"
+                        ],
+                        [
+                            "E6",
+                            "D7"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ],
+                        [
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "F3",
+                            "F1"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B9",
+                        "C8",
+                        "D7",
+                        "E6",
+                        "F5",
+                        "F3",
+                        "F1"
+                    ],
+                    "revenue": 400,
+                    "revenue_str": "A10-B9-C8-D7-E6-F5-F3-F1",
+                    "subsidy": 0
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "ENR",
+            "entity_type": "corporation",
+            "id": 702,
+            "created_at": 1624204790,
+            "kind": "payout"
+        }
+    ],
+    "loaded": true,
+    "created_at": 1624188190,
+    "updated_at": 1624204790
+}


### PR DESCRIPTION
- Make the base game's `init_share_pool` method use the `PRESIDENT_SALES_TO_MARKET` constant - therefore games no longer need to override both the constant and the method to enable presidencies to be sellable
- Move the shared behaviour of trainless corporation shares being worth 50% in 1860, 1862, and 18GB into a single module for improved maintainabillity
- Add a test fixture for 1862 to ensure previous behaviour is maintained