### PR TITLE
Add missing space to train buying text

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -91,7 +91,7 @@ module View
 
           if @game.class::ALLOW_TRAIN_BUY_FROM_OTHERS
             text += "#{@corporation.name} must buy a "\
-                    'train from another corporation, or'
+                    'train from another corporation, or '
           end
 
           text += "#{player.name} must " \


### PR DESCRIPTION
Adds in a missing space from the text when players can buy trains from other players.