### PR TITLE
Pass: new revenue center for 1841

### DIFF
--- a/assets/app/view/game/part/single_revenue.rb
+++ b/assets/app/view/game/part/single_revenue.rb
@@ -9,9 +9,10 @@ module View
       class SingleRevenue < Snabberb::Component
         needs :revenue
         needs :transform, default: 'translate(0 0)'
+        needs :force, default: nil
 
         def render
-          return h(:g) if @revenue.zero?
+          return h(:g) if @revenue.zero? && !@force
 
           circle_props = {
             attrs: {

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -117,6 +117,10 @@ module Engine
         false
       end
 
+      def pass?
+        false
+      end
+
       def visit_cost
         0
       end

--- a/lib/engine/part/pass.rb
+++ b/lib/engine/part/pass.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'city'
+
+module Engine
+  module Part
+    class Pass < City
+      attr_reader :color, :size
+
+      def initialize(revenue, **opts)
+        super
+        @color = (opts[:color] || 'gray').to_sym
+        @size = (opts[:size] || 1).to_i
+      end
+
+      def pass?
+        true
+      end
+    end
+  end
+end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -120,6 +120,20 @@ module Engine
                               loc: params['loc'])
         cache << city
         city
+      when 'pass'
+        pass = Part::Pass.new(params['revenue'],
+                              slots: params['slots'],
+                              groups: params['groups'],
+                              hide: params['hide'],
+                              visit_cost: params['visit_cost'],
+                              route: params['route'],
+                              format: params['format'],
+                              boom: params['boom'],
+                              loc: params['loc'],
+                              color: params['color'],
+                              size: params['size'])
+        cache << pass
+        pass
       when 'town'
         town = Part::Town.new(params['revenue'],
                               groups: params['groups'],


### PR DESCRIPTION
Engine::Part::Pass is a new class that inherits from Engine::Part::City

1841 needs a separate object for a pass because:
* It needs to render differently from a normal city
* It is treated differently for routing and train limits


![41_passes](https://user-images.githubusercontent.com/8494213/165193636-74ba3b54-1644-4cc0-808a-394504c6475c.png)
