### PR TITLE
18NewEngland: keep minors first when resorting (fixes #7502)

### DIFF
--- a/lib/engine/game/g_18_new_england/game.rb
+++ b/lib/engine/game/g_18_new_england/game.rb
@@ -312,7 +312,7 @@ module Engine
         end
 
         def operating_round(round_num)
-          Engine::Round::Operating.new(self, [
+          G18NewEngland::Round::Operating.new(self, [
             G18NewEngland::Step::Bankrupt,
             G18NewEngland::Step::RedeemShares,
             G18NewEngland::Step::Track,

--- a/lib/engine/game/g_18_new_england/round/operating.rb
+++ b/lib/engine/game/g_18_new_england/round/operating.rb
@@ -4,7 +4,7 @@ require_relative '../../../round/operating'
 
 module Engine
   module Game
-    module G1822
+    module G18NewEngland
       module Round
         class Operating < Engine::Round::Operating
           def recalculate_order

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -94,6 +94,16 @@ module Engine
           @entities.size > index
       end
 
+      def recalculate_majors_order
+        # Recalculate order only for major companies
+        index = @entity_index + 1
+        return unless index < @entities.size - 1
+
+        # Find the first major corporation after current operating entity.
+        index += @entities[index..-1].find_index { |c| c.type == :major } || 0
+        @entities[index..-1] = @entities[index..-1].sort
+      end
+
       def operating?
         true
       end


### PR DESCRIPTION
Games that were already affected by this will need to be pinned.