### PR TITLE
Add a border type of 'province'

### DIFF
--- a/assets/app/view/game/part/borders.rb
+++ b/assets/app/view/game/part/borders.rb
@@ -60,6 +60,8 @@ module View
             case border.type
             when :mountain
               :sepia
+            when :province
+              :orange
             when :water
               :blue
             when :impassable
@@ -71,6 +73,10 @@ module View
 
         def border_width(border)
           border.type == :impassable ? '10' : '8'
+        end
+
+        def border_dash(border)
+          border.type == :province ? '20 20' : 'none'
         end
 
         def render_cost(border)
@@ -114,6 +120,7 @@ module View
                             **EDGES[border.edge],
                             stroke: color(border),
                             'stroke-width': border_width(border),
+                            'stroke-dasharray': border_dash(border),
                           })
             children << render_cost(border) if border.cost
           end


### PR DESCRIPTION
A new type of hex border, to show provincial boundaries. Styled as a dashed orange line.

Some existing games (1848 for example) are using the 'mountain' border type for provincial boundaries, but I think it makes sense to have a dedicated type for these borders.

This change has been extracted from pull request #8578. 1858 which has token costs that are calculated by looking at provincial boundaries.