### PR TITLE
18GB: Increase player-count variant flexibility & move to Production

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,7 +17,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p>18NY and 18USA are now in production.</p>
+        <p>18GB, 18NY and 18USA are now in production.</p>
         <p>Learn how to get <a href='https://github.com/tobymao/18xx/wiki/Notifications'>notifications</a> by email, Slack, Discord, and Telegram.</p>
         <p>Please submit problem reports and make suggestions for improvements on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. Join the

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -312,6 +312,8 @@ module Engine
 
         def init_optional_rules(optional_rules)
           optional_rules = super(optional_rules)
+          optional_rules.delete(:two_player_ew) if @players.size != 2
+          optional_rules.delete(:four_player_alt) if @players.size != 4
           @scenario = init_scenario(optional_rules)
           optional_rules
         end

--- a/lib/engine/game/g_18_gb/meta.rb
+++ b/lib/engine/game/g_18_gb/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
 
         GAME_DISPLAY_TITLE = '18GB'
 

--- a/lib/engine/game/g_18_gb/meta.rb
+++ b/lib/engine/game/g_18_gb/meta.rb
@@ -25,15 +25,24 @@ module Engine
             short_name: '2P EW',
             title: '2P East-West Scenario',
             desc: 'Play the East-West (rather than North-South) 2-player setup',
-            players: [2],
           },
           {
             sym: :four_player_alt,
             short_name: '4P Alt',
+            title: '4P Alternate Setup',
             desc: 'Alternate company and corporation mix for 4 players',
-            players: [4],
           },
         ].freeze
+
+        def self.check_options(options, _min_players, _max_players)
+          optional_rules = (options || []).map(&:to_sym)
+
+          two_player_map = optional_rules.include?(:two_player_ew) ? 'East-West' : 'North-South'
+          four_player_setup = optional_rules.include?(:four_player_alt) ? 'Alternative' : 'Standard'
+
+          "The 2P #{two_player_map} map will be used if the game is started with 2 players. The 4P #{four_player_setup} setup " \
+            'will be used if the game is started with 4 players.'
+        end
       end
     end
   end


### PR DESCRIPTION
- Allow player-count-specific variants to be selected in 18GB without limiting the player count of the game. (Variants which match the player count when the game is launched will be used and others ignored.) This allows e.g. a 3-4 player game to be created that will use the 4p alternate setup if it launches with 4 players and the (only) 3p setup if launched with 3 players. This is consistent with the implementations in 18FL and 18VA and closes #8579
- Move 18GB to Production. (No new game/rules-related issues have been raised since #8550 was merged on 30th Nov; the only remaining cosmetic/UI issue is closed by this PR as per the previous point.)