### PR TITLE
18SJ: Fix bug after corporations made IPO (fixes #8128)

### DIFF
--- a/lib/engine/game/g_18_sj/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_sj/step/buy_sell_par_shares.rb
@@ -10,6 +10,22 @@ module Engine
           def can_sell?(entity, bundle)
             super && (@game.oscarian_era || bundle.corporation.floated?)
           end
+
+          def can_ipo_any?(entity)
+            !bought? && @game.corporations.any? do |c|
+              @game.can_par?(c, entity) && can_buy?(entity, c.ipo_shares.first&.to_bundle)
+            end
+          end
+
+          # FIXME: copied from 21moon which has "FIXME: move to common location"
+          def can_buy_any_from_ipo?(entity)
+            @game.corporations.each do |corporation|
+              next unless corporation.ipoed
+              return true if can_buy_shares?(entity, corporation.ipo_shares)
+            end
+
+            false
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_sj/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_sj/step/buy_sell_par_shares.rb
@@ -17,7 +17,6 @@ module Engine
             end
           end
 
-          # FIXME: copied from 21moon which has "FIXME: move to common location"
           def can_buy_any_from_ipo?(entity)
             @game.corporations.each do |corporation|
               next unless corporation.ipoed


### PR DESCRIPTION
This fixes a bug that occur late in the game. If any games is broken by this fix this is probably bad as the game cannot be completed OR my fix is not correct. So if this do break any games I think I need to get this back for a revisit.

(The issue is that no shares can be bought from IPO, and occurs when game enters brown phase - and some corporations are changes from Incremental to Full cap. So it should have no effect on games that have not reached that phase.)