### PR TITLE
18EU Alpha Fixes

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -46,7 +46,10 @@ module View
         }.freeze
 
         def render_part
-          color = (@reservation&.corporation? && @reservation&.reservation_color) || 'white'
+          color = ((@reservation&.corporation? || @reservation&.minor?) &&
+                    @reservation&.reservation_color) ||
+                    'white'
+
           radius = @radius
           show_player_colors = setting_for(:show_player_colors, @game)
           if show_player_colors && (owner = @token&.corporation&.owner) && @game.players.include?(owner)

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -279,11 +279,13 @@ module View
                       size: @current_entity.cash.to_s.size + 2,
                     })
 
+          bid_str = @step.respond_to?(:bid_str) ? @step.bid_str(minor) : 'Place Bid'
+
           [
             input,
             h(:button,
               { on: { click: -> { create_minor_bid(minor, input) } } },
-              'Place Bid'),
+              bid_str),
           ]
         end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2038,7 +2038,7 @@ module Engine
 
       def init_hexes(companies, corporations)
         blockers = {}
-        (companies + corporations).each do |company|
+        (companies + minors + corporations).each do |company|
           abilities(company, :blocks_hexes) do |ability|
             ability.hexes.each do |hex|
               blockers[hex] = company

--- a/lib/engine/game/g_18_eu/entities.rb
+++ b/lib/engine/game/g_18_eu/entities.rb
@@ -127,6 +127,11 @@ module Engine
                 owner_type: 'player',
                 from: %w[ipo market],
               },
+              {
+                type: 'blocks_hexes',
+                owner_type: nil,
+                hexes: ['C8'],
+              },
             ],
           },
           {
@@ -145,6 +150,11 @@ module Engine
                 corporations: %w[BNR DR FS RBSR RPR AIRS SNCF GSR],
                 owner_type: 'player',
                 from: %w[ipo market],
+              },
+              {
+                type: 'blocks_hexes',
+                owner_type: nil,
+                hexes: ['B11'],
               },
             ],
           },
@@ -222,6 +232,11 @@ module Engine
                 owner_type: 'player',
                 from: %w[ipo market],
               },
+              {
+                type: 'blocks_hexes',
+                owner_type: nil,
+                hexes: ['I6'],
+              },
             ],
           },
           {
@@ -278,6 +293,11 @@ module Engine
                 corporations: %w[BNR DR FS RBSR RPR AIRS SNCF GSR],
                 owner_type: 'player',
                 from: %w[ipo market],
+              },
+              {
+                type: 'blocks_hexes',
+                owner_type: nil,
+                hexes: %w[F19 F21],
               },
             ],
           },

--- a/lib/engine/game/g_18_eu/entities.rb
+++ b/lib/engine/game/g_18_eu/entities.rb
@@ -102,6 +102,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
             {
               type: 'exchange',
@@ -120,6 +121,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -144,6 +146,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -168,6 +171,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -187,6 +191,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -206,6 +211,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -225,6 +231,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -249,6 +256,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -268,6 +276,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -287,6 +296,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -311,6 +321,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -330,6 +341,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -349,6 +361,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -368,6 +381,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',
@@ -387,6 +401,7 @@ module Engine
             tokens: [0],
             color: 'black',
             text_color: 'white',
+            reservation_color: nil,
             abilities: [
               {
                 type: 'exchange',

--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -99,7 +99,7 @@ module Engine
           modified_trains = @depot.trains.select { |t| t.name == type }
           new_train = modified_trains.first.clone
           new_train.index = modified_trains.size
-          @depot.insert_train(new_train,new_train.index)
+          @depot.insert_train(new_train, new_train.index)
         end
 
         def ipo_name(_entity = nil)

--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -29,6 +29,8 @@ module Engine
         MUST_BID_INCREMENT_MULTIPLE = true
         TOKENS_FEE = 100
 
+        BIDDING_BOX_MINOR_COLOR = '#c6e9af'
+
         GAME_END_CHECK = { bank: :full_or }.freeze # TODO: extreme edge case of one player remaining
 
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
@@ -68,9 +70,6 @@ module Engine
           @minors.each do |minor|
             train = @depot.upcoming[0]
             buy_train(minor, train, :free)
-            hex = hex_by_id(minor.coordinates)
-            city = minor.city.to_i || 0
-            hex.tile.cities[city].place_token(minor, minor.next_token, free: true)
           end
 
           add_optional_train('3') if @optional_rules&.include?(:extra_three_train)
@@ -105,6 +104,10 @@ module Engine
 
         def ipo_name(_entity = nil)
           'Treasury'
+        end
+
+        def reservation_corporations
+          minors
         end
 
         def init_round
@@ -433,6 +436,10 @@ module Engine
               prev = token
             end
           end
+        end
+
+        def mark_auctioning(minor)
+          minor.reservation_color = self.class::BIDDING_BOX_MINOR_COLOR
         end
       end
     end

--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -100,7 +100,7 @@ module Engine
           modified_trains = @depot.trains.select { |t| t.name == type }
           new_train = modified_trains.first.clone
           new_train.index = modified_trains.size
-          @depot.add_train(new_train)
+          @depot.insert_train(new_train,new_train.index)
         end
 
         def ipo_name(_entity = nil)

--- a/lib/engine/game/g_18_eu/map.rb
+++ b/lib/engine/game/g_18_eu/map.rb
@@ -77,9 +77,9 @@ module Engine
           },
           blue: {
             ['D1'] =>
-                     'offboard=revenue:10,visit_cost:0,route:optional;path=a:0,b:_0;icon=image:port;',
+                     'town=revenue:10,route:optional;path=a:0,b:_0;icon=image:port;',
             %w[B21 E22 I20] =>
-            'offboard=revenue:10,visit_cost:0,route:optional;path=a:3,b:_0;icon=image:port;',
+            'town=revenue:10,route:optional;path=a:3,b:_0;icon=image:port;',
           },
           yellow: {
             ['A10'] =>

--- a/lib/engine/game/g_18_eu/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_eu/step/buy_sell_par_shares.rb
@@ -49,10 +49,39 @@ module Engine
           end
 
           def can_gain?(entity, bundle, exchange: false)
-            return false if exchange && !bundle.corporation.ipoed
-            return false if exchange && @game.corporations_operated.include?(bundle.corporation)
+            return false if exchange &&
+                            (bought? ||
+                             !bundle.corporation.ipoed ||
+                             @game.corporations_operated.include?(bundle.corporation))
 
             super
+          end
+
+          def can_buy_any?(entity)
+            return false if bought?
+
+            super || can_exchange?(entity)
+          end
+
+          def check_legal_buy(entity, shares, exchange: nil, swap: nil, allow_president_change: true)
+            raise GameError, "Cannot buy a share of #{shares&.corporation&.name}" if
+                !can_buy?(entity, shares.to_bundle) && !swap && !exchange
+          end
+
+          def can_exchange?(entity)
+            return true if @game.loading
+            return true if @game.corporations.any? { |c| @game.can_par?(c, entity) }
+
+            @game.minors.any? { |m| m.owner == entity && can_exchange_minor?(m) }
+          end
+
+          def can_exchange_minor?(minor)
+            return true if @game.loading
+
+            connected = connected_corporations(minor)
+            return false if connected.empty?
+
+            connected.any? { |c| !@game.corporations_operated.include?(c) }
           end
         end
       end

--- a/lib/engine/game/g_18_eu/step/final_exchange.rb
+++ b/lib/engine/game/g_18_eu/step/final_exchange.rb
@@ -89,15 +89,10 @@ module Engine
           def can_discard?(minor)
             return true if @game.loading
 
-            ability = @game.abilities(minor, :exchange)
-            connected = @game.exchange_corporations(ability)
+            connected = connected_corporations(minor)
             return true if connected.empty?
 
             connected.any? { |c| !exchange?(c) }
-          end
-
-          def exchange?(corporation)
-            corporation.available_share || @game.share_pool.shares_by_corporation[corporation]&.first
           end
 
           def can_gain?(_entity, bundle, exchange: false)

--- a/lib/engine/game/g_18_eu/step/minor_exchange.rb
+++ b/lib/engine/game/g_18_eu/step/minor_exchange.rb
@@ -8,6 +8,15 @@ module Engine
       module MinorExchange
         include Engine::Step::ShareBuying
 
+        def connected_corporations(minor)
+          ability = @game.abilities(minor, :exchange)
+          @game.exchange_corporations(ability)
+        end
+
+        def exchange?(corporation)
+          corporation.available_share || @game.share_pool.shares_by_corporation[corporation]&.first
+        end
+
         def merge_minor!(minor, corporation, source)
           maybe_remove_token(minor, corporation)
 

--- a/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
+++ b/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
@@ -142,6 +142,7 @@ module Engine
           def selection_bid(bid)
             @auction_triggerer = bid.entity
             target = bid_target(bid)
+            @game.mark_auctioning(target)
 
             @log << "#{@auction_triggerer.name} selects #{target.name} for auction with no initial bid."
             auction_entity(target)
@@ -195,6 +196,7 @@ module Engine
 
           def add_bid(bid)
             target = bid_target(bid)
+            @game.mark_auctioning(target) unless @auction_triggerer
             @auction_triggerer ||= bid.entity
             auction_entity(target) unless @auctioning
             entities.each(&:unpass!) if @bids[@auctioning].none?
@@ -219,6 +221,10 @@ module Engine
             bidder.spend(price, @game.bank) if price.positive?
             @log << "#{bidder.name} wins the auction for #{target.name} "\
                     "with a bid of #{@game.format_currency(price)}"
+
+            hex = @game.hex_by_id(target.coordinates)
+            city = target.city.to_i || 0
+            hex.tile.cities[city].place_token(target, target.next_token, free: true)
           end
 
           def all_passed!

--- a/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
+++ b/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
@@ -90,14 +90,12 @@ module Engine
             entity = entities[entity_index]
             return next_entity! if entity&.passed?
             return unless @auctioning
+            return if can_afford?(entity)
 
-            unless can_afford?(entity)
-              pass_auction(entity)
+            pass_auction(entity)
+            return all_passed! if entities.all?(&:passed?)
 
-              return all_passed! if entities.all?(&:passed?)
-
-              next_entity!
-            end
+            next_entity!
           end
 
           def process_bid(action)

--- a/lib/engine/minor.rb
+++ b/lib/engine/minor.rb
@@ -19,6 +19,7 @@ module Engine
     include Spender
 
     attr_reader :name, :full_name, :type
+    attr_accessor :reservation_color
 
     def initialize(sym:, name:, abilities: [], **opts)
       @name = sym
@@ -26,6 +27,7 @@ module Engine
       @floated = false
       @closed = false
       @type = opts[:type]&.to_sym
+      @reservation_color = opts[:reservation_color]
       init_operator(opts)
       init_abilities(abilities)
     end

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -6,25 +6,33 @@ module Engine
   module Step
     module ShareBuying
       def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true)
-        raise GameError, "Cannot buy a share of #{shares&.corporation&.name}" if
-            !can_buy?(entity, shares.to_bundle) && !swap
+        check_legal_buy(entity,
+                        shares,
+                        exchange: exchange,
+                        swap: swap,
+                        allow_president_change: allow_president_change)
 
         @game.share_pool.buy_shares(entity,
                                     shares,
                                     exchange: exchange,
                                     swap: swap,
                                     allow_president_change: allow_president_change)
-        corporation = shares.corporation
+
+        maybe_place_home_token(shares.corporation)
+      end
+
+      def check_legal_buy(entity, shares, exchange: nil, swap: nil, allow_president_change: true)
+        raise GameError, "Cannot buy a share of #{shares&.corporation&.name}" if
+            !can_buy?(entity, shares.to_bundle) && !swap
+      end
+
+      def maybe_place_home_token(corporation)
         if (@game.class::HOME_TOKEN_TIMING == :float && corporation.floated?) ||
             (@game.class::HOME_TOKEN_TIMING == :par && corporation.ipoed)
           @game.place_home_token(corporation)
         end
       end
 
-      # Returns if a share can be gained by an entity respecting the cert limit
-      # This works irrespective of if that player has sold this round
-      # such as in 1889 for exchanging Dougo
-      #
       def can_gain?(entity, bundle, exchange: false)
         return if !bundle || !entity
 

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -87,7 +87,7 @@ module Engine
         old_tile = hex.tile
         graph = @game.graph_for_entity(entity)
 
-        (@game.companies + @game.corporations).each do |company|
+        (@game.companies + @game.minors + @game.corporations).each do |company|
           break if @game.loading
           next if company.closed? || company == entity
           next unless (ability = @game.abilities(company, :blocks_hexes))


### PR DESCRIPTION
Submitting a batch fix since these almost all invalidate games. Might as well hit them in one fell swoop.

Fixes [7047](https://github.com/tobymao/18xx/issues/7047)
Fixes [7068](https://github.com/tobymao/18xx/issues/7068)
Fixes [7069](https://github.com/tobymao/18xx/issues/7069)
Fixes [7071](https://github.com/tobymao/18xx/issues/7071)
Fixes [7089](https://github.com/tobymao/18xx/issues/7089)
Fixes [7109](https://github.com/tobymao/18xx/issues/7109)
Closes [7080](https://github.com/tobymao/18xx/issues/7080)

Share buying change does not change functionality, just allows for more specific overrides with less duplication of code.

Auction bid_str change already existed in some parts of the file, but not others.

Changes to **base, minor, tracker** and **city slot** allow for coloring the minor currently up for auction, which was only supported for true corporations, as well as being able to show a city reservation for a minor.

<img width="334" alt="Screen Shot 2022-02-13 at 4 13 22 PM" src="https://user-images.githubusercontent.com/15675400/153780356-d50550c8-581f-47bc-8ad3-6fe8fa8b6af5.png">

