### PR TITLE
1852:MO E-train bug fix + more playtest updates

### DIFF
--- a/lib/engine/game/g_18_mo/entities.rb
+++ b/lib/engine/game/g_18_mo/entities.rb
@@ -55,7 +55,7 @@ module Engine
            name: 'Extra Yellow Tile',
            value: 40,
            revenue: 15,
-           desc: 'Lay an extra yellow tile for free one time.',
+           desc: 'Owning corporation my lay an extra yellow tile for free (including free terrain) one time.',
            sym: 'EXY',
            abilities: [{
              type: 'tile_lay',
@@ -74,7 +74,8 @@ module Engine
            name: 'Extra Green Tile',
            value: 40,
            revenue: 15,
-           desc: 'May lay an extra green tile on a connected (non-StL) city for free (including terrain) one time.',
+           desc: 'Owning corporation may upgrade an extra green tile on a connected (non-StL) city for free '\
+                 '(including free terrain) one time.',
            sym: 'EXG',
            color: nil,
            abilities: [{
@@ -116,15 +117,16 @@ module Engine
            }],
          },
          {
-           name: 'Tunnel Blasting Company',
+           name: 'Missouri River Bridge Company',
            value: 40,
            revenue: 10,
-           desc: 'Reduces, for the owning corporation, the cost of laying all mountain tiles by $20.',
+           desc: 'Reduces, for the owning corporation, the cost of laying or upgrading a tile that incurs river terrain '\
+                 'cost by $20 (hexside or printed hex cost).',
            sym: 'TBC',
            abilities: [{
              type: 'tile_discount',
              discount: 20,
-             terrain: 'mountain',
+             terrain: 'water',
              owner_type: 'corporation',
            }],
            color: nil,
@@ -170,10 +172,10 @@ module Engine
            name: 'Mountain Construction Company',
            value: 60,
            revenue: 0,
-           desc: 'Owner receives $20 whenever a tile is laid on a mountain hex. Never closes.',
+           desc: 'Owner receives $40 whenever a tile is laid on a mountain hex. Never closes.',
            sym: 'MCC',
            abilities: [
-                      { type: 'tile_income', income: 20, terrain: 'mountain' },
+                      { type: 'tile_income', income: 40, terrain: 'mountain' },
                       { type: 'close', on_phase: 'never', owner_type: 'corporation' },
         ],
            color: nil,
@@ -192,12 +194,12 @@ module Engine
             abilities: [
               {
                 type: 'token',
-                description: 'Token Quincy (H4) for $40/$60.',
-                desc_detail: 'May place token in Quincy (H4) for $40 if connected, $60 otherwise.',
+                description: 'Token Quincy (H4) for $40/$80.',
+                desc_detail: 'May place token in Quincy (H4) for $40 if connected, $80 otherwise.',
                 hexes: ['H4'],
                 price: 40,
                 count: 1,
-                teleport_price: 60,
+                teleport_price: 80,
               },
             ],
             coordinates: 'A7',
@@ -238,12 +240,12 @@ module Engine
             abilities: [
               {
                 type: 'token',
-                description: 'Token Sedalia (E9) for $40/$60.',
-                desc_detail: 'May place token in Sedalia (E9) for $40 if connected, $60 otherwise.',
+                description: 'Token Sedalia (E9) for $40/$80.',
+                desc_detail: 'May place token in Sedalia (E9) for $40 if connected, $80 otherwise.',
                 hexes: ['E9'],
                 price: 40,
                 count: 1,
-                teleport_price: 60,
+                teleport_price: 80,
               },
             ],
             coordinates: 'C13',
@@ -261,12 +263,12 @@ module Engine
             abilities: [
               {
                 type: 'token',
-                description: 'Token Pleasant Hill (D8) for $40/$60.',
-                desc_detail: 'May place token in Pleasant Hill (D8) for $40 if connected, $60 otherwise.',
+                description: 'Token Pleasant Hill (D8) for $40/$80.',
+                desc_detail: 'May place token in Pleasant Hill (D8) for $40 if connected, $80 otherwise.',
                 hexes: ['D8'],
                 price: 40,
                 count: 1,
-                teleport_price: 60,
+                teleport_price: 80,
               },
             ],
             coordinates: 'J8',

--- a/lib/engine/game/g_18_mo/game.rb
+++ b/lib/engine/game/g_18_mo/game.rb
@@ -72,7 +72,6 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
             price: 100,
             obsolete_on: '3E',
-            rusts_on: '7',
             variants: [
               {
                 name: 'Y3',
@@ -93,7 +92,7 @@ module Engine
                 name: 'G4',
                 distance: [{ 'nodes' => %w[city offboard], 'pay' => 4, 'visit' => 4 },
                            { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
-                price: 240,
+                price: 220,
               },
             ],
           },
@@ -373,8 +372,8 @@ module Engine
           # There should only be one dit_stop at most
           normal_stops, dit_stops = visits.partition { |node| paying_distance['nodes'].include?(node.type) }
 
-          # if no dit stops
-          return visits if dit_stops.empty?
+          # if no dit stops (or E-train)
+          return super if dit_stops.empty?
 
           # return if not enough normal stops
           return visits if normal_stops.size < paying_distance['pay']

--- a/lib/engine/game/g_18_mo/map.rb
+++ b/lib/engine/game/g_18_mo/map.rb
@@ -173,8 +173,7 @@ module Engine
             ['A15'] => 'offboard=revenue:yellow_30|brown_60,groups:W;icon=image:1846/30;path=a:4,b:_0;label=W;',
             ['E1'] => 'offboard=revenue:yellow_20|brown_50;path=a:0,b:_0',
             ['E17'] => 'offboard=revenue:yellow_20|brown_50;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
-            ['J2'] => 'offboard=revenue:yellow_30|brown_40,groups:E;icon=image:1846/50;path=a:0,b:_0;label=E',
-            ['K3'] => 'offboard=revenue:yellow_30|brown_40,groups:E;icon=image:1846/50;path=a:0,b:_0;path=a:1,b:_0;label=E',
+            %w[J2 K3] => 'offboard=revenue:yellow_30|brown_40,groups:E;icon=image:1846/50;path=a:0,b:_0;path=a:1,b:_0;label=E',
             ['K17'] => 'offboard=revenue:yellow_30|brown_60,groups:E;icon=image:1846/30;path=a:2,b:_0;label=E',
 
           },


### PR DESCRIPTION
Fixes #8820 

Playtest updates (from Scott):

- Aurora (J2) should have the same definition as Joliet (K3).
- Change the private company Mountain Construction Company to $40 rebate instead of $20.
   - Change description to
     - Owner receives $40 whenever a yellow tile is laid on a mountain hex by any entity. Never closes.
- Remove hard rust of yellow trains
   - This is not really important, it just never is a factor in this game
- Change the Tunnel Blasting Company to "Missouri River Bridge Company". 
   - Change tile_discount from mountain to water
   - New text is "Reduces, for the owning corporation, the cost of laying or upgrading a tile that incurs river terrain cost by $20 (hexside or printed hex cost).
- All destination costs are 80. Change teleport_price and descriptions for ATSF, MKT, MP.
- Update private text:
   - Extra Green Tile
      - desc: 'Owning corporation may upgrade an extra green tile on a connected (non-StL) city for free (including free terrain) one time.',
   - Extra Yellow Tile
      -  desc: 'Owning corporation may lay an extra yellow tile for free (including free terrain) one time.',