### PR TITLE
18Rhl: Fix Trajekt handling in Rhine Metropoles (fix #7834)

### DIFF
--- a/lib/engine/game/g_18_rhl/entities.rb
+++ b/lib/engine/game/g_18_rhl/entities.rb
@@ -237,7 +237,7 @@ module Engine
               {
                 type: 'teleport',
                 owner_type: 'player',
-                tiles: %w[921 922 923 924 925 926],
+                tiles: %w[921X 922X 923X 924X 925X 926X],
                 hexes: %w[D9 F9 I10],
                 count: 1,
                 when: %w[owning_player_or_turn],

--- a/lib/engine/game/g_18_rhl/map.rb
+++ b/lib/engine/game/g_18_rhl/map.rb
@@ -92,46 +92,52 @@ module Engine
             'code' => 'city=revenue:40;city=revenue:40;path=a:0,b:_1;path=a:1,b:_0;path=a:3,b:_1;path=a:5,b:_0;'\
                       'label=OO',
           },
-          '921' =>
+          '921X' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=D;'\
+            'code' => 'city=revenue:40,slots:1,loc:1;city=revenue:40,slots:2,loc:4;label=D;'\
+                      'path=a:0,b:_0;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_1;path=a:_0,b:_1,track:narrow;'\
                       'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0',
           },
-          '922' =>
+          '922X' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=D;'\
+            'code' => 'city=revenue:40,slots:1,loc:1;city=revenue:40,slots:2,loc:4;label=D;'\
+                      'path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_1;path=a:5,b:_1;path=a:_0,b:_1,track:narrow;'\
+                      'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0;label=D',
+          },
+          '923X' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2,loc:1;city=revenue:40,slots:1,loc:4;label=K;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_1;path=a:_0,b:_1,track:narrow;'\
                       'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0',
           },
-          '923' =>
+          '924X' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=K;'\
+            'code' => 'city=revenue:40,slots:2,loc:1;city=revenue:40,slots:1,loc:4;label=K;'\
+                      'path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_1;path=a:4,b:_1;path=a:_0,b:_1,track:narrow;'\
                       'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0',
           },
-          '924' =>
+          '925X' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=K;'\
+            'code' => 'city=revenue:40,slots:1,loc:1;city=revenue:40,slots:2,loc:4;label=DU;'\
+                      'path=a:0,b:_0;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_1;path=a:_0,b:_1,track:narrow;'\
                       'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0',
           },
-          '925' =>
+          '926X' =>
           {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=DU;'\
-                      'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0',
-          },
-          '926' =>
-          {
-            'count' => 1,
-            'color' => 'green',
-            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:5,b:_0;label=DU;'\
+            'code' => 'city=revenue:40,slots:1,loc:1;city=revenue:40,slots:2,loc:4;label=DU;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_1;path=a:5,b:_1;path=a:_0,b:_1,track:narrow;'\
                       'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0',
           },
           '927' =>
@@ -244,7 +250,7 @@ module Engine
           {
             'count' => 1,
             'color' => 'gray',
-            'code' => 'city=revenue:60,slots:3,loc:center;town=revenue:20,loc:4;path=a:0,b:_0;path=a:1,b:_0;'\
+            'code' => 'city=revenue:60,slots:3,loc:center;town=revenue:20,loc:2;path=a:0,b:_0;path=a:1,b:_0;'\
                       'path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=DU',
           },
           '950' =>

--- a/lib/engine/game/g_18_rhl/round/operating.rb
+++ b/lib/engine/game/g_18_rhl/round/operating.rb
@@ -8,6 +8,14 @@ module Engine
       module Round
         class Operating < Engine::Round::Operating
           attr_accessor :teleport_ability
+
+          def start_operating
+            super
+
+            return if finished?
+
+            @game.update_token_blocking_in_rhine_metropolies(@current_operator)
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_rhl/step/lay_tile_checks.rb
+++ b/lib/engine/game/g_18_rhl/step/lay_tile_checks.rb
@@ -12,6 +12,8 @@ module LayTileChecks
       potentially_close_private(action, @game.angertalbahn)
     when 'E14'
       potentially_remove_ability_from_private(action, @game.prinz_wilhelm_bahn)
+    when 'I10', 'F9', 'D9'
+      @game.update_token_blocking_in_rhine_metropolies(@round.current_operator)
     end
   end
 

--- a/lib/engine/game/g_18_rhl/step/special_token.rb
+++ b/lib/engine/game/g_18_rhl/step/special_token.rb
@@ -36,7 +36,9 @@ module Engine
             place_token(
               @round.teleported,
               action.city,
-              action.token,
+              # Due to changing the token type, this can cause problems when doing undo.
+              # As a fall back assume first available token of type normal/neutral is OK
+              @game.get_token(entity, action.token),
               connected: false,
               special_ability: ability(entity),
               spender: @game.current_entity,

--- a/lib/engine/game/g_18_rhl/step/token.rb
+++ b/lib/engine/game/g_18_rhl/step/token.rb
@@ -13,6 +13,12 @@ module Engine
 
             super
           end
+
+          def place_token(entity, city, token)
+            # Due to changing the token type, this can cause problems when doing undo.
+            # As a fall back assume first available token of type normal/neutral is OK
+            super(entity, city, @game.get_token(entity, token))
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_rhl/step/track.rb
+++ b/lib/engine/game/g_18_rhl/step/track.rb
@@ -24,6 +24,23 @@ module Engine
 
             super
           end
+
+          RHINE_METROPOLIS_HEXES = %w[D9 F9 I10].freeze
+
+          def upgradeable_tiles(entity, hex)
+            return super unless RHINE_METROPOLIS_HEXES.include?(hex.name)
+
+            potential_tiles(entity, hex).map do |tile|
+              tile.rotate!(0)
+              tile
+            end.compact
+          end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            return true if RHINE_METROPOLIS_HEXES.include?(hex.name)
+
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
Redesigned the three green Rhine Metropole hexes to be 2+1/1+2
cities in appearance, but work as one city with 3 slots in
practice. This means that a green such hex that has one or
more slots untokened are passable by everyone. And that such
green hex that are fully tokened are passable for the 3
corporations that have a token in any slot on the hex.

To accomplish this there is a special "make neutral/blocked"
procedure at suitable times during the operation round.
I.e. at start/end of OR, and then any of these 3 hexes
are tokened/upgraded.