### PR TITLE
used cached node_signatures for serializing

### DIFF
--- a/lib/engine/action/run_routes.rb
+++ b/lib/engine/action/run_routes.rb
@@ -51,7 +51,7 @@ module Engine
             'subsidy' => route.subsidy,
             'halts' => route.halts,
             'abilities' => route.abilities,
-            'nodes' => route.nodes.map(&:signature),
+            'nodes' => route.node_signatures,
           }.select { |_, v| v }
         end
 

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -466,13 +466,16 @@ module Engine
           visited_tokens = {}
 
           routes.each do |route|
-            route.visited_stops.each do |node|
-              next unless node.city?
+            route.hexes.each do |hex|
+              hex.tile.stops.each do |node|
+                next unless node.city?
+                next unless route.node_signatures.include?(node.signature)
 
-              node.tokens.each do |token|
-                next if !token || token.corporation != corporation
+                node.tokens.each do |token|
+                  next if !token || token.corporation != corporation
 
-                visited_tokens[token] = true
+                  visited_tokens[token] = true
+                end
               end
             end
           end

--- a/lib/engine/operating_info.rb
+++ b/lib/engine/operating_info.rb
@@ -10,7 +10,7 @@ module Engine
       # Convert the route into connection hexes as upgrades may break the representation
       @routes = runs.to_h { |run| [run.train, run.connection_hexes] }
       @halts = runs.to_h { |run| [run.train, run.halts] }
-      @nodes = runs.to_h { |run| [run.train, run.nodes.map(&:signature)] }
+      @nodes = runs.to_h { |run| [run.train, run.node_signatures] }
       @revenue = revenue
       @dividend = dividend
       @laid_hexes = laid_hexes


### PR DESCRIPTION
Fixes performance issue when serializing routes by caching node signatures. The cache is cleared whenever connection_data is rebuilt so that it doesn't go stale.

Also addresses issue with Harzbahn performance due to having to rebuild route connection_data to determine if a token should be flipped.