### PR TITLE
[1822] punch labels through plain yellow tiles for C and T hexes

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -45,6 +45,10 @@ module Engine
 
         TILE_TYPE = :lawson
 
+        PLAIN_SYMBOL_HEXES = {
+          yellow: %w[D35 B43 K42 M42],
+        }.freeze
+
         MARKET = [
           ['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '550', '600', '650', '700e'],
           ['', '', '', '', '', '', '', '', '', '', '', '', '', '330', '360', '400', '450', '500', '550', '600', '650'],
@@ -1289,11 +1293,15 @@ module Engine
 
         def after_lay_tile(hex, old_tile, tile)
           if old_tile.label
-            # add label to new tile, if this is a plain lay on a label
-            new_tile.label = old_tile.label.to_s unless new_tile.label
+            # add temporary label to designated plain tile lays
+            if PLAIN_SYMBOL_HEXES.include?(tile.color) &&
+               PLAIN_SYMBOL_HEXES[tile.color].include?(hex.id) &&
+               !tile.label
+              tile.label = old_tile.label.to_s
+            end
 
             # remove the label when we upgrade a temporarily labelled tile
-            if PLAIN_SYMBOL_HEXES.include(old_tile.color) &&
+            if PLAIN_SYMBOL_HEXES.include?(old_tile.color) &&
                PLAIN_SYMBOL_HEXES[old_tile.color].include?(hex.id)
               old_tile.label = nil
             end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1287,7 +1287,18 @@ module Engine
           @london_extra_city_index = city.tile.cities.index { |c| c == city }
         end
 
-        def after_lay_tile(hex, tile)
+        def after_lay_tile(hex, old_tile, tile)
+          if old_tile.label
+            # add label to new tile, if this is a plain lay on a label
+            new_tile.label = old_tile.label.to_s unless new_tile.label
+
+            # remove the label when we upgrade a temporarily labelled tile
+            if PLAIN_SYMBOL_HEXES.include(old_tile.color) &&
+               PLAIN_SYMBOL_HEXES[old_tile.color].include?(hex.id)
+              old_tile.label = nil
+            end
+          end
+
           # If we upgraded london, check if we need to add the extra slot from minor 14
           upgrade_london(hex) if hex.name == self.class::LONDON_HEX
 

--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -28,6 +28,7 @@ module Engine
           end
 
           def process_lay_tile(action)
+            old_tile = action.hex.tile
             entity = action.entity
             ability = abilities(entity)
             spender = if !entity.owner
@@ -54,7 +55,7 @@ module Engine
               lay_tile_action(action, spender: spender)
             end
             @in_process = false
-            @game.after_lay_tile(action.hex, action.tile)
+            @game.after_lay_tile(action.hex, old_tile, action.tile)
             ability.use!
 
             if ability.type == :tile_lay && ability.count <= 0 && ability.closed_when_used_up

--- a/lib/engine/game/g_1822/step/track.rb
+++ b/lib/engine/game/g_1822/step/track.rb
@@ -48,10 +48,12 @@ module Engine
           end
 
           def process_lay_tile(action)
+            old_tile = action.hex.tile
+
             lay_tile_action(action)
             pass! unless can_lay_tile?(action.entity)
 
-            @game.after_lay_tile(action.hex, action.tile)
+            @game.after_lay_tile(action.hex, old_tile, action.tile)
           end
 
           def process_pass(action)


### PR DESCRIPTION
This change adds temporary labels to the plain yellow tiles laid on T and S hexes in 1822. They upgrade to named label tiles in green. 

Include hex match logic rather than operating on all plain tile lays over labels so that this can be incorporated selectively into 1822 derivative games. 

FIxes #7132