### PR TITLE
18Tokaido: fix problems introduced by #7372

### DIFF
--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -24,6 +24,8 @@ module Engine
                         orange: '#f48221',
                         brown: '#7b352a')
 
+        attr_reader :drafted_companies
+
         TRACK_RESTRICTION = :permissive
         CURRENCY_FORMAT_STR = '¥%d'
         CERT_LIMIT = { 2 => 24, 3 => 16, 4 => 12 }.freeze
@@ -345,6 +347,8 @@ module Engine
         def sleeper_train
           @sleeper_train ||= company_by_id('ST')
         end
+
+        def draft_finished?; end
       end
     end
   end


### PR DESCRIPTION
18Tokaido uses 18LA's draft, which was modified in PR #7372 to support stopping
the draft once a specified number of companies had been selected; that mechanism
requires a couple more methods in the game class