### PR TITLE
Refactor out the special case label city upgrade check

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1458,6 +1458,9 @@ module Engine
         return false if from.towns.size != to.towns.size
         return false if !from.label && from.cities.size != to.cities.size
 
+        # but don't permit a labelled city to be downgraded to 0 cities.
+        return false if from.label && !from.cities.empty? && to.cities.empty?
+
         # handle case where we are laying a yellow OO tile and want to exclude single-city tiles
         return false if (from.color == :white) && from.label.to_s == 'OO' && from.cities.size != to.cities.size
 

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -806,10 +806,7 @@ module Engine
           return false if to.name == '172L' && from.hex.name != 'C18'
           return false if to.name == '63' && (from.hex.name == 'B11' || from.hex.name == 'C18')
 
-          if %w[B11 C18 N17 J3 J5].include?(from.hex.name)
-            return true if from.color == :green && to.name == '170'
-            return false if to.color == :yellow && to.cities.empty?
-          end
+          return true if %w[B11 C18 N17 J3 J5].include?(from.hex.name) && (from.color == :green && to.name == '170')
 
           super
         end


### PR DESCRIPTION
Refactor out the special case to avoid a labelled city upgrading to plain yellow tiles now it's needed outside 1870