### PR TITLE
Fix autoroute in RouteSelector to update selected_route

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -266,6 +266,8 @@ module View
             path_timeout: setting_for(:path_timeout).to_i,
             route_timeout: setting_for(:route_timeout).to_i,
           )
+          @selected_route = @routes.first
+          store(:selected_route, @selected_route, skip: true)
           store(:routes, @routes)
         end
 


### PR DESCRIPTION
Fixes #7843 

Originally reported as an 1860 bug, this can affect any game after the autorouter is run