### PR TITLE
[1861] Corrected description of the game end timing

### DIFF
--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -826,6 +826,10 @@ module Engine
 
         LAYOUT = :flat
 
+        GAME_END_REASONS_TIMING_TEXT = Base::GAME_END_REASONS_TIMING_TEXT.merge(
+          one_more_full_or_set: 'If the first 8-train is purchased in the first OR of a set the game finishes at the end of the current OR set, otherwise the game ends at the end of the next OR set. In both cases the last OR set is extended to three ORs.',
+        ).freeze
+
         STATUS_TEXT = Base::STATUS_TEXT.merge(
           'national_operates' => ['National railway operates',
                                   'After the minors and majors operates the national runs trains, '\

--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -827,7 +827,11 @@ module Engine
         LAYOUT = :flat
 
         GAME_END_REASONS_TIMING_TEXT = Base::GAME_END_REASONS_TIMING_TEXT.merge(
-          one_more_full_or_set: 'If the first 8-train is purchased in the first OR of a set the game finishes at the end of the current OR set, otherwise the game ends at the end of the next OR set. In both cases the last OR set is extended to three ORs.',
+          one_more_full_or_set:
+            'If the first 8-train is purchased in the first OR of a set the ' \
+            'game finishes at the end of the current OR set, otherwise the ' \
+            'game ends at the end of the next OR set. In both cases the ' \
+            'last OR set is extended to three ORs.',
         ).freeze
 
         STATUS_TEXT = Base::STATUS_TEXT.merge(


### PR DESCRIPTION
Issue #5528 is for the game end description for 1861 on the info tab. It does not correctly describe the game end timing. The game behaviour is correct, it is just the text that needs to be changed.

The game does not always finish after the next set of operating rounds. If the first 8-train is purchased in the first round of an operating round set then the game finishes at the end of the current set (which is extended to three operating rounds). This PR attempts to give a more accurate description of when the game ends. It is far more verbose than the previous description, but I couldn't come up with anything more concise.

This is the relevant paragraph from section 13 of the AAG (second edition) rules:

> The game end is signalled by the purchase of the first 8-train. If this purchase is during the first Operating Round of a set, then complete the Round and play two more (without a Stock Round). Otherwise, complete the Round, execute a Stock Round, and then play three more Operating Rounds.
