### PR TITLE
Propogate skip_track parameter from node.walk to path.walk

### DIFF
--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -57,6 +57,7 @@ module Engine
           node_path.walk(
             visited: visited_paths,
             skip_paths: skip_paths,
+            skip_track: skip_track,
             counter: counter,
             converging: converging_path,
           ) do |path, vp, ct, converging|


### PR DESCRIPTION
Before this change the track gauge was not being checked when track sections between nodes were walked. This meant was possible to walk between two nodes that had intervening narrow gauge track when skip_track had been set to :narrow.

This is needed for 1858, it might not be possible to trigger this bug in other games. In 1858 you're allowed to build broad gauge and narrow gauge track so that they meet at a hex edge, but it's not possible to trace a route or run any trains down a link like this. So you can have something like node, broad gauge track, narrow gauge track, node. As the skip_track setting was not being passed down it was possible for this route to be walked without objecting to the gauge change.