### PR TITLE
Fix 7613

### DIFF
--- a/lib/engine/game/g_18_va/game.rb
+++ b/lib/engine/game/g_18_va/game.rb
@@ -796,6 +796,13 @@ module Engine
           @corporations << corporation
         end
 
+        def reset_corporation(corporation)
+          new_corp = super
+          # Need to reconvert 5-share corporations if the forced conversions event happened. Brown tiles are a good signal.
+          convert(new_corp) if new_corp.type == :five_share && @phase.tiles.include?(:brown)
+          new_corp
+        end
+
         def convert(corporation)
           before = corporation.total_shares
           shares = @_shares.values.select { |share| share.corporation == corporation }

--- a/lib/engine/game/g_18_va/step/bankrupt.rb
+++ b/lib/engine/game/g_18_va/step/bankrupt.rb
@@ -53,7 +53,7 @@ module Engine
             # restricted from buying any trains
             @game.active_step.last_share_sold_price = nil
 
-            if player.companies.empty?
+            unless player.companies.empty?
               @log << "#{player.name}'s companies close: #{player.companies.map(&:sym).join(', ')}"
               player.companies.dup.each(&:close!)
             end


### PR DESCRIPTION
Fixes #7613 
In theory this requires pins, but in practice I'm doubtful. I checked all public games of 18VA and the only active game that has a bankruptcy is the one that triggered the bug report in the first place and is waiting in a spot where it doesn't need a pin.