### PR TITLE
[1868WY] Issuing/Redeeming Shares and EMR

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -14,6 +14,7 @@ require_relative 'step/development_token'
 require_relative 'step/dividend'
 require_relative 'step/double_share_protection'
 require_relative 'step/home_token'
+require_relative 'step/issue_shares'
 require_relative 'step/manual_close_company'
 require_relative 'step/route'
 require_relative 'step/stock_round_action'
@@ -228,6 +229,7 @@ module Engine
             G1868WY::Step::BuyCompany,
             G1868WY::Step::ManualCloseCompany,
             G1868WY::Step::Choose,
+            G1868WY::Step::IssueShares,
             G1868WY::Step::Track,
             G1868WY::Step::Token,
             G1868WY::Step::DoubleHeadTrains,
@@ -769,6 +771,32 @@ module Engine
 
         def player_value(player)
           player.value - player.companies.sum(&:value)
+        end
+
+        def issuable_shares(entity, previously_issued = 0)
+          return [] unless entity.corporation?
+          return [] unless round.steps.find { |step| step.instance_of?(G1868WY::Step::IssueShares) }.active?
+
+          max_size = @phase.name.to_i - (previously_issued || @round.issued)
+
+          bundles_for_corporation(entity, entity).select do |bundle|
+            @share_pool&.fit_in_bank?(bundle) && bundle.num_shares <= max_size && bundle.shares.all?(&:buyable)
+          end
+        end
+
+        def redeemable_shares(entity)
+          return [] unless entity.corporation?
+          return [] unless round.steps.find { |step| step.instance_of?(G1868WY::Step::IssueShares) }.active?
+
+          bundles = bundles_for_corporation(share_pool, entity)
+
+          if entity == union_pacific
+            bundles.reject! { |bundle| (entity.cash < bundle.price) || bundle.shares.find { |s| s.id == UP_DOUBLE_SHARE } }
+          else
+            bundles.reject! { |bundle| entity.cash < bundle.price }
+          end
+
+          bundles
         end
 
         def sellable_bundles(player, corporation)

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -799,6 +799,21 @@ module Engine
           bundles
         end
 
+        def total_emr_buying_power(player, corporation)
+          emergency = (issuable = emergency_issuable_cash(corporation)).zero?
+          corporation.cash + issuable + liquidity(player, emergency: emergency)
+        end
+
+        def emergency_issuable_bundles(corp)
+          return [] if corp.trains.any?
+
+          train = @depot.min_depot_train
+          _min_train_price, max_train_price = train.variants.map { |_, v| v[:price] }.minmax
+          return [] if corp.cash >= max_train_price
+
+          issuable_shares(corp)
+        end
+
         def sellable_bundles(player, corporation)
           bundles = super
 

--- a/lib/engine/game/g_1868_wy/step/buy_train.rb
+++ b/lib/engine/game/g_1868_wy/step/buy_train.rb
@@ -16,6 +16,27 @@ module Engine
             super.concat(choice_actions(entity, cannot_pass: entity.corporation? && must_buy_train?(entity)))
           end
 
+          def issue_text(_entity)
+            'Issue'
+          end
+
+          def buyable_train_variants(train, entity)
+            variants = super
+
+            return variants if variants.size < 2
+
+            min, max = variants.sort_by { |v| v[:price] }
+            return [min] if (min[:price] <= entity.cash) && (entity.cash < max[:price])
+
+            if (last_cash_raised = @last_share_sold_price)
+              must_spend = entity.cash - last_cash_raised + 1
+              must_spend += entity.owner.cash if @last_share_sold_price
+              variants.reject! { |v| v[:price] < must_spend }
+            end
+
+            variants
+          end
+
           def process_choose(action)
             process_choose_big_boy(action)
           end

--- a/lib/engine/game/g_1868_wy/step/issue_shares.rb
+++ b/lib/engine/game/g_1868_wy/step/issue_shares.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/issue_shares'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class IssueShares < Engine::Step::IssueShares
+          def round_state
+            {
+              issued: 0,
+            }
+          end
+
+          def setup
+            @round.issued = 0
+            @redeemed = false
+          end
+
+          def issue_text(_entity)
+            'Issue'
+          end
+
+          def issuable_shares(entity)
+            @redeemed ? [] : @game.issuable_shares(entity, @round.issued)
+          end
+
+          def redeemable_shares(entity)
+            @round.issued.positive? || entity.trains.empty? ? [] : @game.redeemable_shares(entity)
+          end
+
+          def blocks?
+            false
+          end
+
+          def process_sell_shares(action)
+            bundle = action.bundle
+
+            @game.sell_shares_and_change_price(bundle)
+            @round.issued += bundle.num_shares
+          end
+
+          def process_buy_shares(action)
+            @game.share_pool.buy_shares(action.entity, action.bundle)
+            @redeemed = true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* railroads can issue xor redeem shares any time during the OR turn
* can issue up to the phase number (ie issue only 2 shares in phase 2)
* can only redeem if owns a train
* during EMR, must first issue shares, ignoring phase limit; president may go for more expensive train variant