### PR TITLE
[TOP 1871] enforce MUST_SELL_IN_BLOCKS in BuyTrain#can_sell? override

### DIFF
--- a/lib/engine/game/g_1871/step/buy_train.rb
+++ b/lib/engine/game/g_1871/step/buy_train.rb
@@ -57,6 +57,7 @@ module Engine
             return false if entity != bundle.owner
             return false unless @game.check_sale_timing(entity, bundle)
             return false unless sellable_bundle?(bundle)
+            return false if @game.class::MUST_SELL_IN_BLOCKS && @corporations_sold.include?(bundle.corporation)
 
             # This is our new clause for 1871, if this is the corporation
             # selling, we can sell all of them


### PR DESCRIPTION
The constant is set correctly in the game class; in the [base Train EMR module the constant is referenced](https://github.com/tobymao/18xx/blob/a6cb05dc3c2df2bb9f8b31eeba257989aeab4cb3/lib/engine/step/train.rb#L120), but in this override that reference to the constant was missed

[Fixes #8519]