### PR TITLE
18LA2: company and corporation limits

### DIFF
--- a/lib/engine/game/g_18_los_angeles/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_los_angeles/step/buy_sell_par_shares.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1846/step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G18LosAngeles
+      module Step
+        class BuySellParShares < G1846::Step::BuySellParShares
+          def help
+            return unless @game.players.size == 3 || @game.players.size == 4
+
+            num = @game.par_limit - @game.parred_corporations
+            "#{num} more corporation#{num == 1 ? '' : 's'} may be started"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles/step/draft_distribution.rb
+++ b/lib/engine/game/g_18_los_angeles/step/draft_distribution.rb
@@ -16,6 +16,7 @@ module Engine
           def process_bid(_action)
             entities.each(&:unpass!)
             super
+            @game.after_bid
           end
 
           def process_pass(action)
@@ -23,6 +24,17 @@ module Engine
             @round.next_entity_index!
             @round.next_entity_index! if current_entity == action.entity
             action.entity.pass!
+          end
+
+          def finished?
+            @game.draft_finished? || super
+          end
+
+          def help
+            return unless @game.drafted_companies
+
+            num = @game.draft_limit - @game.drafted_companies
+            "#{num} more #{num == 1 ? 'company' : 'companies'} may be drafted"
           end
         end
       end

--- a/lib/engine/game/g_18_los_angeles1/game.rb
+++ b/lib/engine/game/g_18_los_angeles1/game.rb
@@ -67,6 +67,20 @@ module Engine
         def place_second_token_kwargs
           { two_player_only: false, deferred: false }
         end
+
+        def after_par_check_limit!; end
+
+        def after_bid; end
+
+        def draft_finished?; end
+
+        def stock_round
+          Engine::Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            G1846::Step::Assign,
+            G1846::Step::BuySellParShares,
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
instead of removing companies/corporations during setup, 18LA2 does the
following:

* end company draft when limit is reached
* close unstarted corporations when max have been started

This also adds `help` to the draft and stock round steps to inform users how many more companies can be drafted or corporations started.

#7110