### PR TITLE
Rolling Stock: fix player color bug; change defaults; new RS options

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -36,7 +36,9 @@ module View
         inputs << render_game_type
         inputs << render_input('Invite only game', id: 'unlisted', type: :checkbox,
                                                    container_style: { paddingLeft: '0.5rem' })
-        inputs << render_input('Auto Routing', id: 'auto_routing', type: :checkbox, siblings: [auto_route_whats_this])
+        if selected_game_or_variant::AUTOROUTE
+          inputs << render_input('Auto Routing', id: 'auto_routing', type: :checkbox, siblings: [auto_route_whats_this])
+        end
         inputs << h(:p, [render_input('Random Seed', id: :seed, placeholder: 'Optional random seed', label_style: @label_style)])
         inputs << render_game_info
       when :hotseat
@@ -119,6 +121,7 @@ module View
         uncheck_optional_rules
         @optional_rules = []
 
+        preselect_variant(@selected_game)
         update_inputs
       end
 
@@ -151,6 +154,12 @@ module View
       div_props[:style] = { display: 'none' } if @mode == :json
 
       h(:div, div_props, inputs)
+    end
+
+    def preselect_variant(game)
+      game.game_variants.map do |_sym, variant|
+        @selected_variant = variant if variant[:default]
+      end
     end
 
     def uncheck_game_variant

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -504,6 +504,7 @@ module View
         table_props = {
           style: {
             backgroundColor: 'white',
+            color: 'black',
             margin: '0',
             border: '1px solid',
             borderCollapse: 'collapse',
@@ -511,12 +512,12 @@ module View
         }
         tr_props = {
           style: {
-            border: '1px solid',
+            border: '1px solid black',
           },
         }
         th_props = {
           style: {
-            border: '1px solid',
+            border: '1px solid black',
           },
         }
 
@@ -526,9 +527,10 @@ module View
           style: {
             display: 'inline-block',
             backgroundColor: @game.class::STAR_COLORS[@game.cost_level]&.[](0) || 'white',
+            color: 'black',
             padding: '20px 60px 20px 60px',
             border: '1px solid',
-            borderRadius: '5px',
+            borderRadius: '10px',
           },
         }
 

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -46,11 +46,9 @@ module View
       end
 
       def render_title
-        bg_color = if setting_for(:show_player_colors, @game)
-                     player_colors(@game.players)[@player]
-                   else
-                     color_for(:bg2)
-                   end
+        bg_color = setting_for(:show_player_colors, @game) && player_colors(@game.players)[@player]
+        bg_color ||= color_for(:bg2)
+
         props = {
           style: {
             padding: '0.4rem',

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -197,22 +197,31 @@ module Engine
         end
 
         def num_to_draw(players, level)
-          if level != 2 || players.size < 4
-            players.size + 1
-          elsif players.size == 4
-            6
-          else
+          if players.size == 6
             8
+          elsif level != 2 || players.size < 4
+            players.size
+          elsif players.size == 4
+            5
+          else
+            7
           end
+        end
+
+        def num_levels
+          @optional_rules&.include?(:short) ? 5 : 6
         end
 
         def setup_company_deck
           deck = []
-          num = @optional_rules&.include?(:short) ? 5 : 6
-          num.times do |level|
-            matching = @companies.select { |c| @company_level[c] == (level + 1) }
-            drawn = matching.sort_by { rand }.take(num_to_draw(players, level + 1))
-            deck.concat(drawn)
+          num = num_levels
+          num.times do |stars|
+            matching = @companies.select { |c| @company_level[c] == (stars + 1) }
+            highest = matching.max_by(&:value)
+            @company_highlight[highest] = true
+            drawn = matching.reject { |c| c == highest }.sort_by { rand }.take(num_to_draw(players, stars + 1))
+            drawn << highest
+            deck.concat(drawn.sort_by { rand })
           end
           deck
         end

--- a/lib/engine/game/g_rolling_stock/meta.rb
+++ b/lib/engine/game/g_rolling_stock/meta.rb
@@ -16,14 +16,16 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'http://rabenste.in/rollingstock/rules.pdf'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/Rolling-Stock'
+        AUTOROUTE = false
 
-        PLAYER_RANGE = [3, 5].freeze
+        PLAYER_RANGE = [2, 6].freeze
 
         GAME_VARIANTS = [
           sym: :stars,
           name: 'Rolling Stock Stars',
           title: 'Rolling Stock Stars',
           desc: 'Latest version of Rolling Stock',
+          default: true,
         ].freeze
 
         OPTIONAL_RULES = [

--- a/lib/engine/game/g_rolling_stock_stars/game.rb
+++ b/lib/engine/game/g_rolling_stock_stars/game.rb
@@ -83,33 +83,12 @@ module Engine
           self.class::COST_OF_OWNERSHIP
         end
 
-        def num_to_draw(players, stars)
-          if players.size == 6
-            8
-          elsif stars != 2 || players.size < 4
-            players.size
-          elsif players.size == 4
-            5
-          else
-            7
-          end
-        end
-
         def setup_preround
           @phase_counter = 0
         end
 
-        def setup_company_deck
-          deck = []
-          5.times do |stars|
-            matching = @companies.select { |c| @company_level[c] == (stars + 1) }
-            highest = matching.max_by(&:value)
-            @company_highlight[highest] = true
-            drawn = matching.reject { |c| c == highest }.sort_by { rand }.take(num_to_draw(players, stars + 1))
-            drawn << highest
-            deck.concat(drawn.sort_by { rand })
-          end
-          deck
+        def num_levels
+          5
         end
 
         def synergy_value_by_level(company_a, company_b)

--- a/lib/engine/game/meta.rb
+++ b/lib/engine/game/meta.rb
@@ -8,6 +8,7 @@ module Engine
       DEV_STAGE = :prealpha
       PROTOTYPE = false
       DEPENDS_ON = nil
+      AUTOROUTE = true
 
       # game title variations
       GAME_TITLE = nil # canonical title stored in database, defaults to '18xx' part of 'G18xx' module name


### PR DESCRIPTION
Fixes #7600 
Fixes #7601 

* Fix bug where showing player colors would cause it to crash
* Rolling Stock Stars is now the default even on the Rolling Stock new game page
* Rolling Stock now defaults to using the "always include the best company of each color" rule (i.e. same as Stars)
* Rolling Stock now supports 2-6 players (i.e. same as Stars)
* Text color tweak for game_info to make it work with dark-mode

Because of the RS changes, any active Rolling Stock games (not Stars) should be archived.