### PR TITLE
21Moon: fix auction when all players pass

### DIFF
--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -476,7 +476,7 @@ module Engine
         def new_auction_round
           Engine::Round::Auction.new(self, [
           G21Moon::Step::OLSToken,
-          Engine::Step::WaterfallAuction,
+          G21Moon::Step::WaterfallAuction,
         ])
         end
 

--- a/lib/engine/game/g_21_moon/step/waterfall_auction.rb
+++ b/lib/engine/game/g_21_moon/step/waterfall_auction.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/waterfall_auction'
+
+module Engine
+  module Game
+    module G21Moon
+      module Step
+        class WaterfallAuction < Engine::Step::WaterfallAuction
+          def all_passed!
+            companies_without_bids = @companies.reject { |c| @bids[c] && !@bids[c].empty? }.sort_by(&:value)
+
+            end_auction! if companies_without_bids.empty?
+
+            # cheapest company without a bid gets decreased by 10
+            company = companies_without_bids.first
+            value = company.min_bid
+            company.discount += 10
+            new_value = company.min_bid
+            @game.log << "#{company.name} minimum bid decreases from "\
+                         "#{@game.format_currency(value)} to #{@game.format_currency(new_value)}"
+
+            return if new_value.positive?
+
+            # It's now free so the next player is forced to buy it
+            @round.next_entity_index!
+            buy_company(current_entity, company, 0)
+            resolve_bids
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #8050 

This needs to pin any games where all players pass in the initial auction before it completes. I don't have a feel for how often this happens.