### PR TITLE
18GB: Use safe navigation when accessing presidencies variable on SR

### DIFF
--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -110,7 +110,7 @@ module Engine
           end
 
           def already_president?(corporation)
-            @round.presidencies.include?(corporation)
+            @round.presidencies&.include?(corporation)
           end
 
           def can_buy_multiple?(entity, corporation, owner)


### PR DESCRIPTION
Use the safe navigation operator during the check of the stock round's `presidencies` variable in `already_president?`  in `buy_sell_par_shares`.

This avoids any errors where this property is examined during round/step setup. By the time the first player in the stock round is actually able to act, `record_current_presidencies` on the stock buying step will have run and populated the variable.

Closes #8526 