### PR TITLE
Show messages as redacted instead of removing them

### DIFF
--- a/models/game.rb
+++ b/models/game.rb
@@ -126,7 +126,14 @@ class Game < Base
   def to_h(include_actions: false, logged_in_user_id: nil)
     actions_h = include_actions ? actions.map(&:to_h) : []
     if !players.find { |p| p.id == logged_in_user_id } && user_id != logged_in_user_id
-      actions_h.reject! { |a| a['type'] == 'message' }
+      actions_h.map! do |a|
+        if a['type'] == 'message'
+          a['user'] = user_id # Assign all messages to the creator of the game to not leak who sent it
+          a['message'] = '(Message redacted)'
+        end
+
+        a
+      end
     end
     settings_h = settings.to_h
 


### PR DESCRIPTION
Removing the message actions from the array makes the code reassign action numbers, which then become inconsistent. At the very least it is breaking the history, but it is very likely also breaking games with targeted undos.

It is also breaking some important stuff over at 18xx.tools, because the 18xx.games code starts behaving haphazardly.

Try navigating in the history here: https://18xx.games/game/94459?action=6