### PR TITLE
18GB Fixes from pre-alpha test games

### DIFF
--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -529,17 +529,6 @@ module Engine
                 desc_detail: 'Receives 2 additional £50 tokens on the charter when converted to a 10-share corporation',
                 count: 2,
               },
-              {
-                type: 'tile_lay',
-                hexes: ['H17'],
-                tiles: %w[G36 G37 G38],
-                cost: 0,
-                reachable: true,
-                consume_tile_lay: true,
-                description: 'May place a green tile in H17',
-                desc_detail: 'May place a green tile in its home city (H17), instead of the usual yellow tile, even before ' \
-                             'green tiles are normally available',
-              },
             ],
           },
           {

--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -256,7 +256,7 @@ module Engine
               {
                 type: 'token',
                 when: 'owning_player_track',
-                hexes: ['I14'],
+                hexes: ['H9'],
                 teleport_price: 50,
                 price: 0,
                 count: 1,

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -605,8 +605,9 @@ module Engine
           @_shares[share.id] = share
         end
 
-        def emergency_convert_capital(corporation)
-          5 * stock_market.find_share_price(corporation, [:left] * 3).price
+        def convert_capital(corporation, emergency)
+          steps = emergency ? 3 : 2
+          5 * stock_market.find_share_price(corporation, [:left] * steps).price
         end
 
         def convert_to_ten_share(corporation, price_drops = 0, blame_president = false)

--- a/lib/engine/game/g_18_gb/map.rb
+++ b/lib/engine/game/g_18_gb/map.rb
@@ -383,6 +383,7 @@ module Engine
             ['L1'] => 'town=revenue:10;path=a:1,b:_0;path=a:2,b:_0',
           },
           blue: {
+            ['B23'] => '',
             ['C22'] => 'path=a:2,b:4;path=a:5,b:0;upgrade=cost:50,terrain:river;label=S',
             ['I4'] => 'path=a:1,b:2;upgrade=cost:50,terrain:river;label=FT',
           },
@@ -526,6 +527,7 @@ module Engine
             ['K24'] => 'path=a:1,b:2;path=a:1,b:3',
           },
           blue: {
+            ['B23'] => '',
             ['C22'] => 'path=a:2,b:4;path=a:5,b:0;upgrade=cost:50,terrain:river;label=S',
           },
         }.freeze

--- a/lib/engine/game/g_18_gb/scenarios.rb
+++ b/lib/engine/game/g_18_gb/scenarios.rb
@@ -89,7 +89,7 @@ module Engine
               'N' => %w[G0 I0 K0],
               'E' => %w[K0 K22 J27 G26],
               'S' => %w[J27 G26 D27 a25],
-              'W' => %w[a19 C16 C14 E6],
+              'W' => %w[a19 a25 C16 C14 E6],
             },
           },
           '4Std' =>
@@ -118,7 +118,7 @@ module Engine
               'N' => %w[G0 I0 K0],
               'E' => %w[K0 K22 J27 G26],
               'S' => %w[J27 G26 D27 a25],
-              'W' => %w[a19 C16 C14 E6],
+              'W' => %w[a19 a25 C16 C14 E6],
             },
           },
           '4Alt' =>
@@ -147,7 +147,7 @@ module Engine
               'N' => %w[G0 I0 K0],
               'E' => %w[K0 K22 J27 G26],
               'S' => %w[J27 G26 D27 a25],
-              'W' => %w[a19 C16 C14 E6],
+              'W' => %w[a19 a25 C16 C14 E6],
             },
           },
           '5' =>
@@ -176,7 +176,7 @@ module Engine
               'N' => %w[G0 I0 K0],
               'E' => %w[K0 K22 J27 G26],
               'S' => %w[J27 G26 D27 a25],
-              'W' => %w[a19 C16 C14 E6],
+              'W' => %w[a19 a25 C16 C14 E6],
             },
           },
           '6' =>
@@ -205,7 +205,7 @@ module Engine
               'N' => %w[G0 I0 K0],
               'E' => %w[K0 K22 J27 G26],
               'S' => %w[J27 G26 D27 a25],
-              'W' => %w[a19 C16 C14 E6],
+              'W' => %w[a19 a25 C16 C14 E6],
             },
           },
         }.freeze

--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -36,7 +36,7 @@ module Engine
           def entity_choices(corporation)
             return {} unless can_convert?(current_entity, corporation)
 
-            capital_str = @game.format_currency(@game.convert_capital(corporation))
+            capital_str = @game.format_currency(@game.convert_capital(corporation, false))
             { "convert_#{corporation.id}" => "Convert to 10-share (#{capital_str})" }
           end
 

--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -36,7 +36,8 @@ module Engine
           def entity_choices(corporation)
             return {} unless can_convert?(current_entity, corporation)
 
-            { "convert_#{corporation.id}" => 'Convert to 10-share' }
+            capital_str = @game.format_currency(@game.convert_capital(corporation))
+            { "convert_#{corporation.id}" => "Convert to 10-share (#{capital_str})" }
           end
 
           def description

--- a/lib/engine/game/g_18_gb/step/buy_train.rb
+++ b/lib/engine/game/g_18_gb/step/buy_train.rb
@@ -32,7 +32,7 @@ module Engine
           end
 
           def convert_text
-            capital_str = @game.format_currency(@game.emergency_convert_capital(current_entity))
+            capital_str = @game.format_currency(@game.convert_capital(current_entity))
             "Convert to 10-share (#{capital_str})"
           end
 

--- a/lib/engine/game/g_18_gb/step/buy_train.rb
+++ b/lib/engine/game/g_18_gb/step/buy_train.rb
@@ -32,7 +32,7 @@ module Engine
           end
 
           def convert_text
-            capital_str = @game.format_currency(@game.convert_capital(current_entity))
+            capital_str = @game.format_currency(@game.convert_capital(current_entity, true))
             "Convert to 10-share (#{capital_str})"
           end
 

--- a/lib/engine/game/g_18_gb/step/special_token.rb
+++ b/lib/engine/game/g_18_gb/step/special_token.rb
@@ -29,9 +29,8 @@ module Engine
 
           def switch_for_expensive_token(token)
             return token unless token.price.zero?
-            return token unless current_entity.tokens.size > 1
 
-            current_entity.tokens.max_by(&:price)
+            current_entity.tokens.reject(&:used).max_by(&:price)
           end
 
           def process_place_token(action)


### PR DESCRIPTION
Fix bugs:
- CR teleporting with MC generating a "token already used" error
- Missing W flag on Plymouth preventing EW bonus from being paid
- MC token ability was teleporting to York instead of Carlisle
- MSLR charter listed an ability it doesn't have (green normal home city, but it lives on Sheffield, an OO tile)

Usability improvements:
- Empty tile in the Severn estuary made blue to make it clearer it is out of play when it is surrounded by tiles
- Conversion capital in £ displayed on the Convert button in the SR (consistent with when emergency converting in an OR)