### PR TITLE
sell pre-operational shares at new price (1868WY), fix up/down for find_relative_share_price (1868WY, 1822, 1832, 1870, 18CO, 18MT, 18ZOO)

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1778,7 +1778,7 @@ module Engine
         end
 
         def reduced_bundle_price_for_market_drop(bundle)
-          directions = (1..bundle.num_shares).map { |_| :up }
+          directions = (1..bundle.num_shares).map { |_| :down }
           bundle.share_price = @stock_market.find_share_price(bundle.corporation, directions).price
           bundle
         end

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -293,7 +293,7 @@ module Engine
             # Don't count shares that have been sold and will go to yellow unless protected
             next 0 if @sell_queue.any? do |bundle, _|
               bundle.corporation == s.corporation &&
-                !stock_market.find_share_price(s.corporation, Array.new(bundle.num_shares, :up)).counts_for_limit
+                !stock_market.find_share_price(s.corporation, Array.new(bundle.num_shares, :down)).counts_for_limit
             end
 
             s.cert_size

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -773,7 +773,7 @@ module Engine
 
           unless corporation.operated?
             bundles.each do |bundle|
-              directions = [:up] * bundle.num_shares
+              directions = [:down] * bundle.num_shares
               bundle.share_price = stock_market.find_share_price(corporation, directions).price
             end
           end

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -35,6 +35,7 @@ module Engine
         STARTING_CASH = { 3 => 734, 4 => 550, 5 => 440 }.freeze
         CERT_LIMIT = { 3 => 20, 4 => 15, 5 => 12 }.freeze
 
+        SELL_AFTER = :any_time
         POOL_SHARE_DROP = :each
         CAPITALIZATION = :incremental
         SELL_BUY_ORDER = :sell_buy
@@ -765,6 +766,19 @@ module Engine
               reorder_players
               new_stock_round
             end
+        end
+
+        def sellable_bundles(player, corporation)
+          bundles = super
+
+          unless corporation.operated?
+            bundles.each do |bundle|
+              directions = [:up] * bundle.num_shares
+              bundle.share_price = stock_market.find_share_price(corporation, directions).price
+            end
+          end
+
+          bundles
         end
       end
     end

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -781,7 +781,7 @@ module Engine
             # because protecting will keep them white.
             next 0 if !price_protecting && @sell_queue.any? do |bundle, _|
                         bundle.corporation == s.corporation &&
-                          !stock_market.find_share_price(s.corporation, Array.new(bundle.num_shares, :up)).counts_for_limit
+                          !stock_market.find_share_price(s.corporation, Array.new(bundle.num_shares, :down)).counts_for_limit
                       end
 
             s.cert_size

--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1528,7 +1528,7 @@ module Engine
           return bundle if bundle.num_shares == 1
 
           new_price = (0..bundle.num_shares - 1).sum do |max_drops|
-            @stock_market.find_share_price(bundle.corporation, (1..max_drops).map { |_| :up }).price
+            @stock_market.find_share_price(bundle.corporation, (1..max_drops).map { |_| :down }).price
           end
 
           bundle.share_price = new_price / bundle.num_shares

--- a/lib/engine/game/g_18_mt/game.rb
+++ b/lib/engine/game/g_18_mt/game.rb
@@ -271,7 +271,7 @@ module Engine
           return bundle if bundle.num_shares == 1
 
           new_price = (0..bundle.num_shares - 1).sum do |max_drops|
-            @stock_market.find_share_price(bundle.corporation, (1..max_drops).map { |_| :up }).price
+            @stock_market.find_share_price(bundle.corporation, (1..max_drops).map { |_| :down }).price
           end
 
           bundle.share_price = new_price / bundle.num_shares

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -869,7 +869,7 @@ module Engine
         def share_price_updated(entity, revenue)
           direction = if revenue >= threshold(entity)
                         r, c = entity.share_price.coordinates
-                        c + 1 < stock_market.market[r].size ? :right : :down
+                        c + 1 < stock_market.market[r].size ? :right : :up
                       else
                         :stay
                       end

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -94,9 +94,9 @@ module Engine
         when :right
           c += 1
         when :down
-          r -= 1 if r.positive?
-        when :up
           r += 1
+        when :up
+          r -= 1 if r.positive?
         end
         price = share_price(r, c)
         break unless price

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -85,7 +85,7 @@ module Engine
     def find_relative_share_price(share, directions)
       r, c = share.coordinates
 
-      prices = [share_price(r, c)]
+      price = share_price(r, c)
 
       Array(directions).each do |direction|
         case direction
@@ -98,12 +98,9 @@ module Engine
         when :up
           r -= 1 if r.positive?
         end
-        price = share_price(r, c)
-        break unless price
-
-        prices << price
+        price = share_price(r, c) || price
       end
-      prices.last
+      price
     end
 
     def max_reached?


### PR DESCRIPTION
In 1868 Wyoming, shares can be sold from SR1, but if shares are sold before the corporation has operated, the seller receives cash from the bank based on the price of the shares _after_ they are sold.

Also, fix `StockMarket#find_relative_share_price` so that `:up` and `:down` are actually correct, and fix values passed in from other games. Finally, refactor `find_relative_share_price` so it doesn't create and use an unnecessary `Array` (turns out that array was originally my own doing, the leetcode training is paying off :wink: ).