### PR TITLE
Fix 18mex NdM swap rules (fixes both issues in #4758)

### DIFF
--- a/lib/engine/game/g_18_mex/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_mex/step/buy_sell_par_shares.rb
@@ -22,6 +22,15 @@ module Engine
 
           include SwapBuySell
 
+          def can_buy_any?(entity)
+            return true if super
+
+            # If all we can do is swap, ensure we're given the opportunity for it
+            ndm = @game.ndm
+            valid_pool_shares = @game.share_pool.shares_by_corporation[ndm].select { |s| s.percent == 10 }
+            return true if !valid_pool_shares.empty? && swap_buy(entity, ndm, valid_pool_shares[0])
+          end
+
           private
 
           def attempt_ndm_action_on_unavailable?(bundle)

--- a/lib/engine/game/g_18_mex/step/swap_buy_sell.rb
+++ b/lib/engine/game/g_18_mex/step/swap_buy_sell.rb
@@ -4,17 +4,20 @@
 # This module is used in classes that need to support
 # swapping of shares.
 module SwapBuySell
-  # Check if it is possible to buy an NdM IPO or Pool share of 10%
-  # when player swaps in a 5% share.
-  def swap_buy(player, corporation, ipo_or_pool_share)
-    return if @game.ndm != corporation || ipo_or_pool_share.percent != 10
+  # Check if it is possible to buy an NdM share of 10%
+  # when player swaps in a 5% share and return the share to be swapped in.
+  def swap_buy(player, corporation, share)
+    return if @game.ndm != corporation || share.percent != 10
+
+    # Must be in pool, not IPO (rule 3.2.c(5))
+    return unless @game.share_pool.shares_by_corporation[corporation].include?(share)
 
     swap_share = player.shares_of(corporation).find { |s| s.percent == 5 }
     return unless swap_share
 
     # If we were allowed to buy another 5% then swap is OK.
     # We test that a reduced buy of 5% would be allowed.
-    can_buy?(player, bundle_reduced_five_percent([ipo_or_pool_share])) ? swap_share : nil
+    can_buy?(player, bundle_reduced_five_percent([share])) ? swap_share : nil
   end
 
   # Check if it is possible to sell an NdM bundle if player swap 5% share from pool


### PR DESCRIPTION
 - Half shares can be swapped only for full shares in the market, not IPO
 - Swapping wasn't available when it was the only way to buy a share