### PR TITLE
Fix crashing log message (Fixes #7058)

### DIFF
--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -64,7 +64,7 @@ module Engine
       end
 
       def process_pass(action)
-        @log << "#{action.entity.owner.name} (#{action.entity.sym}) declines to place token"
+        @log << "#{action.entity.owner.name} (#{action.entity.id}) declines to place token"
         teleport_complete
       end
 


### PR DESCRIPTION
In case a player owned private gives a teleport token ability
this means that entity is a corporation, and not a company.
This caused the code to crash as sym is not defined for corporations.
By using 'id' instead the crash is avoided, and it gives the
same result as before for when company is owned by a corporation.

This will print, for example:
[15:27] CCE (Tjt) lays tile #925 with rotation 0 on D9 (Duisburg)
[15:39] Krongar (CCE) declines to place token

I think this is good enough, as it is a player declining to use
the special token / teleport ability.