### PR TITLE
18LA2: new setup rules for corporations and companies

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -281,7 +281,7 @@ module Engine
               abilities(corporation, :reservation) do |ability|
                 corporation.remove_ability(ability)
               end
-              place_second_token(corporation, deferred: true)
+              place_second_token(corporation, **place_second_token_kwargs)
             end
           end
           @log << "Privates in the game: #{@companies.reject { |c| c.name.include?('Pass') }.map(&:name).sort.join(', ')}"
@@ -368,6 +368,10 @@ module Engine
 
         def corporation_removal_groups
           two_player? ? [NORTH_GROUP, SOUTH_GROUP] : [GREEN_GROUP]
+        end
+
+        def place_second_token_kwargs
+          { deferred: true }
         end
 
         def place_second_token(corporation, two_player_only: true, deferred: true)

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -32,24 +32,26 @@ module Engine
           'LAS' => '/icons/1846/sc_token.svg',
         }.freeze
 
-        ORANGE_GROUP = [
-          'Beverly Hills Carriage',
-          'South Bay Line',
+        CORPORATIONS_GROUP = %w[
+          ELA
+          LA
+          LAIR
+          PER
+          SF
+          SP
+          UP
         ].freeze
-
-        BLUE_GROUP = [
-          'Chino Hills Excavation',
-          'Los Angeles Citrus',
-          'Los Angeles Steamship',
-        ].freeze
-
-        GREEN_GROUP = %w[LA SF SP].freeze
 
         REMOVED_CORP_SECOND_TOKEN = {
+          'ELA' => 'C4',
           'LA' => 'B9',
-          'SF' => 'C8',
+          'LAIR' => 'E6',
+          'SF' => 'D11',
           'SP' => 'C6',
+          'UP' => 'B13',
         }.freeze
+
+        HOME_TOKEN_TIMING = :float
 
         ABILITY_ICONS = {
           SBL: 'sbl',
@@ -73,6 +75,17 @@ module Engine
           'remove_markers' => ['Remove Markers', 'Remove LA Steamship and LA Citrus markers']
         ).freeze
 
+        def setup
+          super
+          post_setup
+        end
+
+        def post_setup
+          @corporations.each do |corporation|
+            place_home_token(corporation) unless corporation.id == 'PER'
+          end
+        end
+
         def setup_turn
           1
         end
@@ -94,24 +107,16 @@ module Engine
           hexes
         end
 
-        def num_removals(group)
-          return 0 if @players.size == 5
-          return 1 if @players.size == 4
-
-          case group
-          when ORANGE_GROUP, BLUE_GROUP
-            1
-          when GREEN_GROUP
-            2
-          end
+        def num_removals(_group)
+          two_player? ? 2 : 0
         end
 
         def corporation_removal_groups
-          [GREEN_GROUP]
+          two_player? ? [CORPORATIONS_GROUP] : []
         end
 
-        def place_second_token(corporation, **_kwargs)
-          super(corporation, two_player_only: false, deferred: false)
+        def place_second_token_kwargs
+          { two_player_only: true, deferred: false }
         end
 
         def init_round

--- a/lib/engine/game/g_18_los_angeles1/game.rb
+++ b/lib/engine/game/g_18_los_angeles1/game.rb
@@ -13,6 +13,27 @@ module Engine
         include Entities
         include Map
 
+        ORANGE_GROUP = [
+          'Beverly Hills Carriage',
+          'South Bay Line',
+        ].freeze
+
+        BLUE_GROUP = [
+          'Chino Hills Excavation',
+          'Los Angeles Citrus',
+          'Los Angeles Steamship',
+        ].freeze
+
+        GREEN_GROUP = %w[LA SF SP].freeze
+
+        REMOVED_CORP_SECOND_TOKEN = {
+          'LA' => 'B9',
+          'SF' => 'C8',
+          'SP' => 'C6',
+        }.freeze
+
+        def post_setup; end
+
         def game_companies
           @game_companies ||=
             self.class::COMPANIES + (G18LosAngeles::Game::COMPANIES.slice(0, 11).map do |company|
@@ -25,6 +46,26 @@ module Engine
             G18LosAngeles::Game::CORPORATIONS.map do |company|
               self.class::CORPORATIONS_1E[company[:sym]] || company
             end
+        end
+
+        def num_removals(group)
+          return 0 if @players.size == 5
+          return 1 if @players.size == 4
+
+          case group
+          when ORANGE_GROUP, BLUE_GROUP
+            1
+          when GREEN_GROUP
+            2
+          end
+        end
+
+        def corporation_removal_groups
+          [GREEN_GROUP]
+        end
+
+        def place_second_token_kwargs
+          { two_player_only: false, deferred: false }
         end
       end
     end


### PR DESCRIPTION
the new setup rules in 18LA2 are all home tokens (except PER, whose home is
determined on float) are placed at setup and no corporations/companies are
removed, but there is a limit on how many corporations/companies may be
started/drafted (that limit is not implemented here)

exception: 2-player setup now removes *any* 2 random corporations, and still
places two tokens; now all corporations are given a second location, and some of
have changed, so this constant is present in both versions of the game.rb files

* GROUP constants moved to 1st Edition
* 2nd Edition uses new `post_setup` method to place all home corporation tokens;
  1st Edition overrides `post_setup` with a noop
* new method on G1846, `place_second_token_kwargs`, to easily give
  1846/18LA1/18LA2 all different ways of working with a removed corporation's
  second token

#7110