### PR TITLE
Rolling Stock: implement info tab, remove phases, fix bugs

### DIFF
--- a/assets/app/view/game/alternate_corporations.rb
+++ b/assets/app/view/game/alternate_corporations.rb
@@ -439,19 +439,24 @@ module View
             fontSize: '80%',
           },
         }
+
+        rows = []
+        rows << h(:tr, [h('td.left', 'Company Revenue:'),
+                        h(:td, @game.format_currency(@corporation.companies.sum(&:revenue)))])
+        rows << h(:tr, [h('td.left', 'Synergies:'),
+                        h(:td, @game.format_currency(@game.synergy_income(@corporation)))])
+        rows << h(:tr, [h('td.left', 'Cost of Ownership:'),
+                        h(:td, @game.format_currency(@corporation.companies.sum { |c| @game.operating_cost(c) }))])
+        if (extra = @game.ability_income(@corporation)).positive?
+          rows << h(:tr, [h('td.left', 'Ability Income:'), h(:td, @game.format_currency(extra))])
+        end
+
         h(:table, [
           h(:thead, [
             h(:tr, [h('th.left', 'Income'),
                     h(:th, @game.format_currency(@game.total_income(@corporation)))]),
           ]),
-          h(:tbody, body_props, [
-            h(:tr, [h('td.left', 'Company Revenue:'),
-                    h(:td, @game.format_currency(@corporation.companies.sum(&:revenue)))]),
-            h(:tr, [h('td.left', 'Synergies:'),
-                    h(:td, @game.format_currency(@game.synergy_income(@corporation)))]),
-            h(:tr, [h('td.left', 'Cost of Ownership:'),
-                    h(:td, @game.format_currency(@corporation.companies.sum { |c| @game.operating_cost(c) }))]),
-          ]),
+          h(:tbody, body_props, rows),
         ])
       end
     end

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -35,7 +35,7 @@ module View
           children = []
         else
           children = @game.train_power? ? power : trains
-          children.concat(discarded_trains) if @depot.discarded.any?
+          children.concat(discarded_trains) unless @depot.discarded.empty?
         end
         if @game.phase_valid?
           children.concat(phases)
@@ -52,7 +52,7 @@ module View
 
         children = [h(:h3, 'Timeline')]
         children << progress_bar if @game.show_progress_bar?
-        @game.timeline.each { |line| children << h(:p, line) } if @game.timeline.any?
+        @game.timeline.each { |line| children << h(:p, line) } unless @game.timeline.empty?
 
         children
       end
@@ -83,7 +83,7 @@ module View
 
           extra = []
           extra << h(:td, phase[:corporation_sizes].join(', ')) if corporation_sizes
-          extra << h(:td, row_events) if phases_events.any?
+          extra << h(:td, row_events) unless phases_events.empty?
 
           tr_props = @game.phase.available?(phase[:name]) && phase != current_phase ? @dimmed_font_style : {}
 
@@ -104,7 +104,7 @@ module View
         extra = []
         extra << h(:th, 'New Corporation Size') if corporation_sizes
 
-        if status_text.any?
+        unless status_text.empty?
           status_text = [h(:table, { style: { marginTop: '0.3rem' } }, [
             h(:thead, [
               h(:tr, [
@@ -168,7 +168,7 @@ module View
       def trains
         rust_schedule, obsolete_schedule = rust_obsolete_schedule
 
-        show_obsolete_schedule = obsolete_schedule.keys.any?
+        show_obsolete_schedule = !obsolete_schedule.keys.empty?
         show_upgrade = @depot.upcoming.any?(&:discount)
         show_available = @depot.upcoming.any?(&:available_on)
         events = []
@@ -236,7 +236,7 @@ module View
 
           train_content << h(:td, discounts) if show_upgrade
           train_content << h(:td, train.available_on) if show_available
-          train_content << h(:td, event_text) if event_text.any?
+          train_content << h(:td, event_text) unless event_text.empty?
           tr_props = remaining.empty? ? @dimmed_font_style : {}
 
           h(:tr, tr_props, train_content)
@@ -247,7 +247,7 @@ module View
           h(:tr, [h('td.nowrap', { style: { maxWidth: '30vw' } }, desc[0]), h(:td, desc[1])])
         end
 
-        if event_text.any?
+        unless event_text.empty?
           event_text = [h(:table, { style: { marginTop: '0.3rem' } }, [
             h(:thead, [
               h(:tr, [
@@ -273,7 +273,7 @@ module View
                                      { attrs: { title: 'Available after purchase of first train of type' } },
                                      'Available')
         end
-        upcoming_train_header << h(:th, 'Events') if event_text.any?
+        upcoming_train_header << h(:th, 'Events') unless event_text.empty?
 
         [
           h(:h3, 'Trains'),

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -18,6 +18,8 @@ module View
         @depot = @game.depot
         @dimmed_font_style = { style: { color: convert_hex_to_rgba(color_for(:font), 0.7) } }
 
+        return if @layout && @depot.trains.empty?
+
         case @layout
         when :discarded_trains
           @depot.discarded.empty? ? '' : discarded_trains
@@ -29,9 +31,17 @@ module View
       end
 
       def render_body
-        children = @game.train_power? ? power : trains
-        children.concat(discarded_trains) if @depot.discarded.any?
-        children.concat(phases)
+        if @depot.trains.empty?
+          children = []
+        else
+          children = @game.train_power? ? power : trains
+          children.concat(discarded_trains) if @depot.discarded.any?
+        end
+        if @game.phase_valid?
+          children.concat(phases)
+        else
+          children.concat(other_game_status)
+        end
         children.concat(timeline) if timeline
         children.concat(endgame)
         children << h(GameMeta, game: @game)
@@ -459,6 +469,94 @@ module View
           h(:div, "Current power cost: #{@game.format_currency(@game.current_power_cost)}"),
           h(:div, "Next power cost: #{@game.format_currency(@game.next_power_cost)}"),
         ])
+      end
+
+      # Currently, only for Rolling Stock
+      def other_game_status
+        status = []
+
+        unless @game.offering.empty?
+          status << h(:h3, 'Offering')
+          comps = @game.offering.map do |company|
+            h(Company, company: company)
+          end
+          status << h(:div, comps)
+        end
+
+        status << h(:h3, 'Remaining Deck')
+        if @game.company_deck.empty?
+          status << h(:div, '(Empty)')
+        else
+          deck = @game.company_deck.reverse.map do |company|
+            deck_item_style = {
+              display: 'inline-block',
+              backgroundColor: @game.company_colors(company)[0],
+              padding: '4px',
+              border: '1px solid black',
+              height: '20px',
+              margin: '4px',
+            }
+            h(:div, { style: deck_item_style })
+          end
+          status << h(:div, deck)
+        end
+
+        table_props = {
+          style: {
+            backgroundColor: 'white',
+            margin: '0',
+            border: '1px solid',
+            borderCollapse: 'collapse',
+          },
+        }
+        tr_props = {
+          style: {
+            border: '1px solid',
+          },
+        }
+        th_props = {
+          style: {
+            border: '1px solid',
+          },
+        }
+
+        status << h(:h3, 'Current Cost of Ownership')
+
+        cost_card_props = {
+          style: {
+            display: 'inline-block',
+            backgroundColor: @game.class::STAR_COLORS[@game.cost_level]&.[](0) || 'white',
+            padding: '20px 60px 20px 60px',
+            border: '1px solid',
+            borderRadius: '5px',
+          },
+        }
+
+        cost_rows = [h(:tr, tr_props, [h(:th, th_props, 'Level'), h(:th, th_props, 'Cost')])]
+        @game.cost_table[@game.cost_level].each_with_index do |cost, idx|
+          level_props = {
+            style: {
+              backgroundColor: @game.class::STAR_COLORS[idx + 1][0],
+              border: '1px solid',
+            },
+          }
+          td_props = {
+            style: {
+              border: '1px solid',
+            },
+          }
+          cost_rows << h(:tr, tr_props, [
+            h(:td, level_props, ('★' * (idx + 1)).to_s),
+            h(:td, td_props, @game.format_currency(cost)),
+          ])
+        end
+        status << h(:div, cost_card_props, [
+          h(:table, table_props, [
+            h(:tbody, cost_rows),
+          ]),
+        ])
+
+        status
       end
     end
   end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -35,6 +35,8 @@ module View
           @price_protection = @step.price_protection if @step.respond_to?(:price_protection)
           @selected_corporation ||= @price_protection&.corporation
 
+          @bank_first = @step.respond_to?(:bank_first?) && @step.bank_first?
+
           @current_entity = @step.current_entity
           if @last_player != @current_entity && !@auctioning_corporation
             store(:selected_corporation, nil, skip: true)
@@ -63,10 +65,11 @@ module View
           children.concat(render_buttons)
           children << h(SpecialBuy) if @current_actions.include?('special_buy')
           children.concat(render_failed_merge) if @current_actions.include?('failed_merge')
+          children.concat(render_bank_companies) if @bank_first
           children.concat(render_corporations)
           children.concat(render_mergeable_entities) if @current_actions.include?('merge')
           children.concat(render_player_companies) if @current_actions.include?('sell_company')
-          children.concat(render_bank_companies)
+          children.concat(render_bank_companies) unless @bank_first
           children << h(Players, game: @game)
           if @step.respond_to?(:purchasable_companies) && !@step.purchasable_companies(@current_entity).empty?
             children << h(BuyCompanyFromOtherPlayer, game: @game)

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -296,6 +296,7 @@ module View
         else
           color_for(:bg2)
         end
+
       nav_props = {
         attrs: {
           role: 'navigation',
@@ -308,7 +309,7 @@ module View
           top: '0',
           borderBottom: "1px solid #{color_for(:font2)}",
           borderTop: "1px solid #{color_for(:font2)}",
-          boxShadow: "0 5px 0 0 #{color_for(@game.phase.current[:tiles].last)}, 0 6px 0 0 #{color_for(:bg)}",
+          boxShadow: "0 5px 0 0 #{color_for(@game.nav_bar_color)}, 0 6px 0 0 #{color_for(:bg)}",
           backgroundColor: bg_color,
           color: active_player ? contrast_on(bg_color) : color_for(:font2),
           fontSize: 'large',
@@ -372,7 +373,7 @@ module View
     def render_round
       description = @game_data['mode'] == :hotseat ? '[HOTSEAT] ' : ''
       description += "#{@game.class.display_title}: "
-      description += "Phase #{@game.phase.name} - "
+      description += "#{@game.round_phase_string} - "
       name = @round.class.name.split(':').last
       description += @game.round_description(name)
       description += @game.finished ? ' - Game Over' : " - #{@round.description}"

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2824,6 +2824,18 @@ module Engine
       def train_actions_always_use_operating_round_view?
         false
       end
+
+      def nav_bar_color
+        @phase.current[:tiles].last
+      end
+
+      def round_phase_string
+        "Phase #{@phase.name}"
+      end
+
+      def phase_valid?
+        true
+      end
     end
   end
 end

--- a/lib/engine/game/g_rolling_stock/step/buy_sell_shares_bid_companies.rb
+++ b/lib/engine/game/g_rolling_stock/step/buy_sell_shares_bid_companies.rb
@@ -187,6 +187,10 @@ module Engine
             @game.biddable_companies.include?(company) && max_bid(entity) >= company.value
           end
 
+          def bank_first?
+            true
+          end
+
           def setup
             setup_auction
             super

--- a/lib/engine/game/g_rolling_stock/step/close_companies.rb
+++ b/lib/engine/game/g_rolling_stock/step/close_companies.rb
@@ -25,6 +25,7 @@ module Engine
           end
 
           def must_close?(entity)
+            return unless entity.player?
             return if entity.companies.empty?
 
             (entity.cash + entity.companies.sum { |c| @game.company_income(c) }).negative?

--- a/lib/engine/game/g_rolling_stock/step/dividend.rb
+++ b/lib/engine/game/g_rolling_stock/step/dividend.rb
@@ -9,6 +9,7 @@ module Engine
         class Dividend < Engine::Step::Base
           def actions(entity)
             return [] if !entity.corporation? || entity != current_entity
+            return [] if entity.receivership?
 
             %w[dividend]
           end
@@ -19,6 +20,13 @@ module Engine
 
           def dividend_types
             [:variable]
+          end
+
+          def skip!
+            return super if !current_entity.corporation? || !current_entity.receivership?
+
+            @log << "#{current_entity.name} is in receivership and pays #{@game.format_currency(0)}"
+            process_dividend(Action::Dividend.new(current_entity, kind: 'variable', amount: 0))
           end
 
           def process_dividend(action)


### PR DESCRIPTION
* Info tab
* Remove standard notion of phase
* Finish receiver auto-actions
* Bug fixes from hot-seat play through

Common file edits:
* UI::AlternateCorporations - add "ability" income to table
* UI::GameInfo - support for RS info, no trains
* UI::Round::Stock - option to show private companies before corporations
* UI::GamePage - generalize menu bar color and "phase" string
* Engine::Base - support for above

Portion of RS-specific Info tab:

![RS_info](https://user-images.githubusercontent.com/8494213/160971635-f32fb6a7-1188-420a-9c0f-c784c9c3ac01.png)