### PR TITLE
[1880] rocket of china, implement SR trigger, par order, bcr auto par

### DIFF
--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -107,8 +107,11 @@ module View
         ability = @game.abilities(@selected_company, :purchase_train)
         # Show the train that will be bought on the button
         train = @game.depot.depot_trains.first
-        button_text = "Purchase #{train.name} for #{@game.format_currency(train.price)}"
-        button_text = "Get #{train.name} train from depot" if ability.free
+        button_text = if ability&.free
+                        "Acquire #{train.name} train from depot"
+                      else
+                        "Purchase #{train.name} for #{@game.format_currency(train.price)}"
+                      end
         h(:button, { on: { click: purchase } }, button_text)
       end
 

--- a/assets/app/view/game/abilities.rb
+++ b/assets/app/view/game/abilities.rb
@@ -104,10 +104,12 @@ module View
             @selected_company
           ))
         end
-
+        ability = @game.abilities(@selected_company, :purchase_train)
         # Show the train that will be bought on the button
         train = @game.depot.depot_trains.first
-        h(:button, { on: { click: purchase } }, "Purchase #{train.name} for #{@game.format_currency(train.price)}")
+        button_text = "Purchase #{train.name} for #{@game.format_currency(train.price)}"
+        button_text = "Get #{train.name} train from depot" if ability.free
+        h(:button, { on: { click: purchase } }, button_text)
       end
 
       def render_sell_company_button

--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -154,8 +154,8 @@ This company may not be bought in.
 
 ## purchase_train
 
-Immediately purchases (for normal amount) the currently available depot train
-for the owning corporation.
+Immediately purchases the currently available depot train for the owning corporation.
+- `free`: If true, the train cost is free, otherwase at cost. Default false.
 
 ## reservation
 

--- a/lib/engine/ability/purchase_train.rb
+++ b/lib/engine/ability/purchase_train.rb
@@ -5,6 +5,11 @@ require_relative 'base'
 module Engine
   module Ability
     class PurchaseTrain < Base
+      attr_reader :free
+
+      def setup(free: false)
+        @free = free
+      end
     end
   end
 end

--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -25,8 +25,8 @@ module Engine
       @game.phase.buying_train!(nil, train)
     end
 
-    def export_all!(name)
-      @game.log << "-- Event: All #{name} trains are exported --"
+    def export_all!(name, silent: false)
+      @game.log << "-- Event: All #{name} trains are exported --" unless silent
       while (train = @upcoming.first).name == name
         @game.remove_train(train)
         @game.phase.buying_train!(nil, train)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -761,10 +761,7 @@ module Engine
             next_round!
             check_programmed_actions
 
-            # Finalize round setup (for things that need round correctly set like place_home_token)
-            @round.at_start = true
-            @round.setup
-            @round_history << current_action_id
+            finalize_round_setup
           end
         end
       rescue Engine::GameError => e
@@ -772,6 +769,13 @@ module Engine
         @actions.pop
         @exception = e
         @broken_action = action
+      end
+
+      def finalize_round_setup
+        # Finalize round setup (for things that need round correctly set like place_home_token)
+        @round.at_start = true
+        @round.setup
+        @round_history << current_action_id
       end
 
       def maybe_raise!

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3002,6 +3002,8 @@ module Engine
       end
 
       def second_icon(corporation); end
+
+      def after_buying_train(train); end
     end
   end
 end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2089,6 +2089,8 @@ module Engine
         true
       end
 
+      def after_buying_train(train); end
+
       private
 
       def init_graph
@@ -3002,8 +3004,6 @@ module Engine
       end
 
       def second_icon(corporation); end
-
-      def after_buying_train(train); end
     end
   end
 end

--- a/lib/engine/game/g_1880/entities.rb
+++ b/lib/engine/game/g_1880/entities.rb
@@ -35,6 +35,14 @@ module Engine
             value: 45,
             revenue: 15,
             desc: 'For the owner, the value of Taiwan is +20 (with all his companies)',
+            abilities: [
+              {
+                type: 'hex_bonus',
+                owner_type: 'player',
+                hexes: ['N16'],
+                amount: 20,
+              },
+            ],
             color: nil,
           },
           {
@@ -43,6 +51,13 @@ module Engine
             value: 70,
             revenue: 20,
             desc: 'Reduce the cost of laying a tile in a river hex by ¥20 (for all his companies)',
+            abilities: [{
+              type: 'tile_discount',
+              discount: 20,
+              terrain: 'water',
+              owner_type: 'player',
+              when: 'owning_player_track',
+            }],
             color: nil,
           },
           {
@@ -59,6 +74,8 @@ module Engine
             value: 160,
             revenue: 0,
             desc: 'The owner receives the 20% Director’s Certificates of the BCR, BCR may always lay 2 yellow tiles',
+            abilities: [{ type: 'shares', shares: 'BCR_0' },
+                        { type: 'close', when: 'par', corporation: 'BCR' }],
             color: nil,
           },
           {
@@ -69,6 +86,12 @@ module Engine
             desc: 'The owner may exchange the Rocket of China for a currently available train, '\
                   'for one of his companies, during that company’s turn in an Operating Round. '\
                   'Forced exchange into second 4-train.',
+            abilities: [{
+              type: 'purchase_train',
+              owner_type: 'player',
+              when: 'owning_player_or_turn',
+              free: true,
+            }],
             color: nil,
           },
         ].freeze

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -15,7 +15,7 @@ module Engine
         include Entities
 
         attr_accessor :train_marker
-        attr_reader :full_cap_event, :communism, :end_game_triggered, :par_order
+        attr_reader :full_cap_event, :communism, :end_game_triggered, :par_order, :saved_or_round
 
         TRACK_RESTRICTION = :permissive
         TILE_RESERVATION_BLOCKS_OTHERS = :yellow_only
@@ -678,8 +678,14 @@ module Engine
           return if train.name == @depot.upcoming.first.name
 
           @turn += 1
-          @saved_or_round = @round.dup
+          @saved_or_round = @round
           @round = new_stock_round
+        end
+
+        def finalize_round_setup
+          return super unless @round == @saved_or_round
+
+          @round_history << current_action_id
         end
       end
     end

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -456,7 +456,7 @@ module Engine
         end
 
         def status_array(corporation)
-          return if corporation.minor? || !corporation.original_par_price
+          return if corporation.minor? || !corporation.ipoed
 
           status = ["Building Permits: #{corporation.building_permits}"]
           par_location = @par_order[corporation.original_par_price.price].find_index(corporation) + 1

--- a/lib/engine/game/g_1880/map.rb
+++ b/lib/engine/game/g_1880/map.rb
@@ -242,8 +242,9 @@ module Engine
             ['F12'] => 'offboard=revenue:-10,hide:1;path=a:3,b:1',
             %w[F14 J16] => 'offboard=revenue:-10,hide:1;path=a:2,b:0',
             ['I15'] => 'path=a:2,b:5',
-            ['N16'] => 'offboard=revenue:yellow_30|green_30|brown_0|gray_0;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0',
-            ['Q13'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_50;path=a:2,b:_0;path=a:3,b:_0',
+            ['N16'] => 'town=revenue:yellow_30|green_30|brown_0|gray_0;path=a:0,b:_0,terminal:1;'\
+                       'path=a:1,b:_0,terminal:1;path=a:2,b:_0,terminal:1',
+            ['Q13'] => 'town=revenue:yellow_20|green_30|brown_40|gray_50;path=a:2,b:_0,terminal:1;path=a:3,b:_0,terminal:1',
           },
           yellow: {
             %w[F8] => 'city=revenue:20;city=revenue:20;city=revenue:20;city=revenue:20;'\

--- a/lib/engine/game/g_1880/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1880/step/buy_sell_par_shares.rb
@@ -137,6 +137,10 @@ module Engine
             @round.last_to_act = player
             @round.current_actions << action
           end
+
+          def get_par_prices(entity, _corp)
+            super.reject { |p| @game.par_order[p.price].length == 4 }
+          end
         end
       end
     end

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -35,9 +35,13 @@ module Engine
           end
 
           def pass!
-            return super unless current_entity == @game.train_marker && !@round.bought_trains
+            return super unless discard_trains?
 
             discard_all_trains
+          end
+
+          def discard_trains?
+            @game.train_marker && !@round.bought_trains
           end
 
           def discard_all_trains

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -31,7 +31,9 @@ module Engine
           end
 
           def round_state
+            super.merge(
             { bought_trains: false }
+          )
           end
 
           def pass!
@@ -41,7 +43,7 @@ module Engine
           end
 
           def discard_trains?
-            @game.train_marker && !@round.bought_trains
+            @game.train_marker == current_entity && !@round.bought_trains && @game.saved_or_round&.round_num != @round.round_num
           end
 
           def discard_all_trains

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -34,6 +34,19 @@ module Engine
             { bought_trains: false }
           end
 
+          def pass!
+            return super unless current_entity == @game.train_marker && !@round.bought_trains
+
+            discard_all_trains
+          end
+
+          def discard_all_trains
+            train_name = @game.depot.upcoming.first.name
+            @game.log << "#{train_name} has not been bought for a full operating order, "\
+                         "removing all remaining #{train_name} trains"
+            @game.depot.export_all!(train_name, silent: true)
+          end
+
           def setup
             super
             @round.bought_trains = false

--- a/lib/engine/game/g_1880/step/company_pending_par.rb
+++ b/lib/engine/game/g_1880/step/company_pending_par.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/company_pending_par'
+
+module Engine
+  module Game
+    module G1880
+      module Step
+        class CompanyPendingPar < Engine::Step::CompanyPendingPar
+          def process_par(action)
+            super
+            corporation = action.corporation
+            @log << "#{corporation.name} selects ABC building permit"
+            corporation.building_permits = 'ABC'
+          end
+
+          def auto_actions(entity)
+            share = @game.abilities(companies_pending_par.first, :shares).shares.first
+            share_price = @game.stock_market.par_prices.find { |pp| pp.price == 100 }
+            [Engine::Action::Par.new(entity, corporation: share.corporation, share_price: share_price)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880/step/rocket_purchase_train.rb
+++ b/lib/engine/game/g_1880/step/rocket_purchase_train.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1880
+      module Step
+        class RocketPurchaseTrain < Engine::Step::Base
+          ACTIONS = %w[purchase_train].freeze
+
+          def setup
+            @rocket = @game.company_by_id('P7')
+          end
+
+          def description
+            'Rocket of China Train Purchase'
+          end
+
+          def active?
+            !@rocket.closed?
+          end
+
+          def actions(entity)
+            return [] unless @rocket == entity
+            return [] if !current_entity.corporation? || current_entity.owner != @rocket.owner
+            return [] unless can_purchase?(current_entity)
+
+            @buying_corp = current_entity
+            ACTIONS
+          end
+
+          def current_train
+            @game.depot.depot_trains.first
+          end
+
+          def can_purchase?(corp)
+            train = current_train
+            train and room?(corp)
+          end
+
+          def room?(corp)
+            corp.trains.size < @game.train_limit(corp)
+          end
+
+          # Don't want any skipped message for this step
+          def log_skip(_entity); end
+
+          def blocking?
+            false
+          end
+
+          def process_purchase_train(action)
+            rocket = action.entity
+            train = current_train
+
+            raise GameError, "#{@buying_corp.name} can't purchase a #{train.name} train" unless can_purchase?(@buying_corp)
+
+            @log << "#{@buying_corp.name} exchanges the #{rocket.name} for a #{train.name} train"
+
+            rocket.close!
+            @game.buy_train(@buying_corp, train, :free)
+            @game.phase.buying_train!(@buying_corp, train)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880/step/rocket_purchase_train.rb
+++ b/lib/engine/game/g_1880/step/rocket_purchase_train.rb
@@ -24,7 +24,6 @@ module Engine
             return [] if !current_entity.corporation? || current_entity.owner != @rocket.owner
             return [] unless can_purchase?(current_entity)
 
-            @buying_corp = current_entity
             ACTIONS
           end
 
@@ -52,13 +51,11 @@ module Engine
             rocket = action.entity
             train = current_train
 
-            raise GameError, "#{@buying_corp.name} can't purchase a #{train.name} train" unless can_purchase?(@buying_corp)
-
-            @log << "#{@buying_corp.name} exchanges the #{rocket.name} for a #{train.name} train"
+            @log << "#{@round.current_operator.name} exchanges the #{rocket.name} for a #{train.name} train"
 
             rocket.close!
-            @game.buy_train(@buying_corp, train, :free)
-            @game.phase.buying_train!(@buying_corp, train)
+            @game.buy_train(@round.current_operator, train, :free)
+            @game.phase.buying_train!(@round.current_operator, train)
           end
         end
       end

--- a/lib/engine/game/g_1880/step/rocket_purchase_train.rb
+++ b/lib/engine/game/g_1880/step/rocket_purchase_train.rb
@@ -32,7 +32,6 @@ module Engine
           end
 
           def can_purchase?(corp)
-            train = current_train
             train and room?(corp)
           end
 

--- a/lib/engine/game/g_1880/step/selection_auction.rb
+++ b/lib/engine/game/g_1880/step/selection_auction.rb
@@ -16,6 +16,12 @@ module Engine
             @auction_triggerer = current_entity
           end
 
+          def round_state
+            {
+              companies_pending_par: [],
+            }
+          end
+
           def all_passed!
             # Everyone has passed so we need to run a fake OR.
             if @companies.include?(@game.p1)

--- a/lib/engine/game/g_1880/step/simple_draft.rb
+++ b/lib/engine/game/g_1880/step/simple_draft.rb
@@ -39,8 +39,14 @@ module Engine
 
             @log << "#{player.name} chooses #{minor.full_name} (#{minor.name})"
 
+            assign_bcr_share_to_fi(action.entity, minor) if player.shares.find { |s| s.corporation.id == 'BCR' }
+
             @round.next_entity_index!
             action_finalized
+          end
+
+          def assign_bcr_share_to_fi(player, fi)
+            @game.assign_share_to_fi(player.shares.first.corporation, fi)
           end
 
           def action_finalized

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -26,6 +26,7 @@ module Engine
         @game.send("event_#{event['type']}!")
       end
       train.events.clear
+      @game.after_buying_train(train)
     end
 
     def current

--- a/lib/engine/step/selection_auction.rb
+++ b/lib/engine/step/selection_auction.rb
@@ -129,6 +129,7 @@ module Engine
         assign_company(company, player)
 
         player.spend(price, @game.bank) if price.positive?
+        @game.after_buy_company(player, company, price)
 
         @companies.delete(company)
         @log << "#{player.name} wins the auction for #{company.name} "\


### PR DESCRIPTION
more 1880 implementation:
Rocket of china private ability
saved SR triggered in the middle of an OR, then come back to SR when done
implement par order
add par location to corp status array
assign bcr share to FI.

Notes:
- At this point, parred companies are auto allocated to the top available position in each par price, this will change, We're in the middle of implementing a UI for picking exact par choice. 
- The logic to discard all trains is simplified and doesn't include cross buying, or buying trains that do not discard all trains (20, 8e, 10) this is implemented in my local branch and will be added to the next pr, once this is approved & merged