### PR TITLE
[18USA] Resource tile fixes

### DIFF
--- a/lib/engine/game/g_18_usa/step/resource_track.rb
+++ b/lib/engine/game/g_18_usa/step/resource_track.rb
@@ -17,7 +17,7 @@ module Engine
           end
 
           def legal_tile_rotation?(entity, hex, tile)
-            return super unless @game.resource_tile?(tile)
+            return super unless @game.resource_tile?(tile) && tile.color == :yellow
 
             super &&
             tile.exits.any? do |exit|
@@ -35,8 +35,12 @@ module Engine
             end
           end
 
+          def track_upgrade?(_from, to, _hex)
+            super || @game.class::ORE20_TILES.include?(to.name)
+          end
+
           def lay_tile_action(action, entity: nil, spender: nil)
-            if @game.resource_tile?(action.tile)
+            if @game.resource_tile?(action.tile) && action.tile.color == :yellow
               entity ||= action.entity
               corporation = entity.corporation? ? entity : entity.owner
               abilities = @game.abilities_to_lay_resource_tile(action.hex, action.tile, corporation.companies).values
@@ -53,7 +57,9 @@ module Engine
             corporation = entity.corporation? ? entity : entity.owner
 
             super
-            @game.consume_abilities_to_lay_resource_tile(hex, tile, corporation.companies) if @game.resource_tile?(tile)
+            return if !@game.resource_tile?(tile) || tile.color != :yellow
+
+            @game.consume_abilities_to_lay_resource_tile(hex, tile, corporation.companies)
           end
         end
       end


### PR DESCRIPTION
- Only consume resource ability for yellow resource tiles
- Ore20 should count as an upgrade.