### PR TITLE
Remove unneeded local method upgrades_to in 18sj 

### DIFF
--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -823,8 +823,8 @@ module Engine
 
         def upgrades_to?(from, to, _special = false, selected_company: nil)
           # Handle upgrade to Stockholm gray tile
-          return to.name == '131' if from.color == :brown && from.hex.name == 'G10'
-          return false if to.name == '131'
+          return to.name == 'X5' if from.color == :brown && from.hex.name == 'G10'
+          return false if to.name == 'X5'
 
           super
         end

--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -821,14 +821,6 @@ module Engine
           end
         end
 
-        def upgrades_to?(from, to, _special = false, selected_company: nil)
-          # Handle upgrade to Stockholm gray tile
-          return to.name == 'X5' if from.color == :brown && from.hex.name == 'G10'
-          return false if to.name == 'X5'
-
-          super
-        end
-
         def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
           upgrades = super
 


### PR DESCRIPTION
fix #8120:

#8020 updated the tile names. Stockholm gray was changed from 131 to X5.
The local method of upgrades_to?, returns non existent tile 131 when trying to upgrade to gray. The super method handles the upgrade fine, no need to override it.