### PR TITLE
Add a "send test notification" checkbox to webhook settings.

### DIFF
--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -16,6 +16,7 @@ module View
     needs :type
     needs :notifications, store: true, default: nil
     needs :webhook, store: true, default: nil
+    needs :test_webhook_notification, store: true, default: false
 
     TILE_COLORS = Lib::Hex::COLOR.freeze
     ROUTE_COLORS = Lib::Settings::ROUTE_COLORS.freeze
@@ -219,6 +220,15 @@ module View
       end
       elements << render_input('Webhook User ID', id: :webhook_user_id,
                                                   attrs: { value: setting_for(:webhook_user_id) })
+
+      test_webhook_notification_change = lambda do
+        store(:test_webhook_notification, Native(@inputs[:test_webhook_notification]).elm&.checked)
+      end
+      elements << render_input('Send test notification',
+                               id: :test_webhook_notification,
+                               type: :checkbox,
+                               on: { input: test_webhook_notification_change },
+                               attrs: { checked: @test_webhook_notification })
       elements
     end
 

--- a/queue.rb
+++ b/queue.rb
@@ -29,6 +29,12 @@ def send_webhook_notification(user, message)
   end
 end
 
+MessageBus.subscribe '/test_notification' do |msg|
+  user_id = msg.data
+  user = User[user_id]
+  send_webhook_notification(user, 'This is a test notification from 18xx.games.')
+end
+
 MessageBus.subscribe '/turn' do |msg|
   data = msg.data
 

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -70,6 +70,7 @@ class Api
         r.post 'edit' do
           user.update_settings(r.params)
           user.save
+          MessageBus.publish('/test_notification', user.id) if r['test_webhook_notification']
           user.to_h(for_user: true)
         end
 


### PR DESCRIPTION
If checked, a notification is triggered immediately on saving the settings. Only works for webhooks, never sends email.

An alternative would be a "send test notification" button, but then the flow would be edit settings -> save -> click button, which I don't see a good way to do. It would be too easy to press the button after editing settings, but before saving.