### PR TITLE
[1868WY] Double Heading trains

### DIFF
--- a/assets/app/view/game/double_head_trains.rb
+++ b/assets/app/view/game/double_head_trains.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+
+module View
+  module Game
+    class DoubleHeadTrains < Snabberb::Component
+      include Actionable
+      include Lib::Settings
+
+      needs :selected_trains, store: true, default: {}
+
+      def render
+        @step = @game.active_step
+        current_entity = @game.round.current_entity
+        trains = @game.double_head_candidates(current_entity)
+
+        rendered_trains = trains.flat_map do |train|
+          onclick = lambda do
+            @selected_trains[train] = !@selected_trains[train]
+            store(:selected_trains, @selected_trains, skip: false)
+          end
+
+          style = {
+            border: 'solid 1px',
+            display: 'inline-block',
+            cursor: 'pointer',
+            margin: '0.1rem 0rem',
+            padding: '3px 6px',
+            minWidth: '1.5rem',
+            textAlign: 'center',
+            whiteSpace: 'nowrap',
+          }
+
+          bg_color = route_prop(0, :color)
+          style[:backgroundColor] = @selected_trains[train] ? bg_color : color_for(:bg)
+          style[:color] = contrast_on(bg_color)
+
+          [
+            h(:tr,
+              [h('td.middle', [
+                   h(:div, { style: style, on: { click: onclick } }, train.name),
+                 ])]),
+          ]
+        end
+
+        div_props = {
+          key: 'double_head_trains',
+          hook: {
+            destroy: -> { cleanup },
+          },
+        }
+        table_props = {
+          style: {
+            marginTop: '0.5rem',
+            textAlign: 'left',
+          },
+        }
+
+        description = 'Each turn, trains may be added together to run as a single longer train for that turn.'
+
+        h(:div, div_props, [
+            h(:h3, 'Double-Head Trains'),
+            h('div.small_font', description),
+            h(:table, table_props, [
+                h(:thead, [
+                    h(:tr, [
+                        h(:th, 'Train'),
+                      ]),
+                  ]),
+                h(:tbody, rendered_trains),
+              ]),
+            actions,
+          ].compact)
+      end
+
+      def cleanup(skip: true)
+        store(:selected_trains, {}, skip: skip)
+      end
+
+      def actions
+        selected_count = 0
+        cities = 0
+        towns = 0
+
+        trains = @selected_trains.map do |train, selected|
+          next unless selected
+
+          selected_count += 1
+
+          c, t = @game.distance(train)
+          cities += c
+          towns += t
+
+          train
+        end.compact
+
+        disabled = trains.size < 2
+        submit_txt = disabled ? 'Select 2 or more trains' : "Form #{@step.an(cities)} #{cities}+#{towns} train"
+
+        submit = lambda do
+          process_action(Engine::Action::DoubleHeadTrains.new(@game.current_entity, trains: trains))
+          cleanup
+        end
+
+        reset = lambda do
+          cleanup(skip: false)
+        end
+
+        submit_style = {
+          minWidth: '6.5rem',
+          marginTop: '1rem',
+          padding: '0.2rem 0.5rem',
+        }
+
+        h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
+          h(:button, { attrs: { disabled: disabled }, style: submit_style, on: { click: submit } }, submit_txt),
+          h(:button, { style: submit_style, on: { click: reset } }, 'Reset'),
+        ])
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -18,6 +18,7 @@ require 'view/game/map'
 require 'view/game/buy_corporation'
 require 'view/game/route_selector'
 require 'view/game/cash_crisis'
+require 'view/game/double_head_trains'
 
 module View
   module Game
@@ -43,6 +44,8 @@ module View
           left << h(Convert) if @current_actions.include?('convert')
           left << h(SwitchTrains) if @current_actions.include?('switch_trains')
           left << h(ReassignTrains) if @current_actions.include?('reassign_trains')
+          left << h(DoubleHeadTrains) if @current_actions.include?('double_head_trains')
+
           if @current_actions.include?('buy_train')
             left << h(IssueShares) if @current_actions.include?('sell_shares') || @current_actions.include?('buy_shares')
             left << h(BuyTrains)

--- a/lib/engine/action/double_head_trains.rb
+++ b/lib/engine/action/double_head_trains.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class DoubleHeadTrains < Base
+      attr_reader :trains
+
+      def initialize(entity, trains:)
+        super(entity)
+        @trains = trains
+      end
+
+      def self.h_to_args(h, game)
+        {
+          trains: h['trains'].map { |t| game.train_by_id(t) },
+        }
+      end
+
+      def args_to_h
+        {
+          'trains' => @trains.map(&:id),
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -35,6 +35,8 @@ module Engine
         include StubsAreRestricted
         include SwapColorAndStripes
 
+        attr_accessor :double_headed_trains
+
         # overrides
         BANK_CASH = 99_999
         STARTING_CASH = { 3 => 734, 4 => 550, 5 => 440 }.freeze
@@ -157,6 +159,8 @@ module Engine
           update_cache(:minors)
 
           @available_par_groups = %i[par]
+
+          @double_headed_trains = []
         end
 
         def stock_round
@@ -184,6 +188,7 @@ module Engine
             G1868WY::Step::ManualCloseCompany,
             G1868WY::Step::Track,
             G1868WY::Step::Token,
+            G1868WY::Step::DoubleHeadTrains,
             G1868WY::Step::Route,
             G1868WY::Step::Dividend,
             Engine::Step::DiscardTrain,
@@ -737,6 +742,24 @@ module Engine
           update_tile_lists(green_tile, old_tile)
           hex.lay(green_tile)
           @log << "#{corporation.name} lays tile #{green_tile.name} on #{hex.id} (#{old_tile.location_name})"
+        end
+
+        def double_head_candidates(corporation)
+          corporation.trains.reject do |train|
+            train.operated || train.obsolete
+          end
+        end
+
+        def find_and_remove_train_by_id(train_id, buyable: true)
+          train = train_by_id(train_id)
+          @depot.remove_train(train)
+          train.buyable = buyable
+          train.reserved = true
+          train
+        end
+
+        def update_trains_cache
+          update_cache(:trains)
         end
       end
     end

--- a/lib/engine/game/g_1868_wy/step/dividend.rb
+++ b/lib/engine/game/g_1868_wy/step/dividend.rb
@@ -24,6 +24,15 @@ module Engine
           def log_run_payout(entity, kind, revenue, action, payout)
             super unless entity.minor?
           end
+
+          def rust_obsolete_trains!(entity, log: false)
+            super(entity, log: false)
+          end
+
+          def process_dividend(action)
+            super
+            @game.double_headed_trains = []
+          end
         end
       end
     end

--- a/lib/engine/game/g_1868_wy/step/double_head_trains.rb
+++ b/lib/engine/game/g_1868_wy/step/double_head_trains.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../skip_coal_and_oil'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class DoubleHeadTrains < Engine::Step::Base
+          include SkipCoalAndOil
+
+          ACTIONS = %w[double_head_trains pass].freeze
+
+          def setup
+            @game.double_headed_trains = []
+          end
+
+          def description
+            'Double-Head Trains'
+          end
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] unless entity.corporation?
+            return [] unless @game.double_head_candidates(entity).size > 1
+            return [] unless @game.can_run_route?(entity)
+
+            ACTIONS
+          end
+
+          def process_double_head_trains(action)
+            trains = action.trains
+            corporation = action.entity
+
+            raise GameError 'Cannot double head with fewer than 2 trains' if trains.size < 2
+
+            train = get_double_headed_train!(trains)
+
+            train.owner = corporation
+            corporation.trains << train
+
+            @log << "#{corporation.name} forms #{an(train.distance[1]['pay'])} "\
+                    "#{train.name} train by double heading trains: #{trains.map(&:name).sort.join(', ')}"
+          end
+
+          def an(number)
+            case number
+            when 8, 11, 18
+              'an'
+            else
+              'a'
+            end
+          end
+
+          def get_double_headed_train!(trains)
+            @game.double_headed_trains.concat(trains)
+            valid_trains = @game.double_head_candidates(trains.first.owner)
+
+            trains.each do |train|
+              raise GameError "Cannot double head train #{train.id}" unless valid_trains.include?(train)
+
+              # prevent given trains from running individually this OR
+              train.operated = true
+            end
+
+            # double-headed train's ID is formed by combining the the IDs of the
+            # given trains, so that if they are double headed this way again,
+            # the double headed train does not need to be recreated, and the
+            # route auto-selector can use its previous route
+            sym = trains.map(&:id).sort.join('_')
+
+            if (train = @game.train_by_id("#{sym}-0"))
+              # refresh double-headed train that ran previously
+              train.operated = false
+              train.rusted = false
+            else
+              distance, name = combined_distance_and_name(trains)
+
+              train = Engine::Train.new(
+                name: sym,
+                distance: distance,
+                price: 0,
+              )
+
+              # simplify name to C+t form, after id is set via sym
+              train.name = name
+
+              # make train available to @game.train_by_id, but don't keep in
+              # Depot
+              @game.depot.add_train(train)
+              @game.update_trains_cache
+              @game.remove_train(train)
+            end
+
+            # run train this OR, then remove it from company automatically via
+            # base logic for obsolete trains
+            train.obsolete = true
+
+            train
+          end
+
+          def combined_distance_and_name(trains)
+            big_boy_train = false
+
+            cities, towns = trains.each_with_object([0, 0]) do |train, c_t|
+              c, t = @game.distance(train)
+              c_t[0] += c
+              c_t[1] += t
+
+              big_boy_train ||= (train == @game.big_boy_train)
+            end
+
+            distance = [
+              { 'nodes' => ['town'], 'pay' => towns, 'visit' => towns },
+              { 'nodes' => %w[city offboard town], 'pay' => cities, 'visit' => cities },
+            ]
+            name =
+              if big_boy_train
+                "[#{cities}+#{towns}]"
+              else
+                "#{cities}+#{towns}"
+              end
+
+            [distance, name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -181,12 +181,12 @@ module Engine
         @round.routes
       end
 
-      def rust_obsolete_trains!(entity)
+      def rust_obsolete_trains!(entity, log: true)
         rusted_trains = entity.trains.select(&:obsolete).each do |train|
           @game.rust(train)
         end
 
-        @log << '-- Event: Obsolete trains rust --' if rusted_trains.any?
+        @log << '-- Event: Obsolete trains rust --' if log && !rusted_trains.empty?
       end
 
       def pass!


### PR DESCRIPTION
* in this game, 2 or more trains can be combined and run as if their city and town numbers added up (respectively), allowing much greater reach to hit east-west runs and the Golden/Northern spikes earlier
* trains are combined and a new virtual train is created; its ID is based on the train IDs used to make it, so if the same trains are combined in a future OR, the new train's ID will match, and its previous route will be highlighted to run again

[#5011]