### PR TITLE
[1848] implement receivership 

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -82,7 +82,7 @@ module View
 
       def render_info
         num_certs = @game.num_certs(@player)
-        cert_limit = @game.cert_limit
+        cert_limit = @game.cert_limit(@player)
 
         td_cert_props = {
           style: {

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -50,7 +50,7 @@ module View
           children << h(Choose) if @current_actions.include?('choose') && @step.choice_available?(@current_entity)
 
           if @step.respond_to?(:must_sell?) && @step.must_sell?(@current_entity)
-            children << if @game.num_certs(@current_entity) > @game.cert_limit
+            children << if @game.num_certs(@current_entity) > @game.cert_limit(@current_entity)
                           h('div.margined', 'Must sell stock: above certificate limit')
                         else
                           h('div.margined', 'Must sell stock: above 60% limit in corporation(s)')

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1417,11 +1417,13 @@ module Engine
 
         tile = hex&.tile
         if !tile || (tile.reserved_by?(corporation) && tile.paths.any?)
+
           if @round.pending_tokens.any? { |p| p[:entity] == corporation }
             # 1867: Avoid adding the same token twice
             @round.clear_cache!
             return
           end
+
           # If the tile does not have any paths at the present time, clear up the ambiguity when the tile is laid
           # otherwise the entity must choose now.
           hexes =

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2023,6 +2023,10 @@ module Engine
         self.class::MARKET_SHARE_LIMIT
       end
 
+      def cert_limit(_player = nil)
+        @cert_limit
+      end
+
       private
 
       def init_graph
@@ -2051,10 +2055,6 @@ module Engine
 
       def game_cert_limit
         self.class::CERT_LIMIT
-      end
-
-      def cert_limit(_player = nil)
-        @cert_limit
       end
 
       def init_phase

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1416,15 +1416,12 @@ module Engine
         hex = hex_by_id(corporation.coordinates)
 
         tile = hex&.tile
-        puts("here tile + #{tile}") if corporation.name == 'BOE'
         if !tile || (tile.reserved_by?(corporation) && tile.paths.any?)
-          puts("here pending tokens + #{@round.pending_tokens.any?}") if corporation.name == 'BOE'
           if @round.pending_tokens.any? { |p| p[:entity] == corporation }
             # 1867: Avoid adding the same token twice
             @round.clear_cache!
             return
           end
-          puts("here + #{@round.pending_tokens.any?}") if corporation.name == 'BOE'
           # If the tile does not have any paths at the present time, clear up the ambiguity when the tile is laid
           # otherwise the entity must choose now.
           hexes =

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1416,14 +1416,15 @@ module Engine
         hex = hex_by_id(corporation.coordinates)
 
         tile = hex&.tile
+        puts("here tile + #{tile}") if corporation.name == 'BOE'
         if !tile || (tile.reserved_by?(corporation) && tile.paths.any?)
-
+          puts("here pending tokens + #{@round.pending_tokens.any?}") if corporation.name == 'BOE'
           if @round.pending_tokens.any? { |p| p[:entity] == corporation }
             # 1867: Avoid adding the same token twice
             @round.clear_cache!
             return
           end
-
+          puts("here + #{@round.pending_tokens.any?}") if corporation.name == 'BOE'
           # If the tile does not have any paths at the present time, clear up the ambiguity when the tile is laid
           # otherwise the entity must choose now.
           hexes =
@@ -2050,6 +2051,10 @@ module Engine
 
       def game_cert_limit
         self.class::CERT_LIMIT
+      end
+
+      def cert_limit(_player)
+        @cert_limit
       end
 
       def init_phase

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -77,7 +77,7 @@ module Engine
     class Base
       include Game::Meta
 
-      attr_reader :raw_actions, :actions, :bank, :cert_limit, :cities, :companies, :corporations,
+      attr_reader :raw_actions, :actions, :bank, :cities, :companies, :corporations,
                   :depot, :finished, :graph, :hexes, :id, :loading, :loans, :log, :minors,
                   :phase, :players, :operating_rounds, :round, :share_pool, :stock_market, :tile_groups,
                   :tiles, :turn, :total_loans, :undo_possible, :redo_possible, :round_history, :all_tiles,
@@ -2053,7 +2053,7 @@ module Engine
         self.class::CERT_LIMIT
       end
 
-      def cert_limit(_player)
+      def cert_limit(_player = nil)
         @cert_limit
       end
 

--- a/lib/engine/game/g_1848/depot.rb
+++ b/lib/engine/game/g_1848/depot.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../depot'
+
+module Engine
+  module Game
+    module G1848
+      class Depot < Engine::Depot
+        def export!
+          train = @upcoming.first
+          return if train.rusts_on # only export if upcoming train is permanent
+
+          @game.log << "-- Event: A #{train.name} train exports --"
+          remove_train(train)
+          @game.phase.buying_train!(nil, train)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -678,12 +678,15 @@ module Engine
           0
         end
 
+<<<<<<< HEAD
         def market_share_limit(corporation = nil)
           return 100 if corporation == @boe
 
           MARKET_SHARE_LIMIT
         end
 
+=======
+>>>>>>> 4bdea3219 (implent loans)
         def can_take_loan?(entity)
           entity.corporation? &&
             entity.loans.size < maximum_loans(entity) &&

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -35,7 +35,7 @@ module Engine
 
         BOE_STARTING_CASH = 2000
 
-        BOE_STARTING_PRICE = 80
+        BOE_STARTING_PRICE = 70
 
         BOE_ROW = 6
 
@@ -95,7 +95,8 @@ module Engine
           %w[0c 40 50 60 70 80p 90 110 130 160 190],
           %w[0c 30 40 50 60 70p 80 100 120],
           %w[0c 20 30 40 50 60 70],
-          %w[80r
+          %w[70r
+             80r
              90r
              100r
              110r

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -771,7 +771,6 @@ module Engine
 
           # shareholders compensated
           per_share = corporation.par_price.price
-          # total_payout = corporation.total_shares * per_share
           payouts = {}
           @players.each do |player|
             next if corporation.president?(player)

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -546,8 +546,9 @@ module Engine
         end
 
         def operating_round(round_num)
-          Round::Operating.new(self, [
+          G1848::Round::Operating.new(self, [
             G1848::Step::Loan,
+            G1848::Step::CashCrisis,
             Engine::Step::Bankrupt,
             Engine::Step::Exchange,
             G1848::Step::SpecialTrack,
@@ -768,7 +769,7 @@ module Engine
           end
 
           # shareholders compensated
-          per_share = corporation.original_par_price.price
+          per_share = 500
           # total_payout = corporation.total_shares * per_share
           payouts = {}
           @players.each do |player|
@@ -778,7 +779,7 @@ module Engine
             next if amount.zero?
 
             payouts[player] = amount
-            corporation.spend(amount, player)
+            corporation.spend(amount, player, check_cash: false, borrow_from: corporation.owner)
           end
 
           if payouts.any?

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -43,6 +43,8 @@ module Engine
 
         MUST_SELL_IN_BLOCKS = false
 
+        EBUY_PRES_SWAP = false
+
         MARKET = [
           %w[0c
              70

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -527,7 +527,6 @@ module Engine
           @boe.cash = BOE_STARTING_CASH
           @stock_market.set_par(@boe, lookup_boe_price(BOE_STARTING_PRICE))
           @extra_tile_lay = false
-          @private_closed_triggered = false
           @close_corp_count = 0
           @player_corp_close_count = Hash.new { |h, k| h[k] = 0 }
         end
@@ -771,7 +770,7 @@ module Engine
           end
 
           # shareholders compensated
-          per_share = 500
+          per_share = corporation.par_price.price
           # total_payout = corporation.total_shares * per_share
           payouts = {}
           @players.each do |player|

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -515,6 +515,7 @@ module Engine
           @boe.cash = BOE_STARTING_CASH
           @stock_market.set_par(@boe, lookup_boe_price(BOE_STARTING_PRICE))
           @extra_tile_lay = false
+          @private_closed_triggered = false
         end
 
         def new_auction_round

--- a/lib/engine/game/g_1848/round/operating.rb
+++ b/lib/engine/game/g_1848/round/operating.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G1848
+      module Round
+        class Operating < Engine::Round::Operating
+          attr_accessor :cash_crisis_player
+
+          def after_process(action)
+            # Keep track of last_player for Cash Crisis
+            entity = @entities[@entity_index]
+            @cash_crisis_player = entity.player
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/cash_crisis.rb
+++ b/lib/engine/game/g_1848/step/cash_crisis.rb
@@ -13,7 +13,7 @@ module Engine
           def actions(entity)
             return [] unless entity == current_entity
 
-            if @active_entity.nil?
+            unless @active_entity
               @active_entity = entity
               @game.log << "#{@active_entity.name} enters Cash Crisis and owes"\
                            " the bank #{@game.format_currency(needed_cash(@active_entity))}"
@@ -31,7 +31,7 @@ module Engine
           end
 
           def active?
-            active_entities.any?
+            !active_entities.empty?
           end
 
           def active_entities
@@ -59,10 +59,7 @@ module Engine
           end
 
           def sellable_shares?(entity)
-            sum = entity.shares.sum do |share|
-              can_sell?(entity, share.to_bundle) ? 1 : 0
-            end
-            sum.positive?
+            entity.shares.any? { |share| can_sell?(entity, share.to_bundle) }
           end
 
           def can_sell?(entity, bundle)

--- a/lib/engine/game/g_1848/step/cash_crisis.rb
+++ b/lib/engine/game/g_1848/step/cash_crisis.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/emergency_money'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class CashCrisis < Engine::Step::Base
+          include Engine::Step::EmergencyMoney
+
+          def actions(entity)
+            return [] unless entity == current_entity
+
+            if @active_entity.nil?
+              @active_entity = entity
+              @game.log << "#{@active_entity.name} enters Cash Crisis and owes"\
+                           " the bank #{@game.format_currency(needed_cash(@active_entity))}"
+            end
+
+            ['sell_shares']
+          end
+
+          def description
+            'Cash Crisis'
+          end
+
+          def cash_crisis?
+            true
+          end
+
+          def active?
+            active_entities.any?
+          end
+
+          def active_entities
+            return [] unless @round.cash_crisis_player
+            return [] if @active_entity && !sellable_shares?(@active_entity)
+
+            # Rotate players to order starting with the current player
+            [@game.players.rotate(@game.players.index(@round.cash_crisis_player))
+            .find { |p| p.cash.negative? }].compact
+          end
+
+          def needed_cash(entity)
+            -entity.cash
+          end
+
+          def available_cash(_player)
+            0
+          end
+
+          def process_sell_shares(action)
+            super
+            return if action.entity.cash.negative?
+
+            @active_entity = nil
+          end
+
+          def sellable_shares?(entity)
+            sum = entity.shares.sum do |share|
+              can_sell?(entity, share.to_bundle) ? 1 : 0
+            end
+            sum.positive?
+          end
+
+          def can_sell?(entity, bundle)
+            super
+          end
+
+          def swap_sell(_player, _corporation, _bundle, _pool_share); end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/special_track.rb
+++ b/lib/engine/game/g_1848/step/special_track.rb
@@ -10,7 +10,7 @@ module Engine
           def process_lay_tile(action)
             ability = abilities(action.entity)
             super
-            return unless @game.private_closed_triggered
+            return unless @game.private_closed_triggered @game.private_closed_triggered
 
             # close company if company closes and the ability has been used
             company = ability.owner

--- a/lib/engine/game/g_1848/step/special_track.rb
+++ b/lib/engine/game/g_1848/step/special_track.rb
@@ -10,7 +10,7 @@ module Engine
           def process_lay_tile(action)
             ability = abilities(action.entity)
             super
-            return unless @game.private_closed_triggered @game.private_closed_triggered
+            return unless @game.private_closed_triggered
 
             # close company if company closes and the ability has been used
             company = ability.owner


### PR DESCRIPTION
cert limit goes down based on number of companies in receivership and player count
president has further reduction for causing a company to go bankrupt
company pays compensation, if not enough president is liable. 
No personal bankruptcy, player has negative money, and must make it back by earning it elsewhere.