### PR TITLE
Rolling Stock: Fix share price bug; Auto-pass now defaults to on; UI enhancements

### DIFF
--- a/assets/app/view/game/auto_action/close_pass.rb
+++ b/assets/app/view/game/auto_action/close_pass.rb
@@ -13,7 +13,7 @@ module View
         def description
           'Automatically pass in the close companies phase.'\
             ' This will persist from turn to turn.'\
-            ' It will deactivate itself when operting costs increase, unless configured not do so.'\
+            ' It will deactivate itself when you control a company with negative income, unless configured not do so.'\
         end
 
         def render
@@ -21,7 +21,7 @@ module View
 
           children = [h(:h3, name), h(:p, description)]
 
-          children << render_checkbox('Continue to pass even if operating costs change',
+          children << render_checkbox('Continue to pass even when one of your companies has negative income',
                                       'cr_unconditional',
                                       form,
                                       !!@settings&.unconditional)

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -558,7 +558,87 @@ module View
           ]),
         ])
 
+        # show target book/stars for each share price
+        status << h(:h3, @game.share_card_description)
+        sorted_prices = @game.prices.keys.sort
+        share_cards = sorted_prices.map { |p| share_card(@game.prices[p]) }
+        status << h(:div, share_cards)
+
         status
+      end
+
+      def share_card(price)
+        share_card_props = {
+          style: {
+            display: 'inline-block',
+            backgroundColor: 'white',
+            color: 'black',
+            border: '1px solid',
+            borderRadius: '5px',
+            padding: '5px',
+            margin: '0 0 5px 5px',
+          },
+        }
+
+        price_color = if price.price.zero?
+                        'red'
+                      elsif price.end_game_trigger?
+                        'darkgreen'
+                      else
+                        'black'
+                      end
+
+        price_props = {
+          style: {
+            display: 'inline-block',
+            color: price_color,
+            fontSize: '200%',
+            width: '50%',
+          },
+        }
+
+        max_div_props = {
+          style: {
+            display: 'inline-block',
+            backgroundColor: 'lightgray',
+            fontSize: '70%',
+            width: '30%',
+            margin: '0 0 0 0.5rem',
+          },
+        }
+
+        table_props = {
+          style: {
+            fontSize: '70%',
+          },
+        }
+
+        th_props = {
+          style: {
+            backgroundColor: 'lightgray',
+          },
+        }
+
+        children = []
+        price_info = []
+        price_info << h(:div, price_props, price.price)
+        price_info << h(:div, max_div_props, "Max Div: #{@game.format_currency((price.price / 3).to_i)}")
+        children << h(:div, price_info)
+
+        rows = [h(:tr, [h(:th, th_props, 'Shares'), h(:th, th_props, 'Target')])]
+        @game.share_card_array(price).each do |r|
+          rows << h(:tr, [
+            h(:td, r[0]),
+            h(:td, r[1]),
+          ])
+        end
+        children << h(:div, [
+          h(:table, table_props, [
+            h(:tbody, rows),
+          ]),
+        ])
+
+        h(:div, share_card_props, children)
       end
     end
   end

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -228,10 +228,11 @@ module View
         children = []
         children << h('td.center', td_props, [h(:div, div_props, [h(:img, logo_props)])]) unless @hide_logo
 
+        show_percent = @game.show_player_percent?(@player)
         president_marker = corporation.president?(@player) ? '*' : ''
         double_markers = 'd' * shares.count(&:double_cert)
         children << h(:td, td_props, corporation.name + president_marker + double_markers)
-        children << h('td.right', td_props, "#{shares.sum(&:percent)}%")
+        children << h('td.right', td_props, show_percent ? "#{shares.sum(&:percent)}%" : shares.size.to_s)
         h('tr.row', children)
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2847,6 +2847,10 @@ module Engine
       def market_par_bars(_price)
         []
       end
+
+      def show_player_percent?(_player)
+        true
+      end
     end
   end
 end

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -976,6 +976,18 @@ module Engine
         def show_player_percent?(_player)
           false
         end
+
+        def share_card_description
+          'Target Book Value by Share Price'
+        end
+
+        def share_card_array(price)
+          return [] if price.price.zero? || price.end_game_trigger?
+
+          (2..10).map do |idx|
+            [idx.to_s, format_currency(idx * price.price)]
+          end
+        end
       end
     end
   end

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -186,6 +186,18 @@ module Engine
           @log << 'No cost of ownership'
           @cost_table = init_cost_table
           @synergy_income = {}
+
+          add_default_autopass
+        end
+
+        # enable conditiional auto-pass for everyone at the start
+        def add_default_autopass
+          @players.each do |player|
+            @programmed_actions[player] = Engine::Action::ProgramClosePass.new(
+              player,
+              unconditional: false,
+            )
+          end
         end
 
         def setup_preround
@@ -658,19 +670,31 @@ module Engine
 
           return unless @cost_level < new_cost
 
-          old_cost = @cost_level
           @cost_level = new_cost
           @log << "New cost of ownership: #{cost_level_str}"
 
-          disable_auto_close_pass if @cost_table[old_cost][0] != @cost_table[new_cost][0]
+          @log << 'Some companies have negative income' if @players.any? { |p| any_negative_companies?(p) }
+          disable_auto_close_pass
         end
 
         def disable_auto_close_pass
           @programmed_actions.reject! do |entity, action|
-            if action.is_a?(Engine::Action::ProgramClosePass) && !action.unconditional
-              player_log(entity, "Programmed action '#{action}' removed due to operating cost change")
-              true
-            end
+            next unless action.is_a?(Engine::Action::ProgramClosePass) &&
+                !action.unconditional &&
+                any_negative_companies?(entity)
+
+            player_log(entity, "Programmed action '#{action}' removed due to negative company income")
+            true
+          end
+        end
+
+        def any_negative_companies?(player)
+          return false unless player.player?
+          return true if player.companies.any? { |c| company_income(c).negative? }
+
+          @corporations.any? do |corp|
+            corp.owner == player &&
+              corp.companies.any? { |c| company_income(c).negative? }
           end
         end
 
@@ -943,6 +967,14 @@ module Engine
 
         def available_programmed_actions
           [Action::ProgramClosePass]
+        end
+
+        def ipo_name(_corp)
+          'Unissued'
+        end
+
+        def show_player_percent?(_player)
+          false
         end
       end
     end

--- a/lib/engine/game/g_rolling_stock_stars/game.rb
+++ b/lib/engine/game/g_rolling_stock_stars/game.rb
@@ -138,7 +138,7 @@ module Engine
           diff = corporation_stars(corporation, cash) - target_stars(corporation)
           diff = [[diff, 2].min, -2].max
 
-          target = if diff > -2 || diff < 2
+          target = if diff > -2 && diff < 2
                      @stock_market.share_price(r, c + diff)
                    elsif diff == 2
                      right.end_game_trigger? ? right : @stock_market.share_price(r, c + 2)

--- a/lib/engine/game/g_rolling_stock_stars/game.rb
+++ b/lib/engine/game/g_rolling_stock_stars/game.rb
@@ -178,6 +178,18 @@ module Engine
             *rows,
           ]
         end
+
+        def share_card_description
+          'Target Stars by Share Price'
+        end
+
+        def share_card_array(price)
+          return [] if price.price.zero? || price.end_game_trigger?
+
+          (2..7).map do |idx|
+            [idx.to_s, "#{(idx * price.price / 10.0).round}★"]
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #7624 
Fixes #7627 
Fixes #7632 

* Programmed auto-pass for Closing rounds is now defaulted on
* The "conditional" auto-pass now disables when the player has a company with negative income (as opposed to the operation costs just increasing)

New table:
![RSS_target_stars_table](https://user-images.githubusercontent.com/8494213/163691936-34c088c0-7888-4bbf-a7ba-df46869976ad.png)
