### PR TITLE
Add test to check for typos in tile colours

### DIFF
--- a/spec/lib/engine/games/config_spec.rb
+++ b/spec/lib/engine/games/config_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require './spec/spec_helper'
+require './lib/engine/config/tile'
 
 require 'json'
 
 module Engine
+  include Engine::Config::Tile
+  tile_colors = COLORS
   players = ('a'..'z')
 
   Engine::GAME_METAS.each do |game_meta|
@@ -57,6 +60,13 @@ module Engine
         end
         dups = counts.select { |_, count| count > 1 }.keys
         expect(dups).to eq([])
+      end
+
+      it 'tile colors are in COLORS' do
+        game = Engine.game_by_title(game_meta.title).new(max_players, id: 1)
+        game.tiles.each do |tile|
+          expect(tile_colors).to include(tile.color), "Tile #{tile.id}"
+        end
       end
     end
   end

--- a/spec/lib/engine/games/config_spec.rb
+++ b/spec/lib/engine/games/config_spec.rb
@@ -6,8 +6,6 @@ require './lib/engine/config/tile'
 require 'json'
 
 module Engine
-  include Engine::Config::Tile
-  tile_colors = COLORS
   players = ('a'..'z')
 
   Engine::GAME_METAS.each do |game_meta|
@@ -65,7 +63,7 @@ module Engine
       it 'tile colors are in COLORS' do
         game = Engine.game_by_title(game_meta.title).new(max_players, id: 1)
         game.tiles.each do |tile|
-          expect(tile_colors).to include(tile.color), "Tile #{tile.id}"
+          expect(Engine::Config::Tile::COLORS).to include(tile.color), "Tile #{tile.id}"
         end
       end
     end


### PR DESCRIPTION
1822PNW was broken by issue #tobymao/18xx#8732. This was caused by a typo in the colour name part of a tile definition. This adds a rspec test to catch mistakes like this, which are easily made by those of us who think that 'grey' is the correct spelling. It checks that all colour names are part of the Engine::Config::Tile.COLORS list.