### PR TITLE
[1861/1867] Fix nationalisation order

### DIFF
--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -1627,7 +1627,7 @@ module Engine
             corporation.type != :minor
           end
           @log << 'Minors nationalized' if removed.any?
-          removed.each { |c| nationalize!(c) }
+          removed.sort.each { |c| nationalize!(c) }
           @corporations = corporations
         end
 
@@ -1645,7 +1645,7 @@ module Engine
         end
 
         def postevent_trainless_nationalization!
-          trainless = @corporations.select { |c| c.operated? && c.trains.none? }
+          trainless = @corporations.select { |c| c.operated? && c.trains.none? }.sort
 
           @trainless_major = []
           trainless.each do |c|
@@ -1657,7 +1657,7 @@ module Engine
             end
           end
 
-          @trainless_major = @trainless_major.sort.reverse
+          @trainless_major = @trainless_major.sort
           @trainless_nationalization = false
         end
 

--- a/spec/fixtures/1861/167259.json
+++ b/spec/fixtures/1861/167259.json
@@ -1,0 +1,11161 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1672593503,
+      "company": "TSR",
+      "price": 30
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1672593505
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1672593505
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1672593505
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1672593510,
+      "company": "BSS",
+      "price": 45
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1672593511
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1672593511
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1672593512
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1672593514,
+      "company": "MYR",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1672593516
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1672593516
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1672593516
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1672593519,
+      "company": "MRR",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1672593520
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1672593520
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1672593521
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1672593525,
+      "company": "WVR",
+      "price": 90
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1672593526
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1672593527
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1672593527
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1672593539,
+      "corporation": "N",
+      "price": 140
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1672593540
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1672593541
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1672593542
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1672593554,
+      "corporation": "MNN",
+      "price": 140
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1672593555
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1672593556
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1672593572,
+      "corporation": "M-K",
+      "price": 140
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1672593574
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1672593575
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1672593575
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1672593579
+    },
+    {
+      "type": "undo",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1672593583
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1672593584
+    },
+    {
+      "type": "undo",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1672593585
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1672593601,
+      "corporation": "KB",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1672593604
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1672593604
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1672593605
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1672593613,
+      "corporation": "SPW",
+      "price": 130
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1672593620,
+      "corporation": "KK",
+      "price": 110
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1672593623
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1672593631,
+      "corporation": "MV",
+      "price": 110
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 44,
+      "created_at": 1672593754
+    },
+    {
+      "type": "buy_train",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1672593756,
+      "train": "2-0",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 46,
+      "created_at": 1672593761,
+      "hex": "I7",
+      "tile": "8-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1672593763
+    },
+    {
+      "type": "buy_train",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 48,
+      "created_at": 1672593764,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 49,
+      "created_at": 1672593770
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 50,
+      "created_at": 1672593777,
+      "hex": "H10",
+      "tile": "58-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 51,
+      "created_at": 1672593779
+    },
+    {
+      "type": "buy_train",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 52,
+      "created_at": 1672593781,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 53,
+      "created_at": 1672593796
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1672593806,
+      "hex": "B8",
+      "tile": "4-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1672694007
+    },
+    {
+      "type": "buy_train",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 56,
+      "created_at": 1672694011,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 57,
+      "created_at": 1672694013
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 58,
+      "created_at": 1672694021,
+      "hex": "E13",
+      "tile": "58-1",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 59,
+      "created_at": 1672694023
+    },
+    {
+      "type": "buy_train",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 60,
+      "created_at": 1672694024,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 61,
+      "created_at": 1672694026
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1672694032,
+      "hex": "I13",
+      "tile": "6-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1672694036
+    },
+    {
+      "type": "buy_train",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1672694038,
+      "train": "2-5",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 65,
+      "created_at": 1672694039
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 66,
+      "created_at": 1672694043,
+      "hex": "C13",
+      "tile": "9-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1672694046
+    },
+    {
+      "type": "buy_train",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1672694047,
+      "train": "2-6",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1672694057
+    },
+    {
+      "type": "run_routes",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1672694060,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1"
+          ],
+          "revenue": 80,
+          "revenue_str": "H8-G5-E1",
+          "nodes": [
+            "H8-1",
+            "G5-0",
+            "E1-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1672694062
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1672694067,
+      "hex": "J8",
+      "tile": "8-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1672694068
+    },
+    {
+      "type": "run_routes",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1672694070,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H8",
+              "I7",
+              "J8",
+              "K7"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "K7"
+          ],
+          "revenue": 70,
+          "revenue_str": "H8-K7",
+          "nodes": [
+            "H8-2",
+            "K7-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1672694073
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1672694083,
+      "hex": "I11",
+      "tile": "8-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1672694085
+    },
+    {
+      "type": "run_routes",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1672694088,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "I13"
+          ],
+          "revenue": 60,
+          "revenue_str": "H8-H10-I13",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "I13-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1672694090
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1672694093
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1672694096,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "B8",
+            "A9"
+          ],
+          "revenue": 70,
+          "revenue_str": "E1-B8-A9",
+          "nodes": [
+            "E1-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1672694097
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1672694103,
+      "hex": "F14",
+      "tile": "9-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1672694106,
+      "hex": "G15",
+      "tile": "202-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1672694110,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15"
+          ],
+          "revenue": 60,
+          "revenue_str": "D14-E13-G15",
+          "nodes": [
+            "D14-2",
+            "E13-0",
+            "G15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1672694113
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1672694117,
+      "hex": "H14",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1672694118
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1672694121,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "I13",
+              "I11",
+              "H10"
+            ],
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "I13",
+            "H10",
+            "H8"
+          ],
+          "revenue": 60,
+          "revenue_str": "I13-H10-H8",
+          "nodes": [
+            "I13-0",
+            "H10-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1672694122
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1672694127,
+      "hex": "B12",
+      "tile": "9-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1672694130
+    },
+    {
+      "type": "run_routes",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1672694132,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "B12",
+              "A11"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A11"
+          ],
+          "revenue": 60,
+          "revenue_str": "D14-A11",
+          "nodes": [
+            "D14-1",
+            "A11-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 94,
+      "created_at": 1672694138
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 95,
+      "created_at": 1672694169,
+      "corporation": "KR",
+      "price": 200
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1672694178
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 97,
+      "created_at": 1672694178
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 98,
+      "created_at": 1672694179
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1672694182
+    },
+    {
+      "type": "buy_train",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1672694183,
+      "train": "2-7",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1672694184,
+      "train": "2-8",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1672694186
+    },
+    {
+      "type": "run_routes",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1672694190,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1"
+          ],
+          "revenue": 80,
+          "revenue_str": "H8-G5-E1",
+          "nodes": [
+            "H8-1",
+            "G5-0",
+            "E1-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1672694210,
+      "train": "2-9",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1672694224,
+      "hex": "L8",
+      "tile": "8-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1672694225
+    },
+    {
+      "type": "run_routes",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1672694229,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H8",
+              "I7",
+              "J8",
+              "K7"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "K7"
+          ],
+          "revenue": 70,
+          "revenue_str": "H8-K7",
+          "nodes": [
+            "H8-2",
+            "K7-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1672694232
+    },
+    {
+      "type": "undo",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1672694234
+    },
+    {
+      "type": "redo",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1672694244
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1672694251
+    },
+    {
+      "type": "run_routes",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1672694254,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "I13"
+          ],
+          "revenue": 60,
+          "revenue_str": "H8-H10-I13",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "I13-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1672694287,
+      "train": "2-5",
+      "price": 95
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1672694291
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1672694292,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "B8",
+            "A9"
+          ],
+          "revenue": 70,
+          "revenue_str": "E1-B8-A9",
+          "nodes": [
+            "E1-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1672694298
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1672694305
+    },
+    {
+      "type": "run_routes",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1672694307,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15"
+          ],
+          "revenue": 60,
+          "revenue_str": "D14-E13-G15",
+          "nodes": [
+            "D14-2",
+            "E13-0",
+            "G15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1672694321
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1672694326
+    },
+    {
+      "type": "buy_train",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1672694327,
+      "train": "3-0",
+      "price": 225,
+      "variant": "3"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1672694337,
+      "hex": "D14",
+      "tile": "635-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1672694339
+    },
+    {
+      "type": "run_routes",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1672694342,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KB",
+          "entity_type": "corporation",
+          "created_at": 1672694342
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "B12",
+              "A11"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A11"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-A11",
+          "nodes": [
+            "D14-0",
+            "A11-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1672694374,
+      "train": "2-7",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1672694389
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1672694392,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "N",
+          "entity_type": "corporation",
+          "created_at": 1672694392
+        },
+        {
+          "type": "pass",
+          "entity": "MNN",
+          "entity_type": "corporation",
+          "created_at": 1672694392
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1672694393,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SPW",
+          "entity_type": "corporation",
+          "created_at": 1672694393
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 129,
+      "created_at": 1672694393,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KB",
+          "entity_type": "corporation",
+          "created_at": 1672694393
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 130,
+      "created_at": 1672694394
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1672694403,
+      "hex": "G15",
+      "tile": "207-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1672694414,
+      "hex": "G13",
+      "tile": "4-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1672694423,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KR",
+          "entity_type": "corporation",
+          "created_at": 1672694423
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "D14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15",
+            "G13"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-E13-G15-G13",
+          "nodes": [
+            "D14-1",
+            "E13-0",
+            "G15-0",
+            "G13-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1672694427
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1672694438
+    },
+    {
+      "type": "lay_tile",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1672694443,
+      "hex": "H8",
+      "tile": "637-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1672694449,
+      "hex": "H6",
+      "tile": "7-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 138,
+      "created_at": 1672694453,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "N",
+          "entity_type": "corporation",
+          "created_at": 1672694453
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-G5-E1",
+          "nodes": [
+            "H8-1",
+            "G5-0",
+            "E1-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1672694454
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1672694461,
+      "hex": "K7",
+      "tile": "622-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1672694463
+    },
+    {
+      "type": "run_routes",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1672694477,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MNN",
+          "entity_type": "corporation",
+          "created_at": 1672694477
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H8",
+              "I7",
+              "J8",
+              "K7"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "K7"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-K7",
+          "nodes": [
+            "H8-2",
+            "K7-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1672694479
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1672694481
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1672694489,
+      "hex": "H10",
+      "tile": "204-0",
+      "rotation": 1
+    },
+    {
+      "type": "undo",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1672694502
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1672694507,
+      "hex": "G9",
+      "tile": "8-4",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1672694509,
+      "hex": "G11",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1672694522,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "I13"
+          ],
+          "revenue": 70,
+          "revenue_str": "H8-H10-I13",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "I13-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ],
+            [
+              "G13",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-G13-G15",
+          "nodes": [
+            "H8-0",
+            "G13-0",
+            "G15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1672694527
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1672694530
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1672694536,
+      "hex": "B8",
+      "tile": "88-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1672694538
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1672694541,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SPW",
+          "entity_type": "corporation",
+          "created_at": 1672694541
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "B8",
+            "A9"
+          ],
+          "revenue": 80,
+          "revenue_str": "E1-B8-A9",
+          "nodes": [
+            "E1-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1672694549
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1672694551
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1672694576,
+      "hex": "I13",
+      "tile": "15-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1672694578
+    },
+    {
+      "type": "run_routes",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1672694581,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KK",
+          "entity_type": "corporation",
+          "created_at": 1672694581
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-E13-G15",
+          "nodes": [
+            "D14-1",
+            "E13-0",
+            "G15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1672694585
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1672694587
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1672694593,
+      "hex": "C15",
+      "tile": "9-5",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 163,
+      "created_at": 1672694596,
+      "hex": "B16",
+      "tile": "8-5",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1672694602,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KB",
+          "entity_type": "corporation",
+          "created_at": 1672694602
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "D14",
+              "C15",
+              "B16",
+              "A15"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-A15",
+          "nodes": [
+            "D14-0",
+            "A15-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "B12",
+              "A11"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A11"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-A11",
+          "nodes": [
+            "D14-0",
+            "A11-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1672694607
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1672694618,
+      "hex": "J12",
+      "tile": "9-6",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1672694633,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "I13",
+              "H14",
+              "G15"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ],
+          "hexes": [
+            "G15",
+            "I13",
+            "H10",
+            "H8"
+          ],
+          "revenue": 120,
+          "revenue_str": "G15-I13-H10-H8",
+          "nodes": [
+            "I13-0",
+            "G15-0",
+            "H10-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1672694638
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1672694640,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "N",
+          "entity_type": "corporation",
+          "created_at": 1672694640
+        },
+        {
+          "type": "pass",
+          "entity": "MNN",
+          "entity_type": "corporation",
+          "created_at": 1672694640
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1672694641,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SPW",
+          "entity_type": "corporation",
+          "created_at": 1672694641
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1672694645,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KB",
+          "entity_type": "corporation",
+          "created_at": 1672694645
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1672694646
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 173,
+      "created_at": 1672694740,
+      "corporation": "RO",
+      "price": 270
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 174,
+      "created_at": 1672694742
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 175,
+      "created_at": 1672694743
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 176,
+      "created_at": 1672694767,
+      "corporation": "MB",
+      "price": 270
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 177,
+      "created_at": 1672694770
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 178,
+      "created_at": 1672694771
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 179,
+      "created_at": 1672694774
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 180,
+      "created_at": 1672694792,
+      "corporation": "V",
+      "price": 270
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 181,
+      "created_at": 1672694820,
+      "corporation": "E",
+      "price": 240
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1672694834,
+      "hex": "B4",
+      "tile": "621-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1672694838,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "RO",
+          "entity_type": "corporation",
+          "created_at": 1672694838
+        }
+      ],
+      "hex": "B6",
+      "tile": "8-6",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1672694840,
+      "train": "3-1",
+      "price": 225,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1672694842
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1672694845
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1672694854,
+      "hex": "E9",
+      "tile": "6-1",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1672694859,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MB",
+          "entity_type": "corporation",
+          "created_at": 1672694859
+        }
+      ],
+      "hex": "E11",
+      "tile": "4-2",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1672694861,
+      "train": "3-2",
+      "price": 225,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1672694862
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1672694866
+    },
+    {
+      "type": "lay_tile",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1672694874,
+      "hex": "I19",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1672694877,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "V",
+          "entity_type": "corporation",
+          "created_at": 1672694877
+        }
+      ],
+      "hex": "I17",
+      "tile": "58-2",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1672694882,
+      "train": "3-3",
+      "price": 225,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1672694883
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1672694885
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1672694898,
+      "hex": "P6",
+      "tile": "9-7",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1672694902,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "E",
+          "entity_type": "corporation",
+          "created_at": 1672694902
+        }
+      ],
+      "hex": "O7",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1672694905,
+      "train": "3-4",
+      "price": 225,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 200,
+      "created_at": 1672694908
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 201,
+      "created_at": 1672694910
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1672694918,
+      "hex": "K11",
+      "tile": "4-3",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1672694921
+    },
+    {
+      "type": "run_routes",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1672694922,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KR",
+          "entity_type": "corporation",
+          "created_at": 1672694922
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "D14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15",
+            "G13"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-E13-G15-G13",
+          "nodes": [
+            "D14-1",
+            "E13-0",
+            "G15-0",
+            "G13-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1672694923
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1672694925
+    },
+    {
+      "type": "lay_tile",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1672694930,
+      "hex": "I7",
+      "tile": "24-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1672694932
+    },
+    {
+      "type": "run_routes",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1672694937,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "N",
+          "entity_type": "corporation",
+          "created_at": 1672694937
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-9",
+          "connections": [
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-G5-E1",
+          "nodes": [
+            "H8-1",
+            "G5-0",
+            "E1-1"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H8",
+              "H6",
+              "I7",
+              "J8",
+              "K7"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "K7"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-K7",
+          "nodes": [
+            "H8-1",
+            "K7-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 210,
+      "created_at": 1672694939
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 211,
+      "created_at": 1672694946,
+      "hex": "M7",
+      "tile": "6-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 212,
+      "created_at": 1672694949
+    },
+    {
+      "type": "run_routes",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 213,
+      "created_at": 1672694951,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MNN",
+          "entity_type": "corporation",
+          "created_at": 1672694951
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H8",
+              "I7",
+              "J8",
+              "K7"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "K7"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-K7",
+          "nodes": [
+            "H8-2",
+            "K7-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 214,
+      "created_at": 1672694954
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 215,
+      "created_at": 1672694955
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 216,
+      "created_at": 1672694973,
+      "hex": "L10",
+      "tile": "9-9",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 217,
+      "created_at": 1672694975
+    },
+    {
+      "type": "run_routes",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 218,
+      "created_at": 1672694985,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "M-K",
+          "entity_type": "corporation",
+          "created_at": 1672694985
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "I13"
+          ],
+          "revenue": 80,
+          "revenue_str": "H8-H10-I13",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "I13-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ],
+            [
+              "G13",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-G13-G15",
+          "nodes": [
+            "H8-0",
+            "G13-0",
+            "G15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 219,
+      "created_at": 1672694988
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 220,
+      "created_at": 1672695000,
+      "hex": "B4",
+      "tile": "207-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 221,
+      "created_at": 1672695003
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 222,
+      "created_at": 1672695005,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SPW",
+          "entity_type": "corporation",
+          "created_at": 1672695005
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "B8",
+            "A9"
+          ],
+          "revenue": 80,
+          "revenue_str": "E1-B8-A9",
+          "nodes": [
+            "E1-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1672695007
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1672695009
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1672695018,
+      "hex": "M9",
+      "tile": "4-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1672695019
+    },
+    {
+      "type": "run_routes",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1672695021,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KK",
+          "entity_type": "corporation",
+          "created_at": 1672695021
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-E13-G15",
+          "nodes": [
+            "D14-1",
+            "E13-0",
+            "G15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1672695022
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1672695024
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 230,
+      "created_at": 1672695031,
+      "hex": "B12",
+      "tile": "23-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1672695032
+    },
+    {
+      "type": "run_routes",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1672695037,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KB",
+          "entity_type": "corporation",
+          "created_at": 1672695037
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "D14",
+              "C15",
+              "B16",
+              "A15"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-A15",
+          "nodes": [
+            "D14-0",
+            "A15-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "B12",
+              "A11"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A11"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-A11",
+          "nodes": [
+            "D14-0",
+            "A11-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1672695038
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1672695048,
+      "hex": "N8",
+      "tile": "9-10",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1672695050
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1672695059,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ],
+            [
+              "I13",
+              "J12",
+              "K11"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "I13",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 160,
+          "revenue_str": "H8-H10-I13-K11-M9-Q3",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "I13-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1672695062
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1672695071
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 239,
+      "created_at": 1672695073
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1672695075,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MB",
+          "entity_type": "corporation",
+          "created_at": 1672695075
+        },
+        {
+          "type": "pass",
+          "entity": "V",
+          "entity_type": "corporation",
+          "created_at": 1672695075
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1672695076
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1672695076
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1672695077
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1672695077
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1672695078
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1672695078
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1672695079,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KB",
+          "entity_type": "corporation",
+          "created_at": 1672695079
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1672695080
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1672695089,
+      "hex": "C3",
+      "tile": "9-3",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1672695092,
+      "hex": "D2",
+      "tile": "24-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1672695098,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "RO",
+          "entity_type": "corporation",
+          "created_at": 1672695098
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "A9",
+              "B8"
+            ],
+            [
+              "B8",
+              "B6",
+              "A5",
+              "B4"
+            ],
+            [
+              "B4",
+              "C3",
+              "D2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "B4",
+            "E1"
+          ],
+          "revenue": 120,
+          "revenue_str": "A9-B8-B4-E1",
+          "nodes": [
+            "A9-0",
+            "B8-0",
+            "B4-0",
+            "E1-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1672695100
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1672695102
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1672695109,
+      "hex": "E13",
+      "tile": "204-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1672695115,
+      "hex": "F8",
+      "tile": "9-11",
+      "rotation": 1
+    },
+    {
+      "type": "undo",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1672695122
+    },
+    {
+      "type": "undo",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1672695133,
+      "action_id": 253
+    },
+    {
+      "type": "redo",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1672695137
+    },
+    {
+      "type": "redo",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1672695139
+    },
+    {
+      "type": "run_routes",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1672695149,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MB",
+          "entity_type": "corporation",
+          "created_at": 1672695149
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "E11",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "E11",
+            "E13",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 110,
+          "revenue_str": "E9-E11-E13-G15-G13-H8",
+          "nodes": [
+            "E9-0",
+            "E11-0",
+            "E13-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1672695151
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1672695160
+    },
+    {
+      "type": "lay_tile",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1672695164,
+      "hex": "H16",
+      "tile": "9-12",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1672695170,
+      "hex": "I19",
+      "tile": "619-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1672695176,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "V",
+          "entity_type": "corporation",
+          "created_at": 1672695176
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "I19",
+              "I17"
+            ],
+            [
+              "I17",
+              "H16",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "I19",
+            "I17",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 120,
+          "revenue_str": "I19-I17-G15-G13-H8",
+          "nodes": [
+            "I19-0",
+            "I17-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1672695178
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1672695180
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1672695200,
+      "hex": "H10",
+      "tile": "204-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1672695202
+    },
+    {
+      "type": "run_routes",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1672695218,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KR",
+          "entity_type": "corporation",
+          "created_at": 1672695218
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ],
+            [
+              "G13",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-G13-G15",
+          "nodes": [
+            "H8-0",
+            "G13-0",
+            "G15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1672695222
+    },
+    {
+      "type": "pass",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1672695232
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1672695251,
+      "hex": "K11",
+      "tile": "87-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1672695257
+    },
+    {
+      "type": "run_routes",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1672695261,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "K11",
+              "J12",
+              "I13"
+            ],
+            [
+              "I13",
+              "I11",
+              "H10"
+            ],
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "Q3",
+            "M9",
+            "K11",
+            "I13",
+            "H10",
+            "H8"
+          ],
+          "revenue": 160,
+          "revenue_str": "Q3-M9-K11-I13-H10-H8",
+          "nodes": [
+            "Q3-0",
+            "M9-0",
+            "K11-0",
+            "I13-0",
+            "H10-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1672695263
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 277,
+      "created_at": 1672695265
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1672695266
+    },
+    {
+      "type": "lay_tile",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1672695276,
+      "hex": "M7",
+      "tile": "619-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1672695278
+    },
+    {
+      "type": "run_routes",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1672695281,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "N",
+          "entity_type": "corporation",
+          "created_at": 1672695281
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-9",
+          "connections": [
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-G5-E1",
+          "nodes": [
+            "H8-1",
+            "G5-0",
+            "E1-1"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H8",
+              "H6",
+              "I7",
+              "J8",
+              "K7"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "K7"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-K7",
+          "nodes": [
+            "H8-1",
+            "K7-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1672695287
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1672695296,
+      "hex": "I9",
+      "tile": "9-13",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1672695302,
+      "hex": "J10",
+      "tile": "9-14",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1672695311,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MNN",
+          "entity_type": "corporation",
+          "created_at": 1672695311
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H8",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 130,
+          "revenue_str": "H8-K11-M9-Q3",
+          "nodes": [
+            "H8-2",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 286,
+      "created_at": 1672695317
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1672695319
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 288,
+      "created_at": 1672695367,
+      "hex": "I9",
+      "tile": "24-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1672695368
+    },
+    {
+      "type": "run_routes",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 290,
+      "created_at": 1672695377,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "M-K",
+          "entity_type": "corporation",
+          "created_at": 1672695377
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "G15",
+              "H16",
+              "I17"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15",
+            "I17"
+          ],
+          "revenue": 90,
+          "revenue_str": "H8-G13-G15-I17",
+          "nodes": [
+            "H8-0",
+            "G13-0",
+            "G15-0",
+            "I17-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 130,
+          "revenue_str": "H8-H10-K11-M9-Q3",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 291,
+      "created_at": 1672695380
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 292,
+      "created_at": 1672695387,
+      "hex": "B10",
+      "tile": "9-15",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 293,
+      "created_at": 1672695388
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1672695392,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SPW",
+          "entity_type": "corporation",
+          "created_at": 1672695392
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "B8",
+            "A9"
+          ],
+          "revenue": 80,
+          "revenue_str": "E1-B8-A9",
+          "nodes": [
+            "E1-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "undo",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 295,
+      "created_at": 1672695401
+    },
+    {
+      "type": "redo",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1672695408
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1672695410
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1672695412
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1672695426,
+      "hex": "F12",
+      "tile": "9-16",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1672695430,
+      "hex": "G11",
+      "tile": "20-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1672695434,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KK",
+          "entity_type": "corporation",
+          "created_at": 1672695434
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "D14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F12",
+              "G11",
+              "H10"
+            ],
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "H10",
+            "H8"
+          ],
+          "revenue": 90,
+          "revenue_str": "D14-E13-H10-H8",
+          "nodes": [
+            "D14-1",
+            "E13-0",
+            "H10-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1672695438
+    },
+    {
+      "type": "pass",
+      "entity": "KK",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1672695440
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1672695455,
+      "hex": "C7",
+      "tile": "25-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1672695461,
+      "hex": "D8",
+      "tile": "8-7",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 306,
+      "created_at": 1672695467,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "KB",
+          "entity_type": "corporation",
+          "created_at": 1672695467
+        }
+      ],
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "D14",
+              "C15",
+              "B16",
+              "A15"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-A15",
+          "nodes": [
+            "D14-0",
+            "A15-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "B12",
+              "A11"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "A11"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-A11",
+          "nodes": [
+            "D14-0",
+            "A11-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 307,
+      "created_at": 1672695468
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1672695489
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1672695493,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MV",
+          "entity_type": "corporation",
+          "created_at": 1672695493
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ],
+            [
+              "I13",
+              "J12",
+              "K11"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "I13",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 160,
+          "revenue_str": "H8-H10-I13-K11-M9-Q3",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "I13-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1672695495
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1672695496
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1672695509
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1672695518
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1672695520
+    },
+    {
+      "type": "convert",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1672695532
+    },
+    {
+      "type": "merge",
+      "entity": "KR",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1672695820,
+      "corporation": "MK"
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 317,
+      "created_at": 1672695823
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 318,
+      "created_at": 1672695824
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 319,
+      "created_at": 1672695825
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 320,
+      "created_at": 1672695825
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1672695829
+    },
+    {
+      "type": "convert",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1672695843
+    },
+    {
+      "type": "merge",
+      "entity": "N",
+      "entity_type": "corporation",
+      "id": 323,
+      "created_at": 1672695858,
+      "corporation": "SW"
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 324,
+      "created_at": 1672695860
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 325,
+      "created_at": 1672695860
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 326,
+      "created_at": 1672695861
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 327,
+      "created_at": 1672695862
+    },
+    {
+      "type": "merge",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 328,
+      "created_at": 1672695872,
+      "corporation": "KK"
+    },
+    {
+      "type": "pass",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 329,
+      "created_at": 1672695875
+    },
+    {
+      "type": "merge",
+      "entity": "MNN",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1672695882,
+      "corporation": "MKN"
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 331,
+      "created_at": 1672695885
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 332,
+      "created_at": 1672695886
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 333,
+      "created_at": 1672695893
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 334,
+      "created_at": 1672695895
+    },
+    {
+      "type": "convert",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 335,
+      "created_at": 1672695931
+    },
+    {
+      "type": "merge",
+      "entity": "M-K",
+      "entity_type": "corporation",
+      "id": 336,
+      "created_at": 1672695935,
+      "corporation": "NW"
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 337,
+      "created_at": 1672695937
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 338,
+      "created_at": 1672695937
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 339,
+      "created_at": 1672695938
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 340,
+      "created_at": 1672695939
+    },
+    {
+      "type": "pass",
+      "entity": "SPW",
+      "entity_type": "corporation",
+      "id": 341,
+      "created_at": 1672695951
+    },
+    {
+      "type": "pass",
+      "entity": "KB",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1672695954
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 343,
+      "created_at": 1672695956
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 344,
+      "created_at": 1672695985,
+      "corporation": "SV",
+      "price": 330
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 345,
+      "created_at": 1672695987
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 346,
+      "created_at": 1672695988
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 347,
+      "created_at": 1672696004,
+      "corporation": "OK",
+      "price": 240
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 348,
+      "created_at": 1672696006
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 349,
+      "created_at": 1672696008
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 350,
+      "created_at": 1672696025,
+      "corporation": "Y",
+      "price": 330
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 351,
+      "created_at": 1672696031
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 352,
+      "created_at": 1672696037,
+      "corporation": "TR",
+      "price": 330
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 353,
+      "created_at": 1672696041
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 354,
+      "created_at": 1672696073,
+      "hex": "D6",
+      "tile": "8-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 355,
+      "created_at": 1672696076,
+      "hex": "E5",
+      "tile": "9-13",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 356,
+      "created_at": 1672696092,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "RO",
+          "entity_type": "corporation",
+          "created_at": 1672696092
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "A9",
+              "B8"
+            ],
+            [
+              "B8",
+              "B6",
+              "A5",
+              "B4"
+            ],
+            [
+              "B4",
+              "C3",
+              "D2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "B4",
+            "E1"
+          ],
+          "revenue": 120,
+          "revenue_str": "A9-B8-B4-E1",
+          "nodes": [
+            "A9-0",
+            "B8-0",
+            "B4-0",
+            "E1-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 357,
+      "created_at": 1672696096
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 358,
+      "created_at": 1672696097
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 359,
+      "created_at": 1672696110,
+      "hex": "E9",
+      "tile": "14-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 360,
+      "created_at": 1672696139
+    },
+    {
+      "type": "run_routes",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 361,
+      "created_at": 1672696142,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MB",
+          "entity_type": "corporation",
+          "created_at": 1672696142
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "E11",
+              "E13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "E11",
+            "E13",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 120,
+          "revenue_str": "E9-E11-E13-G15-G13-H8",
+          "nodes": [
+            "E9-0",
+            "E11-0",
+            "E13-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 362,
+      "created_at": 1672696144
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 363,
+      "created_at": 1672696146
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 364,
+      "created_at": 1672696155
+    },
+    {
+      "type": "run_routes",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 365,
+      "created_at": 1672696157,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "V",
+          "entity_type": "corporation",
+          "created_at": 1672696157
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "I19",
+              "I17"
+            ],
+            [
+              "I17",
+              "H16",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "I19",
+            "I17",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 120,
+          "revenue_str": "I19-I17-G15-G13-H8",
+          "nodes": [
+            "I19-0",
+            "I17-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 366,
+      "created_at": 1672696158
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 367,
+      "created_at": 1672696160
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 368,
+      "created_at": 1672696169,
+      "hex": "N10",
+      "tile": "201-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 369,
+      "created_at": 1672696174,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SV",
+          "entity_type": "corporation",
+          "created_at": 1672696174
+        }
+      ],
+      "hex": "M9",
+      "tile": "88-1",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 370,
+      "created_at": 1672696187,
+      "train": "3-5",
+      "price": 225,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 371,
+      "created_at": 1672696190
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1672696192
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 373,
+      "created_at": 1672696203,
+      "hex": "H18",
+      "tile": "6-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1672696209,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "Y",
+          "entity_type": "corporation",
+          "created_at": 1672696209
+        }
+      ],
+      "hex": "H16",
+      "tile": "23-1",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 375,
+      "created_at": 1672696214,
+      "train": "3-6",
+      "price": 225,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 376,
+      "created_at": 1672696216
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 377,
+      "created_at": 1672696218
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 378,
+      "created_at": 1672696230,
+      "hex": "K17",
+      "tile": "57-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 379,
+      "created_at": 1672696236,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "TR",
+          "entity_type": "corporation",
+          "created_at": 1672696236
+        }
+      ],
+      "hex": "K15",
+      "tile": "9-17",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 380,
+      "created_at": 1672696256,
+      "train": "4-0",
+      "price": 350,
+      "variant": "4"
+    },
+    {
+      "type": "undo",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1672696291
+    },
+    {
+      "type": "redo",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1672696343
+    },
+    {
+      "type": "pass",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1672696541
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 384,
+      "created_at": 1672696551
+    },
+    {
+      "type": "undo",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 385,
+      "created_at": 1672696565
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 386,
+      "created_at": 1672696569,
+      "hex": "L8",
+      "tile": "24-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 387,
+      "created_at": 1672696571
+    },
+    {
+      "type": "run_routes",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 388,
+      "created_at": 1672696578,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "E",
+          "entity_type": "corporation",
+          "created_at": 1672696578
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ],
+            [
+              "M9",
+              "L8",
+              "K7"
+            ],
+            [
+              "K7",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "Q3",
+            "M9",
+            "K7",
+            "H8"
+          ],
+          "revenue": 170,
+          "revenue_str": "Q3-M9-K7-H8",
+          "nodes": [
+            "Q3-0",
+            "M9-0",
+            "K7-0",
+            "H8-2"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 389,
+      "created_at": 1672696582
+    },
+    {
+      "type": "lay_tile",
+      "entity": "OK",
+      "entity_type": "corporation",
+      "id": 390,
+      "created_at": 1672696594,
+      "hex": "D20",
+      "tile": "202-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "OK",
+      "entity_type": "corporation",
+      "id": 391,
+      "created_at": 1672696596,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "OK",
+          "entity_type": "corporation",
+          "created_at": 1672696596
+        }
+      ],
+      "hex": "D18",
+      "tile": "9-18",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "OK",
+      "entity_type": "corporation",
+      "id": 392,
+      "created_at": 1672696606
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 393,
+      "created_at": 1672696653,
+      "hex": "H6",
+      "tile": "29-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 394,
+      "created_at": 1672696658
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 395,
+      "created_at": 1672696660,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MV",
+          "entity_type": "corporation",
+          "created_at": 1672696660
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "H10",
+              "I11",
+              "I13"
+            ],
+            [
+              "I13",
+              "J12",
+              "K11"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10",
+            "I13",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 160,
+          "revenue_str": "H8-H10-I13-K11-M9-Q3",
+          "nodes": [
+            "H8-0",
+            "H10-0",
+            "I13-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1672696662
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1672696693,
+      "hex": "J8",
+      "tile": "29-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1672696696,
+      "hex": "J6",
+      "tile": "8-8",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1672696700,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MKN",
+          "entity_type": "corporation",
+          "created_at": 1672696700
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 400,
+      "created_at": 1672696744,
+      "train": "3-2",
+      "price": 215
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 401,
+      "created_at": 1672696810,
+      "hex": "G7",
+      "tile": "19-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 402,
+      "created_at": 1672696834,
+      "hex": "E7",
+      "tile": "8-9",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1672696837,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MK",
+          "entity_type": "corporation",
+          "created_at": 1672696837
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 404,
+      "created_at": 1672696871,
+      "train": "3-4",
+      "price": 135
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 405,
+      "created_at": 1672696880,
+      "hex": "K5",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 406,
+      "created_at": 1672696885,
+      "hex": "L4",
+      "tile": "9-19",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 407,
+      "created_at": 1672696892,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SW",
+          "entity_type": "corporation",
+          "created_at": 1672696892
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 408,
+      "created_at": 1672696921,
+      "train": "3-1",
+      "price": 205
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 409,
+      "created_at": 1672696937,
+      "hex": "M3",
+      "tile": "9-12",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 410,
+      "created_at": 1672696940,
+      "hex": "N2",
+      "tile": "8-3",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 411,
+      "created_at": 1672696947,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "NW",
+          "entity_type": "corporation",
+          "created_at": 1672696947
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 412,
+      "created_at": 1672697000,
+      "train": "3-3",
+      "price": 235
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 413,
+      "created_at": 1672697002
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 414,
+      "created_at": 1672697002
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 415,
+      "created_at": 1672697003
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 416,
+      "created_at": 1672697004
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 417,
+      "created_at": 1672697005
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 418,
+      "created_at": 1672697006,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "TR",
+          "entity_type": "corporation",
+          "created_at": 1672697006
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 419,
+      "created_at": 1672697007
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 420,
+      "created_at": 1672697018,
+      "hex": "F4",
+      "tile": "25-1",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 421,
+      "created_at": 1672697023,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "RO",
+          "entity_type": "corporation",
+          "created_at": 1672697023
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 422,
+      "created_at": 1672697025,
+      "train": "4-2",
+      "price": 350,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 423,
+      "created_at": 1672697043
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 424,
+      "created_at": 1672697052,
+      "hex": "F6",
+      "tile": "9-20",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 425,
+      "created_at": 1672697061,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MB",
+          "entity_type": "corporation",
+          "created_at": 1672697061
+        }
+      ],
+      "hex": "G5",
+      "tile": "87-1",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 426,
+      "created_at": 1672697070,
+      "train": "4-3",
+      "price": 350,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 427,
+      "created_at": 1672697073
+    },
+    {
+      "type": "lay_tile",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 428,
+      "created_at": 1672697087,
+      "hex": "H18",
+      "tile": "15-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 429,
+      "created_at": 1672697089,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "V",
+          "entity_type": "corporation",
+          "created_at": 1672697089
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 430,
+      "created_at": 1672697113,
+      "train": "3-0",
+      "price": 360
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 431,
+      "created_at": 1672697129,
+      "hex": "N8",
+      "tile": "23-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 432,
+      "created_at": 1672697130,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "E",
+          "entity_type": "corporation",
+          "created_at": 1672697130
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 433,
+      "created_at": 1672697173,
+      "train": "3-4",
+      "price": 100
+    },
+    {
+      "type": "undo",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 434,
+      "created_at": 1672697219
+    },
+    {
+      "type": "buy_train",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 435,
+      "created_at": 1672697222,
+      "train": "4-0",
+      "price": 1
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 436,
+      "created_at": 1672697226
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 437,
+      "created_at": 1672697248,
+      "hex": "N10",
+      "tile": "207-2",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 438,
+      "created_at": 1672697254,
+      "hex": "O9",
+      "tile": "8-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 439,
+      "created_at": 1672697265,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SV",
+          "entity_type": "corporation",
+          "created_at": 1672697265
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "N10",
+              "M9"
+            ],
+            [
+              "M9",
+              "L8",
+              "K7"
+            ],
+            [
+              "K7",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "N10",
+            "M9",
+            "K7",
+            "H8"
+          ],
+          "revenue": 130,
+          "revenue_str": "N10-M9-K7-H8",
+          "nodes": [
+            "N10-0",
+            "M9-0",
+            "K7-0",
+            "H8-2"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 440,
+      "created_at": 1672697266
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 441,
+      "created_at": 1672697285,
+      "hex": "O3",
+      "tile": "9-21",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1672697286
+    },
+    {
+      "type": "run_routes",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1672697293,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "Y",
+          "entity_type": "corporation",
+          "created_at": 1672697293
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-6",
+          "connections": [
+            [
+              "H18",
+              "H16",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H18",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 120,
+          "revenue_str": "H18-G15-G13-H8",
+          "nodes": [
+            "H18-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1672697295
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 445,
+      "created_at": 1672697307,
+      "hex": "K19",
+      "tile": "8-10",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 446,
+      "created_at": 1672697309
+    },
+    {
+      "type": "pass",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1672697310
+    },
+    {
+      "type": "pass",
+      "entity": "TR",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1672697316
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 449,
+      "created_at": 1672697432,
+      "hex": "P4",
+      "tile": "8-11",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 450,
+      "created_at": 1672697434,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MV",
+          "entity_type": "corporation",
+          "created_at": 1672697434
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 451,
+      "created_at": 1672697437,
+      "train": "5-0",
+      "price": 550,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 452,
+      "created_at": 1672697443
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 453,
+      "created_at": 1672697451,
+      "hex": "H8",
+      "tile": "638-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 454,
+      "created_at": 1672697453
+    },
+    {
+      "type": "run_routes",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1672697477,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ],
+            [
+              "M9",
+              "L8",
+              "K7"
+            ],
+            [
+              "K7",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "Q3",
+            "M9",
+            "K7",
+            "H8"
+          ],
+          "revenue": 190,
+          "revenue_str": "Q3-M9-K7-H8",
+          "nodes": [
+            "Q3-0",
+            "M9-0",
+            "K7-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 456,
+      "created_at": 1672697486,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MKN",
+          "entity_type": "corporation",
+          "created_at": 1672697486
+        }
+      ],
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 457,
+      "created_at": 1672697489
+    },
+    {
+      "type": "pass",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 458,
+      "created_at": 1672697491
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 459,
+      "created_at": 1672697506,
+      "hex": "G15",
+      "tile": "623-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 460,
+      "created_at": 1672697508
+    },
+    {
+      "type": "run_routes",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 461,
+      "created_at": 1672697519,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "E13",
+              "F12",
+              "G11",
+              "H10"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15",
+            "E13",
+            "H10",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 200,
+          "revenue_str": "H8-G13-G15-E13-H10-K11-M9-Q3",
+          "nodes": [
+            "H8-0",
+            "G13-0",
+            "G15-0",
+            "E13-0",
+            "H10-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1672697522,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MK",
+          "entity_type": "corporation",
+          "created_at": 1672697522
+        }
+      ],
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1672697526
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 464,
+      "created_at": 1672697528
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 465,
+      "created_at": 1672697541,
+      "hex": "E7",
+      "tile": "24-4",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1672697543
+    },
+    {
+      "type": "run_routes",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1672697570,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "G5",
+              "F6",
+              "E7",
+              "D8",
+              "C7",
+              "B8"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "G5",
+            "H8",
+            "Q3"
+          ],
+          "revenue": 200,
+          "revenue_str": "A9-B8-G5-H8-Q3",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "G5-0",
+            "H8-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1672697572,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SW",
+          "entity_type": "corporation",
+          "created_at": 1672697572
+        }
+      ],
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1672697578
+    },
+    {
+      "type": "pass",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 470,
+      "created_at": 1672697580
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 471,
+      "created_at": 1672697589,
+      "hex": "E1",
+      "tile": "641-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 472,
+      "created_at": 1672697592
+    },
+    {
+      "type": "run_routes",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1672697599,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "G5",
+            "H8",
+            "Q3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E1-G5-H8-Q3",
+          "nodes": [
+            "G5-0",
+            "E1-0",
+            "H8-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 474,
+      "created_at": 1672697600,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "NW",
+          "entity_type": "corporation",
+          "created_at": 1672697600
+        }
+      ],
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1672697602
+    },
+    {
+      "type": "pass",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1672697604
+    },
+    {
+      "type": "run_routes",
+      "entity": "RSR",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1672697679,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "G5"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "B4",
+              "A5",
+              "B6",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1",
+            "B4",
+            "B8",
+            "A9"
+          ],
+          "revenue": 210,
+          "revenue_str": "H8-G5-E1-B4-B8-A9",
+          "nodes": [
+            "G5-0",
+            "H8-0",
+            "E1-0",
+            "B4-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1672697681
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1672697682
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 480,
+      "created_at": 1672697683
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 481,
+      "created_at": 1672697683
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 482,
+      "created_at": 1672697684
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 483,
+      "created_at": 1672697685
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 484,
+      "created_at": 1672697686
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 485,
+      "created_at": 1672697690
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 486,
+      "created_at": 1672697692
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 487,
+      "created_at": 1672697692
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 488,
+      "created_at": 1672697694
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 489,
+      "created_at": 1672697751,
+      "hex": "O7",
+      "tile": "20-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 490,
+      "created_at": 1672697757
+    },
+    {
+      "type": "run_routes",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 491,
+      "created_at": 1672697792,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SV",
+          "entity_type": "corporation",
+          "created_at": 1672697792
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "H10",
+              "G11",
+              "F12",
+              "E13"
+            ],
+            [
+              "K11",
+              "J10",
+              "I9",
+              "H10"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "N10",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15",
+            "E13",
+            "H10",
+            "K11",
+            "M9",
+            "N10"
+          ],
+          "revenue": 160,
+          "revenue_str": "H8-G13-G15-E13-H10-K11-M9-N10",
+          "nodes": [
+            "G13-0",
+            "H8-0",
+            "G15-0",
+            "E13-0",
+            "H10-0",
+            "K11-0",
+            "M9-0",
+            "N10-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 492,
+      "created_at": 1672697794
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 493,
+      "created_at": 1672697800,
+      "hex": "H18",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 494,
+      "created_at": 1672697802
+    },
+    {
+      "type": "run_routes",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 495,
+      "created_at": 1672697805,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "Y",
+          "entity_type": "corporation",
+          "created_at": 1672697805
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-6",
+          "connections": [
+            [
+              "H18",
+              "H16",
+              "G15"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H18",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 160,
+          "revenue_str": "H18-G15-G13-H8",
+          "nodes": [
+            "H18-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 496,
+      "created_at": 1672697806
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 497,
+      "created_at": 1672697859,
+      "hex": "B4",
+      "tile": "801-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 498,
+      "created_at": 1672697862
+    },
+    {
+      "type": "run_routes",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 499,
+      "created_at": 1672697869,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "G5"
+            ],
+            [
+              "B4",
+              "C3",
+              "D2",
+              "E1"
+            ],
+            [
+              "B8",
+              "B6",
+              "A5",
+              "B4"
+            ],
+            [
+              "A9",
+              "B8"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1",
+            "B4",
+            "B8",
+            "A9"
+          ],
+          "revenue": 220,
+          "revenue_str": "H8-G5-E1-B4-B8-A9",
+          "nodes": [
+            "G5-0",
+            "H8-0",
+            "E1-0",
+            "B4-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 500,
+      "created_at": 1672697871
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 501,
+      "created_at": 1672697876
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 502,
+      "created_at": 1672697888,
+      "hex": "E9",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 503,
+      "created_at": 1672697889
+    },
+    {
+      "type": "run_routes",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 504,
+      "created_at": 1672697902,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "E11",
+              "E13"
+            ],
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H6",
+              "G7",
+              "F8",
+              "E9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15",
+            "E13",
+            "E11",
+            "E9",
+            "Q3"
+          ],
+          "revenue": 240,
+          "revenue_str": "H8-G13-G15-E13-E11-E9-Q3",
+          "nodes": [
+            "G13-0",
+            "H8-0",
+            "G15-0",
+            "E13-0",
+            "E11-0",
+            "E9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 505,
+      "created_at": 1672697904
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 506,
+      "created_at": 1672697908
+    },
+    {
+      "type": "lay_tile",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 507,
+      "created_at": 1672697914,
+      "hex": "I19",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 508,
+      "created_at": 1672697916
+    },
+    {
+      "type": "run_routes",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 509,
+      "created_at": 1672697927,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "V",
+          "entity_type": "corporation",
+          "created_at": 1672697927
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "I17",
+              "I19"
+            ],
+            [
+              "G15",
+              "H16",
+              "I17"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "I19",
+            "I17",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 160,
+          "revenue_str": "I19-I17-G15-G13-H8",
+          "nodes": [
+            "I17-0",
+            "I19-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 510,
+      "created_at": 1672697929
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 511,
+      "created_at": 1672697987,
+      "hex": "J6",
+      "tile": "25-2",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 512,
+      "created_at": 1672697990,
+      "hex": "I5",
+      "tile": "4-3",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 513,
+      "created_at": 1672698004,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "E",
+          "entity_type": "corporation",
+          "created_at": 1672698004
+        }
+      ],
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "E11",
+              "E13"
+            ],
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H6",
+              "G7",
+              "F8",
+              "E9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15",
+            "E13",
+            "E11",
+            "E9",
+            "Q3"
+          ],
+          "revenue": 240,
+          "revenue_str": "H8-G13-G15-E13-E11-E9-Q3",
+          "nodes": [
+            "G13-0",
+            "H8-0",
+            "G15-0",
+            "E13-0",
+            "E11-0",
+            "E9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 514,
+      "created_at": 1672698009
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 515,
+      "created_at": 1672698047,
+      "hex": "I13",
+      "tile": "611-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 516,
+      "created_at": 1672698067
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 517,
+      "created_at": 1672698100,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E9",
+              "E7",
+              "F6",
+              "G5"
+            ],
+            [
+              "E11",
+              "E9"
+            ],
+            [
+              "E13",
+              "E11"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "I13",
+              "H14",
+              "G15"
+            ],
+            [
+              "K11",
+              "J12",
+              "I13"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E9",
+            "E11",
+            "E13",
+            "G15",
+            "I13",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 280,
+          "revenue_str": "H8-G5-E9-E11-E13-G15-I13-K11-M9-Q3",
+          "nodes": [
+            "G5-0",
+            "H8-0",
+            "E9-0",
+            "E11-0",
+            "E13-0",
+            "G15-0",
+            "I13-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 518,
+      "created_at": 1672698103
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 519,
+      "created_at": 1672698106
+    },
+    {
+      "type": "undo",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 520,
+      "created_at": 1672698111
+    },
+    {
+      "type": "undo",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 521,
+      "created_at": 1672698115
+    },
+    {
+      "type": "redo",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 522,
+      "created_at": 1672698119
+    },
+    {
+      "type": "redo",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 523,
+      "created_at": 1672698121
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 524,
+      "created_at": 1672698197,
+      "hex": "D14",
+      "tile": "636-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 525,
+      "created_at": 1672698210,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MKN",
+          "entity_type": "corporation",
+          "created_at": 1672698210
+        }
+      ]
+    },
+    {
+      "type": "run_routes",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 526,
+      "created_at": 1672698225,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E13",
+              "D14"
+            ],
+            [
+              "H10",
+              "G11",
+              "F12",
+              "E13"
+            ],
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "H10",
+            "H8",
+            "Q3"
+          ],
+          "revenue": 200,
+          "revenue_str": "D14-E13-H10-H8-Q3",
+          "nodes": [
+            "E13-0",
+            "D14-0",
+            "H10-0",
+            "H8-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 527,
+      "created_at": 1672698228,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MKN",
+          "entity_type": "corporation",
+          "created_at": 1672698228
+        }
+      ],
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1672698276
+    },
+    {
+      "type": "pass",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 529,
+      "created_at": 1672698278
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 530,
+      "created_at": 1672698299,
+      "hex": "G11",
+      "tile": "47-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 531,
+      "created_at": 1672698301
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 532,
+      "created_at": 1672698304
+    },
+    {
+      "type": "run_routes",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1672698327,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E13",
+              "F12",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "H10",
+              "G11",
+              "G13"
+            ],
+            [
+              "K11",
+              "J10",
+              "I9",
+              "H10"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "E13",
+            "G15",
+            "G13",
+            "H10",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 200,
+          "revenue_str": "H8-E13-G15-G13-H10-K11-M9-Q3",
+          "nodes": [
+            "E13-0",
+            "H8-0",
+            "G15-0",
+            "G13-0",
+            "H10-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 534,
+      "created_at": 1672698344,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MK",
+          "entity_type": "corporation",
+          "created_at": 1672698344
+        }
+      ],
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 535,
+      "created_at": 1672698361,
+      "train": "4-0",
+      "price": 320
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1672698382,
+      "hex": "F2",
+      "tile": "23-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 537,
+      "created_at": 1672698394
+    },
+    {
+      "type": "pass",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 538,
+      "created_at": 1672698399
+    },
+    {
+      "type": "run_routes",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1672698407,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "G5",
+              "F6",
+              "E7",
+              "D8",
+              "C7",
+              "B8"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "G5",
+            "H8",
+            "Q3"
+          ],
+          "revenue": 200,
+          "revenue_str": "A9-B8-G5-H8-Q3",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "G5-0",
+            "H8-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1672698444,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SW",
+          "entity_type": "corporation",
+          "created_at": 1672698444
+        }
+      ],
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1672698457,
+      "train": "3-5",
+      "price": 360
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1672698473,
+      "hex": "G3",
+      "tile": "9-22",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 543,
+      "created_at": 1672698475
+    },
+    {
+      "type": "pass",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 544,
+      "created_at": 1672698477
+    },
+    {
+      "type": "run_routes",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1672698524,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "G5",
+            "H8",
+            "Q3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E1-G5-H8-Q3",
+          "nodes": [
+            "G5-0",
+            "E1-0",
+            "H8-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1672698526,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "NW",
+          "entity_type": "corporation",
+          "created_at": 1672698526
+        }
+      ],
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1672698545,
+      "train": "3-6",
+      "price": 340
+    },
+    {
+      "type": "run_routes",
+      "entity": "RSR",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1672698657,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "G5"
+            ],
+            [
+              "B8",
+              "C7",
+              "C5",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            [
+              "D14",
+              "C13",
+              "B12",
+              "B10",
+              "B8"
+            ],
+            [
+              "E13",
+              "D14"
+            ],
+            [
+              "H10",
+              "G11",
+              "F12",
+              "E13"
+            ],
+            [
+              "K11",
+              "J10",
+              "I9",
+              "H10"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "E1",
+            "B8",
+            "D14",
+            "E13",
+            "H10",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 250,
+          "revenue_str": "H8-G5-E1-B8-D14-E13-H10-K11-M9-Q3",
+          "nodes": [
+            "G5-0",
+            "H8-0",
+            "E1-0",
+            "B8-0",
+            "D14-0",
+            "E13-0",
+            "H10-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1672698660
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 550,
+      "created_at": 1672698661
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 551,
+      "created_at": 1672698662
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 552,
+      "created_at": 1672698663
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1672698664
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1672698665
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 555,
+      "created_at": 1672698666
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 556,
+      "created_at": 1672698679,
+      "hex": "O7",
+      "tile": "47-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 557,
+      "created_at": 1672698687,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "SV",
+          "entity_type": "corporation",
+          "created_at": 1672698687
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 558,
+      "created_at": 1672698690,
+      "train": "5-2",
+      "price": 550,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 559,
+      "created_at": 1672698692
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 560,
+      "created_at": 1672698720,
+      "hex": "H4",
+      "tile": "9-23",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 561,
+      "created_at": 1672698727,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "Y",
+          "entity_type": "corporation",
+          "created_at": 1672698727
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 562,
+      "created_at": 1672698730,
+      "train": "5-3",
+      "price": 550,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 563,
+      "created_at": 1672698732
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 564,
+      "created_at": 1672698744,
+      "hex": "G3",
+      "tile": "27-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 565,
+      "created_at": 1672698746
+    },
+    {
+      "type": "run_routes",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 566,
+      "created_at": 1672698772,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "RO",
+          "entity_type": "corporation",
+          "created_at": 1672698772
+        }
+      ],
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "C5",
+              "D6",
+              "E5",
+              "F4",
+              "G5"
+            ],
+            [
+              "B4",
+              "C5"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "I5",
+              "H4",
+              "G3",
+              "F2",
+              "E1"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "I5"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "C5",
+            "B4",
+            "E1",
+            "I5",
+            "Q3"
+          ],
+          "revenue": 250,
+          "revenue_str": "H8-G5-C5-B4-E1-I5-Q3",
+          "nodes": [
+            "G5-0",
+            "H8-0",
+            "C5-0",
+            "B4-0",
+            "E1-0",
+            "I5-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 567,
+      "created_at": 1672698777
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 568,
+      "created_at": 1672698801,
+      "hex": "E7",
+      "tile": "42-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 569,
+      "created_at": 1672698804
+    },
+    {
+      "type": "run_routes",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 570,
+      "created_at": 1672698813,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MB",
+          "entity_type": "corporation",
+          "created_at": 1672698813
+        }
+      ],
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "E11",
+              "E13"
+            ],
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H6",
+              "G7",
+              "F8",
+              "E9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15",
+            "E13",
+            "E11",
+            "E9",
+            "Q3"
+          ],
+          "revenue": 240,
+          "revenue_str": "H8-G13-G15-E13-E11-E9-Q3",
+          "nodes": [
+            "G13-0",
+            "H8-0",
+            "G15-0",
+            "E13-0",
+            "E11-0",
+            "E9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 571,
+      "created_at": 1672698815
+    },
+    {
+      "type": "lay_tile",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 572,
+      "created_at": 1672698825,
+      "hex": "K11",
+      "tile": "911-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 573,
+      "created_at": 1672698828
+    },
+    {
+      "type": "run_routes",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 574,
+      "created_at": 1672698830,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "V",
+          "entity_type": "corporation",
+          "created_at": 1672698830
+        }
+      ],
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "I17",
+              "I19"
+            ],
+            [
+              "G15",
+              "H16",
+              "I17"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "I19",
+            "I17",
+            "G15",
+            "G13",
+            "H8"
+          ],
+          "revenue": 160,
+          "revenue_str": "I19-I17-G15-G13-H8",
+          "nodes": [
+            "I17-0",
+            "I19-0",
+            "G15-0",
+            "G13-0",
+            "H8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "V",
+      "entity_type": "corporation",
+      "id": 575,
+      "created_at": 1672698831
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 576,
+      "created_at": 1672698842,
+      "hex": "K7",
+      "tile": "623-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 577,
+      "created_at": 1672698844,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "E",
+          "entity_type": "corporation",
+          "created_at": 1672698844
+        }
+      ]
+    },
+    {
+      "type": "buy_train",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 578,
+      "created_at": 1672699008,
+      "train": "6-0",
+      "price": 650,
+      "variant": "6"
+    },
+    {
+      "type": "undo",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 579,
+      "created_at": 1672699103
+    },
+    {
+      "type": "redo",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 580,
+      "created_at": 1672699230
+    },
+    {
+      "type": "undo",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 581,
+      "created_at": 1672699233
+    },
+    {
+      "type": "buy_train",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 582,
+      "created_at": 1672699273,
+      "train": "6-0",
+      "price": 650,
+      "variant": "6"
+    },
+    {
+      "type": "choose",
+      "entity": "MKN",
+      "entity_type": "corporation",
+      "id": 583,
+      "created_at": 1672699293,
+      "choice": "nationalize"
+    },
+    {
+      "type": "choose",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 584,
+      "created_at": 1672699310,
+      "choice": "nationalize"
+    },
+    {
+      "type": "choose",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 585,
+      "created_at": 1672699332,
+      "choice": "nationalize"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 586,
+      "created_at": 1672699518,
+      "hex": "H8",
+      "tile": "639-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 587,
+      "created_at": 1672699526
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 588,
+      "created_at": 1672699577,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "H10",
+              "H8"
+            ],
+            [
+              "I13",
+              "I11",
+              "H10"
+            ],
+            [
+              "K11",
+              "J12",
+              "I13"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "E1",
+            "G5",
+            "H8",
+            "H10",
+            "I13",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 340,
+          "revenue_str": "A9-B8-E1-G5-H8-H10-I13-K11-M9-Q3",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "H10-0",
+            "I13-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 589,
+      "created_at": 1672699585,
+      "hex": "G15",
+      "tile": "640-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 590,
+      "created_at": 1672699609
+    },
+    {
+      "type": "run_routes",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 591,
+      "created_at": 1672699626,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "G5",
+              "F6",
+              "E7",
+              "D8",
+              "C7",
+              "B8"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "E13",
+              "F12",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "H10",
+              "G11",
+              "G13"
+            ],
+            [
+              "K11",
+              "J10",
+              "I9",
+              "H10"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "G5",
+            "H8",
+            "E13",
+            "G15",
+            "G13",
+            "H10",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 310,
+          "revenue_str": "A9-B8-G5-H8-E13-G15-G13-H10-K11-M9-Q3",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "G5-0",
+            "H8-0",
+            "E13-0",
+            "G15-0",
+            "G13-0",
+            "H10-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 592,
+      "created_at": 1672699629,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 593,
+      "created_at": 1672699631
+    },
+    {
+      "type": "run_routes",
+      "entity": "RSR",
+      "entity_type": "corporation",
+      "id": 594,
+      "created_at": 1672699678,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H8",
+              "H6",
+              "I7",
+              "J8",
+              "J6",
+              "K5",
+              "L4",
+              "M3",
+              "N2",
+              "O3",
+              "P4",
+              "Q3"
+            ],
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "G5"
+            ],
+            [
+              "B8",
+              "C7",
+              "C5",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            [
+              "A9",
+              "B8"
+            ]
+          ],
+          "hexes": [
+            "Q3",
+            "H8",
+            "G5",
+            "E1",
+            "B8",
+            "A9"
+          ],
+          "revenue": 330,
+          "revenue_str": "Q3-H8-G5-E1-B8-A9",
+          "nodes": [
+            "H8-0",
+            "Q3-0",
+            "G5-0",
+            "E1-0",
+            "B8-0",
+            "A9-0"
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "D14",
+              "C15",
+              "B16",
+              "A15"
+            ],
+            [
+              "E13",
+              "D14"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "H8",
+              "G9",
+              "G11",
+              "G13"
+            ],
+            [
+              "K11",
+              "J10",
+              "I9",
+              "H8"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "A15",
+            "D14",
+            "E13",
+            "G15",
+            "G13",
+            "H8",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 390,
+          "revenue_str": "A15-D14-E13-G15-G13-H8-K11-M9-Q3",
+          "nodes": [
+            "D14-0",
+            "A15-0",
+            "E13-0",
+            "G15-0",
+            "G13-0",
+            "H8-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 595,
+      "created_at": 1672699696
+    },
+    {
+      "type": "pass",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 596,
+      "created_at": 1672699697
+    },
+    {
+      "type": "pass",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 597,
+      "created_at": 1672699698
+    },
+    {
+      "type": "pass",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 598,
+      "created_at": 1672699701
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 599,
+      "created_at": 1672699704
+    },
+    {
+      "type": "pass",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 600,
+      "created_at": 1672699708
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 601,
+      "created_at": 1672699781,
+      "corporation": "GRR",
+      "share_price": "180,1,8"
+    },
+    {
+      "type": "place_token",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 602,
+      "created_at": 1672699800,
+      "city": "F18-0-0",
+      "slot": 0,
+      "tokener": "GRR"
+    },
+    {
+      "type": "par",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 603,
+      "created_at": 1672699824,
+      "corporation": "NW",
+      "share_price": "180,1,8"
+    },
+    {
+      "type": "place_token",
+      "entity": "NW",
+      "entity_type": "corporation",
+      "id": 604,
+      "created_at": 1672699835,
+      "city": "L12-5-0",
+      "slot": 0,
+      "tokener": "NW"
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 605,
+      "created_at": 1672699843,
+      "corporation": "SW",
+      "share_price": "200,0,8"
+    },
+    {
+      "type": "place_token",
+      "entity": "SW",
+      "entity_type": "corporation",
+      "id": 606,
+      "created_at": 1672699866,
+      "city": "P8-6-0",
+      "slot": 0,
+      "tokener": "SW"
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 607,
+      "created_at": 1672699969,
+      "action_id": 604
+    },
+    {
+      "type": "undo",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 608,
+      "created_at": 1672699972,
+      "action_id": 602
+    },
+    {
+      "type": "par",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 609,
+      "created_at": 1672700016,
+      "corporation": "SE",
+      "share_price": "180,1,8"
+    },
+    {
+      "type": "place_token",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 610,
+      "created_at": 1672700019,
+      "city": "L12-5-0",
+      "slot": 0,
+      "tokener": "SE"
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 611,
+      "created_at": 1672700042,
+      "corporation": "MVR",
+      "share_price": "200,0,8"
+    },
+    {
+      "type": "place_token",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 612,
+      "created_at": 1672700046,
+      "city": "P8-6-0",
+      "slot": 0,
+      "tokener": "MVR"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 613,
+      "created_at": 1672700051,
+      "shares": [
+        "MK_1"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 614,
+      "created_at": 1672700058,
+      "shares": [
+        "GRR_1"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 615,
+      "created_at": 1672700062,
+      "shares": [
+        "SE_1"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 616,
+      "created_at": 1672700074,
+      "shares": [
+        "MVR_1"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 617,
+      "created_at": 1672700082,
+      "shares": [
+        "MK_2"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 618,
+      "created_at": 1672700085,
+      "shares": [
+        "GRR_2"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 619,
+      "created_at": 1672700088,
+      "shares": [
+        "SE_2"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 620,
+      "created_at": 1672700092,
+      "shares": [
+        "MVR_2"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 621,
+      "created_at": 1672700095,
+      "shares": [
+        "MK_3"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 622,
+      "created_at": 1672700100,
+      "shares": [
+        "GRR_3"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 623,
+      "created_at": 1672700103,
+      "shares": [
+        "SE_3"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 624,
+      "created_at": 1672700108,
+      "shares": [
+        "MVR_3"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 625,
+      "created_at": 1672700111,
+      "shares": [
+        "MK_4"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 626,
+      "created_at": 1672700118,
+      "shares": [
+        "SE_4"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 627,
+      "created_at": 1672700122,
+      "shares": [
+        "MVR_4"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 628,
+      "created_at": 1672700139,
+      "shares": [
+        "GRR_4"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 629,
+      "created_at": 1672700144,
+      "shares": [
+        "GRR_5"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 630,
+      "created_at": 1672700148,
+      "shares": [
+        "MVR_5"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 631,
+      "created_at": 1672700156,
+      "shares": [
+        "SE_5"
+      ],
+      "percent": 10,
+      "share_price": false
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 632,
+      "created_at": 1672700160
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 633,
+      "created_at": 1672700162
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 634,
+      "created_at": 1672700172,
+      "hex": "E1",
+      "tile": "642-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 635,
+      "created_at": 1672700175
+    },
+    {
+      "type": "undo",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 636,
+      "created_at": 1672700179
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 637,
+      "created_at": 1672700192,
+      "hex": "K13",
+      "tile": "9-24",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "RO",
+      "entity_type": "corporation",
+      "id": 638,
+      "created_at": 1672700215,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "C5",
+              "D6",
+              "E5",
+              "F4",
+              "G5"
+            ],
+            [
+              "B4",
+              "C5"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "I5",
+              "H4",
+              "G3",
+              "F2",
+              "E1"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "I5"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G5",
+            "C5",
+            "B4",
+            "E1",
+            "I5",
+            "Q3"
+          ],
+          "revenue": 300,
+          "revenue_str": "H8-G5-C5-B4-E1-I5-Q3",
+          "nodes": [
+            "G5-0",
+            "H8-0",
+            "C5-0",
+            "B4-0",
+            "E1-0",
+            "I5-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 639,
+      "created_at": 1672700228,
+      "hex": "K17",
+      "tile": "619-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 640,
+      "created_at": 1672700240,
+      "hex": "L18",
+      "tile": "9-25",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MB",
+      "entity_type": "corporation",
+      "id": 641,
+      "created_at": 1672700244,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "E11",
+              "E13"
+            ],
+            [
+              "E9",
+              "E11"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H6",
+              "G7",
+              "F8",
+              "E9"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G13",
+            "G15",
+            "E13",
+            "E11",
+            "E9",
+            "Q3"
+          ],
+          "revenue": 280,
+          "revenue_str": "H8-G13-G15-E13-E11-E9-Q3",
+          "nodes": [
+            "G13-0",
+            "H8-0",
+            "G15-0",
+            "E13-0",
+            "E11-0",
+            "E9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 642,
+      "created_at": 1672700291,
+      "hex": "N10",
+      "tile": "623-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 643,
+      "created_at": 1672700297,
+      "hex": "M19",
+      "tile": "202-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "SV",
+      "entity_type": "corporation",
+      "id": 644,
+      "created_at": 1672700321,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "K11",
+              "J10",
+              "I9",
+              "H8"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "N10",
+              "M9"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "O9",
+              "N10"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "E1",
+            "G5",
+            "H8",
+            "K11",
+            "M9",
+            "N10",
+            "Q3"
+          ],
+          "revenue": 370,
+          "revenue_str": "A9-B8-E1-G5-H8-K11-M9-N10-Q3",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "K11-0",
+            "M9-0",
+            "N10-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 645,
+      "created_at": 1672700329,
+      "hex": "D16",
+      "tile": "9-10",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 646,
+      "created_at": 1672700334,
+      "hex": "L20",
+      "tile": "8-12",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 647,
+      "created_at": 1672700396,
+      "action_id": 644
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 648,
+      "created_at": 1672700403,
+      "hex": "C7",
+      "tile": "40-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 649,
+      "created_at": 1672700410,
+      "hex": "D16",
+      "tile": "9-10",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "Y",
+      "entity_type": "corporation",
+      "id": 650,
+      "created_at": 1672700429,
+      "routes": [
+        {
+          "train": "5-3",
+          "connections": [
+            [
+              "I5",
+              "J6",
+              "K5",
+              "L4",
+              "M3",
+              "N2",
+              "O3",
+              "P4",
+              "Q3"
+            ],
+            [
+              "E1",
+              "F2",
+              "G3",
+              "H4",
+              "I5"
+            ],
+            [
+              "G5",
+              "F6",
+              "E7",
+              "D8",
+              "C7",
+              "C5",
+              "D4",
+              "D2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "G13",
+              "G11",
+              "G9",
+              "H8"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "H18",
+              "H16",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "Q3",
+            "I5",
+            "E1",
+            "G5",
+            "H8",
+            "G13",
+            "G15",
+            "H18"
+          ],
+          "revenue": 350,
+          "revenue_str": "Q3-I5-E1-G5-H8-G13-G15-H18",
+          "nodes": [
+            "I5-0",
+            "Q3-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "G13-0",
+            "G15-0",
+            "H18-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 651,
+      "created_at": 1672700437,
+      "hex": "P2",
+      "tile": "6-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 652,
+      "created_at": 1672700448
+    },
+    {
+      "type": "run_routes",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 653,
+      "created_at": 1672700506,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "K11",
+              "J10",
+              "I9",
+              "H10"
+            ],
+            [
+              "H10",
+              "G11",
+              "G13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "E13",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "E1",
+            "G5",
+            "H8",
+            "Q3",
+            "M9",
+            "K11",
+            "H10",
+            "G13",
+            "G15",
+            "E13",
+            "D14"
+          ],
+          "revenue": 430,
+          "revenue_str": "A9-B8-E1-G5-H8-Q3-M9-K11-H10-G13-G15-E13-D14",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "Q3-0",
+            "M9-0",
+            "K11-0",
+            "H10-0",
+            "G13-0",
+            "G15-0",
+            "E13-0",
+            "D14-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 654,
+      "created_at": 1672700529,
+      "hex": "I17",
+      "tile": "87-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 655,
+      "created_at": 1672700535,
+      "hex": "J18",
+      "tile": "8-12",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "MV",
+      "entity_type": "corporation",
+      "id": 656,
+      "created_at": 1672700558,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "B8"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "H10",
+              "H8"
+            ],
+            [
+              "I13",
+              "I11",
+              "H10"
+            ],
+            [
+              "K11",
+              "J12",
+              "I13"
+            ],
+            [
+              "M9",
+              "L10",
+              "K11"
+            ],
+            [
+              "Q3",
+              "Q5",
+              "P6",
+              "O7",
+              "N8",
+              "M9"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "E1",
+            "G5",
+            "H8",
+            "H10",
+            "I13",
+            "K11",
+            "M9",
+            "Q3"
+          ],
+          "revenue": 360,
+          "revenue_str": "A9-B8-E1-G5-H8-H10-I13-K11-M9-Q3",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "H10-0",
+            "I13-0",
+            "K11-0",
+            "M9-0",
+            "Q3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 657,
+      "created_at": 1672700598,
+      "hex": "P8",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 658,
+      "created_at": 1672700601,
+      "hex": "O9",
+      "tile": "24-4",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 659,
+      "created_at": 1672700607
+    },
+    {
+      "type": "buy_train",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 660,
+      "created_at": 1672700610,
+      "train": "7-0",
+      "price": 800,
+      "variant": "7"
+    },
+    {
+      "type": "pass",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 661,
+      "created_at": 1672700612
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 662,
+      "created_at": 1672700627,
+      "hex": "F18",
+      "tile": "5-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 663,
+      "created_at": 1672700630,
+      "hex": "G17",
+      "tile": "8-13",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 664,
+      "created_at": 1672700632
+    },
+    {
+      "type": "buy_train",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 665,
+      "created_at": 1672700635,
+      "train": "7-1",
+      "price": 800,
+      "variant": "7"
+    },
+    {
+      "type": "pass",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 666,
+      "created_at": 1672700638
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 667,
+      "created_at": 1672700652,
+      "hex": "L12",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 668,
+      "created_at": 1672700655,
+      "hex": "K13",
+      "tile": "27-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 669,
+      "created_at": 1672700780
+    },
+    {
+      "type": "buy_train",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 670,
+      "created_at": 1672700782,
+      "train": "8-0",
+      "price": 1000,
+      "variant": "8"
+    },
+    {
+      "type": "undo",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 671,
+      "created_at": 1672700811
+    },
+    {
+      "type": "buy_train",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 672,
+      "created_at": 1672700865,
+      "train": "8-0",
+      "price": 1000,
+      "variant": "8"
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 673,
+      "created_at": 1672700966
+    },
+    {
+      "type": "pass",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 674,
+      "created_at": 1672700971
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 675,
+      "created_at": 1672700978,
+      "hex": "L20",
+      "tile": "8-14",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 676,
+      "created_at": 1672700981
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 677,
+      "created_at": 1672700984
+    },
+    {
+      "type": "buy_train",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 678,
+      "created_at": 1672700991,
+      "train": "8-1",
+      "price": 1000,
+      "variant": "8"
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 679,
+      "created_at": 1672701010
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 680,
+      "created_at": 1672701215,
+      "hex": "P8",
+      "tile": "15-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 681,
+      "created_at": 1672701223
+    },
+    {
+      "type": "pass",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 682,
+      "created_at": 1672701241
+    },
+    {
+      "type": "run_routes",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 683,
+      "created_at": 1672701297,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "E13",
+              "D14"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "H10",
+              "G11",
+              "G13"
+            ],
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "D8",
+              "E7",
+              "F6",
+              "G5"
+            ],
+            [
+              "I5",
+              "H4",
+              "G3",
+              "F2",
+              "E1"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "I5"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "N10",
+              "M9"
+            ],
+            [
+              "P8",
+              "O9",
+              "N10"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15",
+            "G13",
+            "H10",
+            "H8",
+            "G5",
+            "E1",
+            "I5",
+            "Q3",
+            "M9",
+            "N10",
+            "P8"
+          ],
+          "revenue": 440,
+          "revenue_str": "D14-E13-G15-G13-H10-H8-G5-E1-I5-Q3-M9-N10-P8",
+          "nodes": [
+            "E13-0",
+            "D14-0",
+            "G15-0",
+            "G13-0",
+            "H10-0",
+            "H8-0",
+            "G5-0",
+            "E1-0",
+            "I5-0",
+            "Q3-0",
+            "M9-0",
+            "N10-0",
+            "P8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 684,
+      "created_at": 1672701298,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 685,
+      "created_at": 1672701300
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 686,
+      "created_at": 1672701320,
+      "hex": "F18",
+      "tile": "15-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 687,
+      "created_at": 1672701324
+    },
+    {
+      "type": "pass",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 688,
+      "created_at": 1672701326
+    },
+    {
+      "type": "run_routes",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 689,
+      "created_at": 1672701355,
+      "routes": [
+        {
+          "train": "7-1",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "B4",
+              "A5",
+              "B6",
+              "B8"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "F18",
+              "G17",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "B4",
+            "E1",
+            "G5",
+            "H8",
+            "Q3",
+            "M9",
+            "K11",
+            "H10",
+            "G13",
+            "G15",
+            "F18"
+          ],
+          "revenue": 460,
+          "revenue_str": "A9-B8-B4-E1-G5-H8-Q3-M9-K11-H10-G13-G15-F18",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "B4-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "Q3-0",
+            "M9-0",
+            "K11-0",
+            "H10-0",
+            "G13-0",
+            "G15-0",
+            "F18-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 690,
+      "created_at": 1672701359,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 691,
+      "created_at": 1672701361
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 692,
+      "created_at": 1672766081,
+      "hex": "M11",
+      "tile": "9-26",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 693,
+      "created_at": 1672766093,
+      "hex": "L12",
+      "tile": "14-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 694,
+      "created_at": 1672766109
+    },
+    {
+      "type": "run_routes",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 695,
+      "created_at": 1672766157,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "N10",
+              "O9",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "L12",
+              "M11",
+              "N10"
+            ],
+            [
+              "K11",
+              "K13",
+              "L12"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "H8",
+              "G9",
+              "G11",
+              "F12",
+              "E13"
+            ],
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "G5"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "B4",
+              "A5",
+              "B6",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "Q3",
+            "N10",
+            "L12",
+            "K11",
+            "H10",
+            "G13",
+            "G15",
+            "E13",
+            "H8",
+            "G5",
+            "E1",
+            "B4",
+            "B8",
+            "A9"
+          ],
+          "revenue": 510,
+          "revenue_str": "Q3-N10-L12-K11-H10-G13-G15-E13-H8-G5-E1-B4-B8-A9",
+          "nodes": [
+            "N10-0",
+            "Q3-0",
+            "L12-0",
+            "K11-0",
+            "H10-0",
+            "G13-0",
+            "G15-0",
+            "E13-0",
+            "H8-0",
+            "G5-0",
+            "E1-0",
+            "B4-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 696,
+      "created_at": 1672766158,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 697,
+      "created_at": 1672766161
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 698,
+      "created_at": 1672766184,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MK",
+          "entity_type": "corporation",
+          "created_at": 1672766185
+        }
+      ]
+    },
+    {
+      "type": "run_routes",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 699,
+      "created_at": 1672766248,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "D14",
+              "C15",
+              "B16",
+              "A15"
+            ],
+            [
+              "B8",
+              "B10",
+              "B12",
+              "C13",
+              "D14"
+            ],
+            [
+              "B4",
+              "A5",
+              "B6",
+              "B8"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "I17",
+              "H16",
+              "G15"
+            ],
+            [
+              "J20",
+              "J18",
+              "I17"
+            ]
+          ],
+          "hexes": [
+            "A15",
+            "D14",
+            "B8",
+            "B4",
+            "E1",
+            "G5",
+            "H8",
+            "Q3",
+            "M9",
+            "K11",
+            "H10",
+            "G13",
+            "G15",
+            "I17",
+            "J20"
+          ],
+          "revenue": 540,
+          "revenue_str": "A15-D14-B8-B4-E1-G5-H8-Q3-M9-K11-H10-G13-G15-I17-J20",
+          "nodes": [
+            "D14-0",
+            "A15-0",
+            "B8-0",
+            "B4-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "Q3-0",
+            "M9-0",
+            "K11-0",
+            "H10-0",
+            "G13-0",
+            "G15-0",
+            "I17-0",
+            "J20-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 700,
+      "created_at": 1672766252,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 701,
+      "created_at": 1672766255
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 702,
+      "created_at": 1672766348,
+      "hex": "P6",
+      "tile": "20-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 703,
+      "created_at": 1672766389
+    },
+    {
+      "type": "pass",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 704,
+      "created_at": 1672766400
+    },
+    {
+      "type": "run_routes",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1672766405,
+      "routes": [
+        {
+          "train": "7-0",
+          "connections": [
+            [
+              "E13",
+              "D14"
+            ],
+            [
+              "G15",
+              "F14",
+              "E13"
+            ],
+            [
+              "G13",
+              "G15"
+            ],
+            [
+              "H10",
+              "G11",
+              "G13"
+            ],
+            [
+              "H8",
+              "H10"
+            ],
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "D2",
+              "D4",
+              "C5",
+              "C7",
+              "D8",
+              "E7",
+              "F6",
+              "G5"
+            ],
+            [
+              "I5",
+              "H4",
+              "G3",
+              "F2",
+              "E1"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "I5"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "N10",
+              "M9"
+            ],
+            [
+              "P8",
+              "O9",
+              "N10"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "E13",
+            "G15",
+            "G13",
+            "H10",
+            "H8",
+            "G5",
+            "E1",
+            "I5",
+            "Q3",
+            "M9",
+            "N10",
+            "P8"
+          ],
+          "revenue": 440,
+          "revenue_str": "D14-E13-G15-G13-H10-H8-G5-E1-I5-Q3-M9-N10-P8",
+          "nodes": [
+            "E13-0",
+            "D14-0",
+            "G15-0",
+            "G13-0",
+            "H10-0",
+            "H8-0",
+            "G5-0",
+            "E1-0",
+            "I5-0",
+            "Q3-0",
+            "M9-0",
+            "N10-0",
+            "P8-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1672766406,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MVR",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1672766410,
+      "train": "2+2-0",
+      "price": 600,
+      "variant": "2+2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1672766429,
+      "hex": "F18",
+      "tile": "611-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1672766442
+    },
+    {
+      "type": "pass",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1672766444
+    },
+    {
+      "type": "run_routes",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 711,
+      "created_at": 1672766446,
+      "routes": [
+        {
+          "train": "7-1",
+          "connections": [
+            [
+              "B8",
+              "A9"
+            ],
+            [
+              "B4",
+              "A5",
+              "B6",
+              "B8"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "F18",
+              "G17",
+              "G15"
+            ]
+          ],
+          "hexes": [
+            "A9",
+            "B8",
+            "B4",
+            "E1",
+            "G5",
+            "H8",
+            "Q3",
+            "M9",
+            "K11",
+            "H10",
+            "G13",
+            "G15",
+            "F18"
+          ],
+          "revenue": 470,
+          "revenue_str": "A9-B8-B4-E1-G5-H8-Q3-M9-K11-H10-G13-G15-F18",
+          "nodes": [
+            "B8-0",
+            "A9-0",
+            "B4-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "Q3-0",
+            "M9-0",
+            "K11-0",
+            "H10-0",
+            "G13-0",
+            "G15-0",
+            "F18-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 712,
+      "created_at": 1672766449,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GRR",
+      "entity_type": "corporation",
+      "id": 713,
+      "created_at": 1672766450,
+      "train": "2+2-1",
+      "price": 600,
+      "variant": "2+2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 714,
+      "created_at": 1672766465,
+      "hex": "L12",
+      "tile": "611-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 715,
+      "created_at": 1672766476
+    },
+    {
+      "type": "pass",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 716,
+      "created_at": 1672766485
+    },
+    {
+      "type": "run_routes",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 717,
+      "created_at": 1672766500,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "N10",
+              "O9",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "L12",
+              "M11",
+              "N10"
+            ],
+            [
+              "K11",
+              "K13",
+              "L12"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "E13",
+              "F14",
+              "G15"
+            ],
+            [
+              "H8",
+              "G9",
+              "G11",
+              "F12",
+              "E13"
+            ],
+            [
+              "G5",
+              "G7",
+              "H8"
+            ],
+            [
+              "E1",
+              "F2",
+              "F4",
+              "G5"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "B4",
+              "A5",
+              "B6",
+              "B8"
+            ],
+            [
+              "B8",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "Q3",
+            "N10",
+            "L12",
+            "K11",
+            "H10",
+            "G13",
+            "G15",
+            "E13",
+            "H8",
+            "G5",
+            "E1",
+            "B4",
+            "B8",
+            "A9"
+          ],
+          "revenue": 520,
+          "revenue_str": "Q3-N10-L12-K11-H10-G13-G15-E13-H8-G5-E1-B4-B8-A9",
+          "nodes": [
+            "N10-0",
+            "Q3-0",
+            "L12-0",
+            "K11-0",
+            "H10-0",
+            "G13-0",
+            "G15-0",
+            "E13-0",
+            "H8-0",
+            "G5-0",
+            "E1-0",
+            "B4-0",
+            "B8-0",
+            "A9-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 718,
+      "created_at": 1672766508,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SE",
+      "entity_type": "corporation",
+      "id": 719,
+      "created_at": 1672766511
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 720,
+      "created_at": 1672766522,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "MK",
+          "entity_type": "corporation",
+          "created_at": 1672766524
+        }
+      ]
+    },
+    {
+      "type": "run_routes",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 721,
+      "created_at": 1672766526,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "D14",
+              "C15",
+              "B16",
+              "A15"
+            ],
+            [
+              "B8",
+              "B10",
+              "B12",
+              "C13",
+              "D14"
+            ],
+            [
+              "B4",
+              "A5",
+              "B6",
+              "B8"
+            ],
+            [
+              "E1",
+              "D2",
+              "C3",
+              "B4"
+            ],
+            [
+              "G5",
+              "F4",
+              "F2",
+              "E1"
+            ],
+            [
+              "H8",
+              "G7",
+              "G5"
+            ],
+            [
+              "Q3",
+              "P4",
+              "O3",
+              "N2",
+              "M3",
+              "L4",
+              "K5",
+              "J6",
+              "J8",
+              "I7",
+              "H8"
+            ],
+            [
+              "M9",
+              "N8",
+              "O7",
+              "P6",
+              "Q5",
+              "Q3"
+            ],
+            [
+              "K11",
+              "L10",
+              "M9"
+            ],
+            [
+              "H10",
+              "I9",
+              "J10",
+              "K11"
+            ],
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "G15",
+              "G13"
+            ],
+            [
+              "I17",
+              "H16",
+              "G15"
+            ],
+            [
+              "J20",
+              "J18",
+              "I17"
+            ]
+          ],
+          "hexes": [
+            "A15",
+            "D14",
+            "B8",
+            "B4",
+            "E1",
+            "G5",
+            "H8",
+            "Q3",
+            "M9",
+            "K11",
+            "H10",
+            "G13",
+            "G15",
+            "I17",
+            "J20"
+          ],
+          "revenue": 540,
+          "revenue_str": "A15-D14-B8-B4-E1-G5-H8-Q3-M9-K11-H10-G13-G15-I17-J20",
+          "nodes": [
+            "D14-0",
+            "A15-0",
+            "B8-0",
+            "B4-0",
+            "E1-0",
+            "G5-0",
+            "H8-0",
+            "Q3-0",
+            "M9-0",
+            "K11-0",
+            "H10-0",
+            "G13-0",
+            "G15-0",
+            "I17-0",
+            "J20-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 722,
+      "created_at": 1672766527,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MK",
+      "entity_type": "corporation",
+      "id": 723,
+      "created_at": 1672766530
+    }
+  ],
+  "id": "hs_rciziaya_1672593499",
+  "players": [
+    {
+      "name": "Player 1",
+      "id": 0
+    },
+    {
+      "name": "Player 2",
+      "id": 1
+    },
+    {
+      "name": "Player 3",
+      "id": 2
+    },
+    {
+      "name": "Player 4",
+      "id": 3
+    }
+  ],
+  "title": "1861",
+  "description": "",
+  "min_players": "4",
+  "max_players": "4",
+  "settings": {
+    "optional_rules": []
+  },
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2023-01-01",
+  "loaded": true,
+  "result": {
+    "0": 2731,
+    "1": 2460,
+    "2": 2336,
+    "3": 3354
+  },
+  "manually_ended": false,
+  "turn": 6,
+  "round": "Operating Round",
+  "acting": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "updated_at": 1672766530
+}

--- a/spec/game_state_spec.rb
+++ b/spec/game_state_spec.rb
@@ -366,5 +366,24 @@ module Engine
         end
       end
     end
+
+    describe '1861' do
+      describe 167_259 do
+        it 'minors are nationalised in operating order' do
+          # Checking RSR token locations and order tells us if the minors
+          # have been nationalised in the correct order.
+          game = game_at_action(game_file, 673)
+          hexes = game.corporation_by_id('RSR').placed_tokens.map(&:hex).map(&:coordinates)
+          expect(hexes).to eq(%w[E1 D14 D20 K17 I19 H8 B4 E9])
+        end
+
+        it 'majors are nationalised in operating order' do
+          # MKN should be the first to be potentially nationalised.
+          game = game_at_action(game_file, 582)
+          corporation = game.corporation_by_id('MKN')
+          expect(game.current_entity).to eq(corporation)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Ian Wilson noted in issue #8572 that minor companies are being nationalised in the wrong order. Where multiple minors are nationalised at the start of phase 4, 6 or 8 this should be done in stock market order. The order can make a difference if the national railway runs out of tokens whilst these minors are being nationalised, it should get the tokens of the first ones to be nationalised.

This pull request fixes this order. It also changes the order of major company nationalisation – this is suppose to happen in stock market order, but it was in reverse stock market order.

There are also tests added for both the minor and major company nationalisation order.

This change has the potential to break a few games as it might change the location of the national railway's tokens, so 1861 and 1867 games will need to be pinned.

I'm submitting this as a draft pull request as there is another open issue (#8589) where the fix will need to pin 1861/1867 games, so it might make sense to push these both through at the same time.