### PR TITLE
1861: Fix bug where nationalised Nikolaev blocked starting minors

### DIFF
--- a/lib/engine/game/g_1861/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1861/step/buy_sell_par_shares.rb
@@ -8,11 +8,12 @@ module Engine
       module Step
         class BuySellParShares < G1867::Step::BuySellParShares
           def ipo_type(entity)
-            if entity.type == :minor && entity.id != 'N' && !@game.corporation_by_id('N').ipoed
+            return 'No home token locations are available' if entity.type == :major && @game.home_token_locations(entity).empty?
+
+            nikolaev = @game.corporation_by_id('N')
+            if entity.type == :minor && entity.id != 'N' && !(nikolaev.ipoed || nikolaev.closed?)
               return 'Nikolaev must be the first corporation'
             end
-
-            return 'No home token locations are available' if entity.type == :major && @game.home_token_locations(entity).empty?
 
             super
           end


### PR DESCRIPTION
Check for a closed Nikolaev when checking if a player should be prevented from starting an auction for a different minor in the stock round.

Closes #7558
Closes #7567