### PR TITLE
fix: 1871 exchange shares blocking buyable treasury shares

### DIFF
--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -793,7 +793,7 @@ module Engine
           end
 
           branch_shares_left = share_pool.shares_by_corporation[branch].size
-          treasury_shares = corporation.shares_by_corporation[corporation].size
+          treasury_shares = corporation.shares_by_corporation[corporation].count(&:buyable)
 
           # Assign the partial capital to the branch
           @bank.spend(branch.par_price.price * branch_shares_left, branch)

--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -437,10 +437,10 @@ module Engine
         end
 
         # Returns true if this tile represents a brown tile on a map C hex
-        def brown_c?(tile)
+        def brown_cx?(tile)
           return false unless tile.color == :brown
 
-          tile.hex.original_tile.label.to_s.include?('C')
+          tile.hex.original_tile.label.to_s.include?('CX')
         end
 
         # Returns true if this tile represents a yellow tile on a map T hex
@@ -467,9 +467,9 @@ module Engine
           elsif yellow_t?(from)
             # if we're upgrading a yellow T, make sure we use T tiles
             return false unless to.label.to_s.include?('T')
-          elsif brown_c?(from)
-            # if we're upgrading a brown C, make sure we use the C tile
-            return false unless to.label.to_s.include?('C')
+          elsif brown_cx?(from)
+            # if we're upgrading the CX hex to gray, make sure we use the CX tile
+            return false unless to.label.to_s.include?('CX')
           elsif !map_x_or_t?(from)
             # normal label checking from base in other cases
             return false unless upgrades_to_correct_label?(from, to)

--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -116,6 +116,13 @@ module Engine
               can_gain?(entity, bundle)
           end
 
+          def can_gain?(entity, bundle, exchange: false)
+            return if !bundle || !entity
+            return true if exchange
+
+            super
+          end
+
           def visible_corporations
             # Always show ML and SL
             @game.corporations[0..1].reject(&:closed?) +

--- a/lib/engine/game/g_1871/step/exchange.rb
+++ b/lib/engine/game/g_1871/step/exchange.rb
@@ -26,6 +26,13 @@ module Engine
             non_buy_action = Engine::Action::Base.new(action.entity)
             @round.current_actions << non_buy_action
           end
+
+          def can_gain?(entity, bundle, exchange: false)
+            return if !bundle || !entity
+            return true if exchange
+
+            super
+          end
         end
       end
     end

--- a/lib/engine/game/g_1871/tiles.rb
+++ b/lib/engine/game/g_1871/tiles.rb
@@ -120,7 +120,7 @@ module Engine
           'PEI15' => {
             'count' => 1,
             'color' => 'gray',
-            'code' => 'city=revenue:80,slots:3;path=a:1,b:_0;path=a:5,b:_0;path=a:4,b:_0;path=a:3,b:_0;path=a:2,b:_0;label=C',
+            'code' => 'city=revenue:80,slots:3;path=a:1,b:_0;path=a:5,b:_0;path=a:4,b:_0;path=a:3,b:_0;path=a:2,b:_0;label=CX',
           },
           'PEI16' => {
             'count' => 1,


### PR DESCRIPTION
This allows games to have unbuyable treasury shares in a corporation without blocking buyable treasury shares from showing up properly. Later on in the process we first call `can_buy` on these shares anyway so filtering for buyable ones when getting the list should be 100% the same except in games like 1871 that has reserved shares sitting around.

I also reorder the "but for other player" buttons to match the order of the normal buttons and fix the same bug as above in a 1871 log line.

Also relabel the C tile to CX as intended and made sure the logic works.