### PR TITLE
18SJ: Correct pay out to corporations [fixes #8381]

### DIFF
--- a/lib/engine/game/g_18_sj/step/dividend.rb
+++ b/lib/engine/game/g_18_sj/step/dividend.rb
@@ -49,6 +49,18 @@ module Engine
 
             super
           end
+
+          def corporation_dividends(entity, per_share)
+            return 0 if entity.minor?
+            # For Oscarian era shares in the Bank pool pay to corporation.
+            # Corporations cannot have shares in Treasury.
+            return dividends_for_entity(entity, @game.bank, per_share) if @game.oscarian_era
+            # Do not pay for any shares for full capitalization corporation
+            return 0 if entity.capitalization == :full
+
+            # Pay out for shares in treasury only. (No IPO for incremental cap corporations)
+            dividends_for_entity(entity, entity, per_share)
+          end
         end
       end
     end


### PR DESCRIPTION
In Oscarian age, bank shares pay to corporation, not IPO shares.

In base game, full cap corporations do not get any pay for shares, while incremental cap corporations only get paid for shares in treasury.