### PR TITLE
1836Jr30: follow 1830 rules for brown shares (fixes #5260)

### DIFF
--- a/lib/engine/game/g_1836_jr30/game.rb
+++ b/lib/engine/game/g_1836_jr30/game.rb
@@ -478,6 +478,10 @@ module Engine
 
           revenue
         end
+
+        def multiple_buy_only_from_market?
+          !optional_rules&.include?(:multiple_brown_from_ipo)
+        end
       end
     end
   end

--- a/lib/engine/game/g_1836_jr30/meta.rb
+++ b/lib/engine/game/g_1836_jr30/meta.rb
@@ -16,6 +16,13 @@ module Engine
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/114572/1836jr-30-rules'
 
         PLAYER_RANGE = [2, 4].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :multiple_brown_from_ipo,
+            short_name: 'Buy Multiple Brown Shares From IPO',
+            desc: 'Multiple brown shares may be bought from IPO as well as from pool',
+          },
+        ].freeze
       end
     end
   end

--- a/spec/fixtures/1836Jr30/2851.json
+++ b/spec/fixtures/1836Jr30/2851.json
@@ -22,7 +22,10 @@
   "max_players": 3,
   "title": "1836Jr30",
   "settings": {
-    "seed": 1.4607318533142025e+38
+    "seed": 1.4607318533142025e+38,
+    "optional_rules": [
+      "multiple_brown_from_ipo"
+    ]
   },
   "status": "finished",
   "turn": 7,


### PR DESCRIPTION
Adds an optional rule to get the old behavior, as 1830 does. I had to change one fixture to give it the optional rule retroactively.