### PR TITLE
Add variant DB3

### DIFF
--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -443,6 +443,7 @@ module Engine
             raise OptionError, 'Variant DB1 not useful in a Unit 2 only game'
           end
           raise OptionError, 'Variant DB2 is for Unit 1' if !units[1] && optional_rules.include?(:db2)
+          raise OptionError, 'Variant DB3 is for Unit 3' if !units[3] && optional_rules.include?(:db3)
           raise OptionError, 'Unit 4 requires Unit 3' if optional_rules.include?(:unit_4) && !units[3]
 
           p_range = case @units.keys.sort.map(&:to_s).join
@@ -717,12 +718,17 @@ module Engine
             locations['C3'] = 'Fort William'
             locations.delete('B8')
           end
+          locations['G7'] = if optional_rules.include?(:db3)
+                              'Falkirk & Airdrie'
+                            else
+                              'Coatbridge & Airdrie'
+                            end
           locations
         end
 
         def upgrades_to?(from, to, special = false, selected_company: nil)
           # handle special-case upgrades
-          return true if force_dit_upgrade?(from, to)
+          return true if force_upgrade?(from, to)
           return false if illegal_upgrade?(from, to) # only really needed for upgrades shown on tile manifest
 
           # deal with striped tiles
@@ -738,8 +744,8 @@ module Engine
           super
         end
 
-        def force_dit_upgrade?(from, to)
-          return false unless (list = DIT_UPGRADES[from.name])
+        def force_upgrade?(from, to)
+          return false unless (list = EXTRA_UPGRADES[from.name])
 
           list.include?(to.name)
         end

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -31,10 +31,13 @@ module Engine
           'F10' => 'Anstruther',
           'G3' => 'Greenock',
           'G5' => 'Glasgow',
-          'G7' => 'Coatbridge & Airdrie',
+          # G7 now handled in game.rb for variant DB3
           'G9' => 'Edinburgh & Leith',
+          'G13' => 'Berwick',
           'H4' => 'Kilmarnock & Ayr',
           'H6' => 'Motherwell',
+          'H10' => 'Galashiels',
+          'I13' => 'Morpeth & Blythe',
           'J2' => 'Stranraer',
           'J6' => 'Dumfries',
           'J10' => 'Carlisle',
@@ -501,11 +504,17 @@ module Engine
           '14' => -1,
           '15' => -1,
         }.freeze
+
+        DB3_TILES = {
+          '58' => 1,
+          '206' => 1,
+        }.freeze
+
         # rubocop:enable Layout/LineLength
 
-        # This includes upgrades for the DB1 kit tiles 887/888. This does not
-        # affect the game without it since none of them are present.
-        DIT_UPGRADES = {
+        # This includes upgrades for the DB1 kit tiles 887/888 and DB3 #206.
+        # Games without DB kits lack those tiles so are unaffected.
+        EXTRA_UPGRADES = {
           # gentle curve to three curves with a halt
           '8' => %w[11],
           # yellow double-dit to green K or X city
@@ -520,9 +529,11 @@ module Engine
           '887' => %w[63 166],
           '888' => %w[63 166],
           # yellow single-dit to green city (also brown/green city)
-          '3' => %w[12 14 15 119],
-          '4' => %w[14 15 119],
-          '58' => %w[12 13 14 15 119],
+          '3' => %w[12 14 15 119 206],
+          '4' => %w[14 15 119 206],
+          '58' => %w[12 13 14 15 119 206],
+          # not a dit at all but a yellow city, how exciting
+          '115' => '206',
           # HACK: for 119 (green/brown tile that upgrades to gray)
           '119' => %w[51],
         }.freeze
@@ -570,6 +581,7 @@ module Engine
           append_game_tiles(gtiles, K6_TILES) if @kits[6]
           append_game_tiles(gtiles, D1_TILES) if @optional_rules.include?(:d1)
           db1_tiles(gtiles) if @optional_rules.include?(:db1)
+          append_game_tiles(gtiles, DB3_TILES) if @optional_rules.include?(:db3)
           gtiles
         end
 
@@ -863,6 +875,19 @@ module Engine
           },
         }.freeze
 
+        DB3_HEXES = {
+          white: {
+            ['I9'] => '',
+            ['J6'] => 'town=revenue:0',
+            ['G13'] => 'city=revenue:0',
+            ['H10'] => 'town=revenue:0;upgrade=cost:100,terrain:mountain',
+            ['F4'] => 'town=revenue:0;border=edge:0,type:impassable;upgrade=cost:100,terrain:mountain',
+          },
+          sepia: {
+            ['F2'] => 'town=revenue:10,loc:4;path=a:4,b:_0;path=a:3,b:_0;town=revenue:10,loc:5;path=a:5,b:_1',
+          },
+        }.freeze
+
         UNIT1_OFFMAP_HEXES = {
           gray: {
             %w[Q7
@@ -963,6 +988,7 @@ module Engine
         def game_hexes
           ghexes = {}
           append_game_hexes(ghexes, DB2_HEXES) if @optional_rules.include?(:db2)
+          append_game_hexes(ghexes, DB3_HEXES) if @optional_rules.include?(:db3)
           append_game_hexes(ghexes, UNIT4_HEXES) if @optional_rules.include?(:unit_4)
           append_game_hexes(ghexes, R1_HEXES) if @regionals[1]
           append_game_hexes(ghexes, R2_HEXES) if @regionals[2]

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -133,6 +133,11 @@ module Engine
             short_name: 'DB2',
             desc: 'Dave Berry variant 2: SECR Changes for Unit 1',
           },
+          {
+            sym: :db3,
+            short_name: 'DB3',
+            desc: 'Dave Berry variant 3: Unit 3 map revision',
+          },
         ].freeze
 
         MUTEX_RULES = [
@@ -207,6 +212,7 @@ module Engine
           return 'Cannot use both bank options' if optional_rules.include?(:big_bank) && optional_rules.include?(:strict_bank)
           return 'Variant DB1 not useful in a Unit 2 only game' if !units[1] && !units[3] && optional_rules.include?(:db1)
           return 'Variant DB2 is for Unit 1' if !units[1] && optional_rules.include?(:db2)
+          return 'Variant DB3 is for Unit 3' if !units[3] && optional_rules.include?(:db3)
           return 'Unit 4 requires Unit 3' if units4 && !units[3]
 
           nil

--- a/lib/engine/game/g_1825/step/track_and_token.rb
+++ b/lib/engine/game/g_1825/step/track_and_token.rb
@@ -185,7 +185,7 @@ module Engine
           end
 
           def legal_tile_rotation?(entity, hex, tile)
-            return super unless @game.force_dit_upgrade?(hex.tile, tile)
+            return super unless @game.force_upgrade?(hex.tile, tile)
 
             # basically a simplified version of the super except with a modified path check to allow dits to upgrade to cities
             return false unless @game.legal_tile_rotation?(entity, hex, tile)


### PR DESCRIPTION
As with the other DB variants, I have implemented only what I think
is the most commonly used set of changes, since 1825 has many options
already.

This implementation does (purely cosmetically) add town names to hex
I13 even in non-DB3 games since that seems harmless.