### PR TITLE
[1861] Add RSR to the route history list

### DIFF
--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -912,6 +912,10 @@ module Engine
           minors + majors + [@national]
         end
 
+        def operated_operators
+          (@corporations + [@national]).select(&:operated?)
+        end
+
         def add_neutral_tokens(_hexes)
           # 1861 doesn't have neutral tokens
           @green_tokens = []


### PR DESCRIPTION
It wasn't possible to view the previous routes run by the RSR as the default implementation of `operated_operators` only includes the `@corporations` and `@minors` arrays. Override this to also include the RSR.

Fixes issue #5620.