### PR TITLE
Add hook to allow cost of a tile lay to be modified

### DIFF
--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -60,6 +60,7 @@ module Engine
           raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
         end
 
+        tile_lay_cost_override!(tile_lay, action, tile, old_tile)
         extra_cost = tile.color == :yellow ? tile_lay[:cost] : tile_lay[:upgrade_cost]
 
         lay_tile(action, extra_cost: extra_cost, entity: entity, spender: spender)
@@ -70,6 +71,9 @@ module Engine
         @round.num_laid_track += 1
         @round.laid_hexes << action.hex
       end
+
+      # This method can be implemented to adjust the cost of a tile lay
+      def tile_lay_cost_override!(tile_lay, action, new_tile, old_tile); end
 
       def track_upgrade?(from, _to, _hex)
         from.color != :white


### PR DESCRIPTION
In 1858 laying a second tile in a turn costs 20, but this cost is halved if one of the tiles adds just narrow gauge track. At the moment there isn't an easy way to modify the cost returned from `Engine::Step::Tracker.get_tile_lay`, without duplicating the entire existing `lay_tile_action` method.

This adds a hook within `lay_tile_action` that can be overridden in a subclass to do this. The default implementation is a no-op.

This is another change extracted from pull request #8578.