### PR TITLE
[1848] BOE dividend payout, more privates impl

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -9,7 +9,7 @@ module Engine
   module Game
     module G1848
       class Game < Game::Base
-        attr_reader :sydney_adelaide_connected
+        attr_reader :sydney_adelaide_connected, :boe
 
         include_meta(G1848::Meta)
         include Map
@@ -255,6 +255,8 @@ module Engine
             name: "Melbourne & Hobson's Bay Railway Company",
             value: 40,
             discount: 10,
+            min_price: 1,
+            max_price: 40,
             revenue: 5,
             desc: 'No special abilities.',
           },
@@ -262,6 +264,8 @@ module Engine
             sym: 'P2',
             name: 'Sydney Railway Company',
             value: 80,
+            min_price: 1,
+            max_price: 80,
             discount: 10,
             revenue: 10,
             desc: 'Owning Public Company or its Director may build one (1) free tile on a desert hex (marked by'\
@@ -296,18 +300,53 @@ module Engine
             name: 'Tasmanian Railways',
             value: 140,
             discount: 30,
+            min_price: 1,
+            max_price: 140,
             revenue: 15,
             desc: 'The Tasmania tile can be placed by a Public Company on one of the dark blue hexes. This is in'\
                   " addition to the company's normal build that turn.",
+                  abilities: [
+                    {
+                      type: 'tile_lay',
+                      hexes: %w[I8 I10 D5],
+                      tiles: %w[241,1],
+                      owner_type: 'corporation',
+                      when: 'owning_corp_or_turn',
+                      count: 1,
+                      free: true,
+                    },
+                  ],
+
           },
           {
             sym: 'P4',
             name: 'The Ghan',
             value: 220,
             discount: 50,
+            min_price: 1,
+            max_price: 220,
             revenue: 20,
             desc: 'Owning Public Company or its Director may receive a one-time discount of £100 on the purchase'\
                   ' of a 2E (Ghan) train. This power does not go away after a 5/5+ train is purchased.',
+            abilities: [
+                    {
+                      type: 'train_discount',
+                      discount: 100,
+                      trains: ['2E'],
+                      count: 1,
+                      owner_type: 'corporation',
+                      when: 'any',
+                    },
+                    {
+                      type: 'train_discount',
+                      discount: 100,
+                      trains: ['2E'],
+                      count: 1,
+                      owner_type: 'player',
+                      when: 'any',
+                    },
+                  ],
+
           },
           {
             sym: 'P5',
@@ -490,6 +529,11 @@ module Engine
         def init_stock_market
           G1848::StockMarket.new(game_market, self.class::CERT_LIMIT_TYPES,
                                  multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
+        end
+
+        def operating_order
+          boe, others = @corporations.select(&:floated?).sort.partition { |c| c.type == :bank }
+          boe + others
         end
 
         def upgrades_to?(from, to, _special = false, selected_company: nil)

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -336,7 +336,7 @@ module Engine
                       trains: ['2E'],
                       count: 1,
                       owner_type: 'corporation',
-                      when: 'any',
+                      when: 'buying_train',
                     },
                     {
                       type: 'train_discount',
@@ -344,7 +344,7 @@ module Engine
                       trains: ['2E'],
                       count: 1,
                       owner_type: 'player',
-                      when: 'any',
+                      when: 'owning_player_or_turn',
                     },
                   ],
 
@@ -522,7 +522,7 @@ module Engine
             Engine::Step::Token,
             Engine::Step::Route,
             G1848::Step::Dividend,
-            Engine::Step::DiscardTrain,
+            Engine::Step::SpecialBuyTrain,
             G1848::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
@@ -531,6 +531,10 @@ module Engine
         def init_stock_market
           G1848::StockMarket.new(game_market, self.class::CERT_LIMIT_TYPES,
                                  multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
+        end
+
+        def init_share_pool
+          G1848::SharePool.new(self)
         end
 
         def operating_order
@@ -598,6 +602,10 @@ module Engine
         # for 3 players corp share limit is 70%
         def corporation_opts
           @players.size == 3 ? { max_ownership_percent: 70 } : {}
+        end
+
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+          super(bundle, allow_president_change: pres_change_ok?(bundle.corporation), swap: nil)
         end
 
         def pres_change_ok?(corporation)

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -504,7 +504,7 @@ module Engine
         end
 
         def stock_round
-          Engine::Round::Stock.new(self, [
+          G1848::Round::Stock.new(self, [
             Engine::Step::DiscardTrain,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -305,13 +305,14 @@ module Engine
             revenue: 15,
             desc: 'The Tasmania tile can be placed by a Public Company on one of the dark blue hexes. This is in'\
                   " addition to the company's normal build that turn.",
-                  abilities: [
+            abilities: [
                     {
                       type: 'tile_lay',
-                      hexes: %w[I8 I10 D5],
-                      tiles: %w[241,1],
+                      hexes: %w[I8 I10],
+                      tiles: %w[241],
                       owner_type: 'corporation',
                       when: 'owning_corp_or_turn',
+                      special: true,
                       count: 1,
                       free: true,
                     },
@@ -515,11 +516,12 @@ module Engine
           Round::Operating.new(self, [
             Engine::Step::Bankrupt,
             Engine::Step::Exchange,
+            G1848::Step::SpecialTrack,
             Engine::Step::BuyCompany,
             G1848::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,
-            Engine::Step::Dividend,
+            G1848::Step::Dividend,
             Engine::Step::DiscardTrain,
             G1848::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
@@ -538,6 +540,7 @@ module Engine
 
         def upgrades_to?(from, to, _special = false, selected_company: nil)
           return %w[5 6 57].include?(to.name) if (from.hex.tile.label.to_s == 'K') && (from.hex.tile.color == 'white')
+          return from.hex.tile.color == 'blue' if selected_company && selected_company.sym == 'P3'
 
           super
         end

--- a/lib/engine/game/g_1848/map.rb
+++ b/lib/engine/game/g_1848/map.rb
@@ -54,6 +54,11 @@ module Engine
           '238' => 1,
           '239' => 3,
           '240' => 2,
+          '241' => {
+            'count' => 1,
+            'color' => 'blue',
+            'code' => 'offboard=revenue:50;icon=image:anchor;path=a:2,b:_0;path=a:1,b:_0',
+          },
           '611' => 4,
           '915' => 1,
         }.freeze

--- a/lib/engine/game/g_1848/round/stock.rb
+++ b/lib/engine/game/g_1848/round/stock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/stock'
+
+module Engine
+  module Game
+    module G1848
+      module Round
+        class Stock < Engine::Round::Stock
+          def sold_out_stock_movement(corp)
+            super if corp != @game.boe
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/share_pool.rb
+++ b/lib/engine/game/g_1848/share_pool.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../../share_pool'
+
+module Engine
+  module Game
+    module G1848
+      class SharePool < Engine::SharePool
+        def fit_in_bank?(bundle)
+          return super unless bundle.corporation == @game.boe
+
+          # no bank limit for boe
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -8,6 +8,12 @@ module Engine
     module G1848
       module Step
         class BuyTrain < Engine::Step::BuyTrain
+          def can_entity_buy_train?(entity)
+            return false if entity == @game.boe
+
+            super
+          end
+
           def buyable_trains(entity)
             # Cannot buy 2E if one is already owned
             owns_2e = entity.trains.any? { |t| t.name == '2E' }

--- a/lib/engine/game/g_1848/step/dividend.rb
+++ b/lib/engine/game/g_1848/step/dividend.rb
@@ -55,16 +55,11 @@ module Engine
           end
 
           def get_token_cities_total_revenue(corporation)
-            total = 0
-            @game.hexes.each do |hex|
-              puts(hex.name.to_s) if hex.name == 'H7'
-              hex.tile.cities.each do |city|
-                next unless city.tokened_by?(corporation)
-
-                total += city.revenue[hex.tile.color]
+            @game.hexes.sum do |hex|
+              hex.tile.cities.sum do |city|
+                 city.tokened_by?(corporation) ? city.revenue[hex.tile.color] : 0  
               end
             end
-            total
           end
         end
       end

--- a/lib/engine/game/g_1848/step/dividend.rb
+++ b/lib/engine/game/g_1848/step/dividend.rb
@@ -7,8 +7,64 @@ module Engine
     module G1848
       module Step
         class Dividend < Engine::Step::Dividend
+          BOE_BASE_PAYOUT = { '2' => 0, '3' => 100, '4' => 100, '5' => 200, '6' => 200, '8' => 300 }.freeze
+
+          def actions(entity)
+            return super unless entity == @game.boe
+
+            # boe always pays if it has any revenue
+            process_dividend(Action::Dividend.new(entity, kind: 'payout'))
+            []
+          end
+
           def corporation_dividends(_entity, _per_share)
             0
+          end
+
+          def change_share_price(entity, payout)
+            return super unless entity == @game.boe
+          end
+
+          def dividend_options(entity)
+            return super unless entity == @game.boe
+
+            revenue = calculate_boe_revenue
+            dividend_types.to_h do |type|
+              payout = send(type, entity, revenue)
+              payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
+              [type, payout.merge(share_price_change(entity, revenue - payout[:corporation]))]
+            end
+          end
+
+          def process_dividend(action)
+            entity = action.entity
+            return super unless entity == @game.boe
+
+            kind = action.kind.to_sym
+            payout = dividend_options(entity)[kind]
+
+            payout_shares(entity, calculate_boe_revenue) if payout[:per_share].positive?
+            pass!
+          end
+
+          def calculate_boe_revenue
+            current_phase_name = @game.phase.current[:name]
+            base_pay = BOE_BASE_PAYOUT[current_phase_name]
+            cities_revenue = get_token_cities_total_revenue(@game.boe)
+            base_pay + cities_revenue
+          end
+
+          def get_token_cities_total_revenue(corporation)
+            total = 0
+            @game.hexes.each do |hex|
+              puts(hex.name.to_s) if hex.name == 'H7'
+              hex.tile.cities.each do |city|
+                next unless city.tokened_by?(corporation)
+
+                total += city.revenue[hex.tile.color]
+              end
+            end
+            total
           end
         end
       end

--- a/lib/engine/game/g_1848/step/dividend.rb
+++ b/lib/engine/game/g_1848/step/dividend.rb
@@ -57,7 +57,7 @@ module Engine
           def get_token_cities_total_revenue(corporation)
             @game.hexes.sum do |hex|
               hex.tile.cities.sum do |city|
-                 city.tokened_by?(corporation) ? city.revenue[hex.tile.color] : 0  
+                city.tokened_by?(corporation) ? city.revenue[hex.tile.color] : 0
               end
             end
           end

--- a/lib/engine/game/g_1848/step/dividend.rb
+++ b/lib/engine/game/g_1848/step/dividend.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class Dividend < Engine::Step::Dividend
+          def corporation_dividends(_entity, _per_share)
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/operating.rb
+++ b/lib/engine/game/g_1848/step/operating.rb
@@ -10,6 +10,7 @@ module Engine
           def skip_entity?(entity)
             return super if entity.name != :COM
 
+            @log << 'COM does not operate, Sydney and Addelaide are not connected' unless @game.sydney_adelaide_connected
             !@game.sydney_adelaide_connected
           end
         end

--- a/lib/engine/game/g_1848/step/special_track.rb
+++ b/lib/engine/game/g_1848/step/special_track.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/special_track'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class SpecialTrack < Engine::Step::SpecialTrack
+          def potential_tiles(entity, hex)
+            return @game.tiles.select { |tile| tile.color == 'blue' } if entity.sym == 'P3'
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -117,7 +117,6 @@ module Engine
         corporation = bundle.corporation
 
         timing = @game.check_sale_timing(entity, bundle)
-
         timing &&
           !(@game.class::TURN_SELL_LIMIT && (bundle.percent + sold_this_turn(corporation)) > @game.class::TURN_SELL_LIMIT) &&
           !(@game.class::MUST_SELL_IN_BLOCKS && @round.players_sold[entity][corporation] == :now) &&


### PR DESCRIPTION
Adding more 1848 impl:
1- p3 and the ability to place the tasmania token in one of two hexes on the map
2- define min max prices for privates
3-  boe dividend math (base pay + for each tokened city)
4- boe price doesn't rise when sold out, not market limit, etc