### PR TITLE
[1880] fix edge case 4t rocket

### DIFF
--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -742,7 +742,7 @@ module Engine
         def after_buying_train(train, source)
           return unless trigger_sr?(train, source)
 
-          if special_edge_case_4t_rocket?(train.name) && @depot.upcoming.first.name != train.name
+          if train_name == '4' && !rocket.closed? && @depot.upcoming.first.name != train.name
             @rocket_train = train
             return
           end
@@ -789,10 +789,6 @@ module Engine
 
         def can_cross_buy?
           @can_cross_buy
-        end
-
-        def special_edge_case_4t_rocket?(train_name)
-          train_name == '4' && !rocket.closed?
         end
       end
     end

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -18,7 +18,7 @@ module Engine
 
         attr_accessor :train_marker
         attr_reader :full_cap_event, :communism, :end_game_triggered, :saved_or_round, :final_operating_rounds,
-                    :foreign_investors_operate
+                    :foreign_investors_operate, :rocket_train
 
         TRACK_RESTRICTION = :permissive
         TILE_RESERVATION_BLOCKS_OTHERS = :yellow_only
@@ -742,6 +742,11 @@ module Engine
         def after_buying_train(train, source)
           return unless trigger_sr?(train, source)
 
+          if special_edge_case_4t_rocket?(train.name) && @depot.upcoming.first.name != train.name
+            @rocket_train = train
+            return
+          end
+
           @sr_triggered = true
           transition_to_next_round!
         end
@@ -784,6 +789,10 @@ module Engine
 
         def can_cross_buy?
           @can_cross_buy
+        end
+
+        def special_edge_case_4t_rocket?(train_name)
+          train_name == '4' && !rocket.closed?
         end
       end
     end

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -742,7 +742,7 @@ module Engine
         def after_buying_train(train, source)
           return unless trigger_sr?(train, source)
 
-          if train_name == '4' && !rocket.closed? && @depot.upcoming.first.name != train.name
+          if train.name == '4' && !rocket.closed? && @depot.upcoming.first.name != train.name
             @rocket_train = train
             return
           end

--- a/lib/engine/game/g_1880/step/assign.rb
+++ b/lib/engine/game/g_1880/step/assign.rb
@@ -69,14 +69,13 @@ module Engine
 
           def process_assign_rocket(action)
             buying_corp = action.target
-            train = @game.depot.upcoming.first
+            train = @game.rocket_train || @game.depot.upcoming.first
             @log << "#{buying_corp.name} exchanges the #{@game.rocket.name} for a #{train.name} train"
 
             @game.rocket.close!
             @game.buy_train(buying_corp, train, :free)
-            @game.phase.buying_train!(buying_corp, train)
-            @game.depot.export_all!(train.name, silent: true) if @round.special_edge_case_4t_rocket
-            @round.special_edge_case_4t_rocket = false
+            @game.phase.buying_train!(buying_corp, train, @game.depot)
+            @game.depot.export_all!(train.name, silent: true)
           end
         end
       end

--- a/lib/engine/game/g_1880/step/assign.rb
+++ b/lib/engine/game/g_1880/step/assign.rb
@@ -11,7 +11,8 @@ module Engine
           def actions(entity)
             return [] if entity.player?
             return [] unless @game.abilities(entity, :assign_corporation)
-            return [] if current_entity.minor? || (entity == @game.p5 && current_entity.building_permits&.include?('D'))
+            return [] if current_entity.minor? ||
+                        (entity == @game.p5 && current_entity.corporation? && current_entity.building_permits&.include?('D'))
 
             return ACTIONS if @game.forced_exchange_rocket? && entity == @game.rocket
             return ACTIONS_WITH_PASS if p5_block? && current_entity.owner == @game.p5.owner
@@ -74,6 +75,8 @@ module Engine
             @game.rocket.close!
             @game.buy_train(buying_corp, train, :free)
             @game.phase.buying_train!(buying_corp, train)
+            @game.depot.export_all!(train.name, silent: true) if @round.special_edge_case_4t_rocket
+            @round.special_edge_case_4t_rocket = false
           end
         end
       end

--- a/lib/engine/game/g_1880/step/assign.rb
+++ b/lib/engine/game/g_1880/step/assign.rb
@@ -75,7 +75,6 @@ module Engine
             @game.rocket.close!
             @game.buy_train(buying_corp, train, :free)
             @game.phase.buying_train!(buying_corp, train, @game.depot)
-            @game.depot.export_all!(train.name, silent: true)
           end
         end
       end

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -35,9 +35,7 @@ module Engine
 
           def round_state
             super.merge(
-            {
-              bought_trains: false,
-            }
+            { bought_trains: false }
           )
           end
 

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -35,7 +35,10 @@ module Engine
 
           def round_state
             super.merge(
-            { bought_trains: false }
+            {
+              bought_trains: false,
+              special_edge_case_4t_rocket: false,
+            }
           )
           end
 
@@ -55,7 +58,14 @@ module Engine
           def discard_all_trains(train_name)
             @game.log << "#{train_name} has not been bought for a full operating order, "\
                          "removing all remaining #{train_name} trains"
-            @game.depot.export_all!(train_name, silent: true)
+            return @game.depot.export_all!(train_name, silent: true) unless special_edge_case_4t_rocket?(train_name)
+
+            @game.depot.export!(train_name, silent: true)
+            @round.special_edge_case_4t_rocket = true
+          end
+
+          def special_edge_case_4t_rocket?(train_name)
+            train_name == '4' && !@game.rocket.closed?
           end
 
           def setup

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -37,7 +37,6 @@ module Engine
             super.merge(
             {
               bought_trains: false,
-              special_edge_case_4t_rocket: false,
             }
           )
           end
@@ -58,14 +57,7 @@ module Engine
           def discard_all_trains(train_name)
             @game.log << "#{train_name} has not been bought for a full operating order, "\
                          "removing all remaining #{train_name} trains"
-            return @game.depot.export_all!(train_name, silent: true) unless special_edge_case_4t_rocket?(train_name)
-
-            @game.depot.export!(train_name, silent: true)
-            @round.special_edge_case_4t_rocket = true
-          end
-
-          def special_edge_case_4t_rocket?(train_name)
-            train_name == '4' && !@game.rocket.closed?
+            @game.depot.export_all!(train_name, silent: true)
           end
 
           def setup


### PR DESCRIPTION
fixes #8781

Edge case where rocket of china hasn't been used AND a full operating order passes on the 4 trains.
see here: 
https://boardgamegeek.com/thread/1042314/forced-exchange-p7-rocket-and-removal-unpurchased
"If no one buys a 4T, as you pick them up to get rid of them, when you pick the first one up, the second one zips off to the P7 owner and then all the rest go away. I'll admit this isn't clear." and "The discarding of the 4-trains is one after the other, so the Rocket of China will be exchanged into the second 4-train in case of all 4-trains are discarded.
Lonny"

fixes #8803 as well. @game.phase.buying_train! has 3 params but the code was only passing 2.