### PR TITLE
18ny future labels

### DIFF
--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -52,13 +52,6 @@ module Engine
 
         NYC_TOKEN_COST = 40
 
-        # These symbols upgrade to plain tiles in these colours
-        PLAIN_SYMBOL_UPGRADES = {
-          yellow: %w[Br R S],
-          green: %w[Bu Br S],
-          brown: %w[Bu],
-        }.freeze
-
         # Two lays with one being an upgrade. Tile lays cost 20
         TILE_COST = 20
         TILE_LAYS = [
@@ -684,18 +677,7 @@ module Engine
           super
         end
 
-        def tile_lay(_hex, old_tile, new_tile)
-          if old_tile.label
-            # add label to new tile, if this is a plain lay on a label.
-            new_tile.label = old_tile.label.to_s unless new_tile.label
-
-            # remove the label when we remove a temporaily labelled tile.
-            if PLAIN_SYMBOL_UPGRADES.include?(old_tile.color) &&
-               PLAIN_SYMBOL_UPGRADES[old_tile.color].include?(old_tile.label.to_s)
-              old_tile.label = nil
-            end
-          end
-
+        def tile_lay(_hex, old_tile, _new_tile)
           return unless old_tile.icons.any? { |icon| icon.name == ERIE_CANAL_ICON }
 
           @log << "#{erie_canal_private.name}'s revenue reduced from #{format_currency(erie_canal_private.revenue)}" \
@@ -725,18 +707,6 @@ module Engine
           else
             false
           end
-        end
-
-        def upgrades_to_correct_label?(from, to)
-          # handle lays of a plain tile over a hex/tile with a label
-
-          if PLAIN_SYMBOL_UPGRADES.include?(to.color) &&
-             PLAIN_SYMBOL_UPGRADES[to.color].include?(from.label.to_s) &&
-             !to.label
-            return true
-          end
-
-          super
         end
 
         def legal_tile_rotation?(entity, hex, tile)

--- a/lib/engine/game/g_18_ny/map.rb
+++ b/lib/engine/game/g_18_ny/map.rb
@@ -302,8 +302,8 @@ module Engine
             %w[D2] => 'city=revenue:0;upgrade=cost:80,terrain:water',
             %w[D4] => 'city=revenue:0;icon=image:18_ny/canal',
             %w[D14] => 'city=revenue:0;icon=image:18_ny/canal',
-            %w[D8] => 'label=R;city=revenue:0;border=edge:1,type:water,cost:60;icon=image:18_ny/canal',
-            %w[D12] => 'label=S;city=revenue:0;border=edge:3,type:impassable;icon=image:18_ny/canal',
+            %w[D8] => 'future_label=label:R,color:green;city=revenue:0;border=edge:1,type:water,cost:60;icon=image:18_ny/canal',
+            %w[D12] => 'future_label=label:S,color:brown;city=revenue:0;border=edge:3,type:impassable;icon=image:18_ny/canal',
             %w[E5] => 'city=revenue:0;border=edge:4,type:water,cost:60',
             %w[E11] => 'city=revenue:0;border=edge:0,type:impassable;border=edge:1,type:impassable',
             %w[E15] => 'city=revenue:0;border=edge:3,type:water,cost:40;icon=image:18_ny/canal',
@@ -314,11 +314,11 @@ module Engine
             %w[J18] => 'city=revenue:0',
             %w[H20] => 'city=revenue:0;border=edge:0,type:water,cost:80;border=edge:1,type:water,cost:80;' \
                        'border=edge:2,type:water,cost:80',
-            %w[K19] => 'label=Br;city=revenue:0;upgrade=cost:80,terrain:water',
+            %w[K19] => 'future_label=label:Br,color:brown;city=revenue:0;upgrade=cost:80,terrain:water',
           },
           yellow: {
-            %w[E3] => 'label=Bu;city=revenue:20,slots:2;border=edge:1,type:water,cost:80;path=a:2,b:_0;path=a:3,b:_0;' \
-                      'path=a:4,b:_0',
+            %w[E3] => 'future_label=label:Bu,color:gray;city=revenue:20,slots:2;border=edge:1,type:water,cost:80;'\
+                      'path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
             %w[F20] => 'label=A;city=revenue:40;upgrade=cost:80,terrain:water;path=a:0,b:_0;path=a:2,b:_0',
             %w[J20] => 'label=N;city=revenue:50;upgrade=cost:80,terrain:water;path=a:3,b:_0',
           },
@@ -345,7 +345,7 @@ module Engine
             %w[J18] => 'city=revenue:0;border=edge:5,type:water,cost:40',
             %w[K19] => 'town=revenue:0;border=edge:1,type:water,cost:40;border=edge:2,type:water,cost:40;' \
                        'border=edge:4,type:water,cost:80',
-            %w[K21] => 'label=Br;city=revenue:0;border=edge:1,type:water,cost:80',
+            %w[K21] => 'future_label=label:Br,color:brown;city=revenue:0;border=edge:1,type:water,cost:80',
           },
         }.freeze
       end

--- a/spec/fixtures/18NY/91810.json
+++ b/spec/fixtures/18NY/91810.json
@@ -1,0 +1,16232 @@
+{
+    "status": "finished",
+    "actions": [
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 1,
+        "created_at": 1658699340,
+        "company": "WPF",
+        "price": 65
+      },
+      {
+        "type": "bid",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 2,
+        "created_at": 1658699816,
+        "company": "PCF",
+        "price": 85
+      },
+      {
+        "type": "bid",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 3,
+        "created_at": 1658699860,
+        "company": "EC",
+        "price": 145
+      },
+      {
+        "type": "bid",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 4,
+        "created_at": 1658699901,
+        "company": "DPC",
+        "price": 155
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 5,
+        "created_at": 1658700145,
+        "company": "DPC",
+        "price": 160
+      },
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 6,
+        "created_at": 1658700807,
+        "company": "SC",
+        "price": 45
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 7,
+        "created_at": 1658702392
+      },
+      {
+        "type": "bid",
+        "price": 20,
+        "entity": 10188,
+        "company": "AIW",
+        "entity_type": "player",
+        "id": 8,
+        "user": 10188,
+        "created_at": 1658704639,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 9,
+        "user": 10188,
+        "created_at": 1658704665
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 10,
+        "created_at": 1658704730
+      },
+      {
+        "type": "bid",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 11,
+        "created_at": 1658704740,
+        "company": "DPC",
+        "price": 165
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 12,
+        "created_at": 1658707580,
+        "company": "WPF",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 13,
+        "created_at": 1658708297,
+        "company": "AIW",
+        "price": 20
+      },
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 14,
+        "created_at": 1658708325,
+        "company": "WPF",
+        "price": 75
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 15,
+        "created_at": 1658709978,
+        "company": "WPF",
+        "price": 80
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 16,
+        "created_at": 1658710052
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 17,
+        "created_at": 1658711116,
+        "company": "DPC",
+        "price": 170
+      },
+      {
+        "type": "bid",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 18,
+        "created_at": 1658711182,
+        "company": "DPC",
+        "price": 175
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 19,
+        "created_at": 1658712533
+      },
+      {
+        "type": "par",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 20,
+        "created_at": 1658712588,
+        "corporation": "D&H",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "bid",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 21,
+        "created_at": 1658712969,
+        "corporation": "1",
+        "price": 150
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 22,
+        "created_at": 1658713343
+      },
+      {
+        "type": "bid",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 23,
+        "created_at": 1658713393,
+        "corporation": "1",
+        "price": 160
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 24,
+        "created_at": 1658714215
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 25,
+        "created_at": 1658742275
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 26,
+        "created_at": 1658743415
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 27,
+        "created_at": 1658750035
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 28,
+        "created_at": 1658750202,
+        "corporation": "10",
+        "price": 100
+      },
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 29,
+        "created_at": 1658753669,
+        "corporation": "10",
+        "price": 105
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 30,
+        "created_at": 1658756739
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 31,
+        "created_at": 1658759796
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 32,
+        "created_at": 1658762287,
+        "corporation": "10",
+        "price": 110
+      },
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 33,
+        "created_at": 1658763409,
+        "corporation": "10",
+        "price": 115
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 34,
+        "created_at": 1658768262,
+        "corporation": "10",
+        "price": 120
+      },
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 35,
+        "created_at": 1658768963,
+        "corporation": "10",
+        "price": 130
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 36,
+        "created_at": 1658770746
+      },
+      {
+        "type": "bid",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 37,
+        "created_at": 1658771354,
+        "corporation": "5",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 38,
+        "created_at": 1658771753
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 39,
+        "created_at": 1658772166
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 40,
+        "created_at": 1658776697
+      },
+      {
+        "type": "bid",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 41,
+        "created_at": 1658777814,
+        "corporation": "6",
+        "price": 120
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 42,
+        "created_at": 1658778066
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 43,
+        "created_at": 1658779210,
+        "corporation": "6",
+        "price": 140
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 44,
+        "created_at": 1658781522
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 45,
+        "created_at": 1658782566
+      },
+      {
+        "type": "bid",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 46,
+        "created_at": 1658786306,
+        "corporation": "11",
+        "price": 140
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 47,
+        "created_at": 1658786587
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 48,
+        "created_at": 1658788947
+      },
+      {
+        "type": "bid",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 49,
+        "created_at": 1658791199,
+        "corporation": "4",
+        "price": 120
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 50,
+        "created_at": 1658793912
+      },
+      {
+        "type": "bid",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 51,
+        "created_at": 1658794105,
+        "corporation": "9",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 52,
+        "created_at": 1658794618
+      },
+      {
+        "type": "bid",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 53,
+        "created_at": 1658794685,
+        "corporation": "2",
+        "price": 150
+      },
+      {
+        "type": "bid",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 54,
+        "created_at": 1658795384,
+        "corporation": "8",
+        "price": 110
+      },
+      {
+        "type": "lay_tile",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 55,
+        "created_at": 1658795418,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1658795420
+          }
+        ],
+        "hex": "G19",
+        "tile": "4-0",
+        "rotation": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 56,
+        "created_at": 1658795421,
+        "train": "2H-0",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 57,
+        "created_at": 1658795422,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1658795423
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 58,
+        "created_at": 1658796356,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1658796355
+          }
+        ],
+        "hex": "E19",
+        "tile": "6-0",
+        "rotation": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 59,
+        "created_at": 1658796360,
+        "loan": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 60,
+        "created_at": 1658796363,
+        "train": "2H-1",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 61,
+        "created_at": 1658796373,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1658796373
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 62,
+        "created_at": 1658798145,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1658798145
+          }
+        ],
+        "hex": "D4",
+        "tile": "5-0",
+        "rotation": 5
+      },
+      {
+        "type": "buy_train",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 63,
+        "created_at": 1658798153,
+        "train": "2H-2",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 64,
+        "created_at": 1658798158,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1658798158
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 65,
+        "created_at": 1658798168,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1658798168
+          }
+        ],
+        "hex": "E5",
+        "tile": "5-1",
+        "rotation": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 66,
+        "created_at": 1658798173,
+        "train": "2H-3",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 67,
+        "created_at": 1658798178,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1658798178
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 68,
+        "created_at": 1658798338,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1658798339
+          }
+        ],
+        "hex": "D12",
+        "tile": "6-1",
+        "rotation": 4
+      },
+      {
+        "type": "buy_train",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 69,
+        "created_at": 1658798358,
+        "train": "2H-4",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 70,
+        "created_at": 1658798363,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1658798365
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 71,
+        "created_at": 1658799147,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1658799146
+          }
+        ],
+        "hex": "E15",
+        "tile": "6-2",
+        "rotation": 2
+      },
+      {
+        "type": "buy_train",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 72,
+        "created_at": 1658799158,
+        "train": "2H-5",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 73,
+        "created_at": 1658799163,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1658799162
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 74,
+        "created_at": 1658838285,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1658838285
+          }
+        ],
+        "hex": "D2",
+        "tile": "6-3",
+        "rotation": 5
+      },
+      {
+        "type": "take_loan",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 75,
+        "created_at": 1658838290,
+        "loan": 1
+      },
+      {
+        "type": "take_loan",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 76,
+        "created_at": 1658838294,
+        "loan": 2
+      },
+      {
+        "type": "buy_train",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 77,
+        "created_at": 1658838297,
+        "train": "2H-6",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 78,
+        "created_at": 1658838300,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1658838299
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 79,
+        "created_at": 1658841792,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1658841794
+          }
+        ],
+        "hex": "E11",
+        "tile": "5-2",
+        "rotation": 3
+      },
+      {
+        "type": "take_loan",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 80,
+        "created_at": 1658841808,
+        "loan": 3
+      },
+      {
+        "type": "buy_train",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 81,
+        "created_at": 1658841811,
+        "train": "2H-7",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 82,
+        "created_at": 1658842039,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1658842041
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "created_at": 1658846475,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 83,
+        "user": 10188,
+        "created_at": 1658846476,
+        "skip": true
+      },
+      {
+        "type": "buy_train",
+        "price": 100,
+        "train": "2H-8",
+        "entity": "9",
+        "variant": "2H",
+        "entity_type": "corporation",
+        "id": 84,
+        "user": 10188,
+        "created_at": 1658846478,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 85,
+        "user": 10188,
+        "created_at": 1658846484
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 86,
+        "user": 10188,
+        "created_at": 1658846489
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 87,
+        "created_at": 1658846497,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1658846497
+          }
+        ]
+      },
+      {
+        "type": "buy_train",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 88,
+        "created_at": 1658846506,
+        "train": "2H-8",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 89,
+        "created_at": 1658846515,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1658846515
+          }
+        ]
+      },
+      {
+        "hex": "H14",
+        "tile": "6-4",
+        "type": "lay_tile",
+        "entity": "D&H",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 90,
+        "user": 5944,
+        "created_at": 1658846994,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "action_id": 89,
+        "entity_type": "corporation",
+        "id": 91,
+        "user": 5944,
+        "created_at": 1658847750
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 92,
+        "created_at": 1658847757,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1658847757
+          }
+        ]
+      },
+      {
+        "type": "buy_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 93,
+        "created_at": 1658847758,
+        "train": "2H-9",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "buy_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 94,
+        "created_at": 1658847759,
+        "train": "2H-10",
+        "price": 100,
+        "variant": "2H"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 95,
+        "created_at": 1658848222,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1658848221
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 96,
+        "user": 5944,
+        "created_at": 1658848224,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 97,
+        "user": 5944,
+        "created_at": 1658848227
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 98,
+        "created_at": 1658848232
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 99,
+        "created_at": 1658848335,
+        "shares": [
+          "D&H_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 100,
+        "created_at": 1658848338
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 101,
+        "created_at": 1658848399
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 102,
+        "created_at": 1658849229
+      },
+      {
+        "type": "lay_tile",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 103,
+        "created_at": 1658850409,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1658850408
+          }
+        ],
+        "hex": "H18",
+        "tile": "8-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 104,
+        "created_at": 1658850413,
+        "routes": [
+          {
+            "train": "2H-0",
+            "connections": [
+              [
+                "E19",
+                "F20"
+              ],
+              [
+                "F20",
+                "G19"
+              ]
+            ],
+            "hexes": [
+              "E19",
+              "F20",
+              "G19"
+            ],
+            "revenue": 70,
+            "revenue_str": "E19-F20-G19",
+            "nodes": [
+              "E19-0",
+              "F20-1",
+              "G19-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 105,
+        "created_at": 1658850416,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1658850416
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 106,
+        "created_at": 1658854050,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1658854050
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 107,
+        "created_at": 1658854054,
+        "routes": [
+          {
+            "train": "2H-2",
+            "connections": [
+              [
+                "D4",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "D4",
+              "E3",
+              "E5"
+            ],
+            "revenue": 60,
+            "revenue_str": "D4-E3-E5",
+            "nodes": [
+              "D4-0",
+              "E3-1",
+              "E5-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 108,
+        "created_at": 1658854073,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1658854073
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 109,
+        "created_at": 1658854079,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1658854079
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 110,
+        "created_at": 1658854089,
+        "routes": [
+          {
+            "train": "2H-3",
+            "connections": [
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ]
+            ],
+            "hexes": [
+              "E3",
+              "E5",
+              "D4"
+            ],
+            "revenue": 60,
+            "revenue_str": "E3-E5-D4",
+            "nodes": [
+              "E3-1",
+              "E5-0",
+              "D4-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "buy_train",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 111,
+        "created_at": 1658854101,
+        "train": "2H-2",
+        "price": 50
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 112,
+        "created_at": 1658854105,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1658854105
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 113,
+        "created_at": 1658857813,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1658857868
+          }
+        ],
+        "hex": "D20",
+        "tile": "3-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 114,
+        "created_at": 1658857826,
+        "routes": [
+          {
+            "train": "2H-1",
+            "connections": [
+              [
+                "E19",
+                "D20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D20",
+              "E19",
+              "F20"
+            ],
+            "revenue": 70,
+            "revenue_str": "D20-E19-F20",
+            "nodes": [
+              "E19-0",
+              "D20-0",
+              "F20-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 115,
+        "created_at": 1658857833,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1658857888
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 116,
+        "created_at": 1658865396,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1658865397
+          }
+        ],
+        "hex": "D14",
+        "tile": "57-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 117,
+        "created_at": 1658865410,
+        "routes": [
+          {
+            "train": "2H-4",
+            "connections": [
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "E11",
+                "D12"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "D12",
+              "E11"
+            ],
+            "revenue": 60,
+            "revenue_str": "D14-D12-E11",
+            "nodes": [
+              "D12-0",
+              "D14-0",
+              "E11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 118,
+        "created_at": 1658865425,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1658865426
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 119,
+        "created_at": 1658865774,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1658865829
+          }
+        ],
+        "hex": "E17",
+        "tile": "9-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 120,
+        "created_at": 1658865781,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1658865836
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 121,
+        "created_at": 1658867253,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1658867252
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 122,
+        "created_at": 1658867274,
+        "routes": [
+          {
+            "train": "2H-8",
+            "connections": [
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "D4",
+                "E3"
+              ]
+            ],
+            "hexes": [
+              "D2",
+              "E3",
+              "D4"
+            ],
+            "revenue": 60,
+            "revenue_str": "D2-E3-D4",
+            "nodes": [
+              "E3-1",
+              "D2-0",
+              "D4-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 123,
+        "created_at": 1658867279,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1658867279
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 124,
+        "created_at": 1658871457,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1658871458
+          }
+        ],
+        "hex": "E13",
+        "tile": "9-1",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 125,
+        "created_at": 1658871474,
+        "routes": [
+          {
+            "train": "2H-7",
+            "connections": [
+              [
+                "E11",
+                "D12"
+              ]
+            ],
+            "hexes": [
+              "D12",
+              "E11"
+            ],
+            "revenue": 40,
+            "revenue_str": "D12-E11",
+            "nodes": [
+              "E11-0",
+              "D12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 126,
+        "created_at": 1658871497,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1658871499
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 127,
+        "created_at": 1658874786,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1658874785
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 128,
+        "created_at": 1658874793,
+        "routes": [
+          {
+            "train": "2H-6",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3"
+            ],
+            "revenue": 60,
+            "revenue_str": "D0-D2-E3",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 129,
+        "created_at": 1658874800,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1658874799
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 130,
+        "created_at": 1658876155,
+        "hex": "H14",
+        "tile": "6-4",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 131,
+        "created_at": 1658876160,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1658876158
+          }
+        ],
+        "hex": "G13",
+        "tile": "3-1",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 132,
+        "created_at": 1658876170,
+        "routes": [
+          {
+            "train": "2H-10",
+            "connections": [
+              [
+                "H14",
+                "I13"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "I13"
+            ],
+            "revenue": 40,
+            "revenue_str": "H14-I13",
+            "nodes": [
+              "H14-0",
+              "I13-0"
+            ]
+          },
+          {
+            "train": "2H-9",
+            "connections": [
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 50,
+            "revenue_str": "H14-G13-H12",
+            "nodes": [
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 133,
+        "created_at": 1658876173,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 134,
+        "created_at": 1658876200,
+        "train": "2H-0",
+        "price": 70
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 135,
+        "created_at": 1658876217,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1658876215
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 136,
+        "created_at": 1658876220
+      },
+      {
+        "type": "par",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 137,
+        "created_at": 1658887680,
+        "corporation": "RWO",
+        "share_price": "70,4,4"
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 138,
+        "created_at": 1658888291
+      },
+      {
+        "type": "sell_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 139,
+        "created_at": 1658924164,
+        "shares": [
+          "D&H_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 140,
+        "created_at": 1658924241,
+        "corporation": "NY&H",
+        "share_price": "80,2,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 141,
+        "created_at": 1658931021,
+        "shares": [
+          "D&H_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 142,
+        "created_at": 1658931025,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1658931026
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 143,
+        "created_at": 1658932117,
+        "shares": [
+          "D&H_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 144,
+        "created_at": 1658932123
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 145,
+        "created_at": 1658935323
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 146,
+        "created_at": 1658938179,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1658938179,
+            "reason": "Corian09 bought on corporation D&H and is unsecure"
+          }
+        ],
+        "shares": [
+          "NY&H_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 147,
+        "created_at": 1658938221
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 148,
+        "created_at": 1658943275,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1658943275
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 149,
+        "created_at": 1658945761
+      },
+      {
+        "type": "lay_tile",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 150,
+        "created_at": 1658946382,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1658946383
+          }
+        ],
+        "hex": "I19",
+        "tile": "4-1",
+        "rotation": 2
+      },
+      {
+        "type": "take_loan",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 151,
+        "created_at": 1658946391,
+        "loan": 6
+      },
+      {
+        "type": "take_loan",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 152,
+        "created_at": 1658946392,
+        "loan": 7
+      },
+      {
+        "type": "buy_train",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 153,
+        "created_at": 1658946392,
+        "train": "4H-0",
+        "price": 200,
+        "variant": "4H"
+      },
+      {
+        "type": "pass",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 154,
+        "created_at": 1658946395,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1658946395
+          }
+        ]
+      },
+      {
+        "hex": "E19",
+        "tile": "619-0",
+        "type": "lay_tile",
+        "entity": "2",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 155,
+        "user": 3828,
+        "created_at": 1658947565,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "created_at": 1658947631,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 156,
+        "user": 3828,
+        "created_at": 1658947574,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "2",
+        "routes": [
+          {
+            "hexes": [
+              "D20",
+              "E19",
+              "F20"
+            ],
+            "nodes": [
+              "E19-0",
+              "D20-0",
+              "F20-1"
+            ],
+            "train": "2H-1",
+            "revenue": 80,
+            "connections": [
+              [
+                "E19",
+                "D20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "revenue_str": "D20-E19-F20"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 157,
+        "user": 3828,
+        "created_at": 1658947578,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "created_at": 1658947639,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 158,
+        "user": 3828,
+        "created_at": 1658947582,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 159,
+        "user": 3828,
+        "created_at": 1658947586,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 160,
+        "user": 3828,
+        "created_at": 1658947622
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 161,
+        "user": 3828,
+        "created_at": 1658947624
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 162,
+        "user": 3828,
+        "created_at": 1658947627
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 163,
+        "user": 3828,
+        "created_at": 1658947629
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 164,
+        "user": 3828,
+        "created_at": 1658947630
+      },
+      {
+        "type": "lay_tile",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 165,
+        "created_at": 1658947638,
+        "hex": "E19",
+        "tile": "619-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 166,
+        "created_at": 1658947651,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1658947708
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 167,
+        "created_at": 1658947654,
+        "routes": [
+          {
+            "train": "2H-1",
+            "connections": [
+              [
+                "E19",
+                "D20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D20",
+              "E19",
+              "F20"
+            ],
+            "revenue": 80,
+            "revenue_str": "D20-E19-F20",
+            "nodes": [
+              "E19-0",
+              "D20-0",
+              "F20-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 168,
+        "created_at": 1658947655,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1658947712
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 169,
+        "created_at": 1658947661
+      },
+      {
+        "hex": "D16",
+        "tile": "9-2",
+        "type": "lay_tile",
+        "entity": "10",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 170,
+        "user": 480,
+        "created_at": 1658959676,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 171,
+        "user": 480,
+        "created_at": 1658959693
+      },
+      {
+        "type": "lay_tile",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 172,
+        "created_at": 1658959710,
+        "hex": "D12",
+        "tile": "15-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 173,
+        "created_at": 1658959715,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1658959714
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 174,
+        "created_at": 1658959721,
+        "routes": [
+          {
+            "train": "2H-4",
+            "connections": [
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "E11",
+                "D12"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "D12",
+              "E11"
+            ],
+            "revenue": 70,
+            "revenue_str": "D14-D12-E11",
+            "nodes": [
+              "D12-0",
+              "D14-0",
+              "E11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 175,
+        "created_at": 1658959733,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1658959732
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 176,
+        "created_at": 1658959762
+      },
+      {
+        "hex": "E3",
+        "tile": "15-1",
+        "type": "lay_tile",
+        "entity": "6",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 177,
+        "user": 4473,
+        "created_at": 1658963324,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 178,
+        "user": 4473,
+        "created_at": 1658963331
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 179,
+        "created_at": 1658963340,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1658963340
+          }
+        ]
+      },
+      {
+        "loan": 10,
+        "type": "take_loan",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 180,
+        "user": 4473,
+        "created_at": 1658963348,
+        "skip": true
+      },
+      {
+        "loan": 11,
+        "type": "take_loan",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 181,
+        "user": 4473,
+        "created_at": 1658963349,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 182,
+        "user": 4473,
+        "created_at": 1658963359
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 183,
+        "user": 4473,
+        "created_at": 1658963362
+      },
+      {
+        "loan": 10,
+        "type": "take_loan",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 184,
+        "user": 4473,
+        "created_at": 1658963379,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 185,
+        "user": 4473,
+        "created_at": 1658963393
+      },
+      {
+        "type": "buy_train",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 186,
+        "created_at": 1658963399,
+        "train": "2H-2",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 187,
+        "created_at": 1658963402,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1658963401
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 188,
+        "created_at": 1658963417,
+        "hex": "E5",
+        "tile": "619-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 189,
+        "created_at": 1658963420,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1658963419
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 190,
+        "created_at": 1658963427,
+        "routes": [
+          {
+            "train": "2H-3",
+            "connections": [
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ]
+            ],
+            "hexes": [
+              "E3",
+              "E5",
+              "D4"
+            ],
+            "revenue": 70,
+            "revenue_str": "E3-E5-D4",
+            "nodes": [
+              "E3-1",
+              "E5-0",
+              "D4-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "scrap_train",
+        "train": "2H-3",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 191,
+        "user": 4473,
+        "created_at": 1658963434,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 192,
+        "user": 4473,
+        "created_at": 1658963442
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 193,
+        "created_at": 1658963448,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1658963447
+          }
+        ]
+      },
+      {
+        "type": "buy_company",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 194,
+        "created_at": 1658963457,
+        "company": "WPF",
+        "price": 115
+      },
+      {
+        "type": "lay_tile",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 195,
+        "created_at": 1658966988,
+        "hex": "D4",
+        "tile": "15-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 196,
+        "created_at": 1658966990,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1658966990
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 197,
+        "created_at": 1658967002,
+        "routes": [
+          {
+            "train": "2H-8",
+            "connections": [
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "E3"
+              ]
+            ],
+            "hexes": [
+              "E5",
+              "D4",
+              "E3"
+            ],
+            "revenue": 80,
+            "revenue_str": "E5-D4-E3",
+            "nodes": [
+              "E5-0",
+              "D4-0",
+              "E3-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 198,
+        "created_at": 1658967029,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1658967029
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 199,
+        "created_at": 1658967034
+      },
+      {
+        "type": "lay_tile",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 200,
+        "created_at": 1658968011,
+        "hex": "E11",
+        "tile": "15-2",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 201,
+        "created_at": 1658968021,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1658968025
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 202,
+        "created_at": 1658968032,
+        "routes": [
+          {
+            "train": "2H-7",
+            "connections": [
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D12",
+                "D14"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "D12",
+              "D14"
+            ],
+            "revenue": 80,
+            "revenue_str": "E11-D12-D14",
+            "nodes": [
+              "E11-0",
+              "D12-0",
+              "D14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 203,
+        "created_at": 1658968048,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1658968052
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 204,
+        "created_at": 1658968055
+      },
+      {
+        "type": "lay_tile",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 205,
+        "created_at": 1658969541,
+        "hex": "D2",
+        "tile": "15-3",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 206,
+        "created_at": 1658969548,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1658969549
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 207,
+        "created_at": 1658969563,
+        "routes": [
+          {
+            "train": "2H-6",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "D4"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "D4"
+            ],
+            "revenue": 90,
+            "revenue_str": "D0-D2-D4",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "D4-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 208,
+        "created_at": 1658969572,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1658969573
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 209,
+        "created_at": 1658969574
+      },
+      {
+        "type": "lay_tile",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 210,
+        "created_at": 1658970298,
+        "hex": "D14",
+        "tile": "15-4",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 211,
+        "created_at": 1658970302,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1658970301
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 212,
+        "created_at": 1658970307,
+        "routes": [
+          {
+            "train": "2H-5",
+            "connections": [
+              [
+                "D14",
+                "D12"
+              ],
+              [
+                "E15",
+                "D14"
+              ]
+            ],
+            "hexes": [
+              "D12",
+              "D14",
+              "E15"
+            ],
+            "revenue": 80,
+            "revenue_str": "D12-D14-E15",
+            "nodes": [
+              "D14-0",
+              "D12-0",
+              "E15-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 213,
+        "created_at": 1658970310,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1658970310
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 214,
+        "created_at": 1658970313
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 215,
+        "created_at": 1658971314,
+        "hex": "H14",
+        "tile": "15-5",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 216,
+        "created_at": 1658971319,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1658971319
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 217,
+        "created_at": 1658971321,
+        "routes": [
+          {
+            "train": "2H-0",
+            "connections": [
+              [
+                "H14",
+                "I13"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "I13"
+            ],
+            "revenue": 60,
+            "revenue_str": "H14-I13",
+            "nodes": [
+              "H14-0",
+              "I13-0"
+            ]
+          },
+          {
+            "train": "2H-10",
+            "connections": [
+              [
+                "H14",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "H12"
+            ],
+            "revenue": 60,
+            "revenue_str": "H14-H12",
+            "nodes": [
+              "H14-0",
+              "H12-0"
+            ]
+          },
+          {
+            "train": "2H-9",
+            "connections": [
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 70,
+            "revenue_str": "H14-G13-H12",
+            "nodes": [
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 218,
+        "created_at": 1658971326,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 219,
+        "created_at": 1658971330,
+        "train": "4H-1",
+        "price": 200,
+        "variant": "4H"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 220,
+        "created_at": 1658971334,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1658971334
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 221,
+        "created_at": 1658971337
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 222,
+        "created_at": 1658972942,
+        "hex": "J20",
+        "tile": "X11-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 223,
+        "created_at": 1658972948,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1658972947
+          }
+        ]
+      },
+      {
+        "loan": 10,
+        "type": "take_loan",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 224,
+        "user": 10188,
+        "created_at": 1658972952,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 225,
+        "user": 10188,
+        "created_at": 1658972959
+      },
+      {
+        "type": "buy_train",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 226,
+        "created_at": 1658972970,
+        "train": "4H-2",
+        "price": 200,
+        "variant": "4H"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 227,
+        "created_at": 1658972973,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1658972973
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 228,
+        "created_at": 1658973077,
+        "hex": "E15",
+        "tile": "619-2",
+        "rotation": 4
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 229,
+        "user": 480,
+        "created_at": 1658973118
+      },
+      {
+        "skip": true,
+        "type": "redo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 230,
+        "user": 480,
+        "created_at": 1658973124
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 231,
+        "created_at": 1658973133
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 232,
+        "created_at": 1658973141,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1658973141
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 233,
+        "created_at": 1658973148,
+        "loan": 10
+      },
+      {
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 234,
+        "created_at": 1658973152,
+        "loan": 11
+      },
+      {
+        "type": "buy_train",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 235,
+        "created_at": 1658973157,
+        "train": "4H-3",
+        "price": 200,
+        "variant": "4H"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 236,
+        "created_at": 1658973199,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1658973199
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 237,
+        "created_at": 1658973220
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 238,
+        "created_at": 1658973424,
+        "shares": [
+          "NY&H_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 239,
+        "created_at": 1658973429
+      },
+      {
+        "type": "sell_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 240,
+        "created_at": 1658975824,
+        "shares": [
+          "D&H_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 241,
+        "created_at": 1658975844,
+        "corporation": "ERIE",
+        "share_price": "90,1,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 242,
+        "created_at": 1659002972,
+        "shares": [
+          "RWO_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 243,
+        "created_at": 1659002988
+      },
+      {
+        "type": "bid",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 244,
+        "created_at": 1659010313,
+        "corporation": "3",
+        "price": 190
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 245,
+        "created_at": 1659013031,
+        "shares": [
+          "NY&H_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 246,
+        "created_at": 1659013070
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 247,
+        "created_at": 1659013577
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 248,
+        "created_at": 1659016305,
+        "shares": [
+          "ERIE_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 249,
+        "created_at": 1659031327
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 250,
+        "created_at": 1659034023
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 251,
+        "created_at": 1659034068
+      },
+      {
+        "type": "lay_tile",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 252,
+        "created_at": 1659037520,
+        "hex": "D18",
+        "tile": "3-2",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 253,
+        "created_at": 1659037525,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1659037525
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 254,
+        "created_at": 1659037533,
+        "routes": [
+          {
+            "train": "2H-1",
+            "connections": [
+              [
+                "E19",
+                "D18"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D18",
+              "E19",
+              "F20"
+            ],
+            "revenue": 80,
+            "revenue_str": "D18-E19-F20",
+            "nodes": [
+              "E19-0",
+              "D18-0",
+              "F20-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 255,
+        "created_at": 1659037536,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1659037536
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 256,
+        "created_at": 1659037539
+      },
+      {
+        "type": "lay_tile",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 257,
+        "created_at": 1659041897,
+        "hex": "D8",
+        "tile": "57-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "3",
+            "created_at": 1659041961,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 258,
+        "user": 3828,
+        "created_at": 1659041904,
+        "skip": true
+      },
+      {
+        "loan": 12,
+        "type": "take_loan",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 259,
+        "user": 3828,
+        "created_at": 1659041913,
+        "skip": true
+      },
+      {
+        "type": "buy_train",
+        "price": 200,
+        "train": "4H-4",
+        "entity": "3",
+        "variant": "4H",
+        "entity_type": "corporation",
+        "id": 260,
+        "user": 3828,
+        "created_at": 1659041917,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "3",
+            "created_at": 1659041988,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 261,
+        "user": 3828,
+        "created_at": 1659041931,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 262,
+        "user": 3828,
+        "created_at": 1659041936,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 263,
+        "user": 3828,
+        "created_at": 1659042061
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 264,
+        "user": 3828,
+        "created_at": 1659042066
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 265,
+        "user": 3828,
+        "created_at": 1659042072
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 266,
+        "user": 3828,
+        "created_at": 1659042081
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 267,
+        "user": 3828,
+        "created_at": 1659042085
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 268,
+        "created_at": 1659042095,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "3",
+            "entity_type": "corporation",
+            "created_at": 1659042152
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 269,
+        "created_at": 1659042097,
+        "loan": 12
+      },
+      {
+        "type": "buy_train",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 270,
+        "created_at": 1659042101,
+        "train": "4H-4",
+        "price": 200,
+        "variant": "4H"
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 271,
+        "created_at": 1659042120,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "3",
+            "entity_type": "corporation",
+            "created_at": 1659042178
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 272,
+        "created_at": 1659042123
+      },
+      {
+        "type": "lay_tile",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 273,
+        "created_at": 1659044029,
+        "hex": "D10",
+        "tile": "8-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 274,
+        "created_at": 1659044040,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1659044040
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 275,
+        "created_at": 1659044053,
+        "routes": [
+          {
+            "train": "2H-4",
+            "connections": [
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "E11",
+                "D12"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "D12",
+              "E11"
+            ],
+            "revenue": 90,
+            "revenue_str": "D14-D12-E11",
+            "nodes": [
+              "D12-0",
+              "D14-0",
+              "E11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 276,
+        "created_at": 1659044063,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1659044063
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 277,
+        "created_at": 1659044083
+      },
+      {
+        "type": "lay_tile",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 278,
+        "created_at": 1659045535,
+        "hex": "E3",
+        "tile": "15-6",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 279,
+        "created_at": 1659045540,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1659045539
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 280,
+        "created_at": 1659045544,
+        "routes": [
+          {
+            "train": "2H-3",
+            "connections": [
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ]
+            ],
+            "hexes": [
+              "E3",
+              "E5",
+              "D4"
+            ],
+            "revenue": 90,
+            "revenue_str": "E3-E5-D4",
+            "nodes": [
+              "E3-0",
+              "E5-0",
+              "D4-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 281,
+        "created_at": 1659045570,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1659045570
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 282,
+        "created_at": 1659045578,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1659045577
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 283,
+        "created_at": 1659045616,
+        "routes": [
+          {
+            "train": "4H-0",
+            "connections": [
+              [
+                "F20",
+                "G19"
+              ],
+              [
+                "G19",
+                "H18",
+                "I19"
+              ],
+              [
+                "I19",
+                "J20"
+              ]
+            ],
+            "hexes": [
+              "F20",
+              "G19",
+              "I19",
+              "J20"
+            ],
+            "revenue": 130,
+            "revenue_str": "F20-G19-I19-J20",
+            "nodes": [
+              "F20-1",
+              "G19-0",
+              "I19-0",
+              "J20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 284,
+        "created_at": 1659045627,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1659045628
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 285,
+        "created_at": 1659045629
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 286,
+        "created_at": 1659045665,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1659045664
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 287,
+        "created_at": 1659045668,
+        "routes": [
+          {
+            "train": "2H-2",
+            "connections": [
+              [
+                "D4",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "D4",
+              "E3",
+              "E5"
+            ],
+            "revenue": 90,
+            "revenue_str": "D4-E3-E5",
+            "nodes": [
+              "D4-0",
+              "E3-0",
+              "E5-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 288,
+        "created_at": 1659045669,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1659045669
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 289,
+        "created_at": 1659045670
+      },
+      {
+        "hex": "D6",
+        "tile": "7-0",
+        "type": "lay_tile",
+        "entity": "9",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 290,
+        "user": 10188,
+        "created_at": 1659049518,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 291,
+        "user": 10188,
+        "created_at": 1659049526
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 292,
+        "created_at": 1659049529,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1659049529
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 293,
+        "created_at": 1659049539,
+        "routes": [
+          {
+            "train": "2H-8",
+            "connections": [
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ]
+            ],
+            "hexes": [
+              "E3",
+              "D4",
+              "D2"
+            ],
+            "revenue": 90,
+            "revenue_str": "E3-D4-D2",
+            "nodes": [
+              "E3-0",
+              "D4-0",
+              "D2-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 294,
+        "created_at": 1659049542,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1659049541
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 295,
+        "created_at": 1659049544
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 296,
+        "created_at": 1659049554,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1659049553
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 297,
+        "created_at": 1659049559,
+        "routes": [
+          {
+            "train": "2H-6",
+            "connections": [
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ]
+            ],
+            "hexes": [
+              "D4",
+              "D2",
+              "E3"
+            ],
+            "revenue": 90,
+            "revenue_str": "D4-D2-E3",
+            "nodes": [
+              "D4-0",
+              "D2-0",
+              "E3-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 298,
+        "created_at": 1659049564,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1659049564
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 299,
+        "created_at": 1659049567
+      },
+      {
+        "type": "lay_tile",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 300,
+        "created_at": 1659051059,
+        "hex": "D10",
+        "tile": "22-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 301,
+        "created_at": 1659051066,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1659051066
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 302,
+        "created_at": 1659051072,
+        "routes": [
+          {
+            "train": "2H-7",
+            "connections": [
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D12",
+                "D14"
+              ]
+            ],
+            "hexes": [
+              "E11",
+              "D12",
+              "D14"
+            ],
+            "revenue": 90,
+            "revenue_str": "E11-D12-D14",
+            "nodes": [
+              "E11-0",
+              "D12-0",
+              "D14-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 303,
+        "created_at": 1659051078,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1659051077
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 304,
+        "created_at": 1659051920,
+        "hex": "D8",
+        "tile": "X13-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 305,
+        "created_at": 1659051927,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1659051927
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 306,
+        "created_at": 1659051936,
+        "routes": [
+          {
+            "train": "2H-5",
+            "connections": [
+              [
+                "D14",
+                "D12"
+              ],
+              [
+                "E15",
+                "D14"
+              ]
+            ],
+            "hexes": [
+              "D12",
+              "D14",
+              "E15"
+            ],
+            "revenue": 90,
+            "revenue_str": "D12-D14-E15",
+            "nodes": [
+              "D14-0",
+              "D12-0",
+              "E15-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 307,
+        "created_at": 1659051940,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1659051940
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 308,
+        "created_at": 1659051945
+      },
+      {
+        "hex": "I15",
+        "tile": "8-2",
+        "type": "lay_tile",
+        "entity": "D&H",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 309,
+        "user": 5944,
+        "created_at": 1659051971,
+        "skip": true
+      },
+      {
+        "hex": "G13",
+        "tile": "5-3",
+        "type": "lay_tile",
+        "entity": "D&H",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 310,
+        "user": 5944,
+        "created_at": 1659051979,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "created_at": 1659051983,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 311,
+        "user": 5944,
+        "created_at": 1659051982,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "routes": [
+          {
+            "hexes": [
+              "H14",
+              "J14"
+            ],
+            "nodes": [
+              "H14-0",
+              "J14-0"
+            ],
+            "train": "4H-1",
+            "revenue": 60,
+            "connections": [
+              [
+                "H14",
+                "I15",
+                "J14"
+              ]
+            ],
+            "revenue_str": "H14-J14"
+          },
+          {
+            "hexes": [
+              "H14",
+              "I13"
+            ],
+            "nodes": [
+              "H14-0",
+              "I13-0"
+            ],
+            "train": "2H-0",
+            "revenue": 60,
+            "connections": [
+              [
+                "H14",
+                "I13"
+              ]
+            ],
+            "revenue_str": "H14-I13"
+          },
+          {
+            "hexes": [
+              "H14",
+              "H12"
+            ],
+            "nodes": [
+              "H14-0",
+              "H12-0"
+            ],
+            "train": "2H-10",
+            "revenue": 60,
+            "connections": [
+              [
+                "H14",
+                "H12"
+              ]
+            ],
+            "revenue_str": "H14-H12"
+          },
+          {
+            "hexes": [
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "nodes": [
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ],
+            "train": "2H-9",
+            "revenue": 80,
+            "connections": [
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "revenue_str": "H14-G13-H12"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 312,
+        "user": 5944,
+        "created_at": 1659051985,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 313,
+        "user": 5944,
+        "created_at": 1659051990,
+        "skip": true
+      },
+      {
+        "type": "scrap_train",
+        "train": "2H-9",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 314,
+        "user": 5944,
+        "created_at": 1659051998,
+        "skip": true
+      },
+      {
+        "type": "scrap_train",
+        "train": "2H-10",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 315,
+        "user": 5944,
+        "created_at": 1659052001,
+        "skip": true
+      },
+      {
+        "type": "scrap_train",
+        "train": "2H-0",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 316,
+        "user": 5944,
+        "created_at": 1659052003,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "action_id": 308,
+        "entity_type": "corporation",
+        "id": 317,
+        "user": 5944,
+        "created_at": 1659052028
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "created_at": 1659052030,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 318,
+        "user": 5944,
+        "created_at": 1659052029,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 319,
+        "user": 5944,
+        "created_at": 1659052036
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 320,
+        "created_at": 1659052038,
+        "hex": "I15",
+        "tile": "8-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 321,
+        "created_at": 1659052041,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659052042
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 322,
+        "created_at": 1659052043,
+        "routes": [
+          {
+            "train": "4H-1",
+            "connections": [
+              [
+                "H14",
+                "I15",
+                "J14"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "J14"
+            ],
+            "revenue": 60,
+            "revenue_str": "H14-J14",
+            "nodes": [
+              "H14-0",
+              "J14-0"
+            ]
+          },
+          {
+            "train": "2H-0",
+            "connections": [
+              [
+                "H14",
+                "I13"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "I13"
+            ],
+            "revenue": 60,
+            "revenue_str": "H14-I13",
+            "nodes": [
+              "H14-0",
+              "I13-0"
+            ]
+          },
+          {
+            "train": "2H-10",
+            "connections": [
+              [
+                "H14",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "H12"
+            ],
+            "revenue": 60,
+            "revenue_str": "H14-H12",
+            "nodes": [
+              "H14-0",
+              "H12-0"
+            ]
+          },
+          {
+            "train": "2H-9",
+            "connections": [
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 70,
+            "revenue_str": "H14-G13-H12",
+            "nodes": [
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 323,
+        "created_at": 1659052044,
+        "kind": "payout"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 324,
+        "created_at": 1659052045,
+        "train": "2H-9"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 325,
+        "created_at": 1659052047,
+        "train": "2H-10"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 326,
+        "created_at": 1659052048,
+        "train": "2H-0"
+      },
+      {
+        "type": "buy_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 327,
+        "created_at": 1659052050,
+        "train": "4H-5",
+        "price": 200,
+        "variant": "4H"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 328,
+        "created_at": 1659052051,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659052053
+          }
+        ]
+      },
+      {
+        "hex": "D6",
+        "tile": "7-0",
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 329,
+        "user": 4473,
+        "created_at": 1659052076,
+        "skip": true
+      },
+      {
+        "hex": "F4",
+        "tile": "9-2",
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 330,
+        "user": 4473,
+        "created_at": 1659052083,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 331,
+        "user": 4473,
+        "created_at": 1659052085,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "created_at": 1659052092,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 332,
+        "user": 4473,
+        "created_at": 1659052093,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "ERIE",
+        "action_id": 328,
+        "entity_type": "corporation",
+        "id": 333,
+        "user": 4473,
+        "created_at": 1659052102
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 334,
+        "created_at": 1659052104
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 335,
+        "created_at": 1659052106,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659052105
+          }
+        ]
+      },
+      {
+        "type": "sell_shares",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 336,
+        "created_at": 1659052107,
+        "shares": [
+          "ERIE_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_train",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 337,
+        "created_at": 1659052110,
+        "train": "6H-0",
+        "price": 300,
+        "variant": "6H"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 338,
+        "created_at": 1659052117,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659052117
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 339,
+        "created_at": 1659052121
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 340,
+        "created_at": 1659054608,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659054608
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 341,
+        "created_at": 1659054628,
+        "routes": [
+          {
+            "train": "4H-2",
+            "connections": [
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "J20",
+                "I19"
+              ]
+            ],
+            "hexes": [
+              "F20",
+              "G19",
+              "I19",
+              "J20"
+            ],
+            "revenue": 130,
+            "revenue_str": "F20-G19-I19-J20",
+            "nodes": [
+              "G19-0",
+              "F20-1",
+              "I19-0",
+              "J20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 342,
+        "created_at": 1659054642,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 343,
+        "created_at": 1659054653,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659054654
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 344,
+        "created_at": 1659054660
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 345,
+        "created_at": 1659055639,
+        "hex": "C11",
+        "tile": "4-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 346,
+        "created_at": 1659055646
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 347,
+        "created_at": 1659055654,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659055654
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 348,
+        "created_at": 1659055700,
+        "routes": [
+          {
+            "train": "4H-3",
+            "connections": [
+              [
+                "E15",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "E15",
+              "E19",
+              "F20"
+            ],
+            "revenue": 130,
+            "revenue_str": "D14-E15-E19-F20",
+            "nodes": [
+              "E15-0",
+              "D14-0",
+              "E19-0",
+              "F20-1"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 349,
+        "created_at": 1659055706,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 350,
+        "created_at": 1659055721,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659055721
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 351,
+        "created_at": 1659055724
+      },
+      {
+        "type": "lay_tile",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 352,
+        "created_at": 1659056465,
+        "auto_actions": [
+          {
+            "type": "destination_connection",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1659056465
+          }
+        ],
+        "hex": "D6",
+        "tile": "9-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 353,
+        "created_at": 1659056477,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1659056476
+          }
+        ]
+      },
+      {
+        "loan": 16,
+        "type": "take_loan",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 354,
+        "user": 3828,
+        "created_at": 1659056524,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 359,
+        "user": 3828,
+        "created_at": 1659088645
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 360,
+        "created_at": 1659088650,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1659088650
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "2",
+        "entity_type": "corporation",
+        "id": 361,
+        "created_at": 1659088654
+      },
+      {
+        "hex": "C11",
+        "tile": "57-2",
+        "type": "lay_tile",
+        "entity": "10",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 363,
+        "user": 480,
+        "created_at": 1659090877,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "created_at": 1659090884,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 364,
+        "user": 480,
+        "created_at": 1659090884,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 365,
+        "user": 480,
+        "created_at": 1659090893
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 366,
+        "user": 480,
+        "created_at": 1659090899
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 367,
+        "created_at": 1659090931,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1659090931
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 368,
+        "created_at": 1659090954,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "corporation",
+            "created_at": 1659090954
+          }
+        ]
+      },
+      {
+        "type": "buy_company",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 369,
+        "created_at": 1659090997,
+        "company": "SC",
+        "price": 75
+      },
+      {
+        "type": "pass",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 370,
+        "created_at": 1659091023
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 371,
+        "created_at": 1659093775,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1659093775
+          }
+        ]
+      },
+      {
+        "type": "take_loan",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 372,
+        "created_at": 1659093784,
+        "loan": 16
+      },
+      {
+        "type": "take_loan",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 373,
+        "created_at": 1659093790,
+        "loan": 17
+      },
+      {
+        "type": "buy_train",
+        "entity": "WPF",
+        "entity_type": "company",
+        "id": 374,
+        "created_at": 1659093809,
+        "train": "6H-1",
+        "price": 150,
+        "variant": "6H"
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 375,
+        "created_at": 1659093812,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1659093812
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 376,
+        "created_at": 1659093816
+      },
+      {
+        "type": "lay_tile",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 377,
+        "created_at": 1659096937,
+        "hex": "H18",
+        "tile": "24-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 378,
+        "created_at": 1659097059,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1659097058
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 379,
+        "created_at": 1659097090,
+        "routes": [
+          {
+            "train": "4H-0",
+            "connections": [
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "J20",
+                "I19"
+              ]
+            ],
+            "hexes": [
+              "F20",
+              "G19",
+              "I19",
+              "J20"
+            ],
+            "revenue": 130,
+            "revenue_str": "F20-G19-I19-J20",
+            "nodes": [
+              "G19-0",
+              "F20-1",
+              "I19-0",
+              "J20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "1",
+        "entity_type": "corporation",
+        "id": 380,
+        "created_at": 1659097093,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1659097092
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 381,
+        "created_at": 1659099475,
+        "hex": "E9",
+        "tile": "4-3",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 382,
+        "created_at": 1659099478,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "3",
+            "entity_type": "corporation",
+            "created_at": 1659099537
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 383,
+        "created_at": 1659099489,
+        "routes": [
+          {
+            "train": "4H-4",
+            "connections": [
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D8",
+                "D6",
+                "D4"
+              ],
+              [
+                "E9",
+                "D8"
+              ]
+            ],
+            "hexes": [
+              "D2",
+              "D4",
+              "D8",
+              "E9"
+            ],
+            "revenue": 100,
+            "revenue_str": "D2-D4-D8-E9",
+            "nodes": [
+              "D4-0",
+              "D2-0",
+              "D8-0",
+              "E9-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 384,
+        "created_at": 1659099492,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "3",
+            "entity_type": "corporation",
+            "created_at": 1659099551
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 385,
+        "user": 3828,
+        "created_at": 1659099516,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 386,
+        "user": 3828,
+        "created_at": 1659099551
+      },
+      {
+        "type": "buy_company",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 387,
+        "created_at": 1659099567,
+        "company": "PCF",
+        "price": 40
+      },
+      {
+        "hex": "F20",
+        "tile": "X10-0",
+        "type": "lay_tile",
+        "entity": "8",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 388,
+        "user": 10188,
+        "created_at": 1659100714,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 389,
+        "user": 10188,
+        "created_at": 1659100730
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 390,
+        "created_at": 1659100739,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1659100738
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 391,
+        "created_at": 1659100801,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "corporation",
+            "created_at": 1659100801
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 392,
+        "created_at": 1659100804
+      },
+      {
+        "hex": "F4",
+        "tile": "9-3",
+        "type": "lay_tile",
+        "entity": "6",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 393,
+        "user": 4473,
+        "created_at": 1659103002,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "created_at": 1659103004,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 394,
+        "user": 4473,
+        "created_at": 1659103004,
+        "skip": true
+      },
+      {
+        "loan": 20,
+        "type": "take_loan",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 395,
+        "user": 4473,
+        "created_at": 1659103010,
+        "skip": true
+      },
+      {
+        "loan": 21,
+        "type": "take_loan",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 396,
+        "user": 4473,
+        "created_at": 1659103012,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "6",
+        "action_id": 392,
+        "entity_type": "corporation",
+        "id": 397,
+        "user": 4473,
+        "created_at": 1659103074
+      },
+      {
+        "hex": "F4",
+        "tile": "9-3",
+        "type": "lay_tile",
+        "entity": "6",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 398,
+        "user": 4473,
+        "created_at": 1659103084,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "created_at": 1659103086,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 399,
+        "user": 4473,
+        "created_at": 1659103087,
+        "skip": true
+      },
+      {
+        "loan": 20,
+        "type": "take_loan",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 400,
+        "user": 4473,
+        "created_at": 1659103090,
+        "skip": true
+      },
+      {
+        "loan": 21,
+        "type": "take_loan",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 401,
+        "user": 4473,
+        "created_at": 1659103091,
+        "skip": true
+      },
+      {
+        "type": "buy_train",
+        "price": 140,
+        "train": "6H-0",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 402,
+        "user": 4473,
+        "created_at": 1659103104,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "created_at": 1659103107,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 403,
+        "user": 4473,
+        "created_at": 1659103107,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "9",
+        "action_id": 392,
+        "entity_type": "corporation",
+        "id": 404,
+        "user": 4473,
+        "created_at": 1659103130
+      },
+      {
+        "type": "lay_tile",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 405,
+        "created_at": 1659103136,
+        "hex": "F4",
+        "tile": "9-3",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 406,
+        "created_at": 1659103139,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1659103139
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 407,
+        "created_at": 1659103142,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "corporation",
+            "created_at": 1659103142
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "6",
+        "entity_type": "corporation",
+        "id": 408,
+        "created_at": 1659103145
+      },
+      {
+        "type": "lay_tile",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 409,
+        "created_at": 1659103389,
+        "hex": "F20",
+        "tile": "X10-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 410,
+        "created_at": 1659103396,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1659103396
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 411,
+        "created_at": 1659103399,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "corporation",
+            "created_at": 1659103398
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 412,
+        "created_at": 1659103400
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 413,
+        "created_at": 1659105764,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1659105762
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 414,
+        "created_at": 1659105765,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "corporation",
+            "created_at": 1659105764
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 415,
+        "created_at": 1659105766
+      },
+      {
+        "type": "lay_tile",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 416,
+        "created_at": 1659105843,
+        "hex": "E13",
+        "tile": "26-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 417,
+        "created_at": 1659105850,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1659105908
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 418,
+        "created_at": 1659105852,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "corporation",
+            "created_at": 1659105911
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 419,
+        "created_at": 1659105854
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 420,
+        "created_at": 1659105904,
+        "hex": "I15",
+        "tile": "25-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 421,
+        "created_at": 1659105906,
+        "hex": "I17",
+        "tile": "8-3",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 422,
+        "created_at": 1659105908
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 423,
+        "created_at": 1659105908,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659105907
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 424,
+        "created_at": 1659105991,
+        "routes": [
+          {
+            "train": "4H-5",
+            "connections": [
+              [
+                "J14",
+                "I15",
+                "H14"
+              ],
+              [
+                "H14",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "J14",
+              "H14",
+              "H12"
+            ],
+            "revenue": 90,
+            "revenue_str": "J14-H14-H12",
+            "nodes": [
+              "J14-0",
+              "H14-0",
+              "H12-0"
+            ]
+          },
+          {
+            "train": "4H-1",
+            "connections": [
+              [
+                "I13",
+                "H14"
+              ],
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "I13",
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 100,
+            "revenue_str": "I13-H14-G13-H12",
+            "nodes": [
+              "I13-0",
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 425,
+        "user": 5944,
+        "created_at": 1659105992,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "created_at": 1659105992,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 426,
+        "user": 5944,
+        "created_at": 1659105994,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 427,
+        "user": 5944,
+        "created_at": 1659105998
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 428,
+        "user": 5944,
+        "created_at": 1659106001
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 429,
+        "created_at": 1659106002,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 430,
+        "created_at": 1659106003,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659106000
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 431,
+        "created_at": 1659106004
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 432,
+        "created_at": 1659107555,
+        "hex": "I21",
+        "tile": "8-4",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 433,
+        "created_at": 1659107559,
+        "hex": "I23",
+        "tile": "4-4",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 434,
+        "created_at": 1659107568
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 435,
+        "created_at": 1659107630,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659107630
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 436,
+        "created_at": 1659107654,
+        "routes": [
+          {
+            "train": "4H-2",
+            "connections": [
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "I19",
+              "G19",
+              "F20"
+            ],
+            "revenue": 140,
+            "revenue_str": "J20-I19-G19-F20",
+            "nodes": [
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 437,
+        "created_at": 1659107674,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 438,
+        "created_at": 1659107677
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 439,
+        "created_at": 1659107686
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 440,
+        "created_at": 1659107694
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 441,
+        "created_at": 1659107932
+      },
+      {
+        "type": "place_token",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 442,
+        "created_at": 1659107964,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659107963
+          }
+        ],
+        "city": "15-1-0",
+        "slot": 1,
+        "cost": 20,
+        "tokener": "ERIE"
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 443,
+        "created_at": 1659107978,
+        "routes": [
+          {
+            "train": "6H-0",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "D6",
+                "D8"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "E5",
+              "D4",
+              "D8"
+            ],
+            "revenue": 180,
+            "revenue_str": "D0-D2-E3-E5-D4-D8",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "E5-0",
+              "D4-0",
+              "D8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 444,
+        "created_at": 1659107981,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 445,
+        "created_at": 1659107984
+      },
+      {
+        "type": "merge",
+        "entity": "ERIE",
+        "corporation": "6",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "created_at": 1659107993,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 446,
+        "user": 4473,
+        "created_at": 1659107994,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 447,
+        "user": 4473,
+        "created_at": 1659108009
+      },
+      {
+        "type": "merge",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 448,
+        "created_at": 1659108023,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659108022
+          }
+        ],
+        "corporation": "6"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 449,
+        "created_at": 1659108041
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 450,
+        "created_at": 1659111830
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 451,
+        "created_at": 1659111850,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659111850
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 452,
+        "created_at": 1659111877,
+        "routes": [
+          {
+            "train": "4H-3",
+            "connections": [
+              [
+                "E15",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "E15",
+              "E19",
+              "F20"
+            ],
+            "revenue": 140,
+            "revenue_str": "D14-E15-E19-F20",
+            "nodes": [
+              "E15-0",
+              "D14-0",
+              "E19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 453,
+        "created_at": 1659111881,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_company",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 454,
+        "created_at": 1659111890,
+        "company": "AIW",
+        "price": 40
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 455,
+        "created_at": 1659111895,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659111895
+          },
+          {
+            "type": "merge",
+            "entity": "1",
+            "entity_type": "corporation",
+            "created_at": 1659111895,
+            "corporation": "1"
+          },
+          {
+            "type": "merge",
+            "entity": "2",
+            "entity_type": "corporation",
+            "created_at": 1659111895,
+            "corporation": "2"
+          }
+        ]
+      },
+      {
+        "type": "merge",
+        "entity": "3",
+        "entity_type": "corporation",
+        "id": 456,
+        "created_at": 1659112957,
+        "corporation": "3"
+      },
+      {
+        "type": "merge",
+        "entity": "10",
+        "entity_type": "corporation",
+        "id": 457,
+        "created_at": 1659120364,
+        "corporation": "10"
+      },
+      {
+        "type": "merge",
+        "entity": "8",
+        "entity_type": "corporation",
+        "id": 458,
+        "created_at": 1659120766,
+        "corporation": "8"
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 459,
+        "created_at": 1659120954
+      },
+      {
+        "type": "merge",
+        "entity": "9",
+        "entity_type": "corporation",
+        "id": 460,
+        "created_at": 1659121542,
+        "corporation": "9"
+      },
+      {
+        "type": "merge",
+        "entity": "5",
+        "entity_type": "corporation",
+        "id": 461,
+        "created_at": 1659122262,
+        "corporation": "5"
+      },
+      {
+        "type": "merge",
+        "entity": "4",
+        "entity_type": "corporation",
+        "id": 462,
+        "created_at": 1659123203,
+        "corporation": "4"
+      },
+      {
+        "type": "sell_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 463,
+        "created_at": 1659130792,
+        "shares": [
+          "NYC_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 464,
+        "created_at": 1659130809,
+        "shares": [
+          "RWO_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 465,
+        "created_at": 1659134319,
+        "shares": [
+          "NYC_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 466,
+        "created_at": 1659134348
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 467,
+        "created_at": 1659135193,
+        "shares": [
+          "NYC_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 468,
+        "created_at": 1659135199
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "shares": [
+          "D&H_3"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 469,
+        "user": 5944,
+        "created_at": 1659135446,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 470,
+        "user": 5944,
+        "created_at": 1659135448,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 471,
+        "user": 5944,
+        "created_at": 1659135450
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 472,
+        "user": 5944,
+        "created_at": 1659135452
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 473,
+        "created_at": 1659135455,
+        "shares": [
+          "D&H_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 474,
+        "created_at": 1659135471
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 475,
+        "created_at": 1659135667,
+        "shares": [
+          "ERIE_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 476,
+        "created_at": 1659135723
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 477,
+        "created_at": 1659135799,
+        "shares": [
+          "RWO_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 478,
+        "created_at": 1659135839
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 479,
+        "created_at": 1659136892,
+        "shares": [
+          "NYC_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 480,
+        "created_at": 1659136908
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 481,
+        "created_at": 1659136927,
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 482,
+        "created_at": 1659138168,
+        "shares": [
+          "NY&H_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 483,
+        "created_at": 1659138181
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 484,
+        "created_at": 1659145819,
+        "shares": [
+          "D&H_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 485,
+        "created_at": 1659145826
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 486,
+        "created_at": 1659147343,
+        "shares": [
+          "ERIE_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 487,
+        "created_at": 1659147354
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 488,
+        "created_at": 1659173290,
+        "shares": [
+          "RWO_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 489,
+        "created_at": 1659173306,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3828,
+            "entity_type": "player",
+            "created_at": 1659173306
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 490,
+        "created_at": 1659185109,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 10188,
+            "entity_type": "player",
+            "created_at": 1659185110
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "shares": [
+          "D&H_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 491,
+        "user": 5944,
+        "created_at": 1659191316,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 492,
+        "user": 5944,
+        "created_at": 1659191357,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 493,
+        "user": 5944,
+        "created_at": 1659191365
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 494,
+        "user": 5944,
+        "created_at": 1659191367
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "shares": [
+          "ERIE_2"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 495,
+        "user": 5944,
+        "created_at": 1659191368,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 496,
+        "user": 5944,
+        "created_at": 1659191374
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 497,
+        "created_at": 1659191408,
+        "shares": [
+          "D&H_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 498,
+        "created_at": 1659191409
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 499,
+        "created_at": 1659197860,
+        "shares": [
+          "D&H_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 500,
+        "created_at": 1659197864
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 501,
+        "created_at": 1659201761,
+        "shares": [
+          "ERIE_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 502,
+        "created_at": 1659201766,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3828,
+            "entity_type": "player",
+            "created_at": 1659201767
+          },
+          {
+            "type": "pass",
+            "entity": 10188,
+            "entity_type": "player",
+            "created_at": 1659201767
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 503,
+        "created_at": 1659201883
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 504,
+        "created_at": 1659203433,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659203432
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 505,
+        "created_at": 1659209947,
+        "shares": [
+          "D&H_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 506,
+        "created_at": 1659209954,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3828,
+            "entity_type": "player",
+            "created_at": 1659209954
+          },
+          {
+            "type": "pass",
+            "entity": 10188,
+            "entity_type": "player",
+            "created_at": 1659209954
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 507,
+        "created_at": 1659210045,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659210044
+          },
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659210044
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 508,
+        "created_at": 1659288026,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1659288027
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 509,
+        "created_at": 1659290672,
+        "routes": [
+          {
+            "train": "6H-1",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "E5",
+              "D4"
+            ],
+            "revenue": 150,
+            "revenue_str": "D0-D2-E3-E5-D4",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "E5-0",
+              "D4-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "11",
+        "entity_type": "corporation",
+        "id": 510,
+        "created_at": 1659290676,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "corporation",
+            "created_at": 1659290675
+          }
+        ]
+      },
+      {
+        "hex": "G5",
+        "tile": "9-4",
+        "type": "lay_tile",
+        "entity": "NYC",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 511,
+        "user": 3828,
+        "created_at": 1659292536,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 512,
+        "user": 3828,
+        "created_at": 1659292547,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "hex": "H6",
+            "type": "claim_hex_token",
+            "entity": "NYC",
+            "created_at": 1659292549,
+            "token_type": "coal",
+            "entity_type": "corporation"
+          },
+          {
+            "hex": "H12",
+            "type": "claim_hex_token",
+            "entity": "NYC",
+            "created_at": 1659292549,
+            "token_type": "coal",
+            "entity_type": "corporation"
+          },
+          {
+            "hex": "I13",
+            "type": "claim_hex_token",
+            "entity": "NYC",
+            "created_at": 1659292549,
+            "token_type": "coal",
+            "entity_type": "corporation"
+          },
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "created_at": 1659292549,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 513,
+        "user": 3828,
+        "created_at": 1659292549,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 514,
+        "user": 3828,
+        "created_at": 1659292617
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "action_id": 510,
+        "entity_type": "corporation",
+        "id": 515,
+        "user": 3828,
+        "created_at": 1659292618
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 516,
+        "created_at": 1659292630,
+        "hex": "G5",
+        "tile": "9-4",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 517,
+        "created_at": 1659292635,
+        "hex": "G21",
+        "tile": "58-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 518,
+        "created_at": 1659292639,
+        "auto_actions": [
+          {
+            "type": "claim_hex_token",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659292639,
+            "hex": "H6",
+            "token_type": "coal"
+          },
+          {
+            "type": "claim_hex_token",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659292639,
+            "hex": "H12",
+            "token_type": "coal"
+          },
+          {
+            "type": "claim_hex_token",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659292639,
+            "hex": "I13",
+            "token_type": "coal"
+          },
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659292639
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 519,
+        "created_at": 1659292670,
+        "routes": [
+          {
+            "train": "4H-0",
+            "connections": [
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ],
+              [
+                "G21",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "E15",
+              "E19",
+              "F20",
+              "G21"
+            ],
+            "revenue": 120,
+            "revenue_str": "E15-E19-F20-G21",
+            "nodes": [
+              "E19-0",
+              "E15-0",
+              "F20-0",
+              "G21-0"
+            ]
+          },
+          {
+            "train": "4H-4",
+            "connections": [
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "H6",
+                "G5",
+                "F4",
+                "E3"
+              ]
+            ],
+            "hexes": [
+              "D2",
+              "E3",
+              "H6"
+            ],
+            "revenue": 90,
+            "revenue_str": "D2-E3-H6",
+            "nodes": [
+              "E3-0",
+              "D2-0",
+              "H6-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 520,
+        "created_at": 1659292674,
+        "kind": "payout"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 521,
+        "created_at": 1659292680,
+        "train": "4H-0"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 522,
+        "created_at": 1659292683,
+        "train": "6H-2",
+        "price": 300,
+        "variant": "6H"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 523,
+        "created_at": 1659292695,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659292695
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 524,
+        "created_at": 1659293432,
+        "hex": "G19",
+        "tile": "57-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 525,
+        "created_at": 1659293436
+      },
+      {
+        "type": "place_token",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 526,
+        "created_at": 1659293438,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659293437
+          }
+        ],
+        "city": "57-2-0",
+        "slot": 0,
+        "cost": 80,
+        "tokener": "D&H"
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 527,
+        "created_at": 1659293460,
+        "routes": [
+          {
+            "train": "4H-5",
+            "connections": [
+              [
+                "I13",
+                "H14"
+              ],
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "I13",
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 100,
+            "revenue_str": "I13-H14-G13-H12",
+            "nodes": [
+              "I13-0",
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          },
+          {
+            "train": "4H-1",
+            "connections": [
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "I19",
+              "G19",
+              "F20"
+            ],
+            "revenue": 150,
+            "revenue_str": "J20-I19-G19-F20",
+            "nodes": [
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "half",
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 528,
+        "user": 5944,
+        "created_at": 1659293463,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 529,
+        "user": 5944,
+        "created_at": 1659293470
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 530,
+        "created_at": 1659293472,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 531,
+        "created_at": 1659293473,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659293472
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 532,
+        "created_at": 1659293986,
+        "hex": "G19",
+        "tile": "15-7",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 533,
+        "created_at": 1659294004
+      },
+      {
+        "type": "place_token",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 534,
+        "created_at": 1659294007,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659294007
+          }
+        ],
+        "city": "15-7-0",
+        "slot": 1,
+        "cost": 60,
+        "tokener": "NY&H"
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 535,
+        "created_at": 1659294056,
+        "routes": [
+          {
+            "train": "4H-2",
+            "connections": [
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "I19",
+              "G19",
+              "F20"
+            ],
+            "revenue": 160,
+            "revenue_str": "J20-I19-G19-F20",
+            "nodes": [
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 536,
+        "created_at": 1659294100,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 537,
+        "created_at": 1659294116,
+        "train": "6H-3",
+        "price": 300,
+        "variant": "6H"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 538,
+        "created_at": 1659294163,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659294163
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 539,
+        "created_at": 1659309494,
+        "hex": "D6",
+        "tile": "24-1",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 540,
+        "created_at": 1659309497
+      },
+      {
+        "type": "place_token",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 541,
+        "created_at": 1659309503,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659309502
+          }
+        ],
+        "city": "X13-0-0",
+        "slot": 1,
+        "cost": 40,
+        "tokener": "ERIE"
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 542,
+        "created_at": 1659309522,
+        "routes": [
+          {
+            "train": "6H-0",
+            "connections": [
+              [
+                "D8",
+                "D6",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "E3"
+              ],
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "D2",
+                "D0"
+              ]
+            ],
+            "hexes": [
+              "D8",
+              "E5",
+              "D4",
+              "E3",
+              "D2",
+              "D0"
+            ],
+            "revenue": 180,
+            "revenue_str": "D8-E5-D4-E3-D2-D0",
+            "nodes": [
+              "D8-0",
+              "E5-0",
+              "D4-0",
+              "E3-0",
+              "D2-0",
+              "D0-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 543,
+        "created_at": 1659309525,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 544,
+        "created_at": 1659309527
+      },
+      {
+        "type": "merge",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 545,
+        "created_at": 1659309533,
+        "corporation": "11"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 546,
+        "created_at": 1659309545,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659309545
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 547,
+        "created_at": 1659320900,
+        "hex": "B12",
+        "tile": "58-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 548,
+        "created_at": 1659320904
+      },
+      {
+        "type": "place_token",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 549,
+        "created_at": 1659320911,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659320912
+          }
+        ],
+        "city": "619-0-0",
+        "slot": 1,
+        "cost": 60,
+        "tokener": "RWO"
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 550,
+        "created_at": 1659320957,
+        "routes": [
+          {
+            "train": "4H-3",
+            "connections": [
+              [
+                "E15",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "E15",
+              "E19",
+              "F20"
+            ],
+            "revenue": 140,
+            "revenue_str": "D14-E15-E19-F20",
+            "nodes": [
+              "E15-0",
+              "D14-0",
+              "E19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 551,
+        "created_at": 1659320963,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 552,
+        "created_at": 1659320988,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659320989
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 553,
+        "created_at": 1659349528,
+        "hex": "F4",
+        "tile": "23-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 554,
+        "created_at": 1659349539,
+        "hex": "G3",
+        "tile": "8-5",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 555,
+        "created_at": 1659349547,
+        "auto_actions": [
+          {
+            "type": "claim_hex_token",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659349547,
+            "hex": "H4",
+            "token_type": "coal"
+          },
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659349547
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 556,
+        "created_at": 1659349600,
+        "routes": [
+          {
+            "train": "4H-4",
+            "connections": [
+              [
+                "C11",
+                "D10",
+                "D12"
+              ],
+              [
+                "B12",
+                "C11"
+              ],
+              [
+                "A11",
+                "B12"
+              ]
+            ],
+            "hexes": [
+              "D12",
+              "C11",
+              "B12",
+              "A11"
+            ],
+            "revenue": 70,
+            "revenue_str": "D12-C11-B12-A11",
+            "nodes": [
+              "C11-0",
+              "D12-0",
+              "B12-0",
+              "A11-0"
+            ]
+          },
+          {
+            "train": "6H-2",
+            "connections": [
+              [
+                "D2",
+                "D0"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "D4",
+              "E3",
+              "H4"
+            ],
+            "revenue": 150,
+            "revenue_str": "D0-D2-D4-E3-H4",
+            "nodes": [
+              "D2-0",
+              "D0-0",
+              "D4-0",
+              "E3-0",
+              "H4-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 557,
+        "user": 3828,
+        "created_at": 1659349605,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 558,
+        "user": 3828,
+        "created_at": 1659349647
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 559,
+        "created_at": 1659349668,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 560,
+        "created_at": 1659349670,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659349669
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 561,
+        "created_at": 1659359613,
+        "hex": "I19",
+        "tile": "57-3",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 562,
+        "created_at": 1659359616
+      },
+      {
+        "type": "place_token",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 563,
+        "created_at": 1659359625,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659359623
+          }
+        ],
+        "city": "X11-0-0",
+        "slot": 1,
+        "cost": 60,
+        "tokener": "D&H"
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 564,
+        "created_at": 1659359632,
+        "routes": [
+          {
+            "train": "4H-5",
+            "connections": [
+              [
+                "J20",
+                "I21",
+                "I23"
+              ],
+              [
+                "I23",
+                "I25"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "I23",
+              "I25"
+            ],
+            "revenue": 110,
+            "revenue_str": "J20-I23-I25",
+            "nodes": [
+              "J20-0",
+              "I23-0",
+              "I25-0"
+            ]
+          },
+          {
+            "train": "4H-1",
+            "connections": [
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "I19",
+              "G19",
+              "F20"
+            ],
+            "revenue": 170,
+            "revenue_str": "J20-I19-G19-F20",
+            "nodes": [
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 565,
+        "created_at": 1659359634,
+        "kind": "half"
+      },
+      {
+        "type": "buy_train",
+        "price": 600,
+        "train": "12H-0",
+        "entity": "D&H",
+        "variant": "12H",
+        "entity_type": "corporation",
+        "id": 566,
+        "user": 5944,
+        "created_at": 1659359650,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 567,
+        "user": 5944,
+        "created_at": 1659359659
+      },
+      {
+        "type": "scrap_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 568,
+        "created_at": 1659359662,
+        "train": "4H-1"
+      },
+      {
+        "type": "buy_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 569,
+        "created_at": 1659359663,
+        "train": "12H-0",
+        "price": 600,
+        "variant": "12H"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 570,
+        "created_at": 1659359665,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659359664
+          }
+        ]
+      },
+      {
+        "hex": "J20",
+        "tile": "X22-0",
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 571,
+        "user": 10188,
+        "created_at": 1659363741,
+        "skip": true
+      },
+      {
+        "hex": "J18",
+        "tile": "6-0",
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "hex": "K17",
+            "type": "claim_hex_token",
+            "entity": "NY&H",
+            "created_at": 1659363746,
+            "token_type": "coal",
+            "entity_type": "corporation"
+          },
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "created_at": 1659363746,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 572,
+        "user": 10188,
+        "created_at": 1659363747,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 573,
+        "user": 10188,
+        "created_at": 1659363773
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 574,
+        "user": 10188,
+        "created_at": 1659363780
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 575,
+        "created_at": 1659363818,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659363817
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 576,
+        "created_at": 1659363824,
+        "routes": [
+          {
+            "train": "6H-3",
+            "connections": [
+              [
+                "J20",
+                "I21",
+                "I23"
+              ],
+              [
+                "I23",
+                "I25"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "I23",
+              "I25"
+            ],
+            "revenue": 120,
+            "revenue_str": "J20-I23-I25",
+            "nodes": [
+              "J20-0",
+              "I23-0",
+              "I25-0"
+            ]
+          },
+          {
+            "train": "4H-2",
+            "connections": [
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "I19",
+              "G19",
+              "F20"
+            ],
+            "revenue": 170,
+            "revenue_str": "J20-I19-G19-F20",
+            "nodes": [
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 577,
+        "created_at": 1659363846,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 578,
+        "created_at": 1659363853,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659363852
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 579,
+        "created_at": 1659364645
+      },
+      {
+        "type": "place_token",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 580,
+        "created_at": 1659364649,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659364649
+          }
+        ],
+        "city": "15-2-0",
+        "slot": 1,
+        "cost": 40,
+        "tokener": "ERIE"
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 581,
+        "created_at": 1659364678,
+        "routes": [
+          {
+            "train": "6H-1",
+            "connections": [
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "E1"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            "revenue": 180,
+            "revenue_str": "H4-E3-D4-D2-E1",
+            "nodes": [
+              "H4-0",
+              "E3-0",
+              "D4-0",
+              "D2-0",
+              "E1-0"
+            ]
+          },
+          {
+            "train": "6H-0",
+            "connections": [
+              [
+                "D8",
+                "D6",
+                "D4"
+              ],
+              [
+                "D4",
+                "E5"
+              ],
+              [
+                "E5",
+                "E3"
+              ],
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "D2",
+                "D0"
+              ]
+            ],
+            "hexes": [
+              "D8",
+              "D4",
+              "E5",
+              "E3",
+              "D2",
+              "D0"
+            ],
+            "revenue": 190,
+            "revenue_str": "D8-D4-E5-E3-D2-D0",
+            "nodes": [
+              "D8-0",
+              "D4-0",
+              "E5-0",
+              "E3-0",
+              "D2-0",
+              "D0-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 582,
+        "created_at": 1659364683,
+        "kind": "half"
+      },
+      {
+        "type": "scrap_train",
+        "train": "6H-0",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 583,
+        "user": 4473,
+        "created_at": 1659364699,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 584,
+        "user": 4473,
+        "created_at": 1659364714
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 585,
+        "created_at": 1659364717,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659364716
+          }
+        ]
+      },
+      {
+        "hex": "D12",
+        "tile": "X24-0",
+        "type": "lay_tile",
+        "entity": "RWO",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 586,
+        "user": 480,
+        "created_at": 1659365299,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 587,
+        "user": 480,
+        "created_at": 1659365302,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "created_at": 1659365311,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 588,
+        "user": 480,
+        "created_at": 1659365312,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 589,
+        "user": 480,
+        "created_at": 1659365326
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 590,
+        "user": 480,
+        "created_at": 1659365331
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 591,
+        "user": 480,
+        "created_at": 1659365333
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 592,
+        "created_at": 1659365339,
+        "hex": "D14",
+        "tile": "63-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 593,
+        "created_at": 1659365342
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 594,
+        "created_at": 1659365343,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659365343
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 595,
+        "created_at": 1659365345,
+        "routes": [
+          {
+            "train": "4H-3",
+            "connections": [
+              [
+                "E15",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "E15",
+              "E19",
+              "F20"
+            ],
+            "revenue": 150,
+            "revenue_str": "D14-E15-E19-F20",
+            "nodes": [
+              "E15-0",
+              "D14-0",
+              "E19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 596,
+        "created_at": 1659365348,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 597,
+        "created_at": 1659365350,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659365350
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "shares": [
+          "RWO_5"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 598,
+        "user": 3828,
+        "created_at": 1659366266,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 3828,
+        "action_id": 597,
+        "entity_type": "player",
+        "id": 599,
+        "user": 3828,
+        "created_at": 1659366298
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 600,
+        "created_at": 1659366327,
+        "shares": [
+          "RWO_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 601,
+        "created_at": 1659366357
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 602,
+        "created_at": 1659367561,
+        "shares": [
+          "D&H_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 603,
+        "created_at": 1659367576
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5944,
+        "shares": [
+          "NYC_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 604,
+        "user": 5944,
+        "created_at": 1659374395,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 605,
+        "user": 5944,
+        "created_at": 1659374411
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5944,
+        "shares": [
+          "NYC_1"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 606,
+        "user": 5944,
+        "created_at": 1659385976,
+        "skip": true
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5944,
+        "shares": [
+          "NY&H_2"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 607,
+        "user": 5944,
+        "created_at": 1659385979,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "action_id": 603,
+        "entity_type": "player",
+        "id": 608,
+        "user": 5944,
+        "created_at": 1659386082
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 609,
+        "user": 5944,
+        "created_at": 1659386090
+      },
+      {
+        "skip": true,
+        "type": "redo",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 610,
+        "user": 5944,
+        "created_at": 1659386093
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 611,
+        "created_at": 1659386191,
+        "shares": [
+          "NYC_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 612,
+        "created_at": 1659386192,
+        "shares": [
+          "NY&H_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 613,
+        "created_at": 1659386195,
+        "corporation": "NYNH",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 614,
+        "created_at": 1659387225,
+        "shares": [
+          "NYC_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4473,
+        "indefinite": false,
+        "entity_type": "player",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4473,
+            "created_at": 1659387228,
+            "entity_type": "player"
+          }
+        ],
+        "unconditional": false,
+        "id": 615,
+        "user": 4473,
+        "created_at": 1659387229,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 616,
+        "user": 4473,
+        "created_at": 1659387235
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 617,
+        "created_at": 1659387236
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 618,
+        "created_at": 1659387958,
+        "shares": [
+          "NY&H_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 619,
+        "created_at": 1659387968
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 620,
+        "created_at": 1659391055,
+        "shares": [
+          "NY&H_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 621,
+        "created_at": 1659391098
+      },
+      {
+        "type": "sell_shares",
+        "entity": 10188,
+        "shares": [
+          "NYC_5"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 622,
+        "user": 10188,
+        "created_at": 1659391949,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 623,
+        "user": 10188,
+        "created_at": 1659392066
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 624,
+        "created_at": 1659392080,
+        "shares": [
+          "D&H_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 625,
+        "created_at": 1659392084
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 626,
+        "created_at": 1659402462,
+        "shares": [
+          "NYNH_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 627,
+        "created_at": 1659402466
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 628,
+        "created_at": 1659402478,
+        "corporation": "NYNH",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 629,
+        "created_at": 1659402480,
+        "corporation": "NYNH",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 630,
+        "created_at": 1659409248,
+        "shares": [
+          "ERIE_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 631,
+        "created_at": 1659409252
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 632,
+        "created_at": 1659435014,
+        "shares": [
+          "ERIE_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 633,
+        "created_at": 1659435029
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 634,
+        "created_at": 1659441160,
+        "shares": [
+          "ERIE_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 635,
+        "created_at": 1659441162
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 636,
+        "created_at": 1659444531,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659444530,
+            "shares": [
+              "NYNH_2"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659444530
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 637,
+        "created_at": 1659445458,
+        "shares": [
+          "NY&H_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 638,
+        "created_at": 1659445462
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 639,
+        "created_at": 1659455932,
+        "shares": [
+          "ERIE_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 640,
+        "created_at": 1659455954
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 641,
+        "created_at": 1659457287
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 642,
+        "created_at": 1659459671,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659459670,
+            "shares": [
+              "NYNH_3"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659459670,
+            "reason": "NYNH is floated"
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 643,
+        "created_at": 1659459716
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 644,
+        "created_at": 1659465150,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659465150
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 645,
+        "created_at": 1659485162
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 646,
+        "created_at": 1659485521
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 647,
+        "created_at": 1659488163
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 648,
+        "created_at": 1659488285
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 649,
+        "created_at": 1659490078,
+        "hex": "D8",
+        "tile": "X23-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 650,
+        "created_at": 1659490089,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659490088
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 651,
+        "created_at": 1659490149,
+        "routes": [
+          {
+            "train": "4H-4",
+            "connections": [
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D8",
+                "D10",
+                "E11"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "D12",
+              "E11",
+              "D8"
+            ],
+            "revenue": 140,
+            "revenue_str": "D14-D12-E11-D8",
+            "nodes": [
+              "D12-0",
+              "D14-0",
+              "E11-0",
+              "D8-0"
+            ]
+          },
+          {
+            "train": "6H-2",
+            "connections": [
+              [
+                "D2",
+                "D0"
+              ],
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "D4",
+                "E3"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D8",
+                "D6",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "D4",
+              "E5",
+              "D8"
+            ],
+            "revenue": 200,
+            "revenue_str": "D0-D2-E3-D4-E5-D8",
+            "nodes": [
+              "D2-0",
+              "D0-0",
+              "E3-0",
+              "D4-0",
+              "E5-0",
+              "D8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 652,
+        "created_at": 1659490151,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 653,
+        "created_at": 1659490156,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659490156
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 654,
+        "created_at": 1659490233,
+        "hex": "G19",
+        "tile": "63-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 655,
+        "created_at": 1659490237
+      },
+      {
+        "type": "place_token",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 656,
+        "created_at": 1659490244,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659490242
+          }
+        ],
+        "city": "57-3-0",
+        "slot": 0,
+        "cost": 20,
+        "tokener": "D&H"
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "routes": [
+          {
+            "hexes": [
+              "I25",
+              "I23",
+              "J20",
+              "I19",
+              "G19",
+              "F20",
+              "E19"
+            ],
+            "nodes": [
+              "I25-0",
+              "I23-0",
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0",
+              "E19-0"
+            ],
+            "train": "12H-0",
+            "revenue": 260,
+            "connections": [
+              [
+                "I25",
+                "I23"
+              ],
+              [
+                "I23",
+                "I21",
+                "J20"
+              ],
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "revenue_str": "I25-I23-J20-I19-G19-F20-E19"
+          },
+          {
+            "hexes": [
+              "I13",
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "nodes": [
+              "I13-0",
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ],
+            "train": "4H-5",
+            "revenue": 120,
+            "connections": [
+              [
+                "I13",
+                "H14"
+              ],
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "revenue_str": "I13-H14-G13-H12"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 657,
+        "user": 5944,
+        "created_at": 1659490268,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 658,
+        "user": 5944,
+        "created_at": 1659490269,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 659,
+        "user": 5944,
+        "created_at": 1659490276
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 660,
+        "user": 5944,
+        "created_at": 1659490277
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 661,
+        "created_at": 1659490280,
+        "routes": [
+          {
+            "train": "12H-0",
+            "connections": [
+              [
+                "I25",
+                "I23"
+              ],
+              [
+                "I23",
+                "I21",
+                "J20"
+              ],
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "I25",
+              "I23",
+              "J20",
+              "I19",
+              "G19",
+              "F20",
+              "E19"
+            ],
+            "revenue": 260,
+            "revenue_str": "I25-I23-J20-I19-G19-F20-E19",
+            "nodes": [
+              "I25-0",
+              "I23-0",
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0",
+              "E19-0"
+            ]
+          },
+          {
+            "train": "4H-5",
+            "connections": [
+              [
+                "I13",
+                "H14"
+              ],
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "I13",
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 120,
+            "revenue_str": "I13-H14-G13-H12",
+            "nodes": [
+              "I13-0",
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 662,
+        "created_at": 1659490281,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 663,
+        "created_at": 1659490283,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659490282
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 664,
+        "created_at": 1659492977,
+        "hex": "E3",
+        "tile": "63-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 665,
+        "created_at": 1659492989,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659492988
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 666,
+        "created_at": 1659493038,
+        "routes": [
+          {
+            "train": "6H-1",
+            "connections": [
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "E1"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            "revenue": 190,
+            "revenue_str": "H4-E3-D4-D2-E1",
+            "nodes": [
+              "H4-0",
+              "E3-0",
+              "D4-0",
+              "D2-0",
+              "E1-0"
+            ]
+          },
+          {
+            "train": "6H-0",
+            "connections": [
+              [
+                "D8",
+                "D6",
+                "D4"
+              ],
+              [
+                "D4",
+                "E5"
+              ],
+              [
+                "E5",
+                "E3"
+              ],
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "D2",
+                "D0"
+              ]
+            ],
+            "hexes": [
+              "D8",
+              "D4",
+              "E5",
+              "E3",
+              "D2",
+              "D0"
+            ],
+            "revenue": 210,
+            "revenue_str": "D8-D4-E5-E3-D2-D0",
+            "nodes": [
+              "D8-0",
+              "D4-0",
+              "E5-0",
+              "E3-0",
+              "D2-0",
+              "D0-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 667,
+        "created_at": 1659493052,
+        "kind": "half"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 668,
+        "created_at": 1659493056,
+        "train": "6H-0"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 669,
+        "created_at": 1659493068,
+        "train": "12H-1",
+        "price": 600,
+        "variant": "12H"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 670,
+        "created_at": 1659493083,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659493082
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 671,
+        "created_at": 1659531133,
+        "hex": "J20",
+        "tile": "X22-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 672,
+        "created_at": 1659531147,
+        "hex": "J18",
+        "tile": "6-0",
+        "rotation": 4
+      },
+      {
+        "type": "place_token",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 673,
+        "created_at": 1659531149,
+        "auto_actions": [
+          {
+            "type": "claim_hex_token",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659531149,
+            "hex": "K17",
+            "token_type": "coal"
+          },
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659531149
+          }
+        ],
+        "city": "6-0-0",
+        "slot": 0,
+        "cost": 20,
+        "tokener": "NY&H"
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 674,
+        "created_at": 1659531199,
+        "routes": [
+          {
+            "train": "6H-3",
+            "connections": [
+              [
+                "K17",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "I23"
+              ],
+              [
+                "I23",
+                "I25"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "J18",
+              "J20",
+              "I23",
+              "I25"
+            ],
+            "revenue": 250,
+            "revenue_str": "K17-J18-J20-I23-I25",
+            "nodes": [
+              "K17-0",
+              "J18-0",
+              "J20-0",
+              "I23-0",
+              "I25-0"
+            ]
+          },
+          {
+            "train": "4H-2",
+            "connections": [
+              [
+                "E19",
+                "F20"
+              ],
+              [
+                "F20",
+                "G19"
+              ],
+              [
+                "G19",
+                "H18",
+                "I19"
+              ]
+            ],
+            "hexes": [
+              "E19",
+              "F20",
+              "G19",
+              "I19"
+            ],
+            "revenue": 140,
+            "revenue_str": "E19-F20-G19-I19",
+            "nodes": [
+              "E19-0",
+              "F20-0",
+              "G19-0",
+              "I19-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 675,
+        "created_at": 1659531230,
+        "kind": "half"
+      },
+      {
+        "type": "scrap_train",
+        "train": "4H-2",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 676,
+        "user": 10188,
+        "created_at": 1659531245,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 677,
+        "user": 10188,
+        "created_at": 1659531255
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 678,
+        "created_at": 1659531256,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659531256
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 679,
+        "created_at": 1659531918,
+        "hex": "I19",
+        "tile": "14-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 680,
+        "created_at": 1659531921
+      },
+      {
+        "type": "place_token",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 681,
+        "created_at": 1659531922,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659531922
+          }
+        ],
+        "city": "14-0-0",
+        "slot": 1,
+        "cost": 80,
+        "tokener": "NYNH"
+      },
+      {
+        "type": "sell_shares",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 682,
+        "created_at": 1659532004,
+        "shares": [
+          "NYNH_4",
+          "NYNH_5",
+          "NYNH_6"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "buy_train",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 683,
+        "created_at": 1659532012,
+        "train": "12H-2",
+        "price": 600,
+        "variant": "12H"
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 684,
+        "created_at": 1659532015,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659532015
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 685,
+        "created_at": 1659539725,
+        "hex": "E15",
+        "tile": "63-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 686,
+        "created_at": 1659539731
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 687,
+        "created_at": 1659539746,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659539744
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 688,
+        "created_at": 1659539754,
+        "routes": [
+          {
+            "train": "4H-3",
+            "connections": [
+              [
+                "E15",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D14",
+              "E15",
+              "E19",
+              "F20"
+            ],
+            "revenue": 160,
+            "revenue_str": "D14-E15-E19-F20",
+            "nodes": [
+              "E15-0",
+              "D14-0",
+              "E19-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 689,
+        "created_at": 1659539771,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 690,
+        "created_at": 1659539914,
+        "train": "6H-0",
+        "price": 300,
+        "variant": "6H"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 691,
+        "created_at": 1659539922,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659539921
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 692,
+        "created_at": 1659542129,
+        "hex": "F20",
+        "tile": "X20-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 693,
+        "created_at": 1659542132
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 694,
+        "created_at": 1659542372,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659542435
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 695,
+        "created_at": 1659542406,
+        "routes": [
+          {
+            "train": "4H-4",
+            "connections": [
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ],
+              [
+                "G19",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "E15",
+              "E19",
+              "F20",
+              "G19"
+            ],
+            "revenue": 170,
+            "revenue_str": "E15-E19-F20-G19",
+            "nodes": [
+              "E19-0",
+              "E15-0",
+              "F20-0",
+              "G19-0"
+            ]
+          },
+          {
+            "train": "6H-2",
+            "connections": [
+              [
+                "D2",
+                "D0"
+              ],
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "D4",
+                "E3"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D8",
+                "D6",
+                "E5"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "D4",
+              "E5",
+              "D8"
+            ],
+            "revenue": 210,
+            "revenue_str": "D0-D2-E3-D4-E5-D8",
+            "nodes": [
+              "D2-0",
+              "D0-0",
+              "E3-0",
+              "D4-0",
+              "E5-0",
+              "D8-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 696,
+        "user": 3828,
+        "created_at": 1659542412,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 697,
+        "user": 3828,
+        "created_at": 1659542437
+      },
+      {
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 698,
+        "user": 3828,
+        "created_at": 1659542440,
+        "skip": true
+      },
+      {
+        "type": "scrap_train",
+        "train": "4H-4",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 699,
+        "user": 3828,
+        "created_at": 1659542443,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 700,
+        "user": 3828,
+        "created_at": 1659542449
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 701,
+        "user": 3828,
+        "created_at": 1659542458
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 702,
+        "created_at": 1659542462,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 703,
+        "created_at": 1659542464,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659542527
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 704,
+        "created_at": 1659544027,
+        "hex": "J18",
+        "tile": "619-3",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 705,
+        "created_at": 1659544031,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659544031
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 706,
+        "created_at": 1659544034,
+        "routes": [
+          {
+            "train": "12H-0",
+            "connections": [
+              [
+                "I25",
+                "I23"
+              ],
+              [
+                "I23",
+                "I21",
+                "J20"
+              ],
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "I25",
+              "I23",
+              "J20",
+              "I19",
+              "G19",
+              "F20",
+              "E19"
+            ],
+            "revenue": 310,
+            "revenue_str": "I25-I23-J20-I19-G19-F20-E19",
+            "nodes": [
+              "I25-0",
+              "I23-0",
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0",
+              "E19-0"
+            ]
+          },
+          {
+            "train": "4H-5",
+            "connections": [
+              [
+                "J20",
+                "J18"
+              ],
+              [
+                "J18",
+                "K17"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "J18",
+              "K17"
+            ],
+            "revenue": 210,
+            "revenue_str": "J20-J18-K17",
+            "nodes": [
+              "J20-0",
+              "J18-0",
+              "K17-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 707,
+        "user": 5944,
+        "created_at": 1659544039,
+        "skip": true
+      },
+      {
+        "type": "scrap_train",
+        "train": "4H-5",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 708,
+        "user": 5944,
+        "created_at": 1659544041,
+        "skip": true
+      },
+      {
+        "type": "buy_train",
+        "price": 800,
+        "train": "5DE-0",
+        "entity": "D&H",
+        "variant": "5DE",
+        "entity_type": "corporation",
+        "id": 709,
+        "user": 5944,
+        "created_at": 1659544042,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 710,
+        "user": 5944,
+        "created_at": 1659544149
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 711,
+        "user": 5944,
+        "created_at": 1659544151
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 712,
+        "user": 5944,
+        "created_at": 1659544154
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 713,
+        "created_at": 1659544155,
+        "kind": "half"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 714,
+        "created_at": 1659544156,
+        "train": "4H-5"
+      },
+      {
+        "type": "buy_train",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 715,
+        "created_at": 1659544159,
+        "train": "5DE-0",
+        "price": 800,
+        "variant": "5DE"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 716,
+        "created_at": 1659544191,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659544191
+          }
+        ]
+      },
+      {
+        "hex": "F12",
+        "tile": "4-0",
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 717,
+        "user": 4473,
+        "created_at": 1659544266,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "ERIE",
+        "action_id": 716,
+        "entity_type": "corporation",
+        "id": 718,
+        "user": 4473,
+        "created_at": 1659544285
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 719,
+        "created_at": 1659544300,
+        "hex": "D12",
+        "tile": "X24-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 720,
+        "created_at": 1659544303,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659544302
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 721,
+        "created_at": 1659544315,
+        "routes": [
+          {
+            "train": "12H-1",
+            "connections": [
+              [
+                "E1",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "D6",
+                "D8"
+              ],
+              [
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "D14",
+                "E15"
+              ],
+              [
+                "E15",
+                "E17",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "E1",
+              "E3",
+              "E5",
+              "D4",
+              "D8",
+              "E11",
+              "D12",
+              "D14",
+              "E15",
+              "E19"
+            ],
+            "revenue": 360,
+            "revenue_str": "E1-E3-E5-D4-D8-E11-D12-D14-E15-E19",
+            "nodes": [
+              "E1-0",
+              "E3-0",
+              "E5-0",
+              "D4-0",
+              "D8-0",
+              "E11-0",
+              "D12-0",
+              "D14-0",
+              "E15-0",
+              "E19-0"
+            ]
+          },
+          {
+            "train": "6H-1",
+            "connections": [
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "D0"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "D4",
+              "D2",
+              "D0"
+            ],
+            "revenue": 190,
+            "revenue_str": "H4-E3-D4-D2-D0",
+            "nodes": [
+              "H4-0",
+              "E3-0",
+              "D4-0",
+              "D2-0",
+              "D0-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 722,
+        "created_at": 1659544330,
+        "kind": "withhold"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 723,
+        "created_at": 1659544333,
+        "train": "6H-1"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 724,
+        "created_at": 1659544335,
+        "train": "5DE-1",
+        "price": 800,
+        "variant": "5DE"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 725,
+        "created_at": 1659544336,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659544336
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 726,
+        "created_at": 1659544784,
+        "hex": "I21",
+        "tile": "25-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 727,
+        "created_at": 1659544791,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659544791
+          }
+        ],
+        "hex": "H20",
+        "tile": "6-1",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 728,
+        "created_at": 1659544803,
+        "routes": [
+          {
+            "train": "6H-3",
+            "connections": [
+              [
+                "K17",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "J18",
+              "J20",
+              "H20",
+              "G21",
+              "F20"
+            ],
+            "revenue": 300,
+            "revenue_str": "K17-J18-J20-H20-G21-F20",
+            "nodes": [
+              "K17-0",
+              "J18-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "half",
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 729,
+        "user": 10188,
+        "created_at": 1659544815,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 730,
+        "user": 10188,
+        "created_at": 1659544826
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 731,
+        "created_at": 1659544832,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 732,
+        "created_at": 1659544840,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659544840
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 733,
+        "created_at": 1659565371,
+        "hex": "E19",
+        "tile": "63-4",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 734,
+        "created_at": 1659565378
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 735,
+        "created_at": 1659565389,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659565388
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 736,
+        "created_at": 1659565427,
+        "routes": [
+          {
+            "train": "6H-0",
+            "connections": [
+              [
+                "D14",
+                "D12"
+              ],
+              [
+                "E15",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ],
+              [
+                "G19",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "D12",
+              "D14",
+              "E15",
+              "E19",
+              "F20",
+              "G19"
+            ],
+            "revenue": 260,
+            "revenue_str": "D12-D14-E15-E19-F20-G19",
+            "nodes": [
+              "D14-0",
+              "D12-0",
+              "E15-0",
+              "E19-0",
+              "F20-0",
+              "G19-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 737,
+        "created_at": 1659565434,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 738,
+        "created_at": 1659565450,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659565449
+          }
+        ]
+      },
+      {
+        "hex": "I17",
+        "tile": "24-2",
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 739,
+        "user": 5944,
+        "created_at": 1659565474,
+        "skip": true
+      },
+      {
+        "hex": "H24",
+        "tile": "8-6",
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 740,
+        "user": 5944,
+        "created_at": 1659565476,
+        "skip": true
+      },
+      {
+        "city": "X22-0-0",
+        "cost": 20,
+        "slot": 2,
+        "type": "place_token",
+        "entity": "NYNH",
+        "tokener": "NYNH",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "created_at": 1659565483,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 741,
+        "user": 5944,
+        "created_at": 1659565483,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYNH",
+        "action_id": 738,
+        "entity_type": "corporation",
+        "id": 742,
+        "user": 5944,
+        "created_at": 1659565507
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 743,
+        "created_at": 1659565517,
+        "hex": "H24",
+        "tile": "8-6",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 744,
+        "created_at": 1659565529,
+        "hex": "H18",
+        "tile": "42-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 745,
+        "created_at": 1659565535,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659565535
+          }
+        ],
+        "city": "X22-0-0",
+        "slot": 2,
+        "cost": 20,
+        "tokener": "NYNH"
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 746,
+        "created_at": 1659565545,
+        "routes": [
+          {
+            "train": "12H-2",
+            "connections": [
+              [
+                "I25",
+                "H24",
+                "G25"
+              ],
+              [
+                "I23",
+                "I25"
+              ],
+              [
+                "J20",
+                "I21",
+                "I23"
+              ],
+              [
+                "I19",
+                "J20"
+              ],
+              [
+                "H14",
+                "I15",
+                "I17",
+                "H18",
+                "I19"
+              ],
+              [
+                "G13",
+                "H14"
+              ],
+              [
+                "H12",
+                "G13"
+              ]
+            ],
+            "hexes": [
+              "G25",
+              "I25",
+              "I23",
+              "J20",
+              "I19",
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 300,
+            "revenue_str": "G25-I25-I23-J20-I19-H14-G13-H12",
+            "nodes": [
+              "I25-0",
+              "G25-0",
+              "I23-0",
+              "J20-0",
+              "I19-0",
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 747,
+        "created_at": 1659565548,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 748,
+        "created_at": 1659565565,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659565565
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 749,
+        "created_at": 1659565656,
+        "hex": "E5",
+        "tile": "63-5",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 750,
+        "created_at": 1659565664
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 751,
+        "created_at": 1659565666,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659565666
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 752,
+        "created_at": 1659565723,
+        "routes": [
+          {
+            "train": "6H-2",
+            "connections": [
+              [
+                "E19",
+                "D20"
+              ],
+              [
+                "F20",
+                "E19"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ]
+            ],
+            "hexes": [
+              "D20",
+              "E19",
+              "F20",
+              "G21",
+              "H20",
+              "J20"
+            ],
+            "revenue": 240,
+            "revenue_str": "D20-E19-F20-G21-H20-J20",
+            "nodes": [
+              "E19-0",
+              "D20-0",
+              "F20-0",
+              "G21-0",
+              "H20-0",
+              "J20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 753,
+        "user": 3828,
+        "created_at": 1659565724,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 754,
+        "user": 3828,
+        "created_at": 1659565736
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 755,
+        "created_at": 1659565737,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 756,
+        "created_at": 1659565745,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659565744
+          }
+        ]
+      },
+      {
+        "hex": "K19",
+        "tile": "5-3",
+        "type": "lay_tile",
+        "entity": "D&H",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 757,
+        "user": 5944,
+        "created_at": 1659565768,
+        "skip": true
+      },
+      {
+        "hex": "I17",
+        "tile": "21-0",
+        "type": "lay_tile",
+        "entity": "D&H",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "created_at": 1659565839,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 758,
+        "user": 5944,
+        "created_at": 1659565840,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 759,
+        "user": 5944,
+        "created_at": 1659565843
+      },
+      {
+        "hex": "I17",
+        "tile": "21-0",
+        "type": "lay_tile",
+        "entity": "D&H",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "created_at": 1659565912,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 760,
+        "user": 5944,
+        "created_at": 1659565912,
+        "skip": true
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "routes": [
+          {
+            "hexes": [
+              "J20",
+              "I19",
+              "J18",
+              "K19",
+              "K17"
+            ],
+            "nodes": [
+              "J20-0",
+              "I19-0",
+              "J18-0",
+              "K19-0",
+              "K17-0"
+            ],
+            "train": "5DE-0",
+            "revenue": 520,
+            "connections": [
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "I17",
+                "J18"
+              ],
+              [
+                "J18",
+                "K19"
+              ],
+              [
+                "K19",
+                "K17"
+              ]
+            ],
+            "revenue_str": "J20-I19-J18-K19-K17"
+          },
+          {
+            "hexes": [
+              "K17",
+              "J18",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "G19",
+              "H14",
+              "H12"
+            ],
+            "nodes": [
+              "K17-0",
+              "J18-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "G19-0",
+              "H14-0",
+              "H12-0"
+            ],
+            "train": "12H-0",
+            "revenue": 410,
+            "connections": [
+              [
+                "K17",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "G19"
+              ],
+              [
+                "G19",
+                "H18",
+                "I17",
+                "I15",
+                "H14"
+              ],
+              [
+                "H14",
+                "H12"
+              ]
+            ],
+            "revenue_str": "K17-J18-J20-H20-G21-F20-G19-H14-H12"
+          }
+        ],
+        "entity_type": "corporation",
+        "id": 761,
+        "user": 5944,
+        "created_at": 1659565923,
+        "skip": true
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 762,
+        "user": 5944,
+        "created_at": 1659565937,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 763,
+        "user": 5944,
+        "created_at": 1659565945
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "D&H",
+        "action_id": 756,
+        "entity_type": "corporation",
+        "id": 764,
+        "user": 5944,
+        "created_at": 1659565946
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 765,
+        "created_at": 1659565950,
+        "hex": "J22",
+        "tile": "4-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 766,
+        "created_at": 1659565953,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659565953
+          }
+        ],
+        "hex": "I17",
+        "tile": "21-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 767,
+        "created_at": 1659565958,
+        "routes": [
+          {
+            "train": "5DE-0",
+            "connections": [
+              [
+                "K17",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "J18",
+              "J20",
+              "H20",
+              "G21",
+              "F20"
+            ],
+            "revenue": 580,
+            "revenue_str": "K17-J18-J20-H20-(G21)-F20",
+            "nodes": [
+              "K17-0",
+              "J18-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0"
+            ]
+          },
+          {
+            "train": "12H-0",
+            "connections": [
+              [
+                "E19",
+                "F20"
+              ],
+              [
+                "F20",
+                "G19"
+              ],
+              [
+                "G19",
+                "H18",
+                "I19"
+              ],
+              [
+                "I19",
+                "J20"
+              ],
+              [
+                "J20",
+                "J22"
+              ]
+            ],
+            "hexes": [
+              "E19",
+              "F20",
+              "G19",
+              "I19",
+              "J20",
+              "J22"
+            ],
+            "revenue": 280,
+            "revenue_str": "E19-F20-G19-I19-J20-J22",
+            "nodes": [
+              "E19-0",
+              "F20-0",
+              "G19-0",
+              "I19-0",
+              "J20-0",
+              "J22-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 768,
+        "created_at": 1659565959,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 769,
+        "created_at": 1659565962,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659565962
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 770,
+        "created_at": 1659566817,
+        "hex": "K19",
+        "tile": "5-3",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 771,
+        "created_at": 1659566824,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659566824
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 772,
+        "created_at": 1659566892,
+        "routes": [
+          {
+            "train": "6H-3",
+            "connections": [
+              [
+                "I23",
+                "I25"
+              ],
+              [
+                "J20",
+                "I21",
+                "I23"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "K17",
+                "K19"
+              ]
+            ],
+            "hexes": [
+              "I25",
+              "I23",
+              "J20",
+              "J18",
+              "K19",
+              "K17"
+            ],
+            "revenue": 280,
+            "revenue_str": "I25-I23-J20-J18-K19-K17",
+            "nodes": [
+              "I23-0",
+              "I25-0",
+              "J20-0",
+              "J18-0",
+              "K19-0",
+              "K17-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "half",
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 773,
+        "user": 10188,
+        "created_at": 1659566983,
+        "skip": true
+      },
+      {
+        "type": "scrap_train",
+        "train": "6H-3",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 774,
+        "user": 10188,
+        "created_at": 1659566986,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 775,
+        "user": 10188,
+        "created_at": 1659566995
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 776,
+        "user": 10188,
+        "created_at": 1659567036
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 777,
+        "created_at": 1659567039,
+        "kind": "withhold"
+      },
+      {
+        "type": "scrap_train",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 778,
+        "created_at": 1659567042,
+        "train": "6H-3"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 779,
+        "created_at": 1659567045,
+        "train": "D-0",
+        "price": 1000,
+        "variant": "D"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 780,
+        "created_at": 1659567048,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659567048
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 781,
+        "user": 480,
+        "created_at": 1659568355,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "created_at": 1659568357,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 782,
+        "user": 480,
+        "created_at": 1659568358,
+        "skip": true
+      },
+      {
+        "type": "sell_shares",
+        "entity": 480,
+        "shares": [
+          "NYC_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 783,
+        "user": 480,
+        "created_at": 1659568390,
+        "skip": true
+      },
+      {
+        "type": "buy_train",
+        "price": 1000,
+        "train": "D-1",
+        "entity": "RWO",
+        "variant": "D",
+        "entity_type": "corporation",
+        "id": 784,
+        "user": 480,
+        "created_at": 1659568400,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 785,
+        "user": 480,
+        "created_at": 1659568414
+      },
+      {
+        "loan": 24,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 786,
+        "user": 480,
+        "created_at": 1659568416,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 787,
+        "user": 480,
+        "created_at": 1659568428
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 788,
+        "user": 480,
+        "created_at": 1659568437
+      },
+      {
+        "loan": 24,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 789,
+        "user": 480,
+        "created_at": 1659568462,
+        "skip": true
+      },
+      {
+        "loan": 25,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 790,
+        "user": 480,
+        "created_at": 1659568472,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 791,
+        "user": 480,
+        "created_at": 1659568486
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 792,
+        "user": 480,
+        "created_at": 1659568493
+      },
+      {
+        "type": "sell_shares",
+        "entity": "RWO",
+        "shares": [
+          "RWO_6",
+          "RWO_7",
+          "RWO_8"
+        ],
+        "percent": 30,
+        "entity_type": "corporation",
+        "id": 793,
+        "user": 480,
+        "created_at": 1659568500,
+        "skip": true
+      },
+      {
+        "loan": 24,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 794,
+        "user": 480,
+        "created_at": 1659568522,
+        "skip": true
+      },
+      {
+        "loan": 25,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 795,
+        "user": 480,
+        "created_at": 1659568525,
+        "skip": true
+      },
+      {
+        "loan": 26,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 796,
+        "user": 480,
+        "created_at": 1659568530,
+        "skip": true
+      },
+      {
+        "loan": 27,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 797,
+        "user": 480,
+        "created_at": 1659568531,
+        "skip": true
+      },
+      {
+        "loan": 28,
+        "type": "take_loan",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 798,
+        "user": 480,
+        "created_at": 1659568533,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "action_id": 780,
+        "entity_type": "corporation",
+        "id": 799,
+        "user": 480,
+        "created_at": 1659568546
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 800,
+        "created_at": 1659568549
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 801,
+        "created_at": 1659568551,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659568550
+          }
+        ]
+      },
+      {
+        "type": "sell_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 802,
+        "created_at": 1659568557,
+        "shares": [
+          "NYC_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 803,
+        "created_at": 1659568570,
+        "shares": [
+          "RWO_6",
+          "RWO_7",
+          "RWO_8"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "buy_train",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 804,
+        "created_at": 1659568576,
+        "train": "D-1",
+        "price": 1000,
+        "variant": "D"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 805,
+        "created_at": 1659568582,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659568580
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 806,
+        "created_at": 1659570929,
+        "hex": "E3",
+        "tile": "X35-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 807,
+        "created_at": 1659570938,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659570937
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 808,
+        "created_at": 1659570987,
+        "routes": [
+          {
+            "train": "5DE-1",
+            "connections": [
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "E1"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "E5",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            "revenue": 660,
+            "revenue_str": "H4-E3-E5-D4-(D2)-E1",
+            "nodes": [
+              "H4-0",
+              "E3-0",
+              "E5-0",
+              "D4-0",
+              "D2-0",
+              "E1-0"
+            ]
+          },
+          {
+            "train": "12H-1",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D6",
+                "D8"
+              ],
+              [
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "D14",
+                "E15"
+              ],
+              [
+                "E15",
+                "E17",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "D4",
+              "D8",
+              "E11",
+              "D12",
+              "D14",
+              "E15",
+              "E19"
+            ],
+            "revenue": 450,
+            "revenue_str": "D0-D2-E3-D4-D8-E11-D12-D14-E15-E19",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "D4-0",
+              "D8-0",
+              "E11-0",
+              "D12-0",
+              "D14-0",
+              "E15-0",
+              "E19-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 809,
+        "created_at": 1659570991,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 810,
+        "created_at": 1659570993,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659570992
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 811,
+        "created_at": 1659571011,
+        "hex": "I17",
+        "tile": "46-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 812,
+        "created_at": 1659571015,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659571015
+          }
+        ],
+        "hex": "J24",
+        "tile": "9-5",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 813,
+        "created_at": 1659571052,
+        "routes": [
+          {
+            "train": "12H-2",
+            "connections": [
+              [
+                "G13",
+                "H12"
+              ],
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "I19",
+                "I17",
+                "I15",
+                "H14"
+              ],
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "J22",
+                "J20"
+              ],
+              [
+                "J26",
+                "J24",
+                "J22"
+              ]
+            ],
+            "hexes": [
+              "H12",
+              "G13",
+              "H14",
+              "I19",
+              "J20",
+              "J22",
+              "J26"
+            ],
+            "revenue": 310,
+            "revenue_str": "H12-G13-H14-I19-J20-J22-J26",
+            "nodes": [
+              "G13-0",
+              "H12-0",
+              "H14-0",
+              "I19-0",
+              "J20-0",
+              "J22-0",
+              "J26-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 814,
+        "created_at": 1659571054,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 815,
+        "created_at": 1659571057,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659571057
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 816,
+        "created_at": 1659575922
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 817,
+        "created_at": 1659575947
+      },
+      {
+        "type": "par",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 818,
+        "created_at": 1659582360,
+        "corporation": "HR",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 819,
+        "created_at": 1659582374
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 820,
+        "created_at": 1659607198,
+        "shares": [
+          "NY&H_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 821,
+        "created_at": 1659607210
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 822,
+        "created_at": 1659612477,
+        "shares": [
+          "NY&H_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 823,
+        "created_at": 1659612506
+      },
+      {
+        "type": "par",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 824,
+        "created_at": 1659615211,
+        "corporation": "B&A",
+        "share_price": "100,0,4"
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 825,
+        "created_at": 1659615223
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 826,
+        "created_at": 1659616852,
+        "shares": [
+          "RWO_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 827,
+        "created_at": 1659616859
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 828,
+        "created_at": 1659618323,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659618322,
+            "shares": [
+              "HR_1"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659618322
+          }
+        ],
+        "corporation": "HR",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 829,
+        "created_at": 1659620160,
+        "shares": [
+          "NYNH_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 830,
+        "created_at": 1659620165
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 831,
+        "created_at": 1659621605,
+        "shares": [
+          "NYNH_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 832,
+        "created_at": 1659621669
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 833,
+        "created_at": 1659621971,
+        "shares": [
+          "B&A_1"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 834,
+        "created_at": 1659621998
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 835,
+        "user": 5944,
+        "created_at": 1659623354
+      },
+      {
+        "skip": true,
+        "type": "redo",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 836,
+        "user": 5944,
+        "created_at": 1659623356
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 837,
+        "created_at": 1659623422,
+        "shares": [
+          "RWO_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 838,
+        "created_at": 1659623425,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659623425,
+            "shares": [
+              "HR_2"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659623425
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 839,
+        "created_at": 1659628657,
+        "shares": [
+          "NYNH_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 840,
+        "created_at": 1659628688
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 841,
+        "created_at": 1659631100,
+        "shares": [
+          "NYNH_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 842,
+        "created_at": 1659631119
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 843,
+        "created_at": 1659632008,
+        "shares": [
+          "B&A_2"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 844,
+        "created_at": 1659632024
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 845,
+        "created_at": 1659632041,
+        "shares": [
+          "NYNH_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 846,
+        "created_at": 1659632057,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659632056,
+            "shares": [
+              "HR_3"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659632056
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 847,
+        "created_at": 1659632571,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 480,
+            "entity_type": "player",
+            "created_at": 1659632570
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 848,
+        "created_at": 1659632936,
+        "shares": [
+          "RWO_8"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 849,
+        "created_at": 1659633029
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 850,
+        "created_at": 1659633356,
+        "shares": [
+          "B&A_3"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 851,
+        "created_at": 1659633376
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 852,
+        "created_at": 1659634226,
+        "shares": [
+          "NYC_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 4473,
+            "shares": [
+              "HR_4"
+            ],
+            "percent": 10,
+            "created_at": 1659634231,
+            "entity_type": "player"
+          },
+          {
+            "type": "program_disable",
+            "entity": 4473,
+            "reason": "HR is floated",
+            "created_at": 1659634231,
+            "entity_type": "player"
+          }
+        ],
+        "id": 853,
+        "user": 5944,
+        "created_at": 1659634231,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 854,
+        "user": 5944,
+        "created_at": 1659634240
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 855,
+        "created_at": 1659634241,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659634240
+          },
+          {
+            "type": "buy_shares",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659634240,
+            "shares": [
+              "HR_4"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659634240,
+            "reason": "HR is floated"
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 856,
+        "created_at": 1659635271,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 480,
+            "entity_type": "player",
+            "created_at": 1659635270
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 857,
+        "created_at": 1659635355,
+        "shares": [
+          "HR_5"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 858,
+        "created_at": 1659635365
+      },
+      {
+        "type": "sell_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 859,
+        "created_at": 1659639473,
+        "shares": [
+          "D&H_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 860,
+        "created_at": 1659639476,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659639475,
+            "reason": "Shares were sold"
+          }
+        ],
+        "shares": [
+          "B&A_4"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 861,
+        "created_at": 1659639599,
+        "shares": [
+          "RWO_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "shares": [
+          "D&H_7"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "share_price": false,
+        "id": 862,
+        "user": 5944,
+        "created_at": 1659639604,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 863,
+        "user": 5944,
+        "created_at": 1659639615
+      },
+      {
+        "type": "buy_shares",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 864,
+        "created_at": 1659639648,
+        "shares": [
+          "D&H_7"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 4473,
+        "entity_type": "player",
+        "id": 865,
+        "created_at": 1659641313,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659641313
+          },
+          {
+            "type": "program_disable",
+            "entity": 480,
+            "entity_type": "player",
+            "created_at": 1659641313,
+            "reason": "Shares were sold"
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 480,
+        "entity_type": "player",
+        "id": 866,
+        "created_at": 1659656508,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 480,
+            "entity_type": "player",
+            "created_at": 1659656509
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 867,
+        "created_at": 1659670041,
+        "shares": [
+          "RWO_6"
+        ],
+        "percent": 10,
+        "share_price": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 868,
+        "created_at": 1659670055
+      },
+      {
+        "type": "pass",
+        "entity": 10188,
+        "entity_type": "player",
+        "id": 869,
+        "created_at": 1659701666
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 5944,
+        "entity_type": "player",
+        "id": 870,
+        "created_at": 1659701716,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 5944,
+            "entity_type": "player",
+            "created_at": 1659701715
+          },
+          {
+            "type": "pass",
+            "entity": 4473,
+            "entity_type": "player",
+            "created_at": 1659701715
+          },
+          {
+            "type": "pass",
+            "entity": 480,
+            "entity_type": "player",
+            "created_at": 1659701715
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 871,
+        "created_at": 1659706500
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 872,
+        "created_at": 1659706511,
+        "hex": "J20",
+        "tile": "X32-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 873,
+        "created_at": 1659706517
+      },
+      {
+        "type": "place_token",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 874,
+        "created_at": 1659706519,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659706584
+          }
+        ],
+        "city": "X32-0-0",
+        "slot": 3,
+        "cost": 80,
+        "tokener": "NYC"
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 875,
+        "created_at": 1659706528,
+        "kind": "payout"
+      },
+      {
+        "type": "sell_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 876,
+        "created_at": 1659706567,
+        "shares": [
+          "RWO_5",
+          "RWO_8",
+          "RWO_6"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "sell_shares",
+        "entity": 3828,
+        "shares": [
+          "NYNH_7",
+          "NYNH_5"
+        ],
+        "percent": 20,
+        "entity_type": "player",
+        "id": 877,
+        "user": 3828,
+        "created_at": 1659706575,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 878,
+        "user": 3828,
+        "created_at": 1659706584
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 879,
+        "created_at": 1659706593,
+        "loan": 24
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 880,
+        "created_at": 1659706594,
+        "loan": 25
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 881,
+        "created_at": 1659706595,
+        "loan": 26
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 882,
+        "created_at": 1659706596,
+        "loan": 27
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 883,
+        "created_at": 1659706597,
+        "loan": 28
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 884,
+        "created_at": 1659706598,
+        "loan": 29
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 885,
+        "created_at": 1659706599,
+        "loan": 30
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 886,
+        "created_at": 1659706600,
+        "loan": 31
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 887,
+        "created_at": 1659706600,
+        "loan": 32
+      },
+      {
+        "type": "take_loan",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 888,
+        "created_at": 1659706601,
+        "loan": 33
+      },
+      {
+        "type": "sell_shares",
+        "entity": 3828,
+        "entity_type": "player",
+        "id": 889,
+        "created_at": 1659706615,
+        "shares": [
+          "NYNH_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_train",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 890,
+        "created_at": 1659706621,
+        "train": "D-2",
+        "price": 1000,
+        "variant": "D"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 891,
+        "created_at": 1659706626,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659706691
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 892,
+        "created_at": 1659706951,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659706950
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 893,
+        "created_at": 1659706975,
+        "routes": [
+          {
+            "train": "5DE-0",
+            "connections": [
+              [
+                "K17",
+                "J18"
+              ],
+              [
+                "J18",
+                "I17",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "F20",
+                "G21"
+              ],
+              [
+                "G21",
+                "H20"
+              ],
+              [
+                "H20",
+                "I21",
+                "J20"
+              ],
+              [
+                "J20",
+                "J22"
+              ],
+              [
+                "J22",
+                "J24",
+                "J26"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "J18",
+              "G19",
+              "F20",
+              "G21",
+              "H20",
+              "J20",
+              "J22",
+              "J26"
+            ],
+            "revenue": 840,
+            "revenue_str": "K17-(J18)-G19-F20-(G21)-(H20)-J20-(J22)-J26",
+            "nodes": [
+              "K17-0",
+              "J18-0",
+              "G19-0",
+              "F20-0",
+              "G21-0",
+              "H20-0",
+              "J20-0",
+              "J22-0",
+              "J26-0"
+            ]
+          },
+          {
+            "train": "12H-0",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "I17",
+                "I15",
+                "H14"
+              ],
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J18",
+              "J20",
+              "I19",
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 410,
+            "revenue_str": "K17-K19-J18-J20-I19-H14-G13-H12",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J18-0",
+              "J20-0",
+              "I19-0",
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 894,
+        "created_at": 1659706976,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 895,
+        "created_at": 1659706978,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659706977
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 896,
+        "created_at": 1659707707,
+        "hex": "E5",
+        "tile": "455-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 897,
+        "created_at": 1659707720,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659707720
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 898,
+        "created_at": 1659707775,
+        "routes": [
+          {
+            "train": "5DE-1",
+            "connections": [
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "E1"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "E5",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            "revenue": 680,
+            "revenue_str": "H4-E3-E5-D4-(D2)-E1",
+            "nodes": [
+              "H4-0",
+              "E3-0",
+              "E5-0",
+              "D4-0",
+              "D2-0",
+              "E1-0"
+            ]
+          },
+          {
+            "train": "12H-1",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D6",
+                "D8"
+              ],
+              [
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "D14",
+                "E15"
+              ],
+              [
+                "E15",
+                "E17",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "D4",
+              "D8",
+              "E11",
+              "D12",
+              "D14",
+              "E15",
+              "E19"
+            ],
+            "revenue": 450,
+            "revenue_str": "D0-D2-E3-D4-D8-E11-D12-D14-E15-E19",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "D4-0",
+              "D8-0",
+              "E11-0",
+              "D12-0",
+              "D14-0",
+              "E15-0",
+              "E19-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 899,
+        "created_at": 1659707779,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 900,
+        "created_at": 1659707781,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659707780
+          }
+        ]
+      },
+      {
+        "hex": "H20",
+        "tile": "15-4",
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 901,
+        "user": 10188,
+        "created_at": 1659708966,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 902,
+        "user": 10188,
+        "created_at": 1659708980
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 903,
+        "created_at": 1659709021,
+        "hex": "E19",
+        "tile": "455-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 904,
+        "created_at": 1659709050,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659709049
+          }
+        ],
+        "hex": "F18",
+        "tile": "9-6",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 905,
+        "created_at": 1659709074,
+        "routes": [
+          {
+            "train": "D-0",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "E19"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "E15",
+                "D14"
+              ],
+              [
+                "D14",
+                "D12"
+              ],
+              [
+                "D12",
+                "D10",
+                "C11"
+              ],
+              [
+                "C11",
+                "B12"
+              ],
+              [
+                "B12",
+                "A11"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J18",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "E19",
+              "E15",
+              "D14",
+              "D12",
+              "C11",
+              "B12",
+              "A11"
+            ],
+            "revenue": 650,
+            "revenue_str": "K17-K19-J18-J20-H20-G21-F20-E19-E15-D14-D12-C11-B12-A11",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J18-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "E19-0",
+              "E15-0",
+              "D14-0",
+              "D12-0",
+              "C11-0",
+              "B12-0",
+              "A11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 906,
+        "created_at": 1659709085,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 907,
+        "created_at": 1659709088,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659709088
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 908,
+        "created_at": 1659709746,
+        "hex": "D12",
+        "tile": "X34-0",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 909,
+        "created_at": 1659709757
+      },
+      {
+        "type": "place_token",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 910,
+        "created_at": 1659709767,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "HR",
+            "entity_type": "corporation",
+            "created_at": 1659709766
+          }
+        ],
+        "city": "455-1-0",
+        "slot": 2,
+        "cost": 60,
+        "tokener": "HR"
+      },
+      {
+        "type": "buy_train",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 911,
+        "created_at": 1659709782,
+        "train": "D-3",
+        "price": 1000,
+        "variant": "D"
+      },
+      {
+        "type": "pass",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 912,
+        "created_at": 1659709784,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "HR",
+            "entity_type": "corporation",
+            "created_at": 1659709784
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 913,
+        "created_at": 1659709930,
+        "hex": "F24",
+        "tile": "9-7",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 914,
+        "created_at": 1659709934,
+        "hex": "F22",
+        "tile": "9-8",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 915,
+        "created_at": 1659709940,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "B&A",
+            "entity_type": "corporation",
+            "created_at": 1659709940
+          }
+        ],
+        "city": "X20-0-0",
+        "slot": 1,
+        "cost": 60,
+        "tokener": "B&A"
+      },
+      {
+        "type": "buy_train",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 916,
+        "created_at": 1659709947,
+        "train": "D-4",
+        "price": 1000,
+        "variant": "D"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 917,
+        "created_at": 1659709951,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "B&A",
+            "entity_type": "corporation",
+            "created_at": 1659709950
+          }
+        ]
+      },
+      {
+        "hex": "D10",
+        "tile": "45-0",
+        "type": "lay_tile",
+        "entity": "RWO",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 918,
+        "user": 480,
+        "created_at": 1659711330,
+        "skip": true
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 919,
+        "user": 480,
+        "created_at": 1659711334,
+        "skip": true
+      },
+      {
+        "city": "X34-0-0",
+        "cost": 20,
+        "slot": 1,
+        "type": "place_token",
+        "entity": "RWO",
+        "tokener": "RWO",
+        "entity_type": "corporation",
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "created_at": 1659711344,
+            "entity_type": "corporation"
+          }
+        ],
+        "id": 920,
+        "user": 480,
+        "created_at": 1659711344,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "RWO",
+        "action_id": 917,
+        "entity_type": "corporation",
+        "id": 921,
+        "user": 480,
+        "created_at": 1659711394
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 922,
+        "created_at": 1659711423,
+        "hex": "H20",
+        "tile": "619-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 923,
+        "created_at": 1659711428
+      },
+      {
+        "type": "place_token",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 924,
+        "created_at": 1659711450,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659711449
+          }
+        ],
+        "city": "63-3-0",
+        "slot": 1,
+        "cost": 20,
+        "tokener": "RWO"
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 925,
+        "created_at": 1659711487,
+        "routes": [
+          {
+            "train": "D-1",
+            "connections": [
+              [
+                "H20",
+                "I21",
+                "J20"
+              ],
+              [
+                "G21",
+                "H20"
+              ],
+              [
+                "F20",
+                "G21"
+              ],
+              [
+                "E19",
+                "F20"
+              ],
+              [
+                "E15",
+                "E17",
+                "E19"
+              ],
+              [
+                "D14",
+                "E13",
+                "E15"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "C11",
+                "D10",
+                "D12"
+              ],
+              [
+                "B12",
+                "C11"
+              ],
+              [
+                "A11",
+                "B12"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "E19",
+              "E15",
+              "D14",
+              "D12",
+              "C11",
+              "B12",
+              "A11"
+            ],
+            "revenue": 520,
+            "revenue_str": "J20-H20-G21-F20-E19-E15-D14-D12-C11-B12-A11",
+            "nodes": [
+              "H20-0",
+              "J20-0",
+              "G21-0",
+              "F20-0",
+              "E19-0",
+              "E15-0",
+              "D14-0",
+              "D12-0",
+              "C11-0",
+              "B12-0",
+              "A11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 926,
+        "created_at": 1659711493,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 927,
+        "created_at": 1659711496,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659711495
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 928,
+        "created_at": 1659711875,
+        "hex": "K19",
+        "tile": "15-4",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 929,
+        "created_at": 1659711887,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659711886
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 930,
+        "created_at": 1659711892,
+        "routes": [
+          {
+            "train": "12H-2",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "J18",
+                "I17",
+                "I19"
+              ],
+              [
+                "I19",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "F22",
+                "F24",
+                "F26"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J18",
+              "I19",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "F26"
+            ],
+            "revenue": 530,
+            "revenue_str": "K17-K19-J18-I19-J20-H20-G21-F20-F26",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J18-0",
+              "I19-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "F26-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 931,
+        "created_at": 1659711894,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 932,
+        "created_at": 1659711897,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659711896
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 933,
+        "created_at": 1659711910,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659711909
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 934,
+        "created_at": 1659711929,
+        "routes": [
+          {
+            "train": "5DE-0",
+            "connections": [
+              [
+                "K17",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "F22",
+                "F24",
+                "F26"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "J18",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "F26"
+            ],
+            "revenue": 860,
+            "revenue_str": "K17-J18-J20-(H20)-(G21)-F20-F26",
+            "nodes": [
+              "K17-0",
+              "J18-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "F26-0"
+            ]
+          },
+          {
+            "train": "12H-0",
+            "connections": [
+              [
+                "J26",
+                "J24",
+                "J22"
+              ],
+              [
+                "J22",
+                "J20"
+              ],
+              [
+                "J20",
+                "K19"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "J18",
+                "I17",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "J26",
+              "J22",
+              "J20",
+              "K19",
+              "J18",
+              "I19",
+              "G19",
+              "F20",
+              "E19"
+            ],
+            "revenue": 450,
+            "revenue_str": "J26-J22-J20-K19-J18-I19-G19-F20-E19",
+            "nodes": [
+              "J26-0",
+              "J22-0",
+              "J20-0",
+              "K19-0",
+              "J18-0",
+              "I19-0",
+              "G19-0",
+              "F20-0",
+              "E19-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 935,
+        "created_at": 1659711931,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 936,
+        "created_at": 1659711932,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659711931
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 937,
+        "created_at": 1659712653,
+        "hex": "D8",
+        "tile": "X33-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 938,
+        "created_at": 1659712656,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659712655
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 939,
+        "created_at": 1659712686,
+        "routes": [
+          {
+            "train": "5DE-1",
+            "connections": [
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "E1"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "E5",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            "revenue": 680,
+            "revenue_str": "H4-E3-E5-D4-(D2)-E1",
+            "nodes": [
+              "H4-0",
+              "E3-0",
+              "E5-0",
+              "D4-0",
+              "D2-0",
+              "E1-0"
+            ]
+          },
+          {
+            "train": "12H-1",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D6",
+                "D8"
+              ],
+              [
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D12",
+                "D10",
+                "C11"
+              ],
+              [
+                "C11",
+                "B12"
+              ],
+              [
+                "B12",
+                "A11"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "D4",
+              "D8",
+              "E11",
+              "D12",
+              "C11",
+              "B12",
+              "A11"
+            ],
+            "revenue": 490,
+            "revenue_str": "D0-D2-E3-D4-D8-E11-D12-C11-B12-A11",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "D4-0",
+              "D8-0",
+              "E11-0",
+              "D12-0",
+              "C11-0",
+              "B12-0",
+              "A11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 940,
+        "created_at": 1659712689,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 941,
+        "created_at": 1659712692,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659712691
+          }
+        ]
+      },
+      {
+        "hex": "F18",
+        "tile": "23-1",
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "id": 942,
+        "user": 10188,
+        "created_at": 1659713199,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 943,
+        "user": 10188,
+        "created_at": 1659713359
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 944,
+        "created_at": 1659714933,
+        "hex": "F18",
+        "tile": "23-1",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 945,
+        "created_at": 1659714957,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659714957
+          }
+        ],
+        "hex": "E21",
+        "tile": "57-4",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 946,
+        "created_at": 1659714977,
+        "routes": [
+          {
+            "train": "D-0",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "G19"
+              ],
+              [
+                "G19",
+                "H18",
+                "I17",
+                "I15",
+                "H14"
+              ],
+              [
+                "H14",
+                "G13"
+              ],
+              [
+                "G13",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J18",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "G19",
+              "H14",
+              "G13",
+              "H12"
+            ],
+            "revenue": 530,
+            "revenue_str": "K17-K19-J18-J20-H20-G21-F20-G19-H14-G13-H12",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J18-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "G19-0",
+              "H14-0",
+              "G13-0",
+              "H12-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 947,
+        "created_at": 1659714980,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 948,
+        "created_at": 1659715011,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659715011
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 949,
+        "created_at": 1659715281,
+        "hex": "K19",
+        "tile": "X21-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 950,
+        "created_at": 1659715285,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659715284
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 951,
+        "created_at": 1659715292,
+        "routes": [
+          {
+            "train": "12H-2",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "J18",
+                "I17",
+                "I19"
+              ],
+              [
+                "I19",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "F22",
+                "F24",
+                "F26"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J18",
+              "I19",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "F26"
+            ],
+            "revenue": 550,
+            "revenue_str": "K17-K19-J18-I19-J20-H20-G21-F20-F26",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J18-0",
+              "I19-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "F26-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 952,
+        "created_at": 1659715306,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 953,
+        "created_at": 1659715307,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659715306
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 954,
+        "created_at": 1659718151,
+        "hex": "D18",
+        "tile": "5-4",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 955,
+        "created_at": 1659718166,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "HR",
+            "entity_type": "corporation",
+            "created_at": 1659718165
+          }
+        ],
+        "hex": "D22",
+        "tile": "9-9",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 956,
+        "created_at": 1659718177,
+        "routes": [
+          {
+            "train": "D-3",
+            "connections": [
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "F22",
+                "F24",
+                "F26"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "F26"
+            ],
+            "revenue": 320,
+            "revenue_str": "J20-H20-G21-F20-F26",
+            "nodes": [
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "F26-0"
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "half",
+        "type": "dividend",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 957,
+        "user": 4473,
+        "created_at": 1659718182,
+        "skip": true
+      },
+      {
+        "skip": true,
+        "type": "undo",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 958,
+        "user": 4473,
+        "created_at": 1659718207
+      },
+      {
+        "type": "dividend",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 959,
+        "created_at": 1659718211,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 960,
+        "created_at": 1659718401,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "HR",
+            "entity_type": "corporation",
+            "created_at": 1659718400
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 961,
+        "created_at": 1659719973,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "B&A",
+            "entity_type": "corporation",
+            "created_at": 1659719972
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 962,
+        "created_at": 1659719976,
+        "routes": [
+          {
+            "train": "D-4",
+            "connections": [
+              [
+                "F26",
+                "F24",
+                "F22",
+                "F20"
+              ],
+              [
+                "F20",
+                "G21"
+              ],
+              [
+                "G21",
+                "H20"
+              ],
+              [
+                "H20",
+                "I21",
+                "J20"
+              ]
+            ],
+            "hexes": [
+              "F26",
+              "F20",
+              "G21",
+              "H20",
+              "J20"
+            ],
+            "revenue": 320,
+            "revenue_str": "F26-F20-G21-H20-J20",
+            "nodes": [
+              "F26-0",
+              "F20-0",
+              "G21-0",
+              "H20-0",
+              "J20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 963,
+        "created_at": 1659719980,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 964,
+        "created_at": 1659719982,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "B&A",
+            "entity_type": "corporation",
+            "created_at": 1659719981
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 965,
+        "created_at": 1659720690,
+        "hex": "C11",
+        "tile": "57-5",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 966,
+        "created_at": 1659720693
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 967,
+        "created_at": 1659720714,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659720713
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 968,
+        "created_at": 1659720718,
+        "routes": [
+          {
+            "train": "D-1",
+            "connections": [
+              [
+                "H20",
+                "I21",
+                "J20"
+              ],
+              [
+                "G21",
+                "H20"
+              ],
+              [
+                "F20",
+                "G21"
+              ],
+              [
+                "E19",
+                "F20"
+              ],
+              [
+                "E15",
+                "E17",
+                "E19"
+              ],
+              [
+                "D14",
+                "E13",
+                "E15"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "C11",
+                "D10",
+                "D12"
+              ],
+              [
+                "B12",
+                "C11"
+              ],
+              [
+                "A11",
+                "B12"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "E19",
+              "E15",
+              "D14",
+              "D12",
+              "C11",
+              "B12",
+              "A11"
+            ],
+            "revenue": 530,
+            "revenue_str": "J20-H20-G21-F20-E19-E15-D14-D12-C11-B12-A11",
+            "nodes": [
+              "H20-0",
+              "J20-0",
+              "G21-0",
+              "F20-0",
+              "E19-0",
+              "E15-0",
+              "D14-0",
+              "D12-0",
+              "C11-0",
+              "B12-0",
+              "A11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 969,
+        "created_at": 1659720725,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 970,
+        "created_at": 1659720729,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659720729
+          },
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659720729
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 971,
+        "created_at": 1659721329,
+        "routes": [
+          {
+            "train": "D-2",
+            "connections": [
+              [
+                "E3",
+                "F4",
+                "G3",
+                "H4"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D8",
+                "D6",
+                "E5"
+              ],
+              [
+                "E11",
+                "D10",
+                "D8"
+              ],
+              [
+                "D12",
+                "E11"
+              ],
+              [
+                "D14",
+                "D12"
+              ],
+              [
+                "E15",
+                "E13",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "K19",
+                "J20"
+              ],
+              [
+                "J18",
+                "K19"
+              ],
+              [
+                "K17",
+                "J18"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "D2",
+              "D4",
+              "E5",
+              "D8",
+              "E11",
+              "D12",
+              "D14",
+              "E15",
+              "E19",
+              "F20",
+              "G21",
+              "H20",
+              "J20",
+              "K19",
+              "J18",
+              "K17"
+            ],
+            "revenue": 1010,
+            "revenue_str": "H4-E3-D2-D4-E5-D8-E11-D12-D14-E15-E19-F20-G21-H20-J20-K19-J18-K17",
+            "nodes": [
+              "E3-0",
+              "H4-0",
+              "D2-0",
+              "D4-0",
+              "E5-0",
+              "D8-0",
+              "E11-0",
+              "D12-0",
+              "D14-0",
+              "E15-0",
+              "E19-0",
+              "F20-0",
+              "G21-0",
+              "H20-0",
+              "J20-0",
+              "K19-0",
+              "J18-0",
+              "K17-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 972,
+        "created_at": 1659721331,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 973,
+        "created_at": 1659721337,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659721402
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 974,
+        "created_at": 1659721366,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659721365
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 975,
+        "created_at": 1659721388,
+        "routes": [
+          {
+            "train": "5DE-0",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "F22",
+                "F24",
+                "F26"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "F26"
+            ],
+            "revenue": 900,
+            "revenue_str": "K17-K19-J20-(H20)-(G21)-F20-F26",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "F26-0"
+            ]
+          },
+          {
+            "train": "12H-0",
+            "connections": [
+              [
+                "K17",
+                "J18"
+              ],
+              [
+                "J18",
+                "J20"
+              ],
+              [
+                "J20",
+                "I19"
+              ],
+              [
+                "I19",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "F20",
+                "E19"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "J18",
+              "J20",
+              "I19",
+              "G19",
+              "F20",
+              "E19"
+            ],
+            "revenue": 450,
+            "revenue_str": "K17-J18-J20-I19-G19-F20-E19",
+            "nodes": [
+              "K17-0",
+              "J18-0",
+              "J20-0",
+              "I19-0",
+              "G19-0",
+              "F20-0",
+              "E19-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 976,
+        "created_at": 1659721390,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "D&H",
+        "entity_type": "corporation",
+        "id": 977,
+        "created_at": 1659721391,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "D&H",
+            "entity_type": "corporation",
+            "created_at": 1659721390
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 978,
+        "created_at": 1659723945,
+        "hex": "K19",
+        "tile": "X31-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 979,
+        "created_at": 1659723949,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659724014
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 980,
+        "created_at": 1659723953,
+        "routes": [
+          {
+            "train": "D-2",
+            "connections": [
+              [
+                "E3",
+                "F4",
+                "G3",
+                "H4"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D8",
+                "D6",
+                "E5"
+              ],
+              [
+                "E11",
+                "D10",
+                "D8"
+              ],
+              [
+                "D12",
+                "E11"
+              ],
+              [
+                "D14",
+                "D12"
+              ],
+              [
+                "E15",
+                "E13",
+                "D14"
+              ],
+              [
+                "E19",
+                "E17",
+                "E15"
+              ],
+              [
+                "F20",
+                "E19"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "K19",
+                "J20"
+              ],
+              [
+                "J18",
+                "K19"
+              ],
+              [
+                "K17",
+                "J18"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "D2",
+              "D4",
+              "E5",
+              "D8",
+              "E11",
+              "D12",
+              "D14",
+              "E15",
+              "E19",
+              "F20",
+              "G21",
+              "H20",
+              "J20",
+              "K19",
+              "J18",
+              "K17"
+            ],
+            "revenue": 1040,
+            "revenue_str": "H4-E3-D2-D4-E5-D8-E11-D12-D14-E15-E19-F20-G21-H20-J20-K19-J18-K17",
+            "nodes": [
+              "E3-0",
+              "H4-0",
+              "D2-0",
+              "D4-0",
+              "E5-0",
+              "D8-0",
+              "E11-0",
+              "D12-0",
+              "D14-0",
+              "E15-0",
+              "E19-0",
+              "F20-0",
+              "G21-0",
+              "H20-0",
+              "J20-0",
+              "K19-0",
+              "J18-0",
+              "K17-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 981,
+        "created_at": 1659723955,
+        "kind": "half"
+      },
+      {
+        "type": "pass",
+        "entity": "NYC",
+        "entity_type": "corporation",
+        "id": 982,
+        "created_at": 1659723972,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYC",
+            "entity_type": "corporation",
+            "created_at": 1659724037
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 983,
+        "created_at": 1659724573,
+        "hex": "D10",
+        "tile": "45-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 984,
+        "created_at": 1659724591,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659724590
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 985,
+        "created_at": 1659724661,
+        "routes": [
+          {
+            "train": "5DE-1",
+            "connections": [
+              [
+                "H4",
+                "G3",
+                "F4",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D4"
+              ],
+              [
+                "D4",
+                "D2"
+              ],
+              [
+                "D2",
+                "E1"
+              ]
+            ],
+            "hexes": [
+              "H4",
+              "E3",
+              "E5",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            "revenue": 680,
+            "revenue_str": "H4-E3-E5-D4-(D2)-E1",
+            "nodes": [
+              "H4-0",
+              "E3-0",
+              "E5-0",
+              "D4-0",
+              "D2-0",
+              "E1-0"
+            ]
+          },
+          {
+            "train": "12H-1",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "D4"
+              ],
+              [
+                "D4",
+                "D6",
+                "D8"
+              ],
+              [
+                "D8",
+                "D10",
+                "E11"
+              ],
+              [
+                "E11",
+                "D12"
+              ],
+              [
+                "D12",
+                "D10",
+                "C11"
+              ],
+              [
+                "C11",
+                "B12"
+              ],
+              [
+                "B12",
+                "A11"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "D4",
+              "D8",
+              "E11",
+              "D12",
+              "C11",
+              "B12",
+              "A11"
+            ],
+            "revenue": 500,
+            "revenue_str": "D0-D2-E3-D4-D8-E11-D12-C11-B12-A11",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "D4-0",
+              "D8-0",
+              "E11-0",
+              "D12-0",
+              "C11-0",
+              "B12-0",
+              "A11-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 986,
+        "created_at": 1659724666,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ERIE",
+        "entity_type": "corporation",
+        "id": 987,
+        "created_at": 1659724670,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "ERIE",
+            "entity_type": "corporation",
+            "created_at": 1659724669
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 988,
+        "created_at": 1659725322,
+        "hex": "E17",
+        "tile": "20-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 989,
+        "created_at": 1659725326,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659725326
+          }
+        ],
+        "hex": "D16",
+        "tile": "8-7",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 990,
+        "created_at": 1659725337,
+        "routes": [
+          {
+            "train": "D-0",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J20"
+              ],
+              [
+                "J20",
+                "J18"
+              ],
+              [
+                "J18",
+                "I17",
+                "H18",
+                "G19"
+              ],
+              [
+                "G19",
+                "F20"
+              ],
+              [
+                "F20",
+                "F18",
+                "E17",
+                "D16",
+                "D14"
+              ],
+              [
+                "D14",
+                "D12"
+              ],
+              [
+                "D12",
+                "D10",
+                "D8"
+              ],
+              [
+                "D8",
+                "D6",
+                "E5"
+              ],
+              [
+                "E5",
+                "E3"
+              ],
+              [
+                "E3",
+                "D2"
+              ],
+              [
+                "D2",
+                "D0"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J20",
+              "J18",
+              "G19",
+              "F20",
+              "D14",
+              "D12",
+              "D8",
+              "E5",
+              "E3",
+              "D2",
+              "D0"
+            ],
+            "revenue": 870,
+            "revenue_str": "K17-K19-J20-J18-G19-F20-D14-D12-D8-E5-E3-D2-D0",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J20-0",
+              "J18-0",
+              "G19-0",
+              "F20-0",
+              "D14-0",
+              "D12-0",
+              "D8-0",
+              "E5-0",
+              "E3-0",
+              "D2-0",
+              "D0-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 991,
+        "created_at": 1659725340,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NY&H",
+        "entity_type": "corporation",
+        "id": 992,
+        "created_at": 1659725343,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NY&H",
+            "entity_type": "corporation",
+            "created_at": 1659725343
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 993,
+        "created_at": 1659725563,
+        "hex": "I19",
+        "tile": "63-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 994,
+        "created_at": 1659725566,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659725565
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 995,
+        "created_at": 1659725577,
+        "routes": [
+          {
+            "train": "12H-2",
+            "connections": [
+              [
+                "K17",
+                "K19"
+              ],
+              [
+                "K19",
+                "J18"
+              ],
+              [
+                "J18",
+                "I17",
+                "I19"
+              ],
+              [
+                "I19",
+                "J20"
+              ],
+              [
+                "J20",
+                "I21",
+                "H20"
+              ],
+              [
+                "H20",
+                "G21"
+              ],
+              [
+                "G21",
+                "F20"
+              ],
+              [
+                "F20",
+                "F22",
+                "F24",
+                "F26"
+              ]
+            ],
+            "hexes": [
+              "K17",
+              "K19",
+              "J18",
+              "I19",
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "F26"
+            ],
+            "revenue": 590,
+            "revenue_str": "K17-K19-J18-I19-J20-H20-G21-F20-F26",
+            "nodes": [
+              "K17-0",
+              "K19-0",
+              "J18-0",
+              "I19-0",
+              "J20-0",
+              "H20-0",
+              "G21-0",
+              "F20-0",
+              "F26-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 996,
+        "created_at": 1659725578,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NYNH",
+        "entity_type": "corporation",
+        "id": 997,
+        "created_at": 1659725580,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "NYNH",
+            "entity_type": "corporation",
+            "created_at": 1659725579
+          }
+        ]
+      },
+      {
+        "type": "lay_tile",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 998,
+        "created_at": 1659726772,
+        "hex": "E17",
+        "tile": "47-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 999,
+        "created_at": 1659726777
+      },
+      {
+        "type": "place_token",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 1000,
+        "created_at": 1659726788,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "HR",
+            "entity_type": "corporation",
+            "created_at": 1659726787
+          }
+        ],
+        "city": "X20-0-0",
+        "slot": 3,
+        "cost": 20,
+        "tokener": "HR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 1001,
+        "created_at": 1659726811,
+        "routes": [
+          {
+            "train": "D-3",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D6",
+                "D8"
+              ],
+              [
+                "D8",
+                "D10",
+                "D12"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "D14",
+                "D16",
+                "E17",
+                "E19"
+              ],
+              [
+                "E19",
+                "F20"
+              ],
+              [
+                "F20",
+                "G21"
+              ],
+              [
+                "G21",
+                "H20"
+              ],
+              [
+                "H20",
+                "I21",
+                "J20"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "E5",
+              "D8",
+              "D12",
+              "D14",
+              "E19",
+              "F20",
+              "G21",
+              "H20",
+              "J20"
+            ],
+            "revenue": 690,
+            "revenue_str": "D0-D2-E3-E5-D8-D12-D14-E19-F20-G21-H20-J20",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "E5-0",
+              "D8-0",
+              "D12-0",
+              "D14-0",
+              "E19-0",
+              "F20-0",
+              "G21-0",
+              "H20-0",
+              "J20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 1002,
+        "created_at": 1659726815,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "HR",
+        "entity_type": "corporation",
+        "id": 1003,
+        "created_at": 1659726820,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "HR",
+            "entity_type": "corporation",
+            "created_at": 1659726819
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 1004,
+        "created_at": 1659730423
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 1005,
+        "created_at": 1659730424,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "B&A",
+            "entity_type": "corporation",
+            "created_at": 1659730424
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 1006,
+        "created_at": 1659730432,
+        "routes": [
+          {
+            "train": "D-4",
+            "connections": [
+              [
+                "D0",
+                "D2"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "E5",
+                "D6",
+                "D8"
+              ],
+              [
+                "D8",
+                "D10",
+                "D12"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "D14",
+                "D16",
+                "E17",
+                "F18",
+                "F20"
+              ],
+              [
+                "F20",
+                "G21"
+              ],
+              [
+                "G21",
+                "H20"
+              ],
+              [
+                "H20",
+                "I21",
+                "J20"
+              ]
+            ],
+            "hexes": [
+              "D0",
+              "D2",
+              "E3",
+              "E5",
+              "D8",
+              "D12",
+              "D14",
+              "F20",
+              "G21",
+              "H20",
+              "J20"
+            ],
+            "revenue": 640,
+            "revenue_str": "D0-D2-E3-E5-D8-D12-D14-F20-G21-H20-J20",
+            "nodes": [
+              "D0-0",
+              "D2-0",
+              "E3-0",
+              "E5-0",
+              "D8-0",
+              "D12-0",
+              "D14-0",
+              "F20-0",
+              "G21-0",
+              "H20-0",
+              "J20-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 1007,
+        "created_at": 1659730435,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "B&A",
+        "entity_type": "corporation",
+        "id": 1008,
+        "created_at": 1659730441,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "B&A",
+            "entity_type": "corporation",
+            "created_at": 1659730440
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 1009,
+        "created_at": 1659739332
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 1010,
+        "created_at": 1659739335,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659739334
+          }
+        ]
+      },
+      {
+        "type": "run_routes",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 1011,
+        "created_at": 1659739384,
+        "routes": [
+          {
+            "train": "D-1",
+            "connections": [
+              [
+                "H20",
+                "I21",
+                "J20"
+              ],
+              [
+                "G21",
+                "H20"
+              ],
+              [
+                "F20",
+                "G21"
+              ],
+              [
+                "E19",
+                "F20"
+              ],
+              [
+                "E15",
+                "E17",
+                "E19"
+              ],
+              [
+                "D14",
+                "E13",
+                "E15"
+              ],
+              [
+                "D12",
+                "D14"
+              ],
+              [
+                "D8",
+                "D10",
+                "D12"
+              ],
+              [
+                "E5",
+                "D6",
+                "D8"
+              ],
+              [
+                "E3",
+                "E5"
+              ],
+              [
+                "D2",
+                "E3"
+              ],
+              [
+                "D0",
+                "D2"
+              ]
+            ],
+            "hexes": [
+              "J20",
+              "H20",
+              "G21",
+              "F20",
+              "E19",
+              "E15",
+              "D14",
+              "D12",
+              "D8",
+              "E5",
+              "E3",
+              "D2",
+              "D0"
+            ],
+            "revenue": 730,
+            "revenue_str": "J20-H20-G21-F20-E19-E15-D14-D12-D8-E5-E3-D2-D0",
+            "nodes": [
+              "H20-0",
+              "J20-0",
+              "G21-0",
+              "F20-0",
+              "E19-0",
+              "E15-0",
+              "D14-0",
+              "D12-0",
+              "D8-0",
+              "E5-0",
+              "E3-0",
+              "D2-0",
+              "D0-0"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "dividend",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 1012,
+        "created_at": 1659739387,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "RWO",
+        "entity_type": "corporation",
+        "id": 1013,
+        "created_at": 1659739390,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": "RWO",
+            "entity_type": "corporation",
+            "created_at": 1659739389
+          }
+        ]
+      }
+    ],
+    "id": "hs_qovtrclf_91810",
+    "players": [
+      {
+        "id": 480,
+        "name": "Ben"
+      },
+      {
+        "id": 3828,
+        "name": "Shaw80"
+      },
+      {
+        "id": 10188,
+        "name": "seangardner"
+      },
+      {
+        "id": 5944,
+        "name": "Bear"
+      },
+      {
+        "id": 4473,
+        "name": "Corian09"
+      }
+    ],
+    "title": "18NY",
+    "description": "18NY - Async, EST, Few Moves per Day",
+    "min_players": 3,
+    "max_players": 5,
+    "user": {
+      "id": 0,
+      "name": "You"
+    },
+    "settings": {
+      "seed": 843600098,
+      "is_async": true,
+      "unlisted": false,
+      "auto_routing": true,
+      "player_order": null,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "turn": 7,
+    "round": "Operating Round",
+    "acting": [
+      480,
+      3828,
+      10188,
+      5944,
+      4473
+    ],
+    "result": {
+      "480": 6128,
+      "3828": 4461,
+      "4473": 6763,
+      "5944": 8592,
+      "10188": 5875
+    },
+    "loaded": true,
+    "created_at": "2022-08-21",
+    "updated_at": 1660624711,
+    "finished_at": 1659739390,
+    "mode": "hotseat"
+  }

--- a/spec/fixtures/18NY/README.md
+++ b/spec/fixtures/18NY/README.md
@@ -1,0 +1,2 @@
+68831: 1st edition game
+91810: 2nd edition game


### PR DESCRIPTION
1st edition:
![image](https://user-images.githubusercontent.com/2993555/185809905-88f21f42-b3fb-4674-99d1-113d2e689970.png)
![image](https://user-images.githubusercontent.com/2993555/185809911-b3bb0b8d-7d9b-4f0a-b08d-13cf02f1004d.png)

2nd edition:
![image](https://user-images.githubusercontent.com/2993555/185809930-19841d48-399a-4ff3-b946-c637b28b4453.png)
![image](https://user-images.githubusercontent.com/2993555/185809937-256f3a36-72fe-413f-8012-7fb8a9c4e899.png)

I think the special logic for fixing the New York tile orientation could be removed by adding stubs to the yellow, green, and brown NY tiles and having the base "track must be preserved" rules, but not only does that change the tiles to differ from the print game, it also might not be easier for players to use - it might look something like this
![image](https://user-images.githubusercontent.com/2993555/185810153-222a873f-912c-4bf3-ac52-6dc92c2ce9ff.png)
(I could see players mistakingly thinking the stubs connect to NY for running trains when no such connection exists yet)