### PR TITLE
[1866] fix event text

### DIFF
--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -70,7 +70,7 @@ module Engine
           'formation' => ['Formation', 'Forced formation of Major Nationals. Order of forming is: '\
                                        'Switzerland, Spain, Benelux, Austro-Hungarian Empire, Italy, France, '\
                                        'Germany, Great Britain.'],
-          'infrastructure_h' => ['Transit Hub', 'The H, transit hub infrastructure, will be available for purchase'\
+          'infrastructure_h' => ['Transit Hub', 'The H, transit hub infrastructure, will be available for purchase. '\
                                                 'The transit hub, gives one tokened city value to the treasury '\
                                                 '(when included on a route).'],
           'infrastructure_p' => ['Palace Car', 'The P, palace car infrastructure, will be available for purchase. '\


### PR DESCRIPTION
Fixes some punctuation in the Info block's event text