### PR TITLE
Show variants in rust schedule / properly hide obsolete schedule

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -151,7 +151,14 @@ module View
         obsolete_schedule = {}
         @depot.trains.group_by(&:name).each do |_name, trains|
           first = trains.first
+
+          base_rust = first.variants.first[1][:rusts_on]
+          base_obsolete = first.variants.first[1][:obsolete_on]
+
           first.variants.each do |name, train_variant|
+            train_variant[:rusts_on] = train_variant[:rusts_on] || base_rust
+            train_variant[:obsolete_on] = train_variant[:obsolete_on] || base_obsolete
+
             unless Array(rust_schedule[train_variant[:rusts_on]]).include?(name)
               rust_schedule[train_variant[:rusts_on]] =
                 Array(rust_schedule[train_variant[:rusts_on]]).append(name)

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -181,7 +181,7 @@ module View
       def trains
         rust_schedule, obsolete_schedule = rust_obsolete_schedule
 
-        show_obsolete_schedule = !obsolete_schedule.keys.compact.empty?
+        show_obsolete_schedule = obsolete_schedule.keys.any?
         show_upgrade = @depot.upcoming.any? { |train| train.variants.any? { |_k, v| v['discount'] } }
         show_salvage = @depot.trains.any?(&:salvage)
         show_available = @depot.upcoming.any?(&:available_on)

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -156,7 +156,7 @@ module View
           # per the train variant initialization.  If other variants
           # do not have an explicit rust/obsolete, inherit the base
           # values for display purposes.
-          _, base_variant = first.variants.first
+          base_variant = first.variants.values[0]
 
           base_rust = base_variant[:rusts_on]
           base_obsolete = base_variant[:obsolete_on]

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -175,7 +175,7 @@ module View
       def trains
         rust_schedule, obsolete_schedule = rust_obsolete_schedule
 
-        show_obsolete_schedule = !obsolete_schedule.keys.empty?
+        show_obsolete_schedule = !obsolete_schedule.keys.compact.empty?
         show_upgrade = @depot.upcoming.any? { |train| train.variants.any? { |_k, v| v['discount'] } }
         show_salvage = @depot.trains.any?(&:salvage)
         show_available = @depot.upcoming.any?(&:available_on)

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -152,12 +152,18 @@ module View
         @depot.trains.group_by(&:name).each do |_name, trains|
           first = trains.first
 
-          base_rust = first.variants.first[1][:rusts_on]
-          base_obsolete = first.variants.first[1][:obsolete_on]
+          # the first variant in this list should be the base variant
+          # per the train variant initialization.  If other variants
+          # do not have an explicit rust/obsolete, inherit the base
+          # values for display purposes.
+          _, base_variant = first.variants.first
+
+          base_rust = base_variant[:rusts_on]
+          base_obsolete = base_variant[:obsolete_on]
 
           first.variants.each do |name, train_variant|
-            train_variant[:rusts_on] = train_variant[:rusts_on] || base_rust
-            train_variant[:obsolete_on] = train_variant[:obsolete_on] || base_obsolete
+            train_variant[:rusts_on] ||= base_rust
+            train_variant[:obsolete_on] ||= base_obsolete
 
             unless Array(rust_schedule[train_variant[:rusts_on]]).include?(name)
               rust_schedule[train_variant[:rusts_on]] =


### PR DESCRIPTION
Fixes #6987

While I was fixing this, I noticed that the obsolete schedule wasn't properly being hidden.  Even if there no obsolete in a game, that dictionary still has `nil` as a key.

| | 1846    |
| ----------- | ----------- |
| Old | ![image](https://user-images.githubusercontent.com/5263073/194175833-0050b3c8-62b1-4179-9c9c-c0495771b6e3.png)  |   
| New | ![image](https://user-images.githubusercontent.com/5263073/194175923-74eb70ad-736f-4239-b9b0-fbe34a28b87d.png) |

| | 1822 PNW |   
| ----------- | ----------- |
| Old | ![image](https://user-images.githubusercontent.com/5263073/194176031-bfe80882-8407-4eb3-92e3-a84e39effb0c.png)  |   
| New | ![image](https://user-images.githubusercontent.com/5263073/194176061-929c4f73-be7b-4cd8-a00d-4402b0fdeb95.png) |

| | 18Scan |   
| ----------- | ----------- |
| Old | ![image](https://user-images.githubusercontent.com/5263073/194176225-ddabcc23-131f-490b-a500-913fce7ece9d.png)  |   
| New | ![image](https://user-images.githubusercontent.com/5263073/194176267-55d0e3c8-cfcb-4d3b-a0ad-829d197cf27e.png) | 


| | 1862|   
| ----------- | ----------- |
| Old | ![image](https://user-images.githubusercontent.com/5263073/194176413-a8f726ab-5d33-40bf-aa4c-8b74a8f85424.png)   |   
| New | ![image](https://user-images.githubusercontent.com/5263073/194176433-76a8094b-7e63-4c5c-999a-4f3ded710e81.png)  |