### PR TITLE
[1868WY] prevent trains from being flipped once purchased

### DIFF
--- a/lib/engine/game/g_1822/step/discard_train.rb
+++ b/lib/engine/game/g_1822/step/discard_train.rb
@@ -14,8 +14,7 @@ module Engine
               @game.remove_train(train)
               @log << "#{action.entity.name} discards #{train.name}, #{train.name} is removed from the game"
             else
-              # Remove any variants on the train before reclaiming it
-              train.variants.select! { |v| v == train.name }
+              train.remove_variants!
               @game.depot.reclaim_train(train)
               @log << "#{action.entity.name} discards #{train.name}"
             end

--- a/lib/engine/game/g_1868_wy/step/buy_train.rb
+++ b/lib/engine/game/g_1868_wy/step/buy_train.rb
@@ -9,6 +9,11 @@ module Engine
       module Step
         class BuyTrain < Engine::Step::BuyTrain
           include G1868WY::SkipCoalAndOil
+
+          def process_buy_train(action)
+            super
+            action.train.remove_variants!
+          end
         end
       end
     end

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -70,6 +70,12 @@ module Engine
       remove_instance_variable(:@local) if defined?(@local)
     end
 
+    # remove unused variants, i.e., the physical train card is not allowed to be
+    # flipped/rotated any more
+    def remove_variants!
+      @variants.select! { |name, _| @name == name }
+    end
+
     def names_to_prices
       @variants.transform_values { |v| v[:price] }
     end


### PR DESCRIPTION
also use new helper function in 1822 when discarding a train (cannot be used on purchase there, as an L can be flipped to a 2 after purchase)

[#5011]