### PR TITLE
21Moon: fix erroneous listing of OLS

### DIFF
--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -671,6 +671,10 @@ module Engine
           corporations.reject(&:minor?).sort_by(&:name)
         end
 
+        def player_sort(entities)
+          entities.reject(&:minor?).sort_by(&:name).group_by(&:owner)
+        end
+
         def lb_trains(corporation)
           corporation.trains.select { |t| @train_base[t] == :lb }
         end

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -494,14 +494,14 @@ module Engine
         def new_operating_round(round_num = 1)
           @or += 1
 
-          round = super
-          upgrade_space_port if @or == 5 || @or == 9
-          event_close_companies! if @or == 7
-
           if @or == 9
             @operating_rounds = 3
             @three_or_round = true
           end
+
+          round = super
+          upgrade_space_port if @or == 5 || @or == 9
+          event_close_companies! if @or == 7
 
           round
         end


### PR DESCRIPTION
I noticed that this shows up under whatever player bought the OLS private:
![Moon_OLS](https://user-images.githubusercontent.com/8494213/155013625-ab26a9a0-3a91-41be-a858-8fd335760ca7.png)

This is an artifact of creating a dummy minor that holds the OLS token until it is replaced. It should never show up as an entity in play. I had taken care of this for the bank, but not for players.

This PR takes care of it for players.

Also takes care of the erroneous **`-- Operating Round 5.1 (of 2) --`** being displayed.