### PR TITLE
[1880] correct Tile Reservation Block

### DIFF
--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -21,7 +21,7 @@ module Engine
                     :foreign_investors_operate, :rocket_train
 
         TRACK_RESTRICTION = :permissive
-        TILE_RESERVATION_BLOCKS_OTHERS = :yellow_only
+        TILE_RESERVATION_BLOCKS_OTHERS = :always
         TILE_UPGRADES_MUST_USE_MAX_EXITS = %i[cities].freeze
         HOME_TOKEN_TIMING = :operating_round
         SELL_BUY_ORDER = :sell_buy


### PR DESCRIPTION
Fixes #8853

TILE_RESERVATION_BLOCKS_OTHERS set to :always as per rules.