### PR TITLE
18Rhl: Enhance info regarding capitalization

### DIFF
--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -97,13 +97,27 @@ module Engine
                   %w[55 60 65 70],
                   %w[50 55 60]].freeze
 
+        STATUS_TEXT = {
+          'incremental' => [
+            'Incremental Cap',
+            'Newly floated corporations used incremental capitalization for all shares sold during the whole game. '\
+            'These corporation also get a one time stock price bump up one step if parring at less than 100. Unsold '\
+            'shares moved to Treasury.',
+          ],
+          'fullcap' => [
+            'Full Cap',
+            'Newly floated corporations use 100% capitalization when floated, and no one time stock price bump. '\
+            'Not yet sold shares moved to Market.',
+          ],
+        }.merge(Base::STATUS_TEXT).freeze
+
         PHASES = [
           {
             name: '2',
             on: '2',
             train_limit: 4,
             tiles: [:yellow],
-            status: [],
+            status: %w[incremental],
             operating_rounds: 1,
           },
           {
@@ -111,7 +125,7 @@ module Engine
             on: '3',
             train_limit: 4,
             tiles: %i[yellow green],
-            status: [],
+            status: %w[incremental],
             operating_rounds: 2,
           },
           {
@@ -119,7 +133,7 @@ module Engine
             on: '4',
             train_limit: 3,
             tiles: %i[yellow green],
-            status: [],
+            status: %w[incremental],
             operating_rounds: 2,
           },
           {
@@ -127,7 +141,7 @@ module Engine
             on: '5',
             train_limit: 2,
             tiles: %i[yellow green brown],
-            status: [],
+            status: %w[fullcap],
             operating_rounds: 3,
           },
           {
@@ -135,7 +149,7 @@ module Engine
             on: '6',
             train_limit: 2,
             tiles: %i[yellow green brown],
-            status: [],
+            status: %w[fullcap],
             operating_rounds: 3,
           },
           {
@@ -143,7 +157,7 @@ module Engine
             on: '8',
             train_limit: 2,
             tiles: %i[yellow green brown gray],
-            status: [],
+            status: %w[fullcap],
             operating_rounds: 3,
           },
         ].freeze


### PR DESCRIPTION
Add information about the two capitalizations that are used
for corporations floated pre and post phase 5 phase change.