### PR TITLE
[1840] Correct private company descriptions

### DIFF
--- a/lib/engine/game/g_1840/entities.rb
+++ b/lib/engine/game/g_1840/entities.rb
@@ -146,7 +146,7 @@ module Engine
               sym: 'KK',
               value: 20,
               revenue: 10,
-              desc: 'Increase income by 20 if tram route runs to or through E21 (when red tile is placed)',
+              desc: 'Increase income by 20 if tram route runs to E21 (when red tile is placed)',
               abilities: [
                 {
                   type: 'hex_bonus',
@@ -178,7 +178,7 @@ module Engine
               sym: 'HB',
               value: 40,
               revenue: 20,
-              desc: 'Increase income by 20 if tram route runs to or through E19 (when red tile is placed)',
+              desc: 'Increase income by 20 if tram route runs to E19 (when red tile is placed)',
               abilities: [
                 {
                   type: 'hex_bonus',
@@ -194,7 +194,7 @@ module Engine
               sym: 'SD',
               value: 50,
               revenue: 25,
-              desc: 'Increase income by 20 if tram route runs to or through D20 (when red tile is placed)',
+              desc: 'Increase income by 20 if tram route runs to D20 (when red tile is placed)',
               abilities: [
                 {
                   type: 'hex_bonus',


### PR DESCRIPTION
1840: Update the descriptions for the private companies Karlskirche, Hofburg, and Stephansdom so they do not suggest a route can run through the relevant tile (since it will be a red tile which does not allow a through route). Closes #8487 