### PR TITLE
[1868WY] cleanup: better function names, remove dead code

### DIFF
--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -120,30 +120,8 @@ module View
 
           children = []
 
-          if @town.double
-            x = radius
-            y = 0
-            angle = layout == :pointy ? -30 : 0
-
-            double_children = []
-            if @town.boom
-              double_children.concat(
-                [
-                  render_boom(transform: "translate(#{-x} #{y})"),
-                  render_boom(transform: "translate(#{x} #{y})"),
-                ]
-              )
-            end
-            double_children.concat([
-              h(:circle, attrs: dot_attrs.merge(transform: "translate(#{-x} #{y})")),
-              h(:circle, attrs: dot_attrs.merge(transform: "translate(#{x} #{y})")),
-            ])
-
-            children << h(:g, { attrs: { transform: "#{translate} rotate(#{angle})" } }, double_children)
-          else
-            children << h(:circle, attrs: dot_attrs)
-            children << render_boom if @town.boom
-          end
+          children << h(:circle, attrs: dot_attrs)
+          children << render_boom if @town.boom
 
           children << render_revenue if @show_revenue
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -139,8 +139,6 @@ module Engine
           init_track_points
           setup_company_price_up_to_face
 
-          setup_event_methods
-
           @development_hexes = init_development_hexes
           @development_token_count = Hash.new(0)
           @placed_development_tokens = Hash.new { |h, k| h[k] = [] }
@@ -227,14 +225,6 @@ module Engine
 
         def par_prices
           @stock_market.share_prices_with_types(@available_par_groups)
-        end
-
-        def setup_event_methods
-          (2..6).each do |phase|
-            self.class.define_method("event_remove_coal_dt_#{phase}!") do
-              event_remove_coal_dt!(phase.to_s)
-            end
-          end
         end
 
         def event_remove_coal_dt!(phase_name)

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -195,8 +195,8 @@ module Engine
         end
 
         def init_round_finished
-          p9_company.close!
-          @log << "#{p9_company.name} closes"
+          durant.close!
+          @log << "#{durant.name} closes"
         end
 
         def event_all_corps_available!
@@ -279,24 +279,100 @@ module Engine
           end
         end
 
-        def p1_company
-          @p1_company ||= company_by_id('P1')
+        def hell_on_wheels
+          @hell_on_wheels ||= company_by_id('P1')
         end
 
-        def p5_company
-          @p5_company ||= company_by_id('P5')
+        def wylie
+          @wylie ||= company_by_id('P2a')
         end
 
-        def p8_company
-          @p8_company ||= company_by_id('P8')
+        def trabing_bros
+          @trabing_bros ||= company_by_id('P2b')
         end
 
-        def p9_company
-          @p9_company ||= company_by_id('P9')
+        def midwest_oil
+          @midwest_oil ||= company_by_id('P2c')
         end
 
-        def p10_company
-          @p10_company ||= company_by_id('P10')
+        def upc_private
+          @upc_private ||= company_by_id('P3a')
+        end
+
+        def bonanza_private
+          @bonanza_private ||= company_by_id('P3b')
+        end
+
+        def fremont
+          @fremont ||= company_by_id('P3c')
+        end
+
+        def dodge
+          @dodge ||= company_by_id('P4a')
+        end
+
+        def lander
+          @lander ||= company_by_id('P4c')
+        end
+
+        def casement
+          @casement ||= company_by_id('P5a')
+        end
+
+        def foncier
+          @foncier ||= company_by_id('P5b')
+        end
+
+        def pac_rr_a
+          @pac_rr_a ||= company_by_id('P5c')
+        end
+
+        def strikebreakers_private
+          @strikebreakers_private ||= company_by_id('P6a')
+        end
+
+        def strikebreakers_coal
+          @strikebreakers_coal ||= @minors.find { |m| m.type == :coal && m.player == strikebreakers_private.player }
+        end
+
+        def teapot_dome_private
+          @teapot_dome_private ||= company_by_id('P6b')
+        end
+
+        def teapot_dome_oil
+          @teapot_dome_oil ||= @minors.find { |m| m.type == :oil && m.player == teapot_dome_private.player }
+        end
+
+        def no_bust
+          @no_bust ||= company_by_id('P6c')
+        end
+
+        def big_boy_private
+          @big_boy_private ||= company_by_id('P7')
+        end
+
+        def pure_oil
+          @pure_oil ||= company_by_id('P8')
+        end
+
+        def lhp_private
+          @lhp_private ||= company_by_id('P9')
+        end
+
+        def durant
+          @durant ||= company_by_id('P10')
+        end
+
+        def ames_bros
+          @ames_bros ||= company_by_id('P11')
+        end
+
+        def union_pacific_coal
+          @union_pacific_coal ||= minor_by_id('UPC')
+        end
+
+        def bonanza
+          @bonanza ||= minor_by_id('BZ')
         end
 
         def track_points_available(entity)

--- a/lib/engine/game/g_1868_wy/step/track.rb
+++ b/lib/engine/game/g_1868_wy/step/track.rb
@@ -21,7 +21,7 @@ module Engine
             # if 1 track point remains and P7 can be bought, block in the track step
             (corporation = entity).corporation? &&
               @game.phase.status.include?('can_buy_companies') &&
-              @game.p5_company.owned_by_player? &&
+              @game.dodge.owned_by_player? &&
               @game.buying_power(entity).positive? &&
               @game.track_points_available(corporation) == (@game.class::YELLOW_POINT_COST - 1)
           end

--- a/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
+++ b/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
@@ -76,7 +76,7 @@ module Engine
               @company_choices = companies
             end
 
-            company.revenue = 0 if company == @game.p8_company
+            company.revenue = 0 if company == @game.lhp_private
 
             @cheapest = @companies.first
             @passed_on_cheapest = {}
@@ -95,14 +95,14 @@ module Engine
 
           def all_passed!
             case @cheapest
-            when @game.p1_company
+            when @game.hell_on_wheels
               unless @passed_on_cheapest.value?('bid')
                 remove_cheapest!
                 @passed_on_cheapest = {}
               end
-            when @game.p9_company
-              increase_discount!(@game.p10_company, 10) if @bids[@game.p10_company].empty?
-              increase_discount!(@game.p9_company, 10)
+            when @game.durant
+              increase_discount!(@game.ames_bros, 10) if @bids[@game.ames_bros].empty?
+              increase_discount!(@game.durant, 10)
               @passed_on_cheapest = {}
             else
               remove_cheapest!

--- a/lib/engine/part/town.rb
+++ b/lib/engine/part/town.rb
@@ -6,7 +6,7 @@ module Engine
   module Part
     class Town < RevenueCenter
       attr_accessor :style
-      attr_reader :to_city, :boom, :double
+      attr_reader :to_city, :boom
 
       def initialize(revenue, **opts)
         super
@@ -14,7 +14,6 @@ module Engine
         @to_city = opts[:to_city]
         @boom = opts[:boom]
         @style = opts[:style]&.to_sym
-        @double = !!opts[:double]
       end
 
       def <=(other)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -143,7 +143,6 @@ module Engine
                               loc: params['loc'],
                               boom: params['boom'],
                               style: params['style'],
-                              double: params['double'],
                               to_city: params['to_city'])
         cache << town
         town


### PR DESCRIPTION
* new/renamed functions with descriptive names instead of IDs for private company and related minor getters
*  remove unused "double" towns (previous iterations of 1868 Wyoming used two down dots next to each other for "double boomtowns", those have been removed from the design)
*  remove unused `setup_event_methods`  