### PR TITLE
Fix terrain costs in 1889, partial rollback of #8679

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1531,7 +1531,7 @@ module Engine
         end
 
         tile.upgrades.sum do |upgrade|
-          discount = ability && upgrade.terrains.include?(ability.terrain) ? ability.discount : 0
+          discount = ability && upgrade.terrains.uniq == [ability.terrain] ? ability.discount : 0
 
           log_cost_discount(spender, ability, discount)
 


### PR DESCRIPTION
In 1889, the SMR private gives a discount of ¥80 to mountain terrain, only if there is no river terrain.

Some other approach will be needed for SMR to continue to work properly while allowing 1880's P4 to also work

Fixes #8744
Reverts one change from #8679 

---

This will fix 1889 but break any 1880 games relying on #8679's terrain ability change.