### PR TITLE
1861/1867: Use FutureLabels for O/Kh tiles

### DIFF
--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -768,7 +768,7 @@ module Engine
             ['P2'] => 'city=revenue:0;upgrade=cost:20,terrain:water',
             %w[F18 M7] => 'city=revenue:0;upgrade=cost:40,terrain:water',
             %w[B4 D20 M19 N10] => 'city=revenue:0;label=Y',
-            ['G15'] => 'city=revenue:0;label=Y;label=Kh',
+            ['G15'] => 'city=revenue:0;label=Y;future_label=label:Kh,color:gray',
             %w[C11 D12 M11] => 'upgrade=cost:80,terrain:water',
             %w[E15 E19 F16 I15 J16 J18] => 'upgrade=cost:40,terrain:water',
             %w[C17 C19 D10 J6 L6 N6 O5 P4] => 'upgrade=cost:20,terrain:water',
@@ -833,9 +833,6 @@ module Engine
         ).freeze
         GREEN_CORPORATIONS = %w[MB Y V TR SV E].freeze
 
-        # This is Kh in 1861
-        HEX_WITH_O_LABEL = %w[G15].freeze
-        HEX_UPGRADES_FOR_O = %w[201 202 207 208 621 622 623 801 640].freeze
         BONUS_CAPITALS = %w[H8].freeze
         BONUS_REVENUE = 'Q3'
         NATIONAL_RESERVATIONS = %w[E1 H8].freeze

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -909,7 +909,7 @@ module Engine
             %w[D8 F8 E13 E15 C17 I15 N12] => 'city=revenue:0',
             ['G15'] => 'city=revenue:0;stub=edge:1',
             %w[E17 D16 O7] => 'city=revenue:0;label=Y',
-            ['J12'] => 'city=revenue:0;label=Y;label=O;upgrade=cost:20,terrain:water',
+            ['J12'] => 'city=revenue:0;label=Y;future_label=label:O,color:gray;upgrade=cost:20,terrain:water',
             ['L10'] => 'town=revenue:0;border=edge:5,type:water,cost:80;stub=edge:0',
             ['H14'] => 'town=revenue:0;border=edge:0,type:impassable',
             %w[C15 B18 H10 M13] => 'town=revenue:0',
@@ -958,8 +958,6 @@ module Engine
         EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
         GAME_END_CHECK = { bank: :current_or, final_phase: :one_more_full_or_set }.freeze
 
-        HEX_WITH_O_LABEL = %w[J12].freeze
-        HEX_UPGRADES_FOR_O = %w[201 202 203 207 208 621 622 623 801 X8].freeze
         BONUS_CAPITALS = %w[F16 L12 O7].freeze
         BONUS_REVENUE = 'D2'
 
@@ -1323,15 +1321,6 @@ module Engine
 
         def corporation_size_name(entity)
           entity.type == :national ? 'Nat’l' : entity.type.capitalize
-        end
-
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
-          # O labelled tile upgrades to Ys until Grey
-          return super unless self.class::HEX_WITH_O_LABEL.include?(from.hex.name)
-
-          return false unless self.class::HEX_UPGRADES_FOR_O.include?(to.name)
-
-          super(from, to, true)
         end
 
         def compute_stops(route)


### PR DESCRIPTION
Use the FutureLabels functionality for the Ottawa (1867) and Kharkov (1861) upgrades, instead of game-specific logic.
This also makes the O/Kh label visible on yellow, green and brown tiles in this hex, which closes #7133