### PR TITLE
Rolling Stock - add investment round programmed auto-pass

### DIFF
--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -40,11 +40,10 @@ module View
 
           if !(available = @game.available_programmed_actions).empty?
             available.each do |type|
-              enabled = @game.programmed_actions[sender].find { |a| a.is_a?(type) }
-              if (method = types[type])
-                settings = enabled if enabled
-                children.concat(method.call(settings))
-              end
+              next unless (method = types[type])
+
+              settings = @game.programmed_actions[sender].find { |a| a.is_a?(type) }
+              children.concat(method.call(settings))
             end
           else
             children << h('p.bold', 'No auto actions are presently available for this game.')

--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -39,10 +39,10 @@ module View
           }.freeze
 
           if !(available = @game.available_programmed_actions).empty?
-            enabled = @game.programmed_actions[sender]
             available.each do |type|
+              enabled = @game.programmed_actions[sender].find { |a| a.is_a?(type) }
               if (method = types[type])
-                settings = enabled if enabled.is_a?(type)
+                settings = enabled if enabled
                 children.concat(method.call(settings))
               end
             end
@@ -303,17 +303,18 @@ module View
         children
       end
 
-      def disable
+      def disable(type)
         process_action(
           Engine::Action::ProgramDisable.new(
             sender,
-            reason: 'user'
+            reason: 'user',
+            original_type: type
           )
         )
       end
 
-      def render_disable
-        render_button('Disable') { disable }
+      def render_disable(settings)
+        render_button('Disable') { disable(settings.type) }
       end
     end
   end

--- a/assets/app/view/game/auto_action/base.rb
+++ b/assets/app/view/game/auto_action/base.rb
@@ -17,7 +17,8 @@ module View
           process_action(
             Engine::Action::ProgramDisable.new(
               @sender,
-              reason: 'user'
+              reason: 'user',
+              original_type: @settings.type
             )
           )
         end

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -329,7 +329,7 @@ module View
       menu_items << item('S|preadsheet', '#spreadsheet')
       menu_items << item("To|ols#{' 📝' if note}", '#tools')
 
-      enabled = @game.programmed_actions[@game.player_by_id(@user['id'])] if @user
+      enabled = !@game.programmed_actions[@game.player_by_id(@user['id'])].empty? if @user
       menu_items << item("A|uto#{' ✅' if enabled}", '#auto') if @game_data[:mode] != :hotseat && !cursor
 
       h('nav#game_menu', nav_props, [

--- a/lib/engine/action/program_disable.rb
+++ b/lib/engine/action/program_disable.rb
@@ -7,7 +7,7 @@ module Engine
     class ProgramDisable < Base
       attr_reader :reason, :original_type
 
-      def initialize(entity, reason:, original_type: '')
+      def initialize(entity, reason:, original_type: nil)
         super(entity)
         @reason = reason
         @original_type = original_type

--- a/lib/engine/action/program_disable.rb
+++ b/lib/engine/action/program_disable.rb
@@ -5,19 +5,26 @@ require_relative 'base'
 module Engine
   module Action
     class ProgramDisable < Base
-      attr_reader :reason
+      attr_reader :reason, :original_type
 
-      def initialize(entity, reason:)
+      def initialize(entity, reason:, original_type: '')
         super(entity)
         @reason = reason
+        @original_type = original_type
       end
 
       def self.h_to_args(h, _game)
-        { reason: h['reason'] }
+        {
+          reason: h['reason'],
+          original_type: h['original_type'],
+        }
       end
 
       def args_to_h
-        { 'reason' => @reason }
+        {
+          'reason' => @reason,
+          'original_type' => @original_type,
+        }
       end
     end
   end

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -102,6 +102,8 @@ module Engine
           custom: 'Max stock price in phase 3 or 10 or end card flipped in phase 10',
         )
 
+        ALLOW_MULTIPLE_PROGRAMS = true
+
         STAR_COLORS = {
           #     main color text     card color standard color highlight text
           1 => ['#cd5c5c', 'white', '#f8ecec', :red,          'yellow'],
@@ -193,7 +195,7 @@ module Engine
         # enable conditiional auto-pass for everyone at the start
         def add_default_autopass
           @players.each do |player|
-            @programmed_actions[player] = Engine::Action::ProgramClosePass.new(
+            @programmed_actions[player] << Engine::Action::ProgramClosePass.new(
               player,
               unconditional: false,
             )
@@ -680,13 +682,15 @@ module Engine
         end
 
         def disable_auto_close_pass
-          @programmed_actions.reject! do |entity, action|
-            next unless action.is_a?(Engine::Action::ProgramClosePass) &&
+          @programmed_actions.each do |entity, action_list|
+            action_list.reject! do |action|
+              next false unless action.is_a?(Engine::Action::ProgramClosePass) &&
                 !action.unconditional &&
                 any_negative_companies?(entity)
 
-            player_log(entity, "Programmed action '#{action}' removed due to negative company income")
-            true
+              player_log(entity, "Programmed action '#{action}' removed due to negative company income")
+              true
+            end
           end
         end
 
@@ -993,7 +997,7 @@ module Engine
         end
 
         def available_programmed_actions
-          [Action::ProgramClosePass]
+          [Action::ProgramSharePass, Action::ProgramClosePass]
         end
 
         def ipo_name(_corp)
@@ -1042,6 +1046,14 @@ module Engine
           chart <<  ["$0 - $#{(num * one_left) - 1}", "$#{two_left}"] if two_left
           chart << ['', ''] while chart.size < 5
           chart
+        end
+
+        def stock_round_name
+          'Investment Phase'
+        end
+
+        def force_unconditional_stock_pass?
+          true
         end
       end
     end

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -523,7 +523,7 @@ module Engine
           income += self.class::FOREIGN_EXTRA_INCOME if entity == @foreign_investor
           return income if entity.companies.empty?
 
-          income = entity.companies.sum { |c| company_income(c) }
+          income += entity.companies.sum { |c| company_income(c) }
           return income unless entity.corporation?
 
           income += synergy_income(entity)
@@ -1054,6 +1054,24 @@ module Engine
 
         def force_unconditional_stock_pass?
           true
+        end
+
+        def liquidity(player, emergency: false)
+          total = player.cash
+          player.shares_by_corporation.reject { |_, s| s.empty? }.each do |corporation, shares|
+            total += dump_cash(corporation, shares.size)
+          end
+          total
+        end
+
+        def dump_cash(corporation, num)
+          value = 0
+          price = corporation.share_price
+          num.times do
+            price = next_price_to_left(price)
+            value += price.price
+          end
+          value
         end
       end
     end

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -1031,6 +1031,14 @@ module Engine
           companies.sort_by(&:value).reverse
         end
 
+        def stock_round_name
+          'Investment Phase'
+        end
+
+        def force_unconditional_stock_pass?
+          true
+        end
+
         def movement_chart(corporation)
           num = num_issued(corporation)
           price = corporation.share_price
@@ -1046,14 +1054,6 @@ module Engine
           chart <<  ["$0 - $#{(num * one_left) - 1}", "$#{two_left}"] if two_left
           chart << ['', ''] while chart.size < 5
           chart
-        end
-
-        def stock_round_name
-          'Investment Phase'
-        end
-
-        def force_unconditional_stock_pass?
-          true
         end
 
         def liquidity(player, emergency: false)

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -68,7 +68,7 @@ module Engine
       end
 
       def remove_programmed_action(entity, type)
-        existing = if type && type != '' && @game.class::ALLOW_MULTIPLE_PROGRAMS
+        existing = if type && @game.class::ALLOW_MULTIPLE_PROGRAMS
                      @game.programmed_actions[entity].find { |a| a.type == type }
                    else
                      @game.programmed_actions[entity].last # delete last added

--- a/lib/engine/step/program.rb
+++ b/lib/engine/step/program.rb
@@ -68,7 +68,7 @@ module Engine
       end
 
       def remove_programmed_action(entity, type)
-        existing = if type && @game.class::ALLOW_MULTIPLE_PROGRAMS
+        existing = if type && type != '' && @game.class::ALLOW_MULTIPLE_PROGRAMS
                      @game.programmed_actions[entity].find { |a| a.type == type }
                    else
                      @game.programmed_actions[entity].last # delete last added

--- a/lib/engine/step/programmer.rb
+++ b/lib/engine/step/programmer.rb
@@ -6,12 +6,17 @@ module Engine
   module Step
     module Programmer
       def programmed_auto_actions(entity)
-        return unless (program = @game.programmed_actions[entity.player])
+        return if (p_list = @game.programmed_actions[entity.player]).empty?
 
-        method = "activate_#{program.type}"
-        return unless respond_to?(method)
+        a_list = []
+        p_list.each do |program|
+          method = "activate_#{program.type}"
+          next unless respond_to?(method)
 
-        send(method, entity, program)
+          new_actions = send(method, entity, program)
+          a_list.concat(new_actions) if new_actions
+        end
+        a_list
       end
     end
   end


### PR DESCRIPTION
Fixes #7934 

This required refactoring @programmed_actions code to allow multiple outstanding programmed actions for the same player.
I've run a few 1830 and Harzbahn cases to make sure I didn't break things, however, since this involves UI code changes in server mode, I couldn't check that as completely as I'd like. I did spot check a few games.

Does not require pinning/archiving.