### PR TITLE
correct the 1870 connection order for multiple corporations

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -837,12 +837,6 @@ module Engine
         def reissued?(corporation)
           @reissued[corporation]
         end
-
-        def close_corporation(corporation)
-          super(corporation)
-          # Game::close_corporation does not close the corp from continuing acting in the round so we need close!
-          corporation.close!
-        end
       end
     end
   end

--- a/lib/engine/game/g_1870/step/check_connection.rb
+++ b/lib/engine/game/g_1870/step/check_connection.rb
@@ -15,10 +15,14 @@ module Engine
           # token to be removed during the SR if a corporation closes
           def auto_actions(entity)
             corporations = if @round.entity_index.zero? || @round.step_passed?(G1870::Step::CheckConnection)
-                             @game.corporations.select { |c| destination(c) }
+                             @round.entities.select { |c| destination?(c) } # destinate in OR order
                            else
                              []
                            end
+
+            # if the current corporation is also destinating, it must run first
+            i = corporations.find_index(@round.current_operator)
+            corporations = [@round.current_operator] + (corporations - [@round.current_operator]) if !i.nil? && i.positive?
 
             [Engine::Action::DestinationConnection.new(
               entity,
@@ -26,7 +30,7 @@ module Engine
             )]
           end
 
-          def destination(corporation)
+          def destination?(corporation)
             return unless (destination = @game.destination_hex(corporation))
             return unless destination.assigned?(corporation)
             return unless (home = @game.home_hex(corporation))

--- a/lib/engine/game/g_1870/step/check_connection.rb
+++ b/lib/engine/game/g_1870/step/check_connection.rb
@@ -21,8 +21,8 @@ module Engine
                            end
 
             # if the current corporation is also destinating, it must run first
-            i = corporations.find_index(@round.current_operator)
-            corporations = [@round.current_operator] + (corporations - [@round.current_operator]) if !i.nil? && i.positive?
+            i = corporations.index(@round.current_operator)
+            corporations = [@round.current_operator] + (corporations - [@round.current_operator]) if i&.positive?
 
             [Engine::Action::DestinationConnection.new(
               entity,


### PR DESCRIPTION
When multiple companies become eligible at the same time, the currently operating company goes first, followed by the other companies in stock price order (p. 22).
Fixes #7145