### PR TITLE
Add definitions for tiles 71 and 108

### DIFF
--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -322,6 +322,7 @@ module Engine
         '105' => 'city=revenue:40,slots:3;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:2,b:_0,track:dual;label=BM',
         '106' => 'junction;path=a:0,b:_0,track:dual;path=a:2,b:_0,track:dual;path=a:4,b:_0,track:dual;path=a:3,b:_0,track:dual',
         '107' => 'junction;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;path=a:3,b:_0,track:dual;path=a:4,b:_0,track:dual',
+        '108' => 'junction;path=a:0,b:_0,track:dual;path=a:3,b:_0,track:dual;path=a:4,b:_0,track:dual;path=a:5,b:_0,track:dual',
         '118' => 'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3',
         '122' => 'city=revenue:80,slots:2;city=revenue:80,slots:2;path=a:0,b:_0;path=a:_0,b:1;path=a:2,b:_1;path=a:_1,b:3;label=T',
         '125' => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',

--- a/lib/engine/config/tile.rb
+++ b/lib/engine/config/tile.rb
@@ -31,7 +31,7 @@ module Engine
         '57' => 'city=revenue:20;path=a:0,b:_0;path=a:_0,b:3',
         '58' => 'town=revenue:10;path=a:0,b:_0;path=a:_0,b:2',
         '69' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:_0,b:3;path=a:2,b:_1;path=a:_1,b:4',
-        # '71' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
+        '71' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:_1,track:narrow;path=a:_1,b:4,track:narrow',
         '72' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:1,track:narrow',
         '73' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:2,track:narrow',
         '74' => 'town=revenue:10;path=a:0,b:_0,track:narrow;path=a:_0,b:3,track:narrow',


### PR DESCRIPTION
Add a couple of standard tile definitions:

- Tile 71 is a gently curved section of narrow gauge track, with two towns on it.
- Tiles 108 dual gauge plain track tile, in a K-arrangement (Lawson-type track).

These are both needed for 1858. This has been extracted from pull request #8578.