### PR TITLE
Run routes through correct nodes when deserializing (fixes #5279)

### DIFF
--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -47,10 +47,16 @@ module View
         return [] unless last_run
 
         halts = operating[operating.keys.max]&.halts
+        nodes = operating[operating.keys.max]&.nodes
         routes = []
         last_run.each do |train, connection_hexes|
-          routes << Engine::Route.new(@game, @game.phase, train, connection_hexes: connection_hexes,
-                                                                 routes: routes, num_halts: halts[train])
+          routes << Engine::Route.new(@game,
+                                      @game.phase,
+                                      train,
+                                      connection_hexes: connection_hexes,
+                                      routes: routes,
+                                      num_halts: halts[train],
+                                      nodes: nodes[train])
         end
 
         routes

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -33,6 +33,7 @@ module View
         return [] if @abilities&.any?
 
         halts = operating[operating.keys.max]&.halts
+        nodes = operating[operating.keys.max]&.nodes
         last_run.map do |train, connection_hexes|
           next unless trains.include?(train)
 
@@ -44,6 +45,7 @@ module View
             connection_hexes: connection_hexes,
             routes: @routes,
             halts: halts[train],
+            nodes: nodes[train],
           )
         end.compact
       end

--- a/lib/engine/action/run_routes.rb
+++ b/lib/engine/action/run_routes.rb
@@ -25,6 +25,7 @@ module Engine
             subsidy: route['subsidy'],
             halts: route['halts'],
             abilities: route['abilities'],
+            nodes: route['nodes'],
           }.select { |_, v| v }
 
           routes << Route.new(
@@ -50,6 +51,7 @@ module Engine
             'subsidy' => route.subsidy,
             'halts' => route.halts,
             'abilities' => route.abilities,
+            'nodes' => route.nodes.map(&:full_id),
           }.select { |_, v| v }
         end
 

--- a/lib/engine/operating_info.rb
+++ b/lib/engine/operating_info.rb
@@ -3,13 +3,14 @@
 module Engine
   # Information about an entities operating round
   class OperatingInfo
-    attr_reader :routes, :halts, :dividend, :revenue, :dividend_kind
+    attr_reader :routes, :halts, :nodes, :dividend, :revenue, :dividend_kind
     attr_accessor :laid_hexes
 
     def initialize(runs, dividend, revenue, laid_hexes, dividend_kind: nil)
       # Convert the route into connection hexes as upgrades may break the representation
       @routes = runs.to_h { |run| [run.train, run.connection_hexes] }
       @halts = runs.to_h { |run| [run.train, run.halts] }
+      @nodes = runs.to_h { |run| [run.train, run.nodes.map(&:full_id)] }
       @revenue = revenue
       @dividend = dividend
       @laid_hexes = laid_hexes

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -14,7 +14,7 @@ module Engine
       end
 
       def full_id
-        "#{hex.id} #{id}"
+        "#{hex.id}-#{tile.name}-#{index}"
       end
 
       def hex

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -13,6 +13,10 @@ module Engine
         @id ||= "#{tile.id}-#{index}"
       end
 
+      def full_id
+        "#{hex.id} #{id}"
+      end
+
       def hex
         @tile&.hex
       end

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -400,7 +400,7 @@ module Engine
 
       return [] if candidates.empty?
 
-      return candidates[0] if candidates.length == 1
+      return candidates[0] if candidates.size == 1
 
       # If we're reconstructing a route with multiple ways to satisfy
       # the connection data (e.g., 457--464, IR7--8), prefer ones that


### PR DESCRIPTION
When serializing a route, save off its nodes (both the hex and the spot on the tile).

When deserializing a route, if the saved nodes are present and there's a choice of nodes to use for some tile, use the one that matches the saved nodes.

Tiles that can fail to deserialize routes correctly without this code include IR7, IR8, and 457-464.

If saved nodes are not present then the deserialization is the same as before, so it's backward compatible.

This code is fine with respect to the comment at https://github.com/tobymao/18xx/issues/5279#issuecomment-1034000192, since if the deserialization code can't find a chain that hits the saved nodes, it just returns the first possibility, as before.