### PR TITLE
[18VA] show 40% to float, Must buy set to always

### DIFF
--- a/lib/engine/game/g_18_va/game.rb
+++ b/lib/engine/game/g_18_va/game.rb
@@ -396,7 +396,7 @@ module Engine
             reservation_color: nil,
           },
           {
-            float_percent: 20,
+            float_percent: 40,
             sym: 'C&O',
             name: 'Chesapeake & Ohio Railway',
             logo: '18_va/CO',
@@ -411,7 +411,7 @@ module Engine
             reservation_color: nil,
           },
           {
-            float_percent: 20,
+            float_percent: 40,
             sym: 'SR',
             name: 'Southern Railway',
             logo: '18_va/SR',
@@ -426,7 +426,7 @@ module Engine
             reservation_color: nil,
           },
           {
-            float_percent: 20,
+            float_percent: 40,
             sym: 'N&W',
             name: 'Norfolk & Western Railway',
             logo: '18_va/NW',
@@ -441,7 +441,7 @@ module Engine
             reservation_color: nil,
           },
           {
-            float_percent: 20,
+            float_percent: 40,
             sym: 'WMR',
             name: 'Western Maryland Railway',
             logo: '18_va/WMR',
@@ -455,7 +455,7 @@ module Engine
             reservation_color: nil,
           },
           {
-            float_percent: 20,
+            float_percent: 40,
             sym: 'RFPR',
             name: 'Richmond, Fredericksburg & Potomac Railroad',
             logo: '18_va/RFPR',
@@ -469,7 +469,7 @@ module Engine
             reservation_color: nil,
           },
           {
-            float_percent: 20,
+            float_percent: 40,
             sym: 'VR',
             name: 'Virginian Railway',
             logo: '18_va/VR',
@@ -815,6 +815,7 @@ module Engine
             shares[0].percent = 20
             new_shares = Array.new(5) { |i| Share.new(corporation, percent: 10, index: i + 4) }
             corporation.type = :ten_share
+            corporation.float_percent = 20
             2.times { corporation.tokens << Engine::Token.new(corporation, price: 100) }
           else
             raise GameError, 'Cannot convert 10 share corporation'

--- a/lib/engine/game/g_18_va/game.rb
+++ b/lib/engine/game/g_18_va/game.rb
@@ -549,6 +549,7 @@ module Engine
         RIC_HEX = 'F11'
         WAS_HEX = 'G4'
         HOME_TOKEN_TIMING = :par
+        MUST_BUY_TRAIN = :always
         SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :operate
         EBUY_OTHER_VALUE = true


### PR DESCRIPTION
Fixes #8845

This will have the 5-share corps display "40% to float", switching to "20% to float" after the first 5 train is purchased.

Edited to add: 

Fixes #8418

MUST_BUY_TRAIN set to :always, as per rule 4.6 of the 18VA rulebook