### PR TITLE
Map legend table improvements for darker themes

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require '../lib/storage'
+require '../lib/settings'
 require 'view/game/axis'
 require 'view/game/hex'
 require 'view/game/tile_confirmation'
@@ -10,6 +11,7 @@ require 'view/game/token_selector'
 module View
   module Game
     class Map < Snabberb::Component
+      include Lib::Settings
       needs :game
       needs :tile_selector, default: nil, store: true
       needs :selected_route, default: nil, store: true
@@ -191,7 +193,7 @@ module View
       end
 
       def render_legend
-        table_props, header, *chart = @game.map_legend
+        table_props, header, *chart = @game.map_legend(color_for(:font), color_for(:yellow), color_for(:green), color_for(:brown), color_for(:gray))
 
         head = header.map do |cell|
           item = cell[:text] || h(:image, { attrs: { href: cell[:image] } })

--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -193,7 +193,13 @@ module View
       end
 
       def render_legend
-        table_props, header, *chart = @game.map_legend(color_for(:font), color_for(:yellow), color_for(:green), color_for(:brown), color_for(:gray))
+        table_props, header, *chart = @game.map_legend(
+          color_for(:font),
+          color_for(:yellow),
+          color_for(:green),
+          color_for(:brown),
+          color_for(:gray)
+        )
 
         head = header.map do |cell|
           item = cell[:text] || h(:image, { attrs: { href: cell[:image] } })

--- a/lib/engine/game/g_18_sj/map.rb
+++ b/lib/engine/game/g_18_sj/map.rb
@@ -192,7 +192,7 @@ module Engine
           true
         end
 
-        def map_legend(font_color, yellow, green, brown, gray)
+        def map_legend(font_color, *_extra_colors)
           [
             # table-wide props
             {
@@ -210,14 +210,31 @@ module Engine
             ],
             # body
             [
-              { text: 'Bergslagen 1', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } } },
+              {
+                text: 'Bergslagen 1',
+                props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+              },
               {
                 text: 'B-b',
-                props: { style: { textAlign: 'center', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+                props: {
+                  style: {
+                    textAlign: 'center',
+                    border: "1px solid #{font_color}",
+                    color: 'white',
+                    backgroundColor: 'grey',
+                  },
+                },
               },
               {
                 text: '50',
-                props: { style: { textAlign: 'right', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+                props: {
+                  style: {
+                    textAlign: 'right',
+                    border: "1px solid #{font_color}",
+                    color: 'white',
+                    backgroundColor: 'grey',
+                  },
+                },
               },
             ],
             [
@@ -232,11 +249,25 @@ module Engine
               },
               {
                 text: 'N-S',
-                props: { style: { textAlign: 'center', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+                props: {
+                  style: {
+                    textAlign: 'center',
+                    border: "1px solid #{font_color}",
+                    color: 'white',
+                    backgroundColor: 'grey',
+                  },
+                },
               },
               {
                 text: '100',
-                props: { style: { textAlign: 'right', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+                props: {
+                  style: {
+                    textAlign: 'right',
+                    border: "1px solid #{font_color}",
+                    color: 'white',
+                    backgroundColor: 'grey',
+                  },
+                },
               },
             ],
             [
@@ -245,14 +276,31 @@ module Engine
               { text: '50', props: { style: { textAlign: 'right', border: "1px solid #{font_color}" } } },
             ],
             [
-              { text: 'Malmfälten 2', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } } },
+              {
+                text: 'Malmfälten 2',
+                props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+              },
               {
                 text: 'M-m-m',
-                props: { style: { textAlign: 'center', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+                props: {
+                  style: {
+                    textAlign: 'center',
+                    border: "1px solid #{font_color}",
+                    color: 'white',
+                    backgroundColor: 'grey',
+                  },
+                },
               },
               {
                 text: '100',
-                props: { style: { textAlign: 'right', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
+                props: {
+                  style: {
+                    textAlign: 'right',
+                    border: "1px solid #{font_color}",
+                    color: 'white',
+                    backgroundColor: 'grey',
+                  },
+                },
               },
             ],
             [

--- a/lib/engine/game/g_18_sj/map.rb
+++ b/lib/engine/game/g_18_sj/map.rb
@@ -192,7 +192,7 @@ module Engine
           true
         end
 
-        def map_legend
+        def map_legend(font_color, yellow, green, brown, gray)
           [
             # table-wide props
             {
@@ -210,14 +210,14 @@ module Engine
             ],
             # body
             [
-              { text: 'Bergslagen 1', props: { style: { border: '1px solid black', color: 'white', backgroundColor: 'grey' } } },
+              { text: 'Bergslagen 1', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } } },
               {
                 text: 'B-b',
-                props: { style: { textAlign: 'center', border: '1px solid black', color: 'white', backgroundColor: 'grey' } },
+                props: { style: { textAlign: 'center', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
               },
               {
                 text: '50',
-                props: { style: { textAlign: 'right', border: '1px solid black', color: 'white', backgroundColor: 'grey' } },
+                props: { style: { textAlign: 'right', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
               },
             ],
             [
@@ -228,31 +228,31 @@ module Engine
             [
               {
                 text: 'Lapplandspilen',
-                props: { style: { border: '1px solid black', color: 'white', backgroundColor: 'grey' } },
+                props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
               },
               {
                 text: 'N-S',
-                props: { style: { textAlign: 'center', border: '1px solid black', color: 'white', backgroundColor: 'grey' } },
+                props: { style: { textAlign: 'center', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
               },
               {
                 text: '100',
-                props: { style: { textAlign: 'right', border: '1px solid black', color: 'white', backgroundColor: 'grey' } },
+                props: { style: { textAlign: 'right', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
               },
             ],
             [
-              { text: 'Malmfälten 1', props: { style: { border: '1px solid black' } } },
-              { text: 'M-m', props: { style: { textAlign: 'center', border: '1px solid black' } } },
-              { text: '50', props: { style: { textAlign: 'right', border: '1px solid black' } } },
+              { text: 'Malmfälten 1', props: { style: { border: "1px solid #{font_color}" } } },
+              { text: 'M-m', props: { style: { textAlign: 'center', border: "1px solid #{font_color}" } } },
+              { text: '50', props: { style: { textAlign: 'right', border: "1px solid #{font_color}" } } },
             ],
             [
-              { text: 'Malmfälten 2', props: { style: { border: '1px solid black', color: 'white', backgroundColor: 'grey' } } },
+              { text: 'Malmfälten 2', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } } },
               {
                 text: 'M-m-m',
-                props: { style: { textAlign: 'center', border: '1px solid black', color: 'white', backgroundColor: 'grey' } },
+                props: { style: { textAlign: 'center', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
               },
               {
                 text: '100',
-                props: { style: { textAlign: 'right', border: '1px solid black', color: 'white', backgroundColor: 'grey' } },
+                props: { style: { textAlign: 'right', border: "1px solid #{font_color}", color: 'white', backgroundColor: 'grey' } },
               },
             ],
             [

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -996,7 +996,7 @@ module Engine
           true
         end
 
-        def map_legend
+        def map_legend(font_color, yellow, green, brown, gray)
           [
             # table-wide props
             {
@@ -1009,42 +1009,42 @@ module Engine
             # header
             [
               { text: 'Tile Color:', props: { style: { border: '1px solid' } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: '#fde900' } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: '#71bf44' } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: '#cb7745' } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: '#bcbdc0' } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{yellow}" } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{green}" } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{brown}" } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{gray}" } } },
             ],
             # body
             [
-              { text: 'Source-X', props: { style: { color: 'white', backgroundColor: 'black' } } },
+              { text: 'Source-X', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'black' } } },
               { text: '20', props: { style: { border: '1px solid' } } },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '60', props: { style: { border: '1px solid' } } },
               { text: '80', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Helium-3', props: { style: { color: 'white', backgroundColor: 'red' } } },
+              { text: 'Helium-3', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'red' } } },
               { text: '30', props: { style: { border: '1px solid' } } },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '50', props: { style: { border: '1px solid' } } },
               { text: '60', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Regolith', props: { style: { border: '1px solid', backgroundColor: 'orange' } } },
+              { text: 'Regolith', props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'orange' } } },
               { text: '20', props: { style: { border: '1px solid' } } },
               { text: '20', props: { style: { border: '1px solid' } } },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '50', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Armacolite', props: { style: { border: '1px solid', backgroundColor: 'yellow' } } },
+              { text: 'Armacolite', props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'yellow' } } },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '30', props: { style: { border: '1px solid' } } },
               { text: '30', props: { style: { border: '1px solid' } } },
               { text: '20', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Magnetite', props: { style: { border: '1px solid' } } },
+              { text: 'Magnetite', props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'white' } } },
               { text: '10', props: { style: { border: '1px solid' } } },
               { text: '10', props: { style: { border: '1px solid' } } },
               { text: '10', props: { style: { border: '1px solid' } } },

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -1009,42 +1009,57 @@ module Engine
             # header
             [
               { text: 'Tile Color:', props: { style: { border: '1px solid' } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{yellow}" } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{green}" } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{brown}" } } },
-              { text: '', props: { style: { border: '1px solid', backgroundColor: "#{gray}" } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: yellow.to_s } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: green.to_s } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: brown.to_s } } },
+              { text: '', props: { style: { border: '1px solid', backgroundColor: gray.to_s } } },
             ],
             # body
             [
-              { text: 'Source-X', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'black' } } },
+              {
+                text: 'Source-X',
+                props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'black' } },
+              },
               { text: '20', props: { style: { border: '1px solid' } } },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '60', props: { style: { border: '1px solid' } } },
               { text: '80', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Helium-3', props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'red' } } },
+              {
+                text: 'Helium-3',
+                props: { style: { border: "1px solid #{font_color}", color: 'white', backgroundColor: 'red' } },
+              },
               { text: '30', props: { style: { border: '1px solid' } } },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '50', props: { style: { border: '1px solid' } } },
               { text: '60', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Regolith', props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'orange' } } },
+              {
+                text: 'Regolith',
+                props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'orange' } },
+              },
               { text: '20', props: { style: { border: '1px solid' } } },
               { text: '20', props: { style: { border: '1px solid' } } },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '50', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Armacolite', props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'yellow' } } },
+              {
+                text: 'Armacolite',
+                props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'yellow' } },
+              },
               { text: '40', props: { style: { border: '1px solid' } } },
               { text: '30', props: { style: { border: '1px solid' } } },
               { text: '30', props: { style: { border: '1px solid' } } },
               { text: '20', props: { style: { border: '1px solid' } } },
             ],
             [
-              { text: 'Magnetite', props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'white' } } },
+              {
+                text: 'Magnetite',
+                props: { style: { border: "1px solid #{font_color}", color: 'black', backgroundColor: 'white' } },
+              },
               { text: '10', props: { style: { border: '1px solid' } } },
               { text: '10', props: { style: { border: '1px solid' } } },
               { text: '10', props: { style: { border: '1px solid' } } },


### PR DESCRIPTION
I initially noticed this while playing 21Moon, where Magnetite was showing black background instead of white background.  In light theme, this happens naturally because the background is white.  This PR changes the following:

1. For table cells which explicitly set text color, now explicitly set border color to `font_color` from settings.  Most cells don't need this because the color of the text is already set to this color. [18SJ and 21Moon]
2. Explicitly set background color and text color for the lower three row headers. [21Moon]
3. Take phase colors (yellow, green, etc.) from settings for column headers. [21Moon]

### 21Moon - Light
| Old      | New |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/5263073/190324122-c2e5dacc-1fff-4235-94c2-d4829a23902d.png) | ![image](https://user-images.githubusercontent.com/5263073/190324537-3409a20f-1c30-4301-8fcf-6198e25862e3.png) |

### 21Moon - Dark
| Old      | New |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/5263073/190324254-e95d8996-facd-43fd-951d-f8f1e59b348b.png) | ![image](https://user-images.githubusercontent.com/5263073/190324451-c84919ec-c011-498c-bec0-259ca197d413.png) |


### 18SJ - Light
| Old      | New |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/5263073/190324148-0004a8dc-67f3-4fc7-b333-02e21a09d63b.png) | ![image](https://user-images.githubusercontent.com/5263073/190324567-53e0e784-8ef8-46e0-8370-53ff44457ef3.png) |

### 18SJ - Dark
| Old      | New |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/5263073/190324275-69760530-2d3d-4e12-b34f-250d121859e2.png) | ![image](https://user-images.githubusercontent.com/5263073/190324480-638cf4d1-9a4a-4f25-9c2b-7abfaeaf14d8.png) |

### Crazy Color Test 

Just to see if everything is working.

![image](https://user-images.githubusercontent.com/5263073/190457257-49fdb482-2007-4813-8590-519a16bf80b1.png)

![image](https://user-images.githubusercontent.com/5263073/190452108-292e0ace-4131-4a6e-9039-d6e9059dee52.png)

