### PR TITLE
1873: add +/- train controls

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2732,15 +2732,15 @@ module Engine
         nil
       end
 
-      def adjustable_train_list?
+      def adjustable_train_list?(_entity)
         false
       end
 
-      def adjustable_train_sizes?
+      def adjustable_train_sizes?(_entity)
         false
       end
 
-      def reset_adjustable_trains!; end
+      def reset_adjustable_trains!(_entity, _routes); end
 
       def operation_round_short_name
         self.class::OPERATION_ROUND_SHORT_NAME

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -400,6 +400,22 @@ module Engine
           new_train
         end
 
+        def unallocate_pool_diesel(entity, train)
+          s_train = entity.trains.find { |t| diesel?(t) }
+          return unless s_train
+          return if train == s_train
+          return unless @subtrains[s_train].include?(train)
+          return unless @subtrains[s_train].size > 1 # always leave one allocated per supertrain
+          return if @subtrains[s_train][0] == train # always leave the first
+          return unless @diesel_pool[train]
+          return unless @diesel_pool[train][:allocated]
+
+          @diesel_pool[train][:allocated] = false
+          @diesel_pool[train][:used] = false
+          @subtrains[s_train].delete(train)
+          @supertrains.delete(train)
+        end
+
         def free_pool_diesels(entity)
           s_train = entity.trains.find { |t| diesel?(t) }
           return unless s_train
@@ -1668,8 +1684,6 @@ module Engine
         def check_distance(route, visits)
           train = route.train
 
-          add_new_diesel(route) if diesel?(route.train)
-
           # no real "distance" for 1873 routes, instead might as well use visits for checks:
           # check that route begins and ends with termini
           corporation = train_owner(route.train)
@@ -1829,16 +1843,6 @@ module Engine
           raise GameError, 'Diesel route has to directly or indirectly connect to concession route'
         end
 
-        def add_new_diesel(route)
-          # add diesel to end if all diesel routes are defined
-          s_train = @supertrains[route.train]
-          num_diesel_routes = route.routes.count { |r| diesel?(r.train) }
-          num_diesels = @subtrains[s_train].size
-          return unless num_diesel_routes == num_diesels
-
-          allocate_pool_diesel(route.train)
-        end
-
         def concession_route_run?(entity, routes)
           return true if entity == @qlb
           return false unless routes
@@ -1948,6 +1952,30 @@ module Engine
         def revenue_str(route)
           str = super
           concession_route?(route.corporation, route) ? "#{str} (concession)" : str
+        end
+
+        def adjustable_train_list?(entity)
+          entity.trains.any? { |t| diesel?(t) }
+        end
+
+        def adjustable_train_label(_entity)
+          'Diesel'
+        end
+
+        # add diesel to end
+        def add_route_train(entity, _routes)
+          diesel = entity.trains.find { |t| diesel?(t) }
+          return unless diesel
+
+          allocate_pool_diesel(diesel)
+        end
+
+        def delete_route_train(entity, route)
+          train = route.train
+          return unless diesel?(train)
+          return if entity.trains.include?(route.train)
+
+          unallocate_pool_diesel(entity, train)
         end
         #
         # end of route methods

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -711,16 +711,19 @@ module Engine
           @corporation_trains[entity] = nil
         end
 
-        def adjustable_train_list?
+        def adjustable_train_list?(_entity)
           true
         end
 
-        def adjustable_train_sizes?
+        def adjustable_train_sizes?(_entity)
           true
         end
 
-        def reset_adjustable_trains!(routes)
-          entity = routes[0].train.owner
+        def adjustable_train_label(_entity)
+          'Train'
+        end
+
+        def reset_adjustable_trains!(entity, _routes)
           raise GameError, 'Unable to find owner' unless entity
 
           return unless @corporation_trains[entity]
@@ -729,8 +732,7 @@ module Engine
           @corporation_trains[entity].each { |t| append_var_train(entity, t) }
         end
 
-        def add_route_train(routes)
-          entity = routes[0].train.owner
+        def add_route_train(entity, _routes)
           raise GameError, 'Unable to find owner' unless entity
 
           current_distance = entity.trains.sum(&:distance)
@@ -742,13 +744,13 @@ module Engine
           raise GameError, "Unable to allocate train of distance #{min_train}" unless new_train
 
           append_var_train(entity, new_train)
-          true
+          new_train
         end
 
-        def delete_route_train(route)
+        def delete_route_train(entity, route)
           train = route.train
-          entity = train.owner
           raise GameError, 'Unable to find owner' unless entity
+          raise GameError, 'Wrong owner' unless entity == train.owner
 
           return false if train.owner.receivership? && must_buy_power?(entity)
           return false if entity.trains.one?
@@ -758,10 +760,10 @@ module Engine
           true
         end
 
-        def increase_route_train(route)
+        def increase_route_train(entity, route)
           train = route.train
-          entity = train.owner
           raise GameError, 'Unable to find owner' unless entity
+          raise GameError, 'Wrong owner' unless entity == train.owner
 
           return if train.distance == MAX_TRAIN
 
@@ -773,10 +775,10 @@ module Engine
           route.train = new_train
         end
 
-        def decrease_route_train(route)
+        def decrease_route_train(entity, route)
           train = route.train
-          entity = train.owner
           raise GameError, 'Unable to find owner' unless entity
+          raise GameError, 'Wrong owner' unless entity == train.owner
 
           return if train.distance == min_train
 


### PR DESCRIPTION
Fixes #5854 

Common code edits:
- UI::RouteSelector - generalize variable train calls to include entity, select route for newly added train
- Engine::Game::Base - support for above

New UI:
![Harzbahn_add_diesel](https://user-images.githubusercontent.com/8494213/156943303-77093ec0-9b9b-4369-b179-ab80a63e0470.png)

