### PR TITLE
fix 8060

### DIFF
--- a/lib/engine/game/g_18_ireland/step/merge.rb
+++ b/lib/engine/game/g_18_ireland/step/merge.rb
@@ -111,7 +111,7 @@ module Engine
               @game.log << "#{previous_proposer.name} already proposed the same exact merger of"\
                            " #{@round.merging.map(&:name).join(', ')}."\
                            ' This is against the rules, clearing proposal.'
-              @round.merging = []
+              @round.merging = nil
               return
             end
 


### PR DESCRIPTION
fix #8060 , setting @round.merging = [] means that any checks on @round.merging having a value returns true, therefore still staying in a middle of a merger and allowing players to vote on the invalid proposed merger.
setting it to nil means the check fails and the active player can propose a different merger