### PR TITLE
[1868WY] helper function for swapping tile colors and stripes, WRC

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -16,6 +16,7 @@ require_relative 'step/track'
 require_relative 'step/waterfall_auction'
 require_relative '../base'
 require_relative '../company_price_up_to_face'
+require_relative '../swap_color_and_stripes'
 require_relative '../stubs_are_restricted'
 
 module Engine
@@ -31,6 +32,7 @@ module Engine
         # Engine::Game includes
         include CompanyPriceUpToFace
         include StubsAreRestricted
+        include SwapColorAndStripes
 
         # overrides
         BANK_CASH = 99_999
@@ -113,6 +115,8 @@ module Engine
         }.freeze
 
         GHOST_TOWN_NAME = 'ghost town'
+
+        WIND_RIVER_CANYON_HEX = 'F12'
 
         def dotify(tile)
           tile.towns.each { |town| town.style = :dot }
@@ -326,10 +330,7 @@ module Engine
         def action_processed(action)
           case action
           when Action::LayTile
-            if action.hex.name == 'G15'
-              action.hex.tile.color = :gray
-              @log << 'Wind River Canyon turns gray; it can never be upgraded'
-            end
+            swap_color_and_stripes(action.hex.tile) if action.hex.name == WIND_RIVER_CANYON_HEX
           end
         end
 

--- a/lib/engine/game/g_1868_wy/map.rb
+++ b/lib/engine/game/g_1868_wy/map.rb
@@ -193,6 +193,13 @@ module Engine
           # gray
           '51' => 2,
 
+          # custom yellow-gray
+          'WRC' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'path=a:0,b:2;label=WRC;stripes=color:gray',
+          },
+
           # custom yellow
           'YC' => {
             'count' => 3,

--- a/lib/engine/game/swap_color_and_stripes.rb
+++ b/lib/engine/game/swap_color_and_stripes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#
+# This module provides a function to flip a tile's the color and stripes, making
+# the color that was the stripes the tile's new effective color. It should be
+# called in after a LayTile action is processed, e.g., in Game#action_processed.
+#
+module SwapColorAndStripes
+  def swap_color_and_stripes(tile)
+    tile.color, tile.stripes.color = tile.stripes.color, tile.color if tile.stripes
+  end
+end

--- a/lib/engine/part/stripes.rb
+++ b/lib/engine/part/stripes.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Engine
   module Part
     class Stripes < Base
-      attr_reader :color
+      attr_accessor :color
 
       def initialize(color)
         @color = color


### PR DESCRIPTION
In 1868 Wyoming, Wind River Canyon (WRC) is a yellow-grey tile, which can be laid from phase 2 (yellow), but can never be upgraded (gray).

Since the new function swaps the color and stripes values, the colors/stripes will visually swap on the tile after it has been laid.

[#5011]

This may also be useful for striped tiles in 1825, 1829, and 1898 [#6083] [#6359] (cc @ventusignis @roseundy)

----

WRC tile before lay -- yellow with gray stripes:

![before](https://user-images.githubusercontent.com/1045173/204156652-086d7f51-edd5-4e07-83de-6c1db9755695.png)

After lay -- gray with yellow stripes:

![after](https://user-images.githubusercontent.com/1045173/204156668-98c0025b-eb2c-4e96-86e4-622654cc2e65.png)
