### PR TITLE
Change border mountain color to sepia to distinguish between brown tiles

### DIFF
--- a/assets/app/view/game/part/borders.rb
+++ b/assets/app/view/game/part/borders.rb
@@ -59,7 +59,7 @@ module View
           color =
             case border.type
             when :mountain
-              :brown
+              :sepia
             when :water
               :blue
             when :impassable


### PR DESCRIPTION
The default color is the same as the brown tiles, making it difficult to see all of the borders easily.  This uses the less-often used sepia color setting for those borders.  As far as I can see, 1825 is the only game with sepia tiles, and it has no map borders to cause conflicts.

Unfortunately, with the default colors, this inverts the text color on borders which have a cost (see below).  How big of an issue is this?  There are other solutions as well, like manually setting the colors in the map files.

![image](https://user-images.githubusercontent.com/5263073/191614712-b4ae1d31-f437-448e-9507-c53a2b0074ec.png)
![image](https://user-images.githubusercontent.com/5263073/191614726-5451f830-b07f-4cf1-b856-f1b534e4678f.png)


![image](https://user-images.githubusercontent.com/5263073/191614846-b286cca5-c1a3-48b8-a06f-8ad34cbdf8c1.png)
![image](https://user-images.githubusercontent.com/5263073/191614860-1ece914b-bd70-42d7-95a3-961abc545740.png)
