### PR TITLE
add dashes to tokens to be color blind friendly

### DIFF
--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -86,12 +86,26 @@ module Lib
     end
 
     def player_colors(players)
+      player_route_props(players, ->(index) { route_prop(index, :color) })
+    end
+
+    def player_colors_with_dash(players)
+      player_route_props(players, lambda { |index|
+        {
+          'color' => route_prop(index, :color),
+          'width' => route_prop(index, :width),
+          'dash' => route_prop(index, :dash),
+        }
+      })
+    end
+
+    def player_route_props(players, getter)
       # Rotate around the user if they're logged in
       if @user && (player_idx = players.index { |p| p.id == @user['id'] })
         players = players.rotate(player_idx)
       end
 
-      players.map.with_index { |p, idx| [p, route_prop(idx, 'color')] }.to_h
+      players.map.with_index { |p, idx| [p, getter.call(idx)] }.to_h
     end
   end
 end

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -49,11 +49,16 @@ module View
           color = ((@reservation&.corporation? || @reservation&.minor?) &&
                     @reservation&.reservation_color) ||
                     'white'
+          dash = nil
+          stroke_width = nil
 
           radius = @radius
           show_player_colors = setting_for(:show_player_colors, @game)
           if show_player_colors && (owner = @token&.corporation&.owner) && @game&.players&.include?(owner)
-            color = player_colors(@game.players)[owner]
+            props = player_colors_with_dash(@game.players)[owner]
+            color = props[:color]
+            dash = props[:dash]
+            stroke_width = props[:width]
             radius -= 4
           end
 
@@ -61,6 +66,9 @@ module View
             r: @radius,
             fill: color,
           }
+          token_attrs[:'stroke'] = color
+          token_attrs[:'stroke-dasharray'] = dash if dash
+          token_attrs[:'stroke-width'] = stroke_width if stroke_width
 
           if (highlight = @game&.highlight_token?(@token))
             radius -= 3


### PR DESCRIPTION
add dashes to tokens to be color blind friendly

![image](https://user-images.githubusercontent.com/2832627/205730335-940f2c48-5c6e-4a63-b54b-228b42e0ca04.png)

