### PR TITLE
18Carolinas: fix payout of exactly half share price

### DIFF
--- a/lib/engine/game/g_18_carolinas/step/dividend.rb
+++ b/lib/engine/game/g_18_carolinas/step/dividend.rb
@@ -29,7 +29,7 @@ module Engine
 
           def share_price_change(entity, revenue)
             curr_price = entity.share_price.price
-            if revenue > curr_price / 2 && revenue < curr_price
+            if revenue >= curr_price / 2 && revenue < curr_price
               {}
             elsif revenue >= curr_price && revenue < 2 * curr_price
               { share_direction: :right, share_times: 1 }


### PR DESCRIPTION
Fixes #8072 

I don't think this will require any pins. There are only two active games. Although the finished game that found this will fail.