### PR TITLE
21Moon: UI support; select traded shares for selling; avoid for buying

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -133,7 +133,10 @@ module View
           },
         }
 
-        h(:div, { style: { marginBottom: '1rem' } }, [h(:div, props, children), h(MapControls)])
+        map_elements = [h(:div, props, children), h(MapControls)]
+        map_elements << render_legend if @game.show_map_legend?
+
+        h(:div, { style: { marginBottom: '1rem' } }, map_elements)
       end
 
       def map_x
@@ -184,6 +187,38 @@ module View
 
       def map_zoom
         Lib::Storage['map_zoom'] || 1
+      end
+
+      def render_legend
+        table_props, header, *chart = @game.map_legend
+
+        head = header.map do |cell|
+          item = cell[:text] || h(:image, { attrs: { href: cell[:image] } })
+          if cell[:props]
+            h(:th, cell[:props], item)
+          else
+            h(:th, item)
+          end
+        end
+
+        rows = chart.map do |r|
+          columns = r.map do |cell|
+            item = cell[:text] || [h(:img, { attrs: { src: cell[:image], height: cell[:image_height] } })]
+            if cell[:props]
+              h(:td, cell[:props], item)
+            else
+              h(:td, item)
+            end
+          end
+          h(:tr, columns)
+        end
+
+        h(:table, table_props, [
+          h(:thead, [
+            h(:tr, head),
+          ]),
+          h(:tbody, rows),
+        ])
       end
     end
   end

--- a/assets/app/view/game/pass.rb
+++ b/assets/app/view/game/pass.rb
@@ -13,7 +13,7 @@ module View
         children = []
         if @actions.include?('pass')
           children << h(PassButton)
-          children << h(PassAutoButton) if @game.round.stock? && @game.active_players_id.include?(@user&.dig('id'))
+          children << h(PassAutoButton) if @game.round.show_auto? && @game.active_players_id.include?(@user&.dig('id'))
         end
         h(:div, children.compact)
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2760,6 +2760,10 @@ module Engine
       def train_power?
         false
       end
+
+      def show_map_legend?
+        false
+      end
     end
   end
 end

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -875,6 +875,12 @@ module Engine
           super
         end
 
+        def sellable_bundles(player, corporation)
+          return super unless @round.active_step.respond_to?(:sellable_bundles)
+
+          @round.active_step.sellable_bundles(player, corporation)
+        end
+
         def upgrade_cost(tile, hex, entity, spender)
           ability = entity.all_abilities.find do |a|
             a.type == :tile_discount &&
@@ -896,6 +902,67 @@ module Engine
           return false unless (corporation = token.corporation)
 
           lb_city?(token.city, corporation)
+        end
+
+        def show_map_legend?
+          true
+        end
+
+        def map_legend
+          [
+            # table-wide props
+            {
+              style: {
+                margin: '0.5rem 0 0.5rem 0',
+                border: '1px solid',
+                borderCollapse: 'collapse',
+              },
+            },
+            # header
+            [
+              { text: 'Tile Color:', props: { style: { border: '1px solid' } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: '#fde900' } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: '#71bf44' } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: '#cb7745' } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: '#bcbdc0' } } },
+            ],
+            # body
+            [
+              { text: 'Source-X', props: { style: { color: 'white', backgroundColor: 'black' } } },
+              { text: '20', props: { style: { border: '1px solid' } } },
+              { text: '40', props: { style: { border: '1px solid' } } },
+              { text: '60', props: { style: { border: '1px solid' } } },
+              { text: '80', props: { style: { border: '1px solid' } } },
+            ],
+            [
+              { text: 'Helium-3', props: { style: { border: '1px solid', backgroundColor: 'red' } } },
+              { text: '30', props: { style: { border: '1px solid' } } },
+              { text: '40', props: { style: { border: '1px solid' } } },
+              { text: '50', props: { style: { border: '1px solid' } } },
+              { text: '60', props: { style: { border: '1px solid' } } },
+            ],
+            [
+              { text: 'Regolith', props: { style: { border: '1px solid', backgroundColor: 'orange' } } },
+              { text: '20', props: { style: { border: '1px solid' } } },
+              { text: '20', props: { style: { border: '1px solid' } } },
+              { text: '40', props: { style: { border: '1px solid' } } },
+              { text: '50', props: { style: { border: '1px solid' } } },
+            ],
+            [
+              { text: 'Armacolite', props: { style: { border: '1px solid', backgroundColor: 'yellow' } } },
+              { text: '40', props: { style: { border: '1px solid' } } },
+              { text: '30', props: { style: { border: '1px solid' } } },
+              { text: '30', props: { style: { border: '1px solid' } } },
+              { text: '20', props: { style: { border: '1px solid' } } },
+            ],
+            [
+              { text: 'Magnetite', props: { style: { border: '1px solid' } } },
+              { text: '10', props: { style: { border: '1px solid' } } },
+              { text: '10', props: { style: { border: '1px solid' } } },
+              { text: '10', props: { style: { border: '1px solid' } } },
+              { text: '10', props: { style: { border: '1px solid' } } },
+            ],
+          ]
         end
       end
     end

--- a/lib/engine/game/g_21_moon/map.rb
+++ b/lib/engine/game/g_21_moon/map.rb
@@ -273,7 +273,7 @@ module Engine
         # rubocop:enable Layout/LineLength
 
         LOCATION_NAMES = {
-          'A3' => 'Helium-3 Mine',
+          'A3' => 'Power Plant',
           'B14' => 'Water Farm',
           'L2' => 'Research Station',
           'M13' => 'Tourism Colony',

--- a/lib/engine/game/g_21_moon/round/corporate.rb
+++ b/lib/engine/game/g_21_moon/round/corporate.rb
@@ -50,6 +50,10 @@ module Engine
           def finished?
             !active_step
           end
+
+          def show_auto?
+            false
+          end
         end
       end
     end

--- a/lib/engine/game/g_21_moon/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_21_moon/step/buy_sell_par_shares.rb
@@ -133,6 +133,32 @@ module Engine
           def must_sell?(entity)
             @game.num_certs(entity) > @game.cert_limit
           end
+
+          def share_flags(shares)
+            return if shares.empty?
+            return 'T' if shares.all? { |s| @round.traded_shares[s] }
+            return 't' if shares.any? { |s| @round.traded_shares[s] }
+          end
+
+          def pool_shares(corporation)
+            @game.share_pool.shares_by_corporation[corporation].group_by(&:percent).values
+                           .map { |shares| best_to_buy(shares) }.sort_by(&:percent).reverse
+          end
+
+          # first try to return an untraded share, then any
+          def best_to_buy(shares)
+            untraded = shares.find { |s| !@round.traded_shares[s] }
+            return untraded if untraded
+
+            shares.first
+          end
+
+          # Bias toward selling traded shares first
+          def sellable_bundles(seller, corp)
+            shares = seller.shares_of(corp).sort_by { |s| [s.president ? 1 : 0, @round.traded_shares[s] ? 0 : 1] }
+            bundles = @game.all_bundles_for_corporation(seller, corp, shares: shares)
+            bundles.select { |bundle| can_sell?(seller, bundle) }
+          end
         end
       end
     end

--- a/lib/engine/game/g_21_moon/step/trade_stock.rb
+++ b/lib/engine/game/g_21_moon/step/trade_stock.rb
@@ -138,6 +138,12 @@ module Engine
 
             @round.pending_trades.shift
           end
+
+          def share_flags(shares)
+            return if shares.empty?
+            return 'T' if shares.all? { |s| @round.traded_shares[s] }
+            return 't' if shares.any? { |s| @round.traded_shares[s] }
+          end
         end
       end
     end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -188,6 +188,10 @@ module Engine
         false
       end
 
+      def show_auto?
+        false
+      end
+
       private
 
       def skip_steps

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -61,6 +61,10 @@ module Engine
         true
       end
 
+      def show_auto?
+        true
+      end
+
       protected
 
       def finish_round

--- a/public/icons/21Moon/RL.svg
+++ b/public/icons/21Moon/RL.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
+<svg version="1.1" viewBox="-0.2 -0.2 8.4 8.4" xmlns="http://www.w3.org/2000/svg">
  <circle cx="4" cy="4" r="4" fill="#fffffe" stroke="#000" stroke-width=".2"/>
  <text x="3.9286735" y="5.6035948" fill="#000000" font-family="Arial" font-size="4.6667px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs">+20</text>
 </svg>


### PR DESCRIPTION
- Remove "Auto pass" button for CRs
- Show which shares have been traded
- Prioritize traded shares for selling and untraded shares for buying
- Add a legend to the map for the mineral value progression

Common code changes:
- UI::Pass - make auto-pass button optional
- Engine::Round::Base - support for above
- Engine::Round::Stock - support for above
- UI::Corporation - allow adding additional flags to stock holdings
- UI::Map - support for map legends
- Engine::Game::Base - support for map legends