### PR TITLE
18GB: Don't allow routes to connect at offboards (for NS/EW bonus)

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -800,7 +800,7 @@ module Engine
         end
 
         def routes_intersect(first, second)
-          !(first.visited_stops & second.visited_stops).empty?
+          !(first.visited_stops & second.visited_stops).reject(&:offboard?).empty?
         end
 
         def route_sets_intersect(first, second)


### PR DESCRIPTION
When allowing multiple trains to connect to satisfy the NS or EW bonuses in 18GB, don't allow this connection to take place through an offboard location. Closes #8532 