### PR TITLE
18SJ: Add discount for E trains (fixes #8232)

### DIFF
--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -163,7 +163,13 @@ module Engine
                     num: 20,
                     available_on: '6',
                     discount: { '4' => 300, '5' => 300, '6' => 300 },
-                    variants: [{ name: 'E', price: 1300 }],
+                    variants: [
+                      {
+                        name: 'E',
+                        price: 1300,
+                        discount: { '4' => 300, '5' => 300, '6' => 300 },
+                      },
+                    ],
                     events: [{ 'type' => 'nationalization' }],
                   }].freeze
 


### PR DESCRIPTION
Base code does not support reuse of base discount for
variant trains. The discount information need to be
repeated.