### PR TITLE
[1871] Fix floating-point issues (fixes #7847 et al)

### DIFF
--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -652,7 +652,7 @@ module Engine
             return
           end
 
-          new_share_percent = (100.0 / @peir_shares.size).round(2)
+          new_share_percent = 100 / @peir_shares.size
           @peir.forced_share_percent = new_share_percent
           peir.share_holders.clear
           @peir_shares.each do |share|
@@ -661,7 +661,7 @@ module Engine
             peir.share_holders[share.owner] += new_share_percent
           end
           peir.share_holders.each do |owner, amount|
-            @log << "#{owner.name} now owns #{amount}% of the PEIR"
+            @log << "#{owner.name} now owns #{100 * amount / (@peir_shares.size * new_share_percent)}% of the PEIR"
           end
 
           peir.owner = peir_owner

--- a/lib/engine/game/g_1871/step/dividend.rb
+++ b/lib/engine/game/g_1871/step/dividend.rb
@@ -30,6 +30,11 @@ module Engine
             {}
           end
 
+          def payout_per_share(entity, revenue)
+            # PEIR rounds up
+            (revenue / entity.total_shares).ceil
+          end
+
           def dividends_for_entity(entity, holder, per_share)
             num = holder.shares_of(entity).select(&:buyable).sum(&:percent) / entity.share_percent
 


### PR DESCRIPTION
I think the fix is simpler than I feared over in my most recent #7847 comment. Judging from all the `ceil`s and such in the code, it looks like the codebase is used to working around this general issue, so I think this change is sufficient to get 1871 into a state where the rest of the hacks can take over.

I still think that the real fix is to do all share math with fractions instead of percentages, but that ship sailed a couple of years ago.

This PR also fixes what turned out to be a separate rounding issue in implementing the rules (this is the actual bug noticed in #7847 before I turned it into a catchall for 1871 floating-point problems).