### PR TITLE
18Rhl: Improve token handling (Fixes #7053)

### DIFF
--- a/lib/engine/ability/teleport.rb
+++ b/lib/engine/ability/teleport.rb
@@ -5,7 +5,8 @@ require_relative 'base'
 module Engine
   module Ability
     class Teleport < Base
-      attr_reader :hexes, :tiles, :cost, :free_tile_lay
+      attr_reader :tiles, :cost, :free_tile_lay
+      attr_accessor :hexes
 
       def setup(hexes:, tiles:, cost: nil, free_tile_lay: false)
         @hexes = hexes

--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -493,8 +493,10 @@ module Engine
           return super unless corporation == cce
           return if corporation.tokens.first&.used == true
 
-          place_free_token(cce, 'E6', 0, silent: false)
-          place_free_token(cce, 'I10', 1, silent: false)
+          cce.coordinates.each_with_index do |coordinate, index|
+            place_free_token(cce, coordinate, index, silent: false)
+          end
+          cce.coordinates = [cce.coordinates.first]
         end
 
         UPGRADES_TO_88 = %w[1 55].freeze

--- a/lib/engine/game/g_18_rhl/step/special_track.rb
+++ b/lib/engine/game/g_18_rhl/step/special_track.rb
@@ -68,14 +68,12 @@ module Engine
             if action.tile == @game.osterath_tile
               # Set location name to Osterath to make the name appear when tokening city in tile
               @game.osterath_tile.hex.location_name = 'Osterath'
+            elsif @game.current_entity.tokens.find { |t| t.hex == action.hex }
+              # Hex already has token so disable special token ability
+              teleport_possible = false
             else
-              if @game.current_entity.tokens.find { |t| t.hex == action.hex }
-                # Hex already has token so disable special token ability
-                teleport_possible = false
-              else
-                # Restrict special token to the actual hex upgraded.
-                ability.hexes = [action.hex.name]
-              end
+              # Restrict special token to the actual upgraded hex.
+              ability.hexes = [action.hex.name]
             end
 
             if teleport_possible

--- a/lib/engine/game/g_18_rhl/step/special_track.rb
+++ b/lib/engine/game/g_18_rhl/step/special_track.rb
@@ -64,15 +64,33 @@ module Engine
 
             return unless ability.type == :teleport
 
-            @round.teleported = @game.current_entity
+            teleport_possible = true
+            if action.tile == @game.osterath_tile
+              # Set location name to Osterath to make the name appear when tokening city in tile
+              @game.osterath_tile.hex.location_name = 'Osterath'
+            else
+              if @game.current_entity.tokens.find { |t| t.hex == action.hex }
+                # Hex already has token so disable special token ability
+                teleport_possible = false
+              else
+                # Restrict special token to the actual hex upgraded.
+                ability.hexes = [action.hex.name]
+              end
+            end
 
-            # Need to keep track of ability that triggered teleport
-            # as the ability does not belong to current entity, but to
-            # player owned ability.
-            @round.teleport_ability = ability
+            if teleport_possible
+              @round.teleported = @game.current_entity
 
-            # Set location name to Osterath to make the name appear when tokening city in tile
-            @game.osterath_tile.hex.location_name = 'Osterath' if action.tile == @game.osterath_tile
+              # Need to keep track of ability that triggered teleport
+              # as the ability does not belong to current entity, but to
+              # player owned ability.
+              @round.teleport_ability = ability
+            else
+              # When removing token teleport we need to remove @round.teleported
+              # as otherwise blocks? (can_token_after_teleport?) crashes
+              @round.teleported = nil
+              action.entity.remove_ability(ability)
+            end
           end
 
           # Private 3 (Sailzuganlage) has all possible tiles, that can be played in all


### PR DESCRIPTION
1. Make general ability teleport attribute hexes read/write (used by fix)
2. Correct 18Rhl teleport abilities so that tokening can only use
   the teleports upgrade hex as teleport token.
3. Correct 18Rhl teleport abilities so that no tokening can take place
   if the ability is used to upgrade an already tokened city
4. CCE first token appeared (in GUI) as E6/I10, and the second as I10.
   By changing start coordinates to just [E6] (from [E6, I10]) during
   placement of home tokens the presentation does now look OK.
   As far as I can tell the coordinates does not have any other
   effect after the corporation has started.