### PR TITLE
Refactor 1870 soft ledge move. Use same logic for 1849

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -258,11 +258,8 @@ module View
               if first_price && !next_row.empty? && next_row[col_i]
                 align = { left: 0, bottom: 0 }
                 arrow = '⭣'
-              # last cell on right (or 1870's soft ledge), not top row
-              elsif !row_i.zero? && (
-                ((col_i + 1) == row_prices.size) ||
-                (row_prices[col_i].type != :ignore_one_sale && row_prices[col_i + 1].type == :ignore_one_sale))
-
+              # last cell on right, not top row
+              elsif !row_i.zero? && @game.stock_market.right_ledge?(row_i, col_i)
                 align = { right: 0, top: 0 }
                 arrow = '⭡'
               else

--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -19,6 +19,14 @@ module Engine
           @game.max_value_reached = true
         end
 
+        def right_ledge?(r, c)
+          price = @market.dig(r, c).price
+          return false if BLOCKED_UP_PRICES.include?(price) && !@game.phase.status.include?('blue_zone')
+          return true if BLOCKED_RIGHT_PRICES.include?(price) && !@game.phase.status.include?('blue_zone')
+
+          super
+        end
+
         def move_up(corporation)
           price = corporation.share_price.price
           return super unless BLOCKED_UP_PRICES.include?(price) && !@game.phase.status.include?('blue_zone')
@@ -31,7 +39,6 @@ module Engine
           return super unless BLOCKED_RIGHT_PRICES.include?(price) && !@game.phase.status.include?('blue_zone')
 
           @game.log << "#{corporation.name} share price blocked from moving right by phase"
-          move_up(corporation)
         end
       end
     end

--- a/lib/engine/game/g_1870/stock_market.rb
+++ b/lib/engine/game/g_1870/stock_market.rb
@@ -13,14 +13,8 @@ module Engine
           move_down(corporation)
         end
 
-        def move_right(corporation)
-          r, c = corporation.share_price.coordinates
-
-          if corporation.share_price.type != :ignore_one_sale && @market.dig(r, c + 1)&.type == :ignore_one_sale
-            return move_up(corporation)
-          end
-
-          super
+        def right_ledge?(r, c)
+          super || (@market.dig(r, c).type != :ignore_one_sale && @market.dig(r, c + 1)&.type == :ignore_one_sale)
         end
       end
     end

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -40,14 +40,18 @@ module Engine
       corporation.original_par_price = share_price
     end
 
+    def right_ledge?(r, c)
+      c + 1 >= @market[r].size
+    end
+
     def move_right(corporation)
       r, c = corporation.share_price.coordinates
 
-      if c + 1 < @market[r].size
+      if right_ledge?(r, c)
+        move_up(corporation) unless one_d?
+      else
         c += 1
         move(corporation, r, c)
-      else
-        move_up(corporation) unless one_d?
       end
     end
 


### PR DESCRIPTION
The methods `move_down` and `move_up` on `lib/engine/game/g_1849/stock_market.rb` now are only there to write stuff to the log. Can we remove them?