### PR TITLE
[1848] Implement privates, loans and routing

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1359,6 +1359,10 @@ module Engine
         []
       end
 
+      def visited_stops(route)
+        route.connection_data.flat_map { |c| [c[:left], c[:right]] }.uniq.compact
+      end
+
       def get(type, id)
         return nil unless type && id
 

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -494,7 +494,7 @@ module Engine
               company.add_ability(no_buy)
             else
               # close company
-              @log << "#{company.name} closes here"
+              @log << "#{company.name} closes"
               company.close!
             end
           end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -743,7 +743,7 @@ module Engine
         end
 
         def revenue_for(route, stops)
-          k_sum = stops.count { |rl| rl.hex.tile.label.to_s == 'K'}
+          k_sum = stops.count { |rl| rl.hex.tile.label.to_s == 'K' }
           super + K_BONUS[k_sum]
         end
       end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -743,7 +743,7 @@ module Engine
         end
 
         def revenue_for(route, stops)
-          k_sum = stops.count { |rl| rl.hex.tile.label.to_s == 'K' ? 1 : 0 }
+          k_sum = stops.count { |rl| rl.hex.tile.label.to_s == 'K'}
           super + K_BONUS[k_sum]
         end
       end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -543,7 +543,7 @@ module Engine
             G1848::Step::Loan,
             Engine::Step::Bankrupt,
             Engine::Step::Exchange,
-            Engine::Step::SpecialTrack,
+            G1848::Step::SpecialTrack,
             Engine::Step::BuyCompany,
             G1848::Step::Track,
             Engine::Step::Token,
@@ -685,8 +685,10 @@ module Engine
 
         def market_share_limit(corporation = nil)
           return 100 if corporation == @boe
+
           MARKET_SHARE_LIMIT
         end
+
         def can_take_loan?(entity)
           entity.corporation? &&
             entity.loans.size < maximum_loans(entity) &&

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -22,6 +22,8 @@ module Engine
 
         STARTING_CASH = { 3 => 840, 4 => 630, 5 => 510, 6 => 430 }.freeze
 
+        K_BONUS = { 0 => 0, 1 => 0, 2 => 50, 3 => 100, 4 => 150, 5 => 200 }.freeze
+
         BOE_STARTING_CASH = 2000
 
         BOE_STARTING_PRICE = 80
@@ -715,8 +717,16 @@ module Engine
             border_edges << "#{edge.hex.id}_#{border.edge}"
           end
           edge_str = "#{edge.hex.id}_#{edge.num}"
-          puts("#{border_edges} #{border_edges.include? edge_str}")
           border_edges.include? edge_str
+        end
+
+        def revenue_for(route, stops)
+          revenue = super
+          k_sum = stops.each.sum do |rl|
+            rl.hex.tile.label.to_s == 'K' ? 1 : 0
+          end
+          bonus = K_BONUS[k_sum]
+          revenue + bonus
         end
       end
     end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -694,8 +694,6 @@ module Engine
 
           old_price = entity.share_price
           boe_old_price = @boe.share_price
-          name = entity.name
-          @log << "#{name} takes a loan and receives #{format_currency(loan.amount)}"
           @boe.spend(loan.amount, entity)
           loan_taken_stock_market_movement(entity)
           log_share_price(entity, old_price)
@@ -706,20 +704,16 @@ module Engine
         end
 
         def loan_taken_stock_market_movement(entity)
+          @log << "#{entity.name} takes a loan and receives #{format_currency(loan.amount)}"
           2.times { @stock_market.move_left(entity) }
           @stock_market.move_right(boe)
         end
 
         # routing logic
-        def check_distance(route, visits, _train = nil)
+        def visited_stops(route)
           modified_guage_changes = get_modified_guage_distance(route)
-          visits += Array.new(modified_guage_changes) { Engine::Part::City.new('0') } if modified_guage_changes.positive?
-          super(route, visits, _train = nil)
-        end
-
-        def route_distance(route)
-          modified_guage_changes = get_modified_guage_distance(route)
-          modified_guage_changes.positive? ? super + modified_guage_changes : super
+          added_stops = modified_guage_changes.positive? ? Array.new(modified_guage_changes) { Engine::Part::City.new('0') } : []
+          super + added_stops
         end
 
         def get_modified_guage_distance(route)

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -540,6 +540,7 @@ module Engine
 
         def operating_round(round_num)
           Round::Operating.new(self, [
+            G1848::Step::Loan,
             Engine::Step::Bankrupt,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,
@@ -663,8 +664,10 @@ module Engine
           end
         end
 
+        # loans
+
         def maximum_loans(entity)
-          entity == @boe ? 0 : 5
+          entity == @boe ? 20 : 5
         end
 
         def init_loans
@@ -680,10 +683,41 @@ module Engine
           0
         end
 
+<<<<<<< HEAD
         def market_share_limit(corporation = nil)
           return 100 if corporation == @boe
           MARKET_SHARE_LIMIT
         end
+=======
+        def can_take_loan?(entity)
+          entity.corporation? &&
+            entity.loans.size < maximum_loans(entity) &&
+            @loans.any?
+        end
+
+        def take_loan(entity, loan)
+          raise GameError, "Cannot take more than #{maximum_loans(entity)} loans" unless can_take_loan?(entity)
+
+          old_price = entity.share_price
+          boe_old_price = @boe.share_price
+          name = entity.name
+          @log << "#{name} takes a loan and receives #{format_currency(loan.amount)}"
+          @boe.spend(loan.amount, entity)
+          loan_taken_stock_market_movement(entity)
+          log_share_price(entity, old_price)
+          log_share_price(@boe, boe_old_price)
+          entity.loans << loan
+          @boe.loans << loan
+          @loans.delete(loan)
+        end
+
+        def loan_taken_stock_market_movement(entity)
+          @stock_market.move_left(entity)
+          @stock_market.move_left(entity)
+          @stock_market.move_right(boe)
+        end
+
+>>>>>>> b075a2db2 (implent loans)
         # routing logic
         def check_distance(route, visits, _train = nil)
           gauge_changes = edge_crossings(route)

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -683,12 +683,10 @@ module Engine
           0
         end
 
-<<<<<<< HEAD
         def market_share_limit(corporation = nil)
           return 100 if corporation == @boe
           MARKET_SHARE_LIMIT
         end
-=======
         def can_take_loan?(entity)
           entity.corporation? &&
             entity.loans.size < maximum_loans(entity) &&
@@ -717,7 +715,6 @@ module Engine
           @stock_market.move_right(boe)
         end
 
->>>>>>> b075a2db2 (implent loans)
         # routing logic
         def check_distance(route, visits, _train = nil)
           gauge_changes = edge_crossings(route)

--- a/lib/engine/game/g_1848/step/loan.rb
+++ b/lib/engine/game/g_1848/step/loan.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class Loan < Engine::Step::Base
+          def actions(entity)
+            return [] if !entity.corporation? || entity != current_entity
+
+            actions = []
+            actions << 'take_loan' unless @loan_taken
+            actions
+          end
+
+          def description
+            'Take Loans'
+          end
+
+          def blocks?
+            false
+          end
+
+          def process_take_loan(action)
+            @loan_taken = true
+            entity = action.entity
+            @game.take_loan(entity, action.loan)
+          end
+
+          def setup
+            # you can only take one loan per OR turn
+            @loan_taken = false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/loan.rb
+++ b/lib/engine/game/g_1848/step/loan.rb
@@ -7,12 +7,12 @@ module Engine
     module G1848
       module Step
         class Loan < Engine::Step::Base
+          ACTIONS = ['take_loan'].freeze
           def actions(entity)
             return [] if !entity.corporation? || entity != current_entity
+            return [] if @loan_taken || !@game.can_take_loan?(entity)
 
-            actions = []
-            actions << 'take_loan' unless @loan_taken
-            actions
+            ACTIONS
           end
 
           def description

--- a/lib/engine/game/g_1848/step/special_track.rb
+++ b/lib/engine/game/g_1848/step/special_track.rb
@@ -16,7 +16,7 @@ module Engine
           def process_lay_tile(action)
             ability = abilities(action.entity)
             super
-            return unless @game.private_closed_triggered @game.private_closed_triggered
+            return unless @game.private_closed_triggered
 
             # close company if company closes and the ability has been used
             company = ability.owner

--- a/lib/engine/game/g_1848/step/special_track.rb
+++ b/lib/engine/game/g_1848/step/special_track.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/special_track'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class SpecialTrack < Engine::Step::SpecialTrack
+          def potential_tiles(entity, hex)
+            return @game.tiles.select { |tile| tile.color == 'blue' } if entity.sym == 'P3'
+
+            super
+          end
+
+          def process_lay_tile(action)
+            ability = abilities(action.entity)
+            super
+            return unless @game.private_closed_triggered @game.private_closed_triggered
+
+            # close company if company closes and the ability has been used
+            company = ability.owner
+            @log << "#{company.name} closes"
+            company.close!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/special_track.rb
+++ b/lib/engine/game/g_1848/step/special_track.rb
@@ -7,12 +7,6 @@ module Engine
     module G1848
       module Step
         class SpecialTrack < Engine::Step::SpecialTrack
-          def potential_tiles(entity, hex)
-            return @game.tiles.select { |tile| tile.color == 'blue' } if entity.sym == 'P3'
-
-            super
-          end
-
           def process_lay_tile(action)
             ability = abilities(action.entity)
             super


### PR DESCRIPTION
more 1848 impl:
1- add routing logic. Map has boundaries, each crossing is a gauge change that adds 0 cost city to route. + train adds one free change to the route
2- privates with abilities retain the ability after company closes if unused. Can be used be either player or  corp until end of game. I made the privates 0 revenue, and can't buy at that point. 
3- added loans logic, boe price goes up, corp goes left twice, can only take one loan per round