### PR TITLE
Implement variant DB1: additional upgrade paths for double dits

### DIFF
--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -439,6 +439,9 @@ module Engine
           raise OptionError, 'K2 not supported without K3' if @kits[2] && !@kits[3]
           raise OptionError, 'Cannot use extra Unit 3 trains without Unit 3' if !@units[3] && optional_rules.include?(:u3p)
           raise OptionError, 'Cannot use K1 or K6 with D1' if (@kits[1] || @kits[6]) && optional_rules.include?(:d1)
+          if !units[1] && !units[3] && optional_rules.include?(:db1)
+            raise OptionError, 'Variant DB1 not useful in a Unit 2 only game'
+          end
           raise OptionError, 'Variant DB2 is for Unit 1' if !units[1] && optional_rules.include?(:db2)
 
           p_range = case @units.keys.sort.map(&:to_s).join

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -489,18 +489,22 @@ module Engine
         }.freeze
         # rubocop:enable Layout/LineLength
 
+        # This includes upgrades for the DB1 kit tiles 887/888. This does not
+        # affect the game without it since none of them are present.
         DIT_UPGRADES = {
           # gentle curve to three curves with a halt
           '8' => %w[11],
           # yellow double-dit to green K or X city
-          '1' => %w[14],
-          '2' => %w[15],
-          '55' => %w[14],
-          '56' => %w[15],
+          '1' => %w[14 888],
+          '2' => %w[15 887],
+          '55' => %w[14 888],
+          '56' => %w[15 887],
           '69' => %w[119],
-          '114' => %w[15],
+          '114' => %w[15 887],
           '198' => %w[119],
           '199' => %w[119],
+          '887' => %w[63 166],
+          '888' => %w[63 166],
           # yellow single-dit to green city (also brown/green city)
           '3' => %w[12 14 15 119],
           '4' => %w[14 15 119],
@@ -544,6 +548,20 @@ module Engine
           append_game_tiles(gtiles, K5_TILES) if @kits[5]
           append_game_tiles(gtiles, K6_TILES) if @kits[6]
           append_game_tiles(gtiles, D1_TILES) if @optional_rules.include?(:d1)
+          gtiles = db1_tiles(gtiles) if @optional_rules.include?(:db1)
+          gtiles
+        end
+
+        def db1_tiles(gtiles)
+          gtiles.delete('87')
+          gtiles.delete('88')
+          eightysevens = ((@units[1] ? 2 : 0) + (@units[3] ? 1 : 0))
+          gtiles['887'] = eightysevens
+          gtiles['888'] = eightysevens
+          if @units[3]
+            gtiles['14'] -= 1
+            gtiles['15'] -= 1
+          end
           gtiles
         end
 

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -487,6 +487,11 @@ module Engine
           },
           '200' => 2,
         }.freeze
+
+        DB1_UNIT3_ANTITILES = {
+          '14' => -1,
+          '15' => -1,
+        }.freeze
         # rubocop:enable Layout/LineLength
 
         # This includes upgrades for the DB1 kit tiles 887/888. This does not
@@ -532,6 +537,13 @@ module Engine
             else
               gtiles[k] = v.dup
             end
+            number = gtiles[k].is_a?(Hash) ? gtiles[k]['count'] : gtiles[k]
+            # this was if number<=0 raise GameError ... end but rubocop gives
+            # a complaint that seems frankly barking to me
+            next if number.positive?
+            raise GameError, "negative number of tile #{k}" if number.negative?
+
+            gtiles.delete(k)
           end
         end
 
@@ -558,10 +570,7 @@ module Engine
           eightysevens = ((@units[1] ? 2 : 0) + (@units[3] ? 1 : 0))
           gtiles['887'] = eightysevens
           gtiles['888'] = eightysevens
-          if @units[3]
-            gtiles['14'] -= 1
-            gtiles['15'] -= 1
-          end
+          append_game_tiles(gtiles, DB1_UNIT3_ANTITILES) if @units[3]
           gtiles
         end
 

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -560,7 +560,7 @@ module Engine
           append_game_tiles(gtiles, K5_TILES) if @kits[5]
           append_game_tiles(gtiles, K6_TILES) if @kits[6]
           append_game_tiles(gtiles, D1_TILES) if @optional_rules.include?(:d1)
-          gtiles = db1_tiles(gtiles) if @optional_rules.include?(:db1)
+          db1_tiles(gtiles) if @optional_rules.include?(:db1)
           gtiles
         end
 

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -119,6 +119,11 @@ module Engine
             desc: 'Do not increase bank size based on number of minors and kits',
           },
           {
+            sym: :db1,
+            short_name: 'DB1',
+            desc: 'Dave Berry variant 1: allow double-dits to upgrade to 887/888',
+          },
+          {
             sym: :db2,
             short_name: 'DB2',
             desc: 'Dave Berry variant 2: SECR Changes for Unit 1',
@@ -192,6 +197,7 @@ module Engine
           return 'Cannot use extra Unit 3 trains without Unit 3' if !units[3] && optional_rules.include?(:u3p)
           return 'Cannot use K1 or K6 with D1' if (kits[1] || kits[6]) && optional_rules.include?(:d1)
           return 'Cannot use both bank options' if optional_rules.include?(:big_bank) && optional_rules.include?(:strict_bank)
+          return 'Variant DB1 not useful in a Unit 2 only game' if !units[1] && !units[3] && optional_rules.include?(:db1)
           return 'Variant DB2 is for Unit 1' if !units[1] && optional_rules.include?(:db2)
 
           nil

--- a/lib/engine/game/g_1825/step/track_and_token.rb
+++ b/lib/engine/game/g_1825/step/track_and_token.rb
@@ -62,6 +62,11 @@ module Engine
             from.color != :white && !(from.color == :yellow && from.preprinted)
           end
 
+          def protect_ns?(tile, hex, entity)
+            (tile.name == '888' || tile.name == '887') &&
+              (hex.id == 'Q13') && (entity.name != 'NS')
+          end
+
           # 1825: pre-printed yellows are not "upgraded"
           def lay_tile_action(action, entity: nil, spender: nil)
             tile = action.tile
@@ -74,10 +79,8 @@ module Engine
             if tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(action.hex)
               raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
             end
-            if (tile.name == '888' || tile.name == '887') &&
-               (action.hex.id == 'Q13') && (entity.name != 'NS')
-              raise GameError, 'Only the NS can place tiles 887/888 on Q13'
-            end
+
+            raise GameError, 'Only the NS can place tiles 887/888 on Q13' if protect_ns?(tile, action.hex, entity)
 
             check_adjacent(old_tile.hex) if @round.num_laid_track.positive?
 

--- a/lib/engine/game/g_1825/step/track_and_token.rb
+++ b/lib/engine/game/g_1825/step/track_and_token.rb
@@ -75,7 +75,7 @@ module Engine
               raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
             end
             if (tile.name == '888' || tile.name == '887') &&
-               action.hex.id == 'Q13' && (entity.name != 'NS')
+               (action.hex.id == 'Q13') && (entity.name != 'NS')
               raise GameError, 'Only the NS can place tiles 887/888 on Q13'
             end
 

--- a/lib/engine/game/g_1825/step/track_and_token.rb
+++ b/lib/engine/game/g_1825/step/track_and_token.rb
@@ -74,6 +74,10 @@ module Engine
             if tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(action.hex)
               raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
             end
+            if (tile.name == '888' || tile.name == '887') &&
+               action.hex.id == 'Q13' && (entity.name != 'NS')
+              raise GameError, 'Only the NS can place tiles 887/888 on Q13'
+            end
 
             check_adjacent(old_tile.hex) if @round.num_laid_track.positive?
 


### PR DESCRIPTION
Unfortunately Dave Barry's kit DB1 is itself full of optional rules.
This implements the rule he "uses in practice", giving the 887/888
tiles to Units 1 and 3 but not 2 where they are primarily for the
more complex variant which he doesn't use in practice.

As with DB2 I have hence only implemented what I think is the most
popular version since 1825 has many options already.