### PR TITLE
[1861/1867] Fix merger token bugs (issue #8589)

### DIFF
--- a/lib/engine/game/g_1867/step/merge.rb
+++ b/lib/engine/game/g_1867/step/merge.rb
@@ -214,8 +214,6 @@ module Engine
               @game.log << "#{target.name} will be above token limit and must decide which tokens to remove"
               @round.corporations_removing_tokens = [target] + @merging
             else
-              move_tokens_to_surviving(target, @merging)
-
               # Add the $40 token back
               if target.tokens.size < 3
                 new_token = Engine::Token.new(target, price: 40)

--- a/lib/engine/game/g_1867/step/reduce_tokens.rb
+++ b/lib/engine/game/g_1867/step/reduce_tokens.rb
@@ -8,7 +8,7 @@ module Engine
       module Step
         class ReduceTokens < Engine::Step::ReduceTokens
           def description
-            "Choose tokens to remove"
+            'Choose tokens to remove'
           end
 
           def token_hex_count(corporation)
@@ -37,12 +37,8 @@ module Engine
           def help
             corporation = current_entity
             issues = []
-            if survivor_tokens_over_limit?(corporation)
-              issues << 'can only keep two tokens'
-            end
-            if survivor_tokens_in_same_hex(corporation).positive?
-              issues << 'cannot have two tokens in the same hex'
-            end
+            issues << 'can only keep two tokens' if survivor_tokens_over_limit?(corporation)
+            issues << 'cannot have two tokens in the same hex' if survivor_tokens_in_same_hex(corporation).positive?
 
             "The new public company #{issues.join(' and ')}. Choose which tokens to remove."
           end
@@ -66,12 +62,13 @@ module Engine
 
             super
 
-            if (token_hex_count(corporation) == 1) && (hexes_with_tokens > 1)
-              # This can only happen in a merger of more than two minors where
-              # there's a hex with multiple tokens. The player has attempted to
-              # remove all but one of the tokens from the map.
-              raise GameError, "#{corporation.id} must have two tokens in different hexes"
-            end
+            return if hexes_with_tokens == 1
+            return if token_hex_count(corporation) > 1
+
+            # This can only happen in a merger of more than two minors where
+            # there's a hex with multiple tokens. The player has attempted to
+            # remove all but one of the tokens from the map.
+            raise GameError, "#{corporation.id} must have two tokens in different hexes"
           end
         end
       end

--- a/lib/engine/game/g_1867/step/reduce_tokens.rb
+++ b/lib/engine/game/g_1867/step/reduce_tokens.rb
@@ -7,6 +7,19 @@ module Engine
     module G1867
       module Step
         class ReduceTokens < Engine::Step::ReduceTokens
+          def description
+            "Choose tokens to remove"
+          end
+
+          def survivor_tokens_in_same_hex(corporation)
+            corporation.placed_tokens.size - corporation.placed_tokens.map(&:hex).uniq.size
+          end
+
+          def survivor_tokens_over_limit?(corporation)
+            corporation.placed_tokens.size - survivor_tokens_in_same_hex(corporation) >
+              @game.class::LIMIT_TOKENS_AFTER_MERGER
+          end
+
           def move_tokens_to_surviving(surviving, others)
             super
 
@@ -18,9 +31,16 @@ module Engine
           end
 
           def help
-            'When merging more than 2 minor corporations the new corporation can only keep 2 tokens.'\
-              ' Choose which tokens to remove.'\
-              ' After merging an additional token will be available on the charter.'
+            corporation = current_entity
+            issues = []
+            if survivor_tokens_over_limit?(corporation)
+              issues << 'can only keep two tokens'
+            end
+            if survivor_tokens_in_same_hex(corporation).positive?
+              issues << 'cannot have two tokens in the same hex'
+            end
+
+            "The new public company #{issues.join(' and ')}. Choose which tokens to remove."
           end
 
           def available_hex(entity, hex)

--- a/lib/engine/game/g_1867/step/reduce_tokens.rb
+++ b/lib/engine/game/g_1867/step/reduce_tokens.rb
@@ -11,8 +11,12 @@ module Engine
             "Choose tokens to remove"
           end
 
+          def token_hex_count(corporation)
+            corporation.placed_tokens.map(&:hex).uniq.size
+          end
+
           def survivor_tokens_in_same_hex(corporation)
-            corporation.placed_tokens.size - corporation.placed_tokens.map(&:hex).uniq.size
+            corporation.placed_tokens.size - token_hex_count(corporation)
           end
 
           def survivor_tokens_over_limit?(corporation)
@@ -53,6 +57,20 @@ module Engine
               [hex]
             else
               super
+            end
+          end
+
+          def process_remove_token(action)
+            corporation = action.entity
+            hexes_with_tokens = token_hex_count(corporation)
+
+            super
+
+            if (token_hex_count(corporation) == 1) && (hexes_with_tokens > 1)
+              # This can only happen in a merger of more than two minors where
+              # there's a hex with multiple tokens. The player has attempted to
+              # remove all but one of the tokens from the map.
+              raise GameError, "#{corporation.id} must have two tokens in different hexes"
             end
           end
         end


### PR DESCRIPTION
Issue #8589 has reported three issues with removing tokens when minor companies merge and there is a hex with more than one of the merging companies' tokens.

1. The help message is misleading.
2. If three or more minors merging it is possible to remove all but one of the tokens.
3. If two tokens are in the same city (not just the same hex) then one gets put back on the minor's charter, and then moved across to the new public company as a zero-cost token.

This pull request fixes all of these.

The changes to `help` fixes the first of these.

The changes to `process_remove_token` fix the second. It makes sure that you can't remove tokens from all but one hex, unless there was already tokens in just one hex.

And the deleted line from `finish_merge_to_major` fixes the last one. This one was being triggered where there were two or three merging minors with tokens in the same city on a brown tile (Moscow/Kiev/Toronto/Montreal). 

This later call to `move_tokens_to_surviving` was normally not doing
anything as the tokens had already been moved. The exception is that if
any tokens have been removed from the map by

The call to `remove_duplicate_tokens` was removing a token from the map and putting it back on the minor's charter, it was then being moved across to the public company by `move_tokens_to_surviving` as a zero cost token, messing up the cost of the public company's tokens. This call to `move_tokens_to_surviving` does not do anything in any other cases as the tokens will already have been moved across to the public company by the earlier call to `move_tokens`. I suspect that this call might have been inherited from code from another game (maybe 1822) and has never been needed here.

This will require pinning existing games of 1861 and 1867. Most games are unlikely to be affected, but there are a few where public companies might have been given zero-cost tokens, or illegally removed all but one token from the map. Pull request #8633 is another pull request for 1861 and 1867 that needs pins, so these could be put through at the same time.