### PR TITLE
Add "Shares %" and "Book Value"

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -589,7 +589,7 @@ module View
       end
 
       def render_player_rusted_book_value
-        render_player_book_value('Rusted Value', ->(c) { rusted_book_value(c) })
+        render_player_book_value('Rusted BV', ->(c) { rusted_book_value(c) })
       end
 
       def render_player_book_value(name, getter)

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -61,6 +61,7 @@ module View
               render_player_value,
               render_player_liquidity,
               render_player_shares,
+              render_player_share_percentages,
               render_player_companies,
               render_player_certs,
             ]),
@@ -568,6 +569,15 @@ module View
           h('th.left', 'Shares'),
           *@game.players.map do |p|
             h('td.padded_number', @game.all_corporations.sum { |c| c.minor? ? 0 : num_shares_of(p, c) })
+          end,
+        ])
+      end
+
+      def render_player_share_percentages
+        h(:tr, tr_default_props, [
+          h('th.left', 'Shares %'),
+          *@game.players.map do |p|
+            h('td.padded_number', @game.all_corporations.sum { |c| c.minor? ? 0 : num_shares_percentage_of(p, c) })
           end,
         ])
       end

--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -581,7 +581,8 @@ module View
       end
 
       def render_player_share_percentages
-        render_player_corporation_summary('Shares %', ->(p, c) { c.minor? ? 0 : percentage_of(p, c) })
+        render_player_corporation_summary('Shares %', ->(p, c) { c.minor? ? 0 : percentage_of(p, c) },
+                                          format: ->(x) { format('%d%%', x) })
       end
 
       def render_player_current_book_value
@@ -595,14 +596,16 @@ module View
       def render_player_book_value(name, getter)
         render_player_corporation_summary(name,
                                           ->(p, c) { num_shares_of(p, c) * getter.call(c) / c.total_shares },
-                                          ->(p) { p.cash })
+                                          format: ->(x) { @game.format_currency(x.round) },
+                                          extra: ->(p) { p.cash })
       end
 
-      def render_player_corporation_summary(name, getter, extra = ->(_) { 0 })
+      def render_player_corporation_summary(name, getter, format: ->(x) { x }, extra: ->(_) { 0 })
         h(:tr, tr_default_props, [
           h('th.left', name),
           *@game.players.map do |p|
-            h('td.padded_number', @game.all_corporations.sum { |c| getter.call(p, c) } + extra.call(p))
+            h('td.padded_number',
+              format.call(@game.all_corporations.sum { |c| getter.call(p, c) } + extra.call(p)))
           end,
         ])
       end

--- a/assets/app/view/game/train_schedule.rb
+++ b/assets/app/view/game/train_schedule.rb
@@ -16,25 +16,6 @@ module View
         max_size == 1 ? '.right' : ''
       end
 
-      def rust_obsolete_schedule
-        rust_schedule = {}
-        obsolete_schedule = {}
-        @game.depot.trains.group_by(&:name).each do |_name, trains|
-          first = trains.first
-          first.variants.each do |name, train_variant|
-            unless Array(rust_schedule[train_variant[:rusts_on]]).include?(name)
-              rust_schedule[train_variant[:rusts_on]] =
-                Array(rust_schedule[train_variant[:rusts_on]]).append(name)
-            end
-            unless Array(obsolete_schedule[train_variant[:obsolete_on]]).include?(name)
-              obsolete_schedule[train_variant[:obsolete_on]] =
-                Array(obsolete_schedule[train_variant[:obsolete_on]]).append(name)
-            end
-          end
-        end
-        [rust_schedule, obsolete_schedule]
-      end
-
       def render
         title_props = {
           style: {
@@ -52,11 +33,12 @@ module View
           },
         }
 
-        rust_schedule, obsolete_schedule = rust_obsolete_schedule
-        trs = if @game.depot.upcoming.empty?
+        depot = @game.depot
+        rust_schedule, obsolete_schedule = depot.rust_obsolete_schedule
+        trs = if depot.upcoming.empty?
                 'No Upcoming Trains'
               else
-                @game.depot.upcoming.group_by(&:name).map do |name, trains|
+                depot.upcoming.group_by(&:name).map do |name, trains|
                   events = []
                   events << h('div.left', "rusts #{rust_schedule[name].join(', ')}") if rust_schedule[name]
                   events << h('div.left', "obsoletes #{obsolete_schedule[name].join(', ')}") if obsolete_schedule[name]

--- a/assets/app/view/share_calculation.rb
+++ b/assets/app/view/share_calculation.rb
@@ -8,7 +8,7 @@ module View
       entity.num_shares_of(corporation, ceil: false)
     end
 
-    def num_shares_percentage_of(entity, corporation)
+    def percentage_of(entity, corporation)
       return corporation.president?(entity) ? 100 : 0 if corporation.minor?
 
       entity.percent_of(corporation)

--- a/assets/app/view/share_calculation.rb
+++ b/assets/app/view/share_calculation.rb
@@ -7,5 +7,11 @@ module View
 
       entity.num_shares_of(corporation, ceil: false)
     end
+
+    def num_shares_percentage_of(entity, corporation)
+      return corporation.president?(entity) ? 100 : 0 if corporation.minor?
+
+      entity.percent_of(corporation)
+    end
   end
 end

--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -130,6 +130,25 @@ module Engine
       end
     end
 
+    def rust_obsolete_schedule
+      rust_schedule = {}
+      obsolete_schedule = {}
+      @trains.group_by(&:name).each do |_name, trains|
+        first = trains.first
+        first.variants.each do |name, train_variant|
+          unless Array(rust_schedule[train_variant[:rusts_on]]).include?(name)
+            rust_schedule[train_variant[:rusts_on]] =
+              Array(rust_schedule[train_variant[:rusts_on]]).append(name)
+          end
+          unless Array(obsolete_schedule[train_variant[:obsolete_on]]).include?(name)
+            obsolete_schedule[train_variant[:obsolete_on]] =
+              Array(obsolete_schedule[train_variant[:obsolete_on]]).append(name)
+          end
+        end
+      end
+      [rust_schedule, obsolete_schedule]
+    end
+
     def cash
       @bank.cash
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2163,7 +2163,10 @@ module Engine
       end
 
       def corporation_opts
-        {}
+        {
+          # use to change the book value of tokens when the tokens are pre-purchased
+          token_book_value_override: nil,
+        }
       end
 
       def init_corporations(stock_market)

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -332,6 +332,12 @@ module Engine
           @loan_value
         end
 
+        def corporation_opts
+          {
+            token_book_value_override: 50,
+          }
+        end
+
         def cannot_pay_interest_str
           '(Liquidate)'
         end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -803,6 +803,12 @@ module Engine
           corporation.spend(CHARTERED_TOKEN_COST * 3, @bank)
         end
 
+        def corporation_opts
+          {
+            token_book_value_override: 50, # average between chartered and unchartered token cost
+          }
+        end
+
         def convert_to_full!(corporation)
           corporation.capitalization = :full
           corporation.always_market_price = false

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -85,7 +85,7 @@ module Engine
           trains = rusted_trains + obsolete_trains
 
           unless trains.empty?
-            rust_value = @trains.filter { |t| trains.include?(t.name) }.sum(&:price)
+            rust_value = @trains.sum { |t| trains.include?(t.name) ? t.price : 0 }
             break
           end
         end

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -64,7 +64,11 @@ module Engine
 
     def current_book_value
       trains = @trains.sum(&:price)
-      tokens = @tokens.filter(&:used).sum { |t| @token_book_value_override || t.price }
+      tokens = if @token_book_value_override
+                 @tokens.size * @token_book_value_override
+               else
+                 @tokens.filter(&:used).sum(&:price)
+               end
       loans = @loans.sum(&:amount)
       trains + tokens + @cash - loans
     end

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -26,6 +26,7 @@ module Engine
       @text_color = opts[:text_color] || '#ffffff'
       @destination_coordinates = opts[:destination_coordinates]
       @destination_icon = opts[:destination_icon] ? "/icons/#{opts[:destination_icon]}" : ''
+      @token_book_value_override = opts[:token_book_value_override]
     end
 
     def operator?
@@ -59,6 +60,13 @@ module Engine
 
     def placed_tokens
       @tokens.select(&:city)
+    end
+
+    def book_value
+      trains = @trains.sum(&:price)
+      tokens = @tokens.filter(&:used).sum { |t| @token_book_value_override || t.price }
+      loans = @loans.sum(&:amount)
+      trains + tokens + @cash - loans
     end
   end
 end

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -67,7 +67,7 @@ module Engine
       tokens = if @token_book_value_override
                  @tokens.size * @token_book_value_override
                else
-                 @tokens.filter(&:used).sum(&:price)
+                 @tokens.sum { |t| t.used ? t.price : 0 }
                end
       loans = @loans.sum(&:amount)
       trains + tokens + @cash - loans


### PR DESCRIPTION
Fixes #8438

1. "Shares %" it the total percentage of shares a player owns
2. "Book Value" is `trains + tokens + cash - loans`
3. "Rusted Book Value" is the "Book Value" excluding the trains that will be rusted or obsoleted next

![image](https://user-images.githubusercontent.com/2832627/204214166-b3056a1a-a592-4c93-8443-5a52bb59b48c.png)
