### PR TITLE
21Moon: show bases when cross-buying trains

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -305,7 +305,7 @@ module View
       def other_trains(other_corp_trains, corporation)
         hidden_trains = false
         trains_to_buy = other_corp_trains.flat_map do |other, trains|
-          trains.group_by(&:name).flat_map do |name, group|
+          trains.group_by { |t| @game.train_purchase_name(t) }.flat_map do |name, group|
             fixed_price = @step.respond_to?(:fixed_price) && @step.fixed_price(group[0])
             input = if fixed_price
                       h('div.right', @game.format_currency(fixed_price))

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2776,6 +2776,10 @@ module Engine
         false
       end
 
+      def train_purchase_name(train)
+        train.name
+      end
+
       # If a game overrides this to true, then if the possible actions for the current entity include any of
       #   buy_train, scrap_train, or reassign_train then
       # the Operating view will be used instead of the Merger round view for train actiosn in a merger round.

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -949,6 +949,10 @@ module Engine
           lb_city?(token.city, corporation)
         end
 
+        def train_purchase_name(train)
+          "#{@train_base[train].to_s.upcase}:#{train.name}"
+        end
+
         def show_map_legend?
           true
         end


### PR DESCRIPTION
Fixes #7364 

New UI when buying trains:
![21Moon_purchase_name](https://user-images.githubusercontent.com/8494213/156249142-0b8fa34f-f74b-4295-93b6-99b82ea50f27.png)

