### PR TITLE
[18CZ] gray normal cities only have 2 slots

### DIFF
--- a/lib/engine/game/g_18_cz/map.rb
+++ b/lib/engine/game/g_18_cz/map.rb
@@ -271,7 +271,7 @@ module Engine
             'count' => 2,
             'color' => 'gray',
             'code' =>
-            'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;' \
+            'city=revenue:60,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;' \
             'path=a:5,b:_0;frame=color:#800080',
           },
         }.freeze


### PR DESCRIPTION
closes #7583 


From fwtwr and user report
![image](https://user-images.githubusercontent.com/1711810/162793714-e929bec6-a811-4353-987e-7562eacc7409.png)
