### PR TITLE
1822: Use FutureLabels for S & T tiles

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1512,7 +1512,7 @@ module Engine
 
       def upgrades_to_correct_label?(from, to)
         # If the from tile has a future label and the to tile is the color for it use that, otherwise use the from's label
-        return from.future_label.label == to.label.to_s if from.future_label && to.color == from.future_label.color
+        return from.future_label.label == to.label.to_s if from.future_label && to.color.to_s == from.future_label.color
 
         from.label == to.label
       end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -529,13 +529,6 @@ module Engine
 
         attr_accessor :bidding_token_per_player, :player_debts
 
-        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
-          upgrades = super
-          return upgrades unless tile_manifest
-
-          upgrades
-        end
-
         def bank_sort(corporations)
           corporations.reject { |c| c.type == :minor }.sort_by(&:name)
         end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -522,8 +522,6 @@ module Engine
         UPGRADABLE_S_YELLOW_CITY_TILE = '57'
         UPGRADABLE_S_YELLOW_ROTATIONS = [2, 5].freeze
         UPGRADABLE_S_HEX_NAME = 'D35'
-        UPGRADABLE_T_YELLOW_CITY_TILES = %w[5 6].freeze
-        UPGRADABLE_T_HEX_NAMES = %w[B43 K42 M42].freeze
 
         UPGRADE_COST_L_TO_2 = 80
 
@@ -534,10 +532,6 @@ module Engine
         def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
           upgrades = super
           return upgrades unless tile_manifest
-
-          upgrades |= [@green_s_tile] if self.class::UPGRADABLE_S_YELLOW_CITY_TILE == tile.name
-          upgrades |= [@green_t_tile] if self.class::UPGRADABLE_T_YELLOW_CITY_TILES.include?(tile.name)
-          upgrades |= [@sharp_city, @gentle_city] if self.class::UPGRADABLE_T_HEX_NAMES.include?(tile.hex.name)
 
           upgrades
         end
@@ -1227,24 +1221,9 @@ module Engine
         end
 
         def upgrades_to?(from, to, _special = false, selected_company: nil)
-          # Check the S hex and potential upgrades
+          # This is needed because the S tile upgrade removes the town in yellow
           if self.class::UPGRADABLE_S_HEX_NAME == from.hex.name && from.color == :white
             return self.class::UPGRADABLE_S_YELLOW_CITY_TILE == to.name
-          end
-
-          if self.class::UPGRADABLE_S_HEX_NAME == from.hex.name &&
-            self.class::UPGRADABLE_S_YELLOW_CITY_TILE == from.name
-            return to.name == 'X3'
-          end
-
-          # Check the T hexes and potential upgrades
-          if self.class::UPGRADABLE_T_HEX_NAMES.include?(from.hex.name) && from.color == :white
-            return self.class::UPGRADABLE_T_YELLOW_CITY_TILES.include?(to.name)
-          end
-
-          if self.class::UPGRADABLE_T_HEX_NAMES.include?(from.hex.name) &&
-            self.class::UPGRADABLE_T_YELLOW_CITY_TILES.include?(from.name)
-            return to.name == '405'
           end
 
           # Special case for Middleton Railway where we remove a town from a tile

--- a/lib/engine/game/g_1822/map.rb
+++ b/lib/engine/game/g_1822/map.rb
@@ -419,14 +419,15 @@ module Engine
             ['G12'] =>
               'city=revenue:0;border=edge:2,type:impassable;border=edge:3,type:water,cost:40',
             ['D35'] =>
-              'city=revenue:20,loc:center;town=revenue:10,loc:1;path=a:_0,b:_1;border=edge:0,type:impassable;label=S',
+              'city=revenue:20,loc:center;town=revenue:10,loc:1;path=a:_0,b:_1;border=edge:0,type:impassable;'\
+              'future_label=label:S,color:green',
             ['M38'] =>
               'city=revenue:20,groups:London;city=revenue:20,groups:London;city=revenue:20,groups:London;'\
               'city=revenue:20,groups:London;city=revenue:20,groups:London;city=revenue:20,groups:London;'\
               'path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;'\
               'label=L',
             %w[B43 K42 M42] =>
-              'city=revenue:0;label=T',
+              'city=revenue:0;future_label=label:T,color:green',
             %w[L19 Q30] =>
               'city=revenue:0;upgrade=cost:20,terrain:swamp',
             %w[H23 H33] =>

--- a/lib/engine/game/g_1822_mrs/game.rb
+++ b/lib/engine/game/g_1822_mrs/game.rb
@@ -174,13 +174,13 @@ module Engine
             ['I42'] =>
               'city=revenue:0;border=edge:1,type:impassable',
             ['D35'] =>
-              'city=revenue:20,loc:center;town=revenue:10,loc:1;path=a:_0,b:_1;label=S',
+              'city=revenue:20,loc:center;town=revenue:10,loc:1;path=a:_0,b:_1;future_label=label:S,color:green',
             ['M38'] =>
               'city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;'\
               'path=a:0,b:_0;path=a:1,b:_1;path=a:2,b:_2;path=a:3,b:_3;path=a:4,b:_4;path=a:5,b:_5;upgrade=cost:20;'\
               'label=L',
             %w[K42 M42] =>
-              'city=revenue:0;label=T',
+              'city=revenue:0;future_label=label:T,color:green',
             %w[L19 Q30] =>
               'city=revenue:0;upgrade=cost:20,terrain:swamp',
             %w[H23 H33] =>


### PR DESCRIPTION
I updated 1822 to use FutureLabels instead of special upgrade logic. The yellow S tile upgrade logic is still needed because the town is removed in yellow.
I also found and fixed a JS v Ruby bug when testing this which is now fixed

![image](https://user-images.githubusercontent.com/2993555/167129047-563e4e9b-9fd9-4e3d-adde-d637b02d79bf.png)
![image](https://user-images.githubusercontent.com/2993555/167129112-8ec0096d-b3ff-4edb-b25a-dec834789995.png)
![image](https://user-images.githubusercontent.com/2993555/167129700-86754b08-8e04-4f0c-95f4-fc30db40f14b.png)
![image](https://user-images.githubusercontent.com/2993555/167129742-3d43d276-7c40-4aa4-a509-d1ebe06b6bc8.png)
![image](https://user-images.githubusercontent.com/2993555/167129993-97f123c6-d53e-4094-b78d-625ac5e6c1ac.png)
