### PR TITLE
18SJ: Correct handling of full cap (fixes #8038)

### DIFF
--- a/lib/engine/game/g_18_sj/step/dividend.rb
+++ b/lib/engine/game/g_18_sj/step/dividend.rb
@@ -28,16 +28,6 @@ module Engine
             end
           end
 
-          # In 18SJ, full cap corporations does not receive any dividends for pool shares (see rule 15.2 step 5)
-          def dividends_for_entity(entity, holder, per_share)
-            return 0 if !@game.oscarian_era &&
-                        entity.corporation? &&
-                        entity.capitalization == :full &&
-                        holder == @game.share_pool
-
-            super
-          end
-
           def process_dividend(action)
             super
 


### PR DESCRIPTION
After this fix redeemed shares appear in Treasury, and shares there
pay to treasury.