### PR TITLE
Handle multiple stubs in a hex

### DIFF
--- a/lib/engine/game/stubs_are_restricted.rb
+++ b/lib/engine/game/stubs_are_restricted.rb
@@ -11,6 +11,6 @@ module StubsAreRestricted
   end
 
   def legal_if_stubbed?(hex, tile)
-    hex.tile.stubs.empty? || tile.exits.include?(hex.tile.stubs.first.edge)
+    hex.tile.stubs.empty? || (hex.tile.stubs.map(&:edge) - tile.exits).empty?
   end
 end

--- a/lib/engine/part/stub.rb
+++ b/lib/engine/part/stub.rb
@@ -18,6 +18,10 @@ module Engine
       def track
         :broad
       end
+
+      def inspect
+        "<#{self.class.name} edge=#{@edge}>"
+      end
     end
   end
 end


### PR DESCRIPTION
Stubs are used to enforce track connections when a tile is laid in a hex. This check is done by `Engine::Game::StubsAreRestricted.legal_if_stubbed?`. This method is currently written to only handle a single stub in a hex, if there are multiple stubs then only the first one is checked against the track exits of the placed tile.

This pull request is to enhance this check to ensure that all stubs are connected by the new tile.

Most games that use stubs only ever have a single stub in a hex, so will not be affected by this change. I could only find two games that have multiple stubs in a hex:

- 18Rhl has two stubs in hex E10 in the Ratingen variant. It has custom code in `legal_tile_rotation?` to check the tile placement is valid. This change would allow that code to be removed. (cc @perwestling).
- 1868 Wyoming has two tiles with two stubs each, J6 and M21. It does not appear to yet have any code to check that the second stub is enforced. (cc @michaeljb).

This pull request is extracted from #8578. 1858 has thirteen hexes which need two stubs to enforce the direction of track laid along the routes of private railway companies.

I've also added a more informative `inspect` message for the `Engine::Part::Stub` class.