### PR TITLE
Correctly identify multi-city upgrades even when there are disconnected cities

### DIFF
--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -357,7 +357,7 @@ module Engine
         new_exits = tile.exits
         new_ctedges = tile.city_town_edges
         extra_cities = [0, new_ctedges.size - old_ctedges.size].max
-        multi_city_upgrade = new_ctedges.size > 1 && old_ctedges.size > 1
+        multi_city_upgrade = tile.cities.size > 1 && hex.tile.cities.size > 1
 
         new_exits.all? { |edge| hex.neighbors[edge] } &&
           !(new_exits & hex_neighbors(entity, hex)).empty? &&


### PR DESCRIPTION
This ensures that only valid tile lays and rotations are shown for e.g. OO tiles with only one connected city upgrading to have both cities connected and is a big UI upgrade for 18GB in particular but also any other current and future titles with these sort of tiles.
- Closes #7333
- Closes #7336