### PR TITLE
18LA2: private company Angeles Public Dump, move to alpha

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -18,6 +18,7 @@ module View
     def render_notification
       message = <<~MESSAGE
 
+        <p><a href='https://github.com/tobymao/18xx/wiki/18LosAngeles#2nd-edition'>18 Los Angeles 2</a> is in alpha.</p>
         <p><a href='https://github.com/tobymao/18xx/wiki/18SJ'>18SJ</a> version 0.92 is now available. Alpha next?</p>
         <p><a href='https://github.com/tobymao/18xx/wiki/1822MX'>1822MX</a> is in alpha.</p>
         <p>18Carolinas, 18NewEngland and 18NewEngland2 are now in production.</p>

--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -311,6 +311,12 @@ Modified station token placement
   placed in a location that the ability is allowed to use. Default false.
 - `neutral`: If true, this ability uses a "neutral" token, which allows all
   corporations to pass through it
+- `check_tokenable`: If false, skip the `tokenable?` check before placing the
+  token. Used in 18LA2 for the Angeles Public Dump, which places a special
+  station token that does not actually belong to the owning corporation, and can
+  therefore be placed in the same city as another token belonging to the owning
+  corporation. Note that this property will bypass all tokenable checks, not
+  just `:existing_token`. Default true.
 
 
 ## sell_company

--- a/lib/engine/ability/token.rb
+++ b/lib/engine/ability/token.rb
@@ -6,11 +6,11 @@ module Engine
   module Ability
     class Token < Base
       attr_reader :hexes, :teleport_price, :extra_action, :from_owner, :discount, :city,
-                  :neutral, :cheater, :special_only, :extra_slot
+                  :neutral, :cheater, :special_only, :extra_slot, :check_tokenable
 
       def setup(hexes:, price: nil, teleport_price: nil, extra_action: nil,
                 from_owner: nil, discount: nil, city: nil, neutral: nil,
-                cheater: nil, extra_slot: nil, special_only: nil)
+                cheater: nil, extra_slot: nil, special_only: nil, check_tokenable: nil)
         @hexes = hexes
         @price = price
         @teleport_price = teleport_price
@@ -22,6 +22,7 @@ module Engine
         @cheater = cheater || false
         @extra_slot = extra_slot || false
         @special_only = special_only || false
+        @check_tokenable = check_tokenable.nil? ? true : check_tokenable
       end
 
       def price(token = nil)

--- a/lib/engine/game/g_18_los_angeles/entities.rb
+++ b/lib/engine/game/g_18_los_angeles/entities.rb
@@ -223,8 +223,29 @@ module Engine
             sym: 'APD',
             value: 40,
             revenue: 10,
-            desc: '',
-            abilities: [],
+            desc: 'Place the -20 station token in any location except for Los Angeles or Long Beach. '\
+                  'This token cannot be used by any corporation and reduces revenue in its location '\
+                  'by $20 for all corporations and minors.',
+            abilities: [
+              {
+                type: 'token',
+                when: 'owning_corp_or_turn',
+                owner_type: 'corporation',
+                hexes: %w[
+                  A4 A6 A8 B5 B9 B11 B13 C4 C8 C12 D5 D7 D9 D11 D13
+                  E4 E6 E10 E12 F9 F11 F13
+                ],
+                price: 0,
+                teleport_price: 0,
+                count: 1,
+                extra_action: true,
+                special_only: true,
+
+                # allow the dump token to be placed next to a real station token
+                # belonging to the owning corporation
+                check_tokenable: false,
+              },
+            ],
           },
           {
             name: 'Los Angeles Paving',
@@ -265,6 +286,7 @@ module Engine
                 teleport_price: 0,
                 count: 1,
                 extra_action: true,
+                special_only: true,
               },
             ],
           },

--- a/lib/engine/game/g_18_los_angeles/meta.rb
+++ b/lib/engine/game/g_18_los_angeles/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :prealpha
+        DEV_STAGE = :alpha
         DEPENDS_ON = '1846'
 
         GAME_DESIGNER = 'Anthony Fryer'

--- a/lib/engine/game/g_18_los_angeles/step/special_token.rb
+++ b/lib/engine/game/g_18_los_angeles/step/special_token.rb
@@ -15,12 +15,18 @@ module Engine
 
             super
 
-            return unless action.entity == @game.rj
-
-            token = action.city.tokens[action.slot]
-            token.logo = token.logo.sub('.svg', '_RJ.svg')
-            token.simple_logo = token.logo
-            @game.rj_token = token
+            if action.entity == @game.rj
+              token = action.city.tokens.reverse.find(&:itself)
+              token.logo = token.logo.sub('.svg', '_RJ.svg')
+              token.simple_logo = token.logo
+              @game.rj_token = token
+            elsif action.entity == @game.dump_company
+              token = action.city.tokens.reverse.find(&:itself)
+              token.corporation = @game.dump_corp
+              token.logo = @game.dump_corp.logo
+              token.simple_logo = token.logo
+              @game.dump_token = token
+            end
           end
         end
       end

--- a/lib/engine/step/special_token.rb
+++ b/lib/engine/step/special_token.rb
@@ -52,12 +52,21 @@ module Engine
         city_string = hex.tile.cities.size > 1 ? " city #{action.city.index}" : ''
         raise GameError, "Cannot place token on #{hex.name}#{city_string}" unless available_hex(entity, hex)
 
+        special_ability = ability(entity)
+        check_tokenable =
+          if special_ability.respond_to?(:check_tokenable)
+            special_ability.check_tokenable
+          else
+            true
+          end
+
         place_token(
           @game.token_owner(entity),
           action.city,
           action.token,
           connected: false,
-          special_ability: ability(entity),
+          special_ability: special_ability,
+          check_tokenable: check_tokenable,
         )
 
         teleport_complete if @round.teleported

--- a/public/logos/18_los_angeles/dump.svg
+++ b/public/logos/18_los_angeles/dump.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#000000"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="4" font-family="Arial" fill="#fff">-20</text></svg>


### PR DESCRIPTION
The Dump places a -$20 station token which blocks everyone--including the
corporation that placed it--and reduces the city's revenue by $20 for all routes

Westminster is the only $10 target for the Dump, and if the Dump is placed there
the net revenue is $0 instead of -$10. Westminster is also a target for the
Steamship (adding $40), and if both are placed there, then the Dump's full
penalty applies for a net revenue of $30.

In order to allow a corporation owning Angeles Public Dump to place the Dump
token in a city where they have a regular token, token abilities have a new
attribute, `check_tokenable`, which can be set to `false` to bypass the usual
tokening requirements; at the time the check is made, the token still belongs to
the owning corporation, rather than the dummy DUMP corporation, and since a new
Token is created when using a special ability in `adjust_token_price_ability!`,
`check_tokenable` was needed to get around the usual token requirement of only
one token per city.