### PR TITLE
Extend Engine::Step::BuySellParSharesViaBid to handle company auctions

### DIFF
--- a/lib/engine/step/buy_sell_par_shares_via_bid.rb
+++ b/lib/engine/step/buy_sell_par_shares_via_bid.rb
@@ -7,6 +7,7 @@ module Engine
   module Step
     class BuySellParSharesViaBid < BuySellParShares
       # Common code between 1867, 18Ireland, and 1877: Stockholm Tramways for auctioning corporations via bid
+      # Can also be used to auction private companies.
       include Engine::Step::PassableAuction
 
       def actions(entity)
@@ -17,6 +18,10 @@ module Engine
         actions << 'bid' if !bought? && can_bid?(entity)
         actions << 'pass' if actions.any? && !actions.include?('pass') && !must_sell?(entity)
         actions
+      end
+
+      def auctioning_company
+        @auctioning
       end
 
       def auctioning_corporation
@@ -57,15 +62,15 @@ module Engine
       end
 
       def add_bid(action)
-        entity = action.entity
-        corporation = action.corporation
+        player = action.entity
+        entity = action.corporation || action.company
         price = action.price
 
         if @auctioning
-          @log << "#{entity.name} bids #{@game.format_currency(price)} for #{corporation.name}"
+          @log << "#{player.name} bids #{@game.format_currency(price)} for #{entity.name}"
         else
-          @log << "#{entity.name} auctions #{corporation.name} for #{@game.format_currency(price)}"
-          @game.place_home_token(action.corporation) if @game.class::HOME_TOKEN_TIMING == :par
+          @log << "#{player.name} auctions #{entity.name} for #{@game.format_currency(price)}"
+          @game.place_home_token(entity) if (@game.class::HOME_TOKEN_TIMING == :par) && !entity.company?
         end
         super(action)
 


### PR DESCRIPTION
`Engine::Step::BuySellParSharesViaBid` implements the style of auction where an available entity is selected for auction, then players get asked to bid or pass until only one person is left. This is used by 1861 and similar games for auctioning corporations (minor companies).

The same style of auction is used in other of of Ian D Wilson's games to auction privates: 1858 only has auctions of privates, and 18BF has auctions of both privates and minors.

This change extends BuySellParSharesViaBid to be able to auction companies as well as corporations. Most of the changes are renaming variables so that they are more general. It also adds an `auctioning_company` method to be called from `View::Game::Round::Stock.render`.

This change has been extracted from pull request #8578.