### PR TITLE
18GB Pre-alpha fixes

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -876,7 +876,7 @@ module Engine
         end
 
         def buy_train(operator, train, price = nil)
-          @train_bought = true
+          @train_bought = true if train.owner == @depot
           super
         end
 

--- a/lib/engine/game/g_18_gb/map.rb
+++ b/lib/engine/game/g_18_gb/map.rb
@@ -392,13 +392,11 @@ module Engine
         HEXES_2P_NW = {
           white: {
             %w[F7 F15 F19 F27 G20 H23 H25 H27 I18 I24 J1 J19 J23 K2] => '',
-            ['C18'] => 'border=edge:4,type:mountain,cost:50',
-            ['D17'] => 'border=edge:1,type:mountain,cost:50;border=edge:4,type:mountain,cost:50',
-            ['D19'] => 'border=edge:1,type:mountain,cost:50;border=edge:5,type:mountain,cost:50',
+            ['D17'] => 'border=edge:4,type:mountain,cost:50',
             %w[E16 E24 G24] => 'border=edge:1,type:mountain,cost:50',
             %w[E20 E22] => 'border=edge:2,type:mountain,cost:50',
             ['J15'] => 'border=edge:3,type:mountain,cost:50',
-            %w[G2 G10 H7] => 'border=edge:5,type:mountain,cost:50',
+            %w[D19 G2 G10 H7] => 'border=edge:5,type:mountain,cost:50',
             ['I8'] => 'border=edge:0,type:mountain,cost:50;border=edge:1,type:mountain,cost:50;' \
                       'border=edge:2,type:mountain,cost:50',
             ['I10'] => 'border=edge:0,type:mountain,cost:50;border=edge:1,type:mountain,cost:50;' \
@@ -417,8 +415,7 @@ module Engine
             ['G14'] => 'city=revenue:0;city=revenue:0;border=edge:3,type:mountain,cost:50;border=edge:4,type:mountain,cost:50;' \
                        'label=OO',
             %w[E18 E26 F17 F23 G6 G22 H5 I16 I20 I22 I26 J7] => 'town=revenue:0',
-            ['C20'] => 'town=revenue:0;border=edge:4,type:mountain,cost:50;border=edge:5,type:mountain,cost:50',
-            ['D21'] => 'town=revenue:0;border=edge:2,type:mountain,cost:50;border=edge:5,type:mountain,cost:50',
+            ['D21'] => 'town=revenue:0;border=edge:5,type:mountain,cost:50',
             ['F25'] => 'town=revenue:0;border=edge:4,type:mountain,cost:50',
             ['G12'] => 'town=revenue:0;border=edge:0,type:mountain,cost:50;border=edge:5,type:mountain,cost:50',
             ['I12'] => 'town=revenue:0;border=edge:2,type:mountain,cost:50;border=edge:3,type:mountain,cost:50',

--- a/lib/engine/game/g_18_gb/map.rb
+++ b/lib/engine/game/g_18_gb/map.rb
@@ -371,6 +371,7 @@ module Engine
           },
           gray: {
             ['A22'] => 'town=revenue:10;path=a:3,b:_0;path=a:4,b:_0',
+            ['B23'] => '',
             ['D15'] => 'path=a:2,b:5',
             ['F3'] => 'path=a:4,b:5;path=a:5,b:0',
             ['F13'] => 'path=a:1,b:5;path=a:4,b:5',
@@ -383,7 +384,6 @@ module Engine
             ['L1'] => 'town=revenue:10;path=a:1,b:_0;path=a:2,b:_0',
           },
           blue: {
-            ['B23'] => '',
             ['C22'] => 'path=a:2,b:4;path=a:5,b:0;upgrade=cost:50,terrain:river;label=S',
             ['I4'] => 'path=a:1,b:2;upgrade=cost:50,terrain:river;label=FT',
           },
@@ -518,6 +518,7 @@ module Engine
           },
           gray: {
             ['A22'] => 'town=revenue:10;path=a:3,b:_0;path=a:4,b:_0',
+            ['B23'] => '',
             ['D15'] => 'path=a:2,b:5',
             ['F13'] => 'path=a:1,b:5;path=a:4,b:5',
             ['I10'] => 'border=edge:0,type:mountain,cost:50;border=edge:1,type:mountain,cost:50;' \
@@ -527,7 +528,6 @@ module Engine
             ['K24'] => 'path=a:1,b:2;path=a:1,b:3',
           },
           blue: {
-            ['B23'] => '',
             ['C22'] => 'path=a:2,b:4;path=a:5,b:0;upgrade=cost:50,terrain:river;label=S',
           },
         }.freeze

--- a/spec/fixtures/18GB/18gb-3p.json
+++ b/spec/fixtures/18GB/18gb-3p.json
@@ -1,0 +1,7486 @@
+{
+    "id": 2,
+    "description": "",
+    "user": {
+        "id": 1,
+        "name": "Andy"
+    },
+    "players": [
+        {
+            "id": 1,
+            "name": "Andy"
+        },
+        {
+            "id": 2,
+            "name": "Eerik"
+        },
+        {
+            "id": 3,
+            "name": "Pete"
+        }
+    ],
+    "max_players": 6,
+    "title": "18GB",
+    "settings": {
+        "seed": 1652597213,
+        "is_async": false,
+        "unlisted": false,
+        "auto_routing": true,
+        "player_order": null,
+        "optional_rules": []
+    },
+    "user_settings": null,
+    "status": "finished",
+    "turn": 6,
+    "round": "Operating Round",
+    "acting": [
+        1,
+        2,
+        3
+    ],
+    "result": {
+        "Andy": 5888,
+        "Pete": 6214,
+        "Eerik": 4013
+    },
+    "actions": [
+        {
+            "type": "bid",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 1,
+            "created_at": 1645645558,
+            "company": "SD",
+            "price": 35
+        },
+        {
+            "type": "bid",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 2,
+            "created_at": 1645645563,
+            "company": "LB",
+            "price": 40
+        },
+        {
+            "type": "bid",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 3,
+            "created_at": 1645645579,
+            "company": "GN",
+            "price": 70
+        },
+        {
+            "type": "bid",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 4,
+            "created_at": 1645645586,
+            "company": "AF",
+            "price": 30
+        },
+        {
+            "type": "bid",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 5,
+            "created_at": 1645645589,
+            "company": "LM",
+            "price": 45
+        },
+        {
+            "type": "bid",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 6,
+            "created_at": 1645645604,
+            "company": "LS",
+            "price": 30
+        },
+        {
+            "type": "bid",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 7,
+            "created_at": 1645645610,
+            "company": "GN",
+            "price": 75
+        },
+        {
+            "type": "pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 8,
+            "created_at": 1645645613
+        },
+        {
+            "type": "bid",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 9,
+            "created_at": 1645645622,
+            "company": "LB",
+            "price": 45
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 10,
+            "created_at": 1645645628
+        },
+        {
+            "type": "bid",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 11,
+            "created_at": 1645645632,
+            "company": "GN",
+            "price": 80
+        },
+        {
+            "type": "bid",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 12,
+            "created_at": 1645645644,
+            "company": "AF",
+            "price": 35
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 13,
+            "created_at": 1645645662
+        },
+        {
+            "type": "bid",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 14,
+            "created_at": 1645645666,
+            "company": "LB",
+            "price": 50
+        },
+        {
+            "type": "bid",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 15,
+            "created_at": 1645645674,
+            "company": "LM",
+            "price": 50
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 16,
+            "created_at": 1645645680
+        },
+        {
+            "type": "pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 17,
+            "created_at": 1645645684
+        },
+        {
+            "type": "bid",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 18,
+            "created_at": 1645645691,
+            "company": "SD",
+            "price": 40
+        },
+        {
+            "type": "bid",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 19,
+            "created_at": 1645645696,
+            "company": "LS",
+            "price": 35
+        },
+        {
+            "type": "pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 20,
+            "created_at": 1645645699
+        },
+        {
+            "type": "bid",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 21,
+            "created_at": 1645645747,
+            "company": "LS",
+            "price": 40
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 22,
+            "created_at": 1645645755
+        },
+        {
+            "type": "pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 23,
+            "created_at": 1645645757
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 24,
+            "created_at": 1645645770
+        },
+        {
+            "type": "par",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 25,
+            "created_at": 1645645872,
+            "corporation": "LYR",
+            "share_price": "80,0,6"
+        },
+        {
+            "type": "par",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 26,
+            "created_at": 1645645883,
+            "corporation": "LNWR",
+            "share_price": "100,0,8"
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 27,
+            "created_at": 1645645890,
+            "unconditional": true,
+            "indefinite": false
+        },
+        {
+            "type": "par",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 28,
+            "created_at": 1645645913,
+            "corporation": "MR",
+            "share_price": "80,0,6"
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 29,
+            "created_at": 1645645926,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645645925
+                }
+            ]
+        },
+        {
+            "type": "par",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 30,
+            "created_at": 1645645931,
+            "corporation": "NER",
+            "share_price": "80,0,6"
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 31,
+            "created_at": 1645645940,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645645939
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 32,
+            "created_at": 1645645942
+        },
+        {
+            "type": "choose_ability",
+            "entity": "GN",
+            "entity_type": "company",
+            "id": 33,
+            "created_at": 1645645957,
+            "choice": "close"
+        },
+        {
+            "type": "place_token",
+            "entity": "GN",
+            "entity_type": "company",
+            "id": 34,
+            "created_at": 1645645959,
+            "city": "I14-4-0",
+            "slot": 0,
+            "tokener": "LNWR"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 35,
+            "created_at": 1645645971,
+            "hex": "I14",
+            "tile": "G36-0",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 36,
+            "created_at": 1645645978,
+            "hex": "I16",
+            "tile": "3-0",
+            "rotation": 2
+        },
+        {
+            "type": "buy_train",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 37,
+            "created_at": 1645645985,
+            "train": "2+1-0",
+            "price": 80,
+            "variant": "2+1"
+        },
+        {
+            "type": "buy_train",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 38,
+            "created_at": 1645645985,
+            "train": "2+1-1",
+            "price": 80,
+            "variant": "2+1"
+        },
+        {
+            "type": "buy_train",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 39,
+            "created_at": 1645645986,
+            "train": "2+1-2",
+            "price": 80,
+            "variant": "2+1"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 40,
+            "created_at": 1645646036,
+            "hex": "H15",
+            "tile": "G02-0",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 41,
+            "created_at": 1645646043,
+            "hex": "H13",
+            "tile": "8-0",
+            "rotation": 4
+        },
+        {
+            "type": "buy_train",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 42,
+            "created_at": 1645646049,
+            "train": "2+1-3",
+            "price": 80,
+            "variant": "2+1"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 43,
+            "created_at": 1645646066
+        },
+        {
+            "hex": "H19",
+            "tile": "G36-1",
+            "type": "lay_tile",
+            "entity": "MR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 44,
+            "user": 1,
+            "created_at": 1645646100,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 45,
+            "user": 1,
+            "created_at": 1645646108
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 46,
+            "created_at": 1645646123,
+            "hex": "H19",
+            "tile": "G38-0",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 47,
+            "created_at": 1645646128,
+            "hex": "I20",
+            "tile": "58-0",
+            "rotation": 2
+        },
+        {
+            "type": "buy_train",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 48,
+            "created_at": 1645646140,
+            "train": "2+1-4",
+            "price": 80,
+            "variant": "2+1"
+        },
+        {
+            "type": "buy_train",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 49,
+            "created_at": 1645646141,
+            "train": "3+1-0",
+            "price": 200,
+            "variant": "3+1"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 50,
+            "created_at": 1645646142
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 51,
+            "created_at": 1645646163,
+            "hex": "J13",
+            "tile": "G38-1",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 52,
+            "created_at": 1645646167,
+            "hex": "J15",
+            "tile": "8-1",
+            "rotation": 1
+        },
+        {
+            "type": "buy_train",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 53,
+            "created_at": 1645646171,
+            "train": "3+1-1",
+            "price": 200,
+            "variant": "3+1"
+        },
+        {
+            "type": "buy_train",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 54,
+            "created_at": 1645646186,
+            "train": "2+1-4",
+            "price": 50
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 55,
+            "created_at": 1645646188
+        },
+        {
+            "hex": "H15",
+            "tile": "G05-0",
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "rotation": 5,
+            "entity_type": "corporation",
+            "id": 56,
+            "user": 2,
+            "created_at": 1645646215,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 57,
+            "user": 2,
+            "created_at": 1645646222
+        },
+        {
+            "hex": "H15",
+            "tile": "G09-0",
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "rotation": 3,
+            "entity_type": "corporation",
+            "id": 58,
+            "user": 2,
+            "created_at": 1645646232,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 59,
+            "user": 2,
+            "created_at": 1645646236
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 60,
+            "created_at": 1645646240,
+            "hex": "H15",
+            "tile": "G08-0",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 61,
+            "created_at": 1645646254
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 62,
+            "created_at": 1645646257,
+            "routes": [
+                {
+                    "train": "2+1-0",
+                    "connections": [
+                        [
+                            "I14",
+                            "J13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I14",
+                        "J13"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "I14-J13",
+                    "nodes": [
+                        "I14-0",
+                        "J13-0"
+                    ]
+                },
+                {
+                    "train": "2+1-1",
+                    "connections": [
+                        [
+                            "I14",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "I14",
+                        "H15"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "I14-H15",
+                    "nodes": [
+                        "I14-0",
+                        "H15-1"
+                    ]
+                },
+                {
+                    "train": "2+1-2",
+                    "connections": [
+                        [
+                            "I14",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "I14",
+                        "I16",
+                        "H15"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "I14-I16-H15",
+                    "nodes": [
+                        "I14-0",
+                        "I16-0",
+                        "H15-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 63,
+            "created_at": 1645646264,
+            "kind": "payout"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 64,
+            "created_at": 1645646278,
+            "hex": "G16",
+            "tile": "G03-0",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 65,
+            "created_at": 1645646360,
+            "hex": "F17",
+            "tile": "58-1",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 66,
+            "created_at": 1645646371,
+            "routes": [
+                {
+                    "train": "2+1-3",
+                    "connections": [
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "G16",
+                        "F17"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "H15-G16-F17",
+                    "nodes": [
+                        "G16-0",
+                        "H15-0",
+                        "F17-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 67,
+            "created_at": 1645646373,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 68,
+            "created_at": 1645646375,
+            "train": "3+1-2",
+            "price": 200,
+            "variant": "3+1"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 69,
+            "created_at": 1645646382
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 70,
+            "created_at": 1645646397,
+            "hex": "H17",
+            "tile": "G19-0",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 71,
+            "created_at": 1645646400,
+            "hex": "I16",
+            "tile": "87-0",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 72,
+            "created_at": 1645646410
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 73,
+            "created_at": 1645646416,
+            "routes": [
+                {
+                    "train": "3+1-0",
+                    "connections": [
+                        [
+                            "I16",
+                            "H15"
+                        ],
+                        [
+                            "H17",
+                            "I16"
+                        ],
+                        [
+                            "H19",
+                            "H17"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I16",
+                        "H17",
+                        "H19"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "H15-I16-H17-H19",
+                    "nodes": [
+                        "I16-0",
+                        "H15-1",
+                        "H17-0",
+                        "H19-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 74,
+            "created_at": 1645646423,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 75,
+            "created_at": 1645646434,
+            "train": "3+1-3",
+            "price": 200,
+            "variant": "3+1"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 76,
+            "created_at": 1645646435
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 77,
+            "created_at": 1645646458,
+            "hex": "J11",
+            "tile": "G19-1",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 78,
+            "created_at": 1645646460,
+            "hex": "J9",
+            "tile": "9-0",
+            "rotation": 0
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 79,
+            "created_at": 1645646462
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 80,
+            "created_at": 1645646470,
+            "routes": [
+                {
+                    "train": "3+1-1",
+                    "connections": [
+                        [
+                            "J11",
+                            "K12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "I14"
+                        ]
+                    ],
+                    "hexes": [
+                        "J11",
+                        "J13",
+                        "I14"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "J11-J13-I14",
+                    "nodes": [
+                        "J11-0",
+                        "J13-0",
+                        "I14-0"
+                    ]
+                },
+                {
+                    "train": "2+1-4",
+                    "connections": [
+                        [
+                            "J13",
+                            "J15",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "J13",
+                        "I16",
+                        "H15"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "J13-I16-H15",
+                    "nodes": [
+                        "J13-0",
+                        "I16-0",
+                        "H15-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 81,
+            "created_at": 1645646473,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 82,
+            "created_at": 1645646476
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 83,
+            "created_at": 1645646537,
+            "shares": [
+                "LNWR_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 84,
+            "created_at": 1645646561,
+            "shares": [
+                "LNWR_2"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 85,
+            "created_at": 1645646568,
+            "shares": [
+                "NER_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 86,
+            "created_at": 1645646568,
+            "unconditional": true,
+            "indefinite": false
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 87,
+            "created_at": 1645646575,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645646574
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 88,
+            "created_at": 1645646579
+        },
+        {
+            "type": "choose_ability",
+            "entity": "LB",
+            "entity_type": "company",
+            "id": 89,
+            "created_at": 1645646634,
+            "choice": "close"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 90,
+            "created_at": 1645646643,
+            "hex": "F21",
+            "tile": "G02-1",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 91,
+            "created_at": 1645646657,
+            "hex": "G22",
+            "tile": "58-2",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 92,
+            "created_at": 1645646661,
+            "routes": [
+                {
+                    "train": "2+1-0",
+                    "connections": [
+                        [
+                            "I14",
+                            "J13"
+                        ]
+                    ],
+                    "hexes": [
+                        "I14",
+                        "J13"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "I14-J13",
+                    "nodes": [
+                        "I14-0",
+                        "J13-0"
+                    ]
+                },
+                {
+                    "train": "2+1-1",
+                    "connections": [
+                        [
+                            "I14",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "I14",
+                        "H15"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "I14-H15",
+                    "nodes": [
+                        "I14-0",
+                        "H15-1"
+                    ]
+                },
+                {
+                    "train": "2+1-2",
+                    "connections": [
+                        [
+                            "I14",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "I14",
+                        "I16",
+                        "H15"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "I14-I16-H15",
+                    "nodes": [
+                        "I14-0",
+                        "I16-0",
+                        "H15-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 93,
+            "created_at": 1645646662,
+            "kind": "payout"
+        },
+        {
+            "type": "choose_ability",
+            "choice": "close",
+            "entity": "SD",
+            "entity_type": "company",
+            "id": 94,
+            "user": 3,
+            "created_at": 1645646707,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 95,
+            "user": 3,
+            "created_at": 1645646715
+        },
+        {
+            "type": "choose_ability",
+            "entity": "SD",
+            "entity_type": "company",
+            "id": 96,
+            "created_at": 1645646730,
+            "choice": "close"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 97,
+            "created_at": 1645646736,
+            "hex": "I12",
+            "tile": "4-0",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 98,
+            "created_at": 1645646782,
+            "hex": "J11",
+            "tile": "G25-0",
+            "rotation": 5
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 99,
+            "created_at": 1645646796,
+            "routes": [
+                {
+                    "train": "2+1-3",
+                    "connections": [
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "G16",
+                        "F17"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "H15-G16-F17",
+                    "nodes": [
+                        "G16-0",
+                        "H15-0",
+                        "F17-0"
+                    ]
+                },
+                {
+                    "train": "3+1-2",
+                    "connections": [
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ]
+                    ],
+                    "hexes": [
+                        "J11",
+                        "I12",
+                        "H15"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "J11-I12-H15",
+                    "nodes": [
+                        "I12-0",
+                        "J11-1",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 100,
+            "created_at": 1645646798,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 101,
+            "created_at": 1645646806
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 102,
+            "created_at": 1645646820,
+            "hex": "G20",
+            "tile": "9-1",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 103,
+            "created_at": 1645646826,
+            "hex": "F21",
+            "tile": "G10-0",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 104,
+            "created_at": 1645646833,
+            "routes": [
+                {
+                    "train": "3+1-0",
+                    "connections": [
+                        [
+                            "F21",
+                            "G20",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "I20"
+                        ]
+                    ],
+                    "hexes": [
+                        "F21",
+                        "H19",
+                        "I20"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "F21-H19-I20",
+                    "nodes": [
+                        "F21-1",
+                        "H19-0",
+                        "I20-0"
+                    ]
+                },
+                {
+                    "train": "3+1-3",
+                    "connections": [
+                        [
+                            "H19",
+                            "H17"
+                        ],
+                        [
+                            "H17",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "H19",
+                        "H17",
+                        "I16",
+                        "H15"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "H19-H17-I16-H15",
+                    "nodes": [
+                        "H19-0",
+                        "H17-0",
+                        "I16-0",
+                        "H15-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 105,
+            "created_at": 1645646834,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 106,
+            "created_at": 1645646873
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 107,
+            "created_at": 1645646882,
+            "hex": "J7",
+            "tile": "4-1",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 108,
+            "created_at": 1645646912,
+            "hex": "I12",
+            "tile": "87-1",
+            "rotation": 4
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 109,
+            "created_at": 1645646912
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 110,
+            "created_at": 1645646912,
+            "routes": [
+                {
+                    "train": "3+1-1",
+                    "connections": [
+                        [
+                            "H15",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I16",
+                        "J13",
+                        "J11"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "H15-I16-J13-J11",
+                    "nodes": [
+                        "H15-1",
+                        "I16-0",
+                        "J13-0",
+                        "J11-0"
+                    ]
+                },
+                {
+                    "train": "2+1-4",
+                    "connections": [
+                        [
+                            "J13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "H13",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "J13",
+                        "I12",
+                        "H15"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "J13-I12-H15",
+                    "nodes": [
+                        "J13-0",
+                        "I12-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 111,
+            "created_at": 1645646913,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 112,
+            "created_at": 1645646932,
+            "train": "3+1-0",
+            "price": 195
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 113,
+            "created_at": 1645646956,
+            "hex": "G24",
+            "tile": "9-2",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 114,
+            "created_at": 1645647094,
+            "hex": "G22",
+            "tile": "204-0",
+            "rotation": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 115,
+            "created_at": 1645647099,
+            "train": "4+2-1",
+            "price": 300,
+            "variant": "4+2"
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 116,
+            "created_at": 1645647101
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 117,
+            "created_at": 1645647117,
+            "hex": "F19",
+            "tile": "8-2",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 118,
+            "created_at": 1645647123,
+            "hex": "G20",
+            "tile": "27-0",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 119,
+            "created_at": 1645647150,
+            "routes": [
+                {
+                    "train": "3+1-2",
+                    "connections": [
+                        [
+                            "F17",
+                            "F19",
+                            "G20",
+                            "F21"
+                        ],
+                        [
+                            "G16",
+                            "F17"
+                        ],
+                        [
+                            "H15",
+                            "G16"
+                        ]
+                    ],
+                    "hexes": [
+                        "F21",
+                        "F17",
+                        "G16",
+                        "H15"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "F21-F17-G16-H15",
+                    "nodes": [
+                        "F17-0",
+                        "F21-1",
+                        "G16-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 120,
+            "created_at": 1645647152,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 121,
+            "created_at": 1645647156,
+            "train": "4+2-2",
+            "price": 300,
+            "variant": "4+2"
+        },
+        {
+            "type": "place_token",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 122,
+            "created_at": 1645647170,
+            "city": "G10-0-1",
+            "slot": 0,
+            "tokener": "MR"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 123,
+            "created_at": 1645647173,
+            "hex": "F23",
+            "tile": "58-3",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 124,
+            "created_at": 1645647175,
+            "hex": "G24",
+            "tile": "24-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 125,
+            "created_at": 1645647180,
+            "routes": [
+                {
+                    "train": "3+1-3",
+                    "connections": [
+                        [
+                            "H19",
+                            "G20",
+                            "F21"
+                        ],
+                        [
+                            "F21",
+                            "F23"
+                        ],
+                        [
+                            "F23",
+                            "G24",
+                            "G26"
+                        ]
+                    ],
+                    "hexes": [
+                        "H19",
+                        "F21",
+                        "F23",
+                        "G26"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "H19-F21-F23-G26",
+                    "nodes": [
+                        "H19-0",
+                        "F21-1",
+                        "F23-0",
+                        "G26-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 126,
+            "created_at": 1645647194,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 127,
+            "created_at": 1645647197,
+            "train": "4+2-3",
+            "price": 300,
+            "variant": "4+2"
+        },
+        {
+            "hex": "J7",
+            "tile": "87-2",
+            "type": "lay_tile",
+            "entity": "NER",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 128,
+            "user": 1,
+            "created_at": 1645647216,
+            "skip": true
+        },
+        {
+            "hex": "I6",
+            "tile": "G18-0",
+            "type": "lay_tile",
+            "entity": "NER",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 129,
+            "user": 1,
+            "created_at": 1645647223,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "NER",
+            "action_id": 127,
+            "entity_type": "corporation",
+            "id": 130,
+            "user": 1,
+            "created_at": 1645647237
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 131,
+            "created_at": 1645647246,
+            "hex": "J7",
+            "tile": "87-2",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 132,
+            "created_at": 1645647252,
+            "hex": "I8",
+            "tile": "7-0",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 133,
+            "created_at": 1645647258,
+            "routes": [
+                {
+                    "train": "3+1-1",
+                    "connections": [
+                        [
+                            "H15",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "I14"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I16",
+                        "J13",
+                        "I14"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "H15-I16-J13-I14",
+                    "nodes": [
+                        "H15-1",
+                        "I16-0",
+                        "J13-0",
+                        "I14-0"
+                    ]
+                },
+                {
+                    "train": "3+1-0",
+                    "connections": [
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I12",
+                        "J13",
+                        "J11"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "H15-I12-J13-J11",
+                    "nodes": [
+                        "H15-0",
+                        "I12-0",
+                        "J13-0",
+                        "J11-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 134,
+            "created_at": 1645647259,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 135,
+            "created_at": 1645647302,
+            "shares": [
+                "MR_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "sell_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 136,
+            "created_at": 1645647313,
+            "shares": [
+                "LNWR_2",
+                "LNWR_0"
+            ],
+            "percent": 60
+        },
+        {
+            "type": "par",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 137,
+            "created_at": 1645647371,
+            "corporation": "NBR",
+            "share_price": "100,0,8"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 138,
+            "created_at": 1645647417,
+            "shares": [
+                "MR_2"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 139,
+            "created_at": 1645647578,
+            "shares": [
+                "LNWR_2"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 140,
+            "created_at": 1645647587,
+            "shares": [
+                "NBR_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "choose",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 141,
+            "created_at": 1645647596,
+            "choice": "convert_NER"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "shares": [
+                "NER_2"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 142,
+            "user": 1,
+            "created_at": 1645647598,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 143,
+            "user": 1,
+            "created_at": 1645647600
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 144,
+            "created_at": 1645647602,
+            "shares": [
+                "NER_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 145,
+            "created_at": 1645647617,
+            "shares": [
+                "LNWR_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 146,
+            "created_at": 1645647623,
+            "shares": [
+                "NER_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 147,
+            "created_at": 1645647629,
+            "shares": [
+                "LYR_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 148,
+            "created_at": 1645647641
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 149,
+            "created_at": 1645647644,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645647644
+                }
+            ],
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 150,
+            "created_at": 1645647649
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 151,
+            "created_at": 1645647679,
+            "hex": "I10",
+            "tile": "9-3",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 152,
+            "created_at": 1645647692,
+            "hex": "H9",
+            "tile": "G41-0",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 153,
+            "created_at": 1645647716,
+            "routes": [
+                {
+                    "train": "3+1-2",
+                    "connections": [
+                        [
+                            "F17",
+                            "F19",
+                            "G20",
+                            "F21"
+                        ],
+                        [
+                            "G16",
+                            "F17"
+                        ],
+                        [
+                            "H15",
+                            "G16"
+                        ]
+                    ],
+                    "hexes": [
+                        "F21",
+                        "F17",
+                        "G16",
+                        "H15"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "F21-F17-G16-H15",
+                    "nodes": [
+                        "F17-0",
+                        "F21-1",
+                        "G16-0",
+                        "H15-0"
+                    ]
+                },
+                {
+                    "train": "4+2-2",
+                    "connections": [
+                        [
+                            "H9",
+                            "G8"
+                        ],
+                        [
+                            "J11",
+                            "I10",
+                            "H9"
+                        ],
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ]
+                    ],
+                    "hexes": [
+                        "G8",
+                        "H9",
+                        "J11",
+                        "I12",
+                        "H15"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "G8-H9-J11-I12-H15",
+                    "nodes": [
+                        "H9-0",
+                        "G8-0",
+                        "J11-1",
+                        "I12-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 154,
+            "created_at": 1645647718,
+            "kind": "payout"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 155,
+            "created_at": 1645647733,
+            "hex": "H21",
+            "tile": "G19-2",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 156,
+            "created_at": 1645647767,
+            "hex": "F23",
+            "tile": "204-1",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 157,
+            "created_at": 1645647779,
+            "routes": [
+                {
+                    "train": "3+1-3",
+                    "connections": [
+                        [
+                            "H19",
+                            "H21"
+                        ],
+                        [
+                            "H21",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "F21"
+                        ]
+                    ],
+                    "hexes": [
+                        "H19",
+                        "H21",
+                        "G22",
+                        "F21"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "H19-H21-G22-F21",
+                    "nodes": [
+                        "H19-0",
+                        "H21-0",
+                        "G22-0",
+                        "F21-0"
+                    ]
+                },
+                {
+                    "train": "4+2-3",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "F23"
+                        ],
+                        [
+                            "F23",
+                            "F21"
+                        ],
+                        [
+                            "F21",
+                            "G20",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "F23",
+                        "F21",
+                        "F17",
+                        "G16",
+                        "H15"
+                    ],
+                    "revenue": 180,
+                    "revenue_str": "G26-F23-F21-F17-G16-H15",
+                    "nodes": [
+                        "G26-0",
+                        "F23-0",
+                        "F21-1",
+                        "F17-0",
+                        "G16-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 158,
+            "created_at": 1645647783,
+            "kind": "payout"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 159,
+            "created_at": 1645647803,
+            "hex": "I6",
+            "tile": "G19-3",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 160,
+            "created_at": 1645647834,
+            "hex": "I4",
+            "tile": "G32-0",
+            "rotation": 0
+        },
+        {
+            "type": "place_token",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 161,
+            "created_at": 1645647846,
+            "city": "G25-0-0",
+            "slot": 0,
+            "tokener": "NBR"
+        },
+        {
+            "type": "convert",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 162,
+            "created_at": 1645647859
+        },
+        {
+            "type": "buy_train",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 163,
+            "created_at": 1645647859,
+            "train": "5+2-0",
+            "price": 500,
+            "variant": "5+2"
+        },
+        {
+            "type": "pass",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 164,
+            "created_at": 1645647859
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 165,
+            "created_at": 1645647864,
+            "shares": [
+                "NBR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 166,
+            "created_at": 1645647916,
+            "hex": "J11",
+            "tile": "G30-0",
+            "rotation": 5
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 167,
+            "created_at": 1645647927,
+            "hex": "F7",
+            "tile": "9-1",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 168,
+            "created_at": 1645647940
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 169,
+            "created_at": 1645647952,
+            "routes": [
+                {
+                    "train": "3+1-1",
+                    "connections": [
+                        [
+                            "J11",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "I14"
+                        ]
+                    ],
+                    "hexes": [
+                        "J11",
+                        "I12",
+                        "J13",
+                        "I14"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "J11-I12-J13-I14",
+                    "nodes": [
+                        "J11-0",
+                        "I12-0",
+                        "J13-0",
+                        "I14-0"
+                    ]
+                },
+                {
+                    "train": "3+1-0",
+                    "connections": [
+                        [
+                            "J11",
+                            "K12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "J15",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "J11",
+                        "J13",
+                        "I16",
+                        "H15"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "J11-J13-I16-H15",
+                    "nodes": [
+                        "J11-0",
+                        "J13-0",
+                        "I16-0",
+                        "H15-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 170,
+            "created_at": 1645647953,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 171,
+            "created_at": 1645647967,
+            "train": "4X-0",
+            "price": 550,
+            "variant": "4X"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 172,
+            "created_at": 1645647977
+        },
+        {
+            "hex": "F21",
+            "tile": "G14-0",
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "rotation": 1,
+            "entity_type": "corporation",
+            "id": 173,
+            "user": 3,
+            "created_at": 1645648031,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 174,
+            "user": 3,
+            "created_at": 1645648042
+        },
+        {
+            "hex": "F21",
+            "tile": "G15-0",
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 175,
+            "user": 3,
+            "created_at": 1645648060,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 176,
+            "user": 3,
+            "created_at": 1645648064
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 177,
+            "created_at": 1645648071,
+            "hex": "F21",
+            "tile": "G15-0",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 178,
+            "created_at": 1645648099,
+            "hex": "F19",
+            "tile": "24-1",
+            "rotation": 3
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 179,
+            "created_at": 1645648111
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 180,
+            "created_at": 1645648125,
+            "routes": [
+                {
+                    "train": "4+2-1",
+                    "connections": [
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "F21",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "G22",
+                            "F21"
+                        ],
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "G16",
+                        "F17",
+                        "F21",
+                        "G22",
+                        "G26"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "H15-G16-F17-F21-G22-G26",
+                    "nodes": [
+                        "G16-0",
+                        "H15-0",
+                        "F17-0",
+                        "F21-1",
+                        "G22-0",
+                        "G26-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 181,
+            "created_at": 1645648128,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 182,
+            "created_at": 1645648132
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 183,
+            "created_at": 1645648170,
+            "hex": "H15",
+            "tile": "G14-0",
+            "rotation": 5
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 184,
+            "created_at": 1645648180,
+            "hex": "E24",
+            "tile": "8-3",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 185,
+            "created_at": 1645648184,
+            "routes": [
+                {
+                    "train": "4+2-3",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "F23"
+                        ],
+                        [
+                            "F23",
+                            "F21"
+                        ],
+                        [
+                            "F21",
+                            "G20",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "F23",
+                        "F21",
+                        "F17",
+                        "G16",
+                        "H15"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "G26-F23-F21-F17-G16-H15",
+                    "nodes": [
+                        "G26-0",
+                        "F23-0",
+                        "F21-0",
+                        "F17-0",
+                        "G16-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 186,
+            "created_at": 1645648196,
+            "kind": "withhold"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 187,
+            "created_at": 1645648197
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 188,
+            "created_at": 1645648246,
+            "hex": "H17",
+            "tile": "G28-0",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 189,
+            "created_at": 1645648263,
+            "hex": "G20",
+            "tile": "46-0",
+            "rotation": 4
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 190,
+            "created_at": 1645648277
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 191,
+            "created_at": 1645648304,
+            "routes": [
+                {
+                    "train": "4+2-2",
+                    "connections": [
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "F17",
+                            "F19",
+                            "F21"
+                        ]
+                    ],
+                    "hexes": [
+                        "J11",
+                        "I12",
+                        "H15",
+                        "G16",
+                        "F17",
+                        "F21"
+                    ],
+                    "revenue": 220,
+                    "revenue_str": "J11-I12-H15-G16-F17-F21",
+                    "nodes": [
+                        "I12-0",
+                        "J11-0",
+                        "H15-0",
+                        "G16-0",
+                        "F17-0",
+                        "F21-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 192,
+            "created_at": 1645648307,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 193,
+            "created_at": 1645648310
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 194,
+            "created_at": 1645648344,
+            "hex": "I16",
+            "tile": "911-0",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 195,
+            "created_at": 1645648360,
+            "hex": "J13",
+            "tile": "G34-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 196,
+            "created_at": 1645648369,
+            "routes": [
+                {
+                    "train": "4X-0",
+                    "connections": [
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "J5",
+                            "I6"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I12",
+                        "J13",
+                        "J11",
+                        "J7",
+                        "I6"
+                    ],
+                    "revenue": 210,
+                    "revenue_str": "H15-J13-J11-I6+£50",
+                    "nodes": [
+                        "H15-0",
+                        "I12-0",
+                        "J13-0",
+                        "J11-0",
+                        "J7-0",
+                        "I6-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 197,
+            "created_at": 1645648372,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 198,
+            "created_at": 1645648386
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 199,
+            "created_at": 1645648443,
+            "hex": "F19",
+            "tile": "43-0",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 200,
+            "created_at": 1645648450,
+            "hex": "G18",
+            "tile": "G41-1",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 201,
+            "created_at": 1645648462
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 202,
+            "created_at": 1645648469,
+            "routes": [
+                {
+                    "train": "4+2-1",
+                    "connections": [
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "F21",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "G22",
+                            "F21"
+                        ],
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "G16",
+                        "F17",
+                        "F21",
+                        "G22",
+                        "G26"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "H15-G16-F17-F21-G22-G26",
+                    "nodes": [
+                        "G16-0",
+                        "H15-0",
+                        "F17-0",
+                        "F21-1",
+                        "G22-0",
+                        "G26-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 203,
+            "created_at": 1645648471,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 204,
+            "created_at": 1645648473
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 205,
+            "created_at": 1645648489,
+            "hex": "H19",
+            "tile": "G34-1",
+            "rotation": 3
+        },
+        {
+            "type": "place_token",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 206,
+            "created_at": 1645648499,
+            "city": "G34-1-0",
+            "slot": 1,
+            "tokener": "NBR"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 207,
+            "created_at": 1645648509,
+            "hex": "J9",
+            "tile": "24-2",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 208,
+            "created_at": 1645648524,
+            "routes": [
+                {
+                    "train": "5+2-0",
+                    "connections": [
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "J15",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H17"
+                        ],
+                        [
+                            "H17",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "G20",
+                            "F21"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I12",
+                        "J13",
+                        "I16",
+                        "H17",
+                        "H19",
+                        "F21"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "H15-I12-J13-I16-H17-H19-F21",
+                    "nodes": [
+                        "H15-0",
+                        "I12-0",
+                        "J13-0",
+                        "I16-0",
+                        "H17-1",
+                        "H19-0",
+                        "F21-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 209,
+            "created_at": 1645648532,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 210,
+            "created_at": 1645648534
+        },
+        {
+            "type": "sell_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 211,
+            "created_at": 1645648548,
+            "shares": [
+                "LNWR_1",
+                "LNWR_0"
+            ],
+            "percent": 60
+        },
+        {
+            "type": "sell_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 212,
+            "created_at": 1645648656,
+            "shares": [
+                "MR_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "shares": [
+                "NER_2"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 213,
+            "user": 3,
+            "created_at": 1645648706,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 214,
+            "user": 3,
+            "created_at": 1645648734
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 215,
+            "created_at": 1645648738,
+            "shares": [
+                "NBR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 216,
+            "created_at": 1645648760,
+            "shares": [
+                "NBR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "sell_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 217,
+            "created_at": 1645648764,
+            "shares": [
+                "LYR_1"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "par",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 218,
+            "created_at": 1645648800,
+            "corporation": "CR",
+            "share_price": "80,0,6"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 219,
+            "created_at": 1645648822,
+            "shares": [
+                "NBR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "sell_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 220,
+            "created_at": 1645648832,
+            "shares": [
+                "NER_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 221,
+            "created_at": 1645648833,
+            "shares": [
+                "NBR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 222,
+            "created_at": 1645648840,
+            "shares": [
+                "CR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 223,
+            "created_at": 1645648845,
+            "shares": [
+                "NBR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 224,
+            "created_at": 1645648859,
+            "shares": [
+                "CR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 225,
+            "created_at": 1645648863,
+            "unconditional": true,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 226,
+            "created_at": 1645648866,
+            "shares": [
+                "CR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 227,
+            "created_at": 1645648874,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645648873
+                }
+            ],
+            "shares": [
+                "NER_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 228,
+            "created_at": 1645648881,
+            "shares": [
+                "CR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 229,
+            "created_at": 1645648893,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645648892
+                }
+            ],
+            "shares": [
+                "NER_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 230,
+            "created_at": 1645648912,
+            "shares": [
+                "NER_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "choose",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 231,
+            "created_at": 1645648931,
+            "choice": "convert_LYR"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 232,
+            "created_at": 1645648945,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645648944
+                }
+            ],
+            "shares": [
+                "LYR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 233,
+            "created_at": 1645648992
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 234,
+            "created_at": 1645649004,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645649003
+                }
+            ],
+            "shares": [
+                "LYR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 235,
+            "created_at": 1645649008,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645649008
+                }
+            ],
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 236,
+            "created_at": 1645649083,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645649082
+                },
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645649082
+                }
+            ],
+            "shares": [
+                "LYR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 237,
+            "created_at": 1645649092,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645649091
+                },
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645649091
+                }
+            ],
+            "shares": [
+                "LYR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 238,
+            "created_at": 1645649108,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645649107
+                },
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645649107
+                }
+            ],
+            "shares": [
+                "LYR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 239,
+            "created_at": 1645649169
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 240,
+            "created_at": 1645649196,
+            "hex": "I18",
+            "tile": "8-2",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 241,
+            "created_at": 1645649220,
+            "hex": "I6",
+            "tile": "G21-0",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 242,
+            "created_at": 1645649234,
+            "routes": [
+                {
+                    "train": "4+2-3",
+                    "connections": [
+                        [
+                            "I16",
+                            "H15"
+                        ],
+                        [
+                            "H19",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "F21",
+                            "G20",
+                            "H19"
+                        ],
+                        [
+                            "F23",
+                            "F21"
+                        ],
+                        [
+                            "G26",
+                            "G24",
+                            "F23"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I16",
+                        "H19",
+                        "F21",
+                        "F23",
+                        "G26"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "H15-I16-H19-F21-F23-G26",
+                    "nodes": [
+                        "I16-0",
+                        "H15-1",
+                        "H19-0",
+                        "F21-0",
+                        "F23-0",
+                        "G26-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 243,
+            "created_at": 1645649278,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 244,
+            "created_at": 1645649280
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 245,
+            "created_at": 1645649329,
+            "hex": "I18",
+            "tile": "23-0",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 246,
+            "created_at": 1645649340,
+            "hex": "I20",
+            "tile": "204-2",
+            "rotation": 0
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 247,
+            "created_at": 1645649343
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 248,
+            "created_at": 1645649359,
+            "routes": [
+                {
+                    "train": "4X-0",
+                    "connections": [
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "J5",
+                            "I6"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I12",
+                        "J13",
+                        "J11",
+                        "J7",
+                        "I6"
+                    ],
+                    "revenue": 220,
+                    "revenue_str": "H15-J13-J11-I6+£50",
+                    "nodes": [
+                        "H15-0",
+                        "I12-0",
+                        "J13-0",
+                        "J11-0",
+                        "J7-0",
+                        "I6-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 249,
+            "created_at": 1645649362,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 250,
+            "created_at": 1645649364
+        },
+        {
+            "type": "place_token",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 251,
+            "created_at": 1645649375,
+            "city": "G30-0-0",
+            "slot": 1,
+            "tokener": "LYR"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 252,
+            "user": 3,
+            "created_at": 1645649395,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 253,
+            "user": 3,
+            "created_at": 1645649404
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 254,
+            "created_at": 1645649407,
+            "hex": "I6",
+            "tile": "G30-1",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 255,
+            "created_at": 1645649432,
+            "hex": "H5",
+            "tile": "3-1",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 256,
+            "created_at": 1645649535,
+            "routes": [
+                {
+                    "train": "4+2-2",
+                    "connections": [
+                        [
+                            "H15",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "J5",
+                            "I6"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I16",
+                        "J13",
+                        "J11",
+                        "J7",
+                        "I6"
+                    ],
+                    "revenue": 220,
+                    "revenue_str": "H15-I16-J13-J11-J7-I6+(SD)",
+                    "nodes": [
+                        "H15-1",
+                        "I16-0",
+                        "J13-0",
+                        "J11-0",
+                        "J7-0",
+                        "I6-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 257,
+            "created_at": 1645649538,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 258,
+            "created_at": 1645649543,
+            "train": "5X-0",
+            "price": 650,
+            "variant": "5X"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 259,
+            "created_at": 1645649556,
+            "hex": "J3",
+            "tile": "G41-2",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 260,
+            "created_at": 1645649556,
+            "hex": "K2",
+            "tile": "8-4",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 261,
+            "created_at": 1645649572,
+            "routes": [
+                {
+                    "train": "5+2-0",
+                    "connections": [
+                        [
+                            "K0",
+                            "K2",
+                            "J3"
+                        ],
+                        [
+                            "J3",
+                            "I4",
+                            "J5",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "I8",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "J9",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "H13",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "K0",
+                        "J3",
+                        "I6",
+                        "J7",
+                        "J11",
+                        "I12",
+                        "H15"
+                    ],
+                    "revenue": 270,
+                    "revenue_str": "K0-J3-I6-J7-J11-I12-H15+(FT)",
+                    "nodes": [
+                        "K0-0",
+                        "J3-0",
+                        "I6-0",
+                        "J7-0",
+                        "J11-0",
+                        "I12-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 262,
+            "created_at": 1645649590,
+            "kind": "withhold"
+        },
+        {
+            "type": "pass",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 263,
+            "created_at": 1645649592
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 264,
+            "created_at": 1645649599,
+            "routes": [
+                {
+                    "train": "4+2-1",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "F21"
+                        ],
+                        [
+                            "F21",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "G22",
+                        "F21",
+                        "F17",
+                        "G16",
+                        "H15"
+                    ],
+                    "revenue": 230,
+                    "revenue_str": "G26-G22-F21-F17-G16-H15",
+                    "nodes": [
+                        "G26-0",
+                        "G22-0",
+                        "F21-1",
+                        "F17-0",
+                        "G16-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 265,
+            "created_at": 1645649614,
+            "hex": "G4",
+            "tile": "G03-1",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 266,
+            "created_at": 1645649640,
+            "hex": "H5",
+            "tile": "87-3",
+            "rotation": 2
+        },
+        {
+            "type": "place_token",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 267,
+            "created_at": 1645649640,
+            "city": "G30-1-0",
+            "slot": 1,
+            "tokener": "CR"
+        },
+        {
+            "type": "buy_train",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 268,
+            "created_at": 1645649653,
+            "train": "4+2-3",
+            "price": 50
+        },
+        {
+            "type": "buy_train",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 269,
+            "created_at": 1645649661,
+            "train": "6X-0",
+            "price": 700,
+            "variant": "6X"
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 270,
+            "created_at": 1645649663
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 271,
+            "created_at": 1645649717,
+            "hex": "I22",
+            "tile": "4-2",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 272,
+            "created_at": 1645649743,
+            "hex": "H17",
+            "tile": "G30-2",
+            "rotation": 0
+        },
+        {
+            "type": "convert",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 273,
+            "created_at": 1645649743
+        },
+        {
+            "type": "buy_train",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 274,
+            "created_at": 1645649743,
+            "train": "6X-1",
+            "price": 700,
+            "variant": "6X"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 275,
+            "created_at": 1645649743
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 276,
+            "created_at": 1645649748,
+            "shares": [
+                "MR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 277,
+            "created_at": 1645649791,
+            "hex": "I20",
+            "tile": "911-1",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 278,
+            "created_at": 1645649795,
+            "hex": "H21",
+            "tile": "G28-1",
+            "rotation": 2
+        },
+        {
+            "type": "place_token",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 279,
+            "created_at": 1645649799,
+            "city": "G28-1-1",
+            "slot": 0,
+            "tokener": "NER"
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 280,
+            "created_at": 1645649810,
+            "routes": [
+                {
+                    "train": "4X-0",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "G20",
+                            "F19",
+                            "G18"
+                        ],
+                        [
+                            "G18",
+                            "H17"
+                        ],
+                        [
+                            "H17",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "I12"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "G22",
+                        "G18",
+                        "H17",
+                        "I16",
+                        "J13",
+                        "I12"
+                    ],
+                    "revenue": 240,
+                    "revenue_str": "G26-G18-H17-J13+£80",
+                    "nodes": [
+                        "G26-0",
+                        "G22-0",
+                        "G18-0",
+                        "H17-0",
+                        "I16-0",
+                        "J13-0",
+                        "I12-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 281,
+            "created_at": 1645649813,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 282,
+            "created_at": 1645649815
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 283,
+            "created_at": 1645649824,
+            "hex": "G6",
+            "tile": "4-0",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 284,
+            "created_at": 1645649831,
+            "hex": "G4",
+            "tile": "G05-0",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 285,
+            "created_at": 1645649883
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 286,
+            "created_at": 1645649951,
+            "routes": [
+                {
+                    "train": "5X-0",
+                    "connections": [
+                        [
+                            "J7",
+                            "I8",
+                            "I6"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "J7"
+                        ],
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G22",
+                            "G20",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ]
+                    ],
+                    "hexes": [
+                        "I6",
+                        "J7",
+                        "J11",
+                        "I12",
+                        "H15",
+                        "G16",
+                        "F17",
+                        "G22",
+                        "G26"
+                    ],
+                    "revenue": 370,
+                    "revenue_str": "I6-J11-H15-G16-G26+£110",
+                    "nodes": [
+                        "J7-0",
+                        "I6-0",
+                        "J11-0",
+                        "I12-0",
+                        "H15-0",
+                        "G16-0",
+                        "F17-0",
+                        "G22-0",
+                        "G26-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 287,
+            "created_at": 1645649954,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 288,
+            "created_at": 1645649976
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 289,
+            "created_at": 1645649986,
+            "hex": "I8",
+            "tile": "29-0",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 290,
+            "created_at": 1645649990,
+            "hex": "J3",
+            "tile": "G36-1",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 291,
+            "created_at": 1645650002,
+            "routes": [
+                {
+                    "train": "5+2-0",
+                    "connections": [
+                        [
+                            "K0",
+                            "K2",
+                            "J3"
+                        ],
+                        [
+                            "J3",
+                            "I4",
+                            "J5",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "I8",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "J9",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "H13",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "K0",
+                        "J3",
+                        "I6",
+                        "J7",
+                        "J11",
+                        "I12",
+                        "H15"
+                    ],
+                    "revenue": 290,
+                    "revenue_str": "K0-J3-I6-J7-J11-I12-H15+(FT)",
+                    "nodes": [
+                        "K0-0",
+                        "J3-0",
+                        "I6-0",
+                        "J7-0",
+                        "J11-0",
+                        "I12-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 292,
+            "created_at": 1645650003,
+            "kind": "withhold"
+        },
+        {
+            "type": "buy_train",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 293,
+            "created_at": 1645650005,
+            "train": "6X-2",
+            "price": 700,
+            "variant": "6X"
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 294,
+            "created_at": 1645650017,
+            "routes": [
+                {
+                    "train": "5X-1",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "F21"
+                        ],
+                        [
+                            "F21",
+                            "F19",
+                            "G18"
+                        ],
+                        [
+                            "G18",
+                            "H17"
+                        ],
+                        [
+                            "H17",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "G22",
+                        "F21",
+                        "G18",
+                        "H17",
+                        "I16",
+                        "H15"
+                    ],
+                    "revenue": 310,
+                    "revenue_str": "G26-F21-G18-H17-H15+£60",
+                    "nodes": [
+                        "G26-0",
+                        "G22-0",
+                        "F21-1",
+                        "G18-0",
+                        "H17-0",
+                        "I16-0",
+                        "H15-1"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 295,
+            "created_at": 1645650062,
+            "hex": "F5",
+            "tile": "G40-0",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 296,
+            "created_at": 1645650103,
+            "hex": "G2",
+            "tile": "8-5",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 297,
+            "created_at": 1645650104
+        },
+        {
+            "type": "run_routes",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 298,
+            "created_at": 1645650116,
+            "routes": [
+                {
+                    "train": "6X-0",
+                    "connections": [
+                        [
+                            "K0",
+                            "K2",
+                            "J3"
+                        ],
+                        [
+                            "J3",
+                            "I4",
+                            "J5",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "H5"
+                        ],
+                        [
+                            "H5",
+                            "G4"
+                        ],
+                        [
+                            "G4",
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ]
+                    ],
+                    "hexes": [
+                        "K0",
+                        "J3",
+                        "I6",
+                        "H5",
+                        "G4",
+                        "F5",
+                        "E6"
+                    ],
+                    "revenue": 340,
+                    "revenue_str": "K0-J3-I6-G4-F5-E6+(FT)+(EW)+£60",
+                    "nodes": [
+                        "K0-0",
+                        "J3-0",
+                        "I6-0",
+                        "H5-0",
+                        "G4-0",
+                        "F5-0",
+                        "E6-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 299,
+            "created_at": 1645650123,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 300,
+            "created_at": 1645650125
+        },
+        {
+            "type": "sell_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 301,
+            "created_at": 1645650143,
+            "shares": [
+                "CR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "shares": [
+                "NBR_8"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 302,
+            "user": 2,
+            "created_at": 1645650144,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 303,
+            "user": 2,
+            "created_at": 1645650155
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 304,
+            "created_at": 1645650161,
+            "shares": [
+                "LNWR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 305,
+            "created_at": 1645650193,
+            "shares": [
+                "NBR_8"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 306,
+            "created_at": 1645650221,
+            "shares": [
+                "LNWR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 307,
+            "created_at": 1645650228,
+            "shares": [
+                "LNWR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 308,
+            "created_at": 1645650249,
+            "unconditional": true,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 309,
+            "created_at": 1645650249,
+            "shares": [
+                "MR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 310,
+            "created_at": 1645650257,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645650256
+                }
+            ],
+            "shares": [
+                "LNWR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 311,
+            "created_at": 1645650262,
+            "shares": [
+                "MR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 312,
+            "created_at": 1645650268,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645650267
+                }
+            ],
+            "shares": [
+                "LNWR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 313,
+            "created_at": 1645650273
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 314,
+            "created_at": 1645650301,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645650300
+                }
+            ],
+            "shares": [
+                "LNWR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 315,
+            "created_at": 1645650305
+        },
+        {
+            "type": "sell_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 316,
+            "created_at": 1645650316,
+            "shares": [
+                "NER_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 317,
+            "created_at": 1645650392,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645650391
+                }
+            ],
+            "shares": [
+                "CR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 318,
+            "created_at": 1645650397
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 319,
+            "created_at": 1645650406
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 320,
+            "created_at": 1645650438,
+            "hex": "G16",
+            "tile": "G05-1",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 321,
+            "created_at": 1645650443,
+            "hex": "I8",
+            "tile": "43-1",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 322,
+            "created_at": 1645650452
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 323,
+            "created_at": 1645650476,
+            "routes": [
+                {
+                    "train": "5X-0",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "G20",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "I8",
+                            "I6"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "G22",
+                        "F17",
+                        "G16",
+                        "H15",
+                        "I12",
+                        "J11",
+                        "I6"
+                    ],
+                    "revenue": 380,
+                    "revenue_str": "G26-G16-H15-J11-I6+£110",
+                    "nodes": [
+                        "G26-0",
+                        "G22-0",
+                        "F17-0",
+                        "G16-0",
+                        "H15-0",
+                        "I12-0",
+                        "J11-0",
+                        "I6-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 324,
+            "created_at": 1645650478,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 325,
+            "created_at": 1645650484
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 326,
+            "created_at": 1645650499,
+            "hex": "H23",
+            "tile": "9-2",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 327,
+            "created_at": 1645650501,
+            "hex": "H25",
+            "tile": "8-2",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 328,
+            "created_at": 1645650514,
+            "routes": [
+                {
+                    "train": "4X-0",
+                    "connections": [
+                        [
+                            "G26",
+                            "H25",
+                            "H23",
+                            "H21"
+                        ],
+                        [
+                            "H21",
+                            "I20"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "H21",
+                        "I20",
+                        "I16",
+                        "J13",
+                        "J11"
+                    ],
+                    "revenue": 270,
+                    "revenue_str": "G26-H21-J13-J11+£90",
+                    "nodes": [
+                        "G26-0",
+                        "H21-1",
+                        "I20-0",
+                        "I16-0",
+                        "J13-0",
+                        "J11-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 329,
+            "created_at": 1645650516,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 330,
+            "created_at": 1645650517
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 331,
+            "created_at": 1645650556,
+            "hex": "G4",
+            "tile": "G14-1",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 332,
+            "created_at": 1645650573,
+            "hex": "H5",
+            "tile": "911-2",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 333,
+            "created_at": 1645650575
+        },
+        {
+            "type": "run_routes",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 334,
+            "created_at": 1645650576,
+            "routes": [
+                {
+                    "train": "6X-0",
+                    "connections": [
+                        [
+                            "K0",
+                            "K2",
+                            "J3"
+                        ],
+                        [
+                            "J3",
+                            "I4",
+                            "J5",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "H5"
+                        ],
+                        [
+                            "H5",
+                            "G4"
+                        ],
+                        [
+                            "G4",
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ]
+                    ],
+                    "hexes": [
+                        "K0",
+                        "J3",
+                        "I6",
+                        "H5",
+                        "G4",
+                        "F5",
+                        "E6"
+                    ],
+                    "revenue": 360,
+                    "revenue_str": "K0-J3-I6-G4-F5-E6+(FT)+(EW)+£60",
+                    "nodes": [
+                        "K0-0",
+                        "J3-0",
+                        "I6-0",
+                        "H5-0",
+                        "G4-1",
+                        "F5-0",
+                        "E6-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 335,
+            "created_at": 1645650591,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 336,
+            "created_at": 1645650591
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 337,
+            "created_at": 1645650591,
+            "hex": "I12",
+            "tile": "911-3",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 338,
+            "created_at": 1645650592,
+            "hex": "I10",
+            "tile": "23-1",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 339,
+            "created_at": 1645650595
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 340,
+            "created_at": 1645650625,
+            "routes": [
+                {
+                    "train": "6X-1",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "F23"
+                        ],
+                        [
+                            "F23",
+                            "F21"
+                        ],
+                        [
+                            "F21",
+                            "G20",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "I20"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "I10",
+                            "H9"
+                        ],
+                        [
+                            "H9",
+                            "G8"
+                        ],
+                        [
+                            "G8",
+                            "F7",
+                            "E6"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "F23",
+                        "F21",
+                        "H19",
+                        "I20",
+                        "I16",
+                        "J13",
+                        "I12",
+                        "H9",
+                        "G8",
+                        "E6"
+                    ],
+                    "revenue": 380,
+                    "revenue_str": "G26-F21-H19-J13-H9-E6+(EW)+£110",
+                    "nodes": [
+                        "G26-0",
+                        "F23-0",
+                        "F21-0",
+                        "H19-0",
+                        "I20-0",
+                        "I16-0",
+                        "J13-0",
+                        "I12-0",
+                        "H9-0",
+                        "G8-0",
+                        "E6-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 341,
+            "created_at": 1645650628,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 342,
+            "created_at": 1645650630
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 343,
+            "created_at": 1645650667,
+            "hex": "J3",
+            "tile": "G34-2",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 344,
+            "created_at": 1645650680,
+            "hex": "I18",
+            "tile": "45-0",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 345,
+            "created_at": 1645650733,
+            "routes": [
+                {
+                    "train": "5+2-0",
+                    "connections": [
+                        [
+                            "F21",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "H21"
+                        ],
+                        [
+                            "H21",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "H17"
+                        ],
+                        [
+                            "H17",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "F21",
+                        "G22",
+                        "H21",
+                        "H19",
+                        "H17",
+                        "I16",
+                        "H15"
+                    ],
+                    "revenue": 250,
+                    "revenue_str": "F21-G22-H21-H19-H17-I16-H15",
+                    "nodes": [
+                        "F21-1",
+                        "G22-0",
+                        "H21-0",
+                        "H19-0",
+                        "H17-0",
+                        "I16-0",
+                        "H15-1"
+                    ]
+                },
+                {
+                    "train": "6X-2",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "G20",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "I20"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "I8",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "J5",
+                            "I4",
+                            "J3"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "G22",
+                        "H19",
+                        "I20",
+                        "I16",
+                        "J13",
+                        "J11",
+                        "I6",
+                        "J3"
+                    ],
+                    "revenue": 430,
+                    "revenue_str": "G26-H19-J13-J11-I6-J3+(FT)+£130",
+                    "nodes": [
+                        "G26-0",
+                        "G22-0",
+                        "H19-0",
+                        "I20-0",
+                        "I16-0",
+                        "J13-0",
+                        "J11-0",
+                        "I6-0",
+                        "J3-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 346,
+            "created_at": 1645650735,
+            "kind": "payout"
+        },
+        {
+            "city": "G05-1-0",
+            "slot": 0,
+            "type": "place_token",
+            "entity": "LNWR",
+            "tokener": "LNWR",
+            "entity_type": "corporation",
+            "id": 347,
+            "user": 3,
+            "created_at": 1645650767,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 348,
+            "user": 3,
+            "created_at": 1645650771
+        },
+        {
+            "hex": "H21",
+            "tile": "G30-3",
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 349,
+            "user": 3,
+            "created_at": 1645650820,
+            "skip": true
+        },
+        {
+            "city": "G30-3-0",
+            "slot": 1,
+            "type": "place_token",
+            "entity": "LNWR",
+            "tokener": "LNWR",
+            "entity_type": "corporation",
+            "id": 350,
+            "user": 3,
+            "created_at": 1645650821,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 351,
+            "user": 3,
+            "created_at": 1645650852
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 352,
+            "user": 3,
+            "created_at": 1645650860
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LS",
+            "entity_type": "company",
+            "id": 353,
+            "created_at": 1645650867,
+            "hex": "H21",
+            "tile": "G30-3",
+            "rotation": 0
+        },
+        {
+            "city": "G30-3-0",
+            "slot": 1,
+            "type": "place_token",
+            "entity": "LNWR",
+            "tokener": "LNWR",
+            "entity_type": "corporation",
+            "id": 354,
+            "user": 3,
+            "created_at": 1645650870,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 355,
+            "user": 3,
+            "created_at": 1645650936
+        },
+        {
+            "type": "place_token",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 356,
+            "created_at": 1645650943,
+            "city": "G14-0-1",
+            "slot": 0,
+            "tokener": "LNWR"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 357,
+            "created_at": 1645650957,
+            "hex": "H9",
+            "tile": "G37-0",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 358,
+            "created_at": 1645650971,
+            "hex": "G2",
+            "tile": "23-2",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 359,
+            "created_at": 1645651045,
+            "routes": [
+                {
+                    "train": "6X-3",
+                    "connections": [
+                        [
+                            "H21",
+                            "H23",
+                            "H25",
+                            "G26"
+                        ],
+                        [
+                            "I20",
+                            "H21"
+                        ],
+                        [
+                            "I16",
+                            "I18",
+                            "I20"
+                        ],
+                        [
+                            "I14",
+                            "I16"
+                        ],
+                        [
+                            "I12",
+                            "I14"
+                        ],
+                        [
+                            "H9",
+                            "I10",
+                            "I12"
+                        ],
+                        [
+                            "G6",
+                            "G8",
+                            "H9"
+                        ],
+                        [
+                            "G4",
+                            "G6"
+                        ],
+                        [
+                            "G0",
+                            "G2",
+                            "G4"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "H21",
+                        "I20",
+                        "I16",
+                        "I14",
+                        "I12",
+                        "H9",
+                        "G6",
+                        "G4",
+                        "G0"
+                    ],
+                    "revenue": 400,
+                    "revenue_str": "G26-H21-I14-H9-G4-G0+(NS)+£130",
+                    "nodes": [
+                        "H21-0",
+                        "G26-0",
+                        "I20-0",
+                        "I16-0",
+                        "I14-0",
+                        "I12-0",
+                        "H9-0",
+                        "G6-0",
+                        "G4-0",
+                        "G0-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 360,
+            "created_at": 1645651047,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 361,
+            "created_at": 1645651057
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 362,
+            "created_at": 1645651070,
+            "hex": "H7",
+            "tile": "9-4",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 363,
+            "created_at": 1645651076,
+            "hex": "G6",
+            "tile": "88-0",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 364,
+            "created_at": 1645651081
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 365,
+            "created_at": 1645651091,
+            "routes": [
+                {
+                    "train": "5X-0",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "G20",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "I8",
+                            "H7",
+                            "G6"
+                        ],
+                        [
+                            "G6",
+                            "G4"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "G22",
+                        "F17",
+                        "G16",
+                        "H15",
+                        "I12",
+                        "J11",
+                        "G6",
+                        "G4"
+                    ],
+                    "revenue": 390,
+                    "revenue_str": "G26-G16-H15-J11-G4+£110",
+                    "nodes": [
+                        "G26-0",
+                        "G22-0",
+                        "F17-0",
+                        "G16-0",
+                        "H15-0",
+                        "I12-0",
+                        "J11-0",
+                        "G6-0",
+                        "G4-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 366,
+            "created_at": 1645651096,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 367,
+            "created_at": 1645651097
+        },
+        {
+            "hex": "I14",
+            "tile": "G34-3",
+            "type": "lay_tile",
+            "entity": "NER",
+            "rotation": 3,
+            "entity_type": "corporation",
+            "id": 368,
+            "user": 1,
+            "created_at": 1645651153,
+            "skip": true
+        },
+        {
+            "hex": "F17",
+            "tile": "88-1",
+            "type": "lay_tile",
+            "entity": "NER",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 369,
+            "user": 1,
+            "created_at": 1645651161,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "NER",
+            "action_id": 367,
+            "entity_type": "corporation",
+            "id": 370,
+            "user": 1,
+            "created_at": 1645651187
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 371,
+            "created_at": 1645651199,
+            "hex": "I22",
+            "tile": "88-1",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 372,
+            "created_at": 1645651202,
+            "hex": "H23",
+            "tile": "23-3",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 373,
+            "created_at": 1645651245,
+            "routes": [
+                {
+                    "train": "4X-0",
+                    "connections": [
+                        [
+                            "G8",
+                            "F7",
+                            "E6"
+                        ],
+                        [
+                            "H9",
+                            "G8"
+                        ],
+                        [
+                            "I12",
+                            "I10",
+                            "H9"
+                        ],
+                        [
+                            "J13",
+                            "I12"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I22",
+                            "I20"
+                        ],
+                        [
+                            "G26",
+                            "H25",
+                            "H23",
+                            "I22"
+                        ]
+                    ],
+                    "hexes": [
+                        "E6",
+                        "G8",
+                        "H9",
+                        "I12",
+                        "J13",
+                        "I16",
+                        "I20",
+                        "I22",
+                        "G26"
+                    ],
+                    "revenue": 300,
+                    "revenue_str": "E6-H9-J13-G26+(EW)+£110",
+                    "nodes": [
+                        "G8-0",
+                        "E6-0",
+                        "H9-0",
+                        "I12-0",
+                        "J13-0",
+                        "I16-0",
+                        "I20-0",
+                        "I22-0",
+                        "G26-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 374,
+            "created_at": 1645651254,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 375,
+            "created_at": 1645651255
+        },
+        {
+            "hex": "F5",
+            "tile": "G38-2",
+            "type": "lay_tile",
+            "entity": "CR",
+            "rotation": 1,
+            "entity_type": "corporation",
+            "id": 376,
+            "user": 1,
+            "created_at": 1645651300,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 377,
+            "user": 1,
+            "created_at": 1645651301,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "CR",
+            "action_id": 375,
+            "entity_type": "corporation",
+            "id": 378,
+            "user": 1,
+            "created_at": 1645651309
+        },
+        {
+            "hex": "I14",
+            "tile": "G34-3",
+            "type": "lay_tile",
+            "entity": "CR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 379,
+            "user": 1,
+            "created_at": 1645651317,
+            "skip": true
+        },
+        {
+            "hex": "F17",
+            "tile": "87-4",
+            "type": "lay_tile",
+            "entity": "CR",
+            "rotation": 3,
+            "entity_type": "corporation",
+            "id": 380,
+            "user": 1,
+            "created_at": 1645651325,
+            "skip": true
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 381,
+            "user": 1,
+            "created_at": 1645651344,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "CR",
+            "action_id": 375,
+            "entity_type": "corporation",
+            "id": 382,
+            "user": 1,
+            "created_at": 1645651367
+        },
+        {
+            "hex": "I14",
+            "tile": "G34-3",
+            "type": "lay_tile",
+            "entity": "CR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 383,
+            "user": 1,
+            "created_at": 1645651377,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "CR",
+            "action_id": 375,
+            "entity_type": "corporation",
+            "id": 384,
+            "user": 1,
+            "created_at": 1645651403
+        },
+        {
+            "city": "G40-0-0",
+            "slot": 0,
+            "type": "place_token",
+            "entity": "CR",
+            "tokener": "CR",
+            "entity_type": "corporation",
+            "id": 385,
+            "user": 1,
+            "created_at": 1645651407,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 386,
+            "user": 1,
+            "created_at": 1645651411
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 387,
+            "created_at": 1645651414,
+            "hex": "F5",
+            "tile": "G38-2",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 388,
+            "created_at": 1645651442,
+            "hex": "F17",
+            "tile": "87-4",
+            "rotation": 3
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 389,
+            "created_at": 1645651444
+        },
+        {
+            "type": "run_routes",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 390,
+            "created_at": 1645651478,
+            "routes": [
+                {
+                    "train": "6X-0",
+                    "connections": [
+                        [
+                            "I22",
+                            "H23",
+                            "H25",
+                            "G26"
+                        ],
+                        [
+                            "I20",
+                            "I22"
+                        ],
+                        [
+                            "I16",
+                            "I18",
+                            "I20"
+                        ],
+                        [
+                            "J13",
+                            "J15",
+                            "I16"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "H9",
+                            "I10",
+                            "I12"
+                        ],
+                        [
+                            "G6",
+                            "G8",
+                            "H9"
+                        ],
+                        [
+                            "F5",
+                            "G6"
+                        ],
+                        [
+                            "G4",
+                            "F5"
+                        ],
+                        [
+                            "G0",
+                            "G2",
+                            "F3",
+                            "G4"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "I22",
+                        "I20",
+                        "I16",
+                        "J13",
+                        "I12",
+                        "H9",
+                        "G6",
+                        "F5",
+                        "G4",
+                        "G0"
+                    ],
+                    "revenue": 380,
+                    "revenue_str": "G26-J13-H9-F5-G4-G0+(NS)+£130",
+                    "nodes": [
+                        "I22-0",
+                        "G26-0",
+                        "I20-0",
+                        "I16-0",
+                        "J13-0",
+                        "I12-0",
+                        "H9-0",
+                        "G6-0",
+                        "F5-0",
+                        "G4-1",
+                        "G0-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 391,
+            "created_at": 1645651480,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 392,
+            "created_at": 1645651482
+        },
+        {
+            "type": "lay_tile",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 393,
+            "created_at": 1645651525,
+            "hex": "H9",
+            "tile": "G34-3",
+            "rotation": 1
+        },
+        {
+            "type": "place_token",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 394,
+            "created_at": 1645651531,
+            "city": "G30-3-0",
+            "slot": 1,
+            "tokener": "MR"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 395,
+            "created_at": 1645651533
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 396,
+            "created_at": 1645651548,
+            "routes": [
+                {
+                    "train": "6X-1",
+                    "connections": [
+                        [
+                            "H21",
+                            "H23",
+                            "H25",
+                            "G26"
+                        ],
+                        [
+                            "I20",
+                            "H21"
+                        ],
+                        [
+                            "I16",
+                            "I18",
+                            "I20"
+                        ],
+                        [
+                            "J13",
+                            "J15",
+                            "I16"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "H9",
+                            "I10",
+                            "I12"
+                        ],
+                        [
+                            "G6",
+                            "G8",
+                            "H9"
+                        ],
+                        [
+                            "G4",
+                            "G6"
+                        ],
+                        [
+                            "G0",
+                            "G2",
+                            "G4"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "H21",
+                        "I20",
+                        "I16",
+                        "J13",
+                        "I12",
+                        "H9",
+                        "G6",
+                        "G4",
+                        "G0"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "G26-H21-J13-H9-G4-G0+(NS)+£130",
+                    "nodes": [
+                        "H21-0",
+                        "G26-0",
+                        "I20-0",
+                        "I16-0",
+                        "J13-0",
+                        "I12-0",
+                        "H9-0",
+                        "G6-0",
+                        "G4-0",
+                        "G0-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 397,
+            "created_at": 1645651550,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 398,
+            "created_at": 1645651551
+        },
+        {
+            "hex": "H7",
+            "tile": "23-4",
+            "type": "lay_tile",
+            "entity": "NBR",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 399,
+            "user": 2,
+            "created_at": 1645651573,
+            "skip": true
+        },
+        {
+            "hex": "G14",
+            "tile": "G19-1",
+            "type": "lay_tile",
+            "entity": "NBR",
+            "rotation": 0,
+            "entity_type": "corporation",
+            "id": 400,
+            "user": 2,
+            "created_at": 1645651589,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "NBR",
+            "action_id": 398,
+            "entity_type": "corporation",
+            "id": 401,
+            "user": 2,
+            "created_at": 1645651667
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 402,
+            "created_at": 1645651675,
+            "hex": "H13",
+            "tile": "24-3",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 403,
+            "created_at": 1645651695,
+            "hex": "G10",
+            "tile": "8-6",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 404,
+            "created_at": 1645651812,
+            "routes": [
+                {
+                    "train": "5+2-0",
+                    "connections": [
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "I10",
+                            "H9"
+                        ],
+                        [
+                            "H9",
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "G6",
+                            "G4"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "I12",
+                        "J13",
+                        "J11",
+                        "H9",
+                        "G6",
+                        "G4"
+                    ],
+                    "revenue": 270,
+                    "revenue_str": "H15-I12-J13-J11-H9-G6-G4+(NS)",
+                    "nodes": [
+                        "H15-0",
+                        "I12-0",
+                        "J13-0",
+                        "J11-0",
+                        "H9-0",
+                        "G6-0",
+                        "G4-0"
+                    ]
+                },
+                {
+                    "train": "6X-2",
+                    "connections": [
+                        [
+                            "G26",
+                            "H25",
+                            "H23",
+                            "I22"
+                        ],
+                        [
+                            "I22",
+                            "I20"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "I8",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "J5",
+                            "I4",
+                            "J3"
+                        ],
+                        [
+                            "J3",
+                            "K2",
+                            "K0"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "I22",
+                        "I20",
+                        "I16",
+                        "J13",
+                        "J11",
+                        "I6",
+                        "J3",
+                        "K0"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "G26-J13-J11-I6-J3-K0+(FT)+£150",
+                    "nodes": [
+                        "G26-0",
+                        "I22-0",
+                        "I20-0",
+                        "I16-0",
+                        "J13-0",
+                        "J11-0",
+                        "I6-0",
+                        "J3-0",
+                        "K0-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 405,
+            "created_at": 1645651814,
+            "kind": "payout"
+        },
+        {
+            "hex": "G14",
+            "tile": "G19-1",
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 406,
+            "user": 3,
+            "created_at": 1645651898,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 407,
+            "user": 3,
+            "created_at": 1645651909
+        },
+        {
+            "type": "place_token",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 408,
+            "created_at": 1645651927,
+            "city": "G34-3-0",
+            "slot": 1,
+            "tokener": "LNWR"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 409,
+            "created_at": 1645651946,
+            "hex": "I10",
+            "tile": "41-0",
+            "rotation": 5
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 410,
+            "created_at": 1645651957
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 411,
+            "created_at": 1645652000,
+            "routes": [
+                {
+                    "train": "6X-3",
+                    "connections": [
+                        [
+                            "G26",
+                            "H25",
+                            "H23",
+                            "I22"
+                        ],
+                        [
+                            "I22",
+                            "I20"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ],
+                        [
+                            "H15",
+                            "I14"
+                        ],
+                        [
+                            "I14",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "I10",
+                            "H9"
+                        ],
+                        [
+                            "H9",
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "G6",
+                            "G4"
+                        ],
+                        [
+                            "G4",
+                            "G2",
+                            "G0"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "I22",
+                        "I20",
+                        "I16",
+                        "H15",
+                        "I14",
+                        "I12",
+                        "H9",
+                        "G6",
+                        "G4",
+                        "G0"
+                    ],
+                    "revenue": 420,
+                    "revenue_str": "G26-H15-I14-H9-G4-G0+(NS)+£130",
+                    "nodes": [
+                        "G26-0",
+                        "I22-0",
+                        "I20-0",
+                        "I16-0",
+                        "H15-1",
+                        "I14-0",
+                        "I12-0",
+                        "H9-0",
+                        "G6-0",
+                        "G4-0",
+                        "G0-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 412,
+            "created_at": 1645652002,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 413,
+            "created_at": 1645652005
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 414,
+            "user": 2,
+            "created_at": 1645652021
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 415,
+            "user": 2,
+            "created_at": 1645652023
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 416,
+            "user": 2,
+            "created_at": 1645652026
+        },
+        {
+            "skip": true,
+            "type": "redo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 417,
+            "user": 2,
+            "created_at": 1645652046
+        },
+        {
+            "skip": true,
+            "type": "redo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 418,
+            "user": 2,
+            "created_at": 1645652047
+        },
+        {
+            "skip": true,
+            "type": "redo",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 419,
+            "user": 2,
+            "created_at": 1645652047
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 420,
+            "created_at": 1645652052,
+            "shares": [
+                "LNWR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 421,
+            "created_at": 1645652065,
+            "corporation": "LNWR",
+            "until_condition": 6,
+            "from_market": true,
+            "auto_pass_after": false
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 422,
+            "created_at": 1645652071,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645652070
+                }
+            ],
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "sell_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 423,
+            "created_at": 1645652085,
+            "shares": [
+                "CR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 424,
+            "created_at": 1645652088,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645652087,
+                    "reason": "Shares were sold"
+                }
+            ],
+            "shares": [
+                "LNWR_8"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 425,
+            "created_at": 1645652094,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645652093,
+                    "reason": "Shares were sold"
+                }
+            ],
+            "shares": [
+                "LNWR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 1,
+            "entity_type": "player",
+            "id": 426,
+            "created_at": 1645652099,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645652098
+                }
+            ],
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 427,
+            "created_at": 1645652111
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 428,
+            "created_at": 1645652118,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645652117
+                }
+            ],
+            "shares": [
+                "LNWR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 429,
+            "created_at": 1645652122
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 430,
+            "created_at": 1645652127,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645652126
+                }
+            ],
+            "shares": [
+                "MR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 3,
+            "entity_type": "player",
+            "id": 431,
+            "created_at": 1645652130,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 3,
+                    "entity_type": "player",
+                    "created_at": 1645652129
+                }
+            ],
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 432,
+            "created_at": 1645652133,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645652133
+                },
+                {
+                    "type": "pass",
+                    "entity": 3,
+                    "entity_type": "player",
+                    "created_at": 1645652133
+                }
+            ],
+            "shares": [
+                "MR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 433,
+            "created_at": 1645652140,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 1,
+                    "entity_type": "player",
+                    "created_at": 1645652139
+                },
+                {
+                    "type": "pass",
+                    "entity": 3,
+                    "entity_type": "player",
+                    "created_at": 1645652139
+                }
+            ],
+            "shares": [
+                "MR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2,
+            "entity_type": "player",
+            "id": 434,
+            "created_at": 1645652159,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 2,
+                    "entity_type": "player",
+                    "created_at": 1645652159
+                }
+            ],
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "place_token",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 435,
+            "created_at": 1645652189,
+            "city": "G34-3-0",
+            "slot": 1,
+            "tokener": "LYR"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 436,
+            "created_at": 1645652204,
+            "hex": "G16",
+            "tile": "G14-2",
+            "rotation": 0
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 437,
+            "created_at": 1645652210
+        },
+        {
+            "type": "run_routes",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 438,
+            "created_at": 1645652218,
+            "routes": [
+                {
+                    "train": "5X-0",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "G20",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "H15",
+                            "H13",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "I8",
+                            "H7",
+                            "G6"
+                        ],
+                        [
+                            "G6",
+                            "G4"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "G22",
+                        "F17",
+                        "G16",
+                        "H15",
+                        "I12",
+                        "J11",
+                        "G6",
+                        "G4"
+                    ],
+                    "revenue": 410,
+                    "revenue_str": "G26-G16-H15-J11-G4+£110",
+                    "nodes": [
+                        "G26-0",
+                        "G22-0",
+                        "F17-0",
+                        "G16-0",
+                        "H15-0",
+                        "I12-0",
+                        "J11-0",
+                        "G6-0",
+                        "G4-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 439,
+            "created_at": 1645652236,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LYR",
+            "entity_type": "corporation",
+            "id": 440,
+            "created_at": 1645652247
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 441,
+            "created_at": 1645652257,
+            "hex": "F5",
+            "tile": "G34-4",
+            "rotation": 3
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 442,
+            "created_at": 1645652267
+        },
+        {
+            "type": "run_routes",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 443,
+            "created_at": 1645652276,
+            "routes": [
+                {
+                    "train": "6X-0",
+                    "connections": [
+                        [
+                            "K0",
+                            "K2",
+                            "J3"
+                        ],
+                        [
+                            "J3",
+                            "I4",
+                            "J5",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "H5"
+                        ],
+                        [
+                            "H5",
+                            "G4"
+                        ],
+                        [
+                            "G4",
+                            "F3",
+                            "F5"
+                        ],
+                        [
+                            "F5",
+                            "E6"
+                        ]
+                    ],
+                    "hexes": [
+                        "K0",
+                        "J3",
+                        "I6",
+                        "H5",
+                        "G4",
+                        "F5",
+                        "E6"
+                    ],
+                    "revenue": 390,
+                    "revenue_str": "K0-J3-I6-G4-F5-E6+(FT)+(EW)+£60",
+                    "nodes": [
+                        "K0-0",
+                        "J3-0",
+                        "I6-0",
+                        "H5-0",
+                        "G4-1",
+                        "F5-0",
+                        "E6-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 444,
+            "created_at": 1645652285,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "CR",
+            "entity_type": "corporation",
+            "id": 445,
+            "created_at": 1645652287
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 446,
+            "created_at": 1645652295,
+            "hex": "F15",
+            "tile": "8-7",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 447,
+            "created_at": 1645652306,
+            "hex": "I14",
+            "tile": "G34-5",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 448,
+            "created_at": 1645652389,
+            "routes": [
+                {
+                    "train": "4X-0",
+                    "connections": [
+                        [
+                            "G16",
+                            "H15"
+                        ],
+                        [
+                            "G16",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "F19",
+                            "G20",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "H21"
+                        ],
+                        [
+                            "H21",
+                            "H23",
+                            "H25",
+                            "G26"
+                        ]
+                    ],
+                    "hexes": [
+                        "H15",
+                        "G16",
+                        "F17",
+                        "G22",
+                        "H21",
+                        "G26"
+                    ],
+                    "revenue": 300,
+                    "revenue_str": "H15-G16-H21-G26+£60",
+                    "nodes": [
+                        "G16-0",
+                        "H15-0",
+                        "F17-0",
+                        "G22-0",
+                        "H21-0",
+                        "G26-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 449,
+            "created_at": 1645652391,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "NER",
+            "entity_type": "corporation",
+            "id": 450,
+            "created_at": 1645652392
+        },
+        {
+            "hex": "D23",
+            "tile": "G19-1",
+            "type": "lay_tile",
+            "entity": "MR",
+            "rotation": 5,
+            "entity_type": "corporation",
+            "id": 451,
+            "user": 1,
+            "created_at": 1645652397,
+            "skip": true
+        },
+        {
+            "hex": "C24",
+            "tile": "58-2",
+            "type": "lay_tile",
+            "entity": "MR",
+            "rotation": 2,
+            "entity_type": "corporation",
+            "id": 452,
+            "user": 1,
+            "created_at": 1645652400,
+            "skip": true
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 453,
+            "user": 1,
+            "created_at": 1645652411
+        },
+        {
+            "skip": true,
+            "type": "undo",
+            "entity": "MR",
+            "action_id": 450,
+            "entity_type": "corporation",
+            "id": 454,
+            "user": 1,
+            "created_at": 1645652475
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 455,
+            "created_at": 1645652480
+        },
+        {
+            "type": "run_routes",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 456,
+            "created_at": 1645652529,
+            "routes": [
+                {
+                    "train": "6X-1",
+                    "connections": [
+                        [
+                            "G26",
+                            "G24",
+                            "F23"
+                        ],
+                        [
+                            "F23",
+                            "F21"
+                        ],
+                        [
+                            "F21",
+                            "G20",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "H21"
+                        ],
+                        [
+                            "H21",
+                            "G22"
+                        ],
+                        [
+                            "G22",
+                            "G20",
+                            "F19",
+                            "F17"
+                        ],
+                        [
+                            "F17",
+                            "G16"
+                        ],
+                        [
+                            "G16",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "F23",
+                        "F21",
+                        "H19",
+                        "H21",
+                        "G22",
+                        "F17",
+                        "G16",
+                        "H15"
+                    ],
+                    "revenue": 390,
+                    "revenue_str": "G26-F21-H19-H21-G16-H15+£60",
+                    "nodes": [
+                        "G26-0",
+                        "F23-0",
+                        "F21-0",
+                        "H19-0",
+                        "H21-0",
+                        "G22-0",
+                        "F17-0",
+                        "G16-0",
+                        "H15-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 457,
+            "created_at": 1645652532,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "MR",
+            "entity_type": "corporation",
+            "id": 458,
+            "created_at": 1645652534
+        },
+        {
+            "type": "pass",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 459,
+            "created_at": 1645652537
+        },
+        {
+            "type": "run_routes",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 460,
+            "created_at": 1645652731,
+            "routes": [
+                {
+                    "train": "5+2-0",
+                    "connections": [
+                        [
+                            "G16",
+                            "H17"
+                        ],
+                        [
+                            "H17",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "J15",
+                            "J13"
+                        ],
+                        [
+                            "J13",
+                            "K12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "I10",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "H13",
+                            "H15"
+                        ]
+                    ],
+                    "hexes": [
+                        "G16",
+                        "H17",
+                        "I16",
+                        "J13",
+                        "J11",
+                        "I12",
+                        "H15"
+                    ],
+                    "revenue": 290,
+                    "revenue_str": "G16-H17-I16-J13-J11-I12-H15+(NS)",
+                    "nodes": [
+                        "G16-1",
+                        "H17-0",
+                        "I16-0",
+                        "J13-0",
+                        "J11-0",
+                        "I12-0",
+                        "H15-0"
+                    ]
+                },
+                {
+                    "train": "6X-2",
+                    "connections": [
+                        [
+                            "G26",
+                            "H25",
+                            "H23",
+                            "I22"
+                        ],
+                        [
+                            "I22",
+                            "I20"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "I14"
+                        ],
+                        [
+                            "I14",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "J11"
+                        ],
+                        [
+                            "J11",
+                            "J9",
+                            "I8",
+                            "I6"
+                        ],
+                        [
+                            "I6",
+                            "J5",
+                            "I4",
+                            "J3"
+                        ],
+                        [
+                            "J3",
+                            "K2",
+                            "K0"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "I22",
+                        "I20",
+                        "I16",
+                        "I14",
+                        "I12",
+                        "J11",
+                        "I6",
+                        "J3",
+                        "K0"
+                    ],
+                    "revenue": 470,
+                    "revenue_str": "G26-I14-J11-I6-J3-K0+(FT)+£150",
+                    "nodes": [
+                        "G26-0",
+                        "I22-0",
+                        "I20-0",
+                        "I16-0",
+                        "I14-0",
+                        "I12-0",
+                        "J11-0",
+                        "I6-0",
+                        "J3-0",
+                        "K0-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "NBR",
+            "entity_type": "corporation",
+            "id": 461,
+            "created_at": 1645652732,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 462,
+            "created_at": 1645652751
+        },
+        {
+            "type": "run_routes",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 463,
+            "created_at": 1645652754,
+            "routes": [
+                {
+                    "train": "6X-3",
+                    "connections": [
+                        [
+                            "G26",
+                            "H25",
+                            "H23",
+                            "I22"
+                        ],
+                        [
+                            "I22",
+                            "I20"
+                        ],
+                        [
+                            "I20",
+                            "I18",
+                            "I16"
+                        ],
+                        [
+                            "I16",
+                            "H15"
+                        ],
+                        [
+                            "H15",
+                            "I14"
+                        ],
+                        [
+                            "I14",
+                            "I12"
+                        ],
+                        [
+                            "I12",
+                            "I10",
+                            "H9"
+                        ],
+                        [
+                            "H9",
+                            "G8",
+                            "G6"
+                        ],
+                        [
+                            "G6",
+                            "G4"
+                        ],
+                        [
+                            "G4",
+                            "G2",
+                            "G0"
+                        ]
+                    ],
+                    "hexes": [
+                        "G26",
+                        "I22",
+                        "I20",
+                        "I16",
+                        "H15",
+                        "I14",
+                        "I12",
+                        "H9",
+                        "G6",
+                        "G4",
+                        "G0"
+                    ],
+                    "revenue": 430,
+                    "revenue_str": "G26-H15-I14-H9-G4-G0+(NS)+£130",
+                    "nodes": [
+                        "G26-0",
+                        "I22-0",
+                        "I20-0",
+                        "I16-0",
+                        "H15-1",
+                        "I14-0",
+                        "I12-0",
+                        "H9-0",
+                        "G6-0",
+                        "G4-0",
+                        "G0-0"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 464,
+            "created_at": 1645652756,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "LNWR",
+            "entity_type": "corporation",
+            "id": 465,
+            "created_at": 1645652759
+        }
+    ],
+    "loaded": true,
+    "created_at": 1645645356,
+    "updated_at": 1645652759
+}

--- a/spec/fixtures/18GB/18gb-5p.json
+++ b/spec/fixtures/18GB/18gb-5p.json
@@ -1,0 +1,15384 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1645655020,
+      "company": "AF",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1645655029,
+      "company": "LB",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1645655033,
+      "company": "GN",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1645655038,
+      "company": "MC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1645655045,
+      "company": "TV",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1645655054,
+      "company": "CH",
+      "price": 30
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1645655077,
+      "skip": true
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1645655082,
+      "company": "TV",
+      "price": 65,
+      "skip": true
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1645655086,
+      "skip": true
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1645655088,
+      "company": "MC",
+      "price": 65,
+      "skip": true
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1645655094,
+      "skip": true
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1645655094,
+      "skip": true
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1645655097,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1645655106,
+      "skip": true
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1645655109,
+      "company": "LS",
+      "price": 30,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1645655173,
+      "action_id": 6,
+      "skip": true
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1645655179
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1645655183,
+      "company": "TV",
+      "price": 65
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1645655186
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1645655190,
+      "company": "LB",
+      "price": 45
+    },
+    {
+      "type": "bid",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1645655194,
+      "company": "LM",
+      "price": 45
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1645655197,
+      "company": "SD",
+      "price": 35
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1645655200,
+      "company": "LS",
+      "price": 30
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1645655203
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1645655206,
+      "company": "MC",
+      "price": 65
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1645655210
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1645655211
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1645655214
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1645655217,
+      "company": "LS",
+      "price": 35
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1645655220
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1645655220
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1645655224,
+      "company": "LB",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1645655227,
+      "company": "AF",
+      "price": 35
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1645655229
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1645655232,
+      "company": "LM",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1645655235
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1645655236
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1645655236
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1645655236
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1645655237
+    },
+    {
+      "type": "par",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1645655252,
+      "corporation": "SWR",
+      "share_price": "75,0,5"
+    },
+    {
+      "type": "par",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1645655266,
+      "corporation": "LYR",
+      "share_price": "75,0,5"
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1645655270,
+      "corporation": "LNWR",
+      "share_price": "100,0,8"
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1645655278,
+      "corporation": "MSLR",
+      "share_price": "70,0,4"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 45,
+      "created_at": 1645655288,
+      "shares": [
+        "LYR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 46,
+      "created_at": 1645655295
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 47,
+      "created_at": 1645655295
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1645655295
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1645655300,
+      "corporation": "GWR",
+      "share_price": "70,0,4"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1645655313,
+      "shares": [
+        "LYR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1645655317
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1645655317
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1645655318
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1645655324
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1645655327,
+      "shares": [
+        "MSLR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1645655335
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1645655335
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1645655336
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1645655337
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1645655343,
+      "shares": [
+        "GWR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1645655344
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1645655345
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1645655345
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1645655345
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1645655346
+    },
+    {
+      "type": "choose_ability",
+      "entity": "LB",
+      "entity_type": "company",
+      "id": 66,
+      "created_at": 1645655352,
+      "choice": "close"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1645655369,
+      "hex": "F21",
+      "tile": "G03-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1645655404,
+      "hex": "E22",
+      "tile": "8-0",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1645655415,
+      "train": "2+1-0",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1645655418
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1645655452,
+      "hex": "A20",
+      "tile": "G36-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1645655476,
+      "hex": "A18",
+      "tile": "8-1",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1645655482,
+      "train": "2+1-1",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1645655483,
+      "train": "2+1-2",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1645655483,
+      "train": "2+1-3",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1645655511,
+      "hex": "H15",
+      "tile": "G02-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1645655539,
+      "hex": "I16",
+      "tile": "58-0",
+      "rotation": 2,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1645655544,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1645655547,
+      "hex": "I16",
+      "tile": "58-0",
+      "rotation": 0,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1645655557,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1645655562,
+      "hex": "I16",
+      "tile": "58-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1645655568,
+      "train": "2+1-4",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "buy_train",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1645655569,
+      "train": "2+1-5",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1645655574
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1645655612,
+      "hex": "H17",
+      "tile": "G19-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1645655624
+    },
+    {
+      "type": "buy_train",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1645655629,
+      "train": "2+1-6",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1645655630,
+      "train": "2+1-7",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1645655632
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1645655641,
+      "hex": "D23",
+      "tile": "G19-1",
+      "rotation": 2,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1645655645,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1645655651,
+      "hex": "D23",
+      "tile": "G18-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1645655662,
+      "hex": "E24",
+      "tile": "9-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 94,
+      "created_at": 1645655671,
+      "train": "2+1-8",
+      "price": 80,
+      "variant": "2+1"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 95,
+      "created_at": 1645655673,
+      "train": "3+1-0",
+      "price": 200,
+      "variant": "3+1"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 96,
+      "created_at": 1645655677
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1645655708,
+      "hex": "E24",
+      "tile": "23-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1645655716,
+      "hex": "F25",
+      "tile": "4-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1645655725,
+      "routes": [
+        {
+          "train": "2+1-0",
+          "connections": [
+            [
+              "F21",
+              "E22",
+              "E24",
+              "F25"
+            ],
+            [
+              "F25",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "F25",
+            "G26"
+          ],
+          "revenue": 80,
+          "revenue_str": "F21-F25-G26",
+          "nodes": [
+            "F21-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1645655730,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1645655734,
+      "train": "3+1-1",
+      "price": 200,
+      "variant": "3+1"
+    },
+    {
+      "type": "buy_train",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1645655736,
+      "train": "3+1-2",
+      "price": 200,
+      "variant": "3+1"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1645655752,
+      "hex": "B21",
+      "tile": "G18-1",
+      "rotation": 2,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1645655761,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1645655765,
+      "hex": "B21",
+      "tile": "G18-1",
+      "rotation": 1,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1645655771,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1645655791,
+      "hex": "B21",
+      "tile": "G18-1",
+      "rotation": 1,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1645655800,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1645655808,
+      "hex": "B21",
+      "tile": "G18-1",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1645655816,
+      "city": "G18-1-0",
+      "slot": 0,
+      "tokener": "SWR"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1645655824,
+      "hex": "B17",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1645655838,
+      "routes": [
+        {
+          "train": "2+1-1",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ]
+          ],
+          "hexes": [
+            "A20",
+            "a19"
+          ],
+          "revenue": 30,
+          "revenue_str": "A20-a19",
+          "nodes": [
+            "A20-0",
+            "a19-0"
+          ]
+        },
+        {
+          "train": "2+1-2",
+          "connections": [
+            [
+              "A20",
+              "A18",
+              "B17",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "A20",
+            "C16"
+          ],
+          "revenue": 30,
+          "revenue_str": "A20-C16",
+          "nodes": [
+            "A20-0",
+            "C16-0"
+          ]
+        },
+        {
+          "train": "2+1-3",
+          "connections": [
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "A20",
+              "A22"
+            ]
+          ],
+          "hexes": [
+            "B21",
+            "A20",
+            "A22"
+          ],
+          "revenue": 50,
+          "revenue_str": "B21-A20-A22",
+          "nodes": [
+            "B21-0",
+            "A20-0",
+            "A22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1645655841,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1645655860,
+      "hex": "G16",
+      "tile": "G03-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1645655871,
+      "hex": "F17",
+      "tile": "4-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1645655878,
+      "routes": [
+        {
+          "train": "2+1-4",
+          "connections": [
+            [
+              "H15",
+              "I16"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I16"
+          ],
+          "revenue": 40,
+          "revenue_str": "H15-I16",
+          "nodes": [
+            "H15-0",
+            "I16-0"
+          ]
+        },
+        {
+          "train": "2+1-5",
+          "connections": [
+            [
+              "H15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G16",
+            "F17"
+          ],
+          "revenue": 70,
+          "revenue_str": "H15-G16-F17",
+          "nodes": [
+            "H15-0",
+            "G16-0",
+            "F17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1645655880,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1645655884,
+      "train": "3+1-3",
+      "price": 200,
+      "variant": "3+1"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1645655921,
+      "hex": "G16",
+      "tile": "G05-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1645655944,
+      "hex": "I16",
+      "tile": "87-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1645655953,
+      "routes": [
+        {
+          "train": "2+1-6",
+          "connections": [
+            [
+              "H17",
+              "G16"
+            ]
+          ],
+          "hexes": [
+            "H17",
+            "G16"
+          ],
+          "revenue": 60,
+          "revenue_str": "H17-G16",
+          "nodes": [
+            "H17-0",
+            "G16-1"
+          ]
+        },
+        {
+          "train": "2+1-7",
+          "connections": [
+            [
+              "H17",
+              "I16"
+            ],
+            [
+              "I16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "H17",
+            "I16",
+            "H15"
+          ],
+          "revenue": 60,
+          "revenue_str": "H17-I16-H15",
+          "nodes": [
+            "H17-0",
+            "I16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1645655954,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1645655958,
+      "train": "3+1-4",
+      "price": 200,
+      "variant": "3+1"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1645655998,
+      "hex": "C24",
+      "tile": "58-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1645656005,
+      "hex": "B25",
+      "tile": "8-2",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1645656015,
+      "routes": [
+        {
+          "train": "2+1-8",
+          "connections": [
+            [
+              "D23",
+              "C22",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "D23",
+            "C24"
+          ],
+          "revenue": 30,
+          "revenue_str": "D23-C24",
+          "nodes": [
+            "D23-0",
+            "C24-0"
+          ]
+        },
+        {
+          "train": "3+1-0",
+          "connections": [
+            [
+              "D23",
+              "E24",
+              "F25"
+            ],
+            [
+              "F25",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "D23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 70,
+          "revenue_str": "D23-F25-G26",
+          "nodes": [
+            "D23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1645656018,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1645656024
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1645656031,
+      "shares": [
+        "SWR_0"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 130,
+      "created_at": 1645656038,
+      "corporation": "NER",
+      "share_price": "100,0,8"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 131,
+      "created_at": 1645656048,
+      "shares": [
+        "LYR_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 132,
+      "created_at": 1645656050
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 133,
+      "created_at": 1645656053,
+      "shares": [
+        "LNWR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 134,
+      "created_at": 1645656057,
+      "shares": [
+        "LNWR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 135,
+      "created_at": 1645656061,
+      "shares": [
+        "NER_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 136,
+      "created_at": 1645656068,
+      "shares": [
+        "MSLR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 137,
+      "created_at": 1645656072,
+      "shares": [
+        "LNWR_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1645656075
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 139,
+      "created_at": 1645656076
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 140,
+      "created_at": 1645656076
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 141,
+      "created_at": 1645656078
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 142,
+      "created_at": 1645656078
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1645656106,
+      "hex": "G20",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1645656127,
+      "hex": "H19",
+      "tile": "G40-0",
+      "rotation": 5,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1645656133,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1645656136,
+      "hex": "H19",
+      "tile": "G40-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1645656151,
+      "routes": [
+        {
+          "train": "2+1-0",
+          "connections": [
+            [
+              "F21",
+              "G20",
+              "H19"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "H19"
+          ],
+          "revenue": 40,
+          "revenue_str": "F21-H19",
+          "nodes": [
+            "F21-0",
+            "H19-0"
+          ]
+        },
+        {
+          "train": "3+1-1",
+          "connections": [
+            [
+              "F21",
+              "E22",
+              "E24",
+              "F25"
+            ],
+            [
+              "F25",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "F25",
+            "G26"
+          ],
+          "revenue": 80,
+          "revenue_str": "F21-F25-G26",
+          "nodes": [
+            "F21-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1645656154,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1645656179,
+      "hex": "J13",
+      "tile": "G37-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1645656217
+    },
+    {
+      "type": "buy_train",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1645656224,
+      "train": "3+1-5",
+      "price": 200,
+      "variant": "3+1"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1645656225,
+      "train": "4+2-0",
+      "price": 300,
+      "variant": "4+2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1645656266,
+      "hex": "F17",
+      "tile": "87-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1645656283,
+      "hex": "F15",
+      "tile": "8-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1645656291,
+      "routes": [
+        {
+          "train": "3+1-3",
+          "connections": [
+            [
+              "H15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "F15",
+              "E14"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G16",
+            "F17",
+            "E14"
+          ],
+          "revenue": 130,
+          "revenue_str": "H15-G16-F17-E14+(LM)",
+          "nodes": [
+            "H15-0",
+            "G16-0",
+            "F17-0",
+            "E14-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1645656295,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1645656300
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1645656315,
+      "hex": "G14",
+      "tile": "G19-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1645656320
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1645656325,
+      "routes": [
+        {
+          "train": "3+1-4",
+          "connections": [
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "H17",
+              "I16"
+            ],
+            [
+              "I16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "G16",
+            "H17",
+            "I16",
+            "H15"
+          ],
+          "revenue": 100,
+          "revenue_str": "G16-H17-I16-H15",
+          "nodes": [
+            "G16-1",
+            "H17-0",
+            "I16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1645656328,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1645656333
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 163,
+      "created_at": 1645656339,
+      "hex": "C22",
+      "tile": "G33-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1645656349,
+      "hex": "A24",
+      "tile": "8-4",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1645656359,
+      "routes": [
+        {
+          "train": "3+1-0",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "D23",
+            "B21"
+          ],
+          "revenue": 130,
+          "revenue_str": "G26-F25-D23-B21+(S)",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "D23-0",
+            "B21-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1645656365,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1645656367
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1645656375,
+      "routes": [
+        {
+          "train": "4+2-1",
+          "connections": [
+            [
+              "C16",
+              "B17",
+              "A18",
+              "A20"
+            ],
+            [
+              "A20",
+              "B21"
+            ],
+            [
+              "B21",
+              "C22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "C16",
+            "A20",
+            "B21",
+            "D23"
+          ],
+          "revenue": 110,
+          "revenue_str": "C16-A20-B21-D23+(S)",
+          "nodes": [
+            "C16-0",
+            "A20-0",
+            "B21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1645656416,
+      "hex": "H17",
+      "tile": "G21-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1645656446,
+      "hex": "E22",
+      "tile": "24-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1645656452
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1645656458,
+      "routes": [
+        {
+          "train": "3+1-1",
+          "connections": [
+            [
+              "F21",
+              "G20",
+              "H19"
+            ],
+            [
+              "H19",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "H19",
+            "H17"
+          ],
+          "revenue": 70,
+          "revenue_str": "F21-H19-H17",
+          "nodes": [
+            "F21-0",
+            "H19-0",
+            "H17-0"
+          ]
+        },
+        {
+          "train": "3+1-2",
+          "connections": [
+            [
+              "F21",
+              "E22",
+              "E24",
+              "F25"
+            ],
+            [
+              "F25",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "F25",
+            "G26"
+          ],
+          "revenue": 90,
+          "revenue_str": "F21-F25-G26",
+          "nodes": [
+            "F21-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1645656459,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1645656511,
+      "hex": "I14",
+      "tile": "G40-1",
+      "rotation": 4
+    },
+    {
+      "type": "choose_ability",
+      "entity": "GN",
+      "entity_type": "company",
+      "id": 175,
+      "created_at": 1645656522,
+      "choice": "close"
+    },
+    {
+      "type": "place_token",
+      "entity": "GN",
+      "entity_type": "company",
+      "id": 176,
+      "created_at": 1645656528,
+      "city": "G40-1-0",
+      "slot": 0,
+      "tokener": "NER"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1645656562,
+      "hex": "I12",
+      "tile": "3-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1645656574,
+      "routes": [
+        {
+          "train": "3+1-5",
+          "connections": [
+            [
+              "J13",
+              "I12"
+            ]
+          ],
+          "hexes": [
+            "J13",
+            "I12"
+          ],
+          "revenue": 30,
+          "revenue_str": "J13-I12",
+          "nodes": [
+            "J13-0",
+            "I12-0"
+          ]
+        },
+        {
+          "train": "4+2-0",
+          "connections": [
+            [
+              "J13",
+              "I14"
+            ],
+            [
+              "I14",
+              "I16"
+            ],
+            [
+              "I16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "J13",
+            "I14",
+            "I16",
+            "H15"
+          ],
+          "revenue": 70,
+          "revenue_str": "J13-I14-I16-H15",
+          "nodes": [
+            "J13-0",
+            "I14-0",
+            "I16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1645656577,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1645656594,
+      "hex": "E18",
+      "tile": "4-2",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1645656609,
+      "hex": "D19",
+      "tile": "8-5",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1645656617,
+      "routes": [
+        {
+          "train": "3+1-3",
+          "connections": [
+            [
+              "H15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "F15",
+              "E14"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G16",
+            "F17",
+            "E14"
+          ],
+          "revenue": 130,
+          "revenue_str": "H15-G16-F17-E14+(LM)",
+          "nodes": [
+            "H15-0",
+            "G16-0",
+            "F17-0",
+            "E14-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1645656619,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1645656627
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1645656642,
+      "hex": "G12",
+      "tile": "4-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1645656652,
+      "hex": "H11",
+      "tile": "8-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1645656659,
+      "routes": [
+        {
+          "train": "3+1-4",
+          "connections": [
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "H17",
+              "I16"
+            ],
+            [
+              "I16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "G16",
+            "H17",
+            "I16",
+            "H15"
+          ],
+          "revenue": 110,
+          "revenue_str": "G16-H17-I16-H15",
+          "nodes": [
+            "G16-1",
+            "H17-1",
+            "I16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1645656664,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1645656671
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1645656701,
+      "hex": "F25",
+      "tile": "204-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1645656710,
+      "hex": "F23",
+      "tile": "4-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1645656718,
+      "routes": [
+        {
+          "train": "3+1-0",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "D23",
+            "B21"
+          ],
+          "revenue": 130,
+          "revenue_str": "G26-F25-D23-B21+(S)",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "D23-0",
+            "B21-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1645656720,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1645656727
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1645656731,
+      "routes": [
+        {
+          "train": "4+2-1",
+          "connections": [
+            [
+              "C16",
+              "B17",
+              "A18",
+              "A20"
+            ],
+            [
+              "A20",
+              "B21"
+            ],
+            [
+              "B21",
+              "C22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "C16",
+            "A20",
+            "B21",
+            "D23"
+          ],
+          "revenue": 110,
+          "revenue_str": "C16-A20-B21-D23+(S)",
+          "nodes": [
+            "C16-0",
+            "A20-0",
+            "B21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 196,
+      "created_at": 1645656738,
+      "shares": [
+        "GWR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 197,
+      "created_at": 1645656742,
+      "shares": [
+        "LYR_1",
+        "LYR_2"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 198,
+      "created_at": 1645656748,
+      "shares": [
+        "MSLR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 199,
+      "created_at": 1645656751,
+      "shares": [
+        "GWR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 200,
+      "created_at": 1645656758,
+      "shares": [
+        "NER_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 201,
+      "created_at": 1645656764,
+      "shares": [
+        "SWR_1"
+      ],
+      "percent": 10,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 202,
+      "created_at": 1645656772,
+      "skip": true
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 203,
+      "created_at": 1645656775,
+      "shares": [
+        "SWR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 204,
+      "created_at": 1645656780,
+      "shares": [
+        "MSLR_2"
+      ],
+      "percent": 20,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 205,
+      "created_at": 1645656789,
+      "skip": true
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 206,
+      "created_at": 1645656794,
+      "shares": [
+        "MSLR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 207,
+      "created_at": 1645656800,
+      "corporation": "CR",
+      "share_price": "90,0,7"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 208,
+      "created_at": 1645656809,
+      "shares": [
+        "NER_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 209,
+      "created_at": 1645656815,
+      "shares": [
+        "GWR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 210,
+      "created_at": 1645656823,
+      "shares": [
+        "SWR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 211,
+      "created_at": 1645656829,
+      "shares": [
+        "SWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1645656837,
+      "shares": [
+        "CR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1645656848,
+      "shares": [
+        "SWR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "choose",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 214,
+      "created_at": 1645656853,
+      "choice": "convert_MSLR"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 215,
+      "created_at": 1645656860,
+      "shares": [
+        "MSLR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 216,
+      "created_at": 1645656864,
+      "shares": [
+        "SWR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 217,
+      "created_at": 1645656869,
+      "shares": [
+        "SWR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 218,
+      "created_at": 1645656873,
+      "shares": [
+        "LYR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 219,
+      "created_at": 1645656880,
+      "shares": [
+        "SWR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 220,
+      "created_at": 1645656888,
+      "shares": [
+        "MSLR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 221,
+      "created_at": 1645656892,
+      "shares": [
+        "SWR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1645656897,
+      "shares": [
+        "SWR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 223,
+      "created_at": 1645656901
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 224,
+      "created_at": 1645656905,
+      "shares": [
+        "NER_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 225,
+      "created_at": 1645656914,
+      "shares": [
+        "SWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 226,
+      "created_at": 1645656919
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 227,
+      "created_at": 1645656926,
+      "shares": [
+        "NER_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 228,
+      "created_at": 1645656929
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1645656929
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 230,
+      "created_at": 1645656937,
+      "shares": [
+        "MSLR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 231,
+      "created_at": 1645656941
+    },
+    {
+      "type": "par",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 232,
+      "created_at": 1645656946,
+      "corporation": "MR",
+      "share_price": "90,0,7"
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 233,
+      "created_at": 1645656952
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 234,
+      "created_at": 1645656953
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 235,
+      "created_at": 1645656954
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 236,
+      "created_at": 1645656957
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 237,
+      "created_at": 1645656963,
+      "shares": [
+        "MR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 238,
+      "created_at": 1645656968
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 239,
+      "created_at": 1645656969
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 240,
+      "created_at": 1645656971
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 241,
+      "created_at": 1645656974
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 242,
+      "created_at": 1645656975
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1645657000,
+      "hex": "D23",
+      "tile": "G22-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1645657017,
+      "hex": "C24",
+      "tile": "88-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1645657023,
+      "city": "G22-0-0",
+      "slot": 0,
+      "tokener": "LNWR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1645657030,
+      "routes": [
+        {
+          "train": "3+1-1",
+          "connections": [
+            [
+              "D23",
+              "C24"
+            ],
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ]
+          ],
+          "hexes": [
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 80,
+          "revenue_str": "D23-C24-a25",
+          "nodes": [
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        },
+        {
+          "train": "3+1-2",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "F21"
+            ],
+            [
+              "F21",
+              "G20",
+              "H19"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "F21",
+            "H19"
+          ],
+          "revenue": 100,
+          "revenue_str": "G26-F25-F21-H19",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "F21-0",
+            "H19-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1645657032,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1645657046,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1645657053,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1645657073,
+      "hex": "G4",
+      "tile": "G02-1",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1645657083,
+      "hex": "G6",
+      "tile": "4-4",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1645657094,
+      "train": "3+1-3",
+      "price": 400
+    },
+    {
+      "type": "pass",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1645657098
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1645657117,
+      "hex": "J15",
+      "tile": "7-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1645657137,
+      "hex": "I14",
+      "tile": "G37-1",
+      "rotation": 4,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1645657140,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1645657146,
+      "hex": "I14",
+      "tile": "G37-1",
+      "rotation": 3,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1645657152,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1645657157,
+      "hex": "I14",
+      "tile": "G37-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1645657174,
+      "routes": [
+        {
+          "train": "3+1-5",
+          "connections": [
+            [
+              "I14",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I16",
+            "H17"
+          ],
+          "revenue": 60,
+          "revenue_str": "I14-I16-H17",
+          "nodes": [
+            "I14-0",
+            "I16-0",
+            "H17-1"
+          ]
+        },
+        {
+          "train": "4+2-0",
+          "connections": [
+            [
+              "H15",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "I14"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "J13",
+              "I12"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I16",
+            "I14",
+            "J13",
+            "I12"
+          ],
+          "revenue": 90,
+          "revenue_str": "H15-I16-I14-J13-I12",
+          "nodes": [
+            "H15-0",
+            "I16-0",
+            "I14-0",
+            "J13-0",
+            "I12-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1645657175,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1645657199,
+      "hex": "H15",
+      "tile": "G10-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1645657223,
+      "hex": "G20",
+      "tile": "24-1",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1645657230,
+      "city": "G10-0-1",
+      "slot": 0,
+      "tokener": "MR"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1645657237,
+      "train": "4+2-3",
+      "price": 300,
+      "variant": "4+2"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1645657239
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1645657293,
+      "hex": "D21",
+      "tile": "58-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1645657297
+    },
+    {
+      "type": "buy_train",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1645657303,
+      "train": "4+2-4",
+      "price": 300,
+      "variant": "4+2"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1645657311
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1645657468,
+      "hex": "F21",
+      "tile": "G06-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1645657474,
+      "city": "G06-0-0",
+      "slot": 0,
+      "tokener": "GWR"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1645657488,
+      "hex": "F19",
+      "tile": "8-6",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1645657497,
+      "routes": [
+        {
+          "train": "3+1-0",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "D23",
+            "B21"
+          ],
+          "revenue": 140,
+          "revenue_str": "G26-F25-D23-B21+(S)",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "D23-1",
+            "B21-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1645657500,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1645657509
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 277,
+      "created_at": 1645657543,
+      "hex": "H9",
+      "tile": "G40-2",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1645657557,
+      "city": "G05-0-1",
+      "slot": 0,
+      "tokener": "MSLR"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1645657585,
+      "hex": "G12",
+      "tile": "88-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1645657593,
+      "routes": [
+        {
+          "train": "3+1-4",
+          "connections": [
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "H17",
+              "I16"
+            ],
+            [
+              "I16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "G16",
+            "H17",
+            "I16",
+            "H15"
+          ],
+          "revenue": 120,
+          "revenue_str": "G16-H17-I16-H15",
+          "nodes": [
+            "G16-1",
+            "H17-1",
+            "I16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1645657595,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1645657600
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1645657616,
+      "hex": "B21",
+      "tile": "G22-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1645657633,
+      "hex": "C20",
+      "tile": "58-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1645657655
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 286,
+      "created_at": 1645657664,
+      "routes": [
+        {
+          "train": "4+2-1",
+          "connections": [
+            [
+              "B21",
+              "C22",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "F17",
+              "G16"
+            ],
+            [
+              "G16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "B21",
+            "D21",
+            "E18",
+            "F17",
+            "G16",
+            "H15"
+          ],
+          "revenue": 140,
+          "revenue_str": "B21-D21-E18-F17-G16-H15",
+          "nodes": [
+            "B21-1",
+            "D21-0",
+            "E18-0",
+            "F17-0",
+            "G16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1645657666,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 288,
+      "created_at": 1645657668
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1645657695,
+      "hex": "F23",
+      "tile": "87-2",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 290,
+      "created_at": 1645657709,
+      "hex": "G22",
+      "tile": "4-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 291,
+      "created_at": 1645657716,
+      "routes": [
+        {
+          "train": "3+1-1",
+          "connections": [
+            [
+              "D23",
+              "C24"
+            ],
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ]
+          ],
+          "hexes": [
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 80,
+          "revenue_str": "D23-C24-a25",
+          "nodes": [
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        },
+        {
+          "train": "3+1-2",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "F21"
+            ],
+            [
+              "F21",
+              "G20",
+              "H19"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "F21",
+            "H19"
+          ],
+          "revenue": 110,
+          "revenue_str": "G26-F25-F21-H19",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "F21-1",
+            "H19-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 292,
+      "created_at": 1645657717,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 293,
+      "created_at": 1645657754,
+      "hex": "J11",
+      "tile": "G19-2",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1645657789,
+      "hex": "J15",
+      "tile": "28-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 295,
+      "created_at": 1645657797
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1645657803,
+      "routes": [
+        {
+          "train": "3+1-5",
+          "connections": [
+            [
+              "I14",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I16",
+            "H17"
+          ],
+          "revenue": 60,
+          "revenue_str": "I14-I16-H17",
+          "nodes": [
+            "I14-0",
+            "I16-0",
+            "H17-1"
+          ]
+        },
+        {
+          "train": "4+2-0",
+          "connections": [
+            [
+              "H15",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "I14"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "J13",
+              "I12"
+            ],
+            [
+              "I12",
+              "J11"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I16",
+            "I14",
+            "J13",
+            "I12",
+            "J11"
+          ],
+          "revenue": 120,
+          "revenue_str": "H15-I16-I14-J13-I12-J11",
+          "nodes": [
+            "H15-0",
+            "I16-0",
+            "I14-0",
+            "J13-0",
+            "I12-0",
+            "J11-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1645657805,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1645657814,
+      "hex": "H3",
+      "tile": "4-5",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1645657838,
+      "hex": "I2",
+      "tile": "G40-3",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1645657842
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1645657848,
+      "routes": [
+        {
+          "train": "3+1-3",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I2"
+            ],
+            [
+              "I2",
+              "I0"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "H3",
+            "I2",
+            "I0"
+          ],
+          "revenue": 80,
+          "revenue_str": "G4-H3-I2-I0",
+          "nodes": [
+            "G4-0",
+            "H3-0",
+            "I2-0",
+            "I0-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1645657851,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1645657857
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1645657882,
+      "hex": "G22",
+      "tile": "204-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1645657896,
+      "hex": "G24",
+      "tile": "8-7",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 306,
+      "created_at": 1645657905,
+      "routes": [
+        {
+          "train": "4+2-3",
+          "connections": [
+            [
+              "H15",
+              "H17"
+            ],
+            [
+              "H17",
+              "H19"
+            ],
+            [
+              "H19",
+              "G20",
+              "G22"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "F23",
+              "G24",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "H19",
+            "G22",
+            "F23",
+            "G26"
+          ],
+          "revenue": 150,
+          "revenue_str": "H15-H17-H19-G22-F23-G26",
+          "nodes": [
+            "H15-1",
+            "H17-0",
+            "H19-0",
+            "G22-0",
+            "F23-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 307,
+      "created_at": 1645657906,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1645657912
+    },
+    {
+      "type": "choose_ability",
+      "entity": "LS",
+      "entity_type": "company",
+      "id": 309,
+      "created_at": 1645657918,
+      "choice": "close"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LS",
+      "entity_type": "company",
+      "id": 310,
+      "created_at": 1645657979,
+      "hex": "H21",
+      "tile": "G18-2",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1645658003,
+      "hex": "H23",
+      "tile": "7-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1645658029,
+      "hex": "H21",
+      "tile": "G27-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1645658036,
+      "routes": [
+        {
+          "train": "3+1-0",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "D23",
+            "B21"
+          ],
+          "revenue": 150,
+          "revenue_str": "G26-F25-D23-B21+(S)",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "D23-1",
+            "B21-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1645658038,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1645658075
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1645658080,
+      "hex": "E18",
+      "tile": "204-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 317,
+      "created_at": 1645658085
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1645658089,
+      "routes": [
+        {
+          "train": "4+2-4",
+          "connections": [
+            [
+              "E14",
+              "F15",
+              "F17"
+            ],
+            [
+              "F17",
+              "G16"
+            ],
+            [
+              "G16",
+              "H15"
+            ],
+            [
+              "H15",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "E14",
+            "F17",
+            "G16",
+            "H15",
+            "I16",
+            "H17"
+          ],
+          "revenue": 180,
+          "revenue_str": "E14-F17-G16-H15-I16-H17+(LM)",
+          "nodes": [
+            "E14-0",
+            "F17-0",
+            "G16-0",
+            "H15-0",
+            "I16-0",
+            "H17-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1645658091,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1645658097
+    },
+    {
+      "type": "place_token",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1645658100,
+      "city": "G40-2-0",
+      "slot": 0,
+      "tokener": "MSLR"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1645658117,
+      "hex": "G10",
+      "tile": "8-8",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 323,
+      "created_at": 1645658130,
+      "hex": "H9",
+      "tile": "G37-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 324,
+      "created_at": 1645658133,
+      "routes": [
+        {
+          "train": "3+1-4",
+          "connections": [
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "H17",
+              "I16"
+            ],
+            [
+              "I16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "G16",
+            "H17",
+            "I16",
+            "H15"
+          ],
+          "revenue": 120,
+          "revenue_str": "G16-H17-I16-H15",
+          "nodes": [
+            "G16-1",
+            "H17-1",
+            "I16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 325,
+      "created_at": 1645658136,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 326,
+      "created_at": 1645658139
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 327,
+      "created_at": 1645658161,
+      "hex": "E16",
+      "tile": "7-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 328,
+      "created_at": 1645658186,
+      "hex": "F15",
+      "tile": "25-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 329,
+      "created_at": 1645658190
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1645658196,
+      "routes": [
+        {
+          "train": "4+2-1",
+          "connections": [
+            [
+              "B21",
+              "C22",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "F17",
+              "G16"
+            ],
+            [
+              "G16",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "B21",
+            "D21",
+            "E18",
+            "F17",
+            "G16",
+            "H15"
+          ],
+          "revenue": 140,
+          "revenue_str": "B21-D21-E18-F17-G16-H15",
+          "nodes": [
+            "B21-1",
+            "D21-0",
+            "E18-0",
+            "F17-0",
+            "G16-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1645658197,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1645658200,
+      "train": "5+2-0",
+      "price": 500,
+      "variant": "5+2"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1645658207
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 334,
+      "created_at": 1645658213,
+      "shares": [
+        "CR_1",
+        "CR_0"
+      ],
+      "percent": 60
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 335,
+      "created_at": 1645658222,
+      "shares": [
+        "LYR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 336,
+      "created_at": 1645658226,
+      "shares": [
+        "LNWR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 337,
+      "created_at": 1645658239,
+      "corporation": "LSWR",
+      "share_price": "90,0,7"
+    },
+    {
+      "type": "choose",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 338,
+      "created_at": 1645658250,
+      "choice": "convert_NER"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 339,
+      "created_at": 1645658254,
+      "shares": [
+        "NER_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 340,
+      "created_at": 1645658264,
+      "shares": [
+        "LNWR_3",
+        "LNWR_0"
+      ],
+      "percent": 60
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 341,
+      "created_at": 1645658278,
+      "corporation": "NBR",
+      "share_price": "100,0,8"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 342,
+      "created_at": 1645658286,
+      "shares": [
+        "NER_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 343,
+      "created_at": 1645658292,
+      "corporation": "GSWR",
+      "share_price": "75,0,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 344,
+      "created_at": 1645658297,
+      "shares": [
+        "LSWR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 345,
+      "created_at": 1645658301,
+      "shares": [
+        "NER_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 346,
+      "created_at": 1645658306,
+      "shares": [
+        "NBR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 347,
+      "created_at": 1645658311,
+      "shares": [
+        "NER_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 348,
+      "created_at": 1645658318,
+      "shares": [
+        "GSWR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 349,
+      "created_at": 1645658321,
+      "shares": [
+        "LSWR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 350,
+      "created_at": 1645658327,
+      "shares": [
+        "NER_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 351,
+      "created_at": 1645658332,
+      "shares": [
+        "NBR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 352,
+      "created_at": 1645658335,
+      "shares": [
+        "LNWR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 353,
+      "created_at": 1645658342,
+      "shares": [
+        "GSWR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 354,
+      "created_at": 1645658346,
+      "shares": [
+        "LSWR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 355,
+      "created_at": 1645658349
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 356,
+      "created_at": 1645658352,
+      "shares": [
+        "NBR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 357,
+      "created_at": 1645658355
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 358,
+      "created_at": 1645658359,
+      "shares": [
+        "GSWR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 359,
+      "created_at": 1645658362,
+      "shares": [
+        "LSWR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 360,
+      "created_at": 1645658367
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 361,
+      "created_at": 1645658437,
+      "shares": [
+        "NBR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 362,
+      "created_at": 1645658441
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 363,
+      "created_at": 1645658447,
+      "shares": [
+        "GSWR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 364,
+      "created_at": 1645658453
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 365,
+      "created_at": 1645658455
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 366,
+      "created_at": 1645658458,
+      "shares": [
+        "GSWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 367,
+      "created_at": 1645658463
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 368,
+      "created_at": 1645658463
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 369,
+      "created_at": 1645658464
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 370,
+      "created_at": 1645658465
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 371,
+      "created_at": 1645658466
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1645658485,
+      "hex": "D23",
+      "tile": "G30-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 373,
+      "created_at": 1645658501,
+      "hex": "D21",
+      "tile": "88-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1645658514,
+      "routes": [
+        {
+          "train": "3+1-1",
+          "connections": [
+            [
+              "F21",
+              "E22",
+              "D23"
+            ],
+            [
+              "D23",
+              "C24"
+            ],
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 170,
+          "revenue_str": "F21-D23-C24-a25+(EW)",
+          "nodes": [
+            "F21-1",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        },
+        {
+          "train": "3+1-2",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "D23",
+            "B21"
+          ],
+          "revenue": 180,
+          "revenue_str": "G26-F25-D23-B21+(S)",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "D23-0",
+            "B21-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 375,
+      "created_at": 1645658515,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 376,
+      "created_at": 1645658554,
+      "hex": "I6",
+      "tile": "G18-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 377,
+      "created_at": 1645658563,
+      "hex": "H5",
+      "tile": "4-6",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 378,
+      "created_at": 1645658568,
+      "train": "5+2-1",
+      "price": 500,
+      "variant": "5+2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 379,
+      "created_at": 1645658568,
+      "train": "5+2-2",
+      "price": 500,
+      "variant": "5+2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 380,
+      "created_at": 1645658650,
+      "hex": "G22",
+      "tile": "911-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1645658695,
+      "hex": "F21",
+      "tile": "G14-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1645658702,
+      "routes": [
+        {
+          "train": "4+2-3",
+          "connections": [
+            [
+              "H15",
+              "H17"
+            ],
+            [
+              "H17",
+              "H19"
+            ],
+            [
+              "H19",
+              "G20",
+              "G22"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "F23",
+              "G24",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "H19",
+            "G22",
+            "F23",
+            "G26"
+          ],
+          "revenue": 160,
+          "revenue_str": "H15-H17-H19-G22-F23-G26",
+          "nodes": [
+            "H15-1",
+            "H17-0",
+            "H19-0",
+            "G22-0",
+            "F23-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1645658704,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 384,
+      "created_at": 1645658712,
+      "train": "3+1-1",
+      "price": 182
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 385,
+      "created_at": 1645658734,
+      "hex": "E26",
+      "tile": "58-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 386,
+      "created_at": 1645658745,
+      "hex": "D25",
+      "tile": "G41-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 387,
+      "created_at": 1645658752,
+      "routes": [
+        {
+          "train": "3+1-0",
+          "connections": [
+            [
+              "G26",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F25",
+            "D23",
+            "B21"
+          ],
+          "revenue": 180,
+          "revenue_str": "G26-F25-D23-B21+(S)",
+          "nodes": [
+            "G26-0",
+            "F25-0",
+            "D23-0",
+            "B21-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 388,
+      "created_at": 1645658754,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 389,
+      "created_at": 1645658760
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 390,
+      "created_at": 1645658776,
+      "hex": "C24",
+      "tile": "911-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 391,
+      "created_at": 1645658810,
+      "hex": "D25",
+      "tile": "G36-1",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 392,
+      "created_at": 1645658825,
+      "city": "G27-0-1",
+      "slot": 0,
+      "tokener": "LSWR"
+    },
+    {
+      "type": "buy_train",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 393,
+      "created_at": 1645658836,
+      "train": "3+1-4",
+      "price": 300
+    },
+    {
+      "type": "buy_train",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 394,
+      "created_at": 1645658840,
+      "train": "4X-0",
+      "price": 550,
+      "variant": "4X"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 395,
+      "created_at": 1645658875,
+      "hex": "H17",
+      "tile": "G30-1",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1645658884,
+      "city": "G30-1-0",
+      "slot": 1,
+      "tokener": "NER"
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1645658893
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1645658899,
+      "routes": [
+        {
+          "train": "4+2-0",
+          "connections": [
+            [
+              "J17",
+              "J15",
+              "I14"
+            ],
+            [
+              "I14",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ],
+            [
+              "H17",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "J17",
+            "I14",
+            "I16",
+            "H17",
+            "H15"
+          ],
+          "revenue": 160,
+          "revenue_str": "J17-I14-I16-H17-H15",
+          "nodes": [
+            "J17-0",
+            "I14-0",
+            "I16-0",
+            "H17-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1645658901,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 400,
+      "created_at": 1645658904,
+      "train": "4X-1",
+      "price": 550,
+      "variant": "4X"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 401,
+      "created_at": 1645658958,
+      "hex": "H15",
+      "tile": "G14-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 402,
+      "created_at": 1645658967
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1645658970,
+      "routes": [
+        {
+          "train": "4+2-4",
+          "connections": [
+            [
+              "E14",
+              "F15",
+              "F17"
+            ],
+            [
+              "F17",
+              "G16"
+            ],
+            [
+              "G16",
+              "H15"
+            ],
+            [
+              "H15",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "E14",
+            "F17",
+            "G16",
+            "H15",
+            "I16",
+            "H17"
+          ],
+          "revenue": 220,
+          "revenue_str": "E14-F17-G16-H15-I16-H17+(LM)",
+          "nodes": [
+            "E14-0",
+            "F17-0",
+            "G16-0",
+            "H15-0",
+            "I16-0",
+            "H17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 404,
+      "created_at": 1645658972,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 405,
+      "created_at": 1645658977
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 406,
+      "created_at": 1645659002,
+      "hex": "G6",
+      "tile": "87-3",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 407,
+      "created_at": 1645659033,
+      "hex": "G16",
+      "tile": "G14-2",
+      "rotation": 1,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 408,
+      "created_at": 1645659037,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 409,
+      "created_at": 1645659045,
+      "hex": "G16",
+      "tile": "G14-2",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 410,
+      "created_at": 1645659054,
+      "train": "4X-2",
+      "price": 550,
+      "variant": "4X"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 411,
+      "created_at": 1645659057
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 412,
+      "created_at": 1645659074,
+      "hex": "F5",
+      "tile": "G37-3",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 413,
+      "created_at": 1645659093,
+      "hex": "F7",
+      "tile": "8-9",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 414,
+      "created_at": 1645659103,
+      "train": "5X-0",
+      "price": 650,
+      "variant": "5X"
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 415,
+      "created_at": 1645659110
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 416,
+      "created_at": 1645659121,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "I0",
+              "I2"
+            ],
+            [
+              "I2",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6"
+            ],
+            [
+              "G6",
+              "G8",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "I0",
+            "I2",
+            "H3",
+            "G4",
+            "G6",
+            "H9"
+          ],
+          "revenue": 140,
+          "revenue_str": "I0-I2-G4-H9+£50",
+          "nodes": [
+            "I0-0",
+            "I2-0",
+            "H3-0",
+            "G4-0",
+            "G6-0",
+            "H9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 417,
+      "created_at": 1645659158,
+      "hex": "F15",
+      "tile": "45-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 418,
+      "created_at": 1645659185,
+      "hex": "G14",
+      "tile": "G26-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 419,
+      "created_at": 1645659189,
+      "city": "G14-2-0",
+      "slot": 0,
+      "tokener": "SWR"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 420,
+      "created_at": 1645659195
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 421,
+      "created_at": 1645659204,
+      "routes": [
+        {
+          "train": "4+2-1",
+          "connections": [
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "A20",
+              "A22"
+            ],
+            [
+              "A22",
+              "B21"
+            ],
+            [
+              "B21",
+              "C20"
+            ]
+          ],
+          "hexes": [
+            "D23",
+            "B21",
+            "A20",
+            "A22",
+            "B21",
+            "C20"
+          ],
+          "revenue": 150,
+          "revenue_str": "D23-B21-A20-A22-B21-C20+(S)",
+          "nodes": [
+            "D23-0",
+            "B21-1",
+            "A20-0",
+            "A22-0",
+            "B21-0",
+            "C20-0"
+          ]
+        },
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 200,
+          "revenue_str": "H15-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 422,
+      "created_at": 1645659207,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 423,
+      "created_at": 1645659227,
+      "hex": "D25",
+      "tile": "G34-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 424,
+      "created_at": 1645659243,
+      "hex": "G20",
+      "tile": "47-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 425,
+      "created_at": 1645659252
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 426,
+      "created_at": 1645659266,
+      "hex": "G14",
+      "tile": "G30-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 427,
+      "created_at": 1645659290,
+      "hex": "E18",
+      "tile": "911-2",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 428,
+      "created_at": 1645659302,
+      "routes": [
+        {
+          "train": "4+2-3",
+          "connections": [
+            [
+              "F21",
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "G14",
+              "H15"
+            ],
+            [
+              "H15",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "E18",
+            "F17",
+            "G14",
+            "H15",
+            "H17"
+          ],
+          "revenue": 240,
+          "revenue_str": "F21-E18-F17-G14-H15-H17",
+          "nodes": [
+            "F21-1",
+            "E18-0",
+            "F17-0",
+            "G14-0",
+            "H15-1",
+            "H17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 429,
+      "created_at": 1645659303,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 430,
+      "created_at": 1645659306
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 431,
+      "created_at": 1645659332,
+      "hex": "I14",
+      "tile": "G34-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 432,
+      "created_at": 1645659339
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 433,
+      "created_at": 1645659347,
+      "routes": [
+        {
+          "train": "4+2-4",
+          "connections": [
+            [
+              "G16",
+              "H15"
+            ],
+            [
+              "H15",
+              "I14"
+            ],
+            [
+              "I14",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "G16",
+            "H15",
+            "I14",
+            "I16",
+            "H17"
+          ],
+          "revenue": 210,
+          "revenue_str": "G16-H15-I14-I16-H17",
+          "nodes": [
+            "G16-0",
+            "H15-0",
+            "I14-0",
+            "I16-0",
+            "H17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 434,
+      "created_at": 1645659348,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 435,
+      "created_at": 1645659352
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 436,
+      "created_at": 1645659367,
+      "hex": "H9",
+      "tile": "G34-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 437,
+      "created_at": 1645659379,
+      "hex": "H7",
+      "tile": "8-10",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 438,
+      "created_at": 1645659392,
+      "train": "4+2-3",
+      "price": 550
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 439,
+      "created_at": 1645659408,
+      "hex": "G4",
+      "tile": "G10-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 440,
+      "created_at": 1645659440,
+      "hex": "J7",
+      "tile": "3-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 441,
+      "created_at": 1645659450,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "J7"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "J7"
+          ],
+          "revenue": 30,
+          "revenue_str": "I6-J7",
+          "nodes": [
+            "I6-0",
+            "J7-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4"
+          ],
+          "revenue": 70,
+          "revenue_str": "I6-H5-G4",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1645659451,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1645659466,
+      "hex": "I22",
+      "tile": "4-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1645659484,
+      "hex": "J23",
+      "tile": "8-3",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 445,
+      "created_at": 1645659509,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 260,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-1",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 446,
+      "created_at": 1645659513,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1645659528,
+      "hex": "I18",
+      "tile": "8-11",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1645659546,
+      "hex": "I20",
+      "tile": "58-3",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 449,
+      "created_at": 1645659554,
+      "city": "G27-0-0",
+      "slot": 0,
+      "tokener": "NER"
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 450,
+      "created_at": 1645659559
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 451,
+      "created_at": 1645659572,
+      "routes": [
+        {
+          "train": "4+2-0",
+          "connections": [
+            [
+              "H15",
+              "I14"
+            ],
+            [
+              "I14",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ],
+            [
+              "H17",
+              "G16"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I14",
+            "I16",
+            "H17",
+            "G16"
+          ],
+          "revenue": 210,
+          "revenue_str": "H15-I14-I16-H17-G16",
+          "nodes": [
+            "H15-0",
+            "I14-0",
+            "I16-0",
+            "H17-0",
+            "G16-1"
+          ]
+        },
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "G26",
+              "G24",
+              "F23"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "H21",
+              "I20"
+            ],
+            [
+              "I20",
+              "I18",
+              "H17"
+            ],
+            [
+              "H17",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F23",
+            "G22",
+            "H21",
+            "I20",
+            "H17",
+            "H15"
+          ],
+          "revenue": 260,
+          "revenue_str": "G26-H21-H17-H15+£60",
+          "nodes": [
+            "G26-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I20-0",
+            "H17-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 452,
+      "created_at": 1645659572,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 453,
+      "created_at": 1645659589,
+      "hex": "H7",
+      "tile": "25-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 454,
+      "created_at": 1645659610,
+      "hex": "I6",
+      "tile": "G21-1",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1645659622,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "G12",
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "D23",
+            "D21",
+            "E18",
+            "F17",
+            "G14",
+            "G12",
+            "H9",
+            "G6",
+            "G4"
+          ],
+          "revenue": 280,
+          "revenue_str": "D23-G14-H9-G4+£110",
+          "nodes": [
+            "D23-0",
+            "D21-0",
+            "E18-0",
+            "F17-0",
+            "G14-0",
+            "G12-0",
+            "H9-0",
+            "G6-0",
+            "G4-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 456,
+      "created_at": 1645659624,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 457,
+      "created_at": 1645659630
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 458,
+      "created_at": 1645659657,
+      "hex": "G4",
+      "tile": "G15-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 459,
+      "created_at": 1645659669,
+      "city": "G34-2-0",
+      "slot": 1,
+      "tokener": "GSWR"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 460,
+      "created_at": 1645659683,
+      "hex": "G2",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 461,
+      "created_at": 1645659697,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "G12",
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7",
+              "F5"
+            ],
+            [
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H5"
+            ]
+          ],
+          "hexes": [
+            "D23",
+            "D21",
+            "E18",
+            "F17",
+            "G14",
+            "G12",
+            "H9",
+            "G8",
+            "F5",
+            "G4",
+            "H5"
+          ],
+          "revenue": 320,
+          "revenue_str": "D23-G14-H9-F5-G4+£110",
+          "nodes": [
+            "D23-0",
+            "D21-0",
+            "E18-0",
+            "F17-0",
+            "G14-0",
+            "G12-0",
+            "H9-0",
+            "G8-0",
+            "F5-0",
+            "G4-0",
+            "H5-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1645659699,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1645659702
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 464,
+      "created_at": 1645659729,
+      "hex": "E20",
+      "tile": "7-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 465,
+      "created_at": 1645659736,
+      "hex": "E22",
+      "tile": "47-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1645659742
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1645659753,
+      "routes": [
+        {
+          "train": "4+2-1",
+          "connections": [
+            [
+              "F21",
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "F17",
+              "G16"
+            ],
+            [
+              "G16",
+              "F15",
+              "G14"
+            ],
+            [
+              "G14",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "F21",
+            "E18",
+            "F17",
+            "G16",
+            "G14",
+            "H15"
+          ],
+          "revenue": 250,
+          "revenue_str": "F21-E18-F17-G16-G14-H15",
+          "nodes": [
+            "F21-1",
+            "E18-0",
+            "F17-0",
+            "G16-0",
+            "G14-0",
+            "H15-1"
+          ]
+        },
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "G26",
+              "G24",
+              "F23"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "C22",
+              "B21"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "A20",
+              "A18",
+              "B17",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "F23",
+            "F25",
+            "D21",
+            "B21",
+            "A20",
+            "C16"
+          ],
+          "revenue": 190,
+          "revenue_str": "G26-F23-F25-D21-B21-A20-C16+(EW)",
+          "nodes": [
+            "G26-0",
+            "F23-0",
+            "F25-0",
+            "D21-0",
+            "B21-1",
+            "A20-0",
+            "C16-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1645659755,
+      "kind": "payout"
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1645659762,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "I0",
+              "I2"
+            ],
+            [
+              "I2",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6"
+            ],
+            [
+              "G6",
+              "G8",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "I0",
+            "I2",
+            "H3",
+            "G4",
+            "G6",
+            "H9"
+          ],
+          "revenue": 180,
+          "revenue_str": "I0-I2-G4-H9+£50",
+          "nodes": [
+            "I0-0",
+            "I2-0",
+            "H3-0",
+            "G4-1",
+            "G6-0",
+            "H9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 470,
+      "created_at": 1645659768,
+      "shares": [
+        "NBR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 471,
+      "created_at": 1645659777,
+      "shares": [
+        "CR_1"
+      ],
+      "percent": 10,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 472,
+      "created_at": 1645659782,
+      "skip": true
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 473,
+      "created_at": 1645659786,
+      "shares": [
+        "CR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "choose",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 474,
+      "created_at": 1645659795,
+      "choice": "convert_GWR"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 475,
+      "created_at": 1645659799,
+      "shares": [
+        "GWR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "choose",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 476,
+      "created_at": 1645659812,
+      "choice": "convert_LYR"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 477,
+      "created_at": 1645659815,
+      "shares": [
+        "LYR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 478,
+      "created_at": 1645659822,
+      "shares": [
+        "GSWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 479,
+      "created_at": 1645659828,
+      "shares": [
+        "MSLR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 480,
+      "created_at": 1645659831,
+      "shares": [
+        "SWR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 481,
+      "created_at": 1645659843,
+      "corporation": "GER",
+      "share_price": "100,0,8"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 482,
+      "created_at": 1645659850,
+      "shares": [
+        "SWR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 483,
+      "created_at": 1645659853,
+      "shares": [
+        "CR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 484,
+      "created_at": 1645659863,
+      "shares": [
+        "MR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 485,
+      "created_at": 1645659869,
+      "shares": [
+        "MR_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 486,
+      "created_at": 1645659873,
+      "shares": [
+        "GER_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 487,
+      "created_at": 1645659878,
+      "shares": [
+        "GSWR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 488,
+      "created_at": 1645659881,
+      "shares": [
+        "GSWR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 489,
+      "created_at": 1645659892,
+      "shares": [
+        "MSLR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 490,
+      "created_at": 1645659896,
+      "shares": [
+        "MSLR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 491,
+      "created_at": 1645659901,
+      "shares": [
+        "GER_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 492,
+      "created_at": 1645659907,
+      "shares": [
+        "CR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 493,
+      "created_at": 1645659910,
+      "shares": [
+        "GSWR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 494,
+      "created_at": 1645659914
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 495,
+      "created_at": 1645659919,
+      "shares": [
+        "MSLR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 496,
+      "created_at": 1645659926,
+      "shares": [
+        "GER_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 497,
+      "created_at": 1645659930,
+      "shares": [
+        "CR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 498,
+      "created_at": 1645659934,
+      "shares": [
+        "CR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 499,
+      "created_at": 1645659939
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 500,
+      "created_at": 1645659945,
+      "shares": [
+        "MSLR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 501,
+      "created_at": 1645659950,
+      "shares": [
+        "GER_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 502,
+      "created_at": 1645659960,
+      "shares": [
+        "CR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 503,
+      "created_at": 1645659966,
+      "shares": [
+        "GSWR_7",
+        "GSWR_8"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 504,
+      "created_at": 1645659975,
+      "shares": [
+        "CR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 505,
+      "created_at": 1645659980
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 506,
+      "created_at": 1645659981
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 507,
+      "created_at": 1645659985,
+      "shares": [
+        "CR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 508,
+      "created_at": 1645659990,
+      "shares": [
+        "CR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 509,
+      "created_at": 1645659994,
+      "shares": [
+        "MSLR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 510,
+      "created_at": 1645659999,
+      "shares": [
+        "NBR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 511,
+      "created_at": 1645660003
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 512,
+      "created_at": 1645660004
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 513,
+      "created_at": 1645660004
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 514,
+      "created_at": 1645660012,
+      "shares": [
+        "CR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 515,
+      "created_at": 1645660014,
+      "shares": [
+        "MSLR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 516,
+      "created_at": 1645660018
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 517,
+      "created_at": 1645660019
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 518,
+      "created_at": 1645660019
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 519,
+      "created_at": 1645660020
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 520,
+      "created_at": 1645660024,
+      "shares": [
+        "CR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 521,
+      "created_at": 1645660029,
+      "shares": [
+        "GSWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 522,
+      "created_at": 1645660034
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 523,
+      "created_at": 1645660034
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 524,
+      "created_at": 1645660034
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 525,
+      "created_at": 1645660036
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 526,
+      "created_at": 1645660039
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 527,
+      "created_at": 1645660061,
+      "hex": "H13",
+      "tile": "8-12",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1645660085,
+      "hex": "I12",
+      "tile": "204-3",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 529,
+      "created_at": 1645660094,
+      "train": "5X-1",
+      "price": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 530,
+      "created_at": 1645660097
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 531,
+      "created_at": 1645660114,
+      "hex": "H21",
+      "tile": "G30-3",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 532,
+      "created_at": 1645660129,
+      "hex": "J9",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1645660140
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 534,
+      "created_at": 1645660179,
+      "routes": [
+        {
+          "train": "4+2-0",
+          "connections": [
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "H17",
+              "I18",
+              "I20"
+            ],
+            [
+              "I20",
+              "H21"
+            ],
+            [
+              "H21",
+              "G22"
+            ],
+            [
+              "G22",
+              "F21"
+            ]
+          ],
+          "hexes": [
+            "G16",
+            "H17",
+            "I20",
+            "H21",
+            "G22",
+            "F21"
+          ],
+          "revenue": 270,
+          "revenue_str": "G16-H17-I20-H21-G22-F21+(EW)",
+          "nodes": [
+            "G16-1",
+            "H17-0",
+            "I20-0",
+            "H21-0",
+            "G22-0",
+            "F21-0"
+          ]
+        },
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ],
+            [
+              "C24",
+              "D25"
+            ],
+            [
+              "D25",
+              "E26"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "G22",
+              "H23",
+              "H21"
+            ],
+            [
+              "H21",
+              "I22"
+            ],
+            [
+              "I22",
+              "J23",
+              "K22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 250,
+          "revenue_str": "a25-D25-H21-K22+£110",
+          "nodes": [
+            "a25-0",
+            "C24-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 535,
+      "created_at": 1645660181,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1645660205,
+      "hex": "G18",
+      "tile": "G41-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 537,
+      "created_at": 1645660212,
+      "hex": "F25",
+      "tile": "911-3",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 538,
+      "created_at": 1645660220,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 280,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1645660225,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1645660238,
+      "hex": "J7",
+      "tile": "87-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1645660261,
+      "hex": "J9",
+      "tile": "24-2",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1645660273,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2",
+              "G0"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 120,
+          "revenue_str": "I6-H5-G4-G0",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "J7",
+            "J11",
+            "I12",
+            "H15"
+          ],
+          "revenue": 130,
+          "revenue_str": "I6-J7-J11-I12-H15",
+          "nodes": [
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "I12-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 543,
+      "created_at": 1645660276,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 544,
+      "created_at": 1645660302,
+      "hex": "J13",
+      "tile": "G34-3",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1645660310,
+      "city": "G34-3-0",
+      "slot": 1,
+      "tokener": "LYR"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1645660313
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1645660316,
+      "routes": [
+        {
+          "train": "4+2-4",
+          "connections": [
+            [
+              "G16",
+              "H15"
+            ],
+            [
+              "H15",
+              "I14"
+            ],
+            [
+              "I14",
+              "I16"
+            ],
+            [
+              "I16",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "G16",
+            "H15",
+            "I14",
+            "I16",
+            "H17"
+          ],
+          "revenue": 210,
+          "revenue_str": "G16-H15-I14-I16-H17",
+          "nodes": [
+            "G16-0",
+            "H15-0",
+            "I14-0",
+            "I16-0",
+            "H17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1645660320,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1645660323,
+      "train": "6X-0",
+      "price": 700,
+      "variant": "6X"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 550,
+      "created_at": 1645660329
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 551,
+      "created_at": 1645660358,
+      "hex": "J25",
+      "tile": "G36-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 552,
+      "created_at": 1645660362,
+      "hex": "J23",
+      "tile": "25-2",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1645660369,
+      "train": "6X-1",
+      "price": 700,
+      "variant": "6X"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1645660372
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 555,
+      "created_at": 1645660381,
+      "hex": "H21",
+      "tile": "G31-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 556,
+      "created_at": 1645660386
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 557,
+      "created_at": 1645660449,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "E16",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G26",
+              "G24",
+              "F23"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "F25",
+            "F23",
+            "G26"
+          ],
+          "revenue": 320,
+          "revenue_str": "G4-H9-G14-G26+£110",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "F23-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 558,
+      "created_at": 1645660453,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 559,
+      "created_at": 1645660457
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 560,
+      "created_at": 1645660477,
+      "hex": "B21",
+      "tile": "G30-4",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 561,
+      "created_at": 1645660497,
+      "hex": "H23",
+      "tile": "26-0",
+      "rotation": 3,
+      "skip": true
+    },
+    {
+      "type": "undo",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 562,
+      "created_at": 1645660502,
+      "skip": true
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 563,
+      "created_at": 1645660516,
+      "hex": "H23",
+      "tile": "27-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 564,
+      "created_at": 1645660523
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 565,
+      "created_at": 1645660534,
+      "routes": [
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20",
+              "E22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-G14-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-1",
+            "G14-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 566,
+      "created_at": 1645660535,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 567,
+      "created_at": 1645660545
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 568,
+      "created_at": 1645660549,
+      "hex": "D23",
+      "tile": "G31-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 569,
+      "created_at": 1645660557,
+      "hex": "E26",
+      "tile": "88-3",
+      "rotation": 4
+    },
+    {
+      "type": "convert",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 570,
+      "created_at": 1645660569
+    },
+    {
+      "type": "buy_train",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 571,
+      "created_at": 1645660579,
+      "train": "5X-1",
+      "price": 200
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 572,
+      "created_at": 1645660585
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 573,
+      "created_at": 1645660699,
+      "routes": [
+        {
+          "train": "5X-2",
+          "connections": [
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "F21",
+              "F23"
+            ],
+            [
+              "E18",
+              "F19",
+              "F21"
+            ],
+            [
+              "F17",
+              "E18"
+            ],
+            [
+              "G14",
+              "F15",
+              "F17"
+            ],
+            [
+              "G12",
+              "G14"
+            ],
+            [
+              "H9",
+              "H11",
+              "G12"
+            ]
+          ],
+          "hexes": [
+            "B21",
+            "D23",
+            "F25",
+            "F23",
+            "F21",
+            "E18",
+            "F17",
+            "G14",
+            "G12",
+            "H9"
+          ],
+          "revenue": 360,
+          "revenue_str": "B21-D23-F21-G14-H9+(S)+£90",
+          "nodes": [
+            "D23-0",
+            "B21-0",
+            "F25-0",
+            "F23-0",
+            "F21-1",
+            "E18-0",
+            "F17-0",
+            "G14-0",
+            "G12-0",
+            "H9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 574,
+      "created_at": 1645660707,
+      "train": "6X-2",
+      "price": 700,
+      "variant": "6X"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 575,
+      "created_at": 1645660713
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 576,
+      "created_at": 1645660725,
+      "hex": "F5",
+      "tile": "G34-4",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 577,
+      "created_at": 1645660732,
+      "city": "G31-1-0",
+      "slot": 2,
+      "tokener": "GSWR"
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 578,
+      "created_at": 1645660738
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 579,
+      "created_at": 1645660790,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "C24",
+              "D23"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 380,
+          "revenue_str": "G4-H9-G14-D23-a25+£140",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 580,
+      "created_at": 1645660791,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 581,
+      "created_at": 1645660804,
+      "hex": "G2",
+      "tile": "27-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 582,
+      "created_at": 1645660808,
+      "city": "G34-4-0",
+      "slot": 1,
+      "tokener": "CR"
+    },
+    {
+      "type": "pass",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 583,
+      "created_at": 1645660813
+    },
+    {
+      "type": "pass",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 584,
+      "created_at": 1645660818
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 585,
+      "created_at": 1645660835,
+      "hex": "I6",
+      "tile": "G30-5",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 586,
+      "created_at": 1645660852,
+      "hex": "I24",
+      "tile": "8-13",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 587,
+      "created_at": 1645660857
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 588,
+      "created_at": 1645660900,
+      "routes": [
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "H17",
+              "H15"
+            ],
+            [
+              "I20",
+              "I18",
+              "H17"
+            ],
+            [
+              "H21",
+              "I20"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D27",
+              "E26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "I20",
+            "H21",
+            "G22",
+            "F23",
+            "F25",
+            "E26",
+            "D27"
+          ],
+          "revenue": 290,
+          "revenue_str": "H15-H17-H21-D27+£80",
+          "nodes": [
+            "H17-0",
+            "H15-1",
+            "I20-0",
+            "H21-0",
+            "G22-0",
+            "F23-0",
+            "F25-0",
+            "E26-0",
+            "D27-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 589,
+      "created_at": 1645660901,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 590,
+      "created_at": 1645660909
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 591,
+      "created_at": 1645660913,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 310,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 592,
+      "created_at": 1645660914,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 593,
+      "created_at": 1645660933,
+      "hex": "J11",
+      "tile": "G28-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 594,
+      "created_at": 1645660938
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 595,
+      "created_at": 1645660947,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2",
+              "G0"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 150,
+          "revenue_str": "I6-H5-G4-G0",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "H15",
+              "H13",
+              "I12"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "I6",
+              "H7",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "H9"
+          ],
+          "revenue": 190,
+          "revenue_str": "H15-I12-J11-J7-I6-H9",
+          "nodes": [
+            "H15-1",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "H9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 596,
+      "created_at": 1645660949,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 597,
+      "created_at": 1645660958
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 598,
+      "created_at": 1645660961,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "E16",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G26",
+              "G24",
+              "F23"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "F25",
+            "F23",
+            "G26"
+          ],
+          "revenue": 320,
+          "revenue_str": "G4-H9-G14-G26+£110",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "F23-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 599,
+      "created_at": 1645660962,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 600,
+      "created_at": 1645660965
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 601,
+      "created_at": 1645660983,
+      "hex": "H19",
+      "tile": "G37-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 602,
+      "created_at": 1645660989
+    },
+    {
+      "type": "buy_train",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 603,
+      "created_at": 1645660993,
+      "train": "6X-3",
+      "price": 700,
+      "variant": "6X"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 604,
+      "created_at": 1645660995
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 605,
+      "created_at": 1645661011,
+      "hex": "A20",
+      "tile": "G34-5",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 606,
+      "created_at": 1645661015
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 607,
+      "created_at": 1645661019,
+      "routes": [
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20",
+              "E22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-G14-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-1",
+            "G14-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 608,
+      "created_at": 1645661020,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 609,
+      "created_at": 1645661025
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 610,
+      "created_at": 1645661048,
+      "hex": "E20",
+      "tile": "21-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 611,
+      "created_at": 1645661070
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 612,
+      "created_at": 1645661075,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "C24",
+              "D23"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 380,
+          "revenue_str": "G4-H9-G14-D23-a25+£140",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 613,
+      "created_at": 1645661077,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 614,
+      "created_at": 1645661091,
+      "hex": "J11",
+      "tile": "G30-6",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 615,
+      "created_at": 1645661095
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 616,
+      "created_at": 1645661143,
+      "routes": [
+        {
+          "train": "6X-0",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "J13",
+              "J11"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "H15",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "J13",
+            "I14",
+            "H15"
+          ],
+          "revenue": 340,
+          "revenue_str": "G4-I6-J11-J13-I14-H15+£60",
+          "nodes": [
+            "H5-0",
+            "G4-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "J13-0",
+            "I14-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 617,
+      "created_at": 1645661145,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 618,
+      "created_at": 1645661158
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 619,
+      "created_at": 1645661163,
+      "hex": "I26",
+      "tile": "3-2",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 620,
+      "created_at": 1645661170,
+      "city": "G31-0-0",
+      "slot": 2,
+      "tokener": "GER"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 621,
+      "created_at": 1645661195,
+      "hex": "G18",
+      "tile": "G38-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 622,
+      "created_at": 1645661234,
+      "routes": [
+        {
+          "train": "6X-1",
+          "connections": [
+            [
+              "J25",
+              "K24",
+              "K22"
+            ],
+            [
+              "I22",
+              "J23",
+              "J25"
+            ],
+            [
+              "H21",
+              "I22"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D25",
+              "E26"
+            ],
+            [
+              "C24",
+              "D25"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "K22",
+            "J25",
+            "I22",
+            "H21",
+            "G22",
+            "F23",
+            "F25",
+            "E26",
+            "D25",
+            "C24",
+            "a25"
+          ],
+          "revenue": 330,
+          "revenue_str": "K22-J25-H21-D25-a25+(EW)+£110",
+          "nodes": [
+            "J25-0",
+            "K22-0",
+            "I22-0",
+            "H21-0",
+            "G22-0",
+            "F23-0",
+            "F25-0",
+            "E26-0",
+            "D25-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 623,
+      "created_at": 1645661235,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 624,
+      "created_at": 1645661239
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 625,
+      "created_at": 1645661246
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 626,
+      "created_at": 1645661293,
+      "routes": [
+        {
+          "train": "6X-2",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "D21",
+              "D23"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "F21",
+              "E20",
+              "E18"
+            ],
+            [
+              "F23",
+              "F21"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "G26",
+              "F25"
+            ]
+          ],
+          "hexes": [
+            "a19",
+            "A20",
+            "B21",
+            "D23",
+            "D21",
+            "E18",
+            "F21",
+            "F23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 430,
+          "revenue_str": "a19-A20-B21-D23-F21-G26+(S)+(EW)+£70",
+          "nodes": [
+            "A20-0",
+            "a19-0",
+            "B21-0",
+            "D23-0",
+            "D21-0",
+            "E18-0",
+            "F21-1",
+            "F23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 627,
+      "created_at": 1645661297,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 628,
+      "created_at": 1645661306
+    },
+    {
+      "type": "place_token",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 629,
+      "created_at": 1645661312,
+      "city": "G30-4-0",
+      "slot": 1,
+      "tokener": "LNWR"
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 630,
+      "created_at": 1645661316
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 631,
+      "created_at": 1645661348,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "G26",
+              "F25"
+            ]
+          ],
+          "hexes": [
+            "a19",
+            "A20",
+            "B21",
+            "D23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 370,
+          "revenue_str": "a19-A20-B21-D23-G26+(S)+(EW)+£70",
+          "nodes": [
+            "A20-0",
+            "a19-0",
+            "B21-0",
+            "D23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 632,
+      "created_at": 1645661350,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 633,
+      "created_at": 1645661353
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 634,
+      "created_at": 1645661396,
+      "routes": [
+        {
+          "train": "5X-2",
+          "connections": [
+            [
+              "G4",
+              "F5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "H15",
+              "H13",
+              "I12"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "I12",
+            "H15"
+          ],
+          "revenue": 310,
+          "revenue_str": "F5-G4-I6-J11-H15+£60",
+          "nodes": [
+            "G4-0",
+            "F5-0",
+            "H5-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "I12-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 635,
+      "created_at": 1645661399
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 636,
+      "created_at": 1645661402
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 637,
+      "created_at": 1645661404
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 638,
+      "created_at": 1645661407,
+      "shares": [
+        "GWR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 639,
+      "created_at": 1645661412,
+      "shares": [
+        "CR_5",
+        "CR_7",
+        "CR_0"
+      ],
+      "percent": 40,
+      "share_price": 25
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 640,
+      "created_at": 1645661422,
+      "shares": [
+        "NBR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 641,
+      "created_at": 1645661426
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 642,
+      "created_at": 1645661431
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 643,
+      "created_at": 1645661431
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 644,
+      "created_at": 1645661432
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 645,
+      "created_at": 1645661435,
+      "shares": [
+        "LSWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 646,
+      "created_at": 1645661439
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 647,
+      "created_at": 1645661440
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 648,
+      "created_at": 1645661441
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 649,
+      "created_at": 1645661443
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 650,
+      "created_at": 1645661445,
+      "shares": [
+        "LSWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 651,
+      "created_at": 1645661451,
+      "shares": [
+        "LYR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 652,
+      "created_at": 1645661455
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 653,
+      "created_at": 1645661457
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 654,
+      "created_at": 1645661457
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 655,
+      "created_at": 1645661461
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 656,
+      "created_at": 1645661463,
+      "shares": [
+        "NBR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 657,
+      "created_at": 1645661468
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 658,
+      "created_at": 1645661468
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 659,
+      "created_at": 1645661469
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 660,
+      "created_at": 1645661469
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 661,
+      "created_at": 1645661475,
+      "shares": [
+        "LYR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 662,
+      "created_at": 1645661478,
+      "shares": [
+        "GER_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 663,
+      "created_at": 1645661482
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 664,
+      "created_at": 1645661486
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 665,
+      "created_at": 1645661487
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 666,
+      "created_at": 1645661488
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 667,
+      "created_at": 1645661489
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 668,
+      "created_at": 1645661497
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 669,
+      "created_at": 1645661504,
+      "routes": [
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "H17",
+              "H15"
+            ],
+            [
+              "I20",
+              "I18",
+              "H17"
+            ],
+            [
+              "H21",
+              "I20"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D27",
+              "E26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "I20",
+            "H21",
+            "G22",
+            "F23",
+            "F25",
+            "E26",
+            "D27"
+          ],
+          "revenue": 290,
+          "revenue_str": "H15-H17-H21-D27+£80",
+          "nodes": [
+            "H17-0",
+            "H15-1",
+            "I20-0",
+            "H21-0",
+            "G22-0",
+            "F23-0",
+            "F25-0",
+            "E26-0",
+            "D27-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 670,
+      "created_at": 1645661506,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 671,
+      "created_at": 1645661516
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 672,
+      "created_at": 1645661518,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 310,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 673,
+      "created_at": 1645661519,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 674,
+      "created_at": 1645661544,
+      "hex": "H5",
+      "tile": "88-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 675,
+      "created_at": 1645661556,
+      "hex": "H7",
+      "tile": "40-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 676,
+      "created_at": 1645661567,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2",
+              "G0"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 150,
+          "revenue_str": "I6-H5-G4-G0",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "H15",
+              "H13",
+              "I12"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "J11",
+              "K10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "I6",
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "G6",
+            "G4"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-I12-J11-J7-I6-G6-G4",
+          "nodes": [
+            "H15-1",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "G6-0",
+            "G4-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 677,
+      "created_at": 1645661569,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 678,
+      "created_at": 1645661575
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 679,
+      "created_at": 1645661578,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "E16",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G26",
+              "G24",
+              "F23"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "F25",
+            "F23",
+            "G26"
+          ],
+          "revenue": 320,
+          "revenue_str": "G4-H9-G14-G26+£110",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "F23-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 680,
+      "created_at": 1645661579,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 681,
+      "created_at": 1645661582
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 682,
+      "created_at": 1645661586
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 683,
+      "created_at": 1645661589,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "C24",
+              "D23"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 380,
+          "revenue_str": "G4-H9-G14-D23-a25+£140",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 684,
+      "created_at": 1645661590,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 685,
+      "created_at": 1645661594
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 686,
+      "created_at": 1645661596,
+      "routes": [
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20",
+              "E22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-G14-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-1",
+            "G14-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 687,
+      "created_at": 1645661598,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 688,
+      "created_at": 1645661599
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 689,
+      "created_at": 1645661607
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 690,
+      "created_at": 1645661612,
+      "routes": [
+        {
+          "train": "6X-0",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "J13",
+              "J11"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "H15",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "J13",
+            "I14",
+            "H15"
+          ],
+          "revenue": 340,
+          "revenue_str": "G4-I6-J11-J13-I14-H15+£60",
+          "nodes": [
+            "H5-0",
+            "G4-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "J13-0",
+            "I14-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 691,
+      "created_at": 1645661613,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 692,
+      "created_at": 1645661614
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 693,
+      "created_at": 1645661639,
+      "hex": "F19",
+      "tile": "25-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 694,
+      "created_at": 1645661646,
+      "city": "G30-2-0",
+      "slot": 0,
+      "tokener": "GER"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 695,
+      "created_at": 1645661653
+    },
+    {
+      "type": "run_routes",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 696,
+      "created_at": 1645661690,
+      "routes": [
+        {
+          "train": "6X-1",
+          "connections": [
+            [
+              "J25",
+              "K24",
+              "K22"
+            ],
+            [
+              "I22",
+              "J23",
+              "J25"
+            ],
+            [
+              "H21",
+              "I22"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "G18",
+              "G20",
+              "G22"
+            ],
+            [
+              "E18",
+              "F19",
+              "G18"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D25",
+              "E26"
+            ],
+            [
+              "C24",
+              "D25"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "K22",
+            "J25",
+            "I22",
+            "H21",
+            "G22",
+            "G18",
+            "E18",
+            "D21",
+            "F25",
+            "E26",
+            "D25",
+            "C24",
+            "a25"
+          ],
+          "revenue": 350,
+          "revenue_str": "K22-J25-H21-G18-D25-a25+(EW)+£110",
+          "nodes": [
+            "J25-0",
+            "K22-0",
+            "I22-0",
+            "H21-0",
+            "G22-0",
+            "G18-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "E26-0",
+            "D25-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 697,
+      "created_at": 1645661692,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 698,
+      "created_at": 1645661694
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 699,
+      "created_at": 1645661722,
+      "hex": "D19",
+      "tile": "25-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 700,
+      "created_at": 1645661735,
+      "hex": "C18",
+      "tile": "8-14",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 701,
+      "created_at": 1645661742
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 702,
+      "created_at": 1645661779,
+      "routes": [
+        {
+          "train": "6X-2",
+          "connections": [
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "F21",
+              "F23"
+            ],
+            [
+              "E18",
+              "E20",
+              "F21"
+            ],
+            [
+              "G18",
+              "F19",
+              "E18"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "B21",
+            "D23",
+            "F25",
+            "F23",
+            "F21",
+            "E18",
+            "G18",
+            "G16"
+          ],
+          "revenue": 320,
+          "revenue_str": "B21-D23-F21-G18-G16+(S)+£50",
+          "nodes": [
+            "D23-0",
+            "B21-0",
+            "F25-0",
+            "F23-0",
+            "F21-1",
+            "E18-0",
+            "G18-0",
+            "G16-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 703,
+      "created_at": 1645661780,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 704,
+      "created_at": 1645661797
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1645661803,
+      "hex": "I10",
+      "tile": "9-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1645661807
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1645661842,
+      "routes": [
+        {
+          "train": "6X-3",
+          "connections": [
+            [
+              "H15",
+              "H17"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "H5",
+              "I6"
+            ],
+            [
+              "G4",
+              "H5"
+            ],
+            [
+              "G0",
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H17",
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 390,
+          "revenue_str": "H17-H15-J11-I6-G4-G0+£90",
+          "nodes": [
+            "H15-1",
+            "H17-0",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1645661845,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1645661849
+    },
+    {
+      "type": "place_token",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1645661855,
+      "city": "G34-5-0",
+      "slot": 1,
+      "tokener": "LNWR"
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 711,
+      "created_at": 1645661858
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 712,
+      "created_at": 1645661859,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "G26",
+              "F25"
+            ]
+          ],
+          "hexes": [
+            "a19",
+            "A20",
+            "B21",
+            "D23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 370,
+          "revenue_str": "a19-A20-B21-D23-G26+(S)+(EW)+£70",
+          "nodes": [
+            "A20-0",
+            "a19-0",
+            "B21-0",
+            "D23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 713,
+      "created_at": 1645661861,
+      "kind": "payout"
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 714,
+      "created_at": 1645661867,
+      "routes": [
+        {
+          "train": "5X-2",
+          "connections": [
+            [
+              "G4",
+              "F5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "H15",
+              "H13",
+              "I12"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "I12",
+            "H15"
+          ],
+          "revenue": 310,
+          "revenue_str": "F5-G4-I6-J11-H15+£60",
+          "nodes": [
+            "G4-0",
+            "F5-0",
+            "H5-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "I12-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 715,
+      "created_at": 1645661877
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 716,
+      "created_at": 1645661880,
+      "routes": [
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "H17",
+              "H15"
+            ],
+            [
+              "I20",
+              "I18",
+              "H17"
+            ],
+            [
+              "H21",
+              "I20"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D27",
+              "E26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "I20",
+            "H21",
+            "G22",
+            "F23",
+            "F25",
+            "E26",
+            "D27"
+          ],
+          "revenue": 290,
+          "revenue_str": "H15-H17-H21-D27+£80",
+          "nodes": [
+            "H17-0",
+            "H15-1",
+            "I20-0",
+            "H21-0",
+            "G22-0",
+            "F23-0",
+            "F25-0",
+            "E26-0",
+            "D27-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 717,
+      "created_at": 1645661882,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 718,
+      "created_at": 1645661891
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 719,
+      "created_at": 1645661893,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 310,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 720,
+      "created_at": 1645661895,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 721,
+      "created_at": 1645661898
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 722,
+      "created_at": 1645661900,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2",
+              "G0"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 150,
+          "revenue_str": "I6-H5-G4-G0",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "H15",
+              "H13",
+              "I12"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "J11",
+              "K10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "I6",
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "G6",
+            "G4"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-I12-J11-J7-I6-G6-G4",
+          "nodes": [
+            "H15-1",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "G6-0",
+            "G4-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 723,
+      "created_at": 1645661902,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 724,
+      "created_at": 1645661908
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 725,
+      "created_at": 1645661961,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "G14",
+              "H15"
+            ],
+            [
+              "G12",
+              "G14"
+            ],
+            [
+              "H9",
+              "H11",
+              "G12"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G12",
+            "H9",
+            "G6",
+            "H5",
+            "G4"
+          ],
+          "revenue": 260,
+          "revenue_str": "H15-G14-H9-G4+£60",
+          "nodes": [
+            "G14-0",
+            "H15-1",
+            "G12-0",
+            "H9-0",
+            "G6-0",
+            "H5-0",
+            "G4-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 726,
+      "created_at": 1645661962,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 727,
+      "created_at": 1645661965
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 728,
+      "created_at": 1645661969
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 729,
+      "created_at": 1645661971,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "C24",
+              "D23"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 380,
+          "revenue_str": "G4-H9-G14-D23-a25+£140",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 730,
+      "created_at": 1645661973,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 731,
+      "created_at": 1645661979
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 732,
+      "created_at": 1645661987,
+      "routes": [
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20",
+              "E22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-G14-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-1",
+            "G14-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 733,
+      "created_at": 1645661992,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 734,
+      "created_at": 1645661994
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 735,
+      "created_at": 1645662003
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 736,
+      "created_at": 1645662005,
+      "routes": [
+        {
+          "train": "6X-0",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "J13",
+              "J11"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "H15",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "J13",
+            "I14",
+            "H15"
+          ],
+          "revenue": 340,
+          "revenue_str": "G4-I6-J11-J13-I14-H15+£60",
+          "nodes": [
+            "H5-0",
+            "G4-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "J13-0",
+            "I14-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 737,
+      "created_at": 1645662006,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 738,
+      "created_at": 1645662007
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 739,
+      "created_at": 1645662012,
+      "hex": "D25",
+      "tile": "G35-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 740,
+      "created_at": 1645662016,
+      "city": "G35-0-0",
+      "slot": 2,
+      "tokener": "GER"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 741,
+      "created_at": 1645662021
+    },
+    {
+      "type": "run_routes",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 742,
+      "created_at": 1645662024,
+      "routes": [
+        {
+          "train": "6X-1",
+          "connections": [
+            [
+              "J25",
+              "K24",
+              "K22"
+            ],
+            [
+              "I22",
+              "J23",
+              "J25"
+            ],
+            [
+              "H21",
+              "I22"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "G18",
+              "G20",
+              "G22"
+            ],
+            [
+              "E18",
+              "F19",
+              "G18"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D25",
+              "E26"
+            ],
+            [
+              "C24",
+              "D25"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "K22",
+            "J25",
+            "I22",
+            "H21",
+            "G22",
+            "G18",
+            "E18",
+            "D21",
+            "F25",
+            "E26",
+            "D25",
+            "C24",
+            "a25"
+          ],
+          "revenue": 350,
+          "revenue_str": "K22-J25-H21-G18-D25-a25+(EW)+£110",
+          "nodes": [
+            "J25-0",
+            "K22-0",
+            "I22-0",
+            "H21-0",
+            "G22-0",
+            "G18-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "E26-0",
+            "D25-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 743,
+      "created_at": 1645662025,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 744,
+      "created_at": 1645662026
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 745,
+      "created_at": 1645662047,
+      "hex": "I26",
+      "tile": "204-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 746,
+      "created_at": 1645662050,
+      "hex": "J25",
+      "tile": "G34-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 747,
+      "created_at": 1645662056
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 748,
+      "created_at": 1645662098,
+      "routes": [
+        {
+          "train": "6X-2",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "D23",
+              "D25"
+            ],
+            [
+              "D21",
+              "D23"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "F21",
+              "E20",
+              "E18"
+            ],
+            [
+              "F23",
+              "F21"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "I26",
+              "I24",
+              "H23",
+              "G22"
+            ],
+            [
+              "J25",
+              "I26"
+            ],
+            [
+              "K22",
+              "K24",
+              "J25"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "D23",
+            "D21",
+            "E18",
+            "F21",
+            "F23",
+            "G22",
+            "I26",
+            "J25",
+            "K22"
+          ],
+          "revenue": 400,
+          "revenue_str": "a25-D25-D23-F21-J25-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "D23-0",
+            "D21-0",
+            "E18-0",
+            "F21-1",
+            "F23-0",
+            "G22-0",
+            "I26-0",
+            "J25-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 749,
+      "created_at": 1645662101,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 750,
+      "created_at": 1645662103
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 751,
+      "created_at": 1645662106
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 752,
+      "created_at": 1645662108,
+      "routes": [
+        {
+          "train": "6X-3",
+          "connections": [
+            [
+              "H15",
+              "H17"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "H5",
+              "I6"
+            ],
+            [
+              "G4",
+              "H5"
+            ],
+            [
+              "G0",
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H17",
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 390,
+          "revenue_str": "H17-H15-J11-I6-G4-G0+£90",
+          "nodes": [
+            "H15-1",
+            "H17-0",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 753,
+      "created_at": 1645662110,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 754,
+      "created_at": 1645662111
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 755,
+      "created_at": 1645662116
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 756,
+      "created_at": 1645662117,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "G26",
+              "F25"
+            ]
+          ],
+          "hexes": [
+            "a19",
+            "A20",
+            "B21",
+            "D23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 370,
+          "revenue_str": "a19-A20-B21-D23-G26+(S)+(EW)+£70",
+          "nodes": [
+            "A20-0",
+            "a19-0",
+            "B21-0",
+            "D23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 757,
+      "created_at": 1645662118,
+      "kind": "payout"
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 758,
+      "created_at": 1645662140,
+      "routes": [
+        {
+          "train": "6X-4",
+          "connections": [
+            [
+              "I0",
+              "I2"
+            ],
+            [
+              "I2",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6"
+            ],
+            [
+              "G6",
+              "H7",
+              "I6"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "J9",
+              "K10",
+              "J11"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "I0",
+            "I2",
+            "H3",
+            "G4",
+            "G6",
+            "I6",
+            "J7",
+            "J11",
+            "I12",
+            "H15"
+          ],
+          "revenue": 360,
+          "revenue_str": "I0-I2-G4-I6-J11-H15+£80",
+          "nodes": [
+            "I0-0",
+            "I2-0",
+            "H3-0",
+            "G4-1",
+            "G6-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "I12-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 759,
+      "created_at": 1645662152,
+      "shares": [
+        "MR_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 760,
+      "created_at": 1645662155,
+      "shares": [
+        "GWR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 761,
+      "created_at": 1645662164
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 762,
+      "created_at": 1645662165
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 763,
+      "created_at": 1645662165
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 764,
+      "created_at": 1645662166
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 765,
+      "created_at": 1645662167
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 766,
+      "created_at": 1645662177
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 767,
+      "created_at": 1645662179,
+      "routes": [
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "H17",
+              "H15"
+            ],
+            [
+              "I20",
+              "I18",
+              "H17"
+            ],
+            [
+              "H21",
+              "I20"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D27",
+              "E26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "I20",
+            "H21",
+            "G22",
+            "F23",
+            "F25",
+            "E26",
+            "D27"
+          ],
+          "revenue": 290,
+          "revenue_str": "H15-H17-H21-D27+£80",
+          "nodes": [
+            "H17-0",
+            "H15-1",
+            "I20-0",
+            "H21-0",
+            "G22-0",
+            "F23-0",
+            "F25-0",
+            "E26-0",
+            "D27-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 768,
+      "created_at": 1645662180,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 769,
+      "created_at": 1645662185
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 770,
+      "created_at": 1645662186,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2",
+              "G0"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 150,
+          "revenue_str": "I6-H5-G4-G0",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "H15",
+              "H13",
+              "I12"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "J11",
+              "K10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "I6",
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "G6",
+            "G4"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-I12-J11-J7-I6-G6-G4",
+          "nodes": [
+            "H15-1",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "G6-0",
+            "G4-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 771,
+      "created_at": 1645662187,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 772,
+      "created_at": 1645662191
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 773,
+      "created_at": 1645662193,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 310,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 774,
+      "created_at": 1645662194,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 775,
+      "created_at": 1645662198
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 776,
+      "created_at": 1645662199,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "G14",
+              "H15"
+            ],
+            [
+              "G12",
+              "G14"
+            ],
+            [
+              "H9",
+              "H11",
+              "G12"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G12",
+            "H9",
+            "G6",
+            "H5",
+            "G4"
+          ],
+          "revenue": 260,
+          "revenue_str": "H15-G14-H9-G4+£60",
+          "nodes": [
+            "G14-0",
+            "H15-1",
+            "G12-0",
+            "H9-0",
+            "G6-0",
+            "H5-0",
+            "G4-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 777,
+      "created_at": 1645662200,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 778,
+      "created_at": 1645662201
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 779,
+      "created_at": 1645662204
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 780,
+      "created_at": 1645662205,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "C24",
+              "D23"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 380,
+          "revenue_str": "G4-H9-G14-D23-a25+£140",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 781,
+      "created_at": 1645662206,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 782,
+      "created_at": 1645662210
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 783,
+      "created_at": 1645662211,
+      "routes": [
+        {
+          "train": "6X-0",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "J13",
+              "J11"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "H15",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "J13",
+            "I14",
+            "H15"
+          ],
+          "revenue": 340,
+          "revenue_str": "G4-I6-J11-J13-I14-H15+£60",
+          "nodes": [
+            "H5-0",
+            "G4-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "J13-0",
+            "I14-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 784,
+      "created_at": 1645662212,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 785,
+      "created_at": 1645662214
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 786,
+      "created_at": 1645662216
+    },
+    {
+      "type": "run_routes",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 787,
+      "created_at": 1645662218,
+      "routes": [
+        {
+          "train": "6X-1",
+          "connections": [
+            [
+              "J25",
+              "K24",
+              "K22"
+            ],
+            [
+              "I22",
+              "J23",
+              "J25"
+            ],
+            [
+              "H21",
+              "I22"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "G18",
+              "G20",
+              "G22"
+            ],
+            [
+              "E18",
+              "F19",
+              "G18"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D25",
+              "E26"
+            ],
+            [
+              "C24",
+              "D25"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "K22",
+            "J25",
+            "I22",
+            "H21",
+            "G22",
+            "G18",
+            "E18",
+            "D21",
+            "F25",
+            "E26",
+            "D25",
+            "C24",
+            "a25"
+          ],
+          "revenue": 360,
+          "revenue_str": "K22-J25-H21-G18-D25-a25+(EW)+£110",
+          "nodes": [
+            "J25-0",
+            "K22-0",
+            "I22-0",
+            "H21-0",
+            "G22-0",
+            "G18-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "E26-0",
+            "D25-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 788,
+      "created_at": 1645662219,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 789,
+      "created_at": 1645662223
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 790,
+      "created_at": 1645662227
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 791,
+      "created_at": 1645662229,
+      "routes": [
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20",
+              "E22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-G14-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-1",
+            "G14-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 792,
+      "created_at": 1645662234,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 793,
+      "created_at": 1645662235
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 794,
+      "created_at": 1645662244
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 795,
+      "created_at": 1645662247,
+      "routes": [
+        {
+          "train": "6X-2",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "D23",
+              "D25"
+            ],
+            [
+              "D21",
+              "D23"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "F21",
+              "E20",
+              "E18"
+            ],
+            [
+              "F23",
+              "F21"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "I26",
+              "I24",
+              "H23",
+              "G22"
+            ],
+            [
+              "J25",
+              "I26"
+            ],
+            [
+              "K22",
+              "K24",
+              "J25"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "D23",
+            "D21",
+            "E18",
+            "F21",
+            "F23",
+            "G22",
+            "I26",
+            "J25",
+            "K22"
+          ],
+          "revenue": 400,
+          "revenue_str": "a25-D25-D23-F21-J25-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "D23-0",
+            "D21-0",
+            "E18-0",
+            "F21-1",
+            "F23-0",
+            "G22-0",
+            "I26-0",
+            "J25-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 796,
+      "created_at": 1645662248,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 797,
+      "created_at": 1645662251
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 798,
+      "created_at": 1645662254
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 799,
+      "created_at": 1645662257,
+      "routes": [
+        {
+          "train": "6X-3",
+          "connections": [
+            [
+              "H15",
+              "H17"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "H5",
+              "I6"
+            ],
+            [
+              "G4",
+              "H5"
+            ],
+            [
+              "G0",
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H17",
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 390,
+          "revenue_str": "H17-H15-J11-I6-G4-G0+£90",
+          "nodes": [
+            "H15-1",
+            "H17-0",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 800,
+      "created_at": 1645662257,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 801,
+      "created_at": 1645662258
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 802,
+      "created_at": 1645662262
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 803,
+      "created_at": 1645662264,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "G26",
+              "F25"
+            ]
+          ],
+          "hexes": [
+            "a19",
+            "A20",
+            "B21",
+            "D23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 370,
+          "revenue_str": "a19-A20-B21-D23-G26+(S)+(EW)+£70",
+          "nodes": [
+            "A20-0",
+            "a19-0",
+            "B21-0",
+            "D23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 804,
+      "created_at": 1645662265,
+      "kind": "payout"
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 805,
+      "created_at": 1645662271,
+      "routes": [
+        {
+          "train": "6X-4",
+          "connections": [
+            [
+              "I0",
+              "I2"
+            ],
+            [
+              "I2",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6"
+            ],
+            [
+              "G6",
+              "H7",
+              "I6"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "J9",
+              "K10",
+              "J11"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "I0",
+            "I2",
+            "H3",
+            "G4",
+            "G6",
+            "I6",
+            "J7",
+            "J11",
+            "I12",
+            "H15"
+          ],
+          "revenue": 360,
+          "revenue_str": "I0-I2-G4-I6-J11-H15+£80",
+          "nodes": [
+            "I0-0",
+            "I2-0",
+            "H3-0",
+            "G4-1",
+            "G6-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "I12-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 806,
+      "created_at": 1645662277
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 807,
+      "created_at": 1645662279,
+      "routes": [
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "H17",
+              "H15"
+            ],
+            [
+              "I20",
+              "I18",
+              "H17"
+            ],
+            [
+              "H21",
+              "I20"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D27",
+              "E26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "I20",
+            "H21",
+            "G22",
+            "F23",
+            "F25",
+            "E26",
+            "D27"
+          ],
+          "revenue": 290,
+          "revenue_str": "H15-H17-H21-D27+£80",
+          "nodes": [
+            "H17-0",
+            "H15-1",
+            "I20-0",
+            "H21-0",
+            "G22-0",
+            "F23-0",
+            "F25-0",
+            "E26-0",
+            "D27-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 808,
+      "created_at": 1645662281,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 809,
+      "created_at": 1645662286
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 810,
+      "created_at": 1645662287,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2",
+              "G0"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 150,
+          "revenue_str": "I6-H5-G4-G0",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "H15",
+              "H13",
+              "I12"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "J11",
+              "K10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "I6",
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "G6",
+            "G4"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-I12-J11-J7-I6-G6-G4",
+          "nodes": [
+            "H15-1",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "G6-0",
+            "G4-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 811,
+      "created_at": 1645662288,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 812,
+      "created_at": 1645662293
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 813,
+      "created_at": 1645662294,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 310,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 814,
+      "created_at": 1645662294,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 815,
+      "created_at": 1645662296
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 816,
+      "created_at": 1645662297,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "G14",
+              "H15"
+            ],
+            [
+              "G12",
+              "G14"
+            ],
+            [
+              "H9",
+              "H11",
+              "G12"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G12",
+            "H9",
+            "G6",
+            "H5",
+            "G4"
+          ],
+          "revenue": 260,
+          "revenue_str": "H15-G14-H9-G4+£60",
+          "nodes": [
+            "G14-0",
+            "H15-1",
+            "G12-0",
+            "H9-0",
+            "G6-0",
+            "H5-0",
+            "G4-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 817,
+      "created_at": 1645662298,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 818,
+      "created_at": 1645662303
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 819,
+      "created_at": 1645662304
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 820,
+      "created_at": 1645662305,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "C24",
+              "D23"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 380,
+          "revenue_str": "G4-H9-G14-D23-a25+£140",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 821,
+      "created_at": 1645662306,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 822,
+      "created_at": 1645662310
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 823,
+      "created_at": 1645662313,
+      "routes": [
+        {
+          "train": "6X-0",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "J13",
+              "J11"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "H15",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "J13",
+            "I14",
+            "H15"
+          ],
+          "revenue": 340,
+          "revenue_str": "G4-I6-J11-J13-I14-H15+£60",
+          "nodes": [
+            "H5-0",
+            "G4-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "J13-0",
+            "I14-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 824,
+      "created_at": 1645662314,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 825,
+      "created_at": 1645662315
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 826,
+      "created_at": 1645662321
+    },
+    {
+      "type": "run_routes",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 827,
+      "created_at": 1645662323,
+      "routes": [
+        {
+          "train": "6X-1",
+          "connections": [
+            [
+              "J25",
+              "K24",
+              "K22"
+            ],
+            [
+              "I22",
+              "J23",
+              "J25"
+            ],
+            [
+              "H21",
+              "I22"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "G18",
+              "G20",
+              "G22"
+            ],
+            [
+              "E18",
+              "F19",
+              "G18"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D25",
+              "E26"
+            ],
+            [
+              "C24",
+              "D25"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "K22",
+            "J25",
+            "I22",
+            "H21",
+            "G22",
+            "G18",
+            "E18",
+            "D21",
+            "F25",
+            "E26",
+            "D25",
+            "C24",
+            "a25"
+          ],
+          "revenue": 360,
+          "revenue_str": "K22-J25-H21-G18-D25-a25+(EW)+£110",
+          "nodes": [
+            "J25-0",
+            "K22-0",
+            "I22-0",
+            "H21-0",
+            "G22-0",
+            "G18-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "E26-0",
+            "D25-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 828,
+      "created_at": 1645662324,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 829,
+      "created_at": 1645662326
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 830,
+      "created_at": 1645662329
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 831,
+      "created_at": 1645662330,
+      "routes": [
+        {
+          "train": "6X-2",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "D23",
+              "D25"
+            ],
+            [
+              "D21",
+              "D23"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "F21",
+              "E20",
+              "E18"
+            ],
+            [
+              "F23",
+              "F21"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "I26",
+              "I24",
+              "H23",
+              "G22"
+            ],
+            [
+              "J25",
+              "I26"
+            ],
+            [
+              "K22",
+              "K24",
+              "J25"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "D23",
+            "D21",
+            "E18",
+            "F21",
+            "F23",
+            "G22",
+            "I26",
+            "J25",
+            "K22"
+          ],
+          "revenue": 400,
+          "revenue_str": "a25-D25-D23-F21-J25-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "D23-0",
+            "D21-0",
+            "E18-0",
+            "F21-1",
+            "F23-0",
+            "G22-0",
+            "I26-0",
+            "J25-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 832,
+      "created_at": 1645662331,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 833,
+      "created_at": 1645662332
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 834,
+      "created_at": 1645662334
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 835,
+      "created_at": 1645662335,
+      "routes": [
+        {
+          "train": "6X-3",
+          "connections": [
+            [
+              "H15",
+              "H17"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "H5",
+              "I6"
+            ],
+            [
+              "G4",
+              "H5"
+            ],
+            [
+              "G0",
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H17",
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 390,
+          "revenue_str": "H17-H15-J11-I6-G4-G0+£90",
+          "nodes": [
+            "H15-1",
+            "H17-0",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 836,
+      "created_at": 1645662336,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 837,
+      "created_at": 1645662338
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 838,
+      "created_at": 1645662339
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 839,
+      "created_at": 1645662340,
+      "routes": [
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20",
+              "E22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-G14-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-1",
+            "G14-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 840,
+      "created_at": 1645662341,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 841,
+      "created_at": 1645662343
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 842,
+      "created_at": 1645662348
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 843,
+      "created_at": 1645662349,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "G26",
+              "F25"
+            ]
+          ],
+          "hexes": [
+            "a19",
+            "A20",
+            "B21",
+            "D23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 370,
+          "revenue_str": "a19-A20-B21-D23-G26+(S)+(EW)+£70",
+          "nodes": [
+            "A20-0",
+            "a19-0",
+            "B21-0",
+            "D23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 844,
+      "created_at": 1645662351,
+      "kind": "payout"
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 845,
+      "created_at": 1645662355,
+      "routes": [
+        {
+          "train": "6X-4",
+          "connections": [
+            [
+              "I0",
+              "I2"
+            ],
+            [
+              "I2",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6"
+            ],
+            [
+              "G6",
+              "H7",
+              "I6"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "J9",
+              "K10",
+              "J11"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "I0",
+            "I2",
+            "H3",
+            "G4",
+            "G6",
+            "I6",
+            "J7",
+            "J11",
+            "I12",
+            "H15"
+          ],
+          "revenue": 360,
+          "revenue_str": "I0-I2-G4-I6-J11-H15+£80",
+          "nodes": [
+            "I0-0",
+            "I2-0",
+            "H3-0",
+            "G4-1",
+            "G6-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "I12-0",
+            "H15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 846,
+      "created_at": 1645662362
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 847,
+      "created_at": 1645662362
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 848,
+      "created_at": 1645662363
+    },
+    {
+      "type": "pass",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 849,
+      "created_at": 1645662364
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 850,
+      "created_at": 1645662365
+    },
+    {
+      "type": "pass",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 851,
+      "created_at": 1645662373
+    },
+    {
+      "type": "run_routes",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 852,
+      "created_at": 1645662374,
+      "routes": [
+        {
+          "train": "4X-1",
+          "connections": [
+            [
+              "H17",
+              "H15"
+            ],
+            [
+              "I20",
+              "I18",
+              "H17"
+            ],
+            [
+              "H21",
+              "I20"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "F23",
+              "G22"
+            ],
+            [
+              "F25",
+              "F23"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D27",
+              "E26"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "H17",
+            "I20",
+            "H21",
+            "G22",
+            "F23",
+            "F25",
+            "E26",
+            "D27"
+          ],
+          "revenue": 290,
+          "revenue_str": "H15-H17-H21-D27+£80",
+          "nodes": [
+            "H17-0",
+            "H15-1",
+            "I20-0",
+            "H21-0",
+            "G22-0",
+            "F23-0",
+            "F25-0",
+            "E26-0",
+            "D27-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NER",
+      "entity_type": "corporation",
+      "id": 853,
+      "created_at": 1645662375,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 854,
+      "created_at": 1645662376
+    },
+    {
+      "type": "run_routes",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 855,
+      "created_at": 1645662377,
+      "routes": [
+        {
+          "train": "5+2-1",
+          "connections": [
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2",
+              "G0"
+            ]
+          ],
+          "hexes": [
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 150,
+          "revenue_str": "I6-H5-G4-G0",
+          "nodes": [
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        },
+        {
+          "train": "5+2-2",
+          "connections": [
+            [
+              "H15",
+              "H13",
+              "I12"
+            ],
+            [
+              "I12",
+              "J11"
+            ],
+            [
+              "J11",
+              "K10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "I6",
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "G6",
+            "G4"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-I12-J11-J7-I6-G6-G4",
+          "nodes": [
+            "H15-1",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "G6-0",
+            "G4-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NBR",
+      "entity_type": "corporation",
+      "id": 856,
+      "created_at": 1645662377,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 857,
+      "created_at": 1645662379
+    },
+    {
+      "type": "run_routes",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 858,
+      "created_at": 1645662380,
+      "routes": [
+        {
+          "train": "4X-0",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "E26",
+              "D25"
+            ],
+            [
+              "F25",
+              "E26"
+            ],
+            [
+              "F23",
+              "F25"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "H21",
+              "H23",
+              "G22"
+            ],
+            [
+              "I22",
+              "H21"
+            ],
+            [
+              "K22",
+              "J23",
+              "I22"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "E26",
+            "F25",
+            "F23",
+            "G22",
+            "H21",
+            "I22",
+            "K22"
+          ],
+          "revenue": 310,
+          "revenue_str": "a25-D25-H21-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "E26-0",
+            "F25-0",
+            "F23-0",
+            "G22-0",
+            "H21-0",
+            "I22-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LSWR",
+      "entity_type": "corporation",
+      "id": 859,
+      "created_at": 1645662381,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 860,
+      "created_at": 1645662382
+    },
+    {
+      "type": "run_routes",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 861,
+      "created_at": 1645662383,
+      "routes": [
+        {
+          "train": "4X-2",
+          "connections": [
+            [
+              "G14",
+              "H15"
+            ],
+            [
+              "G12",
+              "G14"
+            ],
+            [
+              "H9",
+              "H11",
+              "G12"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G6",
+              "H5"
+            ],
+            [
+              "H5",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G12",
+            "H9",
+            "G6",
+            "H5",
+            "G4"
+          ],
+          "revenue": 260,
+          "revenue_str": "H15-G14-H9-G4+£60",
+          "nodes": [
+            "G14-0",
+            "H15-1",
+            "G12-0",
+            "H9-0",
+            "G6-0",
+            "H5-0",
+            "G4-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 862,
+      "created_at": 1645662384,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MSLR",
+      "entity_type": "corporation",
+      "id": 863,
+      "created_at": 1645662385
+    },
+    {
+      "type": "pass",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 864,
+      "created_at": 1645662387
+    },
+    {
+      "type": "run_routes",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 865,
+      "created_at": 1645662388,
+      "routes": [
+        {
+          "train": "5X-0",
+          "connections": [
+            [
+              "G6",
+              "G4"
+            ],
+            [
+              "H9",
+              "G8",
+              "G6"
+            ],
+            [
+              "G12",
+              "G10",
+              "H9"
+            ],
+            [
+              "G14",
+              "G12"
+            ],
+            [
+              "F17",
+              "F15",
+              "G14"
+            ],
+            [
+              "E18",
+              "F17"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "D23",
+              "D21"
+            ],
+            [
+              "C24",
+              "D23"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "G6",
+            "H9",
+            "G12",
+            "G14",
+            "F17",
+            "E18",
+            "D21",
+            "D23",
+            "C24",
+            "a25"
+          ],
+          "revenue": 380,
+          "revenue_str": "G4-H9-G14-D23-a25+£140",
+          "nodes": [
+            "G6-0",
+            "G4-1",
+            "H9-0",
+            "G12-0",
+            "G14-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 866,
+      "created_at": 1645662389,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 867,
+      "created_at": 1645662390
+    },
+    {
+      "type": "run_routes",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 868,
+      "created_at": 1645662391,
+      "routes": [
+        {
+          "train": "6X-0",
+          "connections": [
+            [
+              "H5",
+              "G4"
+            ],
+            [
+              "I6",
+              "H5"
+            ],
+            [
+              "J7",
+              "I6"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7"
+            ],
+            [
+              "J13",
+              "J11"
+            ],
+            [
+              "I14",
+              "J13"
+            ],
+            [
+              "H15",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "G4",
+            "H5",
+            "I6",
+            "J7",
+            "J11",
+            "J13",
+            "I14",
+            "H15"
+          ],
+          "revenue": 340,
+          "revenue_str": "G4-I6-J11-J13-I14-H15+£60",
+          "nodes": [
+            "H5-0",
+            "G4-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "J13-0",
+            "I14-0",
+            "H15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 869,
+      "created_at": 1645662392,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "LYR",
+      "entity_type": "corporation",
+      "id": 870,
+      "created_at": 1645662393
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 871,
+      "created_at": 1645662395
+    },
+    {
+      "type": "run_routes",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 872,
+      "created_at": 1645662396,
+      "routes": [
+        {
+          "train": "6X-1",
+          "connections": [
+            [
+              "J25",
+              "K24",
+              "K22"
+            ],
+            [
+              "I22",
+              "J23",
+              "J25"
+            ],
+            [
+              "H21",
+              "I22"
+            ],
+            [
+              "G22",
+              "H21"
+            ],
+            [
+              "G18",
+              "G20",
+              "G22"
+            ],
+            [
+              "E18",
+              "F19",
+              "G18"
+            ],
+            [
+              "D21",
+              "D19",
+              "E18"
+            ],
+            [
+              "F25",
+              "E24",
+              "E22",
+              "E20",
+              "D21"
+            ],
+            [
+              "E26",
+              "F25"
+            ],
+            [
+              "D25",
+              "E26"
+            ],
+            [
+              "C24",
+              "D25"
+            ],
+            [
+              "a25",
+              "A24",
+              "B25",
+              "C24"
+            ]
+          ],
+          "hexes": [
+            "K22",
+            "J25",
+            "I22",
+            "H21",
+            "G22",
+            "G18",
+            "E18",
+            "D21",
+            "F25",
+            "E26",
+            "D25",
+            "C24",
+            "a25"
+          ],
+          "revenue": 360,
+          "revenue_str": "K22-J25-H21-G18-D25-a25+(EW)+£110",
+          "nodes": [
+            "J25-0",
+            "K22-0",
+            "I22-0",
+            "H21-0",
+            "G22-0",
+            "G18-0",
+            "E18-0",
+            "D21-0",
+            "F25-0",
+            "E26-0",
+            "D25-0",
+            "C24-0",
+            "a25-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 873,
+      "created_at": 1645662397,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GER",
+      "entity_type": "corporation",
+      "id": 874,
+      "created_at": 1645662398
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 875,
+      "created_at": 1645662399
+    },
+    {
+      "type": "run_routes",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 876,
+      "created_at": 1645662401,
+      "routes": [
+        {
+          "train": "6X-2",
+          "connections": [
+            [
+              "C24",
+              "B25",
+              "A24",
+              "a25"
+            ],
+            [
+              "D25",
+              "C24"
+            ],
+            [
+              "D23",
+              "D25"
+            ],
+            [
+              "D21",
+              "D23"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "F21",
+              "E20",
+              "E18"
+            ],
+            [
+              "F23",
+              "F21"
+            ],
+            [
+              "G22",
+              "F23"
+            ],
+            [
+              "I26",
+              "I24",
+              "H23",
+              "G22"
+            ],
+            [
+              "J25",
+              "I26"
+            ],
+            [
+              "K22",
+              "K24",
+              "J25"
+            ]
+          ],
+          "hexes": [
+            "a25",
+            "C24",
+            "D25",
+            "D23",
+            "D21",
+            "E18",
+            "F21",
+            "F23",
+            "G22",
+            "I26",
+            "J25",
+            "K22"
+          ],
+          "revenue": 400,
+          "revenue_str": "a25-D25-D23-F21-J25-K22+(EW)+£110",
+          "nodes": [
+            "C24-0",
+            "a25-0",
+            "D25-0",
+            "D23-0",
+            "D21-0",
+            "E18-0",
+            "F21-1",
+            "F23-0",
+            "G22-0",
+            "I26-0",
+            "J25-0",
+            "K22-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 877,
+      "created_at": 1645662401,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 878,
+      "created_at": 1645662403
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 879,
+      "created_at": 1645662404
+    },
+    {
+      "type": "run_routes",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 880,
+      "created_at": 1645662405,
+      "routes": [
+        {
+          "train": "6X-3",
+          "connections": [
+            [
+              "H15",
+              "H17"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "H5",
+              "I6"
+            ],
+            [
+              "G4",
+              "H5"
+            ],
+            [
+              "G0",
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H17",
+            "H15",
+            "I12",
+            "J11",
+            "J7",
+            "I6",
+            "H5",
+            "G4",
+            "G0"
+          ],
+          "revenue": 390,
+          "revenue_str": "H17-H15-J11-I6-G4-G0+£90",
+          "nodes": [
+            "H15-1",
+            "H17-0",
+            "I12-0",
+            "J11-0",
+            "J7-0",
+            "I6-0",
+            "H5-0",
+            "G4-0",
+            "G0-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 881,
+      "created_at": 1645662406,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MR",
+      "entity_type": "corporation",
+      "id": 882,
+      "created_at": 1645662407
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 883,
+      "created_at": 1645662408
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 884,
+      "created_at": 1645662410,
+      "routes": [
+        {
+          "train": "5+2-0",
+          "connections": [
+            [
+              "H15",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "F17"
+            ],
+            [
+              "F17",
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20",
+              "E22",
+              "D23"
+            ]
+          ],
+          "hexes": [
+            "H15",
+            "G14",
+            "G16",
+            "F17",
+            "E18",
+            "D21",
+            "D23"
+          ],
+          "revenue": 250,
+          "revenue_str": "H15-G14-G16-F17-E18-D21-D23",
+          "nodes": [
+            "H15-1",
+            "G14-0",
+            "G16-0",
+            "F17-0",
+            "E18-0",
+            "D21-0",
+            "D23-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 885,
+      "created_at": 1645662410,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWR",
+      "entity_type": "corporation",
+      "id": 886,
+      "created_at": 1645662411
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 887,
+      "created_at": 1645662413
+    },
+    {
+      "type": "run_routes",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 888,
+      "created_at": 1645662414,
+      "routes": [
+        {
+          "train": "5X-1",
+          "connections": [
+            [
+              "A20",
+              "a19"
+            ],
+            [
+              "B21",
+              "A20"
+            ],
+            [
+              "D23",
+              "C22",
+              "B21"
+            ],
+            [
+              "F25",
+              "E24",
+              "D23"
+            ],
+            [
+              "G26",
+              "F25"
+            ]
+          ],
+          "hexes": [
+            "a19",
+            "A20",
+            "B21",
+            "D23",
+            "F25",
+            "G26"
+          ],
+          "revenue": 370,
+          "revenue_str": "a19-A20-B21-D23-G26+(S)+(EW)+£70",
+          "nodes": [
+            "A20-0",
+            "a19-0",
+            "B21-0",
+            "D23-0",
+            "F25-0",
+            "G26-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 889,
+      "created_at": 1645662415,
+      "kind": "payout"
+    },
+    {
+      "type": "run_routes",
+      "entity": "CR",
+      "entity_type": "corporation",
+      "id": 890,
+      "created_at": 1645662416,
+      "routes": [
+        {
+          "train": "6X-4",
+          "connections": [
+            [
+              "I0",
+              "I2"
+            ],
+            [
+              "I2",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6"
+            ],
+            [
+              "G6",
+              "H7",
+              "I6"
+            ],
+            [
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "J9",
+              "K10",
+              "J11"
+            ],
+            [
+              "J11",
+              "I12"
+            ],
+            [
+              "I12",
+              "H13",
+              "H15"
+            ]
+          ],
+          "hexes": [
+            "I0",
+            "I2",
+            "H3",
+            "G4",
+            "G6",
+            "I6",
+            "J7",
+            "J11",
+            "I12",
+            "H15"
+          ],
+          "revenue": 360,
+          "revenue_str": "I0-I2-G4-I6-J11-H15+£80",
+          "nodes": [
+            "I0-0",
+            "I2-0",
+            "H3-0",
+            "G4-1",
+            "G6-0",
+            "I6-0",
+            "J7-0",
+            "J11-0",
+            "I12-0",
+            "H15-1"
+          ]
+        }
+      ]
+    }
+  ],
+  "id": "hs_xwjorhbx_1",
+  "players": [
+    {
+      "id": 5,
+      "name": "Alice"
+    },
+    {
+      "id": 3,
+      "name": "Brian"
+    },
+    {
+      "id": 2,
+      "name": "Charlie"
+    },
+    {
+      "id": 1,
+      "name": "Devin"
+    },
+    {
+      "id": 4,
+      "name": "Erica"
+    }
+  ],
+  "title": "18GB",
+  "description": "",
+  "max_players": 5,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 1156786302,
+    "is_async": false,
+    "unlisted": false,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "turn": 8,
+  "round": "Operating Round",
+  "acting": [
+    4,
+    2,
+    3,
+    5,
+    1
+  ],
+  "mode": "hotseat",
+  "created_at": "2022-02-23",
+  "loaded": true,
+  "result": {
+    "Devin": 8681,
+    "Alice": 8573,
+    "Erica": 8411,
+    "Charlie": 8402,
+    "Brian": 7570
+  },
+  "updated_at": 1645662416
+}


### PR DESCRIPTION
- Cross-buying a train doesn't count as a train buy occurring in that OR (for train export purposes)
- Change tile B23 to gray rather than blue so track cannot be pointed off the board but it is still visible when surrounded by tiles per previous playtest feedback
- As per designer Dave Berry's latest changes, columns A-C are now removed entirely in the 2-player North-South scenario
- Added two full-game test fixtures to avoid future regression