### PR TITLE
auto-router 1822 revenue needs a routes collection

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -124,6 +124,7 @@ module Engine
               connection_data: connection,
               bitfield: bitfield_from_connection(connection, hexside_bits),
             )
+            route.routes = [route]
             route.revenue(suppress_check_other: true) # defer route-collection checks til later
             train_routes[train] << route
           rescue RouteTooLong


### PR DESCRIPTION
Fixes #7258
1822's game.revenue_for(route) requires a route collection to properly check for home-to-destination bonus