### PR TITLE
18dixie special city upgrades

### DIFF
--- a/assets/app/view/game/part/future_label.rb
+++ b/assets/app/view/game/part/future_label.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'view/game/part/base'
+require 'view/game/part/large_item'
+require 'lib/hex'
+require 'lib/settings'
+
+module View
+  module Game
+    module Part
+      class FutureLabel < Base
+        include Lib::Settings
+        include LargeItem
+
+        LARGE_RADIUS = 18
+        DELTA_X = (LARGE_RADIUS * 2) + 2
+
+        def preferred_render_locations
+          if layout == :flat
+            LARGE_ITEM_LOCATIONS
+          else
+            POINTY_LARGE_ITEM_LOCATIONS
+          end
+        end
+
+        def load_from_tile
+          # multiple future labels, or future labels + large icons not supported
+          @future_label = @tile.future_label
+        end
+
+        def render_part
+          dx = LARGE_RADIUS.round(2)
+          dy = LARGE_RADIUS.round(2)
+
+          color = color_for(@future_label.color) || (Lib::Hex::COLOR[@future_label.color || 'white'])
+          children = [h(:g, [
+            h(:polygon,
+              attrs: { points: hex_points(LARGE_RADIUS, dx, dy), fill: color }),
+            h('text.tile__text',
+              { attrs: { x: dx, y: dy } },
+              @future_label.label.to_s),
+          ].compact)]
+
+          h(:g, { attrs: { transform: "#{rotation_for_layout} translate(#{-LARGE_RADIUS} #{-LARGE_RADIUS})" } }, [
+              h(:g, { attrs: { transform: translate } }, children),
+            ])
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game/part/large_icons.rb
+++ b/assets/app/view/game/part/large_icons.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'view/game/part/base'
+require 'view/game/part/small_item'
 require 'lib/settings'
 
 module View
@@ -8,105 +9,12 @@ module View
     module Part
       class LargeIcons < Base
         include Lib::Settings
+        include LargeItem
 
         needs :game, default: nil, store: true
 
-        P_WIDE_LEFT_CORNER = {
-          region_weights: [5, 6, 7, 12, 13, 14],
-          x: -60,
-          y: 0,
-        }.freeze
-
-        P_WIDE_UPPER_LEFT_CORNER = {
-          region_weights: [0, 1, 2, 6, 7, 8],
-          x: -30,
-          y: -52,
-        }.freeze
-
-        P_WIDE_BOTTOM_LEFT_CORNER = {
-          region_weights: [13, 14, 15, 19, 20, 21],
-          x: -30,
-          y: 52,
-        }.freeze
-
-        P_WIDE_RIGHT_CORNER = {
-          region_weights: [9, 10, 11, 16, 17, 18],
-          x: 60,
-          y: 0,
-        }.freeze
-
-        P_WIDE_UPPER_RIGHT_CORNER = {
-          region_weights: [2, 3, 4, 8, 9, 10],
-          x: 30,
-          y: -52,
-        }.freeze
-
-        P_WIDE_BOTTOM_RIGHT_CORNER = {
-          region_weights: [15, 16, 17, 21, 22, 23],
-          x: 30,
-          y: 52,
-        }.freeze
-
-        PP_WIDE_LEFT_CORNER = {
-          region_weights: [5, 6, 7, 12, 13, 14],
-          x: -52,
-          y: -30,
-        }.freeze
-
-        PP_WIDE_UPPER_LEFT_CORNER = {
-          region_weights: [0, 1, 2, 6, 7, 8],
-          x: 0,
-          y: -60,
-        }.freeze
-
-        PP_WIDE_BOTTOM_LEFT_CORNER = {
-          region_weights: [13, 14, 15, 19, 20, 21],
-          x: -52,
-          y: 30,
-        }.freeze
-
-        PP_WIDE_RIGHT_CORNER = {
-          region_weights: [9, 10, 11, 16, 17, 18],
-          x: 52,
-          y: 30,
-        }.freeze
-
-        PP_WIDE_UPPER_RIGHT_CORNER = {
-          region_weights: [2, 3, 4, 8, 9, 10],
-          x: 52,
-          y: -30,
-        }.freeze
-
-        PP_WIDE_BOTTOM_RIGHT_CORNER = {
-          region_weights: [15, 16, 17, 21, 22, 23],
-          x: 0,
-          y: 60,
-        }.freeze
-
-        LARGE_ITEM_LOCATIONS = [P_WIDE_LEFT_CORNER,
-                                P_WIDE_UPPER_LEFT_CORNER,
-                                P_WIDE_BOTTOM_LEFT_CORNER,
-                                P_WIDE_RIGHT_CORNER,
-                                P_WIDE_UPPER_RIGHT_CORNER,
-                                P_WIDE_BOTTOM_RIGHT_CORNER].freeze
-
-        POINTY_LARGE_ITEM_LOCATIONS = [PP_WIDE_LEFT_CORNER,
-                                       PP_WIDE_UPPER_LEFT_CORNER,
-                                       PP_WIDE_BOTTOM_LEFT_CORNER,
-                                       PP_WIDE_RIGHT_CORNER,
-                                       PP_WIDE_UPPER_RIGHT_CORNER,
-                                       PP_WIDE_BOTTOM_RIGHT_CORNER].freeze
-
         LARGE_RADIUS = 25
         DELTA_X = (LARGE_RADIUS * 2) + 2
-
-        def preferred_render_locations
-          if layout == :flat
-            LARGE_ITEM_LOCATIONS
-          else
-            POINTY_LARGE_ITEM_LOCATIONS
-          end
-        end
 
         def load_from_tile
           # multiple large icons not supported
@@ -167,26 +75,6 @@ module View
           h(:g, { attrs: { transform: "#{rotation_for_layout} translate(#{-LARGE_RADIUS} #{-LARGE_RADIUS})" } }, [
               h(:g, { attrs: { transform: translate } }, children),
             ])
-        end
-
-        def diamond_points(r, cx, cy)
-          s = r * Math.sqrt(2.0)
-          "#{(cx - s).round(2)},#{cy.round(2)} "\
-            "#{cx.round(2)},#{(cy - s).round(2)} "\
-            "#{(cx + s).round(2)},#{cy.round(2)} "\
-            "#{cx.round(2)},#{(cy + s).round(2)}"
-        end
-
-        def hex_points(r, cx, cy)
-          s = r * 2 / Math.sqrt(3.0)
-          f60 = Math.sin(60 / 180 * Math::PI)
-          f30 = Math.sin(30 / 180 * Math::PI)
-          "#{(cx - s).round(2)},#{cy.round(2)} "\
-            "#{(cx - (s * f30)).round(2)},#{(cy - (s * f60)).round(2)} "\
-            "#{(cx + (s * f30)).round(2)},#{(cy - (s * f60)).round(2)} "\
-            "#{(cx + s).round(2)},#{cy.round(2)} "\
-            "#{(cx + (s * f30)).round(2)},#{(cy + (s * f60)).round(2)} "\
-            "#{(cx - (s * f30)).round(2)},#{(cy + (s * f60)).round(2)}"
         end
       end
     end

--- a/assets/app/view/game/part/large_item.rb
+++ b/assets/app/view/game/part/large_item.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'view/game/part/base'
+
+module View
+  module Game
+    module Part
+      module LargeItem
+        P_WIDE_LEFT_CORNER = {
+          region_weights: [5, 6, 7, 12, 13, 14],
+          x: -60,
+          y: 0,
+        }.freeze
+
+        P_WIDE_UPPER_LEFT_CORNER = {
+          region_weights: [0, 1, 2, 6, 7, 8],
+          x: -30,
+          y: -52,
+        }.freeze
+
+        P_WIDE_BOTTOM_LEFT_CORNER = {
+          region_weights: [13, 14, 15, 19, 20, 21],
+          x: -30,
+          y: 52,
+        }.freeze
+
+        P_WIDE_RIGHT_CORNER = {
+          region_weights: [9, 10, 11, 16, 17, 18],
+          x: 60,
+          y: 0,
+        }.freeze
+
+        P_WIDE_UPPER_RIGHT_CORNER = {
+          region_weights: [2, 3, 4, 8, 9, 10],
+          x: 30,
+          y: -52,
+        }.freeze
+
+        P_WIDE_BOTTOM_RIGHT_CORNER = {
+          region_weights: [15, 16, 17, 21, 22, 23],
+          x: 30,
+          y: 52,
+        }.freeze
+
+        PP_WIDE_LEFT_CORNER = {
+          region_weights: [5, 6, 7, 12, 13, 14],
+          x: -52,
+          y: -30,
+        }.freeze
+
+        PP_WIDE_UPPER_LEFT_CORNER = {
+          region_weights: [0, 1, 2, 6, 7, 8],
+          x: 0,
+          y: -60,
+        }.freeze
+
+        PP_WIDE_BOTTOM_LEFT_CORNER = {
+          region_weights: [13, 14, 15, 19, 20, 21],
+          x: -52,
+          y: 30,
+        }.freeze
+
+        PP_WIDE_RIGHT_CORNER = {
+          region_weights: [9, 10, 11, 16, 17, 18],
+          x: 52,
+          y: 30,
+        }.freeze
+
+        PP_WIDE_UPPER_RIGHT_CORNER = {
+          region_weights: [2, 3, 4, 8, 9, 10],
+          x: 52,
+          y: -30,
+        }.freeze
+
+        PP_WIDE_BOTTOM_RIGHT_CORNER = {
+          region_weights: [15, 16, 17, 21, 22, 23],
+          x: 0,
+          y: 60,
+        }.freeze
+
+        LARGE_ITEM_LOCATIONS = [P_WIDE_LEFT_CORNER,
+                                P_WIDE_UPPER_LEFT_CORNER,
+                                P_WIDE_BOTTOM_LEFT_CORNER,
+                                P_WIDE_RIGHT_CORNER,
+                                P_WIDE_UPPER_RIGHT_CORNER,
+                                P_WIDE_BOTTOM_RIGHT_CORNER].freeze
+
+        POINTY_LARGE_ITEM_LOCATIONS = [PP_WIDE_LEFT_CORNER,
+                                       PP_WIDE_UPPER_LEFT_CORNER,
+                                       PP_WIDE_BOTTOM_LEFT_CORNER,
+                                       PP_WIDE_RIGHT_CORNER,
+                                       PP_WIDE_UPPER_RIGHT_CORNER,
+                                       PP_WIDE_BOTTOM_RIGHT_CORNER].freeze
+
+        def preferred_render_locations
+          if layout == :flat
+            LARGE_ITEM_LOCATIONS
+          else
+            POINTY_LARGE_ITEM_LOCATIONS
+          end
+        end
+
+        def diamond_points(r, cx, cy)
+          s = r * Math.sqrt(2.0)
+          "#{(cx - s).round(2)},#{cy.round(2)} "\
+            "#{cx.round(2)},#{(cy - s).round(2)} "\
+            "#{(cx + s).round(2)},#{cy.round(2)} "\
+            "#{cx.round(2)},#{(cy + s).round(2)}"
+        end
+
+        def hex_points(r, cx, cy)
+          s = r * 2 / Math.sqrt(3.0)
+          f60 = Math.sin(60 / 180 * Math::PI)
+          f30 = Math.sin(30 / 180 * Math::PI)
+          "#{(cx - s).round(2)},#{cy.round(2)} "\
+            "#{(cx - (s * f30)).round(2)},#{(cy - (s * f60)).round(2)} "\
+            "#{(cx + (s * f30)).round(2)},#{(cy - (s * f60)).round(2)} "\
+            "#{(cx + s).round(2)},#{cy.round(2)} "\
+            "#{(cx + (s * f30)).round(2)},#{(cy + (s * f60)).round(2)} "\
+            "#{(cx - (s * f30)).round(2)},#{(cy + (s * f60)).round(2)}"
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -74,6 +74,7 @@ module View
         large, normal = @tile.icons.partition(&:large)
         children << render_tile_part(Part::Icons) unless normal.empty?
         children << render_tile_part(Part::LargeIcons) unless large.empty?
+        children << render_tile_part(Part::FutureLabel) if @tile.future_label
 
         children << render_tile_part(Part::Assignments) unless @tile.hex&.assignments&.empty?
         # borders should always be the top layer

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1511,6 +1511,9 @@ module Engine
       end
 
       def upgrades_to_correct_label?(from, to)
+        # If the from tile has a future label and the to tile is the color for it use that, otherwise use the from's label
+        return from.future_label.label == to.label.to_s if from.future_label && to.color == from.future_label.color
+
         from.label == to.label
       end
 

--- a/lib/engine/game/g_18_dixie/map.rb
+++ b/lib/engine/game/g_18_dixie/map.rb
@@ -102,13 +102,13 @@ module Engine
             %w[F10] => 'town=revenue:0;upgrade=cost:40,terrain:river',
 
             %w[D12 E7 F6 F14 G13 H8 J6 J10 K17 L22] => 'city=revenue:0',
-            %w[G23] => 'city=revenue:0;icon=image:18_dixie/AUG.brown,sticky:1',
-            %w[H10] => 'city=revenue:0;icon=image:18_dixie/BHM.green,sticky:1',
-            %w[M7] => 'city=revenue:0;icon=image:18_dixie/MOB.green,sticky:1',
-            %w[I19] => 'city=revenue:0;icon=image:18_dixie/MAC.brown,sticky:1',
-            %w[C11] => 'city=revenue:0;icon=image:18_dixie/NSH.green,sticky:1',
-            %w[L24] => 'city=revenue:0;icon=image:18_dixie/BRU.brown,sticky:1',
-            %w[E3] => 'city=revenue:0;icon=image:18_dixie/MEM.green,sticky:1',
+            %w[G23] => 'city=revenue:0;future_label=label:Aug,color:brown',
+            %w[H10] => 'city=revenue:0;future_label=label:Bhm,color:green',
+            %w[M7] => 'city=revenue:0;future_label=label:Mob,color:green',
+            %w[I19] => 'city=revenue:0;future_label=label:Mac,color:brown',
+            %w[C11] => 'city=revenue:0;future_label=label:Nash,color:green',
+            %w[L24] => 'city=revenue:0;future_label=label:Bru,color:brown',
+            %w[E3] => 'city=revenue:0;future_label=label:Mem,color:green',
             %w[D6] => 'city=revenue:20',
             %w[G17] => 'city=revenue:0,slots:3;label=Atl',
             %w[J16] => 'city=revenue:0;upgrade=cost:20,terrain:river',
@@ -118,7 +118,7 @@ module Engine
           yellow: {
             ['J12'] => 'city=revenue:20;path=a:1,b:_0;path=a:4,b:_0;path=a:3,b:_0;label=Mgm',
             ['F16'] => 'town=revenue:10;path=a:2,b:_0;path=a:5,b:_0',
-            ['E15'] => 'city=revenue:20;path=a:1,b:_0;path=a:5,b:_0;icon=image:18_dixie/CHT.green,sticky:1',
+            ['E15'] => 'city=revenue:20;path=a:1,b:_0;path=a:5,b:_0;future_label=label:Chat,color:green',
           },
         }.freeze
       end

--- a/lib/engine/game/g_18_dixie/map.rb
+++ b/lib/engine/game/g_18_dixie/map.rb
@@ -101,7 +101,14 @@ module Engine
             %w[M9 H20] => 'town=revenue:0;upgrade=cost:20,terrain:river',
             %w[F10] => 'town=revenue:0;upgrade=cost:40,terrain:river',
 
-            %w[C11 D12 E3 E7 F6 F14 G13 G23 H8 H10 I19 J6 J10 K17 L22 L24 M7] => 'city=revenue:0',
+            %w[D12 E7 F6 F14 G13 H8 J6 J10 K17 L22] => 'city=revenue:0',
+            %w[G23] => 'city=revenue:0;icon=image:18_dixie/AUG.brown,sticky:1',
+            %w[H10] => 'city=revenue:0;icon=image:18_dixie/BHM.green,sticky:1',
+            %w[M7] => 'city=revenue:0;icon=image:18_dixie/MOB.green,sticky:1',
+            %w[I19] => 'city=revenue:0;icon=image:18_dixie/MAC.brown,sticky:1',
+            %w[C11] => 'city=revenue:0;icon=image:18_dixie/NSH.green,sticky:1',
+            %w[L24] => 'city=revenue:0;icon=image:18_dixie/BRU.brown,sticky:1',
+            %w[E3] => 'city=revenue:0;icon=image:18_dixie/MEM.green,sticky:1',
             %w[D6] => 'city=revenue:20',
             %w[G17] => 'city=revenue:0,slots:3;label=Atl',
             %w[J16] => 'city=revenue:0;upgrade=cost:20,terrain:river',
@@ -111,7 +118,7 @@ module Engine
           yellow: {
             ['J12'] => 'city=revenue:20;path=a:1,b:_0;path=a:4,b:_0;path=a:3,b:_0;label=Mgm',
             ['F16'] => 'town=revenue:10;path=a:2,b:_0;path=a:5,b:_0',
-            ['E15'] => 'city=revenue:20;path=a:1,b:_0;path=a:5,b:_0;label=P',
+            ['E15'] => 'city=revenue:20;path=a:1,b:_0;path=a:5,b:_0;icon=image:18_dixie/CHT.green,sticky:1',
           },
         }.freeze
       end

--- a/lib/engine/game/g_18_dixie/tiles.rb
+++ b/lib/engine/game/g_18_dixie/tiles.rb
@@ -66,12 +66,13 @@ module Engine
           'X22' => {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:30,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=MEM;icon=image:18_dixie/P.brown',
+            'code' => 'city=revenue:30,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;'\
+                      'label=Mem;future_label=label:P,color:brown',
           },
           '442' => {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:30,slots:2;path=a:2,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=BHM',
+            'code' => 'city=revenue:30,slots:2;path=a:2,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=Bhm',
           },
           '443' => {
             'count' => 1,
@@ -86,12 +87,14 @@ module Engine
           '598' => {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=NSH;icon=image:18_dixie/P.brown',
+            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;'\
+                      'label=Nash;future_label=label:P,color:brown',
           },
           '599' => {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:4,b:_0;path=a:0,b:_0;label=;label=CHT;icon=image:18_dixie/P.brown',
+            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:4,b:_0;path=a:0,b:_0;label=;label=Chat;'\
+                      'future_label=label:P,color:brown',
           },
 
           'X30' => {
@@ -108,7 +111,7 @@ module Engine
           'X32' => {
             'count' => 1,
             'color' => 'brown',
-            'code' => 'city=revenue:50,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=BHM',
+            'code' => 'city=revenue:50,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=Bhm',
           },
           'X33' => {
             'count' => 1,
@@ -147,7 +150,7 @@ module Engine
             'count' => 1,
             'color' => 'gray',
             'code' => 'city=revenue:70,slots:3;'\
-                      'path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;path=a:3,b:_0;label=BHM',
+                      'path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;path=a:3,b:_0;label=Bhm',
           },
         }.freeze
       end

--- a/lib/engine/game/g_18_dixie/tiles.rb
+++ b/lib/engine/game/g_18_dixie/tiles.rb
@@ -66,7 +66,7 @@ module Engine
           'X22' => {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:30,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=P',
+            'code' => 'city=revenue:30,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=MEM;icon=image:18_dixie/P.brown',
           },
           '442' => {
             'count' => 1,
@@ -86,12 +86,12 @@ module Engine
           '598' => {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=P',
+            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:1,b:_0;path=a:0,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=NSH;icon=image:18_dixie/P.brown',
           },
           '599' => {
             'count' => 1,
             'color' => 'green',
-            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:4,b:_0;path=a:0,b:_0;label=P',
+            'code' => 'city=revenue:40,slots:2;path=a:2,b:_0;path=a:4,b:_0;path=a:0,b:_0;label=;label=CHT;icon=image:18_dixie/P.brown',
           },
 
           'X30' => {

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -178,6 +178,15 @@ module Engine
       end
       @tile.icons = @tile.icons.select(&:preprinted)
 
+      if @tile.future_label
+        if @tile.future_label&.color != tile.color
+          @tile.future_label.sticker = tile.future_label
+          tile.future_label = @tile.future_label
+        end
+        # restore old tile's future_label
+        @tile.future_label = @tile.future_label.sticker
+      end
+
       tile.reservations = @tile.reservations
       @tile.reservations = []
 

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -69,6 +69,10 @@ module Engine
         false
       end
 
+      def future_label?
+        false
+      end
+
       def path?
         false
       end

--- a/lib/engine/part/future_label.rb
+++ b/lib/engine/part/future_label.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Part
+    # There are many games where a city gets a plain yellow city, but gets a special green tile, or something similar
+    # where the label changes at some point in the tile upgrade path. This "future label" is to represent that
+    # sticker - has this future label been put on the tile by someone else, or did it come with this?
+    # nil if original; original FutureLabel if it has been modified
+    class FutureLabel < Base
+      attr_accessor :sticker
+      attr_reader :color, :label
+
+      def initialize(label = nil, color = nil)
+        @label = label
+        @color = color
+        @sticker = nil
+      end
+
+      def future_label?
+        true
+      end
+    end
+  end
+end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -15,10 +15,9 @@ module Engine
     include Config::Tile
 
     attr_accessor :blocks_lay, :hex, :icons, :index, :legal_rotations, :location_name,
-                  :name, :opposite, :reservations, :upgrades, :color
-    attr_reader :borders, :cities, :edges, :junction, :nodes, :labels,
-                :parts, :preprinted, :rotation, :stops, :towns, :offboards, :blockers,
-                :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :stripes, :hidden
+                  :name, :opposite, :reservations, :upgrades, :color, :future_label
+    attr_reader :borders, :cities, :edges, :junction, :nodes, :labels, :parts, :preprinted, :rotation, :stops, :towns,
+                :offboards, :blockers, :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :stripes, :hidden
 
     ALL_EDGES = [0, 1, 2, 3, 4, 5].freeze
 
@@ -188,6 +187,8 @@ module Engine
         Part::Frame.new(params['color'], params['color2'])
       when 'stripes'
         Part::Stripes.new(params['color'])
+      when 'future_label'
+        Part::FutureLabel.new(params['label'], params['color'])
       end
     end
 
@@ -234,6 +235,7 @@ module Engine
       @reservation_blocks = opts[:reservation_blocks] || false
       @unlimited = opts[:unlimited] || false
       @labels = []
+      @future_label = nil
       @opposite = nil
       @hidden = opts[:hidden] || false
       @id = "#{@name}-#{@index}"
@@ -587,6 +589,8 @@ module Engine
           @frame = part
         elsif part.stripes?
           @stripes = part
+        elsif part.future_label?
+          @future_label = part
         else
           raise "Part #{part} not separated."
         end


### PR DESCRIPTION
Implement 18Dixies special city upgrades using punch-through tile labels implemented as a part called "FutureLabel" to indicate that it's a label for a future tile, but not the current one

Here is a example of them being used on the Memphis city in 18Dixie - 
In yellow Memphis gets a plain yellow city tile
In green Memphis gets the Memphis green tile
In brown Memphis gets a P brown city tile

![image](https://user-images.githubusercontent.com/2993555/166179729-96e25010-ac86-4de5-9e1c-5c14e9af0665.png)

Care is taken to make sure that when tiles are "returned" that the FutureLabels put on the tiles are restored so that the FutureLabels don't pollute the supply of yellow city tiles.

The benefits of using a part over icons & game code are:
 - Easier to apply to pre-existing and new games
 - The tile image colors match the user's tile color preferences correctly
 - There don't need to be `.svg`s created for each punch through label