### PR TITLE
18GB: Don't check non-existent presidencies variable during an OR

### DIFF
--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -115,7 +115,7 @@ module Engine
 
           def can_buy_multiple?(entity, corporation, owner)
             bought = num_shares_bought(corporation)
-            super && corporation&.president?(entity) && bought < 2 && already_president?(corporation)
+            super && corporation&.president?(entity) && bought < 2 && (@round.operating? || already_president?(corporation))
           end
 
           def num_shares_bought(corporation)


### PR DESCRIPTION
Fix a bug where the `G18GB::Round::Operating` instance was checked for a `presidencies` instance variable which doesn't exist on Operating rounds, only in Stock rounds. This check is not needed when buying after converting to 10-share in emergency money raising and was causing games to become inaccessible if they reached featured a corporation converting to 10-share in EMR whilst in the green area of the market.

Closes #8408 