### PR TITLE
[1868WY] P7 "Big Boy" private

### DIFF
--- a/assets/app/view/game/choose.rb
+++ b/assets/app/view/game/choose.rb
@@ -45,7 +45,7 @@ module View
         div_class = choice_buttons.size < 5 ? '.inline' : ''
         h(:div, [
           h("div#{div_class}", { style: { marginTop: '0.5rem' } }, "#{@game.round.active_step.choice_name}: "),
-          *choice_buttons,
+          h(:div, choice_buttons),
         ])
       end
 

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -45,6 +45,7 @@ module View
           left << h(SwitchTrains) if @current_actions.include?('switch_trains')
           left << h(ReassignTrains) if @current_actions.include?('reassign_trains')
           left << h(DoubleHeadTrains) if @current_actions.include?('double_head_trains')
+          left << h(Choose) if @current_actions.include?('choose')
 
           if @current_actions.include?('buy_train')
             left << h(IssueShares) if @current_actions.include?('sell_shares') || @current_actions.include?('buy_shares')
@@ -68,8 +69,6 @@ module View
             left << h(CorporateBuyShares)
           elsif @current_actions.include?('corporate_sell_shares')
             left << h(CorporateSellShares)
-          elsif @current_actions.include?('choose')
-            left << h(Choose)
           elsif @current_actions.include?('swap_train')
             left << h(SwapTrain)
           elsif @current_actions.include?('buy_corporation')

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -868,7 +868,7 @@ module Engine
               "#{entity.name} moves the [+1+1] token from a #{detached.name} "\
                 "train to a #{@big_boy_train_original.name} train, forming a #{train.name} train"
             else
-              "#{entity.name} ataches the [+1+1] token to a #{@big_boy_train_original.name} "\
+              "#{entity.name} attaches the [+1+1] token to a #{@big_boy_train_original.name} "\
                 "train, forming a #{train.name} train"
             end
 

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -8,6 +8,7 @@ require_relative 'share_pool'
 require_relative 'trains'
 require_relative 'step/buy_company'
 require_relative 'step/buy_train'
+require_relative 'step/choose'
 require_relative 'step/company_pending_par'
 require_relative 'step/development_token'
 require_relative 'step/dividend'
@@ -40,7 +41,9 @@ module Engine
         include StubsAreRestricted
         include SwapColorAndStripes
 
-        attr_accessor :double_headed_trains, :dpr_first_home_status, :up_double_share_protection
+        attr_accessor :big_boy_first_chance, :double_headed_trains, :dpr_first_home_status,
+                      :up_double_share_protection
+        attr_reader :big_boy_train, :big_boy_train_original
 
         # overrides
         BANK_CASH = 99_999
@@ -177,6 +180,8 @@ module Engine
           @up_double_share_protection = {}
 
           setup_spikes
+
+          @big_boy_first_chance = false
         end
 
         def init_share_pool
@@ -222,6 +227,7 @@ module Engine
             Engine::Step::SpecialTrack,
             G1868WY::Step::BuyCompany,
             G1868WY::Step::ManualCloseCompany,
+            G1868WY::Step::Choose,
             G1868WY::Step::Track,
             G1868WY::Step::Token,
             G1868WY::Step::DoubleHeadTrains,
@@ -293,6 +299,10 @@ module Engine
           end
 
           handle_bust_preprinted_and_revenue!
+        end
+
+        def event_close_big_boy!
+          detach_big_boy(log: true)
         end
 
         def float_corporation(corporation)
@@ -833,6 +843,68 @@ module Engine
           update_cache(:trains)
         end
 
+        def attach_big_boy(train, entity)
+          detached = detach_big_boy(log: false)
+
+          @big_boy_train_original = train.dup
+          cities, towns = distance(train).map(&:succ)
+          train.name = "[#{cities}+#{towns}]"
+          train.distance = [
+            {
+              'nodes' => ['town'],
+              'pay' => towns,
+              'visit' => towns,
+            },
+            {
+              'nodes' => %w[city offboard town],
+              'pay' => cities,
+              'visit' => cities,
+            },
+          ]
+          @big_boy_train = train
+
+          @log <<
+            if detached
+              "#{entity.name} moves the [+1+1] token from a #{detached.name} "\
+                "train to a #{@big_boy_train_original.name} train, forming a #{train.name} train"
+            else
+              "#{entity.name} ataches the [+1+1] token to a #{@big_boy_train_original.name} "\
+                "train, forming a #{train.name} train"
+            end
+
+          @big_boy_train
+        end
+
+        def detach_big_boy(log: false)
+          return unless @big_boy_train
+
+          train = @big_boy_train_original
+
+          @log << "The [+1+1] token is detached from the #{train.name} train" if log
+
+          @big_boy_train.name = train.name
+          @big_boy_train.distance = train.distance
+
+          cleanup_big_boy
+
+          train
+        end
+
+        def rust_trains!(train, _entity)
+          detach_big_boy if train.sym == @big_boy_train&.rusts_on
+          super
+        end
+
+        def cleanup_big_boy
+          @big_boy_train_original = nil
+          @big_boy_train = nil
+        end
+
+        def buy_train(operator, train, price = nil)
+          detach_big_boy(log: true) if train == big_boy_train
+          super
+        end
+
         def abilities(entity, type = nil, **kwargs)
           if type == :exchange
             return unless entity == ames_bros
@@ -983,6 +1055,8 @@ module Engine
           case @phase.name
           when '5'
             event_close_ames_brothers!
+          when '8'
+            event_close_big_boy!
           end
         end
       end

--- a/lib/engine/game/g_1868_wy/step/buy_train.rb
+++ b/lib/engine/game/g_1868_wy/step/buy_train.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../../step/buy_train'
 require_relative '../skip_coal_and_oil'
+require_relative 'choose_big_boy'
 
 module Engine
   module Game
@@ -9,6 +10,15 @@ module Engine
       module Step
         class BuyTrain < Engine::Step::BuyTrain
           include G1868WY::SkipCoalAndOil
+          include ChooseBigBoy
+
+          def actions(entity)
+            super.concat(choice_actions(entity, cannot_pass: entity.corporation? && must_buy_train?(entity)))
+          end
+
+          def process_choose(action)
+            process_choose_big_boy(action)
+          end
 
           def process_buy_train(action)
             super

--- a/lib/engine/game/g_1868_wy/step/choose.rb
+++ b/lib/engine/game/g_1868_wy/step/choose.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative 'choose_big_boy'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        # Choose a train for the [+1+1] token right when the "Big Boy" private
+        # is bought by a corporation; apart from this first chance to choose a
+        # train, a train may only be chosen during the BuyTrain step
+        class Choose < Engine::Step::Base
+          include G1868WY::Step::ChooseBigBoy
+
+          def description
+            'Choose a Train'
+          end
+
+          def actions(entity)
+            !@game.big_boy_first_chance && owns_big_boy?(entity) ? choice_actions(entity) : []
+          end
+
+          def log_skip(_entity); end
+
+          def pass_description
+            'Pass (Choose a Train)'
+          end
+
+          def skip!
+            @game.big_boy_first_chance = true if @game.big_boy_private.corporation
+          end
+
+          def process_pass(action)
+            @game.big_boy_first_chance = true
+            log_pass(action.entity)
+            pass!
+          end
+
+          def process_choose(action)
+            @game.big_boy_first_chance = true
+            process_choose_big_boy(action)
+          end
+
+          def blocks?
+            !@game.big_boy_first_chance
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/step/choose_big_boy.rb
+++ b/lib/engine/game/g_1868_wy/step/choose_big_boy.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        module ChooseBigBoy
+          def setup
+            super
+            @chosen = false
+          end
+
+          def choice_actions(entity, cannot_pass: false)
+            return [] unless entity.corporation?
+
+            actions = []
+
+            if (!@game.big_boy_train || !@chosen) && can_use_big_boy?(entity)
+              if owns_big_boy?(entity)
+                actions << 'choose'
+                actions << 'pass' unless cannot_pass
+              elsif !cannot_pass && can_buy_big_boy?(entity)
+                actions << 'pass'
+              end
+            end
+
+            actions
+          end
+
+          def choice_name
+            if @game.big_boy_train
+              "You may move the [+1+1] token from the #{@game.big_boy_train_original.name} train to another train"
+            else
+              'You may attach the [+1+1] token to a train'
+            end
+          end
+
+          def choices
+            big_boy_choices(current_entity).each_with_index.with_object({}) do |(train, index), choices|
+              choices[index.to_s] = "#{train.name} train"
+            end
+          end
+
+          def big_boy_choices(entity)
+            entity.trains.reject { |t| t == @game.big_boy_train || t.obsolete }
+          end
+
+          def can_use_big_boy?(entity)
+            !big_boy_choices(entity).empty?
+          end
+
+          def owns_big_boy?(entity)
+            @game.big_boy_private&.corporation == entity
+          end
+
+          def can_buy_big_boy?(entity)
+            @game.big_boy_private.owned_by_player? &&
+              @game.phase.status.include?('can_buy_companies') &&
+              @game.buying_power(entity).positive?
+          end
+
+          def process_choose_big_boy(action)
+            train = big_boy_choices(action.entity)[action.choice.to_i]
+            @game.attach_big_boy(train, action.entity)
+            @chosen = true
+          end
+
+          def pass_if_cannot_buy_train?(entity)
+            !can_use_big_boy?(entity) &&
+              !(owns_big_boy?(entity) ||
+                can_buy_big_boy?(entity))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this private provides a `+1 +1` token which boosts a train's city and town values by one

* represent the token as `[+1 +1]`, and when assigned to a train, represent the new number in square brackets to distinguish it; e.g., a `2` train becomes `[3+1]`
* wrap choice buttons in a div so that in the train-buying step, all choices are rendered on the same line
  * before, with first choice on one line and the rest on another line: ![](https://i.imgur.com/wJFayNh.png)
  * after, all on one line: ![](https://i.imgur.com/WaSOLlE.png)
* the token can first be assigned when the private is bought (`Choose` step), or during the `BuyTrain` step; `ChooseBigBoy` is implemented as a module so to easily provide the functionality to both possible steps
* the token can be re-assigned to a different train during the `BuyTrain` step

[#5011]