### PR TITLE
[1871] UB doesn't go bankrupt, owner must pitch in (fixes #7526)

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -216,6 +216,7 @@ module Engine
       MUST_EMERGENCY_ISSUE_BEFORE_EBUY = false # corporation must issue shares before ebuy (if possible)
       EBUY_SELL_MORE_THAN_NEEDED = false # true if corporation may continue to sell shares even though enough funds
       EBUY_CAN_SELL_SHARES = true # true if a player can sell shares for ebuy
+      EBUY_OWNER_MUST_HELP = false # owner of ebuying entity is on the hook
 
       # if sold more than needed then cannot then buy a cheaper train in the depot.
       EBUY_SELL_MORE_THAN_NEEDED_LIMITS_DEPOT_TRAIN = false

--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -44,6 +44,7 @@ module Engine
         DISCARDED_TRAINS = :remove
         EBUY_OTHER_VALUE = false
         EBUY_PRES_SWAP = true
+        EBUY_OWNER_MUST_HELP = true
         GAME_END_CHECK = { bankrupt: :immediate, final_phase: :one_more_full_or_set }.freeze
         HOME_TOKEN_TIMING = :float
         MARKET_SHARE_LIMIT = 80
@@ -541,6 +542,17 @@ module Engine
           return false if entity.id == 'PEIR'
 
           super
+        end
+
+        def can_go_bankrupt?(player, corporation)
+          return false if player == @union_bank
+
+          if corporation.owner == @union_bank && company_by_id('UB').owner == player
+            total_emr_buying_power(player, corporation) +
+              total_emr_buying_power(@union_bank, corporation) < @depot.min_depot_price
+          else
+            super
+          end
         end
 
         # The base version of purchasable_companies allows you to purchase most

--- a/lib/engine/step/bankrupt.rb
+++ b/lib/engine/step/bankrupt.rb
@@ -23,7 +23,7 @@ module Engine
 
       def process_bankrupt(action)
         corp = action.entity
-        player = corp.owner
+        player = @game.acting_for_entity(corp.owner)
 
         unless @game.can_go_bankrupt?(player, corp)
           buying_power = @game.format_currency(@game.total_emr_buying_power(player, corp))

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -52,7 +52,7 @@ module Engine
         true
       end
 
-      def buy_train_action(action, entity = nil)
+      def buy_train_action(action, entity = nil, borrow_from: nil)
         entity ||= action.entity
         train = action.train
         train.variant = action.variant
@@ -74,8 +74,18 @@ module Engine
           try_take_player_loan(entity.owner, remaining)
 
           player = entity.owner
-          player.spend(remaining, entity)
-          @log << "#{player.name} contributes #{@game.format_currency(remaining)}"
+
+          if borrow_from && player.cash < remaining
+            current_cash = player.cash
+            extra_needed = remaining - current_cash
+            player.spend(current_cash, entity)
+            @log << "#{player.name} contributes #{@game.format_currency(current_cash)}"
+            borrow_from.spend(extra_needed, entity)
+            @log << "#{borrow_from.name} contributes #{@game.format_currency(extra_needed)}"
+          else
+            player.spend(remaining, entity)
+            @log << "#{player.name} contributes #{@game.format_currency(remaining)}"
+          end
         end
 
         try_take_loan(entity, price)


### PR DESCRIPTION
New behavior:
1) UB needs to buy a train and will not have enough funds on its own.
<img width="265" alt="Screen Shot 2022-06-25 at 2 33 15 PM" src="https://user-images.githubusercontent.com/1295244/175786799-08535998-c2c7-4d32-84bc-040756145432.png">
2) UB sells one of its two shares.
<img width="264" alt="Screen Shot 2022-06-25 at 2 33 50 PM" src="https://user-images.githubusercontent.com/1295244/175786805-f406ec9e-293e-4c11-9d7d-3fab19242fe6.png">
3) UB sells its last share.
<img width="266" alt="Screen Shot 2022-06-25 at 2 34 24 PM" src="https://user-images.githubusercontent.com/1295244/175786807-c979e6ca-b245-4ee8-910f-f4ed7348a315.png">
4) UB owner watshisname sells two shares.
<img width="262" alt="Screen Shot 2022-06-25 at 2 34 53 PM" src="https://user-images.githubusercontent.com/1295244/175786810-752ae275-8d1d-413e-a547-62d2f0ccbd0b.png">
5) Finally there are enough funds to buy a train. Resulting log display:
<img width="344" alt="Screen Shot 2022-06-25 at 2 35 13 PM" src="https://user-images.githubusercontent.com/1295244/175786813-505c0ab9-1ea3-42ed-8c86-28137868a2fd.png">

