### PR TITLE
18GB Server Play bug fixes

### DIFF
--- a/lib/engine/game/g_18_gb/round/operating.rb
+++ b/lib/engine/game/g_18_gb/round/operating.rb
@@ -36,7 +36,7 @@ module Engine
                 # after dividend (withheld, as above) for a receivership corporation in insolvency, it reaches train buying
 
                 # if the corporation is 5-share and cannot afford the cheapest train available, it will first convert to 10-share
-                @game.convert_to_ten_share(entity, 3) if entity.type == '5-share' && entity.cash < @game.depot.min_depot_price
+                @game.convert_to_ten_share(entity, 3) if entity.type == :'5-share' && entity.cash < @game.depot.min_depot_price
 
                 # now the corporation buys the most expensive train that it can afford
                 affordable_trains = @game.depot.depot_trains.select { |train| train.price < entity.cash }

--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -114,7 +114,7 @@ module Engine
           end
 
           def can_convert?(player, corporation)
-            corporation&.type == '5-share' && corporation&.president?(player) && corporation&.operated?
+            corporation&.type == :'5-share' && corporation&.president?(player) && corporation&.operated?
           end
 
           def can_sell?(entity, bundle)

--- a/lib/engine/game/g_18_gb/step/buy_train.rb
+++ b/lib/engine/game/g_18_gb/step/buy_train.rb
@@ -28,7 +28,7 @@ module Engine
           def can_convert?(corporation)
             return false unless corporation&.corporation?
 
-            corporation.type == '5-share' && corporation.trains.empty? && corporation.cash < @game.depot.min_depot_price
+            corporation.type == :'5-share' && corporation.trains.empty? && corporation.cash < @game.depot.min_depot_price
           end
 
           def convert_text


### PR DESCRIPTION
Correct server errors caused by Ruby/Opal differences:
- Add missing `require_relative` statements
- Add attribute readers/accessors
- Refer to corporation symbols and types using symbols rather than strings