### PR TITLE
1828: Clarify why player needs to be chosen during merger

### DIFF
--- a/lib/engine/game/g_1828/step/merger.rb
+++ b/lib/engine/game/g_1828/step/merger.rb
@@ -415,6 +415,7 @@ module Engine
               if sources.any? && sources.first.player? && (players = sources.select do |s|
                                                              @players.include?(s)
                                                            end).size > 1
+                @log << ("#{entity.name} chooses player to trade #{@target.name} share to for #{@merger.name} share")
                 @player_choice =
                   PlayerChoice.new(step_description: "Trade #{@target.name} share for #{@merger.name} share",
                                    choice_description: 'Choose player',


### PR DESCRIPTION
Currently the player who needs to choose someone to swap shares with just gets a "Choose player:" dialog with no indication of what they are choosing for.