### PR TITLE
Sort entities by operating order

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -343,8 +343,6 @@ module Engine
       RAND_C = 12_345
       RAND_M = 2**31
 
-      MAX_OPERATING_ORDER = 1000
-
       def setup_preround; end
 
       def setup; end
@@ -2726,7 +2724,7 @@ module Engine
       end
 
       def player_sort(entities)
-        entities.sort_by { |entity| [operating_order.index(entity) || MAX_OPERATING_ORDER, entity.name] }.group_by(&:owner)
+        entities.sort_by { |entity| [operating_order.index(entity) || Float::INFINITY, entity.name] }.group_by(&:owner)
       end
 
       def bank_sort(corporations)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -343,6 +343,8 @@ module Engine
       RAND_C = 12_345
       RAND_M = 2**31
 
+      MAX_OPERATING_ORDER = 1000
+
       def setup_preround; end
 
       def setup; end
@@ -2724,7 +2726,7 @@ module Engine
       end
 
       def player_sort(entities)
-        entities.sort_by(&:name).group_by(&:owner)
+        entities.sort_by { |entity| [operating_order.index(entity) || MAX_OPERATING_ORDER, entity.name] }.group_by(&:owner)
       end
 
       def bank_sort(corporations)

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -2025,11 +2025,6 @@ module Engine
           @minors.select { |m| m.owner == player }
         end
 
-        def player_sort(entities)
-          minors, majors = entities.partition(&:minor?)
-          (minors.sort_by { |m| m.name.to_i } + majors.sort_by(&:name)).group_by(&:owner)
-        end
-
         def show_game_cert_limit?
           false
         end

--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -221,11 +221,6 @@ module Engine
           @minors + @corporations
         end
 
-        def player_sort(entities)
-          minors, majors = entities.partition(&:minor?)
-          (minors.sort_by { |m| m.name.to_i } + majors.sort_by(&:name)).group_by(&:owner)
-        end
-
         def place_home_token(corporation)
           return if corporation.placed_tokens.any?
 

--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -706,11 +706,6 @@ module Engine
           minors.select { |m| m.owner == player }
         end
 
-        def player_sort(entities)
-          minors, majors = entities.partition(&:minor?)
-          (minors.sort_by { |m| m.name.to_i } + majors.sort_by(&:name)).group_by(&:owner)
-        end
-
         def game_location_names
           if multiplayer?
             {

--- a/lib/engine/game/g_18_new_england/game.rb
+++ b/lib/engine/game/g_18_new_england/game.rb
@@ -463,8 +463,7 @@ module Engine
         end
 
         def player_sort(entities)
-          majors, minors = entities.select(&:corporation?).partition { |c| c.type == :major }
-          (minors.sort_by(&:name) + majors.sort_by(&:name)).group_by(&:owner)
+          super(entities.select(&:corporation?))
         end
 
         def reserve_minor(minor, entity)

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -689,7 +689,7 @@ module Engine
         end
 
         def player_sort(entities)
-          entities.reject(&:minor?).sort_by(&:name).group_by(&:owner)
+          super(entities.reject(&:minor?))
         end
 
         def lb_trains(corporation)


### PR DESCRIPTION
Fixes #7823

Rules citations showing that result will be the same because either minor companies operate according to the face value, or they are specifically accounted for in the operating order.

| Game    | Description |
| ----------- | ----------- |
| 1873     | 4. - In each OR, first the still independent private mining companies operate in ascending order of their face values (see 4.2). _Same result_ |
| 18EU   |  4.4 - Each Operating Round begins with the Minor Companies operating in numerical order from 1 though 15.   _Same result_  |
| 18MAG   | VI.1 - First the minor companies operate in ascending order of number. _Same result_ |
| 18 New England |  The minor companies operate first in descending share price order.  _Because minors are covered by operating order, no need to specifically separate them and do two sorts._ |
| 21Moon | _Take the same group of entities and add the new operating order sorting_  |

1860 specifically omitted because it has some special sorting based on layers...