### PR TITLE
strip param values in User#update_settings

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -23,10 +23,10 @@ class User < Base
   ]).freeze
 
   def update_settings(params)
-    self.name = params['name'] if params['name']
-    self.email = params['email'] if params['email']
+    self.name = params['name'].strip if params['name']
+    self.email = params['email'].strip if params['email']
     params.each do |key, value|
-      settings[key] = value if SETTINGS.include?(key)
+      settings[key] = value&.strip if SETTINGS.include?(key)
     end
 
     settings.delete('webhook_url') if settings['webhook'] != 'custom'


### PR DESCRIPTION
not totally sure if this is the right fix, but we encountered a bug where the custom webhook url wasn't working because somebody accidentally put a trailing space in the Webhook URL input. I also saw a similar, older issue that this should solve https://github.com/tobymao/18xx/issues/8142