### PR TITLE
[1861/1867] Delete `round_end`, use version from base class

### DIFF
--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -1500,12 +1500,6 @@ module Engine
           @loan_value
         end
 
-        def round_end
-          return Engine::Round::Operating if phase.name.to_i >= 8
-
-          G1867::Round::Merger
-        end
-
         def final_operating_rounds
           @final_operating_rounds || super
         end


### PR DESCRIPTION
This method is only called from code that is determining the end of the game, and it will never end after a merger round, so use the base class version of this method which always returns `Round::Operating`.

This fixes tobymao/18xx#8660 which reported that 1861 would not finish if the bank breaks in phase 2, as a merger round never happens.