### PR TITLE
Add clear_graph methods to Game class

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1484,6 +1484,10 @@ module Engine
         graph_for_entity(entity).clear
       end
 
+      def clear_token_graph_for_entity(entity)
+        token_graph_for_entity(entity).clear
+      end
+
       def graph_skip_paths(_entity)
         nil
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1476,6 +1476,14 @@ module Engine
         @graph
       end
 
+      def clear_graph
+        @graph.clear
+      end
+
+      def clear_graph_for_entity(entity)
+        graph_for_entity(entity).clear
+      end
+
       def graph_skip_paths(_entity)
         nil
       end

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -95,7 +95,7 @@ module Engine
         end
 
         @round.tokened = true unless extra_action
-        @game.token_graph_for_entity(entity).clear
+        @game.clear_token_graph_for_entity(entity)
       end
 
       def pay_token_cost(entity, cost)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -121,7 +121,7 @@ module Engine
           end
         end
 
-        graph.clear
+        @game.clear_graph_for_entity(entity)
         free = false
         discount = 0
         teleport = false


### PR DESCRIPTION
This pull request originated as part of PR #8578 for 1858 Iberia and needs an explanation that's far longer than the patch. It's marked as draft, as I'm far from certain as to whether this is the correct approach.

The problem being addressed is 1858's particular routing requirements. 1858 has multiple gauges of track: broad, narrow and dual gauge. To be able to lay track or place a token a corporation much be able to trace a route from one its tokens that only has broad and dual gauge track, or narrow and dual gauge track. If the only route would include both broad and narrow gauge track then this is invalid.

The Graph class cannot currently handle these requirements. It can ignore gauge entirely, or be instructed (through the `skip_paths` setting) to exclude one gauge of track.

Other games that have narrow gauge track work differently:

- 1841 and 18Carolinas allow routes to include both broad and narrow gauge track.
- 1873 effectively only has narrow gauge track (there is some broad gauge track on the board, but that's little more than decoration).
- 18Ireland mainly works with routes being calculated using broad gauge track, with narrow gauge branches being tagged on top of that.
- 1840 has routes that depend on the type of corporation, with lines using broad gauge and Stadtsbahn using narrow gauge. This means it's possible for the type of graph needed to be chosen in `Game.graph_for_entity`.

There are a few different ways I can think of to give 1858 graphs that fulfil its routing requirements. This pull request is needed to implement the first of these, but I'm now thinking that the second might be better.

1. Two graph objects, one for broad gauge, one for narrow gauge.
2. The same as 1, but with a Graph decorator class that combines these into a single object.
3. Rewrite `Graph.compute` to be able to produce a single graph suitable for 1858.

### 1. Two graph objects

This is the approach I have taken so far, and this patch is needed for it.

The `Engine::Game::G1858::Game` class is given two graph attributes, `graph_broad` and `graph_metre`. The former is a Graph object calculated using `skip_paths = :narrow`, and tells you about routes that can be traced from tokens using only broad and dual gauge track; the latter does the same for routes using only narrow and dual gauge track (metre gauge track is the name used for narrow gauge track in 1858).

To use these graphs, various methods are rewritten to check there's a valid route using either of these graphs, for example these methods from [step/token.rb](https://github.com/ollybh/18xx/blob/9b0eb5b739bcdb541990f71ae515a3c7af567ee6/lib/engine/game/g_1858/step/token.rb):
``` 
def available_hex(entity, hex)
  @game.graph_broad.reachable_hexes(entity)[hex] \
    || @game.graph_metre.reachable_hexes(entity)[hex]
end

def check_connected(entity, city, hex)
  return if @game.loading \
    || @game.graph_broad.connected_nodes(entity)[city] \
    || @game.graph_metre.connected_nodes(entity)[city]

    city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
    raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
end
```

This all works well and isn't too complicated, with a couple of exceptions: there are calls deep in `Engine::Step::Tracker.lay_tile` and `Engine::Step::Tokener.place_token` to invalidate the existing graphs when a tile is laid or token is placed. These calls assume that there's a single graph object, but I need to be able to clear both the broad and narrow gauge graphs at this point.

This patch is adding some methods to the Game class that clears the default graph, and changes the calls in the Tracker and Tokener modules to call these instead. This allows G1858::Game to override these methods and instead clear all the graphs.


### 2. Two graph objects wrapped in a decorator class

An alternative approach might be to write a 1858-specific class that mimics the Graph class and encapsulates the graph objects for broad and metre gauge track. Call it GraphSet or something. Make `Engine::Game::G1858::Game.graph` a GraphSet object, it intercepts all calls to the `clear*` methods, `connected_hexes`, `connected_nodes` and so on and handles them appropriately, sending on calls to the individual graph objects and combines their results.

This would minimise the amount of code needed elsewhere, but might be a bit fragile – it's possible that any future changes to the structure or use of Graph objects would inadvertently break this class.


### 3. Rewrite Graph.compute

It would be possible to alter the Graph class so that it is able to produce a graph of nodes and hexes that is suitable for 1858. You'd need a new flag to pass when the Graph object is created to let it know that this behaviour is required. If it is enabled then the `Graph.compute` would need to become more gauge-aware: if you start at node A and walk to node B using a broad gauge path then you can only leave node B using broad gauge paths.

This would invalidate the current optimisation that is the `visited` array that is maintained during the compute process. There might be a second path from node A to node B that uses narrow gauge track, so you can't assume that a node has been fully processed just because you've been there before. `visited` would need to become gauge aware, so you can see if you've been there and looked at broad gauge exits, or narrow gauge exits, or both.

This approach would be the cleanest in terms of removing the need for code changes elsewhere, but I suspect that the amount of added complexity for a single game is probably not desirable.