### PR TITLE
[1848] fix 8303 and move to 48 to beta

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,6 +17,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
+        <p><a href='https://github.com/tobymao/18xx/wiki/1848'>1848</a> is now in Beta.</p>
         <p><a href='https://github.com/tobymao/18xx/wiki/1822PNW'>1822PNW</a> is now in Alpha.</p>
         <p><a href='https://github.com/tobymao/18xx/wiki/18Rhl:-Rhineland'>18Rhl: Rhineland</a> has been reworked, and need renewed Alpha testing.</p>
         <p>Individualized statistics are now available in your profile (once enabled in your settings). If you have any ideas for additional statistics, please submit a feature request.</p>

--- a/lib/engine/game/g_1848/meta.rb
+++ b/lib/engine/game/g_1848/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
 
         GAME_DESIGNER = 'Leonhard Orgler and Helmut Ohley'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1848'

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -53,7 +53,6 @@ module Engine
             trains_to_buy = trains_to_buy.select(&:from_depot?) unless @game.can_buy_trains
             trains_to_buy = trains_to_buy.reject { |t| t.name == '2E' }
             trains_to_buy << ghan_train if can_buy_2e?(entity)
-            trains_to_buy += @depot.depot_trains.reject { |t| t.name == '2E' }
             trains_to_buy.uniq
           end
 

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -197,7 +197,7 @@ module Engine
         variants.reject! { |v| entity.cash < v[:price] } if must_issue_before_ebuy?(entity)
         variants
       end
- 
+
       def setup
         @depot = @game.depot
         @last_share_sold_price = nil

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -60,7 +60,8 @@ module Engine
         exchange = action.exchange
 
         # Check if the train is actually buyable in the current situation
-        raise GameError, 'Not a buyable train' unless buyable_exchangeable_train_variants(train, entity, exchange).include?(train.variant)
+        raise GameError, 'Not a buyable train' unless buyable_exchangeable_train_variants(train, entity,
+                                                                                          exchange).include?(train.variant)
         raise GameError, 'Must pay face value' if must_pay_face_value?(train, entity, price)
         raise GameError, 'An entity cannot buy a train from itself' if train.owner == entity
 
@@ -175,7 +176,7 @@ module Engine
 
       def buyable_exchangeable_train_variants(train, entity, exchange)
         exchange ? exchangeable_train_variants(train, entity) : buyable_train_variants(train, entity)
-       end
+      end
 
       def buyable_train_variants(train, entity)
         return [] unless buyable_trains(entity).any? { |bt| bt.variants[bt.name] }
@@ -185,7 +186,7 @@ module Engine
 
       def exchangeable_train_variants(train, entity)
         discount_info = @game.discountable_trains_for(entity)
-        return [] unless discount_info.any? {|_, discount_train, _, _| discount_train.variants[discount_train.name]}
+        return [] unless discount_info.any? { |_, discount_train, _, _| discount_train.variants[discount_train.name] }
 
         train_vatiant_helper(train, entity)
       end

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -198,7 +198,6 @@ module Engine
         variants
       end
  
-
       def setup
         @depot = @game.depot
         @last_share_sold_price = nil

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -60,7 +60,7 @@ module Engine
         exchange = action.exchange
 
         # Check if the train is actually buyable in the current situation
-        raise GameError, 'Not a buyable train' unless buyable_train_variants(train, entity).include?(train.variant)
+        raise GameError, 'Not a buyable train' unless buyable_exchangeable_train_variants(train, entity, exchange).include?(train.variant)
         raise GameError, 'Must pay face value' if must_pay_face_value?(train, entity, price)
         raise GameError, 'An entity cannot buy a train from itself' if train.owner == entity
 
@@ -173,15 +173,31 @@ module Engine
         depot_trains + other_trains
       end
 
+      def buyable_exchangeable_train_variants(train, entity, exchange)
+        exchange ? exchangeable_train_variants(train, entity) : buyable_train_variants(train, entity)
+       end
+
       def buyable_train_variants(train, entity)
         return [] unless buyable_trains(entity).any? { |bt| bt.variants[bt.name] }
 
+        train_vatiant_helper(train, entity)
+      end
+
+      def exchangeable_train_variants(train, entity)
+        discount_info = @game.discountable_trains_for(entity)
+        return [] unless discount_info.any? {|_, discount_train, _, _| discount_train.variants[discount_train.name]}
+
+        train_vatiant_helper(train, entity)
+      end
+
+      def train_vatiant_helper(train, entity)
         variants = train.variants.values
         return variants if train.owned_by_corporation?
 
         variants.reject! { |v| entity.cash < v[:price] } if must_issue_before_ebuy?(entity)
         variants
       end
+ 
 
       def setup
         @depot = @game.depot


### PR DESCRIPTION
revert of a previous fix that added depot trains to buyable_trains. This fixed upgrading, but broke buying trains at limit.
The fix here is to not use buyable trains when exchanging.

This was 'working' in other games that have exchanges because buyable returned trains, but room? was false. The view doesn't show trains if room? is false . In 1848 this breaks because of the 2E, corps can have room to buy 2e, and not other depot trains. 

Change was tested on 1889 to make sure other games aren't broken.

fixes #8303