### PR TITLE
[1848] fix 8343

### DIFF
--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -129,7 +129,7 @@ module Engine
           end
 
           def pass_if_cannot_buy_train?(entity)
-            must_buy_train?(entity) ? false : true
+            !must_buy_train?(entity)
           end
         end
       end

--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -127,6 +127,10 @@ module Engine
           def president_may_contribute?
             false
           end
+
+          def pass_if_cannot_buy_train?(entity)
+            must_buy_train?(entity) ? false : true
+          end
         end
       end
     end


### PR DESCRIPTION
fixes #8343
Default is to pass train buy if can't buy train. However during forced buy train when corp buys the 2e, this caused to skip train buying, despite the must_buy_train returning true.