### PR TITLE
[1880] More Foreign Investor logic and capitalization event

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -388,6 +388,8 @@ module View
 
         other_corp_rows = entities_rows(@game.corporations.reject { |c| c == @corporation && !c.treasury_as_holding })
 
+        other_minor_rows = entities_rows(@game.minors) if @game.class::MINORS_CAN_OWN_SHARES
+
         num_ipo_shares = share_number_str(@corporation.num_ipo_shares - @corporation.num_ipo_reserved_shares)
         if @game.respond_to?(:reissued?) && @game.reissued?(@corporation) && !num_ipo_shares.empty?
           num_ipo_shares = '* ' + num_ipo_shares
@@ -456,6 +458,7 @@ module View
           *pool_rows,
           *player_rows,
           *other_corp_rows,
+          *other_minor_rows,
         ]
 
         props = { style: { borderCollapse: 'collapse' } }

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -258,6 +258,9 @@ module Engine
       # :lawson Tile type like 1817, 1822
       TILE_TYPE = :normal
 
+      # games where minors can own shares
+      MINORS_CAN_OWN_SHARES = false
+
       # Must an upgrade use the maximum number of exits
       # for track and/or cities?
       # :cities for cities, as in  #611 and #63 in 1822

--- a/lib/engine/game/g_1880/corporation.rb
+++ b/lib/engine/game/g_1880/corporation.rb
@@ -6,7 +6,7 @@ module Engine
   module Game
     module G1880
       class Corporation < Engine::Corporation
-        attr_accessor :building_permits
+        attr_accessor :building_permits, :fully_funded
 
         def floated?
           @floated ||= percent_to_float.zero?

--- a/lib/engine/game/g_1880/entities.rb
+++ b/lib/engine/game/g_1880/entities.rb
@@ -10,7 +10,7 @@ module Engine
             sym: 'P0',
             value: 5,
             revenue: 0,
-            desc: 'Owner recieves one-off payment of 40/70/100 when last 2+2/3/3+3 train is purchased',
+            desc: 'Owner receives one-off payment of 40/70/100 when last 2+2/3/3+3 train is purchased',
             color: nil,
           },
           {

--- a/lib/engine/game/g_1880/minor.rb
+++ b/lib/engine/game/g_1880/minor.rb
@@ -8,6 +8,14 @@ module Engine
     module G1880
       class Minor < Engine::Minor
         include ShareHolder
+        def num_shares_of(corporation, ceil: true)
+          num = percent_of(corporation).to_f / corporation.share_percent
+          ceil ? num.ceil : num
+        end
+
+        def hide_shares?
+          false
+        end
       end
     end
   end

--- a/lib/engine/game/g_1880/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1880/step/buy_sell_par_shares.rb
@@ -113,6 +113,11 @@ module Engine
 
             process_presidents_percent_choice(Action::Choose.new(@parring[:entity], choice: percent_choices.keys.first))
           end
+
+          def process_buy_shares(action)
+            super
+            @game.receive_capital(action.corporation) if @game.full_cap_event
+          end
         end
       end
     end

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1880
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def process_buy_train(action)
+            train = action.train
+            @game.train_marker = action.entity if train.owner == @game.depot
+            super
+            @round.bought_trains = true
+          end
+
+          def round_state
+            { bought_trains: false }
+          end
+
+          def setup
+            super
+            @round.bought_trains = false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880/step/check_fi_connection.rb
+++ b/lib/engine/game/g_1880/step/check_fi_connection.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1880
+      module Step
+        class CheckFIConnection < Engine::Step::Base
+          ACTIONS = %w[destination_connection pass].freeze
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] unless entity.minor?
+            return ['choose'] if @merging
+
+            ACTIONS
+          end
+
+          def description
+            'Foreign investor merge'
+          end
+
+          def blocks?
+            true
+          end
+
+          def auto_actions(entity)
+            return [] if @merging || !current_entity.minor?
+            return [Engine::Action::Pass.new(entity)] unless @game.check_for_foreign_investor_connection(entity)
+
+            [Engine::Action::DestinationConnection.new(entity)]
+          end
+
+          def process_destination_connection(action)
+            corporation = action.entity.shares.first.corporation
+            @merging = { corporation: corporation, fi: action.entity, state: nil }
+            @game.log << "#{action.entity.full_name} and #{corporation.name} are connected"
+            process_merger
+
+            @merging[:state] = :choose_precent
+            return if action.entity.cash.positive?
+
+            process_precent(Action::Choose.new(action.entity, choice: nil))
+          end
+
+          def skip!
+            pass!
+          end
+
+          def process_merger
+            fi = @merging[:fi]
+            share = @merging[:corporation].shares.first
+            @game.share_pool.transfer_shares(share.to_bundle, fi.owner)
+            @game.bank.spend(50, fi.owner)
+            @game.log << "#{fi.owner.name} recieves #{@game.format_currency(50)} and a share of #{share.corporation.name}"
+          end
+
+          def process_choose(action)
+            case @merging[:state]
+            when :choose_precent
+              process_precent(action)
+            when :choose_token
+              process_token(action)
+            end
+          end
+
+          def setup
+            @merging
+          end
+
+          def process_precent(action)
+            fi = @merging[:fi]
+            if fi.cash.positive?
+              amount = action.choice.include?('treasury') ? fi.cash : fi.cash * 0.2
+              destination = action.choice.include?('treasury') ? @merging[:corporation] : current_entity.owner
+              fi.spend(amount, destination, check_positive: false)
+              @game.log << "#{fi.full_name} transfers #{@game.format_currency(amount)} to #{destination.name}"
+            end
+            @merging[:state] = :choose_token
+            return if cheapest_unused_token(@merging[:corporation])
+
+            process_token(Action::Choose.new(fi, choice: 'Discard'))
+          end
+
+          def process_token(action)
+            fi = @merging[:fi]
+            replace_token(fi, fi.tokens.first, cheapest_unused_token(@merging[:corporation])) if action.choice == 'Replace'
+            fi.tokens.first.city.remove_tokens! if action.choice == 'Discard'
+            @game.log << "#{fi.full_name} closes"
+            fi.close!
+
+            pass!
+          end
+
+          def cheapest_unused_token(corp)
+            corp.tokens.reject(&:used).min_by(&:price)
+          end
+
+          def replace_token(fi, fi_token, corp_token)
+            city = fi_token.city
+            @game.log << "#{fi.name}'s token in #{city.hex.name} is replaced with a #{corp_token.corporation.name} token"
+            fi_token.swap!(corp_token, check_tokenable: false)
+          end
+
+          def choice_name
+            case @merging[:state]
+            when :choose_precent
+              "Choose destination for Foreign Investor cash\n"
+            when :choose_token
+              "Replace Token of Foreign Investor with Corporation token?\n"
+            end
+          end
+
+          def choices
+            case @merging[:state]
+            when :choose_precent
+              ["#{@game.format_currency(@merging[:fi].cash)} to #{@merging[:corporation].name} treasury",
+               "#{@game.format_currency(@merging[:fi].cash * 0.2)} to #{current_entity.owner.name}"]
+            when :choose_token
+              %w[Replace Discard]
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
show FI shares in corp view

add b3 event  -> corporations getting more capital if 5 shares are sold, ongoing effect after

FI connection check and merger of FI and corp.

Train marker to round description

FI stops operating event

