### PR TITLE
Show game messages to owner. Make them nicer

### DIFF
--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -196,7 +196,7 @@ module View
             line_props[:style][:fontWeight] = 'bold'
             line_props[:style][:marginTop] = '0.5em'
 
-            sender = line.entity.name || line.user
+            sender = line.entity.name || 'Owner'
             line = "#{sender}: #{line.message}"
           end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -735,7 +735,7 @@ module Engine
       end
 
       def process_single_action(action)
-        if action.user && action.user != acting_for_player(action.entity&.player)&.id
+        if action.user && action.user != acting_for_player(action.entity&.player)&.id && action.type != 'message'
           @log << "• Action(#{action.type}) via Master Mode by: #{player_by_id(action.user)&.name || 'Owner'}"
         end
 

--- a/models/game.rb
+++ b/models/game.rb
@@ -120,7 +120,9 @@ class Game < Base
 
   def to_h(include_actions: false, logged_in_user_id: nil)
     actions_h = include_actions ? actions.map(&:to_h) : []
-    actions_h.reject! { |a| a['type'] == 'message' } unless players.find { |p| p.id == logged_in_user_id }
+    if !players.find { |p| p.id == logged_in_user_id } && user_id != logged_in_user_id
+      actions_h.reject! { |a| a['type'] == 'message' }
+    end
     settings_h = settings.to_h
 
     # Move user settings and hide from other players


### PR DESCRIPTION
Since recently, the messages were being show only to the users in the game, but not to the user that created the game (this is important for the tournaments).

Since a long time ago, when the owner (not in the game) sent a message, the id would show up as the sender and the Master Mode warning would appear. Changed this behaviour.