### PR TITLE
18GB Company descriptions (fix typos, improve consistency)

### DIFF
--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -10,8 +10,8 @@ module Engine
             value: 40,
             revenue: 10,
             desc: "The owner of the LB has priority for starting the LNWR. No other player may buy the Director's " \
-                  'Certificate of the LNWR, and the owner of the London & Birmingham may not buy shares in any other company ' \
-                  "until they have purchased the LNWR Director's Certificate.",
+                  'Certificate of the LNWR, and the owner of the London & Birmingham may not buy shares in any other ' \
+                  "corporation until they have purchased the LNWR Director's Certificate.",
             sym: 'LB',
             color: nil,
             abilities: [
@@ -32,9 +32,9 @@ module Engine
             name: 'Arbroath & Forfar',
             value: 30,
             revenue: 10,
-            desc: 'The Arbroath & Forfar allows a company to take an extra tile action to lay or upgrade a tile in Perth (I2). '\
-                  'The owner of the AF may use this ability once per game, after the AF has closed, for any company which they '\
-                  'control. A tile placed in Perth as a normal tile lay does not close the AF.',
+            desc: 'The Arbroath & Forfar allows a corporation to take an extra tile action to lay or upgrade a tile in Perth ' \
+                  '(I2). The owner of the AF may use this ability once per game, after the AF has closed, for any corporation ' \
+                  'which they control. A tile placed in Perth as a normal tile lay does not close the AF.',
             sym: 'AF',
             color: nil,
             abilities: [
@@ -65,8 +65,8 @@ module Engine
             name: 'Great Northern',
             value: 70,
             revenue: 25,
-            desc: 'The GN allows a company to lay a free Station Marker in York (I14). The GN owner may use this ability once ' \
-                  'per game, after the GN has closed, for any company which they control.',
+            desc: 'The GN allows a corporation to lay a free Station Marker in York (I14). The GN owner may use this ability ' \
+                  'once per game, after the GN has closed, for any corporation which they control.',
             sym: 'GN',
             color: nil,
             abilities: [
@@ -104,7 +104,7 @@ module Engine
             value: 35,
             revenue: 12,
             desc: 'The SD gives a bonus of £10 for Middlesbrough (J13). The owner of the SD may use this bonus for any trains ' \
-                  'owned by companies that they control, from the time that the SD closes until the end of the game.',
+                  'owned by corporations that they control, from the time that the SD closes until the end of the game.',
             sym: 'SD',
             color: nil,
             abilities: [
@@ -133,7 +133,7 @@ module Engine
             value: 45,
             revenue: 15,
             desc: 'The LM gives a bonus of £10 for Liverpool (E14). The owner of the LM may use this bonus for any trains run ' \
-                  'by companies that they control, from the time that the LM closes until the end of the game.',
+                  'by corporations that they control, from the time that the LM closes until the end of the game.',
             sym: 'LM',
             color: nil,
             abilities: [
@@ -161,8 +161,9 @@ module Engine
             name: 'Leicester & Swannington',
             value: 30,
             revenue: 10,
-            desc: 'The LS allows a company to take an extra tile action to lay or upgrade a tile in Leicester (H21). The owner '\
-                  'of the LS may use this ability once per game, after the LS has closed, for any company which they control.',
+            desc: 'The LS allows a corporation to take an extra tile action to lay or upgrade a tile in Leicester (H21). The ' \
+                  'owner of the LS may use this ability once per game, after the LS has closed, for any corporation which they '\
+                  'control.',
             sym: 'LS',
             color: nil,
             abilities: [
@@ -193,12 +194,12 @@ module Engine
             name: 'Taff Vale',
             value: 60,
             revenue: 25,
-            desc: 'The TV allows a company to waive the cost of laying the Severn Tunnel tile - the blue estuary tile marked ' \
-                  '"S" - in hex C22. This follows the usual rules for upgrades, so the game must be in an appropriate phase, ' \
-                  'some part of the new track on the new tile must form part of a route for the company, and the company must ' \
-                  'not be Insolvent. The owner of the TV may use this ability after the TV has closed, for any company which ' \
-                  'they control. If a company places the Severn Tunnel tile without using the ability of the TV, this does not ' \
-                  'force the TV to close.',
+            desc: 'The TV allows a corporation to waive the cost of laying the Severn Tunnel tile - the blue estuary tile ' \
+                  'marked "S" - in hex C22. This follows the usual rules for upgrades, so the game must be in an appropriate ' \
+                  'phase, some part of the new track on the new tile must form part of a route for the corporation, and the ' \
+                  'corporation must not be Insolvent. The owner of the TV may use this ability after the TV has closed, for ' \
+                  'any corporation which they control. If a corporation places the Severn Tunnel tile without using the ' \
+                  'ability of the TV, this does not force the TV to close.',
             sym: 'TV',
             color: nil,
             abilities: [
@@ -231,8 +232,8 @@ module Engine
             name: 'Maryport & Carlisle',
             value: 60,
             revenue: 20,
-            desc: 'The MC allows a company to lay a Station Marker in Carlisle (H9). The MC owner may use this ability once ' \
-                  'per game, after the MC has closed, for any company which they control.',
+            desc: 'The MC allows a corporation to lay a Station Marker in Carlisle (H9). The MC owner may use this ability ' \
+                  'once per game, after the MC has closed, for any corporation which they control.',
             sym: 'MC',
             color: nil,
             abilities: [
@@ -270,7 +271,7 @@ module Engine
             value: 30,
             revenue: 10,
             desc: 'The CH gives a bonus income of £20 for Holyhead (C14). The owner of the CH may use this bonus for any ' \
-                  'trains run by companies that they control, from the time that the CH closes until the end of the game.',
+                  'trains run by corporations that they control, from the time that the CH closes until the end of the game.',
             sym: 'CH',
             color: nil,
             abilities: [
@@ -314,7 +315,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
             ],
@@ -336,7 +337,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
               {
@@ -370,7 +371,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
               {
@@ -403,7 +404,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
             ],
@@ -426,7 +427,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
             ],
@@ -448,7 +449,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
             ],
@@ -470,7 +471,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
             ],
@@ -492,7 +493,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
               {
@@ -525,7 +526,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
               {
@@ -558,7 +559,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 1',
-                desc_detail: 'Receives 1 additional £50 token on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 1 additional £50 token on the charter when converted to a 10-share corporation',
                 count: 1,
               },
             ],
@@ -580,7 +581,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
               {
@@ -613,7 +614,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Conversion tokens: 2',
-                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
+                desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
               {

--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -495,6 +495,17 @@ module Engine
                 desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share company',
                 count: 2,
               },
+              {
+                type: 'tile_lay',
+                hexes: ['H19'],
+                tiles: %w[G36 G37 G38],
+                cost: 0,
+                reachable: true,
+                consume_tile_lay: true,
+                description: 'May place a green tile in H19',
+                desc_detail: 'May place a green tile in its home city (H19), instead of the usual yellow tile, even before ' \
+                             'green tiles are normally available',
+              },
             ],
           },
           {

--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -9,8 +9,8 @@ module Engine
             name: 'London & Birmingham',
             value: 40,
             revenue: 10,
-            desc: "The owner of the L&B has priority for starting the LNWR. No other player may buy the Director's " \
-                  'Certificate of the LNWR, and the owner of the London & Birmingham may not buy shares in any other company' \
+            desc: "The owner of the LB has priority for starting the LNWR. No other player may buy the Director's " \
+                  'Certificate of the LNWR, and the owner of the London & Birmingham may not buy shares in any other company ' \
                   "until they have purchased the LNWR Director's Certificate.",
             sym: 'LB',
             color: nil,
@@ -32,9 +32,9 @@ module Engine
             name: 'Arbroath & Forfar',
             value: 30,
             revenue: 10,
-            desc: 'The Arbroath & Forfar allows a company to take an extra tile lay action to lay or upgrade a tile in Perth ' \
-                  '(I2). The owner of the AF may use this ability once per game, after the AF has closed, for any company ' \
-                  'which they control. A tile placed in Perth as a nomral tile lay does not close the AF.',
+            desc: 'The Arbroath & Forfar allows a company to take an extra tile action to lay or upgrade a tile in Perth (I2). '\
+                  'The owner of the AF may use this ability once per game, after the AF has closed, for any company which they '\
+                  'control. A tile placed in Perth as a normal tile lay does not close the AF.',
             sym: 'AF',
             color: nil,
             abilities: [
@@ -104,7 +104,7 @@ module Engine
             value: 35,
             revenue: 12,
             desc: 'The SD gives a bonus of £10 for Middlesbrough (J13). The owner of the SD may use this bonus for any trains ' \
-                  'owned by Companies that they control, from the time that the SD closes until the end of the game.',
+                  'owned by companies that they control, from the time that the SD closes until the end of the game.',
             sym: 'SD',
             color: nil,
             abilities: [
@@ -133,7 +133,7 @@ module Engine
             value: 45,
             revenue: 15,
             desc: 'The LM gives a bonus of £10 for Liverpool (E14). The owner of the LM may use this bonus for any trains run ' \
-                  'by Companies that they control, from the time that the LM closes until the end of the game.',
+                  'by companies that they control, from the time that the LM closes until the end of the game.',
             sym: 'LM',
             color: nil,
             abilities: [
@@ -161,9 +161,8 @@ module Engine
             name: 'Leicester & Swannington',
             value: 30,
             revenue: 10,
-            desc: 'The LS allows a company to take an extra tile lay action to lay or upgrade a tile in Leicester (H21). The ' \
-                  'owner of the LS may use this ability once per game, after the LS has closed, for any company which they ' \
-                  'control.',
+            desc: 'The LS allows a company to take an extra tile action to lay or upgrade a tile in Leicester (H21). The owner '\
+                  'of the LS may use this ability once per game, after the LS has closed, for any company which they control.',
             sym: 'LS',
             color: nil,
             abilities: [
@@ -271,7 +270,7 @@ module Engine
             value: 30,
             revenue: 10,
             desc: 'The CH gives a bonus income of £20 for Holyhead (C14). The owner of the CH may use this bonus for any ' \
-                  'trains run by Companies that they control, from the time that the CH closes until the end of the game.',
+                  'trains run by companies that they control, from the time that the CH closes until the end of the game.',
             sym: 'CH',
             color: nil,
             abilities: [


### PR DESCRIPTION
- Correct some typos in the private company descriptions
- Also add the missing green-home-hex ability to the Midland Railway