### PR TITLE
1825: implement Francis Tresham's unpublished Unit 4 map

### DIFF
--- a/lib/engine/game/g_1825/entities.rb
+++ b/lib/engine/game/g_1825/entities.rb
@@ -568,6 +568,11 @@ module Engine
             lbsc = corps.find { |corp| corp[:sym] == 'LBSC' }
             lbsc[:abilities] = []
           end
+          # Move HR with Unit 4
+          if @optional_rules.include?(:unit_4)
+            hr = corps.find { |corp| corp[:sym] == 'HR' }
+            hr[:coordinates] = 'A5'
+          end
           add_entities(corps, R3_CORPORATIONS) if @regionals[3]
           add_entities(corps, K5_CORPORATIONS) if @kits[5]
           add_entities(corps, K7_CORPORATIONS) if @kits[7]

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -706,15 +706,18 @@ module Engine
         end
 
         def location_name(coord)
-          unless @location_names
-            @location_names = LOCATION_NAMES.dup
-            if optional_rules.include?(:unit_4)
-              @location_names['A5'] = 'Inverness'
-              @location_names['C3'] = 'Fort William'
-              @location_names.delete('B8')
-            end
-          end
+          @location_names ||= game_location_names
           @location_names[coord]
+        end
+
+        def game_location_names
+          locations = LOCATION_NAMES.dup
+          if optional_rules.include?(:unit_4)
+            locations['A5'] = 'Inverness'
+            locations['C3'] = 'Fort William'
+            locations.delete('B8')
+          end
+          locations
         end
 
         def upgrades_to?(from, to, special = false, selected_company: nil)

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -443,6 +443,7 @@ module Engine
             raise OptionError, 'Variant DB1 not useful in a Unit 2 only game'
           end
           raise OptionError, 'Variant DB2 is for Unit 1' if !units[1] && optional_rules.include?(:db2)
+          raise OptionError, 'Unit 4 requires Unit 3' if optional_rules.include?(:unit_4) && !units[3]
 
           p_range = case @units.keys.sort.map(&:to_s).join
                     when '1'
@@ -702,6 +703,18 @@ module Engine
           return false if tile.name == '166' && !phase_color_cache.include?(:gray)
 
           phase_color_cache.include?(tile.color)
+        end
+
+        def location_name(coord)
+          unless @location_names
+            @location_names = LOCATION_NAMES.dup
+            if optional_rules.include?(:unit_4)
+              @location_names['A5'] = 'Inverness'
+              @location_names['C3'] = 'Fort William'
+              @location_names.delete('B8')
+            end
+          end
+          @location_names[coord]
         end
 
         def upgrades_to?(from, to, special = false, selected_company: nil)

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -7,6 +7,15 @@ module Engine
         LAYOUT = :pointy
 
         LOCATION_NAMES = {
+          # unit 4
+          # Inverness is moved to A5 in location_name in game.rb
+          'c8' => 'Wick',
+          'a2' => 'Ullapool',
+          'a4' => 'Dingwall',
+          'a6' => 'Invergordon',
+          'a8' => 'Elgin',
+          'a12' => 'Fraserburgh',
+          'B0' => 'Malaig',
           # unit 3
           'B8' => 'Inverness',
           'B12' => 'Aberdeen',
@@ -761,6 +770,39 @@ module Engine
           },
         }.freeze
 
+        UNIT4_HEXES = {
+          white: {
+            %w[b7
+               A7
+               A9
+               A11
+               A13
+               B4
+               B10
+               C1] => '',
+            %w[c6
+               b3
+               b5
+               A3
+               B2
+               B6
+               B8
+               C5] => 'upgrade=cost:100,terrain:mountain',
+            %w[c8
+               A5
+               B12] => 'city=revenue:0',
+            %w[a2
+               a4
+               a6
+               C3] => 'town=revenue:0',
+          },
+          sepia: {
+            %w[a8
+               a12] => 'town=revenue:10;path=a:0,b:_0;path=a:5,b:_0',
+            ['B0'] => 'town=revenue:10;path=a:4,b:_0;path=a:5,b:_0',
+          },
+        }.freeze
+
         R1_HEXES = {
           white: {
             %w[R6
@@ -921,6 +963,7 @@ module Engine
         def game_hexes
           ghexes = {}
           append_game_hexes(ghexes, DB2_HEXES) if @optional_rules.include?(:db2)
+          append_game_hexes(ghexes, UNIT4_HEXES) if @optional_rules.include?(:unit_4)
           append_game_hexes(ghexes, R1_HEXES) if @regionals[1]
           append_game_hexes(ghexes, R2_HEXES) if @regionals[2]
           append_game_hexes(ghexes, R3_HEXES) if @regionals[3]

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -54,6 +54,11 @@ module Engine
             players: [4, 5, 6, 7, 8, 9],
           },
           {
+            sym: :unit_4,
+            short_name: 'Unit 4',
+            desc: 'Unpublished Unit 4 map for the north of Scotland',
+          },
+          {
             sym: :r1,
             short_name: 'R1',
             desc: 'Regional Kit 1 - Wales',
@@ -160,6 +165,7 @@ module Engine
           units = {}
           kits = {}
           regionals = {}
+          units4 = false
 
           units[1] = true if optional_rules.include?(:unit_1)
           units[1] = true if optional_rules.include?(:unit_12)
@@ -173,6 +179,8 @@ module Engine
           units[3] = true if optional_rules.include?(:unit_3)
           units[3] = true if optional_rules.include?(:unit_23)
           units[3] = true if optional_rules.include?(:unit_123)
+
+          units4 = true if optional_rules.include?(:unit_4)
 
           kits[1] = true if optional_rules.include?(:k1)
           kits[2] = true if optional_rules.include?(:k2)
@@ -199,6 +207,7 @@ module Engine
           return 'Cannot use both bank options' if optional_rules.include?(:big_bank) && optional_rules.include?(:strict_bank)
           return 'Variant DB1 not useful in a Unit 2 only game' if !units[1] && !units[3] && optional_rules.include?(:db1)
           return 'Variant DB2 is for Unit 1' if !units[1] && optional_rules.include?(:db2)
+          return 'Unit 4 requires Unit 3' if units4 && !units[3]
 
           nil
         end


### PR DESCRIPTION
Francis Tresham never got around to selling this but he distributed
various copies either as envelope stiffeners or at conventions, so
the layout is known.

Fortunately it does not introduce any more companies, trains, money etc
so there's no need to add three options (units 3+4, 2+3+4, 1+2+3+4).

It is intentional that this implementation doesn't add a @units[4];
there's a lot of 'case units.keys.sort.map(&:to_s).join' which would
break.