### PR TITLE
18Rhl: Correct acting_for_entity for method (fixes #8147)

### DIFF
--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -496,7 +496,7 @@ module Engine
         end
 
         def acting_for_entity(entity)
-          return super if entity.owned_by_player?
+          return super if entity.player? || entity.owned_by_player?
 
           WithNameAdapter.new
         end


### PR DESCRIPTION
18Rhl uses this to handle receivership, in case a corporation is
not owned by any player, but method can also be called by player
entity, in which case default implementation is used.