### PR TITLE
Use TILE_UGPRADES_MUST_USE_MAX_EXITS in 1862

### DIFF
--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -68,6 +68,7 @@ module Engine
         CAPITALIZATION = :full
 
         MUST_SELL_IN_BLOCKS = true
+        TILE_UPGRADES_MUST_USE_MAX_EXITS = %i[cities].freeze
 
         MARKET = [
           %w[0c
@@ -503,9 +504,6 @@ module Engine
             D15
         ].freeze
 
-        IPSWITCH_HEX = 'F11'
-        HARWICH_HEX = 'F13'
-
         FREIGHT_BONUS = 20
         PORT_FREIGHT_BONUS = 30
 
@@ -930,12 +928,6 @@ module Engine
           return true if adding_town?(from, to)
 
           super
-        end
-
-        def upgrades_to_correct_label?(from, to)
-          (from.label == to.label) ||
-            (from.label.to_s == 'N' && to.label.to_s == 'I' && from.hex.id == IPSWITCH_HEX) ||
-            (from.label.to_s == 'Y' && to.label.to_s == 'H' && from.hex.id == HARWICH_HEX)
         end
 
         def active_players

--- a/lib/engine/game/g_1862/map.rb
+++ b/lib/engine/game/g_1862/map.rb
@@ -331,14 +331,14 @@ module Engine
             'count' => 1,
             'color' => 'brown',
             'code' => 'city=revenue:80,slots:4;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;'\
-                      'path=a:5,b:_0;label=I',
+                      'path=a:5,b:_0;label=N',
           },
           '796' => 3,
           '797' =>
           {
             'count' => 1,
             'color' => 'brown',
-            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=H',
+            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y',
           },
           '798' => 3,
           '798_1' =>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2993555/179425183-4f98e785-1831-4d10-a5ee-9dd845735aa4.png)

1862 couldn't use a future label for Ipswich because it's already using a LargeIcon for ESR's home, but since the special brown Y and brown N are just a Y and N with one less spoke, the `TILE_UPGRADES_MUST_USE_MAX_EXITS ` setting could be used to get the same effect of having custom labels for the tiles without needing custom logic