### PR TITLE
[1868WY] auction / stock market changes

### DIFF
--- a/lib/engine/game/g_1868_wy/step/dividend.rb
+++ b/lib/engine/game/g_1868_wy/step/dividend.rb
@@ -11,7 +11,14 @@ module Engine
           include G1868WY::SkipCoalAndOil
 
           def share_price_change(entity, revenue = 0)
-            entity.minor? ? {} : super
+            return {} if entity.minor?
+            return { share_direction: :left, share_times: 1 } if revenue.zero?
+
+            if (times = [revenue.div(entity.share_price.price), 3].min).positive?
+              { share_direction: :right, share_times: times }
+            else
+              {}
+            end
           end
 
           def log_run_payout(entity, kind, revenue, action, payout)

--- a/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
+++ b/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
@@ -7,6 +7,12 @@ module Engine
     module G1868WY
       module Step
         class WaterfallAuction < Engine::Step::WaterfallAuction
+          def help
+            return '' unless @choosing
+
+            "#{@choosing_player.name} won the auction for #{@auctioned_company.name}, now chooses one of:"
+          end
+
           def setup
             super
 
@@ -44,7 +50,7 @@ module Engine
             resolve_bids unless @bids[@cheapest].empty?
           end
 
-          def resolve_bids
+          def resolve_bids_for_company(company)
             super unless @choosing
           end
 
@@ -70,6 +76,8 @@ module Engine
               @company_choices = companies
             end
 
+            company.revenue = 0 if company == @game.p8_company
+
             @cheapest = @companies.first
             @passed_on_cheapest = {}
           end
@@ -93,8 +101,8 @@ module Engine
                 @passed_on_cheapest = {}
               end
             when @game.p9_company
-              @log << 'Companies pay out (all players passed or bid on P10)'
-              @game.isr_payout_companies(@bidders[@game.p10_company])
+              increase_discount!(@game.p10_company, 10) if @bids[@game.p10_company].empty?
+              increase_discount!(@game.p9_company, 10)
               @passed_on_cheapest = {}
             else
               remove_cheapest!

--- a/lib/engine/game/g_1868_wy/stock_market.rb
+++ b/lib/engine/game/g_1868_wy/stock_market.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../../stock_market'
+
+module Engine
+  module Game
+    module G1868WY
+      class StockMarket < Engine::StockMarket
+        def move_up(corporation)
+          r, c = corporation.share_price.coordinates
+
+          if r.positive? && share_price(r - 1, c)
+            r -= 1
+          else
+            r += 1
+            c += 1
+          end
+          move(corporation, r, c)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -138,24 +138,28 @@ module Engine
         # Everyone has passed so we need to run a fake OR.
         if @companies.include?(@cheapest)
           # No one has bought anything so we reduce the value of the cheapest company.
-          value = @cheapest.min_bid
-          @cheapest.discount += 5
-          new_value = @cheapest.min_bid
-          @log << "#{@cheapest.name} minimum bid decreases from "\
-                  "#{@game.format_currency(value)} to #{@game.format_currency(new_value)}"
-
-          if new_value <= 0
-            # It's now free so the next player is forced to take it.
-            @round.next_entity_index!
-            buy_company(current_entity, @cheapest, 0)
-            resolve_bids
-          end
+          increase_discount!(@cheapest, 5)
         else
           @game.payout_companies
           @game.or_set_finished
         end
 
         entities.each(&:unpass!)
+      end
+
+      def increase_discount!(company, discount)
+        value = company.min_bid
+        company.discount += discount
+        new_value = company.min_bid
+        @log << "#{company.name} minimum bid decreases from "\
+                "#{@game.format_currency(value)} to #{@game.format_currency(new_value)}"
+
+        return if new_value.positive?
+
+        # It's now free so the next player is forced to take it.
+        @round.next_entity_index!
+        buy_company(current_entity, company, 0)
+        resolve_bids
       end
 
       def placement_bid(bid)


### PR DESCRIPTION
* one small refactor to common engine code: extract function `increase_discount!` in `Engine::Step::WaterfallAuction`
    * in the common code, this function is called just once, but in the 1868WY code it is called consecutively in `G1868WY::Step::WaterfallAuction#all_passed!`

1868 Wyoming changes:

* fix initial auction
    * no more paying revenues
    * P9 and P10 become cheaper if P9 is not bought
    * help text for step when winner of P3/P4 chooses Developer/Surveyor
* private company certs don't count toward end game value
* if sold out at end of SR and at top of market, move down and right, as in 1822
* priority order (by cash after auction, then by passing order for SRs)
* double and triple jumps for paying out double/triple