### PR TITLE
18Dixie: 5 trains come with delayed obsolesence

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -891,6 +891,11 @@ module Engine
           (train.obsolete_on == purchased_train.sym && @depot.discarded.include?(train))
       end
 
+      # Before obsoleting, check if this specific train should obsolete.
+      def obsolete?(train, purchased_train)
+        train.obsolete_on == purchased_train.sym
+      end
+
       def shares
         @corporations.flat_map(&:shares)
       end
@@ -1958,7 +1963,7 @@ module Engine
         owners = Hash.new(0)
 
         trains.each do |t|
-          next if t.obsolete || t.obsolete_on != train.sym
+          next if t.obsolete || !obsolete?(t, train)
 
           obsolete_trains << t.name
           t.obsolete = true

--- a/lib/engine/game/g_18_dixie/companies.rb
+++ b/lib/engine/game/g_18_dixie/companies.rb
@@ -111,11 +111,12 @@ module Engine
             sym: 'P7',
             value: 100,
             revenue: 15,
-            desc: 'The owner of this Private Company may assign one or two spare parts tokens to any existing trains owned by '\
+            desc: 'The owner of this Private Company may assign one or two spare parts tokens (represented on the site by '\
+                  'appending to the train name a ⛭ for each spare part like 5⛭, 3⛭⛭, or 5⛭⛭⛭) to any existing trains owned by '\
                   'a Corporation of which they are the president. This must be done during the Corporation\'s operating turn. '\
                   'The spare parts tokens give the trains delayed obsolecense as described in section [4.6]. If assigning two '\
                   'tokens, both tokens must be assigned at the same time and to the same non-permanent train. Assigning either '\
-                  'or both tokens closes the Private Company. THese tokens cannot be reassigned to another train but the trains '\
+                  'or both tokens closes the Private Company. These tokens cannot be reassigned to another train but the trains '\
                   'can transfer to the SCL or ICG if previously assigned to a train owned by a predecessor. Once assigned '\
                   'to a train, that train cannot be sold to any other Corporation.',
             abilities: [

--- a/lib/engine/game/g_18_dixie/game.rb
+++ b/lib/engine/game/g_18_dixie/game.rb
@@ -362,7 +362,30 @@ module Engine
           Array(phase[:on]).join(', ')
         end
 
+        def give_spare_part_to_train(train)
+          raise GameError "Permanent train #{train.name} cannot get a spare part" unless train.rusts_on
+
+          train.name = train.name + SPARE_PART_CHAR
+        end
+
+        def obsolete?(train, purchased_train)
+          train.rusts_on == purchased_train.sym && train.name.include?(SPARE_PART_CHAR)
+        end
+
+        def rust?(train, purchased_train)
+          super && !train.name.include?(SPARE_PART_CHAR)
+        end
+
+        def remove_spare_part(train)
+          return unless train.name[-1] == SPARE_PART_CHAR
+
+          @log << "#{train.name} uses up a spare part"
+          train.name = train.name[0..-2]
+        end
+
         def rust(train)
+          return if train.name[-1] == SPARE_PART_CHAR
+
           if train.owner.corporation? && train.salvage
             @bank.spend(train.salvage, train.owner)
             @log << "#{train.owner.name} gets #{format_currency(train.salvage)} salvage for rusted #{train.name} train"

--- a/lib/engine/game/g_18_dixie/phases.rb
+++ b/lib/engine/game/g_18_dixie/phases.rb
@@ -40,7 +40,7 @@ module Engine
           },
           {
             name: '5',
-            on: '5',
+            on: '5⛭',
             train_limit: 3,
             tiles: %i[yellow green],
             status: [],

--- a/lib/engine/game/g_18_dixie/step/dividend.rb
+++ b/lib/engine/game/g_18_dixie/step/dividend.rb
@@ -12,6 +12,14 @@ module Engine
           DIVIDEND_TYPES = %i[payout withhold].freeze
           include Engine::Step::HalfPay
           include Engine::Step::MinorHalfPay
+          def rust_obsolete_trains!(entity)
+            rusted_trains = entity.trains.select(&:obsolete).each do |train|
+              @game.remove_spare_part(train)
+              @game.rust(train)
+            end
+
+            @log << '-- Event: Obsolete trains rust --' if rusted_trains.any?
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_dixie/trains.rb
+++ b/lib/engine/game/g_18_dixie/trains.rb
@@ -4,6 +4,7 @@ module Engine
   module Game
     module G18Dixie
       module Trains
+        SPARE_PART_CHAR = '⛭'
         TRAINS = [
           {
             name: '2M',
@@ -40,7 +41,7 @@ module Engine
             num: 4,
           },
           {
-            name: '5',
+            name: '5⛭',
             distance: [{ 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 },
                        { 'nodes' => %w[offboard city], 'pay' => 5, 'visit' => 5 }],
             events: [{ 'type' => 'close_companies' }],


### PR DESCRIPTION
This is using a system similar to 1862 because there is a private that lets a player add additional spare parts which lets a train last longer - the key difference between spare parts in 18Dixie and warranties in 1862 is spare parts are only used after the train /could/ rust, not every time

![image](https://user-images.githubusercontent.com/2993555/190548926-597904e4-3158-487b-ad89-ff51615a7892.png)
