### PR TITLE
Fix for 18NY having both plain and symbol upgrades in some phases.

### DIFF
--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -716,7 +716,11 @@ module Engine
         def upgrades_to_correct_label?(from, to)
           # handle lays of a plain tile over a hex/tile with a label
 
-          return true if PLAIN_SYMBOL_HEXES.include?(to.color) && PLAIN_SYMBOL_HEXES[to.color].include?(from.hex.name)
+          if PLAIN_SYMBOL_HEXES.include?(to.color) &&
+             PLAIN_SYMBOL_HEXES[to.color].include?(from.hex.name) &&
+             !to.label
+            return true
+          end
 
           super
         end


### PR DESCRIPTION
This adds a check to prevent any special tile being laid if it is availabls, as 18NY has special tiles appear in different phases.

Fixes #7374