### PR TITLE
1846 2p: fix string/symbol issue for tokens on upgrade

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -397,7 +397,7 @@ module Engine
 
         def place_token_on_upgrade(action)
           hex_id = action.tile.hex.id
-          return unless action.tile.color == 'green' && @second_tokens_in_green.include?(hex_id)
+          return unless action.tile.color == :green && @second_tokens_in_green.include?(hex_id)
 
           corporation = @second_tokens_in_green[hex_id]
           token = corporation.find_token_by_type


### PR DESCRIPTION
In the Ruby, the tile color is `:green`, not `'green'`, but in the JS `:green` gets translated to `'green'`. This means that in the backend engine, the token didn't actually get placed, leading to the backend and browser disagreeing on what the current step should be.

[Fixes #7361]