### PR TITLE
[1848] - implement p5 and p6 logic

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -249,6 +249,8 @@ module Engine
             discount: -170,
             revenue: 25,
             desc: 'The owner receives a 10% share in the QR. Cannot be bought by a corporation',
+            abilities: [{ type: 'shares', shares: 'QR_1' },
+                        { type: 'no_buy' }],
           },
           {
             sym: 'P6',
@@ -258,6 +260,8 @@ module Engine
             revenue: 30,
             desc: "The owner receives a Director's Share share in the CAR, which must start at a par value of £100."\
                   ' Cannot be bought by a corporation',
+            abilities: [{ type: 'shares', shares: 'CAR_0' },
+                        { type: 'no_buy' }],
           },
         ].freeze
 
@@ -434,6 +438,22 @@ module Engine
           entity.trains.reject { |t| t.name == '2E' }.empty? &&
             !depot.depot_trains.empty? &&
              (self.class::MUST_BUY_TRAIN == :route && @graph.route_info(entity)&.dig(:route_train_purchase))
+        end
+
+        def after_buy_company(player, company, _price)
+          # share_price = 100
+          # # NOTE: This should only ever be P6
+          abilities(company, :shares) do |ability|
+            ability.shares.each do |share|
+              if share.president
+                stock_market.set_par(share.corporation, stock_market.par_prices.find { |p| p.price == 100 })
+                share_pool.buy_shares(player, share, exchange: :free)
+                after_par(share.corporation)
+              else
+                share_pool.buy_shares(player, share, exchange: :free)
+              end
+            end
+          end
         end
       end
     end

--- a/lib/engine/game/g_1848/step/dutch_auction.rb
+++ b/lib/engine/game/g_1848/step/dutch_auction.rb
@@ -54,6 +54,7 @@ module Engine
             company = action.company
             price = company.min_bid
             buy_company(current_entity, company, price)
+            @game.after_buy_company(current_entity, company, price)
             @round.next_entity_index!
           end
 


### PR DESCRIPTION
P5 -> The owner receives a 10% share in the QR. Cannot be bought by a corporation
P6 -> The owner receives a Director's Share share in the CAR, which must start at a par value of £100. Cannot be bought by a corporation

issue #2548 is showing "CAR is always parred at 100 (Presidency is granted by P6)" as implemented, but i don't think it was