### PR TITLE
18LA2: private company Angeles Public Dump

### DIFF
--- a/lib/engine/game/g_18_los_angeles/entities.rb
+++ b/lib/engine/game/g_18_los_angeles/entities.rb
@@ -236,8 +236,24 @@ module Engine
             sym: 'APD',
             value: 40,
             revenue: 10,
-            desc: '',
-            abilities: [],
+            desc: 'Place the -20 station token in any location except for Los Angeles or Long Beach. '\
+                  'This token cannot be used by any corporation and reduces revenue in its location '\
+                  'by $20 for all corporations and minors.',
+            abilities: [
+              {
+                type: 'token',
+                when: 'owning_corp_or_turn',
+                owner_type: 'corporation',
+                hexes: %w[
+                  A4 A6 A8 B5 B9 B11 B13 C4 C8 C12 D5 D7 D9 D11 D13
+                  E4 E6 E10 E12 F9 F11 F13
+                ],
+                price: 0,
+                teleport_price: 0,
+                count: 1,
+                extra_action: true,
+              },
+            ],
           },
           {
             name: 'Los Angeles Paving',

--- a/lib/engine/game/g_18_los_angeles/step/special_token.rb
+++ b/lib/engine/game/g_18_los_angeles/step/special_token.rb
@@ -15,12 +15,18 @@ module Engine
 
             super
 
-            return unless action.entity == @game.rj
-
-            token = action.city.tokens[action.slot]
-            token.logo = token.logo.sub('.svg', '_RJ.svg')
-            token.simple_logo = token.logo
-            @game.rj_token = token
+            if action.entity == @game.rj
+              token = action.city.tokens[action.slot]
+              token.logo = token.logo.sub('.svg', '_RJ.svg')
+              token.simple_logo = token.logo
+              @game.rj_token = token
+            elsif action.entity == @game.apd
+              token = action.city.tokens[action.slot]
+              token.corporation = @game.dump_corp
+              token.logo = @game.dump_corp.logo
+              token.simple_logo = @game.dump_corp.logo
+              @game.dump_token = token
+            end
           end
         end
       end

--- a/public/logos/18_los_angeles/dump.svg
+++ b/public/logos/18_los_angeles/dump.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#000000"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial" fill="#fff">-20</text></svg>


### PR DESCRIPTION
the Dump places a -$20 station token which blocks everyone--including the owning
corporation--and reduces the city's revenue by $20 for everyone's routes

Westminster is the only $10 target for the Dump, and if the Dump is placed there
the total revenue is $0 instead of -$10. Westminster is also a target for the
Steamship (adding $40), and if both are placed there, then the Dump's full
penalty applies for a net revenue of $30