### PR TITLE
show corporation type and escrow in 1856 spreadsheet

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -189,6 +189,7 @@ module View
         treasury << h(:th, render_sort_link('Shares', :treasury)) if @game.separate_treasury?
 
         extra = []
+        extra << h(:th, render_sort_link('Type', :type)) if @game.respond_to?(:type)
         extra << h(:th, render_sort_link('Loans', :loans)) if @game.total_loans&.nonzero?
         extra << h(:th, render_sort_link('Shorts', :shorts)) if @game.respond_to?(:available_shorts)
         if @game.total_loans.positive?
@@ -372,6 +373,8 @@ module View
               corporation.floated? ? [ct.size, [Array.new(train_limit) { |i| ct[i]&.name }]] : [-1, []]
             when :tokens
               @game.count_available_tokens(corporation)
+            when :type
+              @game.type(corporation) if @game.respond_to?(:type)
             when :loans
               corporation.loans.size
             when :shorts
@@ -448,6 +451,7 @@ module View
         end
 
         extra = []
+        extra << h(:td, @game.type(corporation)) if @game.respond_to?(:type)
         extra << h(:td, "#{corporation.loans.size}/#{@game.maximum_loans(corporation)}") if @game.total_loans&.nonzero?
         if @game.respond_to?(:available_shorts)
           taken, total = @game.available_shorts(corporation)

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -189,7 +189,9 @@ module View
         treasury << h(:th, render_sort_link('Shares', :treasury)) if @game.separate_treasury?
 
         extra = []
-        extra << h(:th, render_sort_link('Type', :type)) if @game.respond_to?(:type)
+        if @game.respond_to?(:capitalization_type_desc)
+          extra << h(:th, render_sort_link('Capitalization', :capitalization_type_desc))
+        end
         extra << h(:th, render_sort_link('Loans', :loans)) if @game.total_loans&.nonzero?
         extra << h(:th, render_sort_link('Shorts', :shorts)) if @game.respond_to?(:available_shorts)
         if @game.total_loans.positive?
@@ -373,8 +375,8 @@ module View
               corporation.floated? ? [ct.size, [Array.new(train_limit) { |i| ct[i]&.name }]] : [-1, []]
             when :tokens
               @game.count_available_tokens(corporation)
-            when :type
-              @game.type(corporation) if @game.respond_to?(:type)
+            when :capitalization_type_desc
+              @game.capitalization_type_desc(corporation) if @game.respond_to?(:capitalization_type_desc)
             when :loans
               corporation.loans.size
             when :shorts
@@ -451,7 +453,7 @@ module View
         end
 
         extra = []
-        extra << h(:td, @game.type(corporation)) if @game.respond_to?(:type)
+        extra << h(:td, @game.capitalization_type_desc(corporation)) if @game.respond_to?(:capitalization_type_desc)
         extra << h(:td, "#{corporation.loans.size}/#{@game.maximum_loans(corporation)}") if @game.total_loans&.nonzero?
         if @game.respond_to?(:available_shorts)
           taken, total = @game.available_shorts(corporation)

--- a/lib/engine/game/g_1856/corporation.rb
+++ b/lib/engine/game/g_1856/corporation.rb
@@ -6,7 +6,7 @@ module Engine
   module Game
     module G1856
       class Corporation < Engine::Corporation
-        attr_accessor :escrow, :presidents_share
+        attr_accessor :ipoed, :escrow, :presidents_share
 
         CAPITALIZATION_STRS = {
           full: 'Full',

--- a/lib/engine/game/g_1856/corporation.rb
+++ b/lib/engine/game/g_1856/corporation.rb
@@ -53,7 +53,6 @@ module Engine
         end
 
         def capitalization_type
-          # TODO: escrow
           return :escrow if !@destinated && @game.phase.status.include?('escrow')
           return :incremental if (@destinated && @game.phase.status.include?('escrow')) ||
             @game.phase.status.include?('incremental')

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1072,7 +1072,10 @@ module Engine
         end
 
         def type(corp)
+          return "" unless corp.ipoed
+
           return "#{corp.capitalization_type_desc} (#{corp.escrow || 0})" if corp.capitalization_type == :escrow
+
           corp.capitalization_type_desc
         end
 

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1071,7 +1071,7 @@ module Engine
           end
         end
 
-        def type(corp)
+        def capitalization_type_desc(corp)
           return '' unless corp.ipoed
 
           return "#{corp.capitalization_type_desc} (#{corp.escrow || 0})" if corp.capitalization_type == :escrow

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1071,6 +1071,11 @@ module Engine
           end
         end
 
+        def type(corp)
+          return "#{corp.capitalization_type_desc} (#{corp.escrow || 0})" if corp.capitalization_type == :escrow
+          corp.capitalization_type_desc
+        end
+
         #
         # Get the currently possible upgrades for a tile
         # from: Tile - Tile to upgrade from

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -1072,7 +1072,7 @@ module Engine
         end
 
         def type(corp)
-          return "" unless corp.ipoed
+          return '' unless corp.ipoed
 
           return "#{corp.capitalization_type_desc} (#{corp.escrow || 0})" if corp.capitalization_type == :escrow
 


### PR DESCRIPTION
show corporation type and escrow in 1856 spreadsheet - this makes it very easy to see the amount of capital each company will get when you buy a share

![image](https://user-images.githubusercontent.com/2832627/201476879-d0a91a63-fcf8-4edc-a841-835859581f81.png)

