### PR TITLE
show correct active player if there are multiple

### DIFF
--- a/assets/app/view/game/issue_shares.rb
+++ b/assets/app/view/game/issue_shares.rb
@@ -44,7 +44,7 @@ module View
             end
 
             # confirm if redeeming from a different player
-            if (bundle.owner != @game.bank) && (bundle.owner != @game.current_entity)
+            if (bundle.owner != @game.bank) && (bundle.owner != @game.current_entity) && bundle.owner.player?
               check_consent(bundle.owner, process_redeem)
             else
               process_redeem.call

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -284,7 +284,7 @@ module View
     def active_player
       @game_data[:mode] != :hotseat &&
         !cursor &&
-        @game.active_players_id.include?(@user&.dig('id'))
+        @game.current_entity.player.id == @user['id']
     end
 
     def menu

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -284,7 +284,7 @@ module View
     def active_player
       @game_data[:mode] != :hotseat &&
         !cursor &&
-        @game.current_entity.player.id == @user['id']
+        @game.current_entity.player.id == @user&.dig('id')
     end
 
     def menu


### PR DESCRIPTION
Use current_entity instead of active_players_id in case there are multiple "active" players
Fixes #5847
Fixes #7091
1870 destination connections may cause multiple railroads and players to be "active", but of course only one of them is really the active player.  The Choose buttons work properly, erroring for non-active player. Only the game header showed the active color for all destinating players.