### PR TITLE
Add a flag to allow obsolete trains to be bought between corporations

### DIFF
--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -118,7 +118,8 @@ module Engine
 
     def other_trains(corporation)
       all_others = @trains.reject do |train|
-        !train.buyable || [corporation, self, nil].include?(train.owner)
+        !train.buyable(allow_obsolete_buys: @game.class::ALLOW_OBSOLETE_TRAIN_BUY) ||
+          [corporation, self, nil].include?(train.owner)
       end
 
       return all_others if @game.class::ALLOW_TRAIN_BUY_FROM_OTHER_PLAYERS

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -241,6 +241,7 @@ module Engine
 
       ALLOW_TRAIN_BUY_FROM_OTHERS = true # Allows train buy from other corporations
       ALLOW_TRAIN_BUY_FROM_OTHER_PLAYERS = true # Allows train buy from other player's corporations
+      ALLOW_OBSOLETE_TRAIN_BUY = false # Allows obsolete trains to be bought from other corporations
 
       # Default tile lay, one tile either upgrade or lay at zero cost
       # allows multiple lays, value must be either true, false or :not_if_upgraded

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -102,8 +102,8 @@ module Engine
       owner.is_a?(Depot)
     end
 
-    def buyable
-      @buyable && !@obsolete
+    def buyable(allow_obsolete_buys: false)
+      @buyable && (!@obsolete || allow_obsolete_buys)
     end
 
     def local?


### PR DESCRIPTION
1858 has wounded trains that run for half revenue and can be discarded during the train buying step. You are allowed to buy these wounded trains across between corporations. That isn't possible with the current implementation of obsolete trains: there's a check in `Engine::Train.buyable` that blocks this for an obsolete train.

This patch adds a flag to the game class, `ALLOW_OBSOLETE_TRAIN_BUY`, that can be set to allow obsolete trains to be bought across. It has a default value of `false` and so does not change any behaviour for other games.

This commit has been extracted from pull request #8578.