### PR TITLE
18MEX: Tidy up FutureLabel logic and make it so that blank future labels can be used (18Mex Guadalajara -> gray tile)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1512,7 +1512,7 @@ module Engine
 
       def upgrades_to_correct_label?(from, to)
         # If the from tile has a future label and the to tile is the color for it use that, otherwise use the from's label
-        return from.future_label.label == to.label.to_s if from.future_label && to.color.to_s == from.future_label.color
+        return from.future_label.label == to.label&.to_s if from.future_label && to.color.to_s == from.future_label.color
 
         from.label == to.label
       end

--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -95,7 +95,14 @@ module Engine
             'code' =>
             'town=revenue:10;path=a:2,b:_0;path=a:_0,b:5;upgrade=cost:40,terrain:mountain;label=P;border=edge:2',
           },
-          '480' => 1,
+          '480' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' =>
+            'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;'\
+            'label=G;future_label=color:gray',
+          },
           '481' => 1,
           '482' => 1,
           '483' => 1,
@@ -575,7 +582,9 @@ module Engine
             %w[D3 M10] => 'city=revenue:0;upgrade=cost:60,terrain:mountain',
             %w[D9 H11 N7 T11 T13] => 'upgrade=cost:20,terrain:water',
             %w[F11 G4 H7 K10 L7 M8 R9] => '',
-            %w[G10 I4 O8] => 'city=revenue:0;upgrade=cost:20,terrain:water',
+            %w[G10] => 'city=revenue:0;upgrade=cost:20,terrain:water',
+            %w[I4] => 'city=revenue:0;upgrade=cost:20,terrain:water;future_label=label:L,color:green',
+            %w[O8] => 'city=revenue:0;upgrade=cost:20,terrain:water;future_label=label:G,color:brown',
             %w[G12 K12] => 'upgrade=cost:40,terrain:swamp',
             %w[I8 I10] => 'city=revenue:0',
             %w[J5 L9 P7] => 'town=revenue:0',
@@ -736,7 +745,6 @@ module Engine
           # Needed for special handling of minors in case inital auction not completed
           @stock_round_initiated = false
 
-          @brown_g_tile ||= @tiles.find { |t| t.name == '480' }
           @gray_tile ||= @tiles.find { |t| t.name == '455' }
           @green_l_tile ||= @tiles.find { |t| t.name == '475' }
 
@@ -1127,11 +1135,6 @@ module Engine
           # Copper Canyon cannot be upgraded
           return false if from.name == '470'
 
-          # Guadalajara (O8) can only be upgraded to #480 in brown, and #455 in gray
-          return to.name == '480' if from.color == :green && from.hex.name == 'O8'
-          return to.name == '455' if from.color == :brown && from.hex.name == 'O8'
-          return to.name == '475' if from.color == :yellow && from.hex.name == 'I4'
-
           super
         end
 
@@ -1139,20 +1142,7 @@ module Engine
           # Copper Canyon cannot be upgraded
           return [] if tile.name == '470'
 
-          upgrades = super
-
-          return upgrades unless tile_manifest
-
-          # Tile manifest for standard green cities should show G tile as an option
-          upgrades |= [@brown_g_tile] if @brown_g_tile && STANDARD_GREEN_CITY_TILES.include?(tile.name)
-
-          # Tile manifest for Guadalajara brown (the G tile) should show gray tile as an option
-          upgrades |= [@gray_tile] if @gray_tile && tile.name == '480'
-
-          # Tile manifest for standard yellow cities with curve should show Los Mochos green tile as an option
-          upgrades |= [@green_l_tile] if @green_l_tile && CURVED_YELLOW_CITY.include?(tile.name)
-
-          upgrades
+          super
         end
 
         def tile_lays(entity)

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -178,11 +178,10 @@ module Engine
       end
       @tile.icons = @tile.icons.select(&:preprinted)
 
+      tile.future_label.sticker = tile.future_label if tile.future_label
       if @tile.future_label
-        if @tile.future_label&.color != tile.color
-          @tile.future_label.sticker = tile.future_label
-          tile.future_label = @tile.future_label
-        end
+        # future label transfers over
+        tile.future_label = @tile.future_label if @tile.future_label.color != tile.color.to_s
         # restore old tile's future_label
         @tile.future_label = @tile.future_label.sticker
       end

--- a/spec/fixtures/18MEX/80226.json
+++ b/spec/fixtures/18MEX/80226.json
@@ -1,0 +1,11439 @@
+{
+    "id": 80226,
+    "description": "Restarted",
+    "user": {
+      "id": 4013,
+      "name": "Eludyan"
+    },
+    "players": [
+      {
+        "id": 7112,
+        "name": "Alatar"
+      },
+      {
+        "id": 5951,
+        "name": "Ogg"
+      },
+      {
+        "id": 4013,
+        "name": "Eludyan"
+      },
+      {
+        "id": 488,
+        "name": "beardbru"
+      }
+    ],
+    "max_players": 4,
+    "title": "18MEX",
+    "settings": {
+      "seed": 457649312,
+      "is_async": true,
+      "unlisted": true,
+      "auto_routing": false,
+      "player_order": null,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "status": "finished",
+    "turn": 6,
+    "round": "Operating Round",
+    "acting": [
+      7112,
+      5951,
+      4013,
+      488
+    ],
+    "result": {
+      "Ogg": 3555,
+      "Alatar": 3156,
+      "Eludyan": 4203,
+      "beardbru": 4542
+    },
+    "actions": [
+      {
+        "type": "bid",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 1,
+        "created_at": 1649703241,
+        "company": "MNR",
+        "price": 145
+      },
+      {
+        "type": "bid",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 2,
+        "created_at": 1649710415,
+        "company": "A",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 3,
+        "created_at": 1649713974,
+        "company": "B",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 4,
+        "created_at": 1649714615,
+        "company": "MIR",
+        "price": 105
+      },
+      {
+        "type": "bid",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 5,
+        "created_at": 1649719544,
+        "company": "C",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 6,
+        "created_at": 1649722959,
+        "company": "KCMO",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 7,
+        "created_at": 1649767423,
+        "company": "A",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 8,
+        "created_at": 1649769945,
+        "company": "MCAR",
+        "price": 20
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 9,
+        "created_at": 1649771965
+      },
+      {
+        "type": "par",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 10,
+        "created_at": 1649779219,
+        "corporation": "NdM",
+        "share_price": "75,1,4"
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 11,
+        "created_at": 1649779248
+      },
+      {
+        "type": "par",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 12,
+        "created_at": 1649802995,
+        "corporation": "MC",
+        "share_price": "75,1,4"
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 13,
+        "created_at": 1649803013,
+        "corporation": "MC",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 14,
+        "created_at": 1649803022,
+        "corporation": "MC",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 15,
+        "created_at": 1649803023,
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "par",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 16,
+        "created_at": 1649812963,
+        "corporation": "MEX",
+        "share_price": "60,2,2"
+      },
+      {
+        "type": "par",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 17,
+        "created_at": 1649817350,
+        "corporation": "CHI",
+        "share_price": "60,2,2"
+      },
+      {
+        "type": "par",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 18,
+        "created_at": 1649817901,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1649817901,
+            "reason": "Corporation TM parred"
+          }
+        ],
+        "corporation": "TM",
+        "share_price": "60,2,2"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 19,
+        "created_at": 1649818008,
+        "shares": [
+          "MC_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 20,
+        "created_at": 1649818015,
+        "shares": [
+          "MEX_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 21,
+        "created_at": 1649818104,
+        "corporation": "MEX",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 22,
+        "created_at": 1649819444,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 488,
+            "entity_type": "player",
+            "created_at": 1649819444,
+            "shares": [
+              "CHI_2"
+            ],
+            "percent": 10
+          }
+        ],
+        "corporation": "CHI",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 23,
+        "created_at": 1649819475,
+        "shares": [
+          "TM_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 24,
+        "created_at": 1649819813,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1649819813,
+            "shares": [
+              "MEX_2"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "buy_shares",
+            "entity": 488,
+            "entity_type": "player",
+            "created_at": 1649819813,
+            "shares": [
+              "CHI_3"
+            ],
+            "percent": 10
+          }
+        ],
+        "shares": [
+          "MC_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 25,
+        "created_at": 1649819863,
+        "shares": [
+          "TM_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 26,
+        "created_at": 1649820148,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1649820148,
+            "shares": [
+              "MEX_3"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 488,
+            "entity_type": "player",
+            "created_at": 1649820148,
+            "reason": "CHI is floated"
+          }
+        ],
+        "shares": [
+          "MC_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 27,
+        "created_at": 1649857206,
+        "shares": [
+          "MEX_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 28,
+        "created_at": 1649859854,
+        "shares": [
+          "TM_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 29,
+        "created_at": 1649860286,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1649860285,
+            "reason": "MEX is floated"
+          }
+        ],
+        "shares": [
+          "CHI_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 30,
+        "created_at": 1649902166,
+        "shares": [
+          "MEX_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 31,
+        "created_at": 1649902186,
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 32,
+        "created_at": 1649907115,
+        "shares": [
+          "MEX_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 33,
+        "created_at": 1649955035,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1649955035
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 34,
+        "created_at": 1649970103
+      },
+      {
+        "type": "run_routes",
+        "entity": "A",
+        "entity_type": "minor",
+        "id": 35,
+        "created_at": 1649982909,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "M12"
+              ]
+            ],
+            "hexes": [
+              "M12",
+              "M12"
+            ],
+            "revenue": 30,
+            "revenue_str": "M12-M12",
+            "nodes": [
+              "M12-0",
+              "M12-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "minor",
+        "id": 36,
+        "created_at": 1649982915,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "K6"
+              ]
+            ],
+            "hexes": [
+              "K6",
+              "K6"
+            ],
+            "revenue": 30,
+            "revenue_str": "K6-K6",
+            "nodes": [
+              "K6-0",
+              "K6-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 37,
+        "created_at": 1649982935,
+        "message": "Remember to always hit the dots all you can. They count extra on your run"
+      },
+      {
+        "type": "run_routes",
+        "entity": "C",
+        "entity_type": "minor",
+        "id": 38,
+        "created_at": 1649983219,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "S12",
+                "R13",
+                "Q14"
+              ]
+            ],
+            "hexes": [
+              "Q14",
+              "S12"
+            ],
+            "revenue": 30,
+            "revenue_str": "Q14-S12",
+            "nodes": [
+              "S12-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 39,
+        "created_at": 1649984254,
+        "hex": "I8",
+        "tile": "5-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 40,
+        "created_at": 1649984274,
+        "hex": "J7",
+        "tile": "3-0",
+        "rotation": 4
+      },
+      {
+        "type": "buy_train",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 41,
+        "created_at": 1649984283,
+        "train": "2-3",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 42,
+        "created_at": 1649984596,
+        "hex": "P13",
+        "tile": "473-0",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 43,
+        "created_at": 1649984599,
+        "hex": "Q12",
+        "tile": "8-0",
+        "rotation": 2
+      },
+      {
+        "type": "buy_train",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 44,
+        "created_at": 1649984604,
+        "train": "2-4",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 45,
+        "created_at": 1649984605
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 46,
+        "created_at": 1649986243,
+        "hex": "G6",
+        "tile": "8-1",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 47,
+        "created_at": 1649986246,
+        "hex": "H7",
+        "tile": "9-0",
+        "rotation": 2
+      },
+      {
+        "type": "buy_train",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 48,
+        "created_at": 1649986252,
+        "train": "2-5",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 49,
+        "created_at": 1649986253
+      },
+      {
+        "hex": "K12",
+        "tile": "9-1",
+        "type": "lay_tile",
+        "entity": "TM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 50,
+        "user": 7112,
+        "created_at": 1649986419,
+        "skip": true
+      },
+      {
+        "hex": "M12",
+        "tile": "472-0",
+        "type": "lay_tile",
+        "entity": "TM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 51,
+        "user": 7112,
+        "created_at": 1649986469,
+        "skip": true
+      },
+      {
+        "type": "buy_train",
+        "price": 100,
+        "train": "2-6",
+        "entity": "TM",
+        "variant": "2",
+        "entity_type": "corporation",
+        "id": 52,
+        "user": 7112,
+        "created_at": 1649986474,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 53,
+        "user": 7112,
+        "created_at": 1649986503,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 54,
+        "user": 7112,
+        "created_at": 1649986554,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "action_id": 53,
+        "entity_type": "player",
+        "id": 55,
+        "user": 4013,
+        "created_at": 1649986805
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 7112,
+        "action_id": 49,
+        "entity_type": "player",
+        "id": 56,
+        "user": 4013,
+        "created_at": 1649986807
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 57,
+        "created_at": 1649987210,
+        "hex": "G12",
+        "tile": "8-2",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 58,
+        "created_at": 1649987213,
+        "hex": "F11",
+        "tile": "8-3",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 59,
+        "created_at": 1649987245
+      },
+      {
+        "type": "buy_train",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 60,
+        "created_at": 1649987248,
+        "train": "2-6",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 61,
+        "created_at": 1649987254
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 62,
+        "created_at": 1649987260
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 63,
+        "created_at": 1649987622
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 64,
+        "created_at": 1649989550
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 65,
+        "user": 488,
+        "created_at": 1649993406,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "A",
+        "entity_type": "minor",
+        "id": 66,
+        "user": 488,
+        "created_at": 1649993412
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 67,
+        "created_at": 1649993431
+      },
+      {
+        "type": "run_routes",
+        "entity": "A",
+        "entity_type": "minor",
+        "id": 68,
+        "created_at": 1650023149,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "M12"
+              ]
+            ],
+            "hexes": [
+              "M12",
+              "M12"
+            ],
+            "revenue": 30,
+            "revenue_str": "M12-M12",
+            "nodes": [
+              "M12-0",
+              "M12-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "minor",
+        "id": 69,
+        "created_at": 1650023150,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "K6"
+              ]
+            ],
+            "hexes": [
+              "K6",
+              "K6"
+            ],
+            "revenue": 30,
+            "revenue_str": "K6-K6",
+            "nodes": [
+              "K6-1",
+              "K6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "C",
+        "entity_type": "minor",
+        "id": 70,
+        "created_at": 1650026083,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "S12",
+                "R13",
+                "Q14"
+              ]
+            ],
+            "hexes": [
+              "S12",
+              "Q14"
+            ],
+            "revenue": 30,
+            "revenue_str": "S12-Q14",
+            "nodes": [
+              "S12-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 71,
+        "created_at": 1650028584,
+        "hex": "K8",
+        "tile": "4-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 72,
+        "created_at": 1650028594,
+        "hex": "L9",
+        "tile": "4-1",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 73,
+        "created_at": 1650028606,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I8",
+                "H7",
+                "G6",
+                "E6"
+              ]
+            ],
+            "hexes": [
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6"
+            ],
+            "revenue": 70,
+            "revenue_str": "L9-K8-J7-I8-E6",
+            "nodes": [
+              "K8-0",
+              "L9-0",
+              "J7-0",
+              "I8-0",
+              "E6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 74,
+        "created_at": 1650028609,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 75,
+        "created_at": 1650028617,
+        "train": "2-7",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 76,
+        "created_at": 1650028621
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 77,
+        "created_at": 1650040149,
+        "hex": "M10",
+        "tile": "6-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 78,
+        "created_at": 1650040153
+      },
+      {
+        "type": "place_token",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 79,
+        "created_at": 1650040155,
+        "city": "6-0-0",
+        "slot": 0,
+        "tokener": "MEX"
+      },
+      {
+        "type": "run_routes",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 80,
+        "created_at": 1650040165,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "M10",
+                "O10"
+              ],
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ]
+            ],
+            "hexes": [
+              "P11",
+              "O10",
+              "M10",
+              "L9",
+              "K8",
+              "J7"
+            ],
+            "revenue": 80,
+            "revenue_str": "P11-O10-M10-L9-K8-J7",
+            "nodes": [
+              "O10-0",
+              "P11-0",
+              "M10-0",
+              "L9-0",
+              "K8-0",
+              "J7-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 81,
+        "created_at": 1650040166,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 82,
+        "created_at": 1650040167,
+        "train": "2-8",
+        "price": 100,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 83,
+        "created_at": 1650040168
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 84,
+        "user": 488,
+        "created_at": 1650047602,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 85,
+        "user": 488,
+        "created_at": 1650047614
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 86,
+        "created_at": 1650047620,
+        "hex": "C6",
+        "tile": "9-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 87,
+        "created_at": 1650047623
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 88,
+        "created_at": 1650047630,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "E6",
+                "C6",
+                "A6"
+              ]
+            ],
+            "hexes": [
+              "A6",
+              "E6"
+            ],
+            "revenue": 50,
+            "revenue_str": "A6-E6",
+            "nodes": [
+              "E6-0",
+              "A6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 89,
+        "created_at": 1650047632,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 90,
+        "created_at": 1650047634,
+        "train": "3-0",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 91,
+        "created_at": 1650047647
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 92,
+        "user": 488,
+        "created_at": 1650047647,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 93,
+        "user": 488,
+        "created_at": 1650047650
+      },
+      {
+        "type": "buy_company",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 94,
+        "created_at": 1650047660,
+        "company": "MIR",
+        "price": 150
+      },
+      {
+        "type": "buy_company",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 95,
+        "created_at": 1650047667,
+        "company": "MCAR",
+        "price": 30
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 96,
+        "created_at": 1650047721
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 97,
+        "created_at": 1650048552,
+        "hex": "E10",
+        "tile": "8-4",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 98,
+        "user": 7112,
+        "created_at": 1650048558,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 99,
+        "user": 7112,
+        "created_at": 1650048630,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "routes": [
+          {
+            "hexes": [
+              "D11",
+              "I12"
+            ],
+            "nodes": [
+              "I12-0",
+              "D11-0"
+            ],
+            "train": "2-6",
+            "revenue": 50,
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ]
+            ],
+            "revenue_str": "D11-I12"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 100,
+        "user": 7112,
+        "created_at": 1650048640,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 101,
+        "user": 7112,
+        "created_at": 1650048641,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 102,
+        "user": 7112,
+        "created_at": 1650048664
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 103,
+        "user": 7112,
+        "created_at": 1650048665
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 104,
+        "user": 7112,
+        "created_at": 1650048666
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 105,
+        "user": 7112,
+        "created_at": 1650048668
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 106,
+        "created_at": 1650048679,
+        "hex": "J11",
+        "tile": "8-5",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 107,
+        "created_at": 1650048686
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 108,
+        "created_at": 1650048687
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 109,
+        "created_at": 1650048694,
+        "routes": [
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ]
+            ],
+            "hexes": [
+              "D11",
+              "I12"
+            ],
+            "revenue": 50,
+            "revenue_str": "D11-I12",
+            "nodes": [
+              "I12-0",
+              "D11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 110,
+        "created_at": 1650048696,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 111,
+        "created_at": 1650048707,
+        "train": "3-1",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 112,
+        "created_at": 1650048711
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 113,
+        "created_at": 1650048714
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "shares": [
+          "MEX_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 114,
+        "user": 7112,
+        "created_at": 1650048742,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 115,
+        "user": 7112,
+        "created_at": 1650048773
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 116,
+        "created_at": 1650048781,
+        "shares": [
+          "TM_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 117,
+        "created_at": 1650048788
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "shares": [
+          "CHI_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 118,
+        "user": 5951,
+        "created_at": 1650063483,
+        "skip": true
+      },
+      {
+        "type": "par",
+        "entity": 5951,
+        "corporation": "SPM",
+        "entity_type": "player",
+        "share_price": "70,1,3",
+        "id": 119,
+        "user": 5951,
+        "created_at": 1650063560,
+        "skip": true
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "shares": [
+          "CHI_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 120,
+        "user": 4013,
+        "created_at": 1650119705,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 121,
+        "user": 4013,
+        "created_at": 1650119710,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 488,
+        "action_id": 119,
+        "entity_type": "player",
+        "id": 122,
+        "user": 4013,
+        "created_at": 1650119740
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4013,
+        "action_id": 117,
+        "entity_type": "player",
+        "id": 123,
+        "user": 4013,
+        "created_at": 1650119758
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 124,
+        "user": 5951,
+        "created_at": 1650119776,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 125,
+        "user": 5951,
+        "created_at": 1650119793
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 126,
+        "created_at": 1650119818,
+        "shares": [
+          "MEX_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 127,
+        "created_at": 1650119827
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 128,
+        "created_at": 1650119871,
+        "shares": [
+          "CHI_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 129,
+        "created_at": 1650119877
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 130,
+        "created_at": 1650119892,
+        "corporation": "TM",
+        "until_condition": 1,
+        "from_market": false,
+        "auto_pass_after": true
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 131,
+        "created_at": 1650125880,
+        "shares": [
+          "MEX_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 132,
+        "created_at": 1650126032
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 133,
+        "created_at": 1650128526
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 134,
+        "created_at": 1650138134,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650138134
+          },
+          {
+            "type": "buy_shares",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650138134,
+            "shares": [
+              "TM_5"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650138134,
+            "reason": "1 share(s) bought in TM, end condition met"
+          },
+          {
+            "type": "program_share_pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650138134,
+            "unconditional": false,
+            "indefinite": false
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650138134
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 135,
+        "created_at": 1650144365,
+        "shares": [
+          "TM_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 136,
+        "created_at": 1650144403
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 137,
+        "created_at": 1650146479,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650146477
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650146477
+          }
+        ]
+      },
+      {
+        "type": "sell_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 138,
+        "created_at": 1650158609,
+        "shares": [
+          "MEX_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 139,
+        "created_at": 1650158614,
+        "corporation": "SPM",
+        "share_price": "90,0,5"
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 140,
+        "created_at": 1650158709,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650158708,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 141,
+        "created_at": 1650159133,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650159133,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 142,
+        "created_at": 1650161681,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650161681
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 143,
+        "created_at": 1650170674
+      },
+      {
+        "type": "run_routes",
+        "entity": "A",
+        "entity_type": "minor",
+        "id": 144,
+        "created_at": 1650170775,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "M12"
+              ]
+            ],
+            "hexes": [
+              "M12",
+              "M12"
+            ],
+            "revenue": 30,
+            "revenue_str": "M12-M12",
+            "nodes": [
+              "M12-0",
+              "M12-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "minor",
+        "id": 145,
+        "created_at": 1650170783,
+        "hex": "K6",
+        "tile": "471-0",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "minor",
+        "id": 146,
+        "created_at": 1650170786,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "K6"
+              ]
+            ],
+            "hexes": [
+              "K6",
+              "K6"
+            ],
+            "revenue": 30,
+            "revenue_str": "K6-K6",
+            "nodes": [
+              "K6-0",
+              "K6-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "C",
+        "entity_type": "minor",
+        "id": 147,
+        "created_at": 1650171029,
+        "hex": "S12",
+        "tile": "5-1",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "C",
+        "entity_type": "minor",
+        "id": 148,
+        "created_at": 1650171033,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "S12",
+                "R13",
+                "Q14"
+              ]
+            ],
+            "hexes": [
+              "S12",
+              "Q14"
+            ],
+            "revenue": 30,
+            "revenue_str": "S12-Q14",
+            "nodes": [
+              "S12-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 149,
+        "created_at": 1650199696,
+        "hex": "I8",
+        "tile": "14-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 150,
+        "created_at": 1650199702
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 151,
+        "created_at": 1650199733,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8"
+            ],
+            "revenue": 80,
+            "revenue_str": "M10-L9-K8-J7-I8",
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0"
+            ]
+          },
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "I8",
+                "H7",
+                "G6",
+                "E6"
+              ]
+            ],
+            "hexes": [
+              "E6",
+              "I8"
+            ],
+            "revenue": 50,
+            "revenue_str": "E6-I8",
+            "nodes": [
+              "I8-0",
+              "E6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 152,
+        "created_at": 1650199735,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 153,
+        "created_at": 1650199741,
+        "train": "3-2",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 154,
+        "created_at": 1650199751
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 155,
+        "created_at": 1650218536,
+        "hex": "M10",
+        "tile": "619-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 156,
+        "created_at": 1650218541
+      },
+      {
+        "type": "place_token",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 157,
+        "created_at": 1650218545,
+        "city": "619-0-0",
+        "slot": 1,
+        "tokener": "CHI"
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 158,
+        "created_at": 1650218590,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "I8",
+                "H7",
+                "G6",
+                "E6"
+              ]
+            ],
+            "hexes": [
+              "E6",
+              "I8"
+            ],
+            "revenue": 50,
+            "revenue_str": "E6-I8",
+            "nodes": [
+              "I8-0",
+              "E6-0"
+            ]
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "J7",
+                "I8"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "M10",
+                "L9"
+              ],
+              [
+                "O10",
+                "M10"
+              ],
+              [
+                "P11",
+                "O10"
+              ]
+            ],
+            "hexes": [
+              "I8",
+              "J7",
+              "K8",
+              "L9",
+              "M10",
+              "O10",
+              "P11"
+            ],
+            "revenue": 120,
+            "revenue_str": "I8-J7-K8-L9-M10-O10-P11",
+            "nodes": [
+              "J7-0",
+              "I8-0",
+              "K8-0",
+              "L9-0",
+              "M10-0",
+              "O10-0",
+              "P11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 159,
+        "created_at": 1650218592,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 160,
+        "created_at": 1650218598
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 161,
+        "created_at": 1650218600
+      },
+      {
+        "hex": "G10",
+        "tile": "6-1",
+        "type": "lay_tile",
+        "entity": "TM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 162,
+        "user": 7112,
+        "created_at": 1650218705,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 163,
+        "user": 7112,
+        "created_at": 1650218723
+      },
+      {
+        "hex": "G10",
+        "tile": "57-0",
+        "type": "lay_tile",
+        "entity": "TM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 164,
+        "user": 7112,
+        "created_at": 1650218727,
+        "skip": true
+      },
+      {
+        "hex": "I10",
+        "tile": "6-1",
+        "type": "lay_tile",
+        "entity": "TM",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 165,
+        "user": 7112,
+        "created_at": 1650218731,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 166,
+        "user": 7112,
+        "created_at": 1650218736,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 167,
+        "user": 7112,
+        "created_at": 1650218769
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 168,
+        "user": 7112,
+        "created_at": 1650218770
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 169,
+        "user": 7112,
+        "created_at": 1650218772
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 170,
+        "created_at": 1650218793,
+        "hex": "I10",
+        "tile": "57-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 171,
+        "created_at": 1650218797,
+        "hex": "H9",
+        "tile": "8-6",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 172,
+        "created_at": 1650218800
+      },
+      {
+        "type": "place_token",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 173,
+        "created_at": 1650218802,
+        "city": "14-0-0",
+        "slot": 1,
+        "tokener": "TM"
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 174,
+        "created_at": 1650218835,
+        "routes": [
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ]
+            ],
+            "hexes": [
+              "I12",
+              "D11"
+            ],
+            "revenue": 50,
+            "revenue_str": "I12-D11",
+            "nodes": [
+              "I12-0",
+              "D11-0"
+            ]
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10"
+            ],
+            "revenue": 110,
+            "revenue_str": "M10-L9-K8-J7-I8-I10",
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 175,
+        "created_at": 1650218837,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 176,
+        "created_at": 1650218868
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 177,
+        "created_at": 1650218874
+      },
+      {
+        "hex": "O10",
+        "tile": "479MC-0",
+        "type": "lay_tile",
+        "entity": "MEX",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 178,
+        "user": 4013,
+        "created_at": 1650235917,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 179,
+        "user": 4013,
+        "created_at": 1650235921,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 180,
+        "user": 4013,
+        "created_at": 1650235939
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 181,
+        "user": 4013,
+        "created_at": 1650235941
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 182,
+        "created_at": 1650235946,
+        "hex": "P13",
+        "tile": "478-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 183,
+        "created_at": 1650235962
+      },
+      {
+        "type": "run_routes",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 184,
+        "created_at": 1650235990,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "J7",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8"
+            ],
+            "revenue": 90,
+            "revenue_str": "M10-L9-K8-J7-I8",
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0"
+            ]
+          },
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P11",
+                "O10"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10"
+            ],
+            "revenue": 80,
+            "revenue_str": "P13-P13-P11-O10",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 185,
+        "created_at": 1650235993,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 186,
+        "created_at": 1650235994,
+        "train": "3-3",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 187,
+        "created_at": 1650236009
+      },
+      {
+        "type": "lay_tile",
+        "entity": "A",
+        "entity_type": "minor",
+        "id": 188,
+        "created_at": 1650236017,
+        "hex": "M12",
+        "tile": "472-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "A",
+        "entity_type": "minor",
+        "id": 189,
+        "created_at": 1650236021,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "M12"
+              ]
+            ],
+            "hexes": [
+              "M12",
+              "M12"
+            ],
+            "revenue": 30,
+            "revenue_str": "M12-M12",
+            "nodes": [
+              "M12-0",
+              "M12-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B",
+        "entity_type": "minor",
+        "id": 190,
+        "created_at": 1650236026,
+        "hex": "J5",
+        "tile": "4-2",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "B",
+        "entity_type": "minor",
+        "id": 191,
+        "created_at": 1650236031,
+        "routes": [
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "K6",
+                "J5"
+              ],
+              [
+                "K6"
+              ]
+            ],
+            "hexes": [
+              "J5",
+              "K6",
+              "K6"
+            ],
+            "revenue": 40,
+            "revenue_str": "J5-K6-K6",
+            "nodes": [
+              "K6-0",
+              "J5-0",
+              "K6-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "C",
+        "entity_type": "minor",
+        "id": 192,
+        "created_at": 1650237182
+      },
+      {
+        "type": "run_routes",
+        "entity": "C",
+        "entity_type": "minor",
+        "id": 193,
+        "created_at": 1650237183,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "S12",
+                "R13",
+                "Q14"
+              ]
+            ],
+            "hexes": [
+              "S12",
+              "Q14"
+            ],
+            "revenue": 30,
+            "revenue_str": "S12-Q14",
+            "nodes": [
+              "S12-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "hex": "E6",
+        "tile": "15-0",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 194,
+        "user": 5951,
+        "created_at": 1650244034,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 195,
+        "user": 5951,
+        "created_at": 1650244036,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 196,
+        "user": 5951,
+        "created_at": 1650244055,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 197,
+        "user": 5951,
+        "created_at": 1650244067
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 198,
+        "user": 5951,
+        "created_at": 1650244073
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 199,
+        "user": 5951,
+        "created_at": 1650244076
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 200,
+        "created_at": 1650244100,
+        "hex": "E6",
+        "tile": "15-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 201,
+        "created_at": 1650244103
+      },
+      {
+        "type": "place_token",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 202,
+        "created_at": 1650244104,
+        "city": "15-0-0",
+        "slot": 1,
+        "tokener": "MC"
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 203,
+        "created_at": 1650244144,
+        "routes": [
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8"
+            ],
+            "revenue": 90,
+            "revenue_str": "M10-L9-K8-J7-I8",
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0"
+            ]
+          },
+          {
+            "train": "2-7",
+            "connections": [
+              [
+                "A6",
+                "C6",
+                "E6"
+              ]
+            ],
+            "hexes": [
+              "E6",
+              "A6"
+            ],
+            "revenue": 60,
+            "revenue_str": "E6-A6",
+            "nodes": [
+              "A6-0",
+              "E6-0"
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "I8",
+                "H9",
+                "I10"
+              ],
+              [
+                "E6",
+                "G6",
+                "H7",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "I10",
+              "I8",
+              "E6"
+            ],
+            "revenue": 80,
+            "revenue_str": "I10-I8-E6",
+            "nodes": [
+              "I8-0",
+              "I10-0",
+              "E6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 204,
+        "created_at": 1650244146,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 205,
+        "created_at": 1650244149
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 206,
+        "created_at": 1650244621,
+        "hex": "L9",
+        "tile": "474-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 207,
+        "created_at": 1650244628
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 208,
+        "created_at": 1650244631
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 209,
+        "created_at": 1650244664,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "J7",
+                "I8"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "M10",
+                "L9"
+              ]
+            ],
+            "hexes": [
+              "I8",
+              "J7",
+              "K8",
+              "L9",
+              "M10"
+            ],
+            "revenue": 90,
+            "revenue_str": "I8-J7-K8-L9-M10",
+            "nodes": [
+              "J7-0",
+              "I8-0",
+              "K8-0",
+              "L9-0",
+              "M10-0"
+            ]
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "O10",
+                "M10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "revenue": 110,
+            "revenue_str": "M10-O10-P11-P13-P13",
+            "nodes": [
+              "O10-0",
+              "M10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 210,
+        "created_at": 1650244665,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 211,
+        "created_at": 1650244668,
+        "train": "3'-0",
+        "price": 180,
+        "variant": "3'"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 212,
+        "user": 7112,
+        "created_at": 1650244997,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "routes": [
+          {
+            "hexes": [
+              "I12",
+              "D11"
+            ],
+            "nodes": [
+              "I12-0",
+              "D11-0"
+            ],
+            "train": "2-6",
+            "revenue": 50,
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ]
+            ],
+            "revenue_str": "I12-D11"
+          },
+          {
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10"
+            ],
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0"
+            ],
+            "train": "3-1",
+            "revenue": 110,
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ]
+            ],
+            "revenue_str": "M10-L9-K8-J7-I8-I10"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 213,
+        "user": 7112,
+        "created_at": 1650245001,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 214,
+        "user": 7112,
+        "created_at": 1650245002,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 215,
+        "user": 7112,
+        "created_at": 1650245023,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 216,
+        "user": 7112,
+        "created_at": 1650245025,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 217,
+        "user": 7112,
+        "created_at": 1650245038
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 218,
+        "user": 7112,
+        "created_at": 1650245044
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 219,
+        "user": 7112,
+        "created_at": 1650245077
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 220,
+        "user": 7112,
+        "created_at": 1650245079
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 221,
+        "user": 7112,
+        "created_at": 1650245185
+      },
+      {
+        "hex": "I10",
+        "tile": "15-1",
+        "type": "lay_tile",
+        "entity": "TM",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 222,
+        "user": 7112,
+        "created_at": 1650245299,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 223,
+        "user": 7112,
+        "created_at": 1650245306
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 224,
+        "created_at": 1650245317,
+        "hex": "I10",
+        "tile": "15-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 225,
+        "created_at": 1650245325
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 226,
+        "created_at": 1650245416,
+        "routes": [
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ]
+            ],
+            "hexes": [
+              "I12",
+              "D11"
+            ],
+            "revenue": 50,
+            "revenue_str": "I12-D11",
+            "nodes": [
+              "I12-0",
+              "D11-0"
+            ]
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10"
+            ],
+            "revenue": 120,
+            "revenue_str": "M10-L9-K8-J7-I8-I10",
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 227,
+        "created_at": 1650245419,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 228,
+        "created_at": 1650245422,
+        "train": "3'-1",
+        "price": 180,
+        "variant": "3'"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 229,
+        "created_at": 1650245426
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 230,
+        "created_at": 1650251471,
+        "hex": "M8",
+        "tile": "8-7",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 231,
+        "created_at": 1650251474,
+        "hex": "L7",
+        "tile": "9-2",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 232,
+        "created_at": 1650251478
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 233,
+        "user": 4013,
+        "created_at": 1650251480,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 234,
+        "user": 4013,
+        "created_at": 1650251482
+      },
+      {
+        "type": "place_token",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 235,
+        "created_at": 1650251484,
+        "city": "471-0-0",
+        "slot": 0,
+        "tokener": "MEX"
+      },
+      {
+        "type": "run_routes",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 236,
+        "created_at": 1650251539,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "M10",
+                "O10"
+              ],
+              [
+                "L9",
+                "M10"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "M10",
+              "L9"
+            ],
+            "revenue": 60,
+            "revenue_str": "O10-M10-L9",
+            "nodes": [
+              "M10-0",
+              "O10-0",
+              "L9-0"
+            ]
+          },
+          {
+            "train": "2-8",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P11",
+                "O10"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10"
+            ],
+            "revenue": 80,
+            "revenue_str": "P13-P13-P11-O10",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0"
+            ]
+          },
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "K6"
+              ],
+              [
+                "L9",
+                "M8",
+                "L7",
+                "K6"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ]
+            ],
+            "hexes": [
+              "K6",
+              "K6",
+              "L9",
+              "K8",
+              "J7",
+              "I8"
+            ],
+            "revenue": 90,
+            "revenue_str": "K6-K6-L9-K8-J7-I8",
+            "nodes": [
+              "K6-0",
+              "K6-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 237,
+        "created_at": 1650251541,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 238,
+        "created_at": 1650251542
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "shares": [
+          "NdM_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 239,
+        "user": 7112,
+        "created_at": 1650251843,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 240,
+        "user": 7112,
+        "created_at": 1650251871
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 241,
+        "created_at": 1650251873,
+        "shares": [
+          "CHI_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 242,
+        "created_at": 1650251907
+      },
+      {
+        "type": "par",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 243,
+        "created_at": 1650292321,
+        "corporation": "FCP",
+        "share_price": "70,1,3"
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 244,
+        "created_at": 1650292380,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650292383
+          }
+        ],
+        "corporation": "FCP",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "shares": [
+          "NdM_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 245,
+        "user": 4013,
+        "created_at": 1650325066,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 246,
+        "user": 4013,
+        "created_at": 1650325080
+      },
+      {
+        "type": "par",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 247,
+        "created_at": 1650325129,
+        "corporation": "UdY",
+        "share_price": "90,0,5"
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 248,
+        "created_at": 1650325134
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 249,
+        "created_at": 1650325143,
+        "corporation": "UdY",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "message",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 250,
+        "created_at": 1650325173,
+        "message": "David - you can buy shares in the National now to float it and run it. "
+      },
+      {
+        "type": "sell_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 251,
+        "created_at": 1650329032,
+        "shares": [
+          "MEX_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 252,
+        "created_at": 1650329039,
+        "shares": [
+          "SPM_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 253,
+        "created_at": 1650329125,
+        "shares": [
+          "NdM_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "message",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 254,
+        "created_at": 1650329164,
+        "message": "Thank you!"
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 255,
+        "created_at": 1650329168,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650329167,
+            "reason": "Corporation UdY parred"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 256,
+        "created_at": 1650329592,
+        "shares": [
+          "FCP_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 257,
+        "created_at": 1650329609,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650329609
+          },
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650329609,
+            "reason": "Shares were sold"
+          }
+        ],
+        "corporation": "FCP",
+        "until_condition": 4,
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 258,
+        "created_at": 1650369755,
+        "shares": [
+          "UdY_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 259,
+        "created_at": 1650369766
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 260,
+        "created_at": 1650405795,
+        "shares": [
+          "SPM_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 261,
+        "created_at": 1650405804
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 262,
+        "created_at": 1650406850,
+        "shares": [
+          "NdM_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 263,
+        "created_at": 1650406869,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650406868,
+            "shares": [
+              "FCP_2"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650406868,
+            "reason": "4 share(s) bought in FCP, end condition met"
+          }
+        ]
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "shares": [
+          "CHI_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 264,
+        "user": 5951,
+        "created_at": 1650409721,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 265,
+        "user": 5951,
+        "created_at": 1650409787
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 266,
+        "created_at": 1650409812
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 267,
+        "created_at": 1650409880,
+        "shares": [
+          "UdY_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 268,
+        "created_at": 1650409882
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 269,
+        "created_at": 1650412538,
+        "shares": [
+          "MC_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 270,
+        "created_at": 1650412550
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 271,
+        "created_at": 1650412580,
+        "shares": [
+          "NdM_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 272,
+        "created_at": 1650412601
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 273,
+        "created_at": 1650423142,
+        "shares": [
+          "CHI_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 274,
+        "created_at": 1650423144,
+        "shares": [
+          "FCP_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "indefinite": false,
+        "entity_type": "player",
+        "unconditional": false,
+        "id": 275,
+        "user": 5951,
+        "created_at": 1650423165,
+        "skip": true
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4013,
+        "shares": [
+          "MEX_1",
+          "MEX_2",
+          "MEX_3"
+        ],
+        "percent": 30,
+        "entity_type": "player",
+        "id": 276,
+        "user": 4013,
+        "created_at": 1650465580,
+        "skip": true
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "shares": [
+          "UdY_3"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 277,
+        "user": 4013,
+        "created_at": 1650465611,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 488,
+        "action_id": 274,
+        "entity_type": "player",
+        "id": 278,
+        "user": 4013,
+        "created_at": 1650465634
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4013,
+        "shares": [
+          "MEX_1",
+          "MEX_2"
+        ],
+        "percent": 20,
+        "entity_type": "player",
+        "id": 279,
+        "user": 4013,
+        "created_at": 1650465639,
+        "skip": true
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "shares": [
+          "UdY_3"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 280,
+        "user": 4013,
+        "created_at": 1650465643,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 488,
+        "action_id": 274,
+        "entity_type": "player",
+        "id": 281,
+        "user": 4013,
+        "created_at": 1650465648
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 282,
+        "created_at": 1650465651,
+        "shares": [
+          "MEX_1",
+          "MEX_2",
+          "MEX_3"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 283,
+        "created_at": 1650465654,
+        "shares": [
+          "UdY_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 284,
+        "created_at": 1650465662,
+        "corporation": "UdY",
+        "until_condition": 6,
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 285,
+        "created_at": 1650487639,
+        "shares": [
+          "MC_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 286,
+        "created_at": 1650487644,
+        "shares": [
+          "MC_4",
+          "MC_5"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 287,
+        "created_at": 1650487651
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 288,
+        "created_at": 1650492683
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 289,
+        "created_at": 1650492990,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650492989,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 290,
+        "created_at": 1650509200,
+        "shares": [
+          "UdY_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 291,
+        "created_at": 1650509209,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650509208
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 292,
+        "created_at": 1650511806,
+        "shares": [
+          "SPM_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 293,
+        "created_at": 1650511833
+      },
+      {
+        "type": "sell_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 294,
+        "created_at": 1650512491,
+        "shares": [
+          "UdY_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 295,
+        "created_at": 1650512526,
+        "shares": [
+          "CHI_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 296,
+        "created_at": 1650554384,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650554384
+          },
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650554384,
+            "reason": "Shares were sold"
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 297,
+        "created_at": 1650581405,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650581404
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 298,
+        "created_at": 1650597676,
+        "shares": [
+          "NdM_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 299,
+        "created_at": 1650597681
+      },
+      {
+        "type": "sell_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 300,
+        "created_at": 1650597924,
+        "shares": [
+          "CHI_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 301,
+        "created_at": 1650597930,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650597929,
+            "reason": "Shares were sold"
+          }
+        ],
+        "shares": [
+          "MEX_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 302,
+        "created_at": 1650640369,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650640369,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 303,
+        "created_at": 1650690790,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650690790
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 304,
+        "created_at": 1650745215,
+        "shares": [
+          "NdM_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 305,
+        "created_at": 1650745223
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 306,
+        "created_at": 1650747848
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 307,
+        "created_at": 1650772195,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650772196
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650772196
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 308,
+        "created_at": 1650818414,
+        "shares": [
+          "CHI_1",
+          "CHI_2",
+          "CHI_3"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 309,
+        "created_at": 1650818418,
+        "shares": [
+          "NdM_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 7112,
+        "shares": [
+          "MEX_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 310,
+        "user": 7112,
+        "created_at": 1650825266,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 311,
+        "user": 7112,
+        "created_at": 1650825274
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 312,
+        "created_at": 1650825277,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650825277,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 313,
+        "created_at": 1650826015,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650826018
+          },
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650826018,
+            "reason": "Shares were sold"
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 314,
+        "created_at": 1650849119,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650849118
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 315,
+        "created_at": 1650892025,
+        "shares": [
+          "UdY_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 316,
+        "created_at": 1650892029
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 317,
+        "created_at": 1650900979,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1650900978
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1650900978
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 318,
+        "created_at": 1650903363
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 319,
+        "created_at": 1650903400,
+        "hex": "O8",
+        "tile": "6-1",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 320,
+        "created_at": 1650903404,
+        "hex": "P7",
+        "tile": "3-1",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 321,
+        "created_at": 1650903408
+      },
+      {
+        "type": "buy_train",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 322,
+        "created_at": 1650903416,
+        "train": "3'-0",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 323,
+        "created_at": 1650903418
+      },
+      {
+        "type": "pass",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 324,
+        "created_at": 1650903422
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 325,
+        "created_at": 1650945011,
+        "hex": "O10",
+        "tile": "479MC-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 326,
+        "created_at": 1650945018
+      },
+      {
+        "type": "place_token",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 327,
+        "created_at": 1650945021,
+        "city": "479MC-0-0",
+        "slot": 1,
+        "tokener": "UdY"
+      },
+      {
+        "type": "buy_train",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 328,
+        "created_at": 1650945077,
+        "train": "4-0",
+        "price": 300,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 329,
+        "created_at": 1650945140
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 330,
+        "created_at": 1650945149
+      },
+      {
+        "hex": "F5",
+        "tile": "9-3",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 331,
+        "user": 5951,
+        "created_at": 1650945609,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 332,
+        "user": 5951,
+        "created_at": 1650945615
+      },
+      {
+        "hex": "F5",
+        "tile": "9-3",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 333,
+        "user": 5951,
+        "created_at": 1650946367,
+        "skip": true
+      },
+      {
+        "hex": "G4",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 334,
+        "user": 5951,
+        "created_at": 1650946370,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "routes": [
+          {
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6"
+            ],
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0"
+            ],
+            "train": "3-2",
+            "revenue": 120,
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "E6",
+                "G6",
+                "H7",
+                "I8"
+              ]
+            ],
+            "revenue_str": "M10-L9-K8-J7-I8-E6"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 335,
+        "user": 5951,
+        "created_at": 1650946593,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 336,
+        "user": 5951,
+        "created_at": 1650946595,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 337,
+        "user": 5951,
+        "created_at": 1650946601
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 338,
+        "user": 5951,
+        "created_at": 1650946605
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 339,
+        "user": 5951,
+        "created_at": 1650946610
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 340,
+        "user": 5951,
+        "created_at": 1650946613
+      },
+      {
+        "hex": "K6",
+        "tile": "476-0",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 341,
+        "user": 5951,
+        "created_at": 1650946661,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 342,
+        "user": 5951,
+        "created_at": 1650946667,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 343,
+        "user": 5951,
+        "created_at": 1650946684
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 344,
+        "user": 5951,
+        "created_at": 1650946687
+      },
+      {
+        "hex": "K10",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 345,
+        "user": 5951,
+        "created_at": 1650946916,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 346,
+        "user": 5951,
+        "created_at": 1650946919,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 347,
+        "user": 5951,
+        "created_at": 1650946963
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 348,
+        "user": 5951,
+        "created_at": 1650946971
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 349,
+        "created_at": 1650947008,
+        "hex": "J11",
+        "tile": "25-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 350,
+        "created_at": 1650947012
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 351,
+        "created_at": 1650947021,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "L9",
+                "M10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "E6",
+                "G6",
+                "H7",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6"
+            ],
+            "revenue": 120,
+            "revenue_str": "M10-L9-K8-J7-I8-E6",
+            "nodes": [
+              "L9-0",
+              "M10-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 352,
+        "created_at": 1650947024,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 353,
+        "created_at": 1650947026,
+        "train": "4-1",
+        "price": 300,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 354,
+        "created_at": 1650947030
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 355,
+        "created_at": 1650947102
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 356,
+        "created_at": 1650947122
+      },
+      {
+        "type": "buy_train",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 357,
+        "created_at": 1650947233,
+        "train": "3-1",
+        "price": 180
+      },
+      {
+        "type": "buy_train",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 358,
+        "created_at": 1650947286,
+        "train": "3'-1",
+        "price": 180
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 359,
+        "created_at": 1650947291
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 360,
+        "created_at": 1650947298
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 361,
+        "created_at": 1650947348,
+        "hex": "N9",
+        "tile": "8-8",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 362,
+        "created_at": 1650947355
+      },
+      {
+        "type": "buy_train",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 363,
+        "created_at": 1650947358,
+        "train": "4-2",
+        "price": 300,
+        "variant": "4"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 364,
+        "created_at": 1650981968,
+        "hex": "D3",
+        "tile": "57-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 365,
+        "created_at": 1650981984,
+        "hex": "C2",
+        "tile": "8-9",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 366,
+        "created_at": 1650981990
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 367,
+        "created_at": 1650981994
+      },
+      {
+        "type": "buy_train",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 368,
+        "created_at": 1650982005,
+        "train": "5-0",
+        "price": 450,
+        "variant": "5"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 369,
+        "created_at": 1651015835
+      },
+      {
+        "type": "merge",
+        "entity": "MEX",
+        "corporation": "MEX",
+        "entity_type": "corporation",
+        "id": 370,
+        "user": 4013,
+        "created_at": 1651015880,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 371,
+        "user": 4013,
+        "created_at": 1651015890
+      },
+      {
+        "type": "merge",
+        "entity": "MEX",
+        "entity_type": "corporation",
+        "id": 372,
+        "created_at": 1651015951,
+        "corporation": "MEX"
+      },
+      {
+        "type": "assign",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 373,
+        "created_at": 1651017388,
+        "target": "M10",
+        "target_type": "hex"
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 374,
+        "created_at": 1651025770
+      },
+      {
+        "hex": "O10",
+        "tile": "485MC-0",
+        "type": "lay_tile",
+        "entity": "CHI",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 375,
+        "user": 488,
+        "created_at": 1651071287,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 376,
+        "user": 488,
+        "created_at": 1651071299
+      },
+      {
+        "hex": "E6",
+        "tile": "63-0",
+        "type": "lay_tile",
+        "entity": "CHI",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 377,
+        "user": 488,
+        "created_at": 1651071308,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 378,
+        "user": 488,
+        "created_at": 1651071318
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 379,
+        "created_at": 1651071324,
+        "hex": "M10",
+        "tile": "63-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 380,
+        "created_at": 1651071412,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "J7",
+                "I8"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "M10",
+                "L9"
+              ],
+              [
+                "O10",
+                "M10"
+              ]
+            ],
+            "hexes": [
+              "I8",
+              "J7",
+              "K8",
+              "L9",
+              "M10",
+              "O10"
+            ],
+            "revenue": 140,
+            "revenue_str": "I8-J7-K8-L9-M10-O10",
+            "nodes": [
+              "J7-0",
+              "I8-0",
+              "K8-0",
+              "L9-0",
+              "M10-0",
+              "O10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 381,
+        "created_at": 1651071415,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 382,
+        "created_at": 1651071419
+      },
+      {
+        "hex": "I4",
+        "tile": "6-0",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 383,
+        "user": 5951,
+        "created_at": 1651079962,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 384,
+        "user": 5951,
+        "created_at": 1651079969,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 385,
+        "user": 5951,
+        "created_at": 1651079993
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 386,
+        "user": 5951,
+        "created_at": 1651079996
+      },
+      {
+        "hex": "O10",
+        "tile": "485MC-0",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 387,
+        "user": 5951,
+        "created_at": 1651080015,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 388,
+        "user": 5951,
+        "created_at": 1651080020
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 389,
+        "created_at": 1651080035,
+        "hex": "O10",
+        "tile": "486MC-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 390,
+        "created_at": 1651080097,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "I10",
+                "J11",
+                "I12"
+              ],
+              [
+                "I8",
+                "H9",
+                "I10"
+              ]
+            ],
+            "hexes": [
+              "I12",
+              "I10",
+              "I8"
+            ],
+            "revenue": 100,
+            "revenue_str": "I12-I10-I8",
+            "nodes": [
+              "I10-0",
+              "I12-0",
+              "I8-0"
+            ]
+          },
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "E6",
+                "G6",
+                "H7",
+                "I8"
+              ],
+              [
+                "A6",
+                "C6",
+                "E6"
+              ]
+            ],
+            "hexes": [
+              "P11",
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6",
+              "A6"
+            ],
+            "revenue": 220,
+            "revenue_str": "P11-O10-O10-L9-K8-J7-I8-E6-A6",
+            "nodes": [
+              "O10-0",
+              "P11-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0",
+              "A6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 391,
+        "created_at": 1651080101,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 392,
+        "created_at": 1651080164,
+        "hex": "M8",
+        "tile": "25-1",
+        "rotation": 4
+      },
+      {
+        "type": "place_token",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 393,
+        "created_at": 1651080171,
+        "city": "486MC-0-0",
+        "slot": 3,
+        "tokener": "SPM"
+      },
+      {
+        "type": "run_routes",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 394,
+        "created_at": 1651080200,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "J7",
+                "I8"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "I8",
+              "J7",
+              "K8",
+              "L9",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "revenue": 180,
+            "revenue_str": "I8-J7-K8-L9-O10-O10-P11-P13-P13",
+            "nodes": [
+              "J7-0",
+              "I8-0",
+              "K8-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 395,
+        "created_at": 1651080202,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 396,
+        "created_at": 1651080204,
+        "train": "5-1",
+        "price": 450,
+        "variant": "5"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 397,
+        "created_at": 1651096795,
+        "hex": "P13",
+        "tile": "484-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 398,
+        "created_at": 1651096822,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "J7",
+                "I8"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13",
+                "Q14"
+              ]
+            ],
+            "hexes": [
+              "I8",
+              "J7",
+              "K8",
+              "L9",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "Q14"
+            ],
+            "revenue": 220,
+            "revenue_str": "I8-J7-K8-L9-O10-O10-P11-P13-Q14",
+            "nodes": [
+              "J7-0",
+              "I8-0",
+              "K8-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 399,
+        "created_at": 1651096823,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 400,
+        "created_at": 1651096825
+      },
+      {
+        "hex": "L11",
+        "tile": "8-10",
+        "type": "lay_tile",
+        "entity": "NdM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 401,
+        "user": 7112,
+        "created_at": 1651100593,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 402,
+        "user": 7112,
+        "created_at": 1651100603,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 403,
+        "user": 7112,
+        "created_at": 1651100705
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 404,
+        "user": 7112,
+        "created_at": 1651100707
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 405,
+        "created_at": 1651100747,
+        "hex": "L11",
+        "tile": "8-10",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 406,
+        "created_at": 1651100751
+      },
+      {
+        "type": "place_token",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 407,
+        "created_at": 1651100754,
+        "city": "15-1-0",
+        "slot": 0,
+        "tokener": "NdM"
+      },
+      {
+        "type": "run_routes",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 408,
+        "created_at": 1651100825,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ],
+              [
+                "I10",
+                "J11",
+                "I12"
+              ]
+            ],
+            "hexes": [
+              "D11",
+              "I12",
+              "I10"
+            ],
+            "revenue": 130,
+            "revenue_str": "D11-I12-I10",
+            "nodes": [
+              "I12-0",
+              "D11-0",
+              "I10-0"
+            ]
+          },
+          {
+            "train": "3'-1",
+            "connections": [
+              [
+                "J7",
+                "I8"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "M10",
+                "L9"
+              ],
+              [
+                "O10",
+                "M10"
+              ]
+            ],
+            "hexes": [
+              "I8",
+              "J7",
+              "K8",
+              "L9",
+              "M10",
+              "O10"
+            ],
+            "revenue": 150,
+            "revenue_str": "I8-J7-K8-L9-M10-O10",
+            "nodes": [
+              "J7-0",
+              "I8-0",
+              "K8-0",
+              "L9-0",
+              "M10-0",
+              "O10-0"
+            ]
+          },
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "P13",
+                "Q14"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ]
+            ],
+            "hexes": [
+              "Q14",
+              "P13",
+              "P11",
+              "O10"
+            ],
+            "revenue": 150,
+            "revenue_str": "Q14-P13-P11-O10",
+            "nodes": [
+              "P13-0",
+              "Q14-0",
+              "P11-0",
+              "O10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 409,
+        "created_at": 1651100829,
+        "kind": "payout"
+      },
+      {
+        "hex": "I8",
+        "tile": "63-1",
+        "type": "lay_tile",
+        "entity": "TM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 410,
+        "user": 7112,
+        "created_at": 1651100973,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 411,
+        "user": 7112,
+        "created_at": 1651101015
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 412,
+        "created_at": 1651101022,
+        "hex": "I10",
+        "tile": "63-1",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 413,
+        "created_at": 1651101084,
+        "routes": [
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ],
+              [
+                "I12",
+                "J11",
+                "I10"
+              ],
+              [
+                "D11",
+                "F11",
+                "G12",
+                "I12"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10",
+              "I12",
+              "D11"
+            ],
+            "revenue": 210,
+            "revenue_str": "O10-L9-K8-J7-I8-I10-I12-D11",
+            "nodes": [
+              "L9-0",
+              "O10-1",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0",
+              "I12-0",
+              "D11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 414,
+        "created_at": 1651101086,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 415,
+        "user": 7112,
+        "created_at": 1651101089,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 416,
+        "user": 7112,
+        "created_at": 1651101125
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 417,
+        "created_at": 1651101206
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 418,
+        "created_at": 1651103034,
+        "hex": "F3",
+        "tile": "8-5",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 419,
+        "created_at": 1651103038,
+        "hex": "G4",
+        "tile": "8-7",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 420,
+        "created_at": 1651103047
+      },
+      {
+        "type": "run_routes",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 421,
+        "created_at": 1651103053,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "B3",
+                "D3"
+              ],
+              [
+                "B1",
+                "C2",
+                "B3"
+              ]
+            ],
+            "hexes": [
+              "D3",
+              "B3",
+              "B1"
+            ],
+            "revenue": 120,
+            "revenue_str": "D3-B3-B1",
+            "nodes": [
+              "B3-0",
+              "D3-0",
+              "B1-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 422,
+        "created_at": 1651103055,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 423,
+        "created_at": 1651103064
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 424,
+        "created_at": 1651112611,
+        "hex": "O8",
+        "tile": "619-1",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 425,
+        "created_at": 1651112635,
+        "city": "486MC-0-0",
+        "slot": 3,
+        "tokener": "CHI"
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 426,
+        "created_at": 1651112652,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "M10",
+                "L9"
+              ],
+              [
+                "O10",
+                "M10"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "J7",
+              "K8",
+              "L9",
+              "M10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "revenue": 200,
+            "revenue_str": "J7-K8-L9-M10-O10-P11-P13-P13",
+            "nodes": [
+              "K8-0",
+              "J7-0",
+              "L9-0",
+              "M10-0",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 427,
+        "created_at": 1651112654,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "price": 251,
+        "train": "5-1",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 428,
+        "user": 488,
+        "created_at": 1651112731,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 429,
+        "user": 488,
+        "created_at": 1651112750
+      },
+      {
+        "type": "buy_train",
+        "price": 221,
+        "train": "5-1",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 430,
+        "user": 488,
+        "created_at": 1651112758,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 431,
+        "user": 488,
+        "created_at": 1651112784
+      },
+      {
+        "type": "buy_train",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 432,
+        "created_at": 1651112792,
+        "train": "5-1",
+        "price": 241
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 433,
+        "created_at": 1651114276,
+        "shares": [
+          "UdY_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 434,
+        "created_at": 1651114297
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "shares": [
+          "MC_6"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 435,
+        "user": 5951,
+        "created_at": 1651114562,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 436,
+        "user": 5951,
+        "created_at": 1651114565
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "shares": [
+          "MC_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 437,
+        "user": 5951,
+        "created_at": 1651114571,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 438,
+        "user": 5951,
+        "created_at": 1651114574
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 439,
+        "created_at": 1651114578,
+        "shares": [
+          "MC_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 440,
+        "created_at": 1651114581
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 441,
+        "created_at": 1651114622,
+        "corporation": "MC",
+        "until_condition": 7,
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 442,
+        "created_at": 1651119642,
+        "shares": [
+          "CHI_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 443,
+        "created_at": 1651119670
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 444,
+        "created_at": 1651150021,
+        "shares": [
+          "CHI_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 445,
+        "created_at": 1651150053
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 446,
+        "created_at": 1651156819,
+        "shares": [
+          "UdY_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 447,
+        "created_at": 1651156827,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1651156826,
+            "reason": "Cannot buy MC from IPO"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 448,
+        "created_at": 1651158906,
+        "shares": [
+          "FCP_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 449,
+        "created_at": 1651158911
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 450,
+        "created_at": 1651179475,
+        "shares": [
+          "CHI_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 451,
+        "created_at": 1651179501
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 452,
+        "created_at": 1651204277,
+        "shares": [
+          "CHI_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 453,
+        "created_at": 1651204284
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 454,
+        "created_at": 1651205508,
+        "shares": [
+          "UdY_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 455,
+        "created_at": 1651205521
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 456,
+        "created_at": 1651231742,
+        "shares": [
+          "CHI_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 457,
+        "created_at": 1651231745
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 458,
+        "created_at": 1651232174,
+        "shares": [
+          "CHI_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 459,
+        "created_at": 1651232269
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 460,
+        "created_at": 1651285664,
+        "shares": [
+          "MC_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 461,
+        "created_at": 1651285670,
+        "shares": [
+          "MC_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 462,
+        "created_at": 1651285673
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 463,
+        "created_at": 1651287118,
+        "shares": [
+          "FCP_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 464,
+        "created_at": 1651287126
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 465,
+        "created_at": 1651288775,
+        "shares": [
+          "TM_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 466,
+        "created_at": 1651288778
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 467,
+        "created_at": 1651289708,
+        "shares": [
+          "TM_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 468,
+        "created_at": 1651289710,
+        "shares": [
+          "TM_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 469,
+        "created_at": 1651289728
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 470,
+        "created_at": 1651377315,
+        "shares": [
+          "FCP_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 471,
+        "created_at": 1651377325
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "shares": [
+          "FCP_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 472,
+        "user": 7112,
+        "created_at": 1651384167,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 473,
+        "user": 7112,
+        "created_at": 1651384197
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 474,
+        "created_at": 1651384227,
+        "shares": [
+          "MC_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 475,
+        "created_at": 1651384255
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 476,
+        "created_at": 1651411629
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 477,
+        "created_at": 1651411984,
+        "shares": [
+          "FCP_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 478,
+        "created_at": 1651411988
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 479,
+        "created_at": 1651411996,
+        "corporation": "SPM",
+        "until_condition": 1,
+        "from_market": false,
+        "auto_pass_after": true
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 480,
+        "created_at": 1651441472,
+        "shares": [
+          "FCP_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 481,
+        "created_at": 1651441498
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 482,
+        "created_at": 1651443071
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 483,
+        "created_at": 1651444654,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1651444654
+          },
+          {
+            "type": "buy_shares",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651444654,
+            "shares": [
+              "SPM_4"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651444654,
+            "reason": "1 share(s) bought in SPM, end condition met"
+          },
+          {
+            "type": "program_share_pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651444654,
+            "unconditional": false,
+            "indefinite": false
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651444654
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 484,
+        "created_at": 1651451598,
+        "shares": [
+          "SPM_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 485,
+        "created_at": 1651451749
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 486,
+        "created_at": 1651452686,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1651452686
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651452686
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 487,
+        "created_at": 1651453911
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 488,
+        "created_at": 1651453936,
+        "hex": "O8",
+        "tile": "480-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 489,
+        "created_at": 1651453963
+      },
+      {
+        "type": "run_routes",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 490,
+        "created_at": 1651453987,
+        "routes": [
+          {
+            "train": "3'-0",
+            "connections": [
+              [
+                "O8",
+                "P7"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "P7",
+              "O8",
+              "L9",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "revenue": 210,
+            "revenue_str": "P7-O8-L9-O10-O10-P11-P13-P13",
+            "nodes": [
+              "O8-0",
+              "P7-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 491,
+        "created_at": 1651453988,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 492,
+        "created_at": 1651453992,
+        "train": "6-0",
+        "price": 600,
+        "variant": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 493,
+        "created_at": 1651453996
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 494,
+        "created_at": 1651458103,
+        "hex": "J7",
+        "tile": "141-0",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 495,
+        "created_at": 1651458119,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "O8",
+                "P7"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13",
+                "Q14"
+              ]
+            ],
+            "hexes": [
+              "P7",
+              "O8",
+              "L9",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "Q14"
+            ],
+            "revenue": 230,
+            "revenue_str": "P7-O8-L9-O10-O10-P11-P13-Q14",
+            "nodes": [
+              "O8-0",
+              "P7-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 496,
+        "created_at": 1651458120,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 497,
+        "created_at": 1651458122
+      },
+      {
+        "hex": "I4",
+        "tile": "6-0",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 498,
+        "user": 5951,
+        "created_at": 1651459065,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 499,
+        "user": 5951,
+        "created_at": 1651459370,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 500,
+        "user": 5951,
+        "created_at": 1651459985
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 501,
+        "user": 5951,
+        "created_at": 1651459990
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 502,
+        "created_at": 1651459994,
+        "hex": "K6",
+        "tile": "476-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 503,
+        "created_at": 1651460070,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "E6",
+                "G6",
+                "H7",
+                "I8"
+              ],
+              [
+                "E6",
+                "C6",
+                "A6"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6",
+              "A6"
+            ],
+            "revenue": 210,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-E6-A6",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0",
+              "A6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 504,
+        "created_at": 1651460072,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 505,
+        "created_at": 1651460077
+      },
+      {
+        "hex": "I8",
+        "tile": "63-2",
+        "type": "lay_tile",
+        "entity": "NdM",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 506,
+        "user": 7112,
+        "created_at": 1651460160,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 507,
+        "user": 7112,
+        "created_at": 1651460174
+      },
+      {
+        "hex": "J9",
+        "tile": "9-3",
+        "type": "lay_tile",
+        "entity": "NdM",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 508,
+        "user": 7112,
+        "created_at": 1651460324,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 509,
+        "user": 7112,
+        "created_at": 1651460348
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 510,
+        "created_at": 1651460365,
+        "hex": "K10",
+        "tile": "9-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 511,
+        "created_at": 1651460385
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 512,
+        "created_at": 1651460392
+      },
+      {
+        "type": "buy_train",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 513,
+        "created_at": 1651460396,
+        "train": "6'-0",
+        "price": 600,
+        "variant": "6'"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 514,
+        "created_at": 1651460744,
+        "hex": "I4",
+        "tile": "6-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 515,
+        "created_at": 1651460795
+      },
+      {
+        "type": "place_token",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 516,
+        "created_at": 1651460800,
+        "city": "57-1-0",
+        "slot": 0,
+        "tokener": "FCP"
+      },
+      {
+        "type": "run_routes",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 517,
+        "created_at": 1651460852,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "J5",
+                "K6"
+              ],
+              [
+                "I4",
+                "J5"
+              ],
+              [
+                "D3",
+                "F3",
+                "G4",
+                "I4"
+              ],
+              [
+                "B3",
+                "D3"
+              ],
+              [
+                "B1",
+                "C2",
+                "B3"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "J5",
+              "I4",
+              "D3",
+              "B3",
+              "B1"
+            ],
+            "revenue": 220,
+            "revenue_str": "O10-L9-K8-J7-K6-J5-I4-D3-B3-B1",
+            "nodes": [
+              "L9-0",
+              "O10-1",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "J5-0",
+              "I4-0",
+              "D3-0",
+              "B3-0",
+              "B1-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 518,
+        "created_at": 1651460856,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 519,
+        "created_at": 1651460862
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 520,
+        "created_at": 1651461117,
+        "hex": "N9",
+        "tile": "19-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 521,
+        "created_at": 1651461132,
+        "routes": [
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ],
+              [
+                "I12",
+                "J11",
+                "I10"
+              ],
+              [
+                "D11",
+                "F11",
+                "G12",
+                "I12"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10",
+              "I12",
+              "D11"
+            ],
+            "revenue": 210,
+            "revenue_str": "O10-L9-K8-J7-I8-I10-I12-D11",
+            "nodes": [
+              "L9-0",
+              "O10-1",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0",
+              "I12-0",
+              "D11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 522,
+        "created_at": 1651461135,
+        "kind": "payout"
+      },
+      {
+        "type": "sell_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 523,
+        "created_at": 1651461260,
+        "shares": [
+          "MC_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 524,
+        "created_at": 1651461282,
+        "shares": [
+          "TM_1",
+          "TM_2",
+          "TM_3",
+          "TM_4"
+        ],
+        "percent": 40
+      },
+      {
+        "type": "sell_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 525,
+        "created_at": 1651461309,
+        "shares": [
+          "FCP_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_train",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 526,
+        "created_at": 1651461317,
+        "train": "4D-0",
+        "price": 700,
+        "variant": "4D"
+      },
+      {
+        "hex": "N9",
+        "tile": "45-0",
+        "type": "lay_tile",
+        "entity": "CHI",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 527,
+        "user": 488,
+        "created_at": 1651464583,
+        "skip": true
+      },
+      {
+        "city": "480-0-0",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "CHI",
+        "tokener": "CHI",
+        "entity_type": "corporation",
+        "id": 528,
+        "user": 488,
+        "created_at": 1651464588,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "routes": [
+          {
+            "hexes": [
+              "I10",
+              "M10",
+              "L9",
+              "O8",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "nodes": [
+              "M10-0",
+              "I10-0",
+              "L9-0",
+              "O8-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ],
+            "train": "5-1",
+            "revenue": 280,
+            "connections": [
+              [
+                "M10",
+                "K10",
+                "I10"
+              ],
+              [
+                "L9",
+                "N9",
+                "M10"
+              ],
+              [
+                "O8",
+                "M8",
+                "L9"
+              ],
+              [
+                "O10",
+                "N9",
+                "O8"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "revenue_str": "I10-M10-L9-O8-O10-O10-P11-P13-P13"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 529,
+        "user": 488,
+        "created_at": 1651464639,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 530,
+        "user": 488,
+        "created_at": 1651464740,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 531,
+        "user": 488,
+        "created_at": 1651464747,
+        "skip": true
+      },
+      {
+        "hex": "K10",
+        "tile": "23-0",
+        "type": "lay_tile",
+        "entity": "SPM",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 532,
+        "user": 488,
+        "created_at": 1651464770,
+        "skip": true
+      },
+      {
+        "city": "63-1-0",
+        "slot": 1,
+        "type": "place_token",
+        "entity": "SPM",
+        "tokener": "SPM",
+        "entity_type": "corporation",
+        "id": 533,
+        "user": 488,
+        "created_at": 1651464780,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "SPM",
+        "routes": [
+          {
+            "hexes": [
+              "D11",
+              "I12",
+              "I10",
+              "L9",
+              "O8",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "nodes": [
+              "I12-0",
+              "D11-0",
+              "I10-0",
+              "L9-0",
+              "O8-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ],
+            "train": "6-0",
+            "revenue": 340,
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ],
+              [
+                "I10",
+                "J11",
+                "I12"
+              ],
+              [
+                "L9",
+                "K10",
+                "I10"
+              ],
+              [
+                "O8",
+                "M8",
+                "L9"
+              ],
+              [
+                "O10",
+                "N9",
+                "O8"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "revenue_str": "D11-I12-I10-L9-O8-O10-O10-P11-P13-P13"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 534,
+        "user": 488,
+        "created_at": 1651464819,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 535,
+        "user": 488,
+        "created_at": 1651464821,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 536,
+        "user": 488,
+        "created_at": 1651464826,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "UdY",
+        "action_id": 531,
+        "entity_type": "corporation",
+        "id": 537,
+        "user": 488,
+        "created_at": 1651464836
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "SPM",
+        "action_id": 526,
+        "entity_type": "corporation",
+        "id": 538,
+        "user": 488,
+        "created_at": 1651464840
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 539,
+        "created_at": 1651464851,
+        "hex": "N9",
+        "tile": "45-0",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 540,
+        "created_at": 1651464853,
+        "city": "480-0-0",
+        "slot": 1,
+        "tokener": "CHI"
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 541,
+        "created_at": 1651464876,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "M10",
+                "K10",
+                "I10"
+              ],
+              [
+                "L9",
+                "N9",
+                "M10"
+              ],
+              [
+                "O8",
+                "M8",
+                "L9"
+              ],
+              [
+                "O10",
+                "N9",
+                "O8"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "I10",
+              "M10",
+              "L9",
+              "O8",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "revenue": 280,
+            "revenue_str": "I10-M10-L9-O8-O10-O10-P11-P13-P13",
+            "nodes": [
+              "M10-0",
+              "I10-0",
+              "L9-0",
+              "O8-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 542,
+        "created_at": 1651464878,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 543,
+        "created_at": 1651464883
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 544,
+        "created_at": 1651464892,
+        "hex": "K10",
+        "tile": "23-0",
+        "rotation": 3
+      },
+      {
+        "type": "place_token",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 545,
+        "created_at": 1651464900,
+        "city": "63-1-0",
+        "slot": 1,
+        "tokener": "SPM"
+      },
+      {
+        "type": "run_routes",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 546,
+        "created_at": 1651464930,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "I10",
+                "K10",
+                "L9"
+              ],
+              [
+                "I12",
+                "J11",
+                "I10"
+              ],
+              [
+                "D11",
+                "F11",
+                "G12",
+                "I12"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "I10",
+              "I12",
+              "D11"
+            ],
+            "revenue": 340,
+            "revenue_str": "P13-P13-P11-O10-O10-O8-L9-I10-I12-D11",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "O8-0",
+              "L9-0",
+              "I10-0",
+              "I12-0",
+              "D11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 547,
+        "created_at": 1651464933,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 548,
+        "created_at": 1651464934
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 549,
+        "created_at": 1651491720,
+        "hex": "K6",
+        "tile": "482-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 550,
+        "created_at": 1651491742,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "K6"
+              ],
+              [
+                "J7",
+                "K6"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13",
+                "Q14"
+              ]
+            ],
+            "hexes": [
+              "K6",
+              "K6",
+              "J7",
+              "K8",
+              "L9",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "Q14"
+            ],
+            "revenue": 250,
+            "revenue_str": "K6-K6-J7-K8-L9-O10-O10-P11-P13-Q14",
+            "nodes": [
+              "K6-0",
+              "K6-1",
+              "J7-0",
+              "K8-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 551,
+        "created_at": 1651491749,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 552,
+        "created_at": 1651491750,
+        "train": "4D-1",
+        "price": 700,
+        "variant": "4D"
+      },
+      {
+        "hex": "O8",
+        "tile": "455-0",
+        "type": "lay_tile",
+        "entity": "MC",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 553,
+        "user": 5951,
+        "created_at": 1651501157,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 554,
+        "user": 5951,
+        "created_at": 1651501191
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 555,
+        "created_at": 1651501195,
+        "hex": "I8",
+        "tile": "63-2",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 556,
+        "created_at": 1651501329,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "J7",
+                "I8"
+              ],
+              [
+                "I8",
+                "H7",
+                "G6",
+                "E6"
+              ],
+              [
+                "E6",
+                "C6",
+                "A6"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6",
+              "A6"
+            ],
+            "revenue": 220,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-E6-A6",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0",
+              "A6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 557,
+        "created_at": 1651501332,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 558,
+        "created_at": 1651501374,
+        "train": "4D-2",
+        "price": 700,
+        "variant": "4D"
+      },
+      {
+        "hex": "D3",
+        "tile": "15-2",
+        "type": "lay_tile",
+        "entity": "FCP",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 559,
+        "user": 5951,
+        "created_at": 1651501402,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 560,
+        "user": 5951,
+        "created_at": 1651501410,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 561,
+        "user": 5951,
+        "created_at": 1651501417
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 562,
+        "user": 5951,
+        "created_at": 1651501421
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 563,
+        "created_at": 1651501425,
+        "hex": "O8",
+        "tile": "455-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 564,
+        "created_at": 1651501427,
+        "city": "455-0-0",
+        "slot": 2,
+        "tokener": "FCP"
+      },
+      {
+        "type": "run_routes",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 565,
+        "created_at": 1651501607,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6",
+                "J5"
+              ],
+              [
+                "J5",
+                "I4"
+              ],
+              [
+                "I4",
+                "G4",
+                "F3",
+                "D3"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "J5",
+              "I4",
+              "D3"
+            ],
+            "revenue": 230,
+            "revenue_str": "O10-O10-O8-L9-K8-J7-K6-J5-I4-D3",
+            "nodes": [
+              "O10-1",
+              "O10-0",
+              "O8-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "J5-0",
+              "I4-0",
+              "D3-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 566,
+        "created_at": 1651501609,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 567,
+        "created_at": 1651501618
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 568,
+        "created_at": 1651503320,
+        "hex": "M8",
+        "tile": "40-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 569,
+        "created_at": 1651503400,
+        "routes": [
+          {
+            "train": "6'-0",
+            "connections": [
+              [
+                "K6",
+                "L7",
+                "M8",
+                "O8"
+              ],
+              [
+                "J7",
+                "K6"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "M10",
+                "O10"
+              ],
+              [
+                "I10",
+                "K10",
+                "M10"
+              ],
+              [
+                "I8",
+                "H9",
+                "I10"
+              ]
+            ],
+            "hexes": [
+              "O8",
+              "K6",
+              "J7",
+              "K8",
+              "L9",
+              "O10",
+              "O10",
+              "M10",
+              "I10",
+              "I8"
+            ],
+            "revenue": 300,
+            "revenue_str": "O8-K6-J7-K8-L9-O10-O10-M10-I10-I8",
+            "nodes": [
+              "K6-0",
+              "O8-0",
+              "J7-0",
+              "K8-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "M10-0",
+              "I10-0",
+              "I8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 570,
+        "created_at": 1651503401,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 571,
+        "created_at": 1651503409
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 572,
+        "created_at": 1651503423
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 573,
+        "created_at": 1651503466,
+        "routes": [
+          {
+            "train": "4D-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10"
+            ],
+            "revenue": 300,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-I10",
+            "nodes": [
+              "O10-1",
+              "O10-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 574,
+        "created_at": 1651503467,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 575,
+        "created_at": 1651503468
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 576,
+        "created_at": 1651515083,
+        "hex": "J11",
+        "tile": "46-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 577,
+        "created_at": 1651515087,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "M10",
+                "K10",
+                "I10"
+              ],
+              [
+                "L9",
+                "N9",
+                "M10"
+              ],
+              [
+                "O8",
+                "M8",
+                "L9"
+              ],
+              [
+                "O10",
+                "N9",
+                "O8"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "P13",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "I10",
+              "M10",
+              "L9",
+              "O8",
+              "O10",
+              "O10",
+              "P11",
+              "P13",
+              "P13"
+            ],
+            "revenue": 280,
+            "revenue_str": "I10-M10-L9-O8-O10-O10-P11-P13-P13",
+            "nodes": [
+              "M10-0",
+              "I10-0",
+              "L9-0",
+              "O8-0",
+              "O10-1",
+              "O10-0",
+              "P11-0",
+              "P13-0",
+              "P13-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 578,
+        "created_at": 1651515089,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 579,
+        "created_at": 1651515145
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 580,
+        "created_at": 1651515163,
+        "hex": "Q12",
+        "tile": "25-2",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 581,
+        "created_at": 1651515180,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "I10",
+                "K10",
+                "L9"
+              ],
+              [
+                "I12",
+                "J11",
+                "I10"
+              ],
+              [
+                "D11",
+                "F11",
+                "G12",
+                "I12"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "I10",
+              "I12",
+              "D11"
+            ],
+            "revenue": 340,
+            "revenue_str": "P13-P13-P11-O10-O10-O8-L9-I10-I12-D11",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "O8-0",
+              "L9-0",
+              "I10-0",
+              "I12-0",
+              "D11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 582,
+        "created_at": 1651515182,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 583,
+        "created_at": 1651515209,
+        "train": "5-1",
+        "price": 105
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 584,
+        "created_at": 1651523532
+      },
+      {
+        "type": "run_routes",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 585,
+        "created_at": 1651523557,
+        "routes": [
+          {
+            "train": "4D-1",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6",
+                "L7",
+                "M8",
+                "O8"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "O8"
+            ],
+            "revenue": 440,
+            "revenue_str": "P13-P13-P11-O10-O10-L9-K8-J7-K6-O8",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "O8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 586,
+        "created_at": 1651523558,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 587,
+        "created_at": 1651523560
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 588,
+        "created_at": 1651523970,
+        "hex": "E6",
+        "tile": "63-3",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 589,
+        "created_at": 1651524012,
+        "routes": [
+          {
+            "train": "4D-2",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I8",
+                "H7",
+                "G6",
+                "E6"
+              ],
+              [
+                "E6",
+                "C6",
+                "A6"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6",
+              "A6"
+            ],
+            "revenue": 420,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-E6-A6",
+            "nodes": [
+              "O10-1",
+              "O10-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0",
+              "A6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 590,
+        "created_at": 1651524014,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 591,
+        "created_at": 1651524021
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 592,
+        "created_at": 1651524041,
+        "hex": "I4",
+        "tile": "475-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 593,
+        "created_at": 1651524058
+      },
+      {
+        "type": "run_routes",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 594,
+        "created_at": 1651524100,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6",
+                "J5"
+              ],
+              [
+                "J5",
+                "I4"
+              ],
+              [
+                "I4",
+                "G4",
+                "F3",
+                "D3"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "J5",
+              "I4",
+              "D3"
+            ],
+            "revenue": 240,
+            "revenue_str": "O10-O10-O8-L9-K8-J7-K6-J5-I4-D3",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "O8-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "J5-0",
+              "I4-0",
+              "D3-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 595,
+        "created_at": 1651524101,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 596,
+        "created_at": 1651524105
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 597,
+        "created_at": 1651535359
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 598,
+        "created_at": 1651535375
+      },
+      {
+        "type": "run_routes",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 599,
+        "created_at": 1651535378,
+        "routes": [
+          {
+            "train": "6'-0",
+            "connections": [
+              [
+                "K6",
+                "L7",
+                "M8",
+                "O8"
+              ],
+              [
+                "J7",
+                "K6"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "M10",
+                "O10"
+              ],
+              [
+                "I10",
+                "K10",
+                "M10"
+              ],
+              [
+                "I8",
+                "H9",
+                "I10"
+              ]
+            ],
+            "hexes": [
+              "O8",
+              "K6",
+              "J7",
+              "K8",
+              "L9",
+              "O10",
+              "O10",
+              "M10",
+              "I10",
+              "I8"
+            ],
+            "revenue": 300,
+            "revenue_str": "O8-K6-J7-K8-L9-O10-O10-M10-I10-I8",
+            "nodes": [
+              "K6-0",
+              "O8-0",
+              "J7-0",
+              "K8-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "M10-0",
+              "I10-0",
+              "I8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 600,
+        "created_at": 1651535379,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 601,
+        "created_at": 1651535383
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 602,
+        "user": 7112,
+        "created_at": 1651535386,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 603,
+        "user": 7112,
+        "created_at": 1651535412
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 604,
+        "created_at": 1651535419,
+        "hex": "H9",
+        "tile": "23-1",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 605,
+        "created_at": 1651535429,
+        "routes": [
+          {
+            "train": "4D-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10"
+            ],
+            "revenue": 300,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-I10",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 606,
+        "created_at": 1651535431,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 607,
+        "created_at": 1651535434
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 608,
+        "created_at": 1651535504,
+        "hex": "S12",
+        "tile": "619-0",
+        "rotation": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 609,
+        "created_at": 1651535511,
+        "train": "4D-3",
+        "price": 700,
+        "variant": "4D"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 610,
+        "created_at": 1651535544,
+        "shares": [
+          "SPM_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 611,
+        "created_at": 1651535560
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 612,
+        "created_at": 1651548347,
+        "shares": [
+          "SPM_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 613,
+        "created_at": 1651548355,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1651548355
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 614,
+        "created_at": 1651548476,
+        "shares": [
+          "SPM_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 615,
+        "user": 4013,
+        "created_at": 1651548509
+      },
+      {
+        "skip": true,
+        "type": "redo",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 616,
+        "user": 4013,
+        "created_at": 1651548546
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 617,
+        "created_at": 1651548547
+      },
+      {
+        "type": "sell_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 618,
+        "created_at": 1651618019,
+        "shares": [
+          "FCP_6",
+          "FCP_8"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 619,
+        "created_at": 1651618035,
+        "shares": [
+          "MC_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 620,
+        "created_at": 1651619370,
+        "shares": [
+          "MC_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 621,
+        "created_at": 1651619392,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1651619391,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 622,
+        "created_at": 1651621737,
+        "shares": [
+          "TM_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 623,
+        "created_at": 1651621772,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "entity_type": "player",
+            "created_at": 1651621772
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 624,
+        "created_at": 1651621906,
+        "shares": [
+          "MC_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 625,
+        "created_at": 1651621914
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 626,
+        "created_at": 1651628388,
+        "shares": [
+          "MC_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 627,
+        "created_at": 1651628429
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 628,
+        "created_at": 1651629793,
+        "shares": [
+          "TM_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5951,
+            "created_at": 1651629826,
+            "entity_type": "player"
+          }
+        ],
+        "id": 629,
+        "user": 7112,
+        "created_at": 1651629826,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 630,
+        "user": 5951,
+        "created_at": 1651631209
+      },
+      {
+        "skip": true,
+        "type": "redo",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 631,
+        "user": 4013,
+        "created_at": 1651631231
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 632,
+        "user": 4013,
+        "created_at": 1651631236
+      },
+      {
+        "type": "program_disable",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 633,
+        "created_at": 1651631241,
+        "reason": "user"
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 634,
+        "user": 4013,
+        "created_at": 1651631263
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 635,
+        "created_at": 1651631277,
+        "shares": [
+          "TM_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 636,
+        "created_at": 1651631294
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 637,
+        "created_at": 1651631327,
+        "shares": [
+          "TM_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 638,
+        "created_at": 1651631352
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 639,
+        "created_at": 1651631361,
+        "corporation": "FCP",
+        "until_condition": 3,
+        "from_market": true,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 640,
+        "created_at": 1651667116,
+        "shares": [
+          "TM_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 641,
+        "created_at": 1651667150
+      },
+      {
+        "type": "message",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 642,
+        "created_at": 1651667175,
+        "message": "Oops, I should have only sold 1 FCP.  Now I will be a share short."
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 643,
+        "created_at": 1651667990,
+        "shares": [
+          "FCP_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 644,
+        "created_at": 1651668035
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4013,
+            "shares": [
+              "FCP_6"
+            ],
+            "percent": 10,
+            "created_at": 1651698926,
+            "entity_type": "player"
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "created_at": 1651698926,
+            "entity_type": "player"
+          }
+        ],
+        "id": 645,
+        "user": 5951,
+        "created_at": 1651698927,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 646,
+        "user": 5951,
+        "created_at": 1651698954
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "shares": [
+          "CHI_8"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 647,
+        "user": 5951,
+        "created_at": 1651698965,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 4013,
+            "reason": "Shares were sold",
+            "created_at": 1651698990,
+            "entity_type": "player"
+          }
+        ],
+        "id": 648,
+        "user": 5951,
+        "created_at": 1651698990,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 649,
+        "user": 5951,
+        "created_at": 1651699001
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 650,
+        "user": 5951,
+        "created_at": 1651699008
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "shares": [
+          "SPM_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 651,
+        "user": 5951,
+        "created_at": 1651699013,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 652,
+        "user": 5951,
+        "created_at": 1651699026
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "shares": [
+          "CHI_8"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 653,
+        "user": 5951,
+        "created_at": 1651699058,
+        "skip": true
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "shares": [
+          "SPM_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 654,
+        "user": 5951,
+        "created_at": 1651699061,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 655,
+        "user": 5951,
+        "created_at": 1651699066
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 656,
+        "user": 5951,
+        "created_at": 1651699070
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5951,
+        "shares": [
+          "CHI_8"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 657,
+        "user": 5951,
+        "created_at": 1651709543,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 658,
+        "user": 5951,
+        "created_at": 1651709548
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 659,
+        "created_at": 1651709552,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651709553,
+            "shares": [
+              "FCP_6"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651709553
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 660,
+        "created_at": 1651719476
+      },
+      {
+        "type": "buy_shares",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 661,
+        "created_at": 1651721494,
+        "shares": [
+          "FCP_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 662,
+        "created_at": 1651721506
+      },
+      {
+        "type": "pass",
+        "entity": 5951,
+        "entity_type": "player",
+        "id": 663,
+        "created_at": 1651722265
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 664,
+        "created_at": 1651722271,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4013,
+            "entity_type": "player",
+            "created_at": 1651722270
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 665,
+        "created_at": 1651752057
+      },
+      {
+        "type": "pass",
+        "entity": 7112,
+        "entity_type": "player",
+        "id": 666,
+        "created_at": 1651753490
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 667,
+        "created_at": 1651754612,
+        "hex": "R13",
+        "tile": "24-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 668,
+        "created_at": 1651754656,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ],
+              [
+                "I10",
+                "J11",
+                "I12"
+              ],
+              [
+                "L9",
+                "K10",
+                "I10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "O8",
+                "M8",
+                "L7",
+                "K6"
+              ],
+              [
+                "O10",
+                "N9",
+                "O8"
+              ],
+              [
+                "O10"
+              ]
+            ],
+            "hexes": [
+              "D11",
+              "I12",
+              "I10",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "O8",
+              "O10",
+              "O10"
+            ],
+            "revenue": 320,
+            "revenue_str": "D11-I12-I10-L9-K8-J7-K6-O8-O10-O10",
+            "nodes": [
+              "I12-0",
+              "D11-0",
+              "I10-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "O8-0",
+              "O10-1",
+              "O10-0"
+            ]
+          },
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "O10",
+                "M10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "S12",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13",
+                "R13",
+                "S12"
+              ],
+              [
+                "Q14",
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "O10",
+              "P11",
+              "S12",
+              "P13",
+              "Q14"
+            ],
+            "revenue": 220,
+            "revenue_str": "M10-O10-P11-S12-P13-Q14",
+            "nodes": [
+              "O10-0",
+              "M10-0",
+              "P11-0",
+              "S12-0",
+              "P13-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 669,
+        "created_at": 1651754658,
+        "kind": "payout"
+      },
+      {
+        "hex": "O12",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "UdY",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 670,
+        "user": 4013,
+        "created_at": 1651769800,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 671,
+        "user": 4013,
+        "created_at": 1651769808
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 672,
+        "created_at": 1651769818,
+        "hex": "I4",
+        "tile": "481-0",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 673,
+        "created_at": 1651769830,
+        "routes": [
+          {
+            "train": "4D-1",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6",
+                "L7",
+                "M8",
+                "O8"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "O8"
+            ],
+            "revenue": 440,
+            "revenue_str": "P13-P13-P11-O10-O10-L9-K8-J7-K6-O8",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "O8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 674,
+        "created_at": 1651769831,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 675,
+        "created_at": 1651769833
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 676,
+        "created_at": 1651770705,
+        "hex": "D3",
+        "tile": "15-2",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 677,
+        "created_at": 1651770835,
+        "routes": [
+          {
+            "train": "4D-2",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I8",
+                "H7",
+                "G6",
+                "E6"
+              ],
+              [
+                "E6",
+                "C6",
+                "A6"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6",
+              "A6"
+            ],
+            "revenue": 420,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-E6-A6",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0",
+              "A6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 678,
+        "created_at": 1651770836,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 679,
+        "created_at": 1651770844
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 680,
+        "created_at": 1651782304
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 681,
+        "created_at": 1651782305
+      },
+      {
+        "type": "run_routes",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 682,
+        "created_at": 1651782309,
+        "routes": [
+          {
+            "train": "6'-0",
+            "connections": [
+              [
+                "K6",
+                "L7",
+                "M8",
+                "O8"
+              ],
+              [
+                "J7",
+                "K6"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "M10",
+                "O10"
+              ],
+              [
+                "I10",
+                "K10",
+                "M10"
+              ],
+              [
+                "I8",
+                "H9",
+                "I10"
+              ]
+            ],
+            "hexes": [
+              "O8",
+              "K6",
+              "J7",
+              "K8",
+              "L9",
+              "O10",
+              "O10",
+              "M10",
+              "I10",
+              "I8"
+            ],
+            "revenue": 300,
+            "revenue_str": "O8-K6-J7-K8-L9-O10-O10-M10-I10-I8",
+            "nodes": [
+              "K6-0",
+              "O8-0",
+              "J7-0",
+              "K8-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "M10-0",
+              "I10-0",
+              "I8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 683,
+        "created_at": 1651782310,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 684,
+        "created_at": 1651782314
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 685,
+        "created_at": 1651782317
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 686,
+        "created_at": 1651782318,
+        "routes": [
+          {
+            "train": "4D-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10"
+            ],
+            "revenue": 300,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-I10",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 687,
+        "created_at": 1651782319,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 688,
+        "created_at": 1651782338
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 689,
+        "created_at": 1651785177,
+        "hex": "D3",
+        "tile": "63-4",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 690,
+        "created_at": 1651785191
+      },
+      {
+        "type": "run_routes",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 691,
+        "created_at": 1651785224,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6",
+                "J5"
+              ],
+              [
+                "J5",
+                "I4"
+              ],
+              [
+                "I4",
+                "G4",
+                "F3",
+                "D3"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "J5",
+              "I4",
+              "D3"
+            ],
+            "revenue": 270,
+            "revenue_str": "O10-O10-O8-L9-K8-J7-K6-J5-I4-D3",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "O8-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "J5-0",
+              "I4-0",
+              "D3-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 692,
+        "created_at": 1651785226,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 693,
+        "created_at": 1651785232
+      },
+      {
+        "hex": "S12",
+        "tile": "63-5",
+        "type": "lay_tile",
+        "entity": "CHI",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 694,
+        "user": 488,
+        "created_at": 1651801864,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "routes": [
+          {
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "K8",
+              "J7",
+              "I8"
+            ],
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "O8-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0"
+            ],
+            "train": "4D-3",
+            "revenue": 440,
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ]
+            ],
+            "revenue_str": "P13-P13-P11-O10-O10-O8-L9-K8-J7-I8"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 695,
+        "user": 488,
+        "created_at": 1651801901,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 696,
+        "user": 488,
+        "created_at": 1651801903,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 697,
+        "user": 488,
+        "created_at": 1651801905,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "SPM",
+        "action_id": 693,
+        "entity_type": "corporation",
+        "id": 698,
+        "user": 488,
+        "created_at": 1651801940
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "CHI",
+        "action_id": 693,
+        "entity_type": "corporation",
+        "id": 699,
+        "user": 488,
+        "created_at": 1651801942
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 700,
+        "created_at": 1651801948,
+        "hex": "H11",
+        "tile": "9-4",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 701,
+        "created_at": 1651801954
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 702,
+        "created_at": 1651801980,
+        "routes": [
+          {
+            "train": "4D-3",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "K6"
+            ],
+            "revenue": 460,
+            "revenue_str": "P13-P13-P11-O10-O10-O8-L9-K8-J7-K6-K6",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "O8-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "K6-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 703,
+        "created_at": 1651801984,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 704,
+        "created_at": 1651801987
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 705,
+        "created_at": 1651802003,
+        "hex": "S12",
+        "tile": "63-5",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 706,
+        "created_at": 1651802009,
+        "routes": [
+          {
+            "train": "6-0",
+            "connections": [
+              [
+                "I12",
+                "G12",
+                "F11",
+                "D11"
+              ],
+              [
+                "I10",
+                "J11",
+                "I12"
+              ],
+              [
+                "L9",
+                "K10",
+                "I10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "O8",
+                "M8",
+                "L7",
+                "K6"
+              ],
+              [
+                "O10",
+                "N9",
+                "O8"
+              ],
+              [
+                "O10"
+              ]
+            ],
+            "hexes": [
+              "D11",
+              "I12",
+              "I10",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "O8",
+              "O10",
+              "O10"
+            ],
+            "revenue": 320,
+            "revenue_str": "D11-I12-I10-L9-K8-J7-K6-O8-O10-O10",
+            "nodes": [
+              "I12-0",
+              "D11-0",
+              "I10-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "O8-0",
+              "O10-1",
+              "O10-0"
+            ]
+          },
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "O10",
+                "M10"
+              ],
+              [
+                "P11",
+                "O10"
+              ],
+              [
+                "S12",
+                "Q12",
+                "P11"
+              ],
+              [
+                "P13",
+                "R13",
+                "S12"
+              ],
+              [
+                "Q14",
+                "P13"
+              ]
+            ],
+            "hexes": [
+              "M10",
+              "O10",
+              "P11",
+              "S12",
+              "P13",
+              "Q14"
+            ],
+            "revenue": 230,
+            "revenue_str": "M10-O10-P11-S12-P13-Q14",
+            "nodes": [
+              "O10-0",
+              "M10-0",
+              "P11-0",
+              "S12-0",
+              "P13-0",
+              "Q14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "SPM",
+        "entity_type": "corporation",
+        "id": 707,
+        "created_at": 1651802010,
+        "kind": "payout"
+      },
+      {
+        "type": "message",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 708,
+        "created_at": 1651807420,
+        "message": "I noticed that way after the fact as well"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 709,
+        "created_at": 1651807434
+      },
+      {
+        "type": "run_routes",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 710,
+        "created_at": 1651807449,
+        "routes": [
+          {
+            "train": "4D-1",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6",
+                "L7",
+                "M8",
+                "O8"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "O8"
+            ],
+            "revenue": 440,
+            "revenue_str": "P13-P13-P11-O10-O10-L9-K8-J7-K6-O8",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "O8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 711,
+        "created_at": 1651807450,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "UdY",
+        "entity_type": "corporation",
+        "id": 712,
+        "created_at": 1651807452
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 713,
+        "created_at": 1651843610,
+        "hex": "G6",
+        "tile": "25-1",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 714,
+        "created_at": 1651843622,
+        "routes": [
+          {
+            "train": "4D-2",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I8",
+                "H7",
+                "G6",
+                "E6"
+              ],
+              [
+                "E6",
+                "C6",
+                "A6"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "E6",
+              "A6"
+            ],
+            "revenue": 420,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-E6-A6",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "E6-0",
+              "A6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 715,
+        "created_at": 1651843624,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MC",
+        "entity_type": "corporation",
+        "id": 716,
+        "created_at": 1651843630
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 717,
+        "created_at": 1651870334
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 718,
+        "created_at": 1651870335
+      },
+      {
+        "type": "run_routes",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 719,
+        "created_at": 1651870336,
+        "routes": [
+          {
+            "train": "6'-0",
+            "connections": [
+              [
+                "K6",
+                "L7",
+                "M8",
+                "O8"
+              ],
+              [
+                "J7",
+                "K6"
+              ],
+              [
+                "K8",
+                "J7"
+              ],
+              [
+                "L9",
+                "K8"
+              ],
+              [
+                "O10",
+                "N9",
+                "L9"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "M10",
+                "O10"
+              ],
+              [
+                "I10",
+                "K10",
+                "M10"
+              ],
+              [
+                "I8",
+                "H9",
+                "I10"
+              ]
+            ],
+            "hexes": [
+              "O8",
+              "K6",
+              "J7",
+              "K8",
+              "L9",
+              "O10",
+              "O10",
+              "M10",
+              "I10",
+              "I8"
+            ],
+            "revenue": 300,
+            "revenue_str": "O8-K6-J7-K8-L9-O10-O10-M10-I10-I8",
+            "nodes": [
+              "K6-0",
+              "O8-0",
+              "J7-0",
+              "K8-0",
+              "L9-0",
+              "O10-1",
+              "O10-0",
+              "M10-0",
+              "I10-0",
+              "I8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 720,
+        "created_at": 1651870337,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NdM",
+        "entity_type": "corporation",
+        "id": 721,
+        "created_at": 1651870339
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 722,
+        "created_at": 1651870340
+      },
+      {
+        "type": "run_routes",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 723,
+        "created_at": 1651870340,
+        "routes": [
+          {
+            "train": "4D-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "L9",
+                "N9",
+                "O10"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "I8",
+                "J7"
+              ],
+              [
+                "I10",
+                "H9",
+                "I8"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "L9",
+              "K8",
+              "J7",
+              "I8",
+              "I10"
+            ],
+            "revenue": 300,
+            "revenue_str": "O10-O10-L9-K8-J7-I8-I10",
+            "nodes": [
+              "O10-0",
+              "O10-1",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "I8-0",
+              "I10-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 724,
+        "created_at": 1651870341,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "TM",
+        "entity_type": "corporation",
+        "id": 725,
+        "created_at": 1651870342
+      },
+      {
+        "hex": "H5",
+        "tile": "9-5",
+        "type": "lay_tile",
+        "entity": "FCP",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 726,
+        "user": 5951,
+        "created_at": 1651946657,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 727,
+        "user": 5951,
+        "created_at": 1651946670
+      },
+      {
+        "hex": "C2",
+        "tile": "24-1",
+        "type": "lay_tile",
+        "entity": "FCP",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 728,
+        "user": 5951,
+        "created_at": 1651946675,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 729,
+        "user": 5951,
+        "created_at": 1651946700
+      },
+      {
+        "type": "lay_tile",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 730,
+        "created_at": 1651947891,
+        "hex": "N7",
+        "tile": "7-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 731,
+        "created_at": 1651947905
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 732,
+        "created_at": 1651947967
+      },
+      {
+        "type": "run_routes",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 733,
+        "created_at": 1651948031,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6",
+                "J5"
+              ],
+              [
+                "J5",
+                "I4"
+              ],
+              [
+                "I4",
+                "G4",
+                "F3",
+                "D3"
+              ]
+            ],
+            "hexes": [
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "J5",
+              "I4",
+              "D3"
+            ],
+            "revenue": 270,
+            "revenue_str": "O10-O10-O8-L9-K8-J7-K6-J5-I4-D3",
+            "nodes": [
+              "O10-1",
+              "O10-0",
+              "O8-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "J5-0",
+              "I4-0",
+              "D3-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 734,
+        "created_at": 1651948033,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "FCP",
+        "entity_type": "corporation",
+        "id": 735,
+        "created_at": 1651948047
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 736,
+        "created_at": 1651960104,
+        "hex": "F11",
+        "tile": "24-1",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 737,
+        "created_at": 1651960121,
+        "routes": [
+          {
+            "train": "4D-3",
+            "connections": [
+              [
+                "P13"
+              ],
+              [
+                "P11",
+                "Q12",
+                "P13"
+              ],
+              [
+                "O10",
+                "P11"
+              ],
+              [
+                "O10"
+              ],
+              [
+                "O8",
+                "N9",
+                "O10"
+              ],
+              [
+                "L9",
+                "M8",
+                "O8"
+              ],
+              [
+                "K8",
+                "L9"
+              ],
+              [
+                "J7",
+                "K8"
+              ],
+              [
+                "K6",
+                "J7"
+              ],
+              [
+                "K6"
+              ]
+            ],
+            "hexes": [
+              "P13",
+              "P13",
+              "P11",
+              "O10",
+              "O10",
+              "O8",
+              "L9",
+              "K8",
+              "J7",
+              "K6",
+              "K6"
+            ],
+            "revenue": 460,
+            "revenue_str": "P13-P13-P11-O10-O10-O8-L9-K8-J7-K6-K6",
+            "nodes": [
+              "P13-0",
+              "P13-1",
+              "P11-0",
+              "O10-0",
+              "O10-1",
+              "O8-0",
+              "L9-0",
+              "K8-0",
+              "J7-0",
+              "K6-0",
+              "K6-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 738,
+        "created_at": 1651960122,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CHI",
+        "entity_type": "corporation",
+        "id": 739,
+        "created_at": 1651960128
+      },
+      {
+        "type": "message",
+        "entity": 488,
+        "entity_type": "player",
+        "id": 740,
+        "created_at": 1651960138,
+        "message": "Wll played, Jen."
+      },
+      {
+        "type": "message",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 741,
+        "created_at": 1652016576,
+        "message": "Gg! well played friend. "
+      },
+      {
+        "type": "message",
+        "entity": 4013,
+        "entity_type": "player",
+        "id": 742,
+        "created_at": 1652016590,
+        "message": "I am not starting anything new until after Traxx… I’ll let you know when I do though "
+      }
+    ],
+    "loaded": true,
+    "created_at": 1649643168,
+    "updated_at": 1652016590
+  }


### PR DESCRIPTION
This one took me a while to figure out, I'm surprised I didn't catch onto hex.rb being the problem for me sooner.

Adds FutureLabels for 18Mex. 18Mex has the odd situation of a future label where a label goes away:
![image](https://user-images.githubusercontent.com/2993555/173169188-78a2410d-5254-4559-b54e-25a36b92aaac.png)
![image](https://user-images.githubusercontent.com/2993555/173169207-ffe0babe-fcff-46e8-994f-22b75e4a7fb1.png)
#480 shows the future label in the tile manifest
![image](https://user-images.githubusercontent.com/2993555/173169212-e2842b1f-f869-4e9c-bd4d-a4d5c37a414f.png)


