### PR TITLE
podman updates to allow building on Fedora 35

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,7 +49,8 @@ services:
 
   nginx:
     restart: always
-    build: ./nginx/
+    build:
+      context: ./nginx/
     ports:
       - 80:80
       - 443:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.5'
 
 services:
   rack:
-    build: .
+    build:
+      context: .
     depends_on:
       - db
       - redis
@@ -11,7 +12,8 @@ services:
         max-size: "10m"
 
   queue:
-    build: .
+    build:
+      context: .
     depends_on:
       - db
       - redis
@@ -20,7 +22,8 @@ services:
         max-size: "10m"
 
   redis:
-    build: ./redis/
+    build:
+      context: ./redis/
     ports:
       - 127.0.0.1:6380:6379
     logging:
@@ -28,7 +31,8 @@ services:
         max-size: "10m"
 
   db:
-    build: ./db/
+    build:
+      context: ./db/
     volumes:
       - ./db/data:/var/lib/postgresql/data:Z
     ports:

--- a/scripts/data_dir.sh
+++ b/scripts/data_dir.sh
@@ -19,7 +19,7 @@ if [[ $1 == 'podman' ]]; then
   db_uid=1000
   mapped_db_uid=$(($(grep "^$USER:" /etc/subuid | cut -d: -f2) - 1 + db_uid))
   find db/data -prune -type d ! -user $mapped_db_uid -exec \
-       sudo chown -R $mapped_db_uid:$mapped_db_uid \;
+       sudo chown -R $mapped_db_uid:$mapped_db_uid "{}" \;
 else
   find db/data -prune -type d -user root -exec \
        sudo chown -R "$USER":"$USER" \;


### PR DESCRIPTION
These are changes needed to build using podman on Fedora 35.

### 1. build/context.

If some parts of the build omit the `context` subfield, then podman fails to merge the two yml files correctly.  I could not find any existing podman issues regarding this.

```
rm -f docker-compose.override.yml
ln -s docker-compose.dev.yml docker-compose.override.yml
./scripts/data_dir.sh podman
podman-compose up --build
['podman', '--version', '']
using podman version: 3.4.7
Traceback (most recent call last):
[TRACEBACK OMITTED FOR SPACE]
ValueError: can't merge value of build of type <class 'str'> and <class 'dict'>
make: *** [Makefile:33: dev_up_b] Error 1
```

Per the docs at : https://docs.docker.com/compose/compose-file/compose-file-v3/

This should be equivalent.

>  build can be specified either as a string containing a path to the build context:

> Or, as an object with the path specified under [context](https://docs.docker.com/compose/compose-file/compose-file-v3/#context) ...


### 2. find/exec.

This missing argument to chown causes this to fail, halting the build.  `{}` passes the found file to exec, which allows chown to work corrrectly.

```
./scripts/data_dir.sh podman
chown: missing operand after '100999:100999'
Try 'chown --help' for more information.
```


https://linux.die.net/man/1/find 

> -exec command ;  ... The string '{}' is replaced by the current file name being processed everywhere it occurs in the arguments to the command ...