### PR TITLE
18GB UI improvements

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -434,6 +434,14 @@ module Engine
           @corporations.each { |corp| place_home_token(corp) }
         end
 
+        def timeline
+          @timeline = [
+            '- Tier 2 corporations can only be started from SR2 onwards.',
+            '- At the end of each OR, a train is exported if no new train was purchased from the bank during the OR.',
+            '- After an OR ends with 2 or fewer trains remaining, no more tokens may be placed.',
+          ].freeze
+        end
+
         def event_float_60!
           @log << '-- Event: New corporations float once 60% of their shares have been sold --'
           @corporations.reject(&:floated?).each { |c| c.float_percent = 60 }

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -647,6 +647,7 @@ module Engine
         end
 
         def stock_round
+          @log << '-- Event: Tier 2 corporations are now available --' if @round_counter == 4
           G18GB::Round::Stock.new(self, [
             Engine::Step::HomeToken,
             G18GB::Step::BuySellParShares,

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -66,7 +66,7 @@ module Engine
 
         EBUY_OTHER_VALUE = false
 
-        HOME_TOKEN_TIMING = :float
+        HOME_TOKEN_TIMING = :start
 
         DISCARDED_TRAINS = :remove
 
@@ -572,39 +572,12 @@ module Engine
           return if corporation.tokens.first&.used
 
           hex = hex_by_id(corporation.coordinates)
-
           tile = hex&.tile
-          if !tile || (tile.reserved_by?(corporation) && !tile.paths.empty?)
-
-            # If the tile has no paths at the present time, clear up the ambiguity when the tile is laid
-            # Otherwise, for yellow tiles the corporation is placed disconnected and for other tiles it
-            # chooses now
-            if tile.color == :yellow
-              cities = tile.cities
-              city = cities[1]
-              token = corporation.find_token_by_type
-              return unless city.tokenable?(corporation, tokens: token)
-
-              @log << "#{corporation.name} places a token on #{hex.name}"
-              city.place_token(corporation, token)
-            else
-              @log << "#{corporation.name} must choose city for home token"
-              @round.pending_tokens << {
-                entity: corporation,
-                hexes: [hex],
-                token: corporation.find_token_by_type,
-              }
-            end
-
-            return
-          end
-
           cities = tile.cities
           city = cities.find { |c| c.reserved_by?(corporation) } || cities.first
           token = corporation.find_token_by_type
           return unless city.tokenable?(corporation, tokens: token)
 
-          @log << "#{corporation.name} places a token on #{hex.name}"
           city.place_token(corporation, token)
         end
 

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -476,6 +476,12 @@ module Engine
           end
         end
 
+        def bank_sort(corporations)
+          return super unless @round_counter <= 1
+
+          corporations.sort_by { |c| [@tiers[c.id], c.name] }
+        end
+
         def required_bids_to_pass
           @scenario['required_bids']
         end

--- a/lib/engine/game/g_18_gb/step/track_and_token.rb
+++ b/lib/engine/game/g_18_gb/step/track_and_token.rb
@@ -56,7 +56,7 @@ module Engine
           def lay_tile_action(action)
             tile = action.tile
             tile_lay = get_tile_lay(action.entity)
-            raise GameError, 'Cannot lay a city tile now' if !tile.cities.empty? && @laid_city
+            raise GameError, 'Cannot lay two city tiles in a single OR' if !tile.cities.empty? && @laid_city
 
             lay_tile(action, extra_cost: tile_lay[:cost])
             @game.close_company_in_hex(action.hex)


### PR DESCRIPTION
UI improvements for 18GB:
- The placement of home tokens during game setup is no longer printed in the game log for every single corporation. Alongside this change, code for placing a corporation's home token when the tile was already yellow or green was also removed now this is no longer applicable.
- The bank-owned/unstarted corporations in the Entities tab are now sorted by tier first and then by name during the initial auction round and SR1. (And then only by name from then on, as this information is no longer applicable.)
- When SR2 begins, a log message now reminds players that Tier 2 corporations can be started.
- A Timeline section is added to the Info tab reminding key time-based info, i.e. Tier 2 corp availability in SR2, the train export, and the trigger for end-game restrictions.
- The error message displayed when attempting to lay a second city tile during a corporation's operation is now clearer.

Closes #8179 