### PR TITLE
fix 18co where corps owned shared are ignored to determine pres swap

### DIFF
--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -39,6 +39,8 @@ module Engine
 
         MUST_SELL_IN_BLOCKS = false
 
+        EBUY_PRES_SWAP = false
+
         TILES = {
           '3a' =>
                  {

--- a/lib/engine/step/emergency_money.rb
+++ b/lib/engine/step/emergency_money.rb
@@ -50,7 +50,7 @@ module Engine
 
       def causes_president_swap?(corporation, bundle)
         seller = bundle.owner
-        share_holders = corporation.player_share_holders
+        share_holders = corporation.player_share_holders(corporate: true)
         remaining = share_holders[seller] - bundle.percent
         next_highest = share_holders.reject { |k, _| k == seller }.values.max || 0
         remaining < next_highest


### PR DESCRIPTION
fix #4386

The code change was made in the base package, but the code path is only for games that allow corp ownership of shares,
and not allow president switch during ebuy. I don't think any games with this ruleset would want to ignore corp ownership.

If otherwise, i can create a copy of emergency_money.rb in 18co folder and make the change there. LMK