### PR TITLE
Fixed incorrect region_weights for labels introduced in 6af9cd7cb5fc3…

### DIFF
--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -17,7 +17,7 @@ module View
             y: 0,
           },
           pointy: {
-            region_weights: { [0, 1] => 1.0, [2, 6] => 0.25 },
+            region_weights: { [5, 12] => 1.0, [6] => 0.25 },
             x: -65,
             y: 0,
           },
@@ -30,7 +30,7 @@ module View
             y: 0,
           },
           pointy: {
-            region_weights: { [22, 23] => 1.0, [17, 21] => 0.25 },
+            region_weights: { [11, 18] => 1.0, [17] => 0.25 },
             x: 65,
             y: 0,
           },


### PR DESCRIPTION
…dc464c34dfa7c63e78b43e253dd. I've validated the change on all games using `:pointy` (both tiles and hexes) and specifically checked 1866 which was messed up by the previous change (see https://github.com/tobymao/18xx/pull/7409#discussion_r823423885).