### PR TITLE
[18JP-T] Fix train discount for TC once ability is available.  Fixes #8243

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -302,7 +302,7 @@ module View
             president_assist, _fee = @game.president_assisted_buy(@corporation, train, price)
             entity = @corporation
 
-            if @selected_company && [@corporation, @corporation.owner].include?(@selected_company&.owner) \
+            if @selected_company && [@corporation, @corporation.owner].include?(@selected_company.owner) \
               && @step.respond_to?(:ability_timing)
               @game.abilities(@selected_company, :train_discount, time: @step.ability_timing) do |ability|
                 if ability.trains.include?(train.name)

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -302,7 +302,8 @@ module View
             president_assist, _fee = @game.president_assisted_buy(@corporation, train, price)
             entity = @corporation
 
-            if [@corporation, @corporation.owner].include?(@selected_company&.owner) && @step.respond_to?(:ability_timing)
+            if @selected_company && [@corporation, @corporation.owner].include?(@selected_company&.owner) \
+              && @step.respond_to?(:ability_timing)
               @game.abilities(@selected_company, :train_discount, time: @step.ability_timing) do |ability|
                 if ability.trains.include?(train.name)
                   price = ability.discounted_price(train, price)

--- a/lib/engine/game/g_18_jpt/game.rb
+++ b/lib/engine/game/g_18_jpt/game.rb
@@ -208,7 +208,7 @@ module Engine
             Engine::Step::Route,
             Engine::Step::Dividend,
             Engine::Step::DiscardTrain,
-            Engine::Step::BuyTrain,
+            G18JPT::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
         end

--- a/lib/engine/game/g_18_jpt/step/buy_train.rb
+++ b/lib/engine/game/g_18_jpt/step/buy_train.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G18JPT
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def cheapest_train_price(corporation)
+            cheapest_train = @depot.min_depot_train
+            price = cheapest_train.price
+            # Handle a corporation having train discount ability
+            @game.abilities(corporation, :train_discount, @ability_timing) do |ability|
+              next if ability.count
+
+              price = ability.discounted_price(cheapest_train, price) if ability.trains.include?(cheapest_train.name)
+            end
+            price
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Train discount wasn't being applied, as the '`include?`' in line 305 was evaluating true with no `selected_company`.  Checking that there is a `selected_company` allows the elsif at 312/313 to evaluate, and use the TC company discount.

This still left emergency fund-raising triggered, as the default `depot.min_depot_price` doesn't take discounts into account.  I've created `G18JPT::Step::BuyTrain`, which implements a `cheapest_train_price` that understands the TC's discount ability.

Works on the exported version of the game I hit the bug in, and passes rubocop.