### PR TITLE
[18USA] Rulebook has the incorrect value for DFW's brown tile. 

### DIFF
--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -16,7 +16,7 @@ module Engine
         @teleport_price = teleport_price
         @extra_action = extra_action || false
         @from_owner = from_owner || false
-        @discount = discount || 0
+        @discount = discount
         @city = city
         @neutral = neutral || false
         @cheater = cheater || false

--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -16,7 +16,7 @@ module Engine
         @teleport_price = teleport_price
         @extra_action = extra_action || false
         @from_owner = from_owner || false
-        @discount = discount
+        @discount = discount || 0
         @city = city
         @neutral = neutral || false
         @cheater = cheater || false

--- a/lib/engine/game/g_18_usa/entities.rb
+++ b/lib/engine/game/g_18_usa/entities.rb
@@ -714,9 +714,14 @@ module Engine
             icon: 'subsidy_free_station',
             abilities: [
               {
-                type: 'additional_token',
-                count: 1,
+                type: 'token',
+                when: 'owning_corp_or_turn',
                 owner_type: 'corporation',
+                count: 1,
+                from_owner: false,
+                cheater: 0,
+                special_only: true,
+                hexes: [], # Determined in special_token step
               },
             ],
             id: 'S9',

--- a/lib/engine/game/g_18_usa/entities.rb
+++ b/lib/engine/game/g_18_usa/entities.rb
@@ -717,6 +717,7 @@ module Engine
                 type: 'token',
                 when: 'owning_corp_or_turn',
                 owner_type: 'corporation',
+                price: 0,
                 count: 1,
                 from_owner: false,
                 cheater: 0,

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -905,9 +905,6 @@ module Engine
           return unless (subsidy = corporation.companies.first)
 
           case subsidy.id
-          when 'S9'
-            corporation.tokens << Engine::Token.new(corporation)
-            subsidy.close!
           when 'S10'
             subsidy.owner.tokens.first.hex.tile.icons << Engine::Part::Icon.new('18_usa/plus_ten', 'plus_ten', true)
             subsidy.close!

--- a/lib/engine/game/g_18_usa/map.rb
+++ b/lib/engine/game/g_18_usa/map.rb
@@ -165,7 +165,7 @@ module Engine
           'X14' => {
             'count' => 1,
             'color' => 'brown',
-            'code' => 'city=revenue:80,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;'\
+            'code' => 'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;'\
                       'label=DFW',
           },
           'X15' => {

--- a/lib/engine/game/g_18_usa/step/special_token.rb
+++ b/lib/engine/game/g_18_usa/step/special_token.rb
@@ -11,13 +11,12 @@ module Engine
             super
 
             entity = action.entity
-            return unless entity.id == 'P20'
-
             @game.log << "#{entity.name} closes"
             entity.close!
           end
 
           def available_hex(entity, hex)
+            return s9_available_hex(entity, hex) if entity.id == 'S9'
             return false unless entity.id == 'P20'
             return false if @game.class::COMPANY_TOWN_TILES.include?(hex.tile.name)
 
@@ -26,10 +25,21 @@ module Engine
               @game.graph.connected_hexes(corporation)[hex]
           end
 
+          def s9_available_hex(entity, hex)
+            !hex.tile.cities.empty? &&
+              !hex.tile.cities.first.tokened_by?(entity.owner) &&
+              @game.graph.reachable_hexes(entity.owner).include?(hex)
+          end
+
           def ability(entity)
             return unless entity&.company?
 
-            @game.abilities(entity, :token, time: '%current_step%')
+            possible_times = [
+              '%current_step%',
+              'owning_corp_or_turn',
+            ]
+
+            @game.abilities(entity, :token, time: possible_times)
           end
         end
       end


### PR DESCRIPTION
- Update DFW Brown tile to correct value of 60 (wrong in 1.4 rulebook)
- Change Free station subsidy from extra_token to token ability and allow it to be placed in a tokened out city