### PR TITLE
fix use of round instead of ceil for 1817 bids

### DIFF
--- a/lib/engine/game/g_1817/step/acquire.rb
+++ b/lib/engine/game/g_1817/step/acquire.rb
@@ -415,7 +415,7 @@ module Engine
               10 # while technically the bank bids 0 this isn't done by a player.
             else
               # Needs rounding to 10
-              ((corporation.total_shares * corporation.share_price.price).to_f / 10).round * 10
+              ((corporation.total_shares * corporation.share_price.price).to_f / 10).ceil * 10
             end
           end
 


### PR DESCRIPTION
fixing #8103 

The rules are that the starting bid is "the bid may be any multiple of $10 that is at least the minimum bid
and above the previous bid." and minimum bid is share value * stock price.

if a company has 2 shares at 46 (2*46=92), round method will round it down to 90. Rules require it to be 100. 
ceil is the correct method, always rounding up.

This will probably break some games (games where someone took the starting bid on companies with stock value * shares in the 0-5 last digit values.
