### PR TITLE
[1848] Fix issues

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -338,6 +338,7 @@ module View
               train_props[:style][:color] = contrast_on(color)
             end
             source = @depot.discarded.include?(train) ? 'The Discard' : 'The Depot'
+
             [h(:div, train_props, name),
              h('div.nowrap', train_props, source),
              h('div.right', train_props, @game.format_currency(price)),

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -174,7 +174,7 @@ module View
 
             children.concat(render_emergency_money_raising(owner)) if share_funds_allowed.positive?
           end
-        elsif share_funds_allowed.positive?
+        elsif share_funds_allowed.positive? && @step.can_ebuy_sell_shares?(@corporation)
           children.concat(render_emergency_money_raising(player))
         end
 
@@ -338,7 +338,6 @@ module View
               train_props[:style][:color] = contrast_on(color)
             end
             source = @depot.discarded.include?(train) ? 'The Discard' : 'The Depot'
-
             [h(:div, train_props, name),
              h('div.nowrap', train_props, source),
              h('div.right', train_props, @game.format_currency(price)),

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1841,6 +1841,7 @@ module Engine
 
       def discountable_trains_for(corporation)
         discountable_trains = @depot.depot_trains.select { |train| train.discount || train.variants.any? { |_, v| v[:discount] } }
+
         corporation.trains.flat_map do |train|
           discountable_trains.flat_map do |discount_train|
             discount_info = []
@@ -1860,6 +1861,7 @@ module Engine
                 discount_info << [train, discount_train, v[:name], price]
               end
             end
+
             discount_info
           end.compact
         end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1840,24 +1840,26 @@ module Engine
       end
 
       def discountable_trains_for(corporation)
-        discountable_trains = @depot.depot_trains.select(&:discount)
-
+        discountable_trains = @depot.depot_trains.select { |train| train.discount || train.variants.any? { |_, v| v[:discount] } }
         corporation.trains.flat_map do |train|
           discountable_trains.flat_map do |discount_train|
+            discount_info = []
             discounted_price = discount_train.price(train)
-            next if discount_train.price == discounted_price
-
-            name = discount_train.name
-            discount_info = [[train, discount_train, name, discounted_price]]
+            if discount_train.price > discounted_price
+              name = discount_train.name
+              discount_info = [[train, discount_train, name, discounted_price]]
+            end
 
             # Add variants if any - they have same discount as base version
             discount_train.variants.each do |_, v|
               next if v[:name] == name
 
-              price = v[:price] - (discount_train.price - discounted_price)
-              discount_info << [train, discount_train, v[:name], price]
+              discounted_price = discount_train.price(train, variant: v)
+              if discount_train.price > discounted_price
+                price = v[:price] - (discount_train.price - discounted_price)
+                discount_info << [train, discount_train, v[:name], price]
+              end
             end
-
             discount_info
           end.compact
         end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1847,7 +1847,8 @@ module Engine
             discount_info = []
             discounted_price = discount_train.price(train)
             if discount_train.price > discounted_price
-              discount_info = [[train, discount_train, discount_train.name, discounted_price]]
+              name = discount_train.name
+              discount_info = [[train, discount_train, name, discounted_price]]
             end
 
             # Add variants if any - they have same discount as base version

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1847,8 +1847,7 @@ module Engine
             discount_info = []
             discounted_price = discount_train.price(train)
             if discount_train.price > discounted_price
-              name = discount_train.name
-              discount_info = [[train, discount_train, name, discounted_price]]
+              discount_info = [[train, discount_train, discount_train.name, discounted_price]]
             end
 
             # Add variants if any - they have same discount as base version

--- a/lib/engine/game/g_1848/depot.rb
+++ b/lib/engine/game/g_1848/depot.rb
@@ -14,6 +14,11 @@ module Engine
           remove_train(train)
           @game.phase.buying_train!(nil, train)
         end
+
+        def min_depot_train
+          # 2e doesn't count towards needing a train, should be ignored when checking for min
+          depot_trains.reject { |t| t.name == '2E' }.min_by(&:price)
+        end
       end
     end
   end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -797,7 +797,7 @@ module Engine
               break
             end
             loan = @loans.first
-            take_loan(entity, loan, ebuy)
+            take_loan(entity, loan, ebuy: ebuy)
             remaining -= loan.amount
           end
         end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -52,6 +52,8 @@ module Engine
 
         EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
 
+        DISCARDED_TRAINS = :remove
+
         MARKET = [
           %w[0c
              70

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -269,18 +269,18 @@ module Engine
           },
 
           {
-            name: 'D',
-            distance: 999,
-            price: 1100,
+            name: '8',
+            distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
+                       { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
+            price: 800,
             num: 999,
-            discount: { '4' => 300, '5' => 300, '6' => 300 },
             variants: [
               {
-                name: '8',
-                distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
-                           { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
-                price: 800,
+                name: 'D',
+                distance: 999,
+                price: 1100,
                 num: 999,
+                discount: { '4' => 300, '5' => 300, '6' => 300 },
               },
             ],
           },
@@ -808,7 +808,8 @@ module Engine
         def visited_stops(route)
           modified_guage_changes = get_modified_guage_distance(route)
           added_stops = modified_guage_changes.positive? ? Array.new(modified_guage_changes) { Engine::Part::City.new('0') } : []
-          super + added_stops
+          route_stops = super
+          route.train.name == '2E' ? route_stops : route_stops + added_stops
         end
 
         def check_distance(route, visits, _train = nil)
@@ -922,7 +923,7 @@ module Engine
         def ghan_visited?(visited_node)
           return false unless visited_node
 
-          GHAN_HEXES.include?(visited_node.hex.name)
+          GHAN_HEXES.include?(visited_node&.hex&.name)
         end
 
         def entity_can_use_company?(entity, company)

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -273,13 +273,13 @@ module Engine
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 800,
-            num: 999,
+            num: 20,
             variants: [
               {
                 name: 'D',
                 distance: 999,
                 price: 1100,
-                num: 999,
+                num: 30,
                 discount: { '4' => 300, '5' => 300, '6' => 300 },
               },
             ],
@@ -289,7 +289,7 @@ module Engine
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 2, 'visit' => 99 },
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 200,
-            num: 999,
+            num: 10,
             available_on: '5',
           },
         ].freeze
@@ -943,20 +943,6 @@ module Engine
 
         def ability_used!(company)
           company.all_abilities.dup.each { |ab| company.remove_ability(ab) }
-        end
-
-        def discountable_trains_for(corporation)
-          discountable_trains = @depot.depot_trains.select(&:discount)
-
-          corporation.trains.flat_map do |train|
-            discountable_trains.flat_map do |discount_train|
-              discounted_price = discount_train.price(train)
-              next if discount_train.price == discounted_price
-
-              name = discount_train.name
-              [[train, discount_train, name, discounted_price]]
-            end.compact
-          end
         end
       end
     end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -279,7 +279,7 @@ module Engine
                 name: 'D',
                 distance: 999,
                 price: 1100,
-                num: 30,
+                num: 20,
                 discount: { '4' => 300, '5' => 300, '6' => 300 },
               },
             ],

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -50,6 +50,8 @@ module Engine
 
         CERT_LIMIT_INCLUDES_PRIVATES = false
 
+        EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
+
         MARKET = [
           %w[0c
              70
@@ -267,18 +269,18 @@ module Engine
           },
 
           {
-            name: '8',
-            distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
-                       { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
-            price: 800,
+            name: 'D',
+            distance: 999,
+            price: 1100,
             num: 999,
+            discount: { '4' => 300, '5' => 300, '6' => 300 },
             variants: [
               {
-                name: 'D',
-                distance: 999,
-                price: 1100,
+                name: '8',
+                distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
+                           { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
+                price: 800,
                 num: 999,
-                discount: { '4' => 300, '5' => 300, '6' => 300 },
               },
             ],
           },
@@ -940,6 +942,20 @@ module Engine
 
         def ability_used!(company)
           company.all_abilities.dup.each { |ab| company.remove_ability(ab) }
+        end
+
+        def discountable_trains_for(corporation)
+          discountable_trains = @depot.depot_trains.select(&:discount)
+
+          corporation.trains.flat_map do |train|
+            discountable_trains.flat_map do |discount_train|
+              discounted_price = discount_train.price(train)
+              next if discount_train.price == discounted_price
+
+              name = discount_train.name
+              [[train, discount_train, name, discounted_price]]
+            end.compact
+          end
         end
       end
     end

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -37,12 +37,17 @@ module Engine
             # Cannot buy 2E if one is already owned, can't by non 2e if at limit
             trains_to_buy = at_train_limit?(entity) ? [] : super
             trains_to_buy = trains_to_buy.select(&:from_depot?) unless @game.can_buy_trains
+            trains_to_buy = reject_unaffordable_depot_trains(trains_to_buy) if must_buy_train?(entity)
             if owns_2e?(entity)
               trains_to_buy = trains_to_buy.reject { |t| t.name == '2E' }
             elsif trains_to_buy.none? { |t| t.name == '2E' } && can_buy_2e?(entity)
               trains_to_buy << ghan_train
             end
             trains_to_buy.uniq
+          end
+
+          def reject_unaffordable_depot_trains(trains_to_buy)
+            trains_to_buy.reject { |train| @depot.discarded.include?(train) && train.price > buying_power(entity) }
           end
 
           def owns_2e?(entity)
@@ -81,6 +86,14 @@ module Engine
             return [1, buying_power(entity)] if train.owner.owner == entity.owner
 
             [train.price, train.price]
+          end
+
+          def can_ebuy_sell_shares?(_entity)
+            false
+          end
+
+          def must_take_loan?(_)
+            true
           end
         end
       end

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -37,17 +37,12 @@ module Engine
             # Cannot buy 2E if one is already owned, can't by non 2e if at limit
             trains_to_buy = at_train_limit?(entity) ? [] : super
             trains_to_buy = trains_to_buy.select(&:from_depot?) unless @game.can_buy_trains
-            trains_to_buy = reject_unaffordable_depot_trains(trains_to_buy, entity) if must_buy_train?(entity)
             if owns_2e?(entity)
               trains_to_buy = trains_to_buy.reject { |t| t.name == '2E' }
             elsif trains_to_buy.none? { |t| t.name == '2E' } && can_buy_2e?(entity)
               trains_to_buy << ghan_train
             end
             trains_to_buy.uniq
-          end
-
-          def reject_unaffordable_depot_trains(trains_to_buy, entity)
-            trains_to_buy.reject { |train| @depot.discarded.include?(train) && train.price > buying_power(entity) }
           end
 
           def owns_2e?(entity)

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -92,7 +92,7 @@ module Engine
             false
           end
 
-          def must_take_loan?(_)
+          def must_take_loan?(_entity)
             true
           end
         end

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -37,7 +37,7 @@ module Engine
             # Cannot buy 2E if one is already owned, can't by non 2e if at limit
             trains_to_buy = at_train_limit?(entity) ? [] : super
             trains_to_buy = trains_to_buy.select(&:from_depot?) unless @game.can_buy_trains
-            trains_to_buy = reject_unaffordable_depot_trains(trains_to_buy) if must_buy_train?(entity)
+            trains_to_buy = reject_unaffordable_depot_trains(trains_to_buy, entity) if must_buy_train?(entity)
             if owns_2e?(entity)
               trains_to_buy = trains_to_buy.reject { |t| t.name == '2E' }
             elsif trains_to_buy.none? { |t| t.name == '2E' } && can_buy_2e?(entity)
@@ -46,7 +46,7 @@ module Engine
             trains_to_buy.uniq
           end
 
-          def reject_unaffordable_depot_trains(trains_to_buy)
+          def reject_unaffordable_depot_trains(trains_to_buy, entity)
             trains_to_buy.reject { |train| @depot.discarded.include?(train) && train.price > buying_power(entity) }
           end
 

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -74,8 +74,9 @@ module Engine
       @variants.transform_values { |v| v[:price] }
     end
 
-    def price(exchange_train = nil)
-      @price - (@discount&.dig(exchange_train&.name) || 0)
+    def price(exchange_train = nil, variant: nil)
+      discount = (variant && variant[:discount]) || self.discount
+      @price - (discount&.dig(exchange_train&.name) || 0)
     end
 
     def id


### PR DESCRIPTION
- discount on variant D not showing
- kwargs failure when ebuying
- 2E failing when running across borders
- When ebuying showing discard trains when it shouldn't
- lower amount of "unlimited" trains. 999 trains causes major slowdown (duh!)
- don't show shares to sell when ebuying and can_ebuy_sell_shares is false
- can buy more expensive trains in 1848
