### PR TITLE
Correctly set reservation city index when upgrading tile

### DIFF
--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -143,7 +143,7 @@ module Engine
               next unless ability.hex == coordinates
 
               ability.tile = new_city.tile
-              ability.city = new_city.index
+              ability.city = new_city.tile.cities.find_index(new_city)
             end
           end
 


### PR DESCRIPTION
When a tile with a city reservation was being upgraded, the city number for the reservation ability was being set using the city.index property. This property is set when the tile is initially parsed, and gives the index of the city within the tile's parts list. Most often there is just one city and it's the first thing declared, so this value happens to match the index of the city in the tile.cities array, but if there are multiple cities and they are not declared right at the start of the parts list then this will give an invalid value. This was causing a error in Engine::Ability::Reservation.teardown when it was trying to remove the reservation but using an invalid index in the tile.cities array.