### PR TITLE
[1817] Implement Volatility expansion initial auction

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -138,23 +138,24 @@ module View
           end
           props[:style][:display] = @display
 
-          header_text = @game.respond_to?(:company_header) ? @game.company_header(@company) : 'PRIVATE COMPANY'
           revenue_str = if @game.respond_to?(:company_revenue_str)
                           @game.company_revenue_str(@company)
-                        else
+                        elsif @company.revenue
                           @game.format_currency(@company.revenue)
+                        else
+                          ''
                         end
 
           company_name_str = @game.respond_to?(:company_size) ? "[#{@game.company_size(@company)}] " : ''
           company_name_str += @company.name
 
           children = [
-            h(:div, { style: header_style }, header_text),
+            h(:div, { style: header_style }, @game.company_header(@company)),
             h(:div, company_name_str),
             h(:div, { style: description_style }, @company.desc),
-            h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}"),
-            h(:div, { style: revenue_style }, "Revenue: #{revenue_str}"),
           ]
+          children << h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}") if @company.value
+          children << h(:div, { style: revenue_style }, "Revenue: #{revenue_str}") if @company.revenue
           children << render_bidders if @bids&.any?
 
           unless @company.discount.zero?

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -166,7 +166,7 @@ module View
                     })
 
           buttons = []
-          if @step.min_bid(company) <= @step.max_place_bid(@current_entity, company)
+          if @step.may_bid?(company) && @step.min_bid(company) <= @step.max_place_bid(@current_entity, company)
             bid_str = @step.respond_to?(:bid_str) ? @step.bid_str(company) : 'Place Bid'
             buttons << h(:button, { on: { click: -> { create_bid(company, input) } } }, bid_str)
           end

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -25,8 +25,8 @@ module Engine
       @discount = opts[:discount] || 0
       @min_auction_price = -@discount
       @closed = false
-      @min_price = opts[:min_price] || (@value / 2.0).ceil
-      @max_price = opts[:max_price] || (@value * 2)
+      @min_price = opts[:min_price] || (@value ? (@value / 2.0).ceil : nil)
+      @max_price = opts[:max_price] || (@value ? (@value * 2) : nil)
       @interval = opts[:interval] # Array of prices or nil
       @color = opts[:color] || :yellow
       @text_color = opts[:text_color] || :black

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1965,6 +1965,10 @@ module Engine
         entity&.company? ? entity.owner : entity
       end
 
+      def company_header(_company)
+        'PRIVATE COMPANY'
+      end
+
       private
 
       def init_graph

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -626,6 +626,8 @@ module Engine
           },
         ].freeze
 
+        VOLATILITY_CITY_TILE_COMPANIES = %w[PSM P16 P17 P24].freeze
+
         CORPORATIONS = [
           {
             float_percent: 20,
@@ -1612,10 +1614,22 @@ module Engine
           entity.total_shares.to_s
         end
 
+        def empty_auction_slot
+          @empty_auction_slot ||= Engine::Company.new(sym: '', name: '', value: nil, revenue: nil, desc: '', color: 'LightGrey')
+        end
+
+        def company_header(company)
+          return 'EMPTY SLOT' if company == empty_auction_slot
+
+          super
+        end
+
         private
 
         def new_auction_round
-          log << "Seed Money for initial auction is #{format_currency(self.class::SEED_MONEY)}" unless @round
+          if !@round && !option_volatility_expansion?
+            log << "Seed Money for initial auction is #{format_currency(self.class::SEED_MONEY)}"
+          end
           Engine::Round::Auction.new(self, [
             G1817::Step::SelectionAuction,
           ])

--- a/lib/engine/game/g_1817/step/selection_auction.rb
+++ b/lib/engine/game/g_1817/step/selection_auction.rb
@@ -10,6 +10,7 @@ module Engine
         class SelectionAuction < Engine::Step::Base
           include Engine::Step::PassableAuction
           ACTIONS = %w[bid pass].freeze
+          ACTIONS_NO_PASS = %w[bid].freeze
 
           attr_reader :companies, :seed_money
 
@@ -64,8 +65,10 @@ module Engine
 
           def actions(entity)
             return [] if @companies.empty?
+            return [] unless entity == current_entity
+            return ACTIONS_NO_PASS if @game.option_volatility_expansion? && !@auctioning
 
-            entity == current_entity ? ACTIONS : []
+            ACTIONS
           end
 
           def min_increment
@@ -75,10 +78,40 @@ module Engine
           def setup
             setup_auction
             @companies = @game.companies.dup
-            @seed_money = @game.class::SEED_MONEY
+            setup_tiered_auction
+            @seed_money = @game.option_volatility_expansion? ? nil : @game.class::SEED_MONEY
+          end
+
+          def setup_tiered_auction
+            if @game.option_volatility_expansion?
+              @companies.sort_by! { @game.rand }
+
+              # Pick "Pittsburgh" company
+              city_privates, @companies = @companies.partition { |c| @game.class::VOLATILITY_CITY_TILE_COMPANIES.include?(c.id) }
+              @companies.unshift(city_privates.shift)
+              city_privates.each(&:close!)
+
+              # Create Company Pyramid
+              companies = @companies.dup
+              @tiered_companies = 6.times.with_index.map { |i| companies.shift(i + 1) }
+            else
+              @tiered_companies = [@companies.dup]
+            end
+          end
+
+          def tiered_auction_companies
+            @tiered_companies
+          end
+
+          def may_bid?(company)
+            return false if company == @game.empty_auction_slot
+
+            super
           end
 
           def starting_bid(company)
+            return 0 if @game.option_volatility_expansion?
+
             [0, company.value - @seed_money].max
           end
 
@@ -117,6 +150,7 @@ module Engine
 
           def win_bid(winner, _company)
             player = winner.entity
+            @last_auction_winner = player
             company = winner.company
             price = winner.price
             company.owner = player
@@ -127,7 +161,6 @@ module Engine
               @seed_money -= seed
             end
             player.spend(price, @game.bank) if price.positive?
-            @companies.delete(company)
             @log <<
               if @seed_money && seed.positive?
                 "#{player.name} wins the auction for #{company.name} "\
@@ -137,6 +170,34 @@ module Engine
                 "#{player.name} wins the auction for #{company.name} "\
                   "with a bid of #{@game.format_currency(price)}"
               end
+            company_auction_finished(company)
+          end
+
+          def company_auction_finished(company)
+            @companies.delete(company)
+            return @tiered_companies[0].delete(company) unless @game.option_volatility_expansion?
+
+            @tiered_companies.each do |row|
+              next unless (index = row.index(company))
+
+              row[index] = @game.empty_auction_slot
+              remove_company_from_slot(row, index - 1) if company_in_slot?(row, index - 1) && !company_in_slot?(row, index - 2)
+              remove_company_from_slot(row, index + 1) if company_in_slot?(row, index + 1) && !company_in_slot?(row, index + 2)
+              @tiered_companies.delete(row) if row.all? { |c| c == @game.empty_auction_slot }
+              break
+            end
+          end
+
+          def company_in_slot?(row, index)
+            !index.negative? && row[index] && row[index] != @game.empty_auction_slot
+          end
+
+          def remove_company_from_slot(row, index)
+            company = row[index]
+            company.close!
+            @companies.delete(company)
+            @log << "#{company.name} removed"
+            row[index] = @game.empty_auction_slot
           end
 
           def all_passed!
@@ -149,7 +210,8 @@ module Engine
           def resolve_bids
             super
             entities.each(&:unpass!)
-            @round.goto_entity!(@auction_triggerer)
+            start_player = @game.option_volatility_expansion? && @last_auction_winner ? @last_auction_winner : @auction_triggerer
+            @round.goto_entity!(start_player)
             next_entity!
           end
         end

--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -71,6 +71,10 @@ module Engine
         bids[company]&.find { |b| b.entity == player }&.price || 0
       end
 
+      def may_bid?(_company)
+        true
+      end
+
       def min_bid(_company)
         # Minimum a bid that an entity can bid
         raise NotImplementedError

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -340,6 +340,7 @@ text.number {
   border: 1px solid gainsboro;
   border-radius: 0.7rem;
   align-self: start;
+  min-height: 100px;
 }
 .game.card {
   margin: 0 0.5rem 0.5rem 0;


### PR DESCRIPTION
- [x]  Randomize "Pittsburgh" private
- [x]  Create auction pyramid
- [x]  After each auction, remove any privates with no other private immediately adjacent to it in the row
- [x]  Remove seed money
- [x]  Priority moves to the player after the winning bidder
- [x]  Priority player must initiate an auction