### PR TITLE
[1868WY] Ames Double Share

### DIFF
--- a/assets/app/view/game/issue_shares.rb
+++ b/assets/app/view/game/issue_shares.rb
@@ -70,7 +70,9 @@ module View
                  ''
                end
 
-        str = "#{bundle.num_shares} #{name}(#{@game.format_currency(bundle.price)})"
+        flags = ('d' * bundle.shares.count(&:double_cert))
+
+        str = "#{flags.empty? ? '' : flags + ' '}#{bundle.num_shares} #{name}(#{@game.format_currency(bundle.price)})"
         str += " from #{bundle.owner.name}" if bundle.owner.player?
         h('button.small', { on: { click: block } }, str)
       end

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -23,7 +23,7 @@ module View
               percent: bundle.percent,
             ))
           end
-          double_cert = bundle.shares.any?(&:last_cert) ? '[d]' : ''
+          double_cert = bundle.shares.any? { |s| s.last_cert || s.double_cert } ? '[d]' : ''
           props = {
             style: {
               padding: '0.2rem 0',

--- a/lib/engine/game/g_1868_wy/share_pool.rb
+++ b/lib/engine/game/g_1868_wy/share_pool.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1868WY
+      class SharePool < Engine::SharePool
+        def change_president(presidents_share, swap_to, president, _previous_president)
+          corporation = presidents_share.corporation
+
+          incoming_pres_shares = president.shares_of(corporation)
+
+          double = incoming_pres_shares.find(&:double_cert)
+          shares =
+            if double && incoming_pres_shares.size < 4
+              [double]
+            else
+              incoming_pres_shares.reject(&:double_cert).take(2)
+            end
+          shares.each do |s|
+            move_share(s, swap_to)
+          end
+          move_share(presidents_share, president)
+        end
+
+        def handle_partial(bundle, from, to)
+          move_share(from.shares_of(bundle.corporation).find { |s| !s.double_cert }, to)
+        end
+
+        def swap_double_cert(from, to, corporation)
+          double = from.shares_of(corporation).find(&:double_cert)
+          move_share(double, to)
+          shares = to.shares_of(corporation).select { |s| s.percent == 10 }.take(2)
+          shares.each { |s| move_share(s, from) }
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/step/double_share_protection.rb
+++ b/lib/engine/game/g_1868_wy/step/double_share_protection.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/share_buying'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class DoubleShareProtection < Engine::Step::Base
+          ACTIONS = %w[choose].freeze
+
+          def description
+            'Ames Brothers 20% Share Protection'
+          end
+
+          def protect
+            @game.up_double_share_protection
+          end
+
+          def help
+            old = protect[:prev_president]
+            new = protect[:player]
+            cost = protect[:buy_at_price].price * protect[:num_buyable]
+
+            exchange_text =
+              case protect[:num_buyable]
+              when 0
+                'swap two 10% shares for it. '
+              when 1
+                "buy one 10% share from the bank for #{@game.format_currency(cost)} and then swap two 10% shares for it. "
+              when 2
+                "buy two 10% shares from the bank for #{@game.format_currency(cost)} and then swap two 10% shares for it. "
+              end
+
+            price_text =
+              if @game.union_pacific.share_price.price == protect[:new_price].price
+                ''
+              else
+                cash_text =
+                  if protect[:cash]
+                    ", and #{old.name} will receive #{@game.format_currency(protect[:cash])} from the bank"
+                  else
+                    ''
+                  end
+                'If two 10% shares are swapped, the UP share price will increase to '\
+                  "#{@game.format_currency(protect[:new_price].price)}#{cash_text}. "
+              end
+
+            finish = "Then, the Stock Round will resume from #{old.name}'s turn."
+
+            "The UP president's certificate is temporarily in the bank pool. #{new.name} "\
+              "may either swap the Ames Brothers 20% share for it, or #{exchange_text}#{price_text}#{finish}"
+          end
+
+          def actions(entity)
+            entity == protect[:player] ? ACTIONS : []
+          end
+
+          def log_skip; end
+
+          def log_pass(entity)
+            @log << "#{entity.name} declines to protect the Ames Brothers 20% UP share"
+          end
+
+          def pass_description
+            "Pass (Don't Protect 20% Share)"
+          end
+
+          def active?
+            !protect.empty?
+          end
+
+          def choice_available?(entity)
+            entity == protect[:player]
+          end
+
+          def choices
+            cost = protect[:buy_at_price].price * protect[:num_buyable]
+
+            protect_text =
+              case protect[:num_buyable]
+              when 0
+                'Two 10% certs'
+              when 1
+                "Two 10% certs (buying one for #{@game.format_currency(cost)})"
+              when 2
+                "Two 10% certs (buying two for #{@game.format_currency(cost)})"
+              end
+
+            { 0 => 'Ames Brothers 20% cert', 1 => protect_text }
+          end
+
+          def choice_name
+            'Swap for Presidency'
+          end
+
+          def active_entities
+            [protect[:player]]
+          end
+
+          def blocking?
+            !protect.empty?
+          end
+
+          def post_process
+            @game.up_double_share_protection = {}
+          end
+
+          def process_pass(action)
+            log_pass(action.entity)
+            pass!
+            post_process
+          end
+
+          def process_choose(action)
+            player = action.entity
+
+            if action.choice.zero?
+              @game.swap_up_double_share_and_presidency!
+              @log << "#{player.name} swaps the Ames Brothers 20% share for the UP president's certificate"
+            else
+              old_price = @game.union_pacific.share_price.price
+
+              swap = @game.up_protection_player_bundle
+
+              @game.share_pool.move_share(@game.up_presidency, player)
+              swap&.shares&.each { |s| @game.share_pool.move_share(s, @game.share_pool) }
+              @game.union_pacific.owner = player
+
+              cost = protect[:buy_at_price].price * protect[:num_buyable]
+              player.spend(cost, @game.bank) if cost.positive?
+
+              @log <<
+                case protect[:num_buyable]
+                when 0
+                  "#{player.name} exchanges two 10% UP shares for the UP president's certificate"
+                when 1
+                  "#{player.name} pays #{@game.format_currency(cost)} for one 10% UP share from the bank "\
+                  "pool, then exchanges two 10% shares for the the UP president's certificate"
+                when 2
+                  "#{player.name} pays #{@game.format_currency(cost)} for two 10% UP shares from the bank pool, "\
+                  "then exchanges those two 10% shares for the the UP president's certificate"
+                else
+                  ''
+                end
+
+              row, col = protect[:new_price].coordinates
+              @game.stock_market.move(@game.union_pacific, row, col)
+              @game.log_share_price(@game.union_pacific, old_price)
+
+              if protect[:cash]
+                @game.bank.spend(protect[:cash], protect[:prev_president])
+                @log << "#{protect[:prev_president].name} receives #{@game.format_currency(protect[:cash])} from the bank"
+              end
+            end
+
+            post_process
+          end
+
+          def ipo_type(_entity)
+            :par
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_chesapeake/share_pool.rb
+++ b/lib/engine/game/g_18_chesapeake/share_pool.rb
@@ -7,8 +7,7 @@ module Engine
   module Game
     module G18Chesapeake
       class SharePool < Engine::SharePool
-        def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil,
-                       allow_president_change: true, borrow_from: nil)
+        def buy_shares(entity, shares, **kwargs)
           return super unless shares
           return super unless @game.two_player?
 

--- a/lib/engine/game/g_18_tn/share_pool.rb
+++ b/lib/engine/game/g_18_tn/share_pool.rb
@@ -6,8 +6,7 @@ module Engine
   module Game
     module G18TN
       class SharePool < Engine::SharePool
-        def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil,
-                       allow_president_change: true, borrow_from: nil)
+        def buy_shares(entity, shares, **kwargs)
           super
 
           return if shares.corporation.id != 'L&N' || !@game.lnr.owner

--- a/lib/engine/share.rb
+++ b/lib/engine/share.rb
@@ -58,8 +58,8 @@ module Engine
       "#{self.class.name} - #{id}"
     end
 
-    def to_bundle
-      ShareBundle.new(self)
+    def to_bundle(percent = nil)
+      ShareBundle.new(self, percent)
     end
 
     def inspect

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Engine
   module Step
     module ShareBuying
-      def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil)
+      def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil, silent: nil)
         check_legal_buy(entity,
                         shares,
                         exchange: exchange,
@@ -17,7 +17,8 @@ module Engine
                                     exchange: exchange,
                                     swap: swap,
                                     borrow_from: borrow_from,
-                                    allow_president_change: allow_president_change)
+                                    allow_president_change: allow_president_change,
+                                    silent: silent)
 
         maybe_place_home_token(shares.corporation)
       end


### PR DESCRIPTION
* in the Issue Shares view, add flags to the bundle; this affects 1849
* exchanging the private for the double share counts as a stock round action (ie, the owner cannot sell/buy other shares on the same turn as making the exchange)

Rules Notes:

In 1868 Wyoming, the final private can be exchanged for the "Ames Brothers double share", a 20% certificate for the Union Pacific Railroad, like the last 20% cert that the railroads in 1849 have.

The Ames Brothers share has some additional rules to protect the owner from losing it involuntarily:

* as in 1849, they can exchange two 10% shares for the president's cert to continue holding the double cert
* unlike 1849, if they don't have two 10% shares when the presidency is dumped on them, they may immediately buy 10% shares until they have two, make the swap, and end up holding the Ames double share and the UP president's cert
* when the private closes in phase 5, the exchange happens immediately

[#5011]