### PR TITLE
[1873] Disable autopass in draft if passing is not a valid action.

### DIFF
--- a/lib/engine/game/g_1873/step/draft.rb
+++ b/lib/engine/game/g_1873/step/draft.rb
@@ -134,6 +134,10 @@ module Engine
               end
             end
 
+            unless actions(entity).include?('pass')
+              return [Action::ProgramDisable.new(entity, reason: 'Auction winner cannot pass')]
+            end
+
             [Action::Pass.new(entity)]
           end
 


### PR DESCRIPTION
The winner of the premium auction must buy something and cannot pass. If a player set autopass in draft before winning the auction, this would trigger an illegal move and break the game.

fixes #8345