### PR TITLE
make arrows more compact

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -88,7 +88,7 @@ module View
           tr_props = @game.phase.available?(phase[:name]) && phase != current_phase ? @dimmed_font_style : {}
 
           h(:tr, tr_props, [
-            h(:td, (current_phase == phase ? '→ ' : '') + phase[:name]),
+            h(:td, (current_phase == phase ? '→' : '') + phase[:name]),
             h(:td, @game.info_on_trains(phase)),
             h(:td, phase[:operating_rounds]),
             h(:td, train_limit_to_h(phase[:train_limit])),
@@ -180,7 +180,7 @@ module View
           remaining = @depot.upcoming.select { |t| t.sym == sym }
           train = trains.first
           discounts = train.discount&.group_by { |_k, v| v }&.map do |price, price_discounts|
-            h('span.nowrap', "#{price_discounts.map(&:first).join(', ')} → #{@game.format_currency(price)}")
+            h('span.nowrap', "#{price_discounts.map(&:first).join(', ')}→#{@game.format_currency(price)}")
           end
           discounts = discounts.flat_map { |e| [e, ', '] }[0..-2] if discounts
           names_to_prices = train.names_to_prices
@@ -202,7 +202,7 @@ module View
             end
           end
           event_text = event_text.flat_map { |e| [h('span.nowrap', e), ', '] }[0..-2]
-          name = (@game.info_available_train(first_train, train) ? '→ ' : '') + @game.info_train_name(train)
+          name = (@game.info_available_train(first_train, train) ? '→' : '') + @game.info_train_name(train)
 
           train_content = [
             h(:td, name),
@@ -224,7 +224,7 @@ module View
 
             # needed for 18CZ where a train can be rusted by multiple different trains
             trains_to_rust = rust_schedule.select { |k, _v| k&.include?(key) }.values.flatten.join(', ')
-            rusts << "#{key} → #{trains_to_rust}"
+            rusts << "#{key}→#{trains_to_rust}"
             show_rusts_inline = false
           end
 


### PR DESCRIPTION
This removes spacing around arrows on the Info page

Impetus was to make the 1848 rusting schedule a bit more readable

IMO this change improves readability in general, as the arrows have "natural whitespace" around them, so the add'l whitespace is un-necessary

Old 1830:
![old_1830](https://user-images.githubusercontent.com/1711810/188218494-36986d29-9d40-4fa5-903b-31c38deb45c6.png)

New 1830
![new_1830](https://user-images.githubusercontent.com/1711810/188218491-b314c113-173b-4d31-a4fa-d2ee5d4aa904.png)

The 1848 Info page in question (in-progress, not currently live on the site)
![old_1848](https://user-images.githubusercontent.com/1711810/188218656-b50e36f0-257a-4239-b0a3-35ddb677e8e7.png)

