### PR TITLE
Allow find_pairwise_chain to use saved_nodes even with tile upgrade

### DIFF
--- a/lib/engine/action/run_routes.rb
+++ b/lib/engine/action/run_routes.rb
@@ -51,7 +51,7 @@ module Engine
             'subsidy' => route.subsidy,
             'halts' => route.halts,
             'abilities' => route.abilities,
-            'nodes' => route.nodes.map(&:full_id),
+            'nodes' => route.nodes.map(&:partial_id),
           }.select { |_, v| v }
         end
 

--- a/lib/engine/action/run_routes.rb
+++ b/lib/engine/action/run_routes.rb
@@ -51,7 +51,7 @@ module Engine
             'subsidy' => route.subsidy,
             'halts' => route.halts,
             'abilities' => route.abilities,
-            'nodes' => route.nodes.map(&:partial_id),
+            'nodes' => route.nodes.map(&:signature),
           }.select { |_, v| v }
         end
 

--- a/lib/engine/operating_info.rb
+++ b/lib/engine/operating_info.rb
@@ -10,7 +10,7 @@ module Engine
       # Convert the route into connection hexes as upgrades may break the representation
       @routes = runs.to_h { |run| [run.train, run.connection_hexes] }
       @halts = runs.to_h { |run| [run.train, run.halts] }
-      @nodes = runs.to_h { |run| [run.train, run.nodes.map(&:full_id)] }
+      @nodes = runs.to_h { |run| [run.train, run.nodes.map(&:partial_id)] }
       @revenue = revenue
       @dividend = dividend
       @laid_hexes = laid_hexes

--- a/lib/engine/operating_info.rb
+++ b/lib/engine/operating_info.rb
@@ -10,7 +10,7 @@ module Engine
       # Convert the route into connection hexes as upgrades may break the representation
       @routes = runs.to_h { |run| [run.train, run.connection_hexes] }
       @halts = runs.to_h { |run| [run.train, run.halts] }
-      @nodes = runs.to_h { |run| [run.train, run.nodes.map(&:partial_id)] }
+      @nodes = runs.to_h { |run| [run.train, run.nodes.map(&:signature)] }
       @revenue = revenue
       @dividend = dividend
       @laid_hexes = laid_hexes

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -13,8 +13,8 @@ module Engine
         @id ||= "#{tile.id}-#{index}"
       end
 
-      def full_id
-        "#{hex&.id}-#{tile.name}-#{index}"
+      def partial_id
+        "#{hex&.id}-#{index}"
       end
 
       def hex

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -13,7 +13,7 @@ module Engine
         @id ||= "#{tile.id}-#{index}"
       end
 
-      def partial_id
+      def signature
         "#{hex&.id}-#{index}"
       end
 

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -20,7 +20,7 @@ module Engine
       @subsidy = opts[:subsidy]
       @halts = opts[:halts]
       @abilities = opts[:abilities]
-      @saved_nodes = opts[:nodes] # node.partial_id for every node in the route
+      @saved_nodes = opts[:nodes] # node.signature for every node in the route
       @local_length = @game.local_length
 
       @node_chains = {}
@@ -407,7 +407,7 @@ module Engine
       # pass through the nodes associated with it.
       if @saved_nodes
         candidates.each do |a, b, left, right, middle|
-          return [a, b, left, right, middle] if [left, right, middle].all? { |n| @saved_nodes.include?(n.partial_id) }
+          return [a, b, left, right, middle] if [left, right, middle].all? { |n| @saved_nodes.include?(n.signature) }
         end
       end
 

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -20,7 +20,7 @@ module Engine
       @subsidy = opts[:subsidy]
       @halts = opts[:halts]
       @abilities = opts[:abilities]
-      @saved_nodes = opts[:nodes] # node.full_id for every node in the route
+      @saved_nodes = opts[:nodes] # node.partial_id for every node in the route
       @local_length = @game.local_length
 
       @node_chains = {}
@@ -34,6 +34,7 @@ module Engine
 
     def clear_cache!(all: false, only_routes: false)
       @connection_hexes = nil if all
+      @saved_nodes = nil if all
       @revenue = nil
       @revenue_str = nil
 
@@ -47,7 +48,6 @@ module Engine
       @paths = nil
       @stops = nil
       @subsidy = nil
-      @saved_nodes = nil
       @visited_stops = nil
       @check_connected = nil
       @check_distance = nil
@@ -88,7 +88,7 @@ module Engine
     end
 
     def nodes
-      chains.flat_map { |c| c['nodes'] }.uniq.compact
+      chains.flat_map { |c| c[:nodes] }.uniq.compact
     end
 
     def next_chain(node, chain, other)
@@ -407,7 +407,7 @@ module Engine
       # pass through the nodes associated with it.
       if @saved_nodes
         candidates.each do |a, b, left, right, middle|
-          return [a, b, left, right, middle] if [left, right, middle].all? { |n| @saved_nodes.include?(n.full_id) }
+          return [a, b, left, right, middle] if [left, right, middle].all? { |n| @saved_nodes.include?(n.partial_id) }
         end
       end
 


### PR DESCRIPTION
Fixes #7205 

This changes node.full_id -> node.partial_id so that Engine::Route can use @saved_nodes even across tile upgrades.