### PR TITLE
Revert "refactor game opening button text "Enter" => 'View'"

### DIFF
--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -77,7 +77,7 @@ module View
           end
           JOIN_YELLOW
         when 'active'
-          buttons << render_link(url(@gdata), -> { enter_game(@gdata) }, 'View')
+          buttons << render_link(url(@gdata), -> { enter_game(@gdata) }, 'Enter')
           acting?(@user) ? color_for(:your_turn) : ENTER_GREEN
         when 'finished'
           buttons << render_link(url(@gdata), -> { enter_game(@gdata) }, 'Review')


### PR DESCRIPTION
This reverts commit 384e8a05cf047dce50bd280ec1887f1c8944f2b3.

This commit incorrectly modified the button to display "View" for the logged in player's games. @benjaminxscott elected to not fix that, so reverting instead.