### PR TITLE
validation: Catch all errors in `process_action`

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -748,6 +748,9 @@ module Engine
         @last_processed_action = action.id
 
         self
+      rescue StandardError => e
+        rescue_exception(e, action)
+        self
       end
 
       def process_single_action(action)
@@ -774,6 +777,10 @@ module Engine
           end
         end
       rescue Engine::GameError => e
+        rescue_exception(e, action)
+      end
+
+      def rescue_exception(e, action)
         @raw_actions.pop
         @actions.pop
         @exception = e

--- a/spec/lib/engine/games/g_18_zoo_spec.rb
+++ b/spec/lib/engine/games/g_18_zoo_spec.rb
@@ -26,7 +26,7 @@ module Engine
     shared_examples 'power not implemented' do
       it 'cannot be purchased yet' do
         expect do
-          first_player_buy_power_on_isr(power)
+          first_player_buy_power_on_isr(power).maybe_raise!
         end.to raise_error(Engine::GameError, 'Power logic not yet implemented')
       end
     end
@@ -546,7 +546,7 @@ module Engine
               ],
             }
             expect do
-              game.process_action(action)
+              game.process_action(action).maybe_raise!
             end.to raise_error(Engine::GameError, 'Only one train can use "A tip of sugar"')
           end
         end
@@ -582,7 +582,7 @@ module Engine
               ],
             }
             expect do
-              game.process_action(action)
+              game.process_action(action).maybe_raise!
             end.to raise_error(Engine::GameError, 'Only one train can bypass a tokened-out city')
           end
         end
@@ -608,7 +608,7 @@ module Engine
               ],
             }
             expect do
-              game.process_action(action)
+              game.process_action(action).maybe_raise!
             end.to raise_error(Engine::GameError,
                                'City with only \'Work in progress\' slot cannot be bypassed')
           end
@@ -641,7 +641,7 @@ module Engine
               ],
             }
             expect do
-              game.process_action(action)
+              game.process_action(action).maybe_raise!
             end.to raise_error(Engine::GameError, 'Route can only bypass one tokened-out city')
           end
         end
@@ -677,7 +677,7 @@ module Engine
               ],
             }
             expect do
-              game.process_action(action)
+              game.process_action(action).maybe_raise!
             end.to raise_error(Engine::GameError, 'Only one train can bypass a tokened-out city')
           end
         end
@@ -703,7 +703,7 @@ module Engine
               ],
             }
             expect do
-              game.process_action(action)
+              game.process_action(action).maybe_raise!
             end.to raise_error(Engine::GameError,
                                'City with only \'Work in progress\' slot cannot be bypassed')
           end
@@ -724,7 +724,7 @@ module Engine
               'tile' => '9-0',
               'rotation' => 1,
             }
-            expect { game.process_action(action) }.to raise_error(TypeError)
+            expect { game.process_action(action).maybe_raise! }.to raise_error(TypeError)
           end
         end
       end


### PR DESCRIPTION
In `validate.rb`'s `run_game()` function, the game engine is loaded outside of the `begin`/`rescue` block, before calling `maybe_raise!` inside the block, so that an error in the game state can be caught without crashing the whole program.

The changes in the recent PRs #8735, #8756, and #8787 all changed/removed certain game objects like trains and tiles. This caused the game engine to error out when in `process_action` when converting the action to a hash (for example, the 1852: Missouri change removed some trains from the roster, so actions using the removed trains tried calling `@train.id` where `@train` was `nil`) before `process_single_action` was called.

That made the `validate.rb` functions impossible to use to identify which games to archive; the `NoMethodError` on the `nil` train crashed the whole thing.

An alternative change in `run_game()` would be to move the game load into the `begin`/`rescue` block, but when the other kinds of errors are raised, the `engine` ends up being `nil`, causing the code in the `rescue` block to just raise further errors.


https://github.com/tobymao/18xx/blob/94ac0bbc49a3de286a9d74e6b3cb51249ec017ef/validate.rb#L22-L39