### PR TITLE
18SJ: Align tiles to AAG standard (fixes #8020)

### DIFF
--- a/lib/engine/game/g_18_sj/map.rb
+++ b/lib/engine/game/g_18_sj/map.rb
@@ -7,9 +7,9 @@ module Engine
         TILES = {
           '5' => 4,
           '6' => 4,
-          '7' => 20,
-          '8' => 20,
-          '9' => 20,
+          '7' => 'unlimited',
+          '8' => 'unlimited',
+          '9' => 'unlimited',
           '14' => 4,
           '15' => 4,
           '16' => 2,
@@ -40,15 +40,15 @@ module Engine
           '57' => 5,
           '63' => 2,
           '70' => 1,
-          '131' =>
+          '611' => 2,
+          '619' => 3,
+          'X1' =>
           {
             'count' => 1,
-            'color' => 'gray',
-            'code' =>
-            'city=revenue:90,slots:4;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=Y',
           },
-          '171' => 1,
-          '298SJ' =>
+          'X2' =>
           {
             'count' => 1,
             'color' => 'green',
@@ -56,7 +56,13 @@ module Engine
                       'city=revenue:40,groups:Stockholm;city=revenue:40,groups:Stockholm;path=a:0,b:_0;path=a:_0,b:2;'\
                       'path=a:3,b:_1;path=a:_1,b:2;path=a:4,b:_2;path=a:_2,b:2;path=a:5,b:_3;path=a:_3,b:2',
           },
-          '299SJ' =>
+          'X3' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:2;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=Y',
+          },
+          'X4' =>
           {
             'count' => 1,
             'color' => 'brown',
@@ -64,20 +70,20 @@ module Engine
                       'city=revenue:70,groups:Stockholm;city=revenue:70,groups:Stockholm;path=a:0,b:_0;path=a:_0,b:2;'\
                       'path=a:3,b:_1;path=a:_1,b:2;path=a:4,b:_2;path=a:_2,b:2;path=a:5,b:_3;path=a:_3,b:2',
           },
-          '440' =>
+          'X5' =>
           {
             'count' => 1,
-            'color' => 'green',
-            'code' => 'city=revenue:40,slots:2;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=Y',
+            'color' => 'gray',
+            'code' =>
+            'city=revenue:90,slots:4;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
           },
-          '466' =>
+          'X6' =>
           {
             'count' => 1,
-            'color' => 'brown',
-            'code' => 'city=revenue:60,slots:2;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=Y',
+            'color' => 'gray',
+            'code' => 'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;'\
+                      'path=a:5,b:_0',
           },
-          '611' => 2,
-          '619' => 3,
         }.freeze
 
         LOCATION_NAMES = {


### PR DESCRIPTION
This will break 18SJ games as some tiles have changed names. Can be good to pin them to let alpha play test continue - and finished games can be archived.

Here is how tile set looked like before this change:
![image](https://user-images.githubusercontent.com/2631151/175868382-13908d5c-54b7-432a-9f30-e755cc5d1dad.png)

And after the change:
![image](https://user-images.githubusercontent.com/2631151/175868458-c1358af7-4049-427d-9800-4ae22f3bc41a.png)
