### PR TITLE
[1868WY] Stock Round Action

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -5,13 +5,13 @@ require_relative 'map'
 require_relative 'meta'
 require_relative 'trains'
 require_relative 'step/buy_company'
-require_relative 'step/buy_sell_par_shares'
 require_relative 'step/buy_train'
 require_relative 'step/company_pending_par'
 require_relative 'step/development_token'
 require_relative 'step/dividend'
 require_relative 'step/manual_close_company'
 require_relative 'step/route'
+require_relative 'step/stock_round_action'
 require_relative 'step/token'
 require_relative 'step/track'
 require_relative 'step/waterfall_auction'
@@ -164,8 +164,8 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,
-            G1868WY::Step::BuySellParShares,
             G1868WY::Step::ManualCloseCompany,
+            G1868WY::Step::StockRoundAction,
           ])
         end
 

--- a/lib/engine/game/g_1868_wy/step/stock_round_action.rb
+++ b/lib/engine/game/g_1868_wy/step/stock_round_action.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+require_relative '../../../step/tokener'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        # a Stock Round action is one of the following:
+        # - sell then buy
+        # - choose new home for DPR after all its tokens BUST
+        # - exchange Ames Bros private for UP double share, then may sell 1-2 of those shares
+        class StockRoundAction < Engine::Step::BuySellParShares
+          def description
+            'Stock Round Action'
+          end
+
+          def actions(entity)
+            return [] if tokened?
+            return [] unless entity == current_entity
+            return ['sell_shares'] if must_sell?(entity)
+
+            actions = []
+            actions << 'sell_shares' if can_sell_any?(entity)
+            actions << 'buy_shares' if can_buy_any?(entity)
+            actions << 'par' if can_ipo_any?(entity)
+            actions << 'pass' unless actions.empty?
+
+            actions
+          end
+
+          def get_par_prices(entity, _corp)
+            @game.par_prices.select { |p| p.price * 2 <= entity.cash }
+          end
+
+          def process_buy_shares(action)
+            entity = action.entity
+            player = entity.player
+            bundle = action.bundle
+
+            buy_shares(player, bundle)
+
+            track_action(action, bundle.corporation)
+          end
+
+          def process_sell_shares(action)
+            player = action.entity
+            bundle = action.bundle
+            corporation = bundle.corporation
+
+            sell_shares(player, bundle)
+            track_action(action, corporation)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* placing DPR's home or exchanging the private for the UP double share takes up the full stock round action, preventing any selling then buying to happen
* placing DPR's home or exchanging the private for the UP double share are implemented in later PRs
* available par prices vary by phase

[#5011]