### PR TITLE
Auction fix

### DIFF
--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -312,7 +312,7 @@ module View
             },
           }
 
-          @selected_corporation = @step.auctioning if @step.auctioning&.corporation?
+          @selected_corporation = @step.auctioning if @step.auctioning.is_a?(Engine::Corporation)
 
           @step.available.select(&:corporation?).map do |corporation|
             children = []


### PR DESCRIPTION
I managed to break games (at least Harzbahn 1873) with an extra check i did in the auction view. The auctioning enity in Harzbahn 1873 was a String, so the .corporation? check failed.