### PR TITLE
18LA2: private company Redondo Junction

### DIFF
--- a/lib/engine/game/g_18_los_angeles/entities.rb
+++ b/lib/engine/game/g_18_los_angeles/entities.rb
@@ -263,8 +263,23 @@ module Engine
             sym: 'RJ',
             value: 50,
             revenue: 10,
-            desc: '',
-            abilities: [],
+            desc: 'Place the "RJ" token in any location except Los Angeles or Long Beach. This token '\
+                  'acts as a station token for the owning corporation until Phase IV.',
+            abilities: [
+              {
+                type: 'token',
+                when: 'owning_corp_or_turn',
+                owner_type: 'corporation',
+                hexes: %w[
+                  A4 A6 A8 B5 B9 B11 B13 C4 C8 C12 D5 D7 D9 D11 D13
+                  E4 E6 E10 E12 F9 F11 F13
+                ],
+                price: 0,
+                teleport_price: 0,
+                count: 1,
+                extra_action: true,
+              },
+            ],
           },
           {
             name: 'RKO Pictures',

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -29,6 +29,7 @@ module Engine
                         purple: '#832e9a')
 
         attr_reader :drafted_companies, :parred_corporations
+        attr_accessor :rj_token
 
         ASSIGNMENT_TOKENS = {
           'LAC' => '/icons/18_los_angeles/lac_token.svg',
@@ -82,7 +83,7 @@ module Engine
         BOOMTOWN_REVENUE_DESC = 'RKO'
 
         EVENTS_TEXT = G1846::Game::EVENTS_TEXT.merge(
-          'remove_markers' => ['Remove Markers', 'Remove LA Steamship, LA Citrus, and RKO Pictures markers']
+          'remove_markers' => ['Remove Tokens & Markers', 'Remove RJ token and LA Steamship, LA Citrus, and RKO Pictures markers']
         ).freeze
 
         CORPORATION_START_LIMIT = {
@@ -275,6 +276,10 @@ module Engine
           @dch ||= company_by_id('DC&H')
         end
 
+        def rj
+          @rj ||= company_by_id('RJ')
+        end
+
         def block_for_steamboat?
           false
         end
@@ -377,6 +382,22 @@ module Engine
 
         def east_west_desc
           'E/W or N/S'
+        end
+
+        def event_remove_markers!
+          super
+
+          # piggy-back on the markers event to avoid redefining all the trains
+          # from 1846 just for the sake of adding a single new event
+          event_remove_rj_token!
+        end
+
+        def event_remove_rj_token!
+          return unless rj_token
+
+          @log << "-- Event: #{rj_token.corporation.id}'s \"RJ\" token removed from #{rj_token.hex.id} --"
+          rj_token.destroy!
+          @rj_token = nil
         end
       end
     end

--- a/lib/engine/game/g_18_los_angeles/step/special_token.rb
+++ b/lib/engine/game/g_18_los_angeles/step/special_token.rb
@@ -14,6 +14,13 @@ module Engine
             end
 
             super
+
+            return unless action.entity == @game.rj
+
+            token = action.city.tokens[action.slot]
+            token.logo = token.logo.sub('.svg', '_RJ.svg')
+            token.simple_logo = token.logo
+            @game.rj_token = token
           end
         end
       end

--- a/lib/engine/token.rb
+++ b/lib/engine/token.rb
@@ -2,8 +2,8 @@
 
 module Engine
   class Token
-    attr_reader :logo, :simple_logo, :extra
-    attr_accessor :city, :price, :type, :used, :status, :hex, :corporation
+    attr_reader :extra
+    attr_accessor :city, :price, :type, :used, :status, :hex, :corporation, :logo, :simple_logo
 
     def initialize(corporation, price: 0, logo: nil, simple_logo: nil, type: :normal)
       @corporation = corporation

--- a/public/logos/18_los_angeles/ELA_RJ.svg
+++ b/public/logos/18_los_angeles/ELA_RJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ff0000"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial" fill="#fff">RJ</text></svg>

--- a/public/logos/18_los_angeles/LAIR_RJ.svg
+++ b/public/logos/18_los_angeles/LAIR_RJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#b8ffff"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial">RJ</text></svg>

--- a/public/logos/18_los_angeles/LA_RJ.svg
+++ b/public/logos/18_los_angeles/LA_RJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#00830e"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial" fill="#fff">RJ</text></svg>

--- a/public/logos/18_los_angeles/PER_RJ.svg
+++ b/public/logos/18_los_angeles/PER_RJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ff6a00"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial">RJ</text></svg>

--- a/public/logos/18_los_angeles/SF_RJ.svg
+++ b/public/logos/18_los_angeles/SF_RJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ff7fed"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial">RJ</text></svg>

--- a/public/logos/18_los_angeles/SP_RJ.svg
+++ b/public/logos/18_los_angeles/SP_RJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#0026ff"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial" fill="#fff">RJ</text></svg>

--- a/public/logos/18_los_angeles/UP_RJ.svg
+++ b/public/logos/18_los_angeles/UP_RJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#727272"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial" fill="#fff">RJ</text></svg>


### PR DESCRIPTION
Redondo Junction lets the owning corporation place a token it can use as an
extra station token, until Phase IV, when the token is removed (it persists
after the company closes in Phase III)

To make it obvious which corporation owns the RJ token, each corporation has a
simple RJ "logo"--just the letters "RJ" and the corporation's color--and when
the RJ token is placed, that token's `logo` and `simple_logo` are replaced by
the corporation's RJ logo

Here's how it looks when LA uses the RJ token; LA's home is Pasadena, it has placed
another normal token in Alhambra to the southeast, and the extra token from Redondo
Junction to the west in Burbank.

![Screenshot from 2022-03-05 17-27-12](https://user-images.githubusercontent.com/1045173/156904896-8b2a8045-4ae5-4096-8b1d-7741bb02d8ba.png)


#7110