### PR TITLE
Display ability descriptions for all corporation cards, now including minors

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -75,10 +75,7 @@ module View
             children << render_minors(ms)
           end
         end
-
-        abilities_to_display = @corporation.all_abilities.select do |ability|
-          ability.owner.corporation? && ability.description
-        end
+        abilities_to_display = @corporation.all_abilities.select(&:description)
         children << render_abilities(abilities_to_display) if abilities_to_display.any?
 
         extras = []


### PR DESCRIPTION
I went looking for `MINOR` and `game_minors` and the only game I saw that had a minor with an ability that had a description other than 18Dixie was 1893
18Dixie:
![image](https://user-images.githubusercontent.com/2993555/155985565-d97e8893-a03f-424a-8736-12bc7baf6307.png)
1893 EKB shows the ability description now
![image](https://user-images.githubusercontent.com/2993555/155986336-7fb49de0-b44b-49ce-8373-358872e5131b.png)
The minors in 1835 which have abilities, but not descriptions, are unaffected
![image](https://user-images.githubusercontent.com/2993555/155986880-7d35906c-2a60-4963-be1e-a5576e8c3f52.png)

I also trimmed the description of the EKB's ability so that it doesn't get clipped