### PR TITLE
18GB: Fix issue with check for existing presidencies at start of SR

### DIFF
--- a/lib/engine/game/g_18_gb/round/stock.rb
+++ b/lib/engine/game/g_18_gb/round/stock.rb
@@ -9,10 +9,20 @@ module Engine
         class Stock < Engine::Round::Stock
           attr_accessor :presidencies
 
+          def record_current_presidencies
+            @presidencies = @game.corporations.select { |corp| corp.president?(current_entity) }
+          end
+
+          def setup
+            super
+
+            record_current_presidencies
+          end
+
           def start_entity
             super
 
-            @presidencies = @game.corporations.select { |corp| corp.president?(current_entity) }
+            record_current_presidencies
           end
         end
       end


### PR DESCRIPTION
18GB: Fix an issue where the 'presidencies' variable on the stock round (used to record presidencies the player possessed at the start of their stock round turn, to check eligibility for double-buys) was being set on player change in the stock round but not at the beginning of a new stock round.

Closes #8402 

