### PR TITLE
Rolling Stock (Stars): fix egregious order of IPO bug

### DIFF
--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -698,7 +698,7 @@ module Engine
         end
 
         def ipo_companies
-          @companies.select { |c| c.owner&.player? && c.owner != @foreign_investor }.sort_by(&:value)
+          @companies.select { |c| c.owner&.player? && c.owner != @foreign_investor }.sort_by(&:value).reverse
         end
 
         def available_par_prices(company)

--- a/lib/engine/game/g_rolling_stock_stars/meta.rb
+++ b/lib/engine/game/g_rolling_stock_stars/meta.rb
@@ -16,7 +16,7 @@ module Engine
         GAME_ALIASES = ['Rolling Stock Stars'].freeze
         GAME_IS_VARIANT_OF = GRollingStock::Meta
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/Rolling-Stock'
-        GAME_RULES_URL = 'https://github.com/beorn7/rolling_stock/blob/master/rules.pdf'
+        GAME_RULES_URL = 'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/RSS.pdf'
         GAME_SUBTITLE = nil
         GAME_TITLE = 'Rolling Stock Stars'
 


### PR DESCRIPTION
Fixes #7616 

This will invalidate any Rolling Stock or Rolling Stock Stars game past turn 1