### PR TITLE
18GB 2E Updates

### DIFF
--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -137,7 +137,7 @@ module Engine
               name: 'Liverpool & Manchester',
               value: 45,
               revenue: 15,
-              desc: 'The LM gives a bonus of £10 for Liverpool (E14). The owner of the LM may use this bonus for any trains ' \
+              desc: 'The LM gives a bonus of £20 for Liverpool (E14). The owner of the LM may use this bonus for any trains ' \
                     'run by corporations that they control, from the time that the LM closes until the end of the game.',
               sym: 'LM',
               color: nil,
@@ -157,7 +157,7 @@ module Engine
                   type: 'hex_bonus',
                   when: 'owning_playing_or_turn',
                   owner_type: 'player',
-                  amount: 10,
+                  amount: 20,
                   hexes: ['E14'],
                 },
               ],

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -479,7 +479,7 @@ module Engine
           return unless end_game_restrictions?
           return if @end_game_near
 
-          @log << '-- Event: End game restrictions are now in place (no more tokens may be placed, no shares may be sold) --'
+          @log << '-- Event: End game restrictions are now in place: no more tokens may be placed --'
           @end_game_near = true
         end
 
@@ -1092,7 +1092,7 @@ module Engine
 
         def or_round_finished
           depot.export! unless @train_bought
-          trigger_end_game_restrictions if @depot.upcoming.size <= 3
+          trigger_end_game_restrictions if @depot.upcoming.size <= 2
         end
 
         def end_now?(after)

--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -42,11 +42,7 @@ module Engine
           end
 
           def description
-            if @game.end_game_restrictions_active?
-              'Buy Shares or Convert Corporations'
-            else
-              'Sell then Buy Shares, or Convert Corporations'
-            end
+            'Sell then Buy Shares, or Convert Corporations'
           end
 
           def abilities(entity, **kwargs, &block)
@@ -134,7 +130,6 @@ module Engine
           end
 
           def can_sell?(entity, bundle)
-            return if @game.end_game_restrictions_active?
             return if converted?
             return super unless @game.class::PRESIDENT_SALES_TO_MARKET
             return unless bundle


### PR DESCRIPTION
Updates as per designer Dave Berry:

- The LM private company should give a £20 bonus to Liverpool, not £10.
- The second-edition playtest end-game variant is being updated to trigger with 2 or fewer (instead of 3 or fewer) trains remaining at the end of an OR, and to only block token placement and not also share sales as per the previous version of this rule.