### PR TITLE
getting started on 18 Los Angeles 2nd Edition

### DIFF
--- a/lib/engine/game/g_18_los_angeles/meta.rb
+++ b/lib/engine/game/g_18_los_angeles/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :production
+        DEV_STAGE = :prealpha
         DEPENDS_ON = '1846'
 
         GAME_DESIGNER = 'Anthony Fryer'
@@ -20,9 +20,17 @@ module Engine
           '1846 Rules' =>
                 'https://s3-us-west-2.amazonaws.com/gmtwebsiteassets/1846/1846-RULES-GMT.pdf',
         }.freeze
-        GAME_TITLE = '18 Los Angeles'
+        GAME_TITLE = '18 Los Angeles 2'
+        # GAME_DISPLAY_TITLE = '18 Los Angeles'
         GAME_SUBTITLE = 'Railroading in the City of Angels'
-        GAME_ALIASES = ['18LA'].freeze
+        GAME_ALIASES = ['18LA 2'].freeze
+        # GAME_VARIANTS = [
+        #   {
+        #     sym: :first_ed,
+        #     name: '1st Edition',
+        #     title: '18 Los Angeles',
+        #   },
+        # ].freeze
 
         PLAYER_RANGE = [2, 5].freeze
         OPTIONAL_RULES = [

--- a/lib/engine/game/g_18_los_angeles/meta.rb
+++ b/lib/engine/game/g_18_los_angeles/meta.rb
@@ -23,7 +23,7 @@ module Engine
         GAME_TITLE = '18 Los Angeles 2'
         # GAME_DISPLAY_TITLE = '18 Los Angeles'
         GAME_SUBTITLE = 'Railroading in the City of Angels'
-        GAME_ALIASES = ['18LA 2'].freeze
+        GAME_ALIASES = ['18LA'].freeze
         # GAME_VARIANTS = [
         #   {
         #     sym: :first_ed,

--- a/lib/engine/game/g_18_los_angeles1.rb
+++ b/lib/engine/game/g_18_los_angeles1.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G18LosAngeles1
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles1/game.rb
+++ b/lib/engine/game/g_18_los_angeles1/game.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../g_18_los_angeles/game'
+require_relative 'meta'
+
+module Engine
+  module Game
+    module G18LosAngeles1
+      class Game < G18LosAngeles::Game
+        include_meta(G18LosAngeles1::Meta)
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles1/meta.rb
+++ b/lib/engine/game/g_18_los_angeles1/meta.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+require_relative '../g_18_los_angeles/meta'
+
+module Engine
+  module Game
+    module G18LosAngeles1
+      module Meta
+        include Game::Meta
+        include G18LosAngeles::Meta
+
+        DEV_STAGE = :production
+        DEPENDS_ON = '18 Los Angeles 2'
+
+        GAME_TITLE = '18 Los Angeles'
+        GAME_ALIASES = ['18LA'].freeze
+        # GAME_IS_VARIANT_OF = G18LosAngeles::Meta
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles1/meta.rb
+++ b/lib/engine/game/g_18_los_angeles1/meta.rb
@@ -14,7 +14,6 @@ module Engine
         DEPENDS_ON = '18 Los Angeles 2'
 
         GAME_TITLE = '18 Los Angeles'
-        GAME_ALIASES = ['18LA'].freeze
         # GAME_IS_VARIANT_OF = G18LosAngeles::Meta
       end
     end

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -37,7 +37,8 @@ module Engine
       G1889 => ['1889', 'Shikoku', 'Shikoku 1889', 'History of Shikoku Railways'],
       G18Chesapeake => %w[18Chesapeake Chessie],
       G18ChesapeakeOffTheRails => ['ChesapeakeOTR', 'OTR', '18Chesapeake: Off the Rails'],
-      G18LosAngeles => ['18 Los Angeles', '18LosAngeles', '18LA'],
+      G18LosAngeles1 => ['18 Los Angeles', '18LosAngeles', '18LA'],
+      G18LosAngeles => ['18 Los Angeles 2', '18LosAngeles2', '18LA2'],
     }.each do |game_module, fuzzy_titles|
       expected_title = game_module.const_get('Meta').title
 

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -37,8 +37,8 @@ module Engine
       G1889 => ['1889', 'Shikoku', 'Shikoku 1889', 'History of Shikoku Railways'],
       G18Chesapeake => %w[18Chesapeake Chessie],
       G18ChesapeakeOffTheRails => ['ChesapeakeOTR', 'OTR', '18Chesapeake: Off the Rails'],
-      G18LosAngeles1 => ['18 Los Angeles', '18LosAngeles', '18LA'],
-      G18LosAngeles => ['18 Los Angeles 2', '18LosAngeles2', '18LA2'],
+      G18LosAngeles1 => ['18 Los Angeles'],
+      G18LosAngeles => ['18 Los Angeles 2', '18LA'],
     }.each do |game_module, fuzzy_titles|
       expected_title = game_module.const_get('Meta').title
 


### PR DESCRIPTION
* `g_18_los_angeles1/` and `G18LosAngeles1` will now contain code for the 1st
  Edition

* `g_18_los_angeles/` and `G18LosAngeles` will now contain code for the 2nd
  Edition

* `G18LosAngeles` has `GAME_TITLE = '18 Los Angeles 2'` while `G18LosAngeles1`
  has `GAME_TITLE = '18 Los Angeles'`; this means no DB migrations will be needed
  for the 1st Edition to continue to work

* `G18LosAngeles1` inherits from `G18LosAngeles` so that when the 2nd Edition is
  production ready, we can easily combine the two editions back into a single
  game entry, with the first edition being turned into a checkmark option. When
  that happens, the currently commented out lines in the two `meta.rb` files will
  be uncommented.

* as I make the actual changes necessary for the 2nd Edition, code that is
  specific to the 1st Edition will be moved from `g_18_los_angeles/` to
  `g_18_los_angeles1/`; starting with all the code in `g_18_los_angeles/`
  minimizes the diff for this initial change

#7110