### PR TITLE
Log share movement direction (implements #4308)

### DIFF
--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -687,13 +687,13 @@ module Engine
         def take_loan(entity, loan)
           raise GameError, "Cannot take more than #{maximum_loans(entity)} loans" unless can_take_loan?(entity)
 
-          price = entity.share_price.price
+          old_price = entity.share_price
           name = entity.name
           name += " (#{entity.owner.name})" if @round.is_a?(Engine::Round::Stock)
           @log << "#{name} takes a loan and receives #{format_currency(loan.amount)}"
           @bank.spend(loan.amount, entity)
           loan_taken_stock_market_movement(entity)
-          log_share_price(entity, price)
+          log_share_price(entity, old_price)
           entity.loans << loan
           @loans.delete(loan)
         end
@@ -713,9 +713,9 @@ module Engine
           @loans << loan
           return unless adjust_share_price
 
-          price = entity.share_price.price
+          old_price = entity.share_price
           loan_payoff_stock_market_movement(entity)
-          log_share_price(entity, price)
+          log_share_price(entity, old_price)
         end
 
         def loan_payoff_stock_market_movement(entity)

--- a/lib/engine/game/g_1817/step/acquire.rb
+++ b/lib/engine/game/g_1817/step/acquire.rb
@@ -291,11 +291,11 @@ module Engine
 
             # Step 7b, unpaid loans affect stock price and may mean a corporation falls into acquisition.
             if @unpaid_loans.positive?
-              price = @buyer.share_price.price
+              old_price = @buyer.share_price
               @unpaid_loans.times do
                 @game.loan_taken_stock_market_movement(@buyer)
               end
-              @game.log_share_price(@buyer, price)
+              @game.log_share_price(@buyer, old_price)
               if @buyer.share_price.acquisition? && @round.offering.include?(@buyer)
                 # Can no longer be offered this round
                 @log << "#{@buyer.name} falls into acquisition and will not be offered for sale this round"

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -682,9 +682,9 @@ module Engine
         def close_p16
           company = company_by_id('P16')
           @log << "#{company.name} closes"
-          from = company.owner.share_price.price
+          old_price = company.owner.share_price
           stock_market.move_left(company.owner)
-          log_share_price(company.owner, from)
+          log_share_price(company.owner, old_price)
           company.close!
         end
 

--- a/lib/engine/game/g_1822_mx/step/issue_shares.rb
+++ b/lib/engine/game/g_1822_mx/step/issue_shares.rb
@@ -9,7 +9,7 @@ module Engine
         class IssueShares < Engine::Game::G1822::Step::IssueShares
           def process_sell_shares(action)
             @game.share_pool.sell_shares(action.bundle)
-            old_price = action.entity.share_price.price
+            old_price = action.entity.share_price
             action.bundle.shares.size.times { @game.stock_market.move_left(action.entity) }
             @game.log_share_price(action.entity, old_price)
             pass!

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -550,9 +550,9 @@ module Engine
         def close_p16
           company = company_by_id('P16')
           @log << "#{company.name} closes"
-          from = company.owner.share_price.price
+          old_price = company.owner.share_price
           stock_market.move_left(company.owner)
-          log_share_price(company.owner, from)
+          log_share_price(company.owner, old_price)
           company.close!
         end
 

--- a/lib/engine/game/g_1824/round/first_stock.rb
+++ b/lib/engine/game/g_1824/round/first_stock.rb
@@ -43,9 +43,9 @@ module Engine
             # It is possible a regional has been sold out - handle stock movement for that
 
             @game.corporations.select { |c| @game.regional?(c) && c.floated? }.sort.each do |corp|
-              prev = corp.share_price.price
+              old_price = corp.share_price
               sold_out_stock_movement(corp) if sold_out?(corp)
-              @game.log_share_price(corp, prev)
+              @game.log_share_price(corp, old_price)
             end
 
             @game.log << 'First stock round is finished - any unsold Pre-State Railways, Coal Railways, ' \

--- a/lib/engine/game/g_1824/round/stock.rb
+++ b/lib/engine/game/g_1824/round/stock.rb
@@ -9,9 +9,9 @@ module Engine
         class Stock < Engine::Round::Stock
           def finish_round
             @game.corporations.select(&:floated?).sort.each do |corp|
-              prev = corp.share_price.price
+              old_price = corp.share_price
               sold_out_stock_movement(corp) if sold_out?(corp)
-              @game.log_share_price(corp, prev)
+              @game.log_share_price(corp, old_price)
             end
           end
         end

--- a/lib/engine/game/g_1846/step/bankrupt.rb
+++ b/lib/engine/game/g_1846/step/bankrupt.rb
@@ -17,9 +17,9 @@ module Engine
             if (bundle = @game.emergency_issuable_bundles(corp).max_by(&:num_shares))
               @game.share_pool.sell_shares(bundle)
 
-              price = corp.share_price.price
+              old_price = corp.share_price
               bundle.num_shares.times { @game.stock_market.move_left(corp) }
-              @game.log_share_price(corp, price)
+              @game.log_share_price(corp, old_price)
 
               @game.round.emergency_issued = true
             end

--- a/lib/engine/game/g_1846/step/buy_train.rb
+++ b/lib/engine/game/g_1846/step/buy_train.rb
@@ -83,9 +83,9 @@ module Engine
 
             @game.share_pool.sell_shares(bundle)
 
-            price = corporation.share_price.price
+            old_price = corporation.share_price
             bundle.num_shares.times { @game.stock_market.move_left(corporation) }
-            @game.log_share_price(corporation, price)
+            @game.log_share_price(corporation, old_price)
 
             @round.emergency_issued = true
           end

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -1365,13 +1365,13 @@ module Engine
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
-          price = corporation.share_price.price
+          old_price = corporation.share_price
 
           @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
           num_shares = bundle.num_shares
           num_shares -= 1 if corporation.share_price.type == :ignore_one_sale
           num_shares.times { @stock_market.move_left(corporation) } if selling_movement?(corporation)
-          log_share_price(corporation, price)
+          log_share_price(corporation, old_price)
           check_bankruptcy!(corporation)
         end
 

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1192,7 +1192,7 @@ module Engine
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
-          price = corporation.share_price.price
+          old_price = corporation.share_price
 
           @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
           num_shares = bundle.num_shares
@@ -1201,7 +1201,7 @@ module Engine
             num_shares -= 2 if corporation.share_price.type == :ignore_two_sales
           end
           num_shares.times { @stock_market.move_left(corporation) } if selling_movement?(corporation)
-          log_share_price(corporation, price)
+          log_share_price(corporation, old_price)
           check_bankruptcy!(corporation)
         end
 
@@ -1796,9 +1796,9 @@ module Engine
           shares = entity.shares.take(num_shares)
           bundle = ShareBundle.new(shares)
           @share_pool.sell_shares(bundle)
-          price = entity.share_price.price
+          old_price = entity.share_price
           num_shares.times { @stock_market.move_left(entity) }
-          log_share_price(entity, price)
+          log_share_price(entity, old_price)
           check_bankruptcy!(entity)
         end
 

--- a/lib/engine/game/g_1866/step/issue_shares.rb
+++ b/lib/engine/game/g_1866/step/issue_shares.rb
@@ -16,12 +16,12 @@ module Engine
           def process_sell_shares(action)
             bundle = action.bundle
             corporation = bundle.corporation
-            price = corporation.share_price.price
+            old_price = corporation.share_price
             @game.share_pool.sell_shares(action.bundle)
             @game.player_sold_shares[corporation.owner][corporation] = true
 
             bundle.num_shares.times { @game.stock_market.move_left(corporation) }
-            @game.log_share_price(corporation, price)
+            @game.log_share_price(corporation, old_price)
             pass!
           end
 

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -1201,12 +1201,12 @@ module Engine
           repay_loan(corporation, corporation.loans.first) while corporation.cash >= @loan_value && !corporation.loans.empty?
 
           # Move once automatically
-          price = corporation.share_price.price
+          old_price = corporation.share_price
           stock_market.move_left(corporation)
 
           nationalization_loan_movement(corporation)
           nationalization_transfer_assets(corporation)
-          log_share_price(corporation, price)
+          log_share_price(corporation, old_price)
 
           # Payout players for shares
           per_share = corporation.share_price.price

--- a/lib/engine/game/g_1870/step/price_protection.rb
+++ b/lib/engine/game/g_1870/step/price_protection.rb
@@ -92,7 +92,7 @@ module Engine
             bundle, corporation_owner = @game.sell_queue.shift
 
             corporation = bundle.corporation
-            price = corporation.share_price.price
+            old_price = corporation.share_price
 
             hit_soft_ledge = false
             bundle.num_shares.times do
@@ -115,7 +115,7 @@ module Engine
             @log << "#{corporation_owner.name} #{verb} price protect #{num_presentation} of #{corporation.name}"
             @log << "#{corporation.name} hits the ledge" if hit_soft_ledge
 
-            @game.log_share_price(corporation, price)
+            @game.log_share_price(corporation, old_price)
 
             @round.recalculate_order if @round.respond_to?(:recalculate_order)
           end

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -769,10 +769,10 @@ module Engine
           if (diff = r_cost - entity.cash).positive?
             @bank.spend(diff, entity)
             @log << "Bank pays #{format_currency(diff)} to #{entity.name}"
-            price = entity.share_price.price
-            if diff > price
-              [(diff / price).to_i, 3].min.times { @stock_market.move_up(entity) }
-              log_share_price(entity, price)
+            old_price = entity.share_price
+            if diff > old_price.price
+              [(diff / old_price.price).to_i, 3].min.times { @stock_market.move_up(entity) }
+              log_share_price(entity, old_price)
             end
           end
 
@@ -1458,7 +1458,7 @@ module Engine
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
-          price = corporation.share_price.price
+          old_price = corporation.share_price
 
           @share_pool.sell_shares(bundle, allow_president_change: pres_change_ok?(corporation), swap: swap)
           if corporation == @mhe
@@ -1474,7 +1474,7 @@ module Engine
             @stock_market.move_up(corporation)
             @stock_market.move_down(corporation)
           end
-          log_share_price(corporation, price)
+          log_share_price(corporation, old_price)
         end
 
         def pres_change_ok?(corporation)

--- a/lib/engine/game/g_1877_stockholm_tramways/game.rb
+++ b/lib/engine/game/g_1877_stockholm_tramways/game.rb
@@ -273,11 +273,11 @@ module Engine
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
-          price = corporation.share_price.price
+          old_price = corporation.share_price
 
           @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
           (bundle.num_shares + 1).div(2).times { @stock_market.move_left(corporation) } unless @sl
-          log_share_price(corporation, price)
+          log_share_price(corporation, old_price)
         end
 
         def operating_round(round_num)

--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1423,7 +1423,7 @@ module Engine
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
-          price = corporation.share_price.price
+          old_price = corporation.share_price
           was_president = corporation.president?(bundle.owner)
           was_issued = bundle.owner == bundle.corporation
 
@@ -1434,7 +1434,7 @@ module Engine
 
           share_drop_num.times { @stock_market.move_down(corporation) }
 
-          log_share_price(corporation, price) if self.class::SELL_MOVEMENT != :none
+          log_share_price(corporation, old_price) if self.class::SELL_MOVEMENT != :none
         end
 
         def shares_for_presidency_swap(shares, num_shares)

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -696,11 +696,11 @@ module Engine
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
-          price = corporation.share_price.price
+          old_price = corporation.share_price
           was_president = corporation.president?(bundle.owner)
           @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
           bundle.num_shares.times { @stock_market.move_down(corporation) } if non_president_sales_drop_price? || was_president
-          log_share_price(corporation, price)
+          log_share_price(corporation, old_price)
         end
 
         def insolvent?(corp)
@@ -825,9 +825,9 @@ module Engine
 
           # update share price
           unless price_drops.zero?
-            prev = corporation.share_price.price
+            old_price = corporation.share_price
             price_drops.times { @stock_market.move_down(corporation) }
-            log_share_price(corporation, prev)
+            log_share_price(corporation, old_price)
           end
 
           # add new capital

--- a/lib/engine/game/g_18_mt/game.rb
+++ b/lib/engine/game/g_18_mt/game.rb
@@ -221,7 +221,7 @@ module Engine
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
           corporation = bundle.corporation
-          price = corporation.share_price.price
+          old_price = corporation.share_price
           was_president = corporation.president?(bundle.owner)
           was_issued = bundle.owner == bundle.corporation
 
@@ -232,7 +232,7 @@ module Engine
 
           share_drop_num.times { @stock_market.move_down(corporation) }
 
-          log_share_price(corporation, price) if self.class::SELL_MOVEMENT != :none
+          log_share_price(corporation, old_price) if self.class::SELL_MOVEMENT != :none
         end
 
         def buying_power(entity)

--- a/lib/engine/game/g_18_new_england/step/issue_shares.rb
+++ b/lib/engine/game/g_18_new_england/step/issue_shares.rb
@@ -34,9 +34,9 @@ module Engine
           def pass!
             if @round.issued.positive?
               # drop share price after all issuing is done
-              price = current_entity.share_price.price
+              old_price = current_entity.share_price
               @round.issued.times { @game.stock_market.move_left(current_entity) }
-              @game.log_share_price(current_entity, price)
+              @game.log_share_price(current_entity, old_price)
             end
 
             super

--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -474,11 +474,11 @@ module Engine
 
         def handle_share_price_increase_for_newly_floated_corporations
           @newly_floated.each do |corp|
-            prev = corp.share_price.price
+            old_price = corp.share_price
 
             stock_market.move_up(corp)
-            @log << "The share price of the newly floated #{corp.name} increases" if prev != corp.share_price.price
-            log_share_price(corp, prev)
+            @log << "The share price of the newly floated #{corp.name} increases" if old_price.price != corp.share_price.price
+            log_share_price(corp, old_price)
           end
           @newly_floated = []
         end

--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -954,10 +954,10 @@ module Engine
           major.companies.dup.each(&:close!)
 
           # Decrease share price two step and then give compensation with this price
-          prev = major.share_price.price
+          old_price = major.share_price
           @stock_market.move_left(major)
           @stock_market.move_left(major)
-          log_share_price(major, prev)
+          log_share_price(major, old_price)
           refund = major.share_price.price
           @players.each do |p|
             refund_amount = 0

--- a/lib/engine/game/g_18_usa/round/stock.rb
+++ b/lib/engine/game/g_18_usa/round/stock.rb
@@ -9,12 +9,12 @@ module Engine
         class Stock < G1817::Round::Stock
           def finish_round
             @game.corporations.select(&:floated?).sort.each do |corp|
-              prev = corp.share_price.price
+              old_price = corp.share_price
               sold_out_stock_movement(corp) if sold_out?(corp) && @game.sold_out_increase?(corp)
               shares_in_pool = corp.num_market_shares
               price_drops = shares_in_pool * 2
               price_drops.times { @game.stock_market.move_down(corp) }
-              @game.log_share_price(corp, prev)
+              @game.log_share_price(corp, old_price)
             end
             @game.corporations.select(&:floated?).each do |corp|
               if tokens_needed?(corp)

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -670,11 +670,12 @@ module Engine
         end
 
         def log_share_price(entity, from, additional_info = '')
-          to = entity.share_price.price
-          return unless from != to
+          from_price = from.price
+          to_price = entity.share_price.price
+          return unless from_price != to_price
 
-          @log << "#{entity.name}'s share price changes from #{format_currency(from)} "\
-                  "to #{format_currency(to)} #{additional_info}"
+          @log << "#{entity.name}'s share price changes from #{format_currency(from_price)} "\
+                  "to #{format_currency(to_price)} #{additional_info}"
         end
 
         def revenue_for(route, stops)

--- a/lib/engine/game/g_18_zoo/step/buy_train.rb
+++ b/lib/engine/game/g_18_zoo/step/buy_train.rb
@@ -51,17 +51,17 @@ module Engine
             return if is_discarded
 
             if !@round.any_train_brought && !old_train
-              prev = entity.share_price.price
+              old_price = entity.share_price
               @game.stock_market.move_right(entity)
-              @game.log_share_price(entity, prev, '(new-train bonus)')
+              @game.log_share_price(entity, old_price, '(new-train bonus)')
               @round.any_train_brought = true
             end
 
             return unless @game.first_train_of_new_phase
 
-            prev = entity.share_price.price
+            old_price = entity.share_price
             @game.stock_market.move_right(entity)
-            @game.log_share_price(entity, prev, '(new-phase bonus)')
+            @game.log_share_price(entity, old_price, '(new-phase bonus)')
             @game.first_train_of_new_phase = false
           end
 

--- a/lib/engine/game/g_18_zoo/step/choose_ability_on_sr.rb
+++ b/lib/engine/game/g_18_zoo/step/choose_ability_on_sr.rb
@@ -140,9 +140,9 @@ module Engine
           @log << "#{current_entity.name} uses \"Whatsup\" for #{corporation.name}, "\
                   "paying #{@game.format_currency(train.price)} to buy a #{train.name}"
 
-          prev = corporation.share_price.price
+          old_price = corporation.share_price
           @game.stock_market.move_right(corporation)
-          @game.log_share_price(corporation, prev, '(whatsup bonus)')
+          @game.log_share_price(corporation, old_price, '(whatsup bonus)')
 
           @game.whatsup.close!
         end

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -575,7 +575,7 @@ module Engine
 
         def corporate_round_finished
           @corporations.select { |c| c.floated? && c.type != :minor }.sort.each do |corp|
-            prev = corp.share_price.price
+            old_price = corp.share_price
 
             @stock_market.move_up(corp) if sold_out?(corp) && sold_out_increase?(corp)
             if corp.operated?
@@ -591,7 +591,7 @@ module Engine
               price_drops.times { @stock_market.move_down(corp) }
             end
 
-            log_share_price(corp, prev)
+            log_share_price(corp, old_price)
           end
         end
 

--- a/lib/engine/game/g_21_moon/step/corporate_buy_sell_shares.rb
+++ b/lib/engine/game/g_21_moon/step/corporate_buy_sell_shares.rb
@@ -95,7 +95,7 @@ module Engine
             corp = action.entity
             bundle = action.bundle
             floated = corp.floated?
-            price = corp.share_price.price
+            old_price = corp.share_price
 
             @log << "#{corp.name} issues #{share_str(bundle)} of #{corp.name} to the market"\
                     " and receives #{@game.format_currency(bundle.price)}"
@@ -104,7 +104,7 @@ module Engine
                                              spender: @game.bank,
                                              receiver: corp)
             @game.stock_market.move_down(corp) if floated
-            @game.log_share_price(corp, price)
+            @game.log_share_price(corp, old_price)
             @game.float_corporation(corp) if corp.floatable && floated != corp.floated?
 
             track_action(action, corp)

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -71,7 +71,7 @@ module Engine
         corporations_to_move_price.sort.each do |corp|
           next unless corp.share_price
 
-          prev = corp.share_price.price
+          old_price = corp.share_price
 
           sold_out_stock_movement(corp) if sold_out?(corp) && @game.sold_out_increase?(corp)
           pool_share_drop = @game.class::POOL_SHARE_DROP
@@ -85,7 +85,7 @@ module Engine
             end
           price_drops.times { @game.stock_market.move_down(corp) }
 
-          @game.log_share_price(corp, prev)
+          @game.log_share_price(corp, old_price)
         end
       end
 

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -156,7 +156,7 @@ module Engine
         # For any company without a share price, skip price movement
         return unless entity.share_price
 
-        prev = entity.share_price.price
+        old_price = entity.share_price
 
         right_times = 0
         Array(payout[:share_times]).zip(Array(payout[:share_direction])).each do |share_times, direction|
@@ -174,7 +174,7 @@ module Engine
             end
           end
         end
-        @game.log_share_price(entity, prev, right_times)
+        @game.log_share_price(entity, old_price, right_times)
       end
 
       def routes


### PR DESCRIPTION
Most of the code changes are because the signature of `log_share_price` changed (it used to take an integer for the old price, now it needs to take a `SharePrice`).