### PR TITLE
18MS future labels

### DIFF
--- a/lib/engine/game/g_18_ms/game.rb
+++ b/lib/engine/game/g_18_ms/game.rb
@@ -175,7 +175,6 @@ module Engine
           'remove_tokens' => ['Remove Tokens', 'New Orleans route bonus removed']
         ).freeze
 
-        HEXES_FOR_GRAY_TILE = %w[C9 E11].freeze
         COMPANY_1_AND_2 = %w[AGS BS].freeze
 
         def chattanooga_hex
@@ -393,16 +392,6 @@ module Engine
               @log << "Route bonus is removed from #{get_location_name(hex_name)} (#{hex_name})"
             end
           end
-        end
-
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
-          # Only allow tile gray tile (446) in Montgomery (E11) or Birmingham (C9)
-          return to.name == '446' if from.color == :brown && HEXES_FOR_GRAY_TILE.include?(from.hex.name)
-
-          # Only allow tile Mobile City brown tile in Mobile City hex (H6)
-          return to.name == 'X31b' if from.color == :green && from.hex.name == 'H6'
-
-          super
         end
 
         def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)

--- a/lib/engine/game/g_18_ms/map.rb
+++ b/lib/engine/game/g_18_ms/map.rb
@@ -103,7 +103,9 @@ module Engine
             %w[E7 F2 F6 F8 G1 G7] => 'upgrade=cost:20,terrain:water',
             ['H2'] => 'upgrade=cost:40,terrain:water',
             ['H8'] => 'town=revenue:0;upgrade=cost:20,terrain:water',
-            %w[C7 C9 E5 E9 E11 H6] => 'city=revenue:0',
+            %w[C7 E5 E9] => 'city=revenue:0',
+            %w[H6] => 'city=revenue:0;future_label=label:Mob,color:brown',
+            %w[C9 E11] => 'city=revenue:0;future_label=label:BM,color:gray',
             %w[B2 C5 D6 G3 H4] => 'town=revenue:0',
           },
           red: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2993555/173209736-14a7a591-4c2e-4bb7-ba5f-5c6ff6e92b73.png)
I left `all_potential_upgrades` in so that the tile manifest still shows the upgrade paths