### PR TITLE
[1880] shares, foreign investors, broker fees

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -225,6 +225,11 @@ module Engine
       # loans taken during ebuy can lead to receviership
       EBUY_CORP_LOANS_RECEIVERSHIP = false
 
+      # where should sold shares go to?
+      # :bank - bank pool
+      # :corporation - back to corporation/ipo
+      SOLD_SHARES_DESTINATION = :bank
+
       # when is the home token placed? on...
       # par
       # float

--- a/lib/engine/game/g_1880/entities.rb
+++ b/lib/engine/game/g_1880/entities.rb
@@ -83,6 +83,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'F8',
             color: '#BA6128',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -93,6 +95,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'F8',
             color: 'black',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -103,6 +107,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'F8',
             color: '#534074',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -113,6 +119,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'F8',
             color: '#008A8B',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -122,6 +130,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'B8',
             color: '#9D8359',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -131,6 +141,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'J2',
             color: '#004294',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -140,6 +152,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'N12',
             color: '#282F1A',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -149,6 +163,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'O5',
             color: '#507EAE',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -158,6 +174,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'M3',
             color: '#94121D',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -167,6 +185,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'J6',
             color: '#A83B5B',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -176,6 +196,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'K15',
             color: '#40743A',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -185,6 +207,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'K13',
             color: '#452518',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -194,6 +218,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'D12',
             color: '#B3932C',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
           {
             float_percent: 20,
@@ -203,6 +229,8 @@ module Engine
             tokens: [0, 40, 100],
             coordinates: 'L10',
             color: '#A4391F',
+            max_ownership_percent: 100,
+            always_market_price: true,
           },
         ].freeze
 

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -16,6 +16,9 @@ module Engine
 
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy
+        SELL_MOVEMENT = :down_per_10
+        MARKET_SHARE_LIMIT = 100
+        EBUY_PRES_SWAP = false
         CURRENCY_FORMAT_STR = '¥%s'
 
         BANK_CASH = 37_860
@@ -23,6 +26,12 @@ module Engine
         CERT_LIMIT = { 3 => 20, 4 => 16, 5 => 14, 6 => 12, 7 => 11 }.freeze
 
         STARTING_CASH = { 3 => 600, 4 => 480, 5 => 400, 6 => 340, 7 => 300 }.freeze
+
+        EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+          'float_30' => ['30% to Float', 'Corporations must have 30% of their shares sold to float'],
+          'float_40' => ['40% to Float', 'Corporations must have 40% of their shares sold to float'],
+          'float_60' => ['60% to Float', 'Corporations must have 60% of their shares sold to float'],
+        ).freeze
 
         STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(
           pays_bonus: :yellow,
@@ -133,7 +142,14 @@ module Engine
                     rusts_on: '4+4',
                     num: 5,
                   },
-                  { name: '3', distance: 3, price: 180, rusts_on: '6', num: 5 },
+                  {
+                    name: '3',
+                    distance: 3,
+                    price: 180,
+                    rusts_on: '6',
+                    num: 5,
+                    events: [{ 'type' => 'float_30' }],
+                  },
                   {
                     name: '3+3',
                     distance: [{ 'nodes' => %w[city offboard town], 'pay' => 3, 'visit' => 3 },
@@ -142,7 +158,14 @@ module Engine
                     rusts_on: '6E',
                     num: 5,
                   },
-                  { name: '4', distance: 4, price: 300, rusts_on: '8', num: 5 },
+                  {
+                    name: '4',
+                    distance: 4,
+                    price: 300,
+                    rusts_on: '8',
+                    num: 5,
+                    events: [{ 'type' => 'float_40' }],
+                  },
                   {
                     name: '4+4',
                     distance: [{ 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 4 },
@@ -151,7 +174,13 @@ module Engine
                     rusts_on: '8E',
                     num: 5,
                   },
-                  { name: '6', distance: 6, price: 600, num: 5 },
+                  {
+                    name: '6',
+                    distance: 6,
+                    price: 600,
+                    num: 5,
+                    events: [{ 'type' => 'float_60' }],
+                  },
                   {
                     name: '6E',
                     distance: [{ 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 99 }],
@@ -180,21 +209,16 @@ module Engine
         def next_round!
           @round =
             case @round
-            when Round::Stock
+            when Engine::Round::Stock
               @operating_rounds = @phase.operating_rounds
               reorder_players
               new_operating_round
-            when Round::Operating
-              if @round.round_num < @operating_rounds
+            when Engine::Round::Operating
+              if @round.round_num
                 or_round_finished
                 new_operating_round(@round.round_num + 1)
-              else
-                @turn += 1
-                or_round_finished
-                or_set_finished
-                new_stock_round
               end
-            when Round::Draft
+            when Engine::Round::Draft
               new_stock_round
             when init_round.class
               init_round_finished
@@ -203,8 +227,91 @@ module Engine
             end
         end
 
+        def stock_round
+          G1880::Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::BuySellParShares,
+          ])
+        end
+
+        def operating_round(round_num)
+          Engine::Round::Operating.new(self, [
+            Engine::Step::Exchange,
+            Engine::Step::Track,
+            Engine::Step::Token,
+            G1880::Step::Route,
+            G1880::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            Engine::Step::BuyTrain,
+          ], round_num: round_num)
+        end
+
+        def init_share_pool
+          G1880::SharePool.new(self)
+        end
+
+        def init_minors
+          game_minors.map { |minor| G1880::Minor.new(**minor) }
+        end
+
+        def setup
+          # reserve last 5 shares of each corp
+          @corporations.each do |c|
+            c.shares.last(5).each { |s| s.buyable = false }
+          end
+        end
+
         def p1
           company_by_id('P1')
+        end
+
+        def event_float_30!
+          @log << "-- Event: #{EVENTS_TEXT['float_30'][1]} --"
+          @float_percent = 30
+          non_floated_corporations { |c| c.float_percent = @float_percent }
+        end
+
+        def event_float_40!
+          @log << "-- Event: #{EVENTS_TEXT['float_40'][1]} --"
+          @float_percent = 40
+          non_floated_corporations { |c| c.float_percent = @float_percent }
+        end
+
+        def event_float_60!
+          @log << "-- Event: #{EVENTS_TEXT['float_60'][1]} --"
+          @float_percent = 60
+          non_floated_corporations { |c| c.float_percent = @float_percent }
+        end
+
+        def float_corporation(corporation)
+          @log << "#{corporation.name} floats"
+
+          @bank.spend(corporation.par_price.price * 5, corporation)
+          @log << "#{corporation.name} receives #{format_currency(corporation.cash)}"
+
+          # reserve share for foreign investor
+          foreign_investor = @minors.find { |m| m.owner == corporation.owner }
+          return if foreign_investor.shares.any?
+
+          @share_pool.transfer_shares(corporation.ipo_shares.first.to_bundle, foreign_investor)
+          @log << "#{foreign_investor.full_name} receives a share of #{corporation.name}"
+        end
+
+        def player_card_minors(player)
+          @minors.select { |m| m.owner == player }
+        end
+
+        def route_trains(entity)
+          entity.minor? ? [@depot.min_depot_train] : super
+        end
+
+        def train_owner(train)
+          train.owner == @depot ? lessee : train.owner
+        end
+
+        def lessee
+          current_entity
         end
       end
     end

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -17,9 +17,9 @@ module Engine
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy
         SELL_MOVEMENT = :down_per_10
-        MARKET_SHARE_LIMIT = 100
         EBUY_PRES_SWAP = false
         CURRENCY_FORMAT_STR = '¥%s'
+        SOLD_SHARES_DESTINATION = :corporation
 
         BANK_CASH = 37_860
 
@@ -292,7 +292,7 @@ module Engine
 
           # reserve share for foreign investor
           foreign_investor = @minors.find { |m| m.owner == corporation.owner }
-          return if foreign_investor.shares.any?
+          return unless foreign_investor.shares.empty?
 
           @share_pool.transfer_shares(corporation.ipo_shares.first.to_bundle, foreign_investor)
           @log << "#{foreign_investor.full_name} receives a share of #{corporation.name}"

--- a/lib/engine/game/g_1880/minor.rb
+++ b/lib/engine/game/g_1880/minor.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../../minor'
+require_relative '../../share_holder'
+
+module Engine
+  module Game
+    module G1880
+      class Minor < Engine::Minor
+        include ShareHolder
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880/round/stock.rb
+++ b/lib/engine/game/g_1880/round/stock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/stock'
+
+module Engine
+  module Game
+    module G1880
+      module Round
+        class Stock < Engine::Round::Stock
+          def sold_out?(corporation)
+            (corporation.num_ipo_shares - corporation.num_ipo_reserved_shares).zero?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880/share_pool.rb
+++ b/lib/engine/game/g_1880/share_pool.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../../share_pool'
+
+module Engine
+  module Game
+    module G1880
+      class SharePool < Engine::SharePool
+        def sell_shares(bundle, allow_president_change: true, swap: nil, silent: nil)
+          entity = bundle.owner
+
+          verb = entity.corporation? && entity == bundle.corporation ? 'issues' : 'sells'
+
+          price = bundle.price
+          price -= swap.price if swap
+
+          percent = bundle.percent
+          percent -= swap.percent if swap
+          broker_fee = (percent / 10) * 5
+          price -= broker_fee
+          swap_text = swap ? " and a #{swap.percent}% share" : ''
+          swap_to_entity = swap ? entity : nil
+
+          unless silent
+            @log << "#{entity.name} #{verb} #{num_presentation(bundle)} " \
+                    "of #{bundle.corporation.name} and receives #{@game.format_currency(price)} '\
+                    '(broker fee: #{@game.format_currency(broker_fee)})#{swap_text}"
+          end
+
+          transfer_shares(bundle,
+                          bundle.corporation,
+                          spender: @bank,
+                          receiver: entity,
+                          price: price,
+                          allow_president_change: allow_president_change,
+                          swap: swap,
+                          swap_to_entity: swap_to_entity)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880/share_pool.rb
+++ b/lib/engine/game/g_1880/share_pool.rb
@@ -6,35 +6,16 @@ module Engine
   module Game
     module G1880
       class SharePool < Engine::SharePool
-        def sell_shares(bundle, allow_president_change: true, swap: nil, silent: nil)
-          entity = bundle.owner
+        def log_sell_shares(entity, verb, bundle, price, swap_text)
+          fee = additional_price_adjustments(bundle)
+          @log << "#{entity.name} #{verb} #{num_presentation(bundle)} " \
+                  "of #{bundle.corporation.name} and receives #{@game.format_currency(price)}" \
+                  " (broker fee: #{@game.format_currency(fee)})#{swap_text}"
+        end
 
-          verb = entity.corporation? && entity == bundle.corporation ? 'issues' : 'sells'
-
-          price = bundle.price
-          price -= swap.price if swap
-
+        def additional_price_adjustments(bundle)
           percent = bundle.percent
-          percent -= swap.percent if swap
-          broker_fee = (percent / 10) * 5
-          price -= broker_fee
-          swap_text = swap ? " and a #{swap.percent}% share" : ''
-          swap_to_entity = swap ? entity : nil
-
-          unless silent
-            @log << "#{entity.name} #{verb} #{num_presentation(bundle)} " \
-                    "of #{bundle.corporation.name} and receives #{@game.format_currency(price)} '\
-                    '(broker fee: #{@game.format_currency(broker_fee)})#{swap_text}"
-          end
-
-          transfer_shares(bundle,
-                          bundle.corporation,
-                          spender: @bank,
-                          receiver: entity,
-                          price: price,
-                          allow_president_change: allow_president_change,
-                          swap: swap,
-                          swap_to_entity: swap_to_entity)
+          (percent / 10) * 5
         end
       end
     end

--- a/lib/engine/game/g_1880/step/dividend.rb
+++ b/lib/engine/game/g_1880/step/dividend.rb
@@ -1,27 +1,14 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/dividend'
-require_relative '../../../step/minor_half_pay'
+require_relative '../../../step/minor_withold'
 
 module Engine
   module Game
     module G1880
       module Step
         class Dividend < Engine::Step::Dividend
-          def actions(entity)
-            return [] if entity.minor?
-
-            super
-          end
-
-          def skip!
-            return super if current_entity.corporation? && !current_entity.minor?
-
-            process_dividend(Action::Dividend.new(
-              current_entity,
-              kind: 'withhold',
-            ))
-          end
+          include Engine::Step::MinorWithold
         end
       end
     end

--- a/lib/engine/game/g_1880/step/dividend.rb
+++ b/lib/engine/game/g_1880/step/dividend.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+require_relative '../../../step/minor_half_pay'
+
+module Engine
+  module Game
+    module G1880
+      module Step
+        class Dividend < Engine::Step::Dividend
+          def actions(entity)
+            return [] if entity.minor?
+
+            super
+          end
+
+          def skip!
+            return super if current_entity.corporation? && !current_entity.minor?
+
+            process_dividend(Action::Dividend.new(
+              current_entity,
+              kind: 'withhold',
+            ))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880/step/route.rb
+++ b/lib/engine/game/g_1880/step/route.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/route'
+
+module Engine
+  module Game
+    module G1880
+      module Step
+        class Route < Engine::Step::Route
+          def actions(entity)
+            return [] if !entity.operator? ||
+            (entity.runnable_trains.empty? && !entity.minor?) ||
+            !@game.can_run_route?(entity)
+
+            ACTIONS
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -127,22 +127,31 @@ module Engine
 
       price = bundle.price
       price -= swap.price if swap
+      price -= additional_price_adjustments(bundle)
       swap_text = swap ? " and a #{swap.percent}% share" : ''
       swap_to_entity = swap ? entity : nil
 
-      unless silent
-        @log << "#{entity.name} #{verb} #{num_presentation(bundle)} " \
-                "of #{bundle.corporation.name} and receives #{@game.format_currency(price)}#{swap_text}"
-      end
+      log_sell_shares(entity, verb, bundle, price, swap_text) unless silent
+
+      transfer_to = @game.class::SOLD_SHARES_DESTINATION == :corporation ? bundle.corporation : self
 
       transfer_shares(bundle,
-                      self,
+                      transfer_to,
                       spender: @bank,
                       receiver: entity,
                       price: price,
                       allow_president_change: allow_president_change,
                       swap: swap,
                       swap_to_entity: swap_to_entity)
+    end
+
+    def log_sell_shares(entity, verb, bundle, price, swap_text)
+      @log << "#{entity.name} #{verb} #{num_presentation(bundle)} " \
+              "of #{bundle.corporation.name} and receives #{@game.format_currency(price)}#{swap_text}"
+    end
+
+    def additional_price_adjustments(_bundle)
+      0
     end
 
     def share_pool?

--- a/lib/engine/step/minor_withold.rb
+++ b/lib/engine/step/minor_withold.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Engine
+  module Step
+    module MinorWithold
+      def actions(entity)
+        return [] if entity.minor?
+        return [] if entity.corporation? && entity.type == :minor
+
+        super
+      end
+
+      def skip!
+        return super if current_entity.corporation? && !current_entity.minor?
+
+        process_dividend(Action::Dividend.new(
+          current_entity,
+          kind: 'withhold',
+        ))
+      end
+    end
+  end
+end


### PR DESCRIPTION
always market price & no limit on ownership
add float precent change events 
add partial cap during float
add foreign investor share when floating a corp 
foreign leases train
auto withold dividends for foreign investors 
add broker fee on selling shares
remove set SR (in this game SR happen in the middle of an OR when a train type is bought our or removed, will be implemented later)
sold share go to ipo, never to market

Note: Foreign investor owning share doesn't show up in the UI, will need to fix the view files to fix this bug.