### PR TITLE
[1848] Fix when 'must take loan' messages appear

### DIFF
--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -98,8 +98,13 @@ module Engine
             false
           end
 
-          def must_take_loan?(_entity)
-            true
+          def must_take_loan?(corporation)
+            price = cheapest_train_price(corporation)
+            @game.buying_power(corporation) < price
+          end
+
+          def cheapest_train_price(corporation)
+            buyable_trains(corporation).reject { |t| t.name == '2E' }.min_by(&:price).price
           end
 
           def round_state


### PR DESCRIPTION
closes #8357 

When a company has enough money
![Screenshot 2022-09-20 3 44 16 PM](https://user-images.githubusercontent.com/1711810/191378559-d7f34966-283a-41a0-a166-675e7153b2ec.png)

When a company has enough for a 2E but not a real train
![image](https://user-images.githubusercontent.com/1711810/191378650-4c11bc60-29d0-4330-86d6-e6b02e283d8e.png)