### PR TITLE
18GB 2E tweaks: G33 tile extra track & private company descriptions

### DIFF
--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -65,12 +65,13 @@ module Engine
             name: 'Great Northern',
             value: 70,
             revenue: 25,
-            desc: 'The GN allows a corporation to lay a Station Marker in York (I14). A space is reserved for the GN until '\
-                  'the blue phase, otherwise an empty space must be available in York. The GN owner may use this ability ' \
-                  'once per game, after the GN has closed, for any corporation which they control. The station is free if ' \
-                  'the corporation can trace a route to York, otherwise it costs £50. After laying the marker, the ' \
-                  'corporation also gains the ability to lay a green tile in York as one of its standard tile actions, ' \
-                  'instead of the usual yellow tile, even before green tiles are normally available.',
+            desc: 'The GN allows a corporation to lay an additional Station Marker in York (I14). A space is reserved for ' \
+                  'the GN until the blue phase, otherwise an empty space must be available in York. The GN owner may use ' \
+                  'this ability once per game, after the GN has closed, for any corporation which they control. The station ' \
+                  'is free if the corporation can trace a route to York, otherwise it costs £50. The marker is in addition to ' \
+                  'the standard station markers of the corporation. After laying the marker, the corporation also gains the ' \
+                  'ability to lay a green tile in York as one of its standard tile actions, instead of the usual yellow tile, ' \
+                  'even before green tiles are normally available.',
             sym: 'GN',
             color: nil,
             abilities: [
@@ -236,12 +237,13 @@ module Engine
             name: 'Maryport & Carlisle',
             value: 50,
             revenue: 20,
-            desc: 'The MC allows a corporation to lay a Station Marker in Carlisle (H9). A space is reserved for the MC ' \
-                  'until the blue phase, otherwise an empty space must be available in Carlisle. The MC owner may use this ' \
-                  'ability once per game, after the MC has closed, for any corporation which they control. The station is ' \
-                  'free if the corporation can trace a route to Carlisle, otherwise it costs £50.  After laying the marker, ' \
-                  'the corporation also gains the ability to lay a green tile in Carlisle as one of its standard tile ' \
-                  'actions, instead of the usual yellow tile, even before green tiles are normally available.',
+            desc: 'The MC allows a corporation to lay an additional Station Marker in Carlisle (H9). A space is reserved for ' \
+                  'the MC until the blue phase, otherwise an empty space must be available in Carlisle. The MC owner may use ' \
+                  'this ability once per game, after the MC has closed, for any corporation which they control. The station ' \
+                  'is free if the corporation can trace a route to Carlisle, otherwise it costs £50.  The marker is in ' \
+                  'addition to the standard station markers of the corporation. After laying the marker, the corporation also ' \
+                  'gains the ability to lay a green tile in Carlisle as one of its standard tile actions, instead of the ' \
+                  'usual yellow tile, even before green tiles are normally available.',
             sym: 'MC',
             color: nil,
             abilities: [

--- a/lib/engine/game/g_18_gb/entities.rb
+++ b/lib/engine/game/g_18_gb/entities.rb
@@ -65,11 +65,11 @@ module Engine
             name: 'Great Northern',
             value: 70,
             revenue: 25,
-            desc: 'The GN allows a corporation to lay an additional Station Marker in York (I14). A space is reserved for ' \
+            desc: 'The GN allows a corporation to lay an additional station token in York (I14). A space is reserved for ' \
                   'the GN until the blue phase, otherwise an empty space must be available in York. The GN owner may use ' \
-                  'this ability once per game, after the GN has closed, for any corporation which they control. The station ' \
-                  'is free if the corporation can trace a route to York, otherwise it costs £50. The marker is in addition to ' \
-                  'the standard station markers of the corporation. After laying the marker, the corporation also gains the ' \
+                  'this ability once per game, after the GN has closed, for any corporation which they control. The token ' \
+                  'is free if the corporation can trace a route to York, otherwise it costs £50. The token is in addition to ' \
+                  'the standard station tokens of the corporation. After laying the token, the corporation also gains the ' \
                   'ability to lay a green tile in York as one of its standard tile actions, instead of the usual yellow tile, ' \
                   'even before green tiles are normally available.',
             sym: 'GN',
@@ -237,11 +237,11 @@ module Engine
             name: 'Maryport & Carlisle',
             value: 50,
             revenue: 20,
-            desc: 'The MC allows a corporation to lay an additional Station Marker in Carlisle (H9). A space is reserved for ' \
+            desc: 'The MC allows a corporation to lay an additional station token in Carlisle (H9). A space is reserved for ' \
                   'the MC until the blue phase, otherwise an empty space must be available in Carlisle. The MC owner may use ' \
-                  'this ability once per game, after the MC has closed, for any corporation which they control. The station ' \
-                  'is free if the corporation can trace a route to Carlisle, otherwise it costs £50.  The marker is in ' \
-                  'addition to the standard station markers of the corporation. After laying the marker, the corporation also ' \
+                  'this ability once per game, after the MC has closed, for any corporation which they control. The token ' \
+                  'is free if the corporation can trace a route to Carlisle, otherwise it costs £50.  The token is in ' \
+                  'addition to the standard station tokens of the corporation. After laying the token, the corporation also ' \
                   'gains the ability to lay a green tile in Carlisle as one of its standard tile actions, instead of the ' \
                   'usual yellow tile, even before green tiles are normally available.',
             sym: 'MC',

--- a/lib/engine/game/g_18_gb/map.rb
+++ b/lib/engine/game/g_18_gb/map.rb
@@ -224,7 +224,7 @@ module Engine
           {
             'count' => 1,
             'color' => 'blue',
-            'code' => 'path=a:2,b:4;path=a:2,b:5,track:dual;path=a:5,b:0;icon=image:18_gb/plus_30;label=S',
+            'code' => 'path=a:2,b:3;path=a:2,b:4;path=a:2,b:5,track:dual;path=a:5,b:0;icon=image:18_gb/plus_30;label=S',
           },
         }.freeze
         GRAY_TILES = {


### PR DESCRIPTION
- Add an extra piece of track to the blue Severn Tunnel tile G33 to match 2E physical copies being produced and enable an edge case where track is laid in Merthyr Tydfil (C20) pointing in to the Severn estuary (C22). In practice this is an extremely rare case and the track is entirely additional so should not impact existing games.
- Update the MC and GN private company descriptions to be clear that the station token provided is additional rather than an existing token of the corporation. Furthermore, update the language to refer to tokens as 'tokens' throughout rather than 'markers'. Closes #8411 