### PR TITLE
1849: Parring counts as moving stock token into market (fixes #7937)

### DIFF
--- a/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
@@ -14,6 +14,8 @@ module Engine
 
           def process_par(action)
             super
+
+            @game.moved_this_turn << action.corporation
             @log << "#{action.entity.name} may buy up to two additional shares."
           end
 


### PR DESCRIPTION
May cause some pinning.