### PR TITLE
18GB Alpha changes

### DIFF
--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -234,7 +234,7 @@ module Engine
           },
           {
             name: 'Maryport & Carlisle',
-            value: 60,
+            value: 50,
             revenue: 20,
             desc: 'The MC allows a corporation to lay a Station Marker in Carlisle (H9). A space is reserved for the MC until ' \
                   'the blue phase, otherwise an empty space must be available in Carlisle. The MC owner may use this ability ' \

--- a/lib/engine/game/g_18_gb/meta.rb
+++ b/lib/engine/game/g_18_gb/meta.rb
@@ -16,7 +16,7 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18GB'
         GAME_LOCATION = 'Great Britain'
         GAME_PUBLISHER = :golden_spike
-        GAME_RULES_URL = 'https://drive.google.com/file/d/1i4Sfje2blnEIzrQi5DvISSSa1Kz2s7Ur/view'
+        GAME_RULES_URL = 'https://docs.google.com/document/d/12yNo5WAi6ywc6N5XmTl-FvAZeI5kLwCMkxhgf7jgNSk/view'
 
         PLAYER_RANGE = [2, 6].freeze
         OPTIONAL_RULES = [


### PR DESCRIPTION
- Update the Info page's rules link to point to 2nd edition rules rather than 1st edition (consistent with wiki)
- The MC private should cost £50, not £60 (2nd edition rules change)