### PR TITLE
Revert "18JP-T: Allow corporation to have a train discount ability"

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -227,11 +227,6 @@ module View
                   entity = @selected_company
                 end
               end
-            else
-              # Handle a corporation having train discount ability
-              @game.abilities(@corporation, :train_discount, time: @step.ability_timing) do |ability|
-                price = ability.discounted_price(train, price) if ability.trains.include?(train.name)
-              end
             end
 
             price = @game.discard_discount(train, price)


### PR DESCRIPTION
This reverts commit e1320ef8c7cf3c9a36cf7e6da0e47a2642e894d8.

The commit broke train discounts in two ways:
1. It made them automatic. This should not be the case for discounts that have a "count" of how many times it can be used
2. It did not call use! on the ability to, so that "count" was updated.