### PR TITLE
18GB: Show tier information on corp charters during auction and SR1

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -539,6 +539,7 @@ module Engine
 
         def status_array(corp)
           status = []
+          status << ["Tier #{@tiers[corp.id]}", 'bold'] if @round_counter <= 1
           status << %w[10-share bold] if corp.type == :'10-share'
           status << %w[5-share bold] if corp.type == :'5-share'
           status << %w[Insolvent bold] if insolvent?(corp)


### PR DESCRIPTION
Show which tier a corporation is in on its charter during the initial auction and SR1 (rather than this only being visible in the log and by which corporations are visible to purchase shares).

After SR1 the information is no longer relevant (since any corporation can be IPOed), so no longer needs to be displayed.