### PR TITLE
[1848] Fix issues

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -11,7 +11,7 @@ module Engine
     module G1848
       class Game < Game::Base
         attr_reader :sydney_adelaide_connected, :boe, :private_closed_triggered, :take_out_loan_triggered,
-                    :can_buy_trains
+                    :can_buy_trains, :com_can_operate
 
         include_meta(G1848::Meta)
         include Map

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -636,9 +636,9 @@ module Engine
           super
         end
 
-        def sar
-          # SAR is used for graph to find adelaide (to connect to sydney for starting COM)
-          @sar ||= @corporations.find { |corporation| corporation.name == 'SAR' }
+        def dummy_corp
+          # dummy corp is used for graph to find adelaide (to connect to sydney for starting COM)
+          @dummy_corp ||= Engine::Corporation.new(name: 'Dummy Corp', sym: 'Dummy Corp', tokens: [], coordinates: 'G6')
         end
 
         def tasmania
@@ -659,8 +659,8 @@ module Engine
 
         def check_for_sydney_adelaide_connection
           graph = Graph.new(self, home_as_token: true, no_blocking: true)
-          graph.compute(sar)
-          graph.reachable_hexes(sar).include?(sydney)
+          graph.compute(dummy_corp)
+          graph.reachable_hexes(dummy_corp).include?(sydney)
         end
 
         def event_com_connected!

--- a/lib/engine/game/g_1848/step/check_com_formation.rb
+++ b/lib/engine/game/g_1848/step/check_com_formation.rb
@@ -37,7 +37,7 @@ module Engine
           end
 
           def process_destination_connection(_action)
-            @game.log << 'Sydney and Adelaide are connected - COM may start operating'
+            @game.log << 'Sydney and Adelaide are connected - COM may start operating' unless @game.com_can_operate
             @game.event_com_connected!
           end
         end

--- a/lib/engine/game/g_1848/step/dividend.rb
+++ b/lib/engine/game/g_1848/step/dividend.rb
@@ -48,7 +48,7 @@ module Engine
 
           def get_token_cities_total_revenue(corporation)
             corporation.tokens.sum do |token|
-              token.city.revenue[token.hex.tile.color]
+              token.city.revenue[token.hex.tile.color] || 0
             end
           end
         end


### PR DESCRIPTION
fix minor issues:
- use a dummy corp instead of SAR to check if sydney-adelaide are connected
- do not show log that com can operate via connectivity if it already can via phase change
- if corp goes into receivership, and boe gets a token on a white tile. OR 0 in that case when calculating revenue