### PR TITLE
18GB Train buying

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -572,6 +572,16 @@ module Engine
           @_shares[share.id] = share
         end
 
+        def emergency_convert_bundles(corporation)
+          return [] if corporation.trains.any?
+          return [] if corporation.cash >= @depot.min_depot_price
+
+          shares = (1..5).map { |i| Engine::Share.new(corporation, percent: 20, index: 4 + i) }
+          bundle = Engine::ShareBundle.new(shares)
+          bundle.share_price = stock_market.find_share_price(corporation, [:left] * 3).price
+          [bundle]
+        end
+
         def convert_to_ten_share(corporation, price_drops = 0)
           # update corporation type and report conversion
           corporation.type = '10-share'

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -573,10 +573,10 @@ module Engine
         end
 
         def emergency_convert_bundles(corporation)
-          return [] if corporation.trains.any?
+          return [] unless corporation.trains.empty?
           return [] if corporation.cash >= @depot.min_depot_price
 
-          shares = (1..5).map { |i| Engine::Share.new(corporation, percent: 20, index: 4 + i) }
+          shares = (0..4).map { |i| Engine::Share.new(corporation, percent: 20, index: 4 + i) }
           bundle = Engine::ShareBundle.new(shares)
           bundle.share_price = stock_market.find_share_price(corporation, [:left] * 3).price
           [bundle]

--- a/lib/engine/game/g_18_gb/round/operating.rb
+++ b/lib/engine/game/g_18_gb/round/operating.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require_relative '../../../round/operating'
+require_relative '../../../action/buy_train'
 require_relative '../../../action/dividend'
+require_relative '../../../action/pass'
 require_relative '../../../action/run_routes'
 
 module Engine
@@ -10,10 +12,33 @@ module Engine
       module Round
         class Operating < Engine::Round::Operating
           def after_process(action)
-            if (entity = @entities[@entity_index]).receivership? || @game.insolvent?(entity)
+            entity = @entities[@entity_index]
+
+            if entity.receivership? || @game.insolvent?(entity)
               case action
               when Engine::Action::RunRoutes
+                # once an insolvent or receivership corporation runs its routes, automatically submit a Withhold for them
                 process_action(Engine::Action::Dividend.new(entity, kind: 'withhold')) if action.routes.any?
+              end
+            end
+
+            if entity.receivership? && @game.insolvent?(entity)
+              case action
+              when Engine::Action::Dividend
+                # after dividend (withheld, as above) for a receivership corporation in insolvency, it reaches train buying
+
+                # if the corporation is 5-share and cannot afford the cheapest train available, it will first convert to 10-share
+                @game.convert_to_ten_share(entity, 3) if entity.type == '5-share' && entity.cash < @game.depot.min_depot_price
+
+                # now the corporation buys the most expensive train that it can afford
+                affordable_trains = @game.depot.depot_trains.select { |train| train.price < entity.cash }
+                if affordable_trains.empty?
+                  # none affordable - pass instead
+                  process_action(Engine::Action::Pass.new(entity))
+                else
+                  train = affordable_trains.max_by(&:price)
+                  process_action(Engine::Action::BuyTrain.new(entity, train: train, price: train.price))
+                end
               end
             end
 

--- a/lib/engine/game/g_18_gb/step/buy_train.rb
+++ b/lib/engine/game/g_18_gb/step/buy_train.rb
@@ -14,7 +14,7 @@ module Engine
             actions = []
             actions << 'sell_shares' if entity.trains.empty? && can_convert?(entity)
             actions << 'buy_train' if can_buy_train?(entity)
-            actions << 'pass' unless actions.empty? || must_buy_train?(entity)
+            actions << 'pass' if !actions.empty? && !must_buy_train?(entity)
             actions
           end
 

--- a/lib/engine/game/g_18_gb/step/route.rb
+++ b/lib/engine/game/g_18_gb/step/route.rb
@@ -21,7 +21,7 @@ module Engine
 
             if entity.receivership? && entity.trains.empty? && @game.can_run_route?(entity) && !can_afford_depot_train?(entity)
               @game.make_insolvent(entity)
-            elsif @game.insolvent?(entity) && can_afford_dept_train?(entity)
+            elsif @game.insolvent?(entity) && can_afford_depot_train?(entity)
               @game.clear_insolvent(entity)
             end
           end


### PR DESCRIPTION
- If a corporation does not own a train, does not buy one from another company, and does not have sufficient money to buy the cheapest available new train, it enters emergency money raising
- A five-share corporation in emergency money raising may convert to a ten-share company, dropping three steps instead of two
- After converting during EMR, the corporation must buy a new train if it can afford one
- Corporations in receivership buy the most expensive available train if there is more than one available
- Corporations in receivership which are 5-share corporations will convert if they cannot afford the cheapest train in the depot