### PR TITLE
Add exchange_price parameter to Engine::Step::ShareBuying.buy_shares

### DIFF
--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -5,7 +5,8 @@ require_relative 'base'
 module Engine
   module Step
     module ShareBuying
-      def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil, silent: nil)
+      def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil,
+                     allow_president_change: true, borrow_from: nil, silent: nil)
         check_legal_buy(entity,
                         shares,
                         exchange: exchange,
@@ -15,6 +16,7 @@ module Engine
         @game.share_pool.buy_shares(entity,
                                     shares,
                                     exchange: exchange,
+                                    exchange_price: exchange_price,
                                     swap: swap,
                                     borrow_from: borrow_from,
                                     allow_president_change: allow_president_change,


### PR DESCRIPTION
If exchanging a company for a share bundle the share price paid might need to be adjusted. Accept an `exchange_price` parameter and pass this on to `Engine::SharePool.buy_shares`.

This is another commit extracted from pull request #8578. This is needed for 1858 where exchanging a private company for a president's share means you only pay for half of the president's share.