### PR TITLE
[1866] Minor corporation close bug

### DIFF
--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -1635,7 +1635,10 @@ module Engine
               @log << "#{loan_str} #{corporation.name} pays #{format_currency(loan)}"
               corporation.spend(loan, @bank)
             end
-            corporation.loans.clear
+            corporation.loans.dup.each do |l|
+              corporation.loans.delete(l)
+              @loans << l
+            end
           end
 
           tokens = []


### PR DESCRIPTION
- If a company closes push the back into the loan market. Have no impact in the game, only so it shows the correct amount of loans in the market tab.

Does not affect the currect games.