### PR TITLE
18GB Private Companies

### DIFF
--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -101,8 +101,8 @@ module Engine
           },
           {
             name: 'Stockton & Darlington',
-            value: 45,
-            revenue: 15,
+            value: 35,
+            revenue: 12,
             desc: 'The SD gives a bonus of £10 for Middlesbrough (J13). The owner of the SD may use this bonus for any trains ' \
                   'owned by Companies that they control, from the time that the SD closes until the end of the game.',
             sym: 'SD',
@@ -193,7 +193,7 @@ module Engine
           {
             name: 'Taff Vale',
             value: 60,
-            revenue: 20,
+            revenue: 25,
             desc: 'The TV allows a company to waive the cost of laying the Severn Tunnel tile - the blue estuary tile marked ' \
                   '"S" - in hex C22. This follows the usual rules for upgrades, so the game must be in an appropriate phase, ' \
                   'some part of the new track on the new tile must form part of a route for the company, and the company must ' \

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -359,6 +359,13 @@ module Engine
           company.value = 0
         end
 
+        def close_company_in_hex(hex)
+          @companies.each do |company|
+            block = abilities(company, :blocks_hexes)
+            close_company(company) if block.hexes.include?(hex.coordinates)
+          end
+        end
+
         def game_companies
           scenario_comps = @scenario['companies']
           self.class::COMPANIES.select { |comp| scenario_comps.include?(comp['sym']) }
@@ -619,6 +626,10 @@ module Engine
             Engine::Step::HomeToken,
             G18GB::Step::BuySellParShares,
           ])
+        end
+
+        def hex_blocked_by_ability?(_entity, ability, hex)
+          phase.tiles.include?(:blue) ? false : super
         end
 
         def special_green_hexes(corporation)

--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -51,6 +51,7 @@ module Engine
 
           def choices_ability(company)
             return {} unless company.company?
+            return {} unless @game.turn > 1
 
             ability = @game.abilities(company, :choose_ability)
             return {} unless ability

--- a/lib/engine/game/g_18_gb/step/special_token.rb
+++ b/lib/engine/game/g_18_gb/step/special_token.rb
@@ -27,17 +27,25 @@ module Engine
             [token, special_ability]
           end
 
+          def switch_for_expensive_token(token)
+            return token unless token.price.zero?
+            return token unless current_entity.tokens.size > 1
+
+            current_entity.tokens.max_by(&:price)
+          end
+
           def process_place_token(action)
             hex = action.city.hex
             city_string = hex.tile.cities.size > 1 ? " city #{action.city.index}" : ''
             raise GameError, "Cannot place token on #{hex.name}#{city_string}" unless available_hex(action.entity, hex)
 
+            token = switch_for_expensive_token(action.token)
             action.city.remove_reservation!(action.entity)
 
             place_token(
               action.entity,
               action.city,
-              action.token,
+              token,
               connected: false,
               special_ability: ability(action.entity),
               spender: current_entity,

--- a/lib/engine/game/g_18_gb/step/track_and_token.rb
+++ b/lib/engine/game/g_18_gb/step/track_and_token.rb
@@ -43,6 +43,7 @@ module Engine
             raise GameError, 'Cannot lay a city tile now' if !tile.cities.empty? && @laid_city
 
             lay_tile(action, extra_cost: tile_lay[:cost])
+            @game.close_company_in_hex(action.hex)
             @laid_city = true unless action.tile.cities.empty?
             @round.num_laid_track += 1
             @round.laid_hexes << action.hex


### PR DESCRIPTION
- Second-edition private company price and revenue changes
- Private companies can't be closed in SR1
- From blue phase onwards, companies can be force-closed by building in their hex
- When using the GC or MC token abilities, a 10-share Caledonian Railway can keep back its free token and use a more expensive available token instead