### PR TITLE
[1846 2P] add "end after final train purchased" to end game list

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -411,7 +411,8 @@ module View
       end
 
       def endgame
-        rows = @game.class::GAME_END_CHECK.map do |reason, timing|
+        values = @game.game_end_check_values
+        rows = values.map do |reason, timing|
           reason_str = @game.class::GAME_END_REASONS_TEXT[reason]
           if reason == :bankrupt
             reason_str = case @game.class::BANKRUPTCY_ENDS_GAME_AFTER


### PR DESCRIPTION
closes #7232 

Covers 2P for 46 and 52

![Screenshot 2022-02-19 10 20 16 AM](https://user-images.githubusercontent.com/1711810/154814160-91cce8fe-fb88-4280-b443-7fc0f8d830f2.png)
