### PR TITLE
18Rhl: Correct bankruptcy for corporation in receivership

### DIFF
--- a/lib/engine/game/g_18_rhl/step/bankrupt.rb
+++ b/lib/engine/game/g_18_rhl/step/bankrupt.rb
@@ -77,7 +77,7 @@ module Engine
             @log << "#{corp.name} buys a #{cheapest.name} train for #{cheapest.price} from #{source}, "\
                     "using previous president's cash of #{format(president_contribution)}, the treasury "\
                     "of #{format(remaining)} and the Bank paying the remaining #{format(price)}"
-            corp.spend(remaining, @game.bank)
+            corp.spend(remaining, @game.bank) if remaining.positive?
             @game.buy_train(corp, cheapest, :free)
             @game.phase.buying_train!(corp, cheapest)
             fee = 100

--- a/lib/engine/game/g_18_rhl/step/buy_train.rb
+++ b/lib/engine/game/g_18_rhl/step/buy_train.rb
@@ -21,6 +21,14 @@ module Engine
           def round_state
             { bought_trains: [] }
           end
+
+          def ebuy_president_can_contribute?(corporation)
+            corporation.receivership? ? false : super
+          end
+
+          def president_may_contribute?(entity, _shell = nil)
+            entity.receivership? ? false : super
+          end
         end
       end
     end


### PR DESCRIPTION
The train buy for receivership after player bankruptcy is
handled automatically so no need to render Buy Trains.

Also fixed bug in case remaining cash in corporation is 0.

Fixes #7674