### PR TITLE
18LA2 - map and entity config changes

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -3,6 +3,8 @@
 require_relative 'entities'
 require_relative 'map'
 require_relative 'meta'
+require_relative 'step/draft_2p_distribution'
+require_relative 'step/draft_distribution'
 require_relative '../company_price_up_to_face'
 require_relative '../base'
 

--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -284,8 +284,8 @@ module Engine
               place_second_token(corporation, deferred: true)
             end
           end
-          @log << "Privates in the game: #{@companies.reject { |c| c.name.include?('Pass') }.map(&:name).join(', ')}"
-          @log << "Corporations in the game: #{@corporations.map(&:name).join(', ')}"
+          @log << "Privates in the game: #{@companies.reject { |c| c.name.include?('Pass') }.map(&:name).sort.join(', ')}"
+          @log << "Corporations in the game: #{@corporations.map(&:name).sort.join(', ')}"
 
           @cert_limit = init_cert_limit
 

--- a/lib/engine/game/g_18_los_angeles/entities.rb
+++ b/lib/engine/game/g_18_los_angeles/entities.rb
@@ -70,16 +70,21 @@ module Engine
           },
           {
             name: 'Chino Hills Excavation',
-            value: 60,
+            value: 50,
             revenue: 20,
-            desc: 'Reduces, for the owning corporation, the cost of laying all hill tiles and '\
-                  'tunnel/pass hexsides by $20.',
+            desc: 'Reduces, for the owning corporation, the total terrain cost for all tile lays by $20.',
             sym: 'CHE',
             abilities: [
               {
                 type: 'tile_discount',
                 discount: 20,
                 terrain: 'mountain',
+                owner_type: 'corporation',
+              },
+              {
+                type: 'tile_discount',
+                discount: 20,
+                terrain: 'water',
                 owner_type: 'corporation',
               },
             ],
@@ -89,14 +94,14 @@ module Engine
             name: 'Los Angeles Citrus',
             value: 60,
             revenue: 15,
-            desc: 'The owning corporation may assign Los Angeles Citrus to either Riverside (C14) '\
-                  'or Port of Long Beach (F7), to add $30 to all routes it runs to this location.',
+            desc: 'The owning corporation may assign Los Angeles Citrus to Oxnard (B1), Yorba Linda '\
+                  '(D13), or Irvine (F15), to add $30 to all routes it runs to this location.',
             sym: 'LAC',
             abilities: [
               {
                 type: 'assign_hexes',
                 when: 'owning_corp_or_turn',
-                hexes: %w[C14 F7],
+                hexes: %w[B1 D13 F15],
                 count: 1,
                 owner_type: 'corporation',
               },
@@ -113,15 +118,15 @@ module Engine
             name: 'Los Angeles Steamship',
             value: 40,
             revenue: 10,
-            desc: 'The owning corporation may assign the Los Angeles Steamship to one of Oxnard ('\
-                  'B1), Santa Monica (C2), Port of Long Beach (F7), or Westminster (F9), to add $'\
-                  '20 per port symbol to all routes it runs to this location.',
+            desc: 'The owning corporation may assign the Los Angeles Steamship to Oxnard (B1), '\
+                  'Santa Monica (C2), or Westminster (F9), to add $20 per port symbol to all '\
+                  'routes it runs to this location.',
             sym: 'LAS',
             abilities: [
               {
                 type: 'assign_hexes',
                 when: 'owning_corp_or_turn',
-                hexes: %w[B1 C2 F7 F9],
+                hexes: %w[B1 C2 F9],
                 count_per_or: 1,
                 owner_type: 'corporation',
               },
@@ -135,30 +140,9 @@ module Engine
             color: nil,
           },
           {
-            name: 'South Bay Line',
-            value: 40,
-            revenue: 15,
-            desc: 'The owning corporation may make an extra $0 cost tile upgrade of either Redondo '\
-                  'Beach (E4) or Torrance (E6), but not both.',
-            sym: 'SBL',
-            abilities: [
-              {
-                type: 'tile_lay',
-                when: 'owning_corp_or_turn',
-                owner_type: 'corporation',
-                free: true,
-                hexes: %w[E4 E6],
-                tiles: %w[14 15 619],
-                special: false,
-                count: 1,
-              },
-            ],
-            color: nil,
-          },
-          {
             name: 'Puente Trolley',
             value: 40,
-            revenue: 15,
+            revenue: 10,
             desc: 'The owning corporation may lay an extra $0 cost yellow tile in Puente (C10), '\
                   'even if they are not connected to Puente.',
             sym: 'PT',
@@ -247,6 +231,38 @@ module Engine
             ],
             color: nil,
           },
+          {
+            name: 'Angeles Public Dump',
+            sym: 'APD',
+            value: 40,
+            revenue: 10,
+            desc: '',
+            abilities: [],
+          },
+          {
+            name: 'Los Angeles Paving',
+            sym: 'LAP',
+            value: 60,
+            revenue: 15,
+            desc: '',
+            abilities: [],
+          },
+          {
+            name: 'Redondo Junction',
+            sym: 'RJ',
+            value: 50,
+            revenue: 10,
+            desc: '',
+            abilities: [],
+          },
+          {
+            name: 'RKO Pictures',
+            sym: 'RP',
+            value: 40,
+            revenue: 10,
+            desc: '',
+            abilities: [],
+          },
         ].freeze
 
         CORPORATIONS = [
@@ -263,7 +279,7 @@ module Engine
                 description: 'Reserved $40/$60 Culver City (C4) token',
                 hexes: ['C4'],
                 price: 40,
-                teleport_price: 60,
+                teleport_price: 100,
               },
               { type: 'reservation', hex: 'C4', remove: 'IV' },
             ],
@@ -314,7 +330,6 @@ module Engine
             logo: '18_los_angeles/PER',
             simple_logo: '18_los_angeles/PER.alt',
             tokens: [0, 80, 80, 80],
-            coordinates: 'F13',
             color: '#ff6a00',
             text_color: 'black',
             always_market_price: true,
@@ -327,17 +342,8 @@ module Engine
             logo: '18_los_angeles/SF',
             simple_logo: '18_los_angeles/SF.alt',
             tokens: [0, 80, 80, 80, 80],
-            abilities: [
-              {
-                type: 'token',
-                description: 'Reserved $40 Montebello (C8) token',
-                hexes: ['C8'],
-                count: 1,
-                price: 40,
-              },
-              { type: 'reservation', hex: 'C8', remove: 'IV' },
-            ],
-            coordinates: 'D13',
+            abilities: [],
+            coordinates: 'E12',
             color: '#ff7fed',
             text_color: 'black',
             always_market_price: true,
@@ -357,7 +363,7 @@ module Engine
                 hexes: ['C6'],
                 price: 40,
                 count: 1,
-                teleport_price: 100,
+                teleport_price: 60,
               },
               { type: 'reservation', hex: 'C6', remove: 'IV' },
             ],

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -88,7 +88,7 @@ module Engine
           hexes = super
 
           hexes.each do |hex|
-            hex.ignore_for_axes = true if %w[a9 G14].include?(hex.id)
+            hex.ignore_for_axes = true if %w[a5 a9 G14].include?(hex.id)
           end
 
           hexes

--- a/lib/engine/game/g_18_los_angeles/map.rb
+++ b/lib/engine/game/g_18_los_angeles/map.rb
@@ -61,6 +61,7 @@ module Engine
           'C10' => 'Puente',
           'C12' => 'Walnut',
           'C14' => 'Riverside',
+          'D1' => 'LAX',
           'D3' => 'El Segundo',
           'D5' => 'Gardena',
           'D7' => 'Compton',
@@ -86,34 +87,38 @@ module Engine
         HEXES = {
           white: {
             ['C10'] => '',
-            ['D3'] => 'upgrade=cost:40,terrain:water',
+            ['D3'] => 'upgrade=cost:30,terrain:water',
             ['A4'] => 'city=revenue:0;border=edge:0,type:mountain,cost:20',
             ['B3'] => 'border=edge:3,type:mountain,cost:20;border=edge:4,type:mountain,cost:20',
             ['B9'] => 'city=revenue:0;border=edge:3,type:mountain,cost:20;border=edge:1,type:water,cost:40',
             ['B13'] => 'city=revenue:0;border=edge:2,type:mountain,cost:20;'\
-                       'border=edge:3,type:mountain,cost:20;label=Z',
-            ['B7'] => 'city=revenue:0;border=edge:4,type:water,cost:40;border=edge:5,type:water,cost:40',
+                       'border=edge:4,type:mountain,cost:20;label=Z',
+            ['B7'] => 'border=edge:4,type:water,cost:40;border=edge:5,type:water,cost:40',
             ['C8'] => 'city=revenue:0;border=edge:2,type:water,cost:40',
             ['D5'] => 'city=revenue:0;border=edge:3,type:water,cost:40',
             ['C12'] => 'city=revenue:0;upgrade=cost:40,terrain:mountain',
             ['D9'] => 'city=revenue:0;border=edge:4,type:water,cost:40;stub=edge:0',
             ['D11'] => 'city=revenue:0;border=edge:1,type:water,cost:40',
-            ['E4'] => 'city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1',
-            ['E6'] => 'city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1;stub=edge:4',
-            ['E10'] => 'city=revenue:0;border=edge:0,type:water,cost:40;stub=edge:1',
+            ['E4'] => 'city=revenue:0',
+            ['E6'] => 'city=revenue:0;stub=edge:4',
+            ['E10'] => 'city=revenue:0;border=edge:0,type:water,cost:20;stub=edge:1',
             ['E12'] => 'city=revenue:0;label=Z',
             ['E14'] => 'upgrade=cost:40,terrain:mountain;border=edge:5,type:mountain,cost:20',
             %w[A6 C4 F11] => 'city=revenue:0',
             ['D7'] => 'city=revenue:0;stub=edge:5',
           },
           gray: {
+            ['a5'] => 'offboard=revenue:0,visit_cost:100;path=a:0,b:_0;path=a:5,b:_0',
+
             ['B5'] => 'city=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;'\
                       'border=edge:1,type:mountain,cost:20',
             ['C2'] => 'city=revenue:10;icon=image:port;icon=image:port;path=a:2,b:_0;path=a:4,b:_0;'\
-                      'path=a:5,b:_0;',
-            ['D13'] => 'city=revenue:20,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;',
-            ['F9'] => 'city=revenue:10;border=edge:3,type:water,cost:40;icon=image:port;'\
+                      'path=a:5,b:_0;path=a:0,b:_0;',
+            ['D13'] => 'city=revenue:20,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;'\
+                       'icon=image:18_los_angeles/meat;',
+            ['F9'] => 'city=revenue:10;border=edge:3,type:water,cost:20;icon=image:port;'\
                       'icon=image:port;path=a:3,b:_0;path=a:4,b:_0',
+            ['F3'] => 'offboard=revenue:0,visit_cost:100;path=a:3,b:_0',
             ['F5'] => 'path=a:2,b:3',
             ['a9'] => 'offboard=revenue:0,visit_cost:100;path=a:0,b:_0',
             ['G14'] => 'offboard=revenue:0,visit_cost:100;path=a:2,b:_0',
@@ -121,31 +126,33 @@ module Engine
           red: {
             ['A2'] => 'city=revenue:yellow_30|brown_50,groups:NW;label=N/W;icon=image:1846/20;'\
                       'path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1',
-            ['A10'] => 'offboard=revenue:yellow_20|brown_40,groups:N|NW|NE;label=N;'\
+            ['A10'] => 'offboard=revenue:yellow_20|brown_40,groups:NE;label=N/E;'\
                        'border=edge:0,type:mountain,cost:20;border=edge:1,type:mountain,cost:20;'\
-                       'border=edge:5,type:mountain,cost:20;icon=image:1846/30;path=a:0,b:_0;'\
+                       'border=edge:5,type:mountain,cost:20;icon=image:1846/20;path=a:0,b:_0;'\
                        'path=a:1,b:_0;path=a:5,b:_0',
-            ['A12'] => 'offboard=revenue:yellow_20|brown_40,groups:N|NW|NE;label=N;'\
+            ['A12'] => 'offboard=revenue:yellow_20|brown_40,groups:NE;label=N/E;'\
                        'border=edge:0,type:mountain,cost:20;border=edge:5,type:mountain,cost:20;'\
                        'icon=image:1846/20;path=a:0,b:_0;path=a:5,b:_0',
             ['A14'] => 'offboard=revenue:yellow_20|brown_40,groups:NE;label=N/E;'\
-                       'border=edge:0,type:mountain,cost:20;icon=image:1846/20;path=a:0,b:_0',
-            ['B1'] => 'offboard=revenue:yellow_40|brown_10,groups:W|NW|SW;label=W;icon=image:port;'\
-                      'icon=image:1846/30;path=a:4,b:_0;path=a:5,b:_0',
-            ['B15'] => 'offboard=revenue:yellow_20|brown_50,groups:E|NE|SE;label=E;'\
-                       'icon=image:1846/30;path=a:1,b:_0',
-            ['C14'] => 'offboard=revenue:yellow_30|brown_70,groups:E|NE|SE;label=E;'\
-                       'icon=image:1846/30;icon=image:18_los_angeles/meat;path=a:1,b:_0;'\
-                       'path=a:2,b:_0',
+                       'icon=image:1846/20;path=a:0,b:_0',
+            ['B1'] => 'offboard=revenue:yellow_40|brown_10,groups:W|NW|SW;label=W;icon=image:1846/30;'\
+                      'icon=image:port;icon=image:18_los_angeles/meat;path=a:4,b:_0;path=a:5,b:_0',
+            ['B15'] => 'offboard=revenue:yellow_30|brown_50,groups:E|NE|SE;label=E;'\
+                       'icon=image:1846/30;path=a:1,b:_0;border=edge:1,type:mountain,cost:20',
+            ['C14'] => 'offboard=revenue:yellow_20|brown_70,groups:E|NE|SE;label=E;'\
+                       'icon=image:1846/30;path=a:1,b:_0;path=a:2,b:_0',
+            ['D1'] => 'offboard=revenue:yellow_0|brown_60,groups:W|NW|SW;label=W;'\
+                      'icon=image:1846/20;icon=image:port;icon=image:18_los_angeles/meat;'\
+                      'path=a:3,b:_0;path=a:4,b:_0',
             ['D15'] => 'offboard=revenue:yellow_20|brown_40,groups:E|NE|SE;label=E;'\
                        'icon=image:1846/30;path=a:0,b:_0;path=a:1,b:_0',
             ['E16'] => 'offboard=revenue:yellow_20|brown_40,groups:SE;label=S/E;icon=image:1846/20;'\
                        'path=a:1,b:_0',
             ['F15'] => 'offboard=revenue:yellow_20|brown_50,groups:SE;label=S/E;'\
                        'border=edge:2,type:mountain,cost:20;path=a:1,b:_0;path=a:2,b:_0;'\
-                       'icon=image:1846/20',
-            ['F7'] => 'offboard=revenue:yellow_20|brown_40,groups:S|SE|SW;label=S;path=a:3,b:_0;'\
-                      'icon=image:1846/50;icon=image:18_los_angeles/meat;icon=image:port',
+                       'icon=image:1846/20;icon=image:18_los_angeles/meat',
+            ['F7'] => 'offboard=revenue:yellow_20|brown_40,groups:SW;label=S/W;path=a:3,b:_0;'\
+                      'icon=image:1846/50',
           },
           yellow: {
             ['A8'] => 'city=revenue:20;path=a:1,b:_0;path=a:5,b:_0;border=edge:4,type:mountain,cost:20',

--- a/lib/engine/game/g_18_los_angeles/meta.rb
+++ b/lib/engine/game/g_18_los_angeles/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_DESIGNER = 'Anthony Fryer'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18LosAngeles'
-        GAME_PUBLISHER = %i[traxx sea_horse].freeze
+        GAME_PUBLISHER = %i[traxx].freeze
         GAME_RULES_URL = {
           '18 Los Angeles Rules' =>
                           'https://drive.google.com/file/d/16di_KBlGYnmdAMvjl2ZiqvyeB7wTAJ_4/view?usp=sharing',

--- a/lib/engine/game/g_18_los_angeles/meta.rb
+++ b/lib/engine/game/g_18_los_angeles/meta.rb
@@ -23,7 +23,7 @@ module Engine
         GAME_TITLE = '18 Los Angeles 2'
         # GAME_DISPLAY_TITLE = '18 Los Angeles'
         GAME_SUBTITLE = 'Railroading in the City of Angels'
-        GAME_ALIASES = ['18LA'].freeze
+        GAME_ALIASES = %w[18LA 18LA_2].freeze
         # GAME_VARIANTS = [
         #   {
         #     sym: :first_ed,

--- a/lib/engine/game/g_18_los_angeles1/entities.rb
+++ b/lib/engine/game/g_18_los_angeles1/entities.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G18LosAngeles1
+      module Entities
+        # companies found only in 1st Edition
+        COMPANIES = [
+          {
+            name: 'South Bay Line',
+            value: 40,
+            revenue: 15,
+            desc: 'The owning corporation may make an extra $0 cost tile upgrade of either Redondo '\
+                  'Beach (E4) or Torrance (E6), but not both.',
+            sym: 'SBL',
+            abilities: [
+              {
+                type: 'tile_lay',
+                when: 'owning_corp_or_turn',
+                owner_type: 'corporation',
+                free: true,
+                hexes: %w[E4 E6],
+                tiles: %w[14 15 619],
+                special: false,
+                count: 1,
+              },
+            ],
+            color: nil,
+          },
+        ].freeze
+
+        # companies with different properties in 1st Edition
+        COMPANIES_1E = {
+          'CHE' => {
+            name: 'Chino Hills Excavation',
+            value: 60,
+            revenue: 20,
+            desc: 'Reduces, for the owning corporation, the cost of laying '\
+                  'all hill tiles and tunnel/pass hexsides by $20.',
+            sym: 'CHE',
+            abilities: [
+              {
+                type: 'tile_discount',
+                discount: 20,
+                terrain: 'mountain',
+                owner_type: 'corporation',
+              },
+            ],
+            color: nil,
+          },
+
+          'LAC' => {
+            name: 'Los Angeles Citrus',
+            value: 60,
+            revenue: 15,
+            desc: 'The owning corporation may assign Los Angeles Citrus to either Riverside (C14) '\
+                  'or Port of Long Beach (F7), to add $30 to all routes it runs to this location.',
+            sym: 'LAC',
+            abilities: [
+              {
+                type: 'assign_hexes',
+                when: 'owning_corp_or_turn',
+                hexes: %w[C14 F7],
+                count: 1,
+                owner_type: 'corporation',
+              },
+              {
+                type: 'assign_corporation',
+                when: 'sold',
+                count: 1,
+                owner_type: 'corporation',
+              },
+            ],
+            color: nil,
+          },
+
+          'LAS' => {
+            name: 'Los Angeles Steamship',
+            value: 40,
+            revenue: 10,
+            desc: 'The owning corporation may assign the Los Angeles Steamship to one of Oxnard ('\
+                  'B1), Santa Monica (C2), Port of Long Beach (F7), or Westminster (F9), to add $'\
+                  '20 per port symbol to all routes it runs to this location.',
+            sym: 'LAS',
+            abilities: [
+              {
+                type: 'assign_hexes',
+                when: 'owning_corp_or_turn',
+                hexes: %w[B1 C2 F7 F9],
+                count_per_or: 1,
+                owner_type: 'corporation',
+              },
+              {
+                type: 'assign_corporation',
+                when: 'sold',
+                count: 1,
+                owner_type: 'corporation',
+              },
+            ],
+            color: nil,
+          },
+          'PT' => {
+            name: 'Puente Trolley',
+            value: 40,
+            revenue: 15,
+            desc: 'The owning corporation may lay an extra $0 cost yellow tile in Puente (C10), '\
+                  'even if they are not connected to Puente.',
+            sym: 'PT',
+            abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['C10'] },
+                        {
+                          type: 'tile_lay',
+                          when: 'owning_corp_or_turn',
+                          owner_type: 'corporation',
+                          free: true,
+                          hexes: ['C10'],
+                          tiles: %w[7 8 9],
+                          count: 1,
+                        }],
+            color: nil,
+          },
+        }.freeze
+
+        # corporations with different properties in 1st Edition
+        CORPORATIONS_1E = {
+          'ELA' => {
+            float_percent: 20,
+            sym: 'ELA',
+            name: 'East Los Angeles & San Pedro Railroad',
+            logo: '18_los_angeles/ELA',
+            simple_logo: '18_los_angeles/ELA.alt',
+            tokens: [0, 80, 80, 80, 80, 80],
+            abilities: [
+              {
+                type: 'token',
+                description: 'Reserved $40/$60 Culver City (C4) token',
+                hexes: ['C4'],
+                price: 40,
+                teleport_price: 60,
+              },
+              { type: 'reservation', hex: 'C4', remove: 'IV' },
+            ],
+            coordinates: 'C12',
+            color: '#ff0000',
+            always_market_price: true,
+            reservation_color: nil,
+          },
+          'PER' => {
+            float_percent: 20,
+            sym: 'PER',
+            name: 'Pacific Electric Railroad',
+            logo: '18_los_angeles/PER',
+            simple_logo: '18_los_angeles/PER.alt',
+            tokens: [0, 80, 80, 80],
+            coordinates: 'F13',
+            color: '#ff6a00',
+            text_color: 'black',
+            always_market_price: true,
+            reservation_color: nil,
+          },
+          'SF' => {
+            float_percent: 20,
+            sym: 'SF',
+            name: 'Santa Fe Railroad',
+            logo: '18_los_angeles/SF',
+            simple_logo: '18_los_angeles/SF.alt',
+            tokens: [0, 80, 80, 80, 80],
+            abilities: [
+              {
+                type: 'token',
+                description: 'Reserved $40 Montebello (C8) token',
+                hexes: ['C8'],
+                count: 1,
+                price: 40,
+              },
+              { type: 'reservation', hex: 'C8', remove: 'IV' },
+            ],
+            coordinates: 'D13',
+            color: '#ff7fed',
+            text_color: 'black',
+            always_market_price: true,
+            reservation_color: nil,
+          },
+          'SP' => {
+            float_percent: 20,
+            sym: 'SP',
+            name: 'Southern Pacific Railroad',
+            logo: '18_los_angeles/SP',
+            simple_logo: '18_los_angeles/SP.alt',
+            tokens: [0, 80, 80, 80, 80],
+            abilities: [
+              {
+                type: 'token',
+                description: 'Reserved $40/$100 Los Angeles (C6) token',
+                hexes: ['C6'],
+                price: 40,
+                count: 1,
+                teleport_price: 100,
+              },
+              { type: 'reservation', hex: 'C6', remove: 'IV' },
+            ],
+            coordinates: 'C2',
+            color: '#0026ff',
+            always_market_price: true,
+            reservation_color: nil,
+          },
+        }.freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles1/game.rb
+++ b/lib/engine/game/g_18_los_angeles1/game.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../g_18_los_angeles/game'
+require_relative 'entities'
+require_relative 'map'
 require_relative 'meta'
 
 module Engine
@@ -8,6 +10,22 @@ module Engine
     module G18LosAngeles1
       class Game < G18LosAngeles::Game
         include_meta(G18LosAngeles1::Meta)
+        include Entities
+        include Map
+
+        def game_companies
+          @game_companies ||=
+            self.class::COMPANIES + (G18LosAngeles::Game::COMPANIES.slice(0, 11).map do |company|
+                                       self.class::COMPANIES_1E[company[:sym]] || company
+                                     end)
+        end
+
+        def game_corporations
+          @game_corporations ||=
+            G18LosAngeles::Game::CORPORATIONS.map do |company|
+              self.class::CORPORATIONS_1E[company[:sym]] || company
+            end
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_los_angeles1/map.rb
+++ b/lib/engine/game/g_18_los_angeles1/map.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G18LosAngeles1
+      module Map
+        HEXES = {
+          white: {
+            ['C10'] => '',
+            ['D3'] => 'upgrade=cost:40,terrain:water',
+            ['A4'] => 'city=revenue:0;border=edge:0,type:mountain,cost:20',
+            ['B3'] => 'border=edge:3,type:mountain,cost:20;border=edge:4,type:mountain,cost:20',
+            ['B9'] => 'city=revenue:0;border=edge:3,type:mountain,cost:20;border=edge:1,type:water,cost:40',
+            ['B13'] => 'city=revenue:0;border=edge:2,type:mountain,cost:20;'\
+                       'border=edge:3,type:mountain,cost:20;label=Z',
+            ['B7'] => 'city=revenue:0;border=edge:4,type:water,cost:40;border=edge:5,type:water,cost:40',
+            ['C8'] => 'city=revenue:0;border=edge:2,type:water,cost:40',
+            ['D5'] => 'city=revenue:0;border=edge:3,type:water,cost:40',
+            ['C12'] => 'city=revenue:0;upgrade=cost:40,terrain:mountain',
+            ['D9'] => 'city=revenue:0;border=edge:4,type:water,cost:40;stub=edge:0',
+            ['D11'] => 'city=revenue:0;border=edge:1,type:water,cost:40',
+            ['E4'] => 'city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1',
+            ['E6'] => 'city=revenue:0;icon=image:18_los_angeles/sbl,sticky:1;stub=edge:4',
+            ['E10'] => 'city=revenue:0;border=edge:0,type:water,cost:40;stub=edge:1',
+            ['E12'] => 'city=revenue:0;label=Z',
+            ['E14'] => 'upgrade=cost:40,terrain:mountain;border=edge:5,type:mountain,cost:20',
+            %w[A6 C4 F11] => 'city=revenue:0',
+            ['D7'] => 'city=revenue:0;stub=edge:5',
+          },
+          gray: {
+            ['B5'] => 'city=revenue:20;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;'\
+                      'border=edge:1,type:mountain,cost:20',
+            ['C2'] => 'city=revenue:10;icon=image:port;icon=image:port;path=a:2,b:_0;path=a:4,b:_0;'\
+                      'path=a:5,b:_0;',
+            ['D13'] => 'city=revenue:20,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;',
+            ['F9'] => 'city=revenue:10;border=edge:3,type:water,cost:40;icon=image:port;'\
+                      'icon=image:port;path=a:3,b:_0;path=a:4,b:_0',
+            ['F5'] => 'path=a:2,b:3',
+            ['a9'] => 'offboard=revenue:0,visit_cost:100;path=a:0,b:_0',
+            ['G14'] => 'offboard=revenue:0,visit_cost:100;path=a:2,b:_0',
+          },
+          red: {
+            ['A2'] => 'city=revenue:yellow_30|brown_50,groups:NW;label=N/W;icon=image:1846/20;'\
+                      'path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1',
+            ['A10'] => 'offboard=revenue:yellow_20|brown_40,groups:N|NW|NE;label=N;'\
+                       'border=edge:0,type:mountain,cost:20;border=edge:1,type:mountain,cost:20;'\
+                       'border=edge:5,type:mountain,cost:20;icon=image:1846/30;path=a:0,b:_0;'\
+                       'path=a:1,b:_0;path=a:5,b:_0',
+            ['A12'] => 'offboard=revenue:yellow_20|brown_40,groups:N|NW|NE;label=N;'\
+                       'border=edge:0,type:mountain,cost:20;border=edge:5,type:mountain,cost:20;'\
+                       'icon=image:1846/20;path=a:0,b:_0;path=a:5,b:_0',
+            ['A14'] => 'offboard=revenue:yellow_20|brown_40,groups:NE;label=N/E;'\
+                       'border=edge:0,type:mountain,cost:20;icon=image:1846/20;path=a:0,b:_0',
+            ['B1'] => 'offboard=revenue:yellow_40|brown_10,groups:W|NW|SW;label=W;icon=image:port;'\
+                      'icon=image:1846/30;path=a:4,b:_0;path=a:5,b:_0',
+            ['B15'] => 'offboard=revenue:yellow_20|brown_50,groups:E|NE|SE;label=E;'\
+                       'icon=image:1846/30;path=a:1,b:_0',
+            ['C14'] => 'offboard=revenue:yellow_30|brown_70,groups:E|NE|SE;label=E;'\
+                       'icon=image:1846/30;icon=image:18_los_angeles/meat;path=a:1,b:_0;'\
+                       'path=a:2,b:_0',
+            ['D15'] => 'offboard=revenue:yellow_20|brown_40,groups:E|NE|SE;label=E;'\
+                       'icon=image:1846/30;path=a:0,b:_0;path=a:1,b:_0',
+            ['E16'] => 'offboard=revenue:yellow_20|brown_40,groups:SE;label=S/E;icon=image:1846/20;'\
+                       'path=a:1,b:_0',
+            ['F15'] => 'offboard=revenue:yellow_20|brown_50,groups:SE;label=S/E;'\
+                       'border=edge:2,type:mountain,cost:20;path=a:1,b:_0;path=a:2,b:_0;'\
+                       'icon=image:1846/20',
+            ['F7'] => 'offboard=revenue:yellow_20|brown_40,groups:S|SE|SW;label=S;path=a:3,b:_0;'\
+                      'icon=image:1846/50;icon=image:18_los_angeles/meat;icon=image:port',
+          },
+          yellow: {
+            ['A8'] => 'city=revenue:20;path=a:1,b:_0;path=a:5,b:_0;border=edge:4,type:mountain,cost:20',
+            ['B11'] => 'city=revenue:20;border=edge:2,type:mountain,cost:20;'\
+                       'border=edge:3,type:mountain,cost:20;path=a:1,b:_0;path=a:4,b:_0',
+            ['C6'] => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:4,b:_0;label=Z;'\
+                      'border=edge:0,type:water,cost:40',
+            ['E8'] => 'city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;'\
+                      'city=revenue:10,groups:LongBeach;city=revenue:10,groups:LongBeach;'\
+                      'path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_2;path=a:4,b:_3;stub=edge:0;label=LB',
+            ['F13'] => 'city=revenue:20,slots:2;path=a:1,b:_0;path=a:3,b:_0',
+          },
+        }.freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles1/meta.rb
+++ b/lib/engine/game/g_18_los_angeles1/meta.rb
@@ -15,6 +15,7 @@ module Engine
 
         GAME_TITLE = '18 Los Angeles'
         # GAME_IS_VARIANT_OF = G18LosAngeles::Meta
+        GAME_ALIASES = ['18LA_1'].freeze
       end
     end
   end

--- a/lib/engine/game/g_18_los_angeles1/meta.rb
+++ b/lib/engine/game/g_18_los_angeles1/meta.rb
@@ -13,6 +13,8 @@ module Engine
         DEV_STAGE = :production
         DEPENDS_ON = '18 Los Angeles 2'
 
+        GAME_PUBLISHER = %i[traxx sea_horse].freeze
+
         GAME_TITLE = '18 Los Angeles'
         # GAME_IS_VARIANT_OF = G18LosAngeles::Meta
         GAME_ALIASES = ['18LA_1'].freeze

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -37,8 +37,8 @@ module Engine
       G1889 => ['1889', 'Shikoku', 'Shikoku 1889', 'History of Shikoku Railways'],
       G18Chesapeake => %w[18Chesapeake Chessie],
       G18ChesapeakeOffTheRails => ['ChesapeakeOTR', 'OTR', '18Chesapeake: Off the Rails'],
-      G18LosAngeles1 => ['18 Los Angeles'],
-      G18LosAngeles => ['18 Los Angeles 2', '18LA'],
+      G18LosAngeles1 => ['18 Los Angeles', '18LA1'],
+      G18LosAngeles => ['18 Los Angeles 2', '18LA', '18LA2'],
     }.each do |game_module, fuzzy_titles|
       expected_title = game_module.const_get('Meta').title
 


### PR DESCRIPTION
* new map
* entity changes that can be handled in config (e.g., changing homes/reservations etc)
* new private companies are stubbed out (will implement their new abilities later)
* some minor miscellaneous things: meta.rb changes, make `/map/18LA1` and `/map/18LA2` URLs work as expected, fix imports, when logging companies/corporations in the game for 1846-family games, log them in sorted order

The most substantial code changes are in `lib/engine/game/g_18_los_angeles1/game.rb`, which adds logic so that 18LA1 can use the entities from 18LA2 and only override them when different values are set via the constants `COMPANIES_1E` and `CORPORATIONS_1E`

Local validation has been done to confirm this doesn't break any existing 18LA games.

#7110