### PR TITLE
Add reserve_city param to tile.add_reservation

### DIFF
--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -360,9 +360,9 @@ module Engine
       @reservations.any? { |r| [r, r.owner].include?(corporation) }
     end
 
-    def add_reservation!(entity, city, slot = nil)
-      # Single city, assume the first
-      city = 0 if @cities.one?
+    def add_reservation!(entity, city, slot = nil, reserve_city = true)
+      # Single city, assume the first unless reserve_city is false
+      city = 0 if @cities.one? && reserve_city
       slot = @cities[city].get_slot(entity) if city && slot.nil?
 
       if city && slot


### PR DESCRIPTION
Add reserve_city parameter to add_reservation method in tile.rb 

In my prototype a city can get disjoint into 2 cities. Without this change, the reservation was automatically assigned to one of them rather than leaving the choice to the president when the corporation operates for the first time.