### PR TITLE
1861/1867 player value fix

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1130,7 +1130,7 @@ module Engine
         self.class::SOLD_OUT_INCREASE
       end
 
-      def log_share_price(entity, from, steps = nil)
+      def log_share_price(entity, from, steps = nil, log_steps: false)
         from_price = from.price
         to = entity.share_price
         to_price = to.price
@@ -1139,7 +1139,7 @@ module Engine
         jumps = ''
         if steps
           steps = share_jumps(steps)
-          jumps = " (#{steps} steps)" unless steps < 2
+          jumps = " (#{steps} step#{steps == 1 ? '' : 's'})" if (steps > 1) || log_steps
         end
 
         r1, c1 = from.coordinates


### PR DESCRIPTION
* fix bug where non-president certs are sometimes counted as double-value for presidents when calculating `player_value` * change var name in loop; `player.shares` is really an array of the share certificates, some of which (president shares) or two shares (this is what caused the bug)
* simplify `player_value`; always account for the endgame shift
* change end_game! to remove the loans when price is dropped, so that `player_value` doesn't need to check if game is over
* add param to optionally log steps when stock price is changed, to make it more clear when a single loan is paid off

[Fixes #8573]