### PR TITLE
[1822PNW] in stock rounds, use 1822 discard train step

### DIFF
--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -548,7 +548,7 @@ module Engine
 
         def stock_round
           G1822PNW::Round::Stock.new(self, [
-            Engine::Step::DiscardTrain,
+            G1822::Step::DiscardTrain,
             G1822PNW::Step::BuySellParShares,
           ])
         end


### PR DESCRIPTION
Fixes #8521 by inheriting the logic to permanently remove the special trains when they are discarded