### PR TITLE
18GB - small UI updates for 2E playtest variant

### DIFF
--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -129,13 +129,8 @@ module Engine
             corporation&.type == :'5-share' && corporation&.president?(player) && corporation&.operated?
           end
 
-          def can_sell_any?(entity)
-            return false if @game.end_game_restrictions_active?
-
-            super
-          end
-
           def can_sell?(entity, bundle)
+            return if @game.end_game_restrictions_active?
             return if converted?
             return super unless @game.class::PRESIDENT_SALES_TO_MARKET
             return unless bundle

--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -42,7 +42,11 @@ module Engine
           end
 
           def description
-            'Sell then Buy Shares, or Convert Corporations'
+            if @game.end_game_restrictions_active?
+              'Buy Shares or Convert Corporations'
+            else
+              'Sell then Buy Shares, or Convert Corporations'
+            end
           end
 
           def abilities(entity, **kwargs, &block)

--- a/lib/engine/game/g_18_gb/step/track_and_token.rb
+++ b/lib/engine/game/g_18_gb/step/track_and_token.rb
@@ -23,6 +23,16 @@ module Engine
             actions
           end
 
+          def description
+            @game.end_game_restrictions_active? ? 'Lay Track' : 'Place a Token or Lay Track'
+          end
+
+          def pass_description
+            verb = @acted ? 'Done' : 'Skip'
+            actions = @game.end_game_restrictions_active? ? 'Track' : 'Token/Track'
+            "#{verb} (#{actions})"
+          end
+
           def can_place_token?(entity)
             return false if @game.end_game_restrictions_active?
 


### PR DESCRIPTION
- Don't show Sell buttons in the stock round once selling shares is no longer possible due to end-game restrictions
- Update the step descriptions (and the Pass button) for stock trading and track-and-token steps so that these are more accurate in cases where end-game restrictions are active