### PR TITLE
21Moon: More robust tile-to-base checking

### DIFF
--- a/lib/engine/action/use_graph.rb
+++ b/lib/engine/action/use_graph.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class UseGraph < Base
+      attr_reader :graph_id
+
+      def initialize(entity, graph_id:)
+        super(entity)
+        @graph_id = graph_id
+      end
+
+      def self.h_to_args(h, _game)
+        {
+          graph_id: h['graph_id'],
+        }
+      end
+
+      def args_to_h
+        {
+          'graph_id' => @graph_id,
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #8010 

No pinning necessary. This should be backwards compatible.

It also addresses a weak spot in my previous code that didn't look at newly-added paths to see which base was being used for the track lay