### PR TITLE
Rolling Stock: remove auto stock pass; fix par bug

### DIFF
--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -649,7 +649,7 @@ module Engine
 
           return unless @cost_level < new_cost
 
-          old_cost = new_cost
+          old_cost = @cost_level
           @cost_level = new_cost
           @log << "New cost of ownership: #{cost_level_str}"
 
@@ -933,7 +933,7 @@ module Engine
         end
 
         def available_programmed_actions
-          [Action::ProgramSharePass, Action::ProgramClosePass]
+          [Action::ProgramClosePass]
         end
       end
     end

--- a/lib/engine/game/g_rolling_stock/round/investment.rb
+++ b/lib/engine/game/g_rolling_stock/round/investment.rb
@@ -16,6 +16,10 @@ module Engine
           end
 
           def finish_round; end
+
+          def show_auto?
+            false
+          end
         end
       end
     end

--- a/lib/engine/game/g_rolling_stock/step/ipo_company.rb
+++ b/lib/engine/game/g_rolling_stock/step/ipo_company.rb
@@ -87,7 +87,7 @@ module Engine
             if par_price >= company.value
               par_price - company.value
             else
-              (share_price.price * 2) - company.value
+              (par_price * 2) - company.value
             end
           end
 


### PR DESCRIPTION
* Stock auto-pass conflicts with Close auto-pass, so removed Stock auto-pass
* Found and fixed a bug with finding legal par prices