### PR TITLE
Auto router fix with games that have multiple graphs

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -20,7 +20,8 @@ module Engine
       connections = {}
       trains = @game.route_trains(corporation)
 
-      nodes = @game.graph.connected_nodes(corporation).keys.sort_by do |node|
+      graph = @game.graph_for_entity(corporation)
+      nodes = graph.connected_nodes(corporation).keys.sort_by do |node|
         revenue = trains
           .map { |train| node.route_revenue(@game.phase, train) }
           .max
@@ -59,8 +60,8 @@ module Engine
         node_now = Time.now
 
         node_abort = false
-
-        node.walk(corporation: corporation, skip_paths: skip_paths) do |_, vp|
+        walk_corporation = graph.no_blocking? ? nil : corporation
+        node.walk(corporation: walk_corporation, skip_paths: skip_paths) do |_, vp|
           if node_abort || Time.now - node_now > node_timeout
             path_walk_timed_out = true
             node_abort = true

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -60,6 +60,10 @@ module Engine
       @tokens[corporation]
     end
 
+    def no_blocking?
+      @no_blocking
+    end
+
     def tokenable_cities(corporation)
       # A list of all tokenable cities per corporation
       return @tokenable_cities[corporation] if @tokenable_cities.key?(corporation)


### PR DESCRIPTION
Engine::Graph - Expose the no_blocking option.
Engine::AutoRouter - Use the @game.graph_for_entity(corporation) to get the correct graph. If you have initialized the graph with no_blocking option on, make sure the auto router method work the same way as computes node.walk in the graph class.

I dont know if this will sabotage the auto router in any games?