### PR TITLE
[1868WY] par: add green/brown sections, LNP and OSL get free home green tile

### DIFF
--- a/lib/engine/game/g_1868_wy/entities.rb
+++ b/lib/engine/game/g_1868_wy/entities.rb
@@ -41,18 +41,29 @@ module Engine
             coordinates: '',
             color: '#4D2674',
           ),
+          # rubocop:disable Layout/LineLength
           def_corporation(
             sym: 'LNP',
             name: 'Laramie, North Park and Pacific Railroad and Telegraph Company',
             coordinates: 'M21',
             color: '#FFC425',
             text_color: 'black',
+            abilities: [{
+              type: 'base',
+              description: 'Free Home Green Tile',
+              desc_detail: "If M21 does not have a green tile when LNP starts, the green tile is immediately placed for free (skipping yellow if necessary) and does not count against LNP's track points.",
+            }],
           ),
           def_corporation(
             sym: 'OSL',
             name: 'Oregon Short Line Railroad',
             coordinates: 'J6',
             color: '#492F24',
+            abilities: [{
+              type: 'base',
+              description: 'Free Home Green Tile',
+              desc_detail: "If J6 does not have a green tile when OSL starts, the green tile is immediately placed for free (skipping yellow if necessary) and does not count against OSL's track points.",
+            }],
           ),
           def_corporation(
             sym: 'RCL',
@@ -61,7 +72,6 @@ module Engine
             color: '#FFFFFF',
             text_color: 'black',
           ),
-          # rubocop:disable Layout/LineLength
           def_corporation(
             sym: 'UP',
             name: 'Union Pacific Railroad',

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -5,7 +5,9 @@ require_relative 'map'
 require_relative 'meta'
 require_relative 'trains'
 require_relative 'step/buy_company'
+require_relative 'step/buy_sell_par_shares'
 require_relative 'step/buy_train'
+require_relative 'step/company_pending_par'
 require_relative 'step/development_token'
 require_relative 'step/dividend'
 require_relative 'step/route'
@@ -77,6 +79,8 @@ module Engine
           'rust_coal_dt_4' => ['Remove Phase 4 Coal DTs', 'Remove Phase 4 Coal Development Tokens'],
           'rust_coal_dt_5' => ['Remove Phase 5 Coal DTs', 'Remove Phase 5 Coal Development Tokens'],
           'rust_coal_dt_6' => ['Remove Phase 6 Coal DTs', 'Remove Phase 6 Coal Development Tokens'],
+          'green_par' => ['Green Par Available', 'Railroads may now par at 90 or 100.'],
+          'brown_par' => ['Brown Par Available', 'Railroads may now par at 110 or 120.'],
         ).freeze
         STATUS_TEXT = Base::STATUS_TEXT.merge(
           'all_corps_available' => ['All Corporations Available',
@@ -137,6 +141,17 @@ module Engine
           @coal_companies = init_coal_companies
           @minors.concat(@coal_companies)
           update_cache(:minors)
+
+          @available_par_groups = %i[par]
+        end
+
+        def stock_round
+          Engine::Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            G1868WY::Step::BuySellParShares,
+          ])
         end
 
         def operating_round(round_num)
@@ -158,7 +173,7 @@ module Engine
 
         def new_auction_round
           Engine::Round::Auction.new(self, [
-            Engine::Step::CompanyPendingPar,
+            G1868WY::Step::CompanyPendingPar,
             G1868WY::Step::WaterfallAuction,
           ])
         end
@@ -184,6 +199,22 @@ module Engine
             corporation.capitalization = :full
             corporation.float_percent = 60
           end
+        end
+
+        def event_green_par!
+          @log << "-- Event: #{EVENTS_TEXT[:green_par][1]} --"
+          @available_par_groups << :par_1
+          update_cache(:share_prices)
+        end
+
+        def event_brown_par!
+          @log << "-- Event: #{EVENTS_TEXT[:brown_par][1]} --"
+          @available_par_groups << :par_2
+          update_cache(:share_prices)
+        end
+
+        def par_prices
+          @stock_market.share_prices_with_types(@available_par_groups)
         end
 
         def setup_event_methods
@@ -615,6 +646,19 @@ module Engine
           end
 
           bundles
+        end
+
+        def after_par(corporation)
+          return unless corporation.id == 'LNP' || corporation.id == 'OSL'
+
+          hex = hex_by_id(corporation.coordinates)
+          old_tile = hex.tile
+          return if old_tile.color == :green || old_tile.color == :brown
+
+          green_tile = tile_by_id("G#{old_tile.label}-0")
+          update_tile_lists(green_tile, old_tile)
+          hex.lay(green_tile)
+          @log << "#{corporation.name} lays tile #{green_tile.name} on #{hex.id} (#{old_tile.location_name})"
         end
       end
     end

--- a/lib/engine/game/g_1868_wy/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1868_wy/step/buy_sell_par_shares.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          def get_par_prices(entity, _corp)
+            @game.par_prices.select { |p| p.price * 2 <= entity.cash }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/step/company_pending_par.rb
+++ b/lib/engine/game/g_1868_wy/step/company_pending_par.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/company_pending_par'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class CompanyPendingPar < Engine::Step::CompanyPendingPar
+          def get_par_prices(_entity, _corp)
+            @game.par_prices
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/trains.rb
+++ b/lib/engine/game/g_1868_wy/trains.rb
@@ -56,9 +56,9 @@ module Engine
 
         TRAINS = [
           def_train('2',  80, '2+2',  120, 7, rusts_on: '4', on: nil),
-          def_train('3', 180, '3+2',  220, 6, rusts_on: '6'),
+          def_train('3', 180, '3+2',  220, 6, rusts_on: '6', events: [{ 'type' => 'green_par' }]),
           def_train('4', 300, '4+3',  360, 6, rusts_on: '8', events: [{ 'type' => 'all_corps_available' }]),
-          def_train('5', 500, '5+4',  580, 5, events: [{ 'type' => 'full_capitalization' }]),
+          def_train('5', 500, '5+4',  580, 5, events: [{ 'type' => 'full_capitalization' }, { 'type' => 'brown_par' }]),
           def_train('6', 600, '6+5',  700, 3),
           def_train('7', 800, '7+5',  900, 2),
           def_train('8', 1000, '8+5', 1100, 15),


### PR DESCRIPTION
* in phase 3, the green par prices become usable; in phase 5, the brown ones become usable
* the home tokens for LNP and OSL start in cities that are not connected until green, so if the green tile has not already been laid when they start, they get the tile for free