### PR TITLE
Modified cheater to always be boolean instead of specifying a slot

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1681,7 +1681,7 @@ module Engine
         end
 
         def minor_14_token_ability
-          Engine::Ability::Token.new(type: 'token', hexes: [], price: 20, cheater: 1)
+          Engine::Ability::Token.new(type: 'token', hexes: [], price: 20)
         end
 
         def mail_contract_bonus(entity, routes)
@@ -1757,8 +1757,7 @@ module Engine
 
         def place_destination_token(entity, hex, token)
           city = hex.tile.cities.first
-          cheater_slot = city.available_slots.positive? ? 0 : city.slots
-          city.place_token(entity, token, free: true, check_tokenable: false, cheater: cheater_slot)
+          city.place_token(entity, token, free: true, check_tokenable: false, cheater: true)
           hex.tile.icons.reject! { |icon| icon.name == "#{entity.id}_destination" }
 
           ability = entity.all_abilities.find { |a| a.type == :destination }
@@ -1953,9 +1952,6 @@ module Engine
           @company_trains['P13'] = find_and_remove_train_by_id('P+-0', buyable: false)
           @company_trains['P14'] = find_and_remove_train_by_id('P+-1', buyable: false)
           @company_trains['P19'] = find_and_remove_train_by_id('LP-0', buyable: false)
-
-          # Setup the minor 14 ability
-          corporation_by_id(self.class::MINOR_14_ID).add_ability(minor_14_token_ability) if self.class::MINOR_14_ID
         end
 
         def setup_destinations

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1093,7 +1093,7 @@ module Engine
           @green_t_tile ||= @tiles.find { |t| t.name == '405' }
 
           # Initialize the extra city which minor 14 might add
-          @minor_14_city_index = nil
+          @minor_14_city_exit = nil
 
           # Initialize the player depts, if player have to take an emergency loan
           @player_debts = Hash.new { |h, k| h[k] = 0 }
@@ -1263,10 +1263,11 @@ module Engine
         def after_place_pending_token(city)
           return unless city.hex.name == self.class::MINOR_14_HOME_HEX
 
-          # Save the extra token city index in london. We need this if we acquire the minor 14 and chooses to remove
+          # Save the extra token city exit in london. We need this if we acquire the minor 14 and chooses to remove
           # the token from london. The city where the 14's home token used to be is now open for other companies to
-          # token. If we do an upgrade to london, make sure this city still is open.
-          @minor_14_city_index = city.tile.cities.index { |c| c == city }
+          # token. If we do an upgrade to london, make sure this city still is open.  Save the exit instead of the
+          # index because the index can change
+          @minor_14_city_exit = city.hex.tile.paths.find { |p| p.city == city }.edges[0].num
         end
 
         def after_lay_tile(hex, old_tile, tile)
@@ -1832,9 +1833,9 @@ module Engine
         end
 
         def upgrade_minor_14_home_hex(hex)
-          return unless @minor_14_city_index
+          return unless @minor_14_city_exit
 
-          extra_city = hex.tile.cities[@minor_14_city_index]
+          extra_city = hex.tile.paths.find { |p| p.edges[0].num == @minor_14_city_exit }.city
           return unless extra_city.tokens.size == 1
 
           extra_city.tokens[extra_city.normal_slots] = nil

--- a/lib/engine/game/g_1822/step/pending_token.rb
+++ b/lib/engine/game/g_1822/step/pending_token.rb
@@ -27,6 +27,8 @@ module Engine
             end
 
             connected = action.entity.id != @game.class::MINOR_14_ID
+            city.tokens << nil if action.entity.id == @game.class::MINOR_14_ID
+            city.tokens << nil unless city.get_slot(action.entity)
             place_token(token.corporation, city, token, connected: connected, extra_action: true,
                                                         check_tokenable: false)
             @round.pending_tokens.shift

--- a/lib/engine/game/g_18_los_angeles/entities.rb
+++ b/lib/engine/game/g_18_los_angeles/entities.rb
@@ -174,7 +174,7 @@ module Engine
                 count: 1,
                 extra_action: true,
                 from_owner: true,
-                cheater: 0,
+                cheater: true,
                 special_only: true,
                 discount: 0,
                 hexes: %w[A2 A4 A6 A8 B5 B7 B9 B11 B13 C2 C4 C6 C8 C12 D5 D7 D9

--- a/lib/engine/game/g_18_scan/entities.rb
+++ b/lib/engine/game/g_18_scan/entities.rb
@@ -136,7 +136,7 @@ module Engine
               {
                 type: 'token',
                 hexes: ['B11'],
-                cheater: 1,
+                cheater: true,
                 price: 0,
                 special_only: true,
               },
@@ -161,7 +161,7 @@ module Engine
               {
                 type: 'token',
                 hexes: ['F11'],
-                cheater: 1,
+                cheater: true,
                 price: 0,
                 special_only: true,
               },
@@ -186,7 +186,7 @@ module Engine
               {
                 type: 'token',
                 hexes: ['D7'],
-                cheater: 1,
+                cheater: true,
                 price: 0,
                 special_only: true,
               },

--- a/lib/engine/game/g_18_usa/entities.rb
+++ b/lib/engine/game/g_18_usa/entities.rb
@@ -391,7 +391,7 @@ module Engine
               extra_action: true,
               from_owner: true,
               special_only: true,
-              cheater: 0,
+              cheater: true,
             ],
           },
           # P21
@@ -721,7 +721,7 @@ module Engine
                 price: 0,
                 count: 1,
                 from_owner: false,
-                cheater: 0,
+                cheater: true,
                 special_only: true,
                 hexes: [], # Determined in special_token step
               },

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -121,7 +121,7 @@ module Engine
         open_slot = @tokens.find_index.with_index do |t, i|
           t.nil? && @reservations[i].nil?
         end
-        return [open_slot || @tokens.size, cheater].max if cheater
+        return open_slot || @tokens.size if cheater
 
         reservation || open_slot
       end


### PR DESCRIPTION
When a game specifies a slot for a cheater token, that slot can cause extra slots to appear when the tile is upgraded or when the cheater disappears.

A small change was needed for 1822 to make sure Minor 14 (which has a bit different behavior than a cheater) still worked.

The following games will have to be pinned/archived after this change because of the extra slot either allowing an invalid token placement or
allowing a company to pass through a city that should otherwise be tokened:

40005
63892
65571
71413
82164
83068
39042