### PR TITLE
Spreadsheet player history: include rounds even if no value change

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -101,7 +101,6 @@ module View
           values = @game.players.map do |p|
             p.history.find { |h2| h2.round == h.round }.value
           end
-          next if values == last_values
 
           delta_v = (last_values || Array.new(values.size, 0)).map(&:-@).zip(values).map(&:sum) if @delta_value
           last_values = values

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -760,6 +760,7 @@ module Engine
       end
 
       def store_player_info
+        return unless @round.show_in_history?
         @players.each do |p|
           p.history << PlayerInfo.new(@round.class.short_name, turn, @round.round_num, player_value(p))
         end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -761,6 +761,7 @@ module Engine
 
       def store_player_info
         return unless @round.show_in_history?
+
         @players.each do |p|
           p.history << PlayerInfo.new(@round.class.short_name, turn, @round.round_num, player_value(p))
         end

--- a/lib/engine/game/g_18_co/round/presidents_choice.rb
+++ b/lib/engine/game/g_18_co/round/presidents_choice.rb
@@ -63,14 +63,14 @@ module Engine
             @game.finished || @game.presidents_choice == :done || @entities.empty?
           end
 
+          def show_in_history?
+            false
+          end
+
           private
 
           def finish_round
             @game.presidents_choice = :done
-          end
-
-          def show_in_history?
-            false
           end
         end
       end

--- a/lib/engine/game/g_18_co/round/presidents_choice.rb
+++ b/lib/engine/game/g_18_co/round/presidents_choice.rb
@@ -68,6 +68,10 @@ module Engine
           def finish_round
             @game.presidents_choice = :done
           end
+
+          def show_in_history?
+            false
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_ny/round/capitalization.rb
+++ b/lib/engine/game/g_18_ny/round/capitalization.rb
@@ -27,6 +27,10 @@ module Engine
             skip_steps
             next_entity! if finished?
           end
+
+          def show_in_history?
+            false
+          end
         end
       end
     end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -196,6 +196,10 @@ module Engine
         false
       end
 
+      def show_in_history?
+        true
+      end
+
       private
 
       def skip_steps

--- a/lib/engine/round/choices.rb
+++ b/lib/engine/round/choices.rb
@@ -12,6 +12,10 @@ module Engine
       def self.short_name
         'Choices'
       end
+
+      def show_in_history?
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
* Show rounds in the spreadsheet player history table even if there is no change in values - this is less confusing and works well with the Delta view where a change of £0 is shown for these rounds rather than excluding them altogether. Closes #7961 
* Rather than excluding based on the lack of value changes, we then deliberately exclude rounds which exist for programmatic reasons or weren't shown in the previous display to keep consistent behaviour: all choices "rounds" (especially relevant for 1822 games), 18CO president's choice, and 18NY capitalization rounds.