### PR TITLE
[1858] Operating round structure and track laying

### DIFF
--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -19,6 +19,8 @@ module Engine
         include G1858::Trains
         include StubsAreRestricted
 
+        attr_reader :graph_broad, :graph_metre
+
         GAME_END_CHECK = { bank: :current_or }.freeze
         BANKRUPTCY_ALLOWED = false
 
@@ -46,6 +48,145 @@ module Engine
           { lay: true, upgrade: true },
           { lay: true, upgrade: true, cost: 20, cannot_reuse_same_hex: true },
         ].freeze
+
+        def setup
+          # We need three different graphs for tracing routes for entities:
+          #  - @graph_broad traces routes along broad and dual gauge track.
+          #  - @graph_metre traces routes along metre and dual gauge track.
+          #  - @graph uses any track. This is going to include illegal routes
+          #    (using both broad and metre gauge track) but will just be used
+          #    by things like the auto-router where the route will get rejected.
+          @graph_broad = Graph.new(self, skip_track: :narrow, home_as_token: true)
+          @graph_metre = Graph.new(self, skip_track: :broad, home_as_token: true)
+
+          @stubs = setup_stubs
+        end
+
+        # Create stubs along the routes of the private railways.
+        def setup_stubs
+          stubs = Hash.new { |k, v| k[v] = [] }
+          @minors.each do |minor|
+            next unless minor.coordinates.size > 1
+
+            home_hexes = hexes.select { |hex| minor.coordinates.include?(hex.coordinates) }
+            home_hexes.each do |hex|
+              tile = hex.tile
+              next unless tile.color == :white
+
+              hex.neighbors.each do |edge, neighbor|
+                next unless home_hexes.include?(neighbor)
+
+                stub = Engine::Part::Stub.new(edge)
+                tile.stubs << stub
+                stubs[minor] << { tile: tile, stub: stub }
+              end
+            end
+          end
+
+          stubs
+        end
+
+        # Removes the stubs from the private railway's home hexes.
+        def release_stubs(minor)
+          stubs = @stubs[minor]
+          return unless stubs
+
+          stubs.each { |tile_stub| tile_stub[:tile].stubs.delete(tile_stub[:stub]) }
+          @stubs.delete(minor)
+        end
+
+        def clear_graph_for_entity(_entity)
+          @graph.clear
+          @graph_broad.clear
+          @graph_metre.clear
+        end
+
+        def clear_token_graph_for_entity(entity)
+          clear_graph_for_entity(entity)
+        end
+
+        def operating_round(round_num = 1)
+          @round_num = round_num
+          Engine::Round::Operating.new(self, [
+            G1858::Step::Track,
+            Engine::Step::Token,
+            Engine::Step::Route,
+            Engine::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            Engine::Step::BuyTrain,
+            Engine::Step::IssueShares,
+          ], round_num: round_num)
+        end
+
+        # Returns the company object for a private railway given its associated
+        # minor object. If passed a company then returns that company.
+        def private_company(entity)
+          return entity if entity.company?
+
+          @companies.find { |company| company.sym == entity.id }
+        end
+
+        # Returns the minor object for a private railway given its associated
+        # company object. If passed a minor then returns that minor.
+        def private_minor(entity)
+          return entity if entity.minor?
+
+          @minors.find { |minor| minor.id == entity.sym }
+        end
+
+        # Returns true if the hex is this private railway's home hex.
+        def home_hex?(operator, hex)
+          operator.coordinates.include?(hex.coordinates)
+        end
+
+        def tile_lays(entity)
+          entity.corporation? ? TILE_LAYS : MINOR_TILE_LAYS
+        end
+
+        def metre_gauge_upgrade(old_tile, new_tile)
+          # Check if the only new track on the tile is metre gauge
+          old_track = old_tile.paths.map(&:track)
+          new_track = new_tile.paths.map(&:track)
+          old_track.each { |t| new_track.slice!(new_track.index(t) || new_track.size) }
+          new_track.uniq == [:narrow]
+        end
+
+        def upgrade_cost(tile, hex, entity, _spender)
+          return 0 if tile.upgrades.empty?
+          return 0 if entity.minor? && home_hex?(entity, hex)
+
+          cost = tile.upgrades[0].cost
+          return cost unless metre_gauge_upgrade(tile, hex.tile)
+
+          discount = cost / 2
+          log_cost_discount(entity, nil, discount, :terrain)
+          cost - discount
+        end
+
+        def tile_cost_with_discount(_tile, _hex, entity, _spender, cost)
+          return cost if @round.gauges_added.one? # First tile lay.
+          return cost unless @round.gauges_added.include?([:narrow])
+
+          discount = 10
+          log_cost_discount(entity, nil, discount, :tile_lay)
+          cost - discount
+        end
+
+        def log_cost_discount(entity, _ability, discount, reason = :terrain)
+          return unless discount.positive?
+
+          @log << "#{entity.name} receives a #{format_currency(discount)} " \
+                  "#{reason == :terrain ? 'terrain' : 'second tile'} " \
+                  'discount for metre gauge track'
+        end
+
+        def payout_companies
+          return if private_closure_round == :in_progress
+
+          # Private railways owned by public companies don't pay out.
+          exchanged_companies = @companies.select { |company| company.owner&.corporation? }
+          super(ignore: exchanged_companies.map(&:id))
+        end
       end
     end
   end

--- a/lib/engine/game/g_1858/graph.rb
+++ b/lib/engine/game/g_1858/graph.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../../graph'
+
+module Engine
+  module Game
+    module G1858
+      class Graph < Engine::Graph
+        # Alters the default handling of node's in an entity's home hexes in
+        # two ways:
+        # 1. The entity's +coordinates+ and +city+ attributes are arrays in
+        # matching order, so that a city is only included if its index is in
+        # the +city+ array at the same position as the hex in the +coordinates+
+        # array.
+        # 2. Where a home hex only has plain track then a dummy node is created
+        # to allow routes to be traced out from this hex.
+        def home_hex_nodes(entity)
+          nodes = {}
+          hexes = Array(entity.coordinates).map { |h| @game.hex_by_id(h) }
+          cities = Array(entity.city)
+          hexes.zip(cities).each do |hex, city_idx|
+            if city_idx
+              nodes[hex.tile.cities[city_idx]] = true
+            elsif hex.tile.city_towns.any?
+              hex.tile.city_towns.each { |ct| nodes[ct] = true }
+            else
+              # Plain track in a home hex (or no tile or track). Create a
+              # node for each track path to allow routes to be traced out
+              # from this hex.
+              hex.tile.paths.each { |path| nodes[G1858::Part::PathNode.new(path)] = true }
+            end
+          end
+          nodes
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858/path_node.rb
+++ b/lib/engine/game/g_1858/path_node.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../../part/node'
+
+module Engine
+  module Game
+    module G1858
+      module Part
+        # This class exists to allow an Engine::Part:Path to be converted to an
+        # Engine::Part::Node. This is needed for tracing routes out from plain
+        # track segments on tiles in private company home hexes, if there are
+        # no existing nodes connected to the path.
+        class PathNode < Engine::Part::Node
+          def initialize(path)
+            @path = path
+          end
+
+          def paths
+            [@path]
+          end
+
+          def inspect
+            "<#{self.class.name}: hex: #{@path.hex.coordinates}, " \
+              "exits: #{@path.exits.join(',')}, track: #{@path.track}>"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -110,8 +110,8 @@ module Engine
           def hex_neighbors(entity, hex)
             hexes_broad = @game.graph_broad.connected_hexes(entity)[hex]
             hexes_metre = @game.graph_metre.connected_hexes(entity)[hex]
-            hexes = [hexes_broad, hexes_metre].compact.inject([], :|)
-            hexes if hexes.any?
+            hexes = [*hexes_broad, *hexes_metre].uniq
+            hexes unless hexes.empty?
           end
 
           def check_track_restrictions!(entity, old_tile, new_tile)

--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G1858
+      module Step
+        class Track < Engine::Step::Track
+          def actions(entity)
+            return [] unless entity == current_entity
+            return [] if !entity.minor? && !entity.corporation?
+            return [] unless can_lay_tile?(entity)
+
+            ACTIONS
+          end
+
+          def round_state
+            # An extra field to track whether each tile lay only adds narrow gauge track.
+            super.merge({ gauges_added: [] })
+          end
+
+          def setup
+            super
+            @round.gauges_added = []
+          end
+
+          def new_track_gauge(old_tile, new_tile)
+            old_track = old_tile.paths.map(&:track)
+            new_track = new_tile.paths.map(&:track)
+            old_track.each { |t| new_track.slice!(new_track.index(t) || new_track.size) }
+            new_track.uniq
+          end
+
+          def lay_tile(action, extra_cost: 0, entity: nil, spender: nil)
+            old_tile = action.hex.tile
+            new_tile = action.tile
+            @round.gauges_added << new_track_gauge(old_tile, new_tile)
+
+            super
+          end
+
+          def process_lay_tile(action)
+            entity = action.entity
+            spender = entity.minor? ? entity.owner : nil
+            lay_tile_action(action, spender: spender)
+            pass! unless can_lay_tile?(entity)
+          end
+
+          def potential_tiles(entity, hex)
+            tiles = super
+            return tiles unless @game.phase.name == '2'
+
+            # Metre gauge track is not available until phase 3.
+            tiles.reject { |tile| tile.paths.map(&:track).include?(:narrow) }
+          end
+
+          def can_lay_tile?(entity)
+            # Don't check whether the company has enough cash to pay for the tile
+            # lay as this can be paid by the company president.
+            action = get_tile_lay(entity)
+            return false unless action
+
+            # Check whether there are any hexes where track can be laid. After a
+            # couple of operating rounds many of the private railway companies
+            # will not be able to lay track, so this step (and so their entire
+            # operating turn) can be skipped if it not possible to add track.
+            hexes = (@game.graph_broad.connected_hexes(entity).keys +
+                     @game.graph_metre.connected_hexes(entity).keys).uniq
+            hexes.any? { |hex| available_hex(entity, hex) }
+          end
+
+          # If a public company does not have enough money to pay its terrain or
+          # extra tile costs then transfer money from the company's president to
+          # pay for these.
+          def subsidise_track(corporation, cost)
+            return unless corporation.corporation?
+            return unless cost.positive?
+            return unless cost > corporation.cash
+
+            president = corporation.owner
+            shortfall = cost - corporation.cash
+            if shortfall > corporation.owner.cash
+              raise GameError, "The tile lay costs #{@game.format_currency(cost)} but " \
+                               "#{corporation.name} has #{@game.format_currency(corporation.cash)} and " \
+                               "#{president.name} has #{@game.format_currency(president.cash)}"
+            end
+            @game.log << "#{president.name} contributes #{@game.format_currency(shortfall)} " \
+                         "towards the cost of #{corporation.name}'s tile lay"
+            president.spend(shortfall, corporation)
+          end
+
+          # Override the default implementation to give a better log message.
+          # This also allows a more intuitive name to be used for the method for
+          # the player contributing money for the tile, instead of abusing
+          # try_take_loan.
+          def pay_tile_cost!(entity, tile, rotation, hex, spender, cost, _extra_cost)
+            subsidise_track(spender, cost)
+            spender.spend(cost, @game.bank) if cost.positive?
+
+            message = ''
+            message += "#{spender.name} spends #{@game.format_currency(cost)} and " if cost.positive?
+            message += "#{entity.name} " if cost.zero? || (entity != spender)
+            message += "lays tile ##{tile.name}"
+            message += " with rotation #{rotation} on #{hex.name}"
+            message += " (#{tile.location_name})" unless tile.location_name.to_s.empty?
+            @log << message
+          end
+
+          def hex_neighbors(entity, hex)
+            hexes_broad = @game.graph_broad.connected_hexes(entity)[hex]
+            hexes_metre = @game.graph_metre.connected_hexes(entity)[hex]
+            hexes = [hexes_broad, hexes_metre].compact.inject([], :|)
+            hexes if hexes.any?
+          end
+
+          def check_track_restrictions!(entity, old_tile, new_tile)
+            return if @game.loading || !entity.operator?
+
+            raise GameError, 'New track must override old one' if !@game.class::ALLOW_REMOVING_TOWNS &&
+                old_tile.city_towns.any? do |old_city|
+                  new_tile.city_towns.none? { |new_city| (old_city.exits - new_city.exits).empty? }
+                end
+
+            # Need to check twice whether this tile is OK, once using routes along
+            # broad/dual gauge track, and once allow metre/dual gauge.
+            if !valid_tile_lay?(entity, old_tile, new_tile, @game.graph_broad) &&
+                !valid_tile_lay?(entity, old_tile, new_tile, @game.graph_metre)
+              # # The check for private railways home hexes is needed in case a private
+              # # builds plain track that's not connected to a revenue centre, it will
+              # # not be classed as a connected path.
+              # XXX Is this still needed after the graphing changes? XXX
+              # && !(entity.minor? && entity.home_hex?(new_tile.hex))
+              raise GameError, 'Must use new track or change city value'
+            end
+          end
+
+          def valid_tile_lay?(entity, old_tile, new_tile, graph)
+            return false unless graph.connected_hexes(entity).include?(new_tile.hex)
+
+            old_paths = old_tile.paths
+            changed_city = false
+            used_new_track = false
+
+            new_tile.paths.each do |np|
+              next unless graph.connected_paths(entity)[np]
+
+              op = old_paths.find { |path| np <= path }
+              used_new_track = true unless op
+              old_revenues = op&.nodes && op.nodes.map(&:max_revenue).sort
+              new_revenues = np&.nodes && np.nodes.map(&:max_revenue).sort
+              changed_city = true unless old_revenues == new_revenues
+            end
+
+            used_new_track || changed_city
+          end
+
+          # Finds whether track lays in a hex are blocked by a private company.
+          # Some hexes are blocked by two private companies. In this case either
+          # one can lay track in the hex.
+          def ability_blocking_hex(operator, hex)
+            return false unless hex.tile.color == :white # Upgrades are never blocked.
+
+            privates = (@game.companies + @game.minors).reject(&:closed?)
+            blocking_abilities = privates.map do |entity|
+              ability = @game.abilities(entity, :blocks_hexes)
+              next unless ability
+
+              ability if @game.hex_blocked_by_ability?(operator, ability, hex)
+            end.compact
+            return false unless blocking_abilities.any?
+
+            # This hex is blocked by something. Check if this can be ignored.
+            blocking_abilities.none? do |ability|
+              blocker = ability.owner
+              (operator == blocker) || (operator == blocker.owner)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -126,12 +126,8 @@ module Engine
             # broad/dual gauge track, and once allow metre/dual gauge.
             if !valid_tile_lay?(entity, old_tile, new_tile, @game.graph_broad) &&
                 !valid_tile_lay?(entity, old_tile, new_tile, @game.graph_metre)
-              # # The check for private railways home hexes is needed in case a private
-              # # builds plain track that's not connected to a revenue centre, it will
-              # # not be classed as a connected path.
-              # XXX Is this still needed after the graphing changes? XXX
-              # && !(entity.minor? && entity.home_hex?(new_tile.hex))
-              raise GameError, 'Must use new track or change city value'
+              raise GameError, 'Must have a broad gauge or metre gauge route ' \
+                               'to new track, or upgrade a city'
             end
           end
 


### PR DESCRIPTION
This adds the overall structure of the operating round for 1858, and the code for laying track. 1858 has several differences from other games which have had to be implemented here.

### Broad gauge and narrow gauge routes

Routes for laying track (and placing tokens and running trains) start at a token (or a home hex for a minor) and are traced on either broad/dual gauge track or narrow/dual gauge track. Routes cannot include both narrow and broad gauge track. This is implemented by having two graph objects created, with `skip_track: :narrow` and `skip_track: :broad`. Various methods in the track step check both of these graphs to see if a tile placement is valid on either of them.

### Discounts for narrow gauge track

Terrain costs are halved for yellow narrow gauge tiles. Also the Pt20 cost of a second tile is halved if either the first or the second tile is only adding narrow gauge track. `gauges_added` is included in the round state to record the type of tracks that are added by each tile placement so this can be tracked.

### Private railway home hexes and routes

Private railway companies are implemented using linked company and minor entities. The minors lay track in an operating round and skip all other steps. When laying track they can only place yellow tiles and must be able to trace a route back to on of their home hexes. A subclass of Graph is used to trace routes from home hexes, the default implementation of this class does not work when there is plain track in a home hex that is not connected to a node. A PathNode class is created for this, it pretends that there is a node in these plain track segments so that `Node.walk` can start at these locations.

### Stubs in private railway home hexes

Stubs are used to force yellow tiles to be laid along the routes of the private railways. These are created at the start of the game by the `setup_stubs` method. A `clear_stubs` method is included in this pull request, though nothing here invokes that method. It will be called when a private is acquired by a corporation or it closes.

### Two abilities blocking the same hex

Privates have `blocks_hex` abilities to stop other people from laying track in their home hexes. A few hexes on the map are the home hexes for two private companies, in this case either minor (or a corporation that ones one of the privates) can lay track in the hex. The code in `ability_blocking_hex` allows this to happen.

### President can pay for track

If a corporation or minor cannot afford the cost of a tile lay this will be paid by the president.
