### PR TITLE
Prohibit entities from buying trains from themselves

### DIFF
--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -62,6 +62,7 @@ module Engine
         # Check if the train is actually buyable in the current situation
         raise GameError, 'Not a buyable train' unless buyable_train_variants(train, entity).include?(train.variant)
         raise GameError, 'Must pay face value' if must_pay_face_value?(train, entity, price)
+        raise GameError, 'An entity cannot buy a train from itself' if train.owner == entity
 
         remaining = price - buying_power(entity)
         if remaining.positive? && president_may_contribute?(entity, action.shell)


### PR DESCRIPTION
Fixes #6707
After the change, loading the affected game from the ticket shows a "game cannot be continued error". The error is hard to trigger manually by its nature
![image](https://user-images.githubusercontent.com/2993555/173210228-b6abad6c-7f6a-47bf-a1bf-8ca5df29aab2.png)
