### PR TITLE
18Rhl: custom adapter returned by acting_for_entity? for receivership situations should include entity defaults

### DIFF
--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -506,6 +506,8 @@ module Engine
         end
 
         class WithNameAdapter
+          include Engine::Entity
+
           def name
             'Receivership'
           end


### PR DESCRIPTION
Include the entity defaults in the `WithNameAdapter` returned by `acting_for_entity?` in 18Rhl, so that when other parts of the code check if this entity is a player etc. it responds appropriately. Closes #8466 