### PR TITLE
Add support for Google Chat webhook.

### DIFF
--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -12,6 +12,16 @@ module Hooks
     req = Net::HTTP::Post.new(uri)
     req.content_type = 'application/json'
 
+    notify_prefix =
+      case uri.host
+      when 'chat.googleapis.com'
+        'users/'
+      else
+        '@'
+      end
+
+    message = "<#{notify_prefix}#{user.settings['webhook_user_id']}> #{message}"
+
     req.body =
       case uri.host
       when 'discord.com', 'discordapp.com'

--- a/queue.rb
+++ b/queue.rb
@@ -17,6 +17,18 @@ Bus.configure
 
 ASSETS = Assets.new(precompiled: PRODUCTION)
 
+def send_webhook_notification(user, message)
+  return if user.settings['notifications'] != 'webhook'
+  return if (user.settings['webhook_user_id']&.strip || '') == ''
+
+  begin
+    Hooks.send(user, message)
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    puts e.backtrace
+    puts e
+  end
+end
+
 MessageBus.subscribe '/turn' do |msg|
   data = msg.data
 
@@ -24,19 +36,9 @@ MessageBus.subscribe '/turn' do |msg|
   game = Game[data['game_id']]
   minute_ago = (Time.now - 60).to_i
 
-  users.each do |user|
-    next if user.settings['notifications'] != 'webhook'
-    next if (user.settings['webhook_user_id']&.strip || '') == ''
-
-    begin
-      message = "<@#{user.settings['webhook_user_id']}> #{data['type']} in #{game.title} \"#{game.description}\" " \
-                "(#{game.round} #{game.turn})\n#{data['game_url']}"
-      Hooks.send(user, message)
-    rescue Exception => e # rubocop:disable Lint/RescueException
-      puts e.backtrace
-      puts e
-    end
-  end
+  message = "#{data['type']} in #{game.title} \"#{game.description}\" " \
+            "(#{game.round} #{game.turn})\n#{data['game_url']}"
+  users.each { send_webhook_notification(user, message) }
 
   users = users.reject do |user|
     notifications = user.settings['notifications'] || 'none'


### PR DESCRIPTION
Google Chat requires the format <users/123> to notify users rather than the more common <@123>.