### PR TITLE
[1866] Same hex twice

### DIFF
--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -1285,9 +1285,10 @@ module Engine
         end
 
         def revenue_for(route, stops)
-          if route.hexes.size != route.hexes.uniq.size &&
-            route.hexes.none? { |h| self.class::DOUBLE_HEX.include?(h.name) }
-            raise GameError, 'Route visits same hex twice'
+          route.hexes.group_by(&:itself).each do |k, v|
+            next if v.size < 2 || self.class::DOUBLE_HEX.include?(k.name)
+
+            raise GameError, "Route visits same hex #{k.name} twice"
           end
 
           train = route.train


### PR DESCRIPTION
- Fixed the minor bug. If you run a train from a double town hex, you could run through both cities on the C-tile "C4"

A very special case, but it could affect games if people have done it.