### PR TITLE
18LA2: changes for private company Chino Hills Excavation

### DIFF
--- a/lib/engine/game/g_18_los_angeles/entities.rb
+++ b/lib/engine/game/g_18_los_angeles/entities.rb
@@ -69,28 +69,6 @@ module Engine
             color: nil,
           },
           {
-            name: 'Chino Hills Excavation',
-            value: 50,
-            revenue: 20,
-            desc: 'Reduces, for the owning corporation, the total terrain cost for all tile lays by $20.',
-            sym: 'CHE',
-            abilities: [
-              {
-                type: 'tile_discount',
-                discount: 20,
-                terrain: 'mountain',
-                owner_type: 'corporation',
-              },
-              {
-                type: 'tile_discount',
-                discount: 20,
-                terrain: 'water',
-                owner_type: 'corporation',
-              },
-            ],
-            color: nil,
-          },
-          {
             name: 'Los Angeles Citrus',
             value: 60,
             revenue: 15,
@@ -229,6 +207,15 @@ module Engine
                           D13 E4 E6 E10 E12 F7 F9 F11 F13],
               },
             ],
+            color: nil,
+          },
+          {
+            name: 'Chino Hills Excavation',
+            value: 50,
+            revenue: 20,
+            desc: 'Reduces, for the owning corporation, the total terrain cost for all tile lays by $20.',
+            sym: 'CHE2',
+            abilities: [],
             color: nil,
           },
           {

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -29,7 +29,7 @@ module Engine
                         purple: '#832e9a')
 
         attr_reader :drafted_companies, :parred_corporations
-        attr_accessor :rj_token
+        attr_accessor :rj_token, :use_che_discount
 
         ASSIGNMENT_TOKENS = {
           'LAC' => '/icons/18_los_angeles/lac_token.svg',
@@ -99,6 +99,8 @@ module Engine
           4 => 10,
           5 => 11,
         }.freeze
+
+        CHE_DISCOUNT = 20
 
         def setup
           super
@@ -222,10 +224,10 @@ module Engine
             G1846::Step::Bankrupt,
             Engine::Step::Assign,
             G18LosAngeles::Step::SpecialToken,
-            G1846::Step::SpecialTrack,
+            G18LosAngeles::Step::SpecialTrack,
             G1846::Step::BuyCompany,
             G1846::Step::IssueShares,
-            G1846::Step::TrackAndToken,
+            G18LosAngeles::Step::TrackAndToken,
             Engine::Step::Route,
             G1846::Step::Dividend,
             Engine::Step::DiscardTrain,
@@ -278,6 +280,23 @@ module Engine
 
         def rj
           @rj ||= company_by_id('RJ')
+        end
+
+        def che
+          @che ||= company_by_id('CHE2')
+        end
+
+        def upgrade_cost(tile, _hex, entity, spender)
+          @use_che_discount ||= che&.owner == entity && !tile.upgrades.empty?
+
+          cost = super
+          return cost unless @use_che_discount
+
+          discount = self.class::CHE_DISCOUNT
+          @log << "#{spender.name} receives a discount of "\
+                  "#{format_currency(discount)} from "\
+                  "#{che.name}"
+          cost - discount
         end
 
         def block_for_steamboat?

--- a/lib/engine/game/g_18_los_angeles/step/special_track.rb
+++ b/lib/engine/game/g_18_los_angeles/step/special_track.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1846/step/special_track'
+require_relative 'tracker'
+
+module Engine
+  module Game
+    module G18LosAngeles
+      module Step
+        class SpecialTrack < G1846::Step::SpecialTrack
+          include Tracker
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles/step/track_and_token.rb
+++ b/lib/engine/game/g_18_los_angeles/step/track_and_token.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1846/step/track_and_token'
+require_relative 'tracker'
+
+module Engine
+  module Game
+    module G18LosAngeles
+      module Step
+        class TrackAndToken < G1846::Step::TrackAndToken
+          include Tracker
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles/step/tracker.rb
+++ b/lib/engine/game/g_18_los_angeles/step/tracker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G18LosAngeles
+      module Step
+        module Tracker
+          def process_lay_tile(action)
+            @game.use_che_discount = false
+            super
+          end
+
+          def remove_border_calculate_cost!(tile, entity, spender)
+            total_cost, types = super
+            return [total_cost, types] unless @game.che&.owner == entity
+
+            @game.use_che_discount = total_cost.positive?
+
+            [total_cost, types]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_los_angeles1/entities.rb
+++ b/lib/engine/game/g_18_los_angeles1/entities.rb
@@ -27,11 +27,7 @@ module Engine
             ],
             color: nil,
           },
-        ].freeze
-
-        # companies with different properties in 1st Edition
-        COMPANIES_1E = {
-          'CHE' => {
+          {
             name: 'Chino Hills Excavation',
             value: 60,
             revenue: 20,
@@ -48,7 +44,10 @@ module Engine
             ],
             color: nil,
           },
+        ].freeze
 
+        # companies with different properties in 1st Edition
+        COMPANIES_1E = {
           'LAC' => {
             name: 'Los Angeles Citrus',
             value: 60,

--- a/lib/engine/game/g_18_los_angeles1/game.rb
+++ b/lib/engine/game/g_18_los_angeles1/game.rb
@@ -50,7 +50,7 @@ module Engine
 
         def game_companies
           @game_companies ||=
-            self.class::COMPANIES + (G18LosAngeles::Game::COMPANIES.slice(0, 11).map do |company|
+            self.class::COMPANIES + (G18LosAngeles::Game::COMPANIES.slice(0, 10).map do |company|
                                        self.class::COMPANIES_1E[company[:sym]] || company
                                      end)
         end
@@ -91,6 +91,24 @@ module Engine
         def after_bid; end
 
         def draft_finished?; end
+
+        def operating_round(round_num)
+          @round_num = round_num
+          G1846::Round::Operating.new(self, [
+            G1846::Step::Bankrupt,
+            Engine::Step::Assign,
+            G18LosAngeles::Step::SpecialToken,
+            G1846::Step::SpecialTrack,
+            G1846::Step::BuyCompany,
+            G1846::Step::IssueShares,
+            G1846::Step::TrackAndToken,
+            Engine::Step::Route,
+            G1846::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            G1846::Step::BuyTrain,
+            [G1846::Step::BuyCompany, { blocks: true }],
+          ], round_num: round_num)
+        end
 
         def stock_round
           Engine::Round::Stock.new(self, [


### PR DESCRIPTION
1E: $20 discount to all mountain costs, can apply to more than mountain in a
single tile lay, e.g., two separate borders, or a border and the main tile
upgrade cost

2E: $20 discount for all terrain costs, but limited to one discount per tile lay

The existing `tile_discount` ability has no configurable mechanism for being
limited to a single use, so a tile's `borders` and `upgrades` are checked and raise
the flag if any terrain is found, in which case the CHE discount can be used.

In entities files, treat 1E/2E versions as completely different companies, instead of one
where the 1E definition overrides the 2E definition, so that the different IDs
can be used in the game logic to apply the different "ability" separately

#7110