### PR TITLE
Enable the default auto actions (SR pass, SR buy) in 18Mag.

### DIFF
--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -130,10 +130,6 @@ module Engine
           @location_names[coord]
         end
 
-        def available_programmed_actions
-          []
-        end
-
         def setup
           @sik = @corporations.find { |c| c.name == 'SIK' }
           @skev = @corporations.find { |c| c.name == 'SKEV' }


### PR DESCRIPTION
As far as I can tell there's nothing about 18Mag that prevents these from working normally. I tested it out locally and it seems to work fine. Based on commit history it ended up this way because of a big 18Mag refactor landing almost at the same time as the initial auto actions commits.