### PR TITLE
[1858] Stock round: auctions, buying and selling shares

### DIFF
--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -221,7 +221,6 @@ module Engine
           minors.sort_by { |m| PRIVATE_ORDER[m.id] } + corporations.sort_by(&:name)
         end
 
-
         def payout_companies
           return if private_closure_round == :in_progress
 

--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares_via_bid'
+
+module Engine
+  module Game
+    module G1858
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParSharesViaBid
+          # Buy actions that will end a player's turn in the stock round.
+          PURCHASE_ACTIONS = [Action::Bid, Action::BuyShares, Action::Par].freeze
+
+          def actions(entity)
+            return [] unless entity == current_entity
+            return %w[bid pass] if @auctioning
+            return ['sell_shares'] if must_sell?(entity)
+            return [] if bought?
+
+            actions = []
+
+            # Sell actions.
+            # Exchanging a private company for a share certificate from the
+            # company treasury is also a sell action, but this is handled
+            # through the companies' abilities rather than these actions.
+            actions << 'sell_shares' if can_sell_any?(entity)
+
+            # Buy actions.
+            # Starting a public company by exchanging a private company for the
+            # president's certificate is also a buy action, but this is handled
+            # through the companies' abilities rather than these actions.
+            actions << 'buy_shares' if can_buy_any?(entity) || can_exchange_any?(entity)
+            actions << 'par' if can_ipo_any?(entity)
+            actions << 'bid' if can_bid_any?(entity)
+
+            actions << 'pass' unless actions.empty?
+
+            actions
+          end
+
+          def pass_description
+            if @auctioning
+              "Pass (on #{auctioning.id})"
+            elsif @round.current_actions.empty?
+              'Pass'
+            else
+              'Done'
+            end
+          end
+
+          def bank_first?
+            true # Show bank owned private companies before public companies
+          end
+
+          def process_par(action)
+            super
+            pass!
+          end
+
+          def can_ipo_any?(entity)
+            # Can't start a public company by directly buying its president's
+            # certificate until the start of phase 5.
+            super && @game.phase.status.include?('public_companies')
+          end
+
+          def min_bid(company)
+            if @auctioning
+              highest_bid(company).price + min_increment
+            else
+              company.min_bid
+            end
+          end
+
+          def max_bid(player, _company)
+            return 0 unless @game.num_certs(player) < @game.cert_limit
+
+            player.cash
+          end
+
+          def win_bid(winner, _company)
+            player = winner.entity
+            company = winner.company
+            price = winner.price
+
+            @log << "#{player.name} wins bid on #{company.name} for #{@game.format_currency(price)}"
+            @game.purchase_company(player, company, price)
+            @auctioning = nil
+
+            # Player to the right of the person who started the auction is next to go.
+            @acted = false
+            @round.next_entity_index!
+          end
+
+          def auctionable_companies
+            @game.buyable_bank_owned_companies
+          end
+
+          def can_bid_any?(player)
+            auctionable_companies.any? { |company| can_bid_company?(player, company) }
+          end
+
+          def can_bid_company?(player, company)
+            (@auctioning.nil? || @auctioning == company) &&
+            auctionable_companies.include?(company) &&
+              (min_bid(company) <= player.cash)
+          end
+
+          def log_skip(entity)
+            super unless @round.current_actions.any?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -28,7 +28,7 @@ module Engine
             # Starting a public company by exchanging a private company for the
             # president's certificate is also a buy action, but this is handled
             # through the companies' abilities rather than these actions.
-            actions << 'buy_shares' if can_buy_any?(entity) || can_exchange_any?(entity)
+            actions << 'buy_shares' if can_buy_any?(entity)
             actions << 'par' if can_ipo_any?(entity)
             actions << 'bid' if can_bid_any?(entity)
 

--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -99,13 +99,13 @@ module Engine
           end
 
           def can_bid_company?(player, company)
-            (@auctioning.nil? || @auctioning == company) &&
-            auctionable_companies.include?(company) &&
+            (!@auctioning || @auctioning == company) &&
+              auctionable_companies.include?(company) &&
               (min_bid(company) <= player.cash)
           end
 
           def log_skip(entity)
-            super unless @round.current_actions.any?
+            super if @round.current_actions.empty?
           end
         end
       end


### PR DESCRIPTION
This is the start of the stock round implementation for 1858. Buying and selling shares is fairly normal, the main difference being that you can't directly par a corporation before phase 5. Before that point corporations can only be started by exchanging a private railway company, this is to be added in a later commit.

In a stock round you can also put up a private company for auction. Everyone gets a chance to bid on this company, until only one person is left. This is implemented using the Engine::Step::BuySellParSharesViaBid code from 1861/1867.