### PR TITLE
18MEX: Handle NdM 5% corner case (fixes #7360)

### DIFF
--- a/lib/engine/game/g_18_mex/step/swap_buy_sell.rb
+++ b/lib/engine/game/g_18_mex/step/swap_buy_sell.rb
@@ -7,7 +7,7 @@ module SwapBuySell
   # Check if it is possible to buy an NdM share of 10%
   # when player swaps in a 5% share and return the share to be swapped in.
   def swap_buy(player, corporation, share)
-    return if @game.ndm != corporation || share.percent != 10
+    return if @game.ndm != corporation || share.percent != 10 || @game.num_certs(player) == @game.cert_limit
 
     # Must be in pool, not IPO (rule 3.2.c(5))
     return unless @game.share_pool.shares_by_corporation[corporation].include?(share)


### PR DESCRIPTION
When at cert limit, you are allowed to by yet another 5% share in NdM
as they do not count towards cert limit. But you are not allowed to
buy swap a 5% for a 10%.