### PR TITLE
Tiles tab: don't show potential upgrades with non-matching cities

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1552,12 +1552,13 @@ module Engine
         # correct label?
         return false unless upgrades_to_correct_label?(from, to)
 
-        # honors existing town/city counts?
+        # honors existing town/city counts and connections?
         # - allow labelled cities to upgrade regardless of count; they're probably
         #   fine (e.g., 18Chesapeake's OO cities merge to one city in brown)
         # - TODO: account for games that allow double dits to upgrade to one town
         return false if from.towns.size != to.towns.size
         return false if !from.label && from.cities.size != to.cities.size && !upgrade_ignore_num_cities(from)
+        return false unless from.city_town_edges_are_subset_of?(to.city_town_edges)
 
         # but don't permit a labelled city to be downgraded to 0 cities.
         return false if from.label && !from.cities.empty? && to.cities.empty?

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1558,7 +1558,7 @@ module Engine
         # - TODO: account for games that allow double dits to upgrade to one town
         return false if from.towns.size != to.towns.size
         return false if !from.label && from.cities.size != to.cities.size && !upgrade_ignore_num_cities(from)
-        return false unless from.city_town_edges_are_subset_of?(to.city_town_edges)
+        return false if from.cities.size > 1 && !from.city_town_edges_are_subset_of?(to.city_town_edges)
 
         # but don't permit a labelled city to be downgraded to 0 cities.
         return false if from.label && !from.cities.empty? && to.cities.empty?

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1558,7 +1558,7 @@ module Engine
         # - TODO: account for games that allow double dits to upgrade to one town
         return false if from.towns.size != to.towns.size
         return false if !from.label && from.cities.size != to.cities.size && !upgrade_ignore_num_cities(from)
-        return false if from.cities.size > 1 && !from.city_town_edges_are_subset_of?(to.city_town_edges)
+        return false if from.cities.size > 1 && to.cities.size > 1 && !from.city_town_edges_are_subset_of?(to.city_town_edges)
 
         # but don't permit a labelled city to be downgraded to 0 cities.
         return false if from.label && !from.cities.empty? && to.cities.empty?

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -395,15 +395,11 @@ module Engine
       ct_edges.values
     end
 
-    def city_town_edges_match?(city_edges, other_city_edges)
-      city_edges.all? { |e| other_city_edges.include?(e) }
-    end
-
     def city_town_edges_are_subset_of?(other_cte)
       cte = city_town_edges
       ALL_EDGES.any? do |rotation|
         rotated = other_cte.map { |city| city.map { |edge| rotate(edge, rotation) } }
-        cte.all? { |city| rotated.any? { |other_city| city_town_edges_match?(city, other_city) } }
+        cte.all? { |city| rotated.any? { |other_city| (city - other_city).empty? } }
       end
     end
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -398,8 +398,11 @@ module Engine
     def city_town_edges_are_subset_of?(other_cte)
       cte = city_town_edges
       ALL_EDGES.any? do |rotation|
-        rotated = other_cte.map { |city| city.map { |edge| rotate(edge, rotation) } }
-        cte.all? { |city| rotated.any? { |other_city| (city - other_city).empty? } }
+        cte.all? do |city|
+          other_cte.any? do |other_city|
+            city.all? { |edge| other_city.include?(rotate(edge, rotation)) }
+          end
+        end
       end
     end
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -395,6 +395,18 @@ module Engine
       ct_edges.values
     end
 
+    def city_town_edges_match?(city_edges, other_city_edges)
+      city_edges.all? { |e| other_city_edges.include?(e) }
+    end
+
+    def city_town_edges_are_subset_of?(other_cte)
+      cte = city_town_edges
+      ALL_EDGES.any? do |rotation|
+        rotated = other_cte.map { |city| city.map { |edge| rotate(edge, rotation) } }
+        cte.all? { |city| rotated.any? { |other_city| city_town_edges_match?(city, other_city) } }
+      end
+    end
+
     def compute_loc(loc = nil)
       return nil unless loc && loc != 'center'
 


### PR DESCRIPTION
Update the `upgrades_to?` check in the base game definition to account not just for the quantities of city/towns on the two tiles being compared, but also that each city/town on the old tile is present (in terms of a city/town with the same combination of edge connections) on the new tile.

- This avoids the issue of illegal multi-city tile upgrades being visible in the tile manifest when clicking on a tile to check valid upgrades - which closes #8488 
- To avoid adding an overhead to every upgrade check in all games, this check is only performed for multi-city tiles (e.g. OO tiles) - single-city tiles are already well-covered by the existing check that all edge connections are preserved
- This also means fewer illegal-to-place tiles are passed into the `legal_tile_rotations` check in track-laying step to be filtered at that stage. That check still catches elements such as track being pointed at impassable tiles or the edge of the map.