### PR TITLE
1870 Add check for city count matching on yellow lay for labelled hexes.

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -801,7 +801,11 @@ module Engine
           return false if to.name == '171K' && from.hex.name != 'B11'
           return false if to.name == '172L' && from.hex.name != 'C18'
           return false if to.name == '63' && (from.hex.name == 'B11' || from.hex.name == 'C18')
-          return %w[B11 C18 N17 J3 J5].include?(from.hex.name) if from.color == :green && to.name == '170'
+
+          if %w[B11 C18 N17 J3 J5].include?(from.hex.name)
+            return true if from.color == :green && to.name == '170'
+            return false if to.color == :yellow && to.cities.empty?
+          end
 
           super
         end


### PR DESCRIPTION
Some of the normal upgrade checks are suppressed for labelled tiles as they can have odd rules. 
Add a check for yellow lays in 70. 

Fixes https://github.com/tobymao/18xx/issues/7059