### PR TITLE
[1868WY] variant: winner of P2-P6 chooses which company to take

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -206,6 +206,26 @@ module Engine
           setup_spikes
 
           @big_boy_first_chance = false
+
+          return if @optional_rules.include?(:p2_p6_choice)
+
+          removals = COMPANY_CHOICES.keys
+          COMPANY_CHOICES.each do |_, companies|
+            removals.concat(companies.sort_by { rand }.take(2))
+          end
+
+          @companies.reject! do |c|
+            next unless removals.include?(c.id)
+
+            @round.active_step.companies.delete(c)
+            c.close!
+            true
+          end
+          @log << 'Available P2-P6 companies:'
+
+          @companies.slice(1, 5).map(&:name).each do |company|
+            @log << "- #{company}"
+          end
         end
 
         def init_share_pool

--- a/lib/engine/game/g_1868_wy/meta.rb
+++ b/lib/engine/game/g_1868_wy/meta.rb
@@ -20,6 +20,16 @@ module Engine
         GAME_FULL_TITLE = '1868: Boom and Bust in the Coal Mines and Oil Fields of Wyoming'
 
         PLAYER_RANGE = [3, 5].freeze
+
+        OPTIONAL_RULES = [
+          {
+            sym: :p2_p6_choice,
+            short_name: 'P2-P6 choice',
+            desc: 'The winners of the privates P2 through P6 in the auction choose to take one of '\
+                  'the three corresponding private companies, rather than those being randomly '\
+                  'chosen during setup.',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
+++ b/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
@@ -16,8 +16,11 @@ module Engine
           def setup
             super
 
-            choice_companies = @game.class::COMPANY_CHOICES.values.flatten
-            @companies.reject! { |c| choice_companies.include?(c.id) }
+            if @game.optional_rules.include?(:p2_p6_choice)
+              choice_companies = @game.class::COMPANY_CHOICES.values.flatten
+              @companies.reject! { |c| choice_companies.include?(c.id) }
+            end
+
             @passed_on_cheapest = {}
           end
 
@@ -119,7 +122,14 @@ module Engine
             elsif !(@auctioning || @choosing)
               @passed_on_cheapest[action.entity] = 'bid'
             end
-            super
+
+            if @choosing
+              action.entity.unpass!
+              placement_bid(action)
+            else
+              super
+            end
+
             maybe_all_passed!
           end
 


### PR DESCRIPTION
There are three P2 companies: P2a, P2b, and P2c. The same is true for P3-P6. The default way to play is randomly choose one of each to be in the auction; the rules also include a variant where the auction winner has a choice of which private to take.

[#5011]