### PR TITLE
18GB Pre-alpha rules completeness

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -496,6 +496,10 @@ module Engine
           !@phase.status.include?('only_pres_drop')
         end
 
+        def num_certs(entity)
+          entity.shares.sum(&:cert_size)
+        end
+
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
           price = corporation.share_price.price
@@ -592,10 +596,14 @@ module Engine
           5 * stock_market.find_share_price(corporation, [:left] * 3).price
         end
 
-        def convert_to_ten_share(corporation, price_drops = 0)
+        def convert_to_ten_share(corporation, price_drops = 0, blame_president = false)
           # update corporation type and report conversion
           corporation.type = '10-share'
-          @log << "#{corporation.id} converts into a 10-share company"
+          @log << (if blame_president
+                     "#{corporation.owner.name} converts #{corporation.id} into a 10-share corporation"
+                   else
+                     "#{corporation.id} converts into a 10-share corporation"
+                   end)
 
           # update existing shares to 10% shares
           original_shares = shares_for_corporation(corporation)

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -753,11 +753,7 @@ module Engine
         end
 
         def compass_points_in_network(network_hexes)
-          @scenario['compass-hexes'].select do |_compass, compasshexes|
-            network_hexes.any? do |coords|
-              compasshexes.include?(coords)
-            end
-          end.map(&:first)
+          @scenario['compass-hexes'].reject { |_compass, compass_hexes| (network_hexes & compass_hexes).empty? }.map(&:first)
         end
 
         def ns_bonus

--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -62,7 +62,7 @@ module Engine
           def process_choose(action)
             _action, corporation_id = action.choice.split('_')
             corporation = @game.corporations.find { |c| c.id == corporation_id }
-            @game.convert_to_ten_share(corporation, 2)
+            @game.convert_to_ten_share(corporation, 2, true)
             @round.current_actions << action
           end
 

--- a/lib/engine/game/g_18_gb/step/buy_train.rb
+++ b/lib/engine/game/g_18_gb/step/buy_train.rb
@@ -12,7 +12,7 @@ module Engine
             return [] if entity != current_entity
 
             actions = []
-            actions << 'choose' if can_convert?(entity)
+            actions << 'convert' if can_convert?(entity)
             actions << 'buy_train' if can_buy_train?(entity)
             actions << 'pass' if !actions.empty? && !must_buy_train?(entity)
             actions
@@ -31,22 +31,12 @@ module Engine
             corporation.type == '5-share' && corporation.trains.empty? && corporation.cash < @game.depot.min_depot_price
           end
 
-          def choice_available?(entity)
-            can_convert?(entity)
-          end
-
-          def choice_name
-            'Convert'
-          end
-
-          def choices
-            return {} unless can_convert?(current_entity)
-
+          def convert_text
             capital_str = @game.format_currency(@game.emergency_convert_capital(current_entity))
-            { "convert_#{current_entity.id}" => "Convert to 10-share (#{capital_str})" }
+            "Convert to 10-share (#{capital_str})"
           end
 
-          def process_choose(action)
+          def process_convert(action)
             return unless action.entity.corporation? && can_convert?(action.entity)
 
             @game.convert_to_ten_share(action.entity, 3)

--- a/lib/engine/game/g_18_gb/step/buy_train.rb
+++ b/lib/engine/game/g_18_gb/step/buy_train.rb
@@ -60,15 +60,19 @@ module Engine
             depot_trains = [] if entity.cash < @depot.min_depot_price
 
             other_trains = @depot.other_trains(entity)
-            other_trains = [] if entity.cash.zero?
+            other_trains = [] if entity.cash.zero? || must_buy_new_train?(entity)
             other_trains.reject! { |t| illegal_train_buy?(entity, t) }
 
             depot_trains + other_trains
           end
 
+          def must_buy_new_train?(entity)
+            must_buy_train?(entity) && @round.emergency_converted
+          end
+
           def must_buy_train?(entity)
-            cheapest = @game.depot.min_depot_price
-            entity.trains.empty? && cheapest.positive? && entity.cash > cheapest
+            mandatory = @game.depot.max_depot_price
+            entity.trains.empty? && mandatory.positive? && entity.cash >= mandatory
           end
         end
       end

--- a/lib/engine/game/g_18_gb/step/emr_share_buying.rb
+++ b/lib/engine/game/g_18_gb/step/emr_share_buying.rb
@@ -35,6 +35,16 @@ module Engine
             false
           end
 
+          def log_pass(entity)
+            return if bought?
+
+            @log << "#{entity.name} declines buying a share of #{@round.current_operator.id} after conversion"
+          end
+
+          def pass!
+            @passed = true
+          end
+
           def description
             'Optionally buy a share after conversion'
           end


### PR DESCRIPTION
Bring 18GB up to pre-alpha test game readiness by completing the final item on the implementation checklist and fixing a few small snags
- North-South and East-West bonuses can now be achieved by chaining together multiple trains - closes #6982
- Certificate limit includes all certificates, even those for corporations in the "no share buying limit" section of the market
- Emergency fund raising changed from a `choose` to a `convert` action - both more accurate, and also enables conversion when train buying is also possible (for the case when the president wants to reject buying from other corporations)
- Corporations are only obligated to buy a train if they can afford the most expensive one currently available and could otherwise choose to skip and keep raising funds