### PR TITLE
Fix river partitions rendering on map URL

### DIFF
--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -304,7 +304,6 @@ module View
               h(:g, { attrs: { transform: "translate(#{x.round(2)} #{y.round(2)}) rotate(#{-revert_angle})" } }, [
                 h(CitySlot, city: @city,
                             edge: @edge,
-                            game: @game,
                             token: token,
                             slot_index: slot_index,
                             extra_token: @city.extra_tokens.include?(token),

--- a/assets/app/view/game/part/city.rb
+++ b/assets/app/view/game/part/city.rb
@@ -304,6 +304,7 @@ module View
               h(:g, { attrs: { transform: "translate(#{x.round(2)} #{y.round(2)}) rotate(#{-revert_angle})" } }, [
                 h(CitySlot, city: @city,
                             edge: @edge,
+                            game: @game,
                             token: token,
                             slot_index: slot_index,
                             extra_token: @city.extra_tokens.include?(token),

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -52,7 +52,7 @@ module View
 
           radius = @radius
           show_player_colors = setting_for(:show_player_colors, @game)
-          if show_player_colors && (owner = @token&.corporation&.owner) && @game.players.include?(owner)
+          if show_player_colors && (owner = @token&.corporation&.owner) && @game&.players&.include?(owner)
             color = player_colors(@game.players)[owner]
             radius -= 4
           end

--- a/assets/app/view/game/part/partitions.rb
+++ b/assets/app/view/game/part/partitions.rb
@@ -54,10 +54,7 @@ module View
 
           @tile.partitions.each do |partition|
             next if partition.type != :divider && partition.blockers.none? do |blocker|
-              is_blocked = @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
-              puts @tile.name
-              puts is_blocked
-              is_blocked.nil? || is_blocked
+              @game.nil? ||  @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
             end
 
             a_control = VERTICES[(partition.a + partition.a_sign) % 6]

--- a/assets/app/view/game/part/partitions.rb
+++ b/assets/app/view/game/part/partitions.rb
@@ -54,7 +54,7 @@ module View
 
           @tile.partitions.each do |partition|
             next if partition.type != :divider && partition.blockers.none? do |blocker|
-              @game.nil? || @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
+              !@game || @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
             end
 
             a_control = VERTICES[(partition.a + partition.a_sign) % 6]

--- a/assets/app/view/game/part/partitions.rb
+++ b/assets/app/view/game/part/partitions.rb
@@ -54,7 +54,10 @@ module View
 
           @tile.partitions.each do |partition|
             next if partition.type != :divider && partition.blockers.none? do |blocker|
-              @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
+              is_blocked = @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
+              puts @tile.name
+              puts is_blocked
+              is_blocked.nil? || is_blocked
             end
 
             a_control = VERTICES[(partition.a + partition.a_sign) % 6]

--- a/assets/app/view/game/part/partitions.rb
+++ b/assets/app/view/game/part/partitions.rb
@@ -54,7 +54,7 @@ module View
 
           @tile.partitions.each do |partition|
             next if partition.type != :divider && partition.blockers.none? do |blocker|
-              @game.nil? ||  @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
+              @game.nil? || @game&.abilities(blocker, :blocks_partition)&.blocks?(partition.type)
             end
 
             a_control = VERTICES[(partition.a + partition.a_sign) % 6]

--- a/lib/engine/game/g_18_rhl/map.rb
+++ b/lib/engine/game/g_18_rhl/map.rb
@@ -106,7 +106,7 @@ module Engine
             'color' => 'green',
             'code' => 'city=revenue:40,slots:1,loc:1;city=revenue:40,slots:2,loc:4;label=D;'\
                       'path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_1;path=a:5,b:_1;path=a:_0,b:_1,track:narrow;'\
-                      'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0;label=D',
+                      'upgrade=cost:50,terrain:river;icon=image:18_rhl/trajekt,sticky:0',
           },
           'X923' =>
           {


### PR DESCRIPTION
Fixes #7387

1. Tile in RHL had two of the same label on it.

![image](https://user-images.githubusercontent.com/5263073/193922221-ce1ecd40-dd4b-4121-b05f-f90119d920a3.png) -----> ![image](https://user-images.githubusercontent.com/5263073/193922117-36f7832f-e028-477d-8fe1-0e8e52e5184f.png)

2. In the map view, `@game` is nil, so CitySlot needs to handle a nil game (18Rhl map view was previously throwing an undefined method error)

![image](https://user-images.githubusercontent.com/5263073/193922956-a012b443-91d7-4c06-adc9-c767982d61e3.png)


3. In the map view, `@game` is nil, so partitions should render if that's the case, so they appear on the map view.
![image](https://user-images.githubusercontent.com/5263073/193923503-51af1195-da0c-4e9a-8a39-5470bb9005e5.png)
