### PR TITLE
21Moon: Speed fix; receivership fixes to match rules; OLS ruling on bankruptcy

### DIFF
--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -737,11 +737,11 @@ module Engine
         end
 
         def sp_revenue(routes)
-          routes_revenue(routes.select { |r| @train_base[r.train] == :sp })
+          routes_revenue(routes.select { |r| @train_base[r.train] == :sp && !r.train.owner.receivership? })
         end
 
         def lb_revenue(routes)
-          routes_revenue(routes.select { |r| @train_base[r.train] == :lb })
+          routes_revenue(routes.select { |r| @train_base[r.train] == :lb || r.train.owner.receivership? })
         end
 
         def submit_revenue_str(routes, _render_halts)
@@ -805,10 +805,12 @@ module Engine
 
         def close_corporation(corporation, quiet: false)
           # move any shares owned by the corp to the market, ignoring 50% market limit
-          corporation.shares_by_corporation.each do |other, _|
-            shares = corporation.shares_of(other)
-            shares.each do |share|
-              @share_pool.transfer_shares(share.to_bundle, @share_pool)
+          if corporation.corporation?
+            corporation.shares_by_corporation.each do |other, _|
+              shares = corporation.shares_of(other)
+              shares.each do |share|
+                @share_pool.transfer_shares(share.to_bundle, @share_pool)
+              end
             end
           end
 

--- a/lib/engine/game/g_21_moon/step/bankrupt.rb
+++ b/lib/engine/game/g_21_moon/step/bankrupt.rb
@@ -53,9 +53,10 @@ module Engine
             @game.active_step.last_share_issued_price = nil
             @game.active_step.last_share_sold_price = nil
 
+            # leave OLS token on board
             @game.minors
               .select { |minor| minor.owner == player }
-              .each { |minor| @game.close_corporation(minor, quiet: true) }
+              .each(&:close!)
 
             if player.companies.any?
               @log << "#{player.name}'s companies close: #{player.companies.map(&:sym).join(', ')}"

--- a/lib/engine/game/g_21_moon/step/bankrupt.rb
+++ b/lib/engine/game/g_21_moon/step/bankrupt.rb
@@ -42,7 +42,7 @@ module Engine
               bundle = ShareBundle.new(shares)
               @game.share_pool.sell_shares(bundle, allow_president_change: true)
 
-              if corporation.owner == player && corporation.share_price.price.positive?
+              if corporation.owner == player && corporation.share_price.price.positive? && corporation != corp
                 @log << "-- #{corporation.name} enters receivership (it has no president) --"
                 corporation.owner = @game.share_pool
               end
@@ -62,13 +62,12 @@ module Engine
               player.companies.dup.each(&:close!)
             end
 
-            @log << "#{@game.format_currency(player.cash)} is transferred from "\
-                    "#{player.name} to #{corp.name}"
-            player.spend(player.cash, corp) if player.cash.positive?
-
             @game.corporations.dup.each do |corporation|
               @game.close_corporation(corporation) if corporation.share_price&.type == :close
             end
+
+            # close the trainless corporation
+            @game.close_corporation(corp)
 
             @game.declare_bankrupt(player)
           end

--- a/lib/engine/game/g_21_moon/step/route.rb
+++ b/lib/engine/game/g_21_moon/step/route.rb
@@ -11,7 +11,7 @@ module Engine
             return [] if !entity.operator? || entity.runnable_trains.empty? || !@game.can_run_route?(entity)
 
             actions = %w[run_routes]
-            actions << 'choose' if can_move?(entity)
+            actions << 'choose' if can_move?(entity) && !entity.receivership?
             actions
           end
 

--- a/lib/engine/game/g_21_moon/step/token.rb
+++ b/lib/engine/game/g_21_moon/step/token.rb
@@ -7,6 +7,12 @@ module Engine
     module G21Moon
       module Step
         class Token < Engine::Step::Token
+          def actions(entity)
+            return [] if entity.corporation? && entity.receivership?
+
+            super
+          end
+
           def process_place_token(action)
             super
 

--- a/lib/engine/game/g_21_moon/step/track.rb
+++ b/lib/engine/game/g_21_moon/step/track.rb
@@ -59,8 +59,10 @@ module Engine
           # this is where we see whether the track extends from LB, SP or both
           #
           def check_track_restrictions!(entity, old_tile, new_tile)
-            @lb_connected = new_tile.paths.any? { |np| @game.lb_graph.connected_paths(entity)[np] }
-            @sp_connected = new_tile.paths.any? { |np| @game.sp_graph.connected_paths(entity)[np] }
+            unless @game.loading
+              @lb_connected = new_tile.paths.any? { |np| @game.lb_graph.connected_paths(entity)[np] }
+              @sp_connected = new_tile.paths.any? { |np| @game.sp_graph.connected_paths(entity)[np] }
+            end
 
             check_border_crossing(entity, new_tile)
 

--- a/lib/engine/game/g_21_moon/step/track.rb
+++ b/lib/engine/game/g_21_moon/step/track.rb
@@ -7,6 +7,12 @@ module Engine
     module G21Moon
       module Step
         class Track < Engine::Step::Track
+          def actions(entity)
+            return [] if entity.corporation? && entity.receivership?
+
+            super
+          end
+
           def setup
             super
 


### PR DESCRIPTION
* Fixed needless Graph calls during loading
* Added clarified receivership functionality
* OLS no longer removes its token if player owner bankrupts

There is a chance that some games will need to be pinned.