### PR TITLE
18Rhl: Fixes for receivership (Fixes #7064)

### DIFF
--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -265,7 +265,7 @@ module Engine
             G18Rhl::Step::SpecialToken, # Must be before regular track lay (due to private No. 4)
             G18Rhl::Step::Track,
             G18Rhl::Step::RheBonusCheck,
-            Engine::Step::Token,
+            G18Rhl::Step::Token,
             Engine::Step::Route,
             G18Rhl::Step::Dividend,
             Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_18_rhl/step/bankrupt.rb
+++ b/lib/engine/game/g_18_rhl/step/bankrupt.rb
@@ -70,15 +70,18 @@ module Engine
 
             return unless corp.owner == @game.share_pool
 
+            remaining = corp.cash
             cheapest = @game.depot.min_depot_train
-            price = cheapest.price
+            price = cheapest.price - remaining - president_contribution
             source = cheapest.owner.name
-            @log << "#{corp.name} receives a #{cheapest.name} train from #{source}, using previous president's "\
-                    "#{format(president_contribution)}, the Bank paying the rest"
+            @log << "#{corp.name} buys a #{cheapest.name} train for #{cheapest.price} from #{source}, "\
+                    "using previous president's cash of #{format(president_contribution)}, the treasury "\
+                    "of #{format(remaining)} and the Bank paying the remaining #{format(price)}"
+            corp.spend(remaining, @game.bank)
             @game.buy_train(corp, cheapest, :free)
             @game.phase.buying_train!(corp, cheapest)
             fee = 100
-            bank_loan = price - corp.cash - president_contribution + fee
+            bank_loan = price + fee
             corp.spend(bank_loan, @game.bank, check_cash: false)
             @log << "#{corp.name} need to borrow #{format(bank_loan)} from the Bank, including the #{format(fee)} fee"
           end

--- a/lib/engine/game/g_18_rhl/step/special_token.rb
+++ b/lib/engine/game/g_18_rhl/step/special_token.rb
@@ -9,7 +9,7 @@ module Engine
         class SpecialToken < Engine::Step::SpecialToken
           def ability(entity)
             return unless entity
-            return if entity != @round.teleported || !entity.corporation?
+            return if entity != @round.teleported || !entity.corporation? || entity.receivership?
 
             # As the ability is player owned instead of owned by current entity
             # we have saved it when doing teleport, and now we return it.

--- a/lib/engine/game/g_18_rhl/step/special_track.rb
+++ b/lib/engine/game/g_18_rhl/step/special_track.rb
@@ -12,6 +12,7 @@ module Engine
 
           def abilities(entity, **kwargs, &block)
             return if !entity.company? ||
+                      entity.receivership? ||
                       # Do not allow any tile lay if tokening has been used
                       @round.tokened ||
                       # Do not allow special tile lay after train buys (to avoid exploits)

--- a/lib/engine/game/g_18_rhl/step/token.rb
+++ b/lib/engine/game/g_18_rhl/step/token.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/token'
+
+module Engine
+  module Game
+    module G18Rhl
+      module Step
+        class Token < Engine::Step::Token
+          def actions(entity)
+            # Do not allow any token if receivership
+            return [] if entity.receivership?
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_rhl/step/track.rb
+++ b/lib/engine/game/g_18_rhl/step/track.rb
@@ -11,8 +11,8 @@ module Engine
           include LayTileChecks
 
           def actions(entity)
-            # Do not allow any tile lay if tokening has been used
-            return [] if @round.tokened
+            # Do not allow any tile lay if tokening has been used, or if receivership
+            return [] if @round.tokened || entity.receivership?
 
             super
           end


### PR DESCRIPTION
- Correct calculation of remaining treasury in receivership,
  improving the log message.
- Do not let receivership do track or token actions