### PR TITLE
[1889] adjust UR card background to match icon

### DIFF
--- a/lib/engine/game/g_1889/game.rb
+++ b/lib/engine/game/g_1889/game.rb
@@ -424,7 +424,7 @@ module Engine
             simple_logo: '1889/UR.alt',
             tokens: [0, 40, 40],
             coordinates: 'B7',
-            color: '#7b352a',
+            color: '#6f533e',
             reservation_color: nil,
           },
         ].freeze


### PR DESCRIPTION
I figured the icon was the canonical color


Before:
![Screenshot 2022-04-05 11 05 30 AM](https://user-images.githubusercontent.com/1711810/161821597-5ec37bb1-eeda-4133-8565-645de79670f6.png)

After:
![Screenshot 2022-04-05 11 05 09 AM](https://user-images.githubusercontent.com/1711810/161821615-aa731428-d274-403a-bb53-f6736aa78144.png)

