### PR TITLE
[1848] minor improvements + perth bug fix

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -461,7 +461,10 @@ module View
             interest_props[:style][:backgroundColor] = color
             interest_props[:style][:color] = contrast_on(color)
           end
-          extra << h(:td, interest_props, @game.format_currency(@game.interest_owed(corporation)).to_s)
+          if @game.corporation_show_interest?
+            extra << h(:td, interest_props,
+                       @game.format_currency(@game.interest_owed(corporation)).to_s)
+          end
         end
         extra << h(:td, @game.corporation_size_name(corporation)) if @diff_corp_sizes
 

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -193,7 +193,7 @@ module View
         extra << h(:th, render_sort_link('Shorts', :shorts)) if @game.respond_to?(:available_shorts)
         if @game.total_loans.positive?
           extra << h(:th, render_sort_link('Buying Power', :buying_power))
-          extra << h(:th, render_sort_link('Interest Due', :interest))
+          extra << h(:th, render_sort_link('Interest Due', :interest)) if @game.corporation_show_interest?
         end
         if (@diff_corp_sizes = @game.all_corporations.any? { |c| @game.corporation_size(c) != :small })
           extra << h(:th, render_sort_link('Size', :corp_size))

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -606,6 +606,7 @@ module Engine
             G1848::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,
+            G1848::Step::BlockingLoan,
             G1848::Step::Dividend,
             Engine::Step::DiscardTrain,
             G1848::Step::SpecialBuyTrain,
@@ -957,6 +958,13 @@ module Engine
 
         def ability_used!(company)
           company.all_abilities.dup.each { |ab| company.remove_ability(ab) }
+        end
+
+        def first_column?(entity)
+          return unless entity.corporation?
+
+          _r, c = entity.share_price.coordinates
+          c == 1
         end
       end
     end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -841,9 +841,21 @@ module Engine
         end
 
         def revenue_for(route, stops)
-          k_sum = stops.count { |rl| rl.hex&.tile&.label&.to_s == 'K' || rl.hex&.tile&.future_label&.label.to_s == 'K' }
-          k_sum = 0 if route.train.name == '2E' # 2E can't get k bonus
-          super + K_BONUS[k_sum]
+          super + K_BONUS[k_sum(route, stops)]
+        end
+
+        def k_sum(route, stops)
+          return 0 if route.train.name == '2E' || !stops
+
+          stops.count { |rl| rl.hex&.tile&.label&.to_s == 'K' || rl.hex&.tile&.future_label&.label.to_s == 'K' }
+        end
+
+        def revenue_str(route)
+          return super unless k_sum(route, route.stops) > 1
+
+          k_sum_string = ' + k'
+          (k_sum(route, route.stops) - 1).times { k_sum_string += '-k' }
+          super + k_sum_string
         end
 
         # recievership

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -289,7 +289,7 @@ module Engine
           {
             name: '2E',
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 2, 'visit' => 99 },
-                       { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
+                       { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
             price: 200,
             num: 10,
             available_on: '5',

--- a/lib/engine/game/g_1848/map.rb
+++ b/lib/engine/game/g_1848/map.rb
@@ -102,7 +102,8 @@ module Engine
             ['A18'] =>
                    'offboard=revenue:yellow_10|green_20|brown_30|gray_40;path=a:5,b:_0;path=a:0,b:_0',
             ['D1'] =>
-                   'city=revenue:yellow_20|green_40|brown_60|gray_80;path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1;path=a:3,b:_0,terminal:1;label=K',
+                   'city=revenue:yellow_20|green_40|brown_60|gray_80;path=a:4,b:_0,terminal:1;' \
+                   'path=a:5,b:_0,terminal:1;path=a:3,b:_0,terminal:1;label=K',
             ['I21'] => 'offboard=revenue:yellow_0|green_100|brown_200|gray_300',
           },
           blue: {

--- a/lib/engine/game/g_1848/map.rb
+++ b/lib/engine/game/g_1848/map.rb
@@ -102,7 +102,7 @@ module Engine
             ['A18'] =>
                    'offboard=revenue:yellow_10|green_20|brown_30|gray_40;path=a:5,b:_0;path=a:0,b:_0',
             ['D1'] =>
-                   'city=revenue:yellow_20|green_40|brown_60|gray_80;path=a:4,b:_0;path=a:5,b:_0;path=a:3,b:_0;label=K',
+                   'city=revenue:yellow_20|green_40|brown_60|gray_80;path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1;path=a:3,b:_0,terminal:1;label=K',
             ['I21'] => 'offboard=revenue:yellow_0|green_100|brown_200|gray_300',
           },
           blue: {

--- a/lib/engine/game/g_1848/step/blocking_loan.rb
+++ b/lib/engine/game/g_1848/step/blocking_loan.rb
@@ -16,7 +16,7 @@ module Engine
             return [] if entity == @game.boe
 
             actions = []
-            actions += %w[take_loan pass] if check_blocking_loan(entity)
+            actions << %w[take_loan pass] if check_blocking_loan(entity)
             actions
           end
 

--- a/lib/engine/game/g_1848/step/blocking_loan.rb
+++ b/lib/engine/game/g_1848/step/blocking_loan.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative 'skip_boe'
+
+module Engine
+  module Game
+    module G1848
+      module Step
+        class BlockingLoan < Engine::Step::Base
+          include SkipBoe
+          # Used when a company is one step away from receivership & places a token.
+          # Should be able to take a loan before receivership
+          def actions(entity)
+            return [] if !entity.corporation? || entity != current_entity
+            return [] if entity == @game.boe
+
+            actions = []
+            actions += %w[take_loan pass] if check_blocking_loan(entity)
+            actions
+          end
+
+          def check_blocking_loan(entity)
+            @game.can_take_loan?(entity) && !@round.loan_taken && @game.first_column?(entity) && entity.trains.empty?
+          end
+
+          def description
+            'Take Loans'
+          end
+
+          def blocks?
+            true
+          end
+
+          def process_take_loan(action)
+            entity = action.entity
+            @game.take_loan(entity, action.loan)
+            @round.loan_taken = true
+          end
+
+          def round_state
+            super.merge({
+                          # has player taken a loan this or already
+                          loan_taken: false,
+                        })
+          end
+
+          def setup
+            # you can only take one loan per OR turn
+            @round.loan_taken = false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1848/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1848/step/buy_sell_par_shares.rb
@@ -25,11 +25,10 @@ module Engine
           def must_sell?(entity)
             return false unless can_sell_any?(entity)
             return true if @game.num_certs(entity) > @game.cert_limit(entity)
-    
+
             !@game.can_hold_above_corp_limit?(entity) &&
               @game.corporations.any? { |corp| !corp.holding_ok?(entity) }
           end
-
         end
       end
     end

--- a/lib/engine/game/g_1848/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1848/step/buy_sell_par_shares.rb
@@ -21,6 +21,15 @@ module Engine
 
             super
           end
+
+          def must_sell?(entity)
+            return false unless can_sell_any?(entity)
+            return true if @game.num_certs(entity) > @game.cert_limit(entity)
+    
+            !@game.can_hold_above_corp_limit?(entity) &&
+              @game.corporations.any? { |corp| !corp.holding_ok?(entity) }
+          end
+
         end
       end
     end


### PR DESCRIPTION
add blocking loan step for cases where a company has 0 trains, one step away from receivership. Should able to put down token and get a loan
add k bonus string revenue
fix perth, fix #8186 
check for player cert limit not game cert limit in must_sell?
fixed #8197 
hide show interest in spreadsheet