### PR TITLE
1877: Stockholm Tramways fixed not allowed to run acquired trains

### DIFF
--- a/lib/engine/game/g_1877_stockholm_tramways/game.rb
+++ b/lib/engine/game/g_1877_stockholm_tramways/game.rb
@@ -427,7 +427,10 @@ module Engine
           end
 
           other.spend(other.cash, corp) if other.cash.positive?
-          other.trains.each { |train| train.owner = corp }
+          other.trains.each do |train|
+            train.owner = corp
+            train.operated = false
+          end
           corp.trains.concat(other.trains)
           @log << "Transferred trains and treasury from #{other.name} to #{corp.name}"
 


### PR DESCRIPTION
Closes #8028. Breaks all games in which the run trains step has been skipped due to not being allowed to run acquired trains. Currently, there is only one known game in which the issue has occurred.