### PR TITLE
Add Alcamo name to C3 hex

### DIFF
--- a/lib/engine/game/g_1849/map.rb
+++ b/lib/engine/game/g_1849/map.rb
@@ -108,6 +108,7 @@ module Engine
           'A13' => 'Milazzo',
           'B14' => 'Messina',
           'C1' => 'Trapani',
+          'C3' => 'Alcamo',
           'C5' => 'Palermo',
           'C9' => 'St. Stefano',
           'C15' => 'Calabria',


### PR DESCRIPTION
Fixes #7772 

The issue says the name should be "Alcano", but all the references I saw used "Alcamo"
<img src="https://user-images.githubusercontent.com/5263073/172074086-14937206-96ec-4c65-ac0f-f8b299ab200c.png" width="40%" height="40%">
<img src="https://user-images.githubusercontent.com/5263073/172074115-3cac8dd0-0cb0-4491-8bcf-90a42e61d4d7.png" width="40%" height="40%">
![image](https://user-images.githubusercontent.com/5263073/172074132-b5f0612a-a8c3-4efa-8c6b-6d793d2ef21a.png)
