### PR TITLE
[1868WY] Endgame, new round structure, and P6c NO BUST private

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2504,6 +2504,10 @@ module Engine
         nil
       end
 
+      def final_or_in_set?(round)
+        round.round_num == @operating_rounds
+      end
+
       def end_now?(after)
         return false unless after
         return true if after == :immediate
@@ -2511,7 +2515,7 @@ module Engine
         return false unless @round.is_a?(round_end)
         return true if after == :current_or
 
-        final_or_in_set = @round.round_num == @operating_rounds
+        final_or_in_set = final_or_in_set?(@round)
 
         return (@turn == @final_turn) if final_or_in_set && (after == :one_more_full_or_set)
 

--- a/lib/engine/game/g_1868_wy/meta.rb
+++ b/lib/engine/game/g_1868_wy/meta.rb
@@ -23,6 +23,13 @@ module Engine
 
         OPTIONAL_RULES = [
           {
+            sym: :async,
+            short_name: 'Async-friendly Dev Rounds',
+            desc: 'In Development Rounds from phase 5, players go through the Stock '\
+                  'Round order once to place Coal and Oil tokens together, instead '\
+                  'of going through the order once for Coal and another time for Oil.',
+          },
+          {
             sym: :p2_p6_choice,
             short_name: 'P2-P6 choice',
             desc: 'The winners of the privates P2 through P6 in the auction choose to take one of '\

--- a/lib/engine/game/g_1868_wy/round/bust.rb
+++ b/lib/engine/game/g_1868_wy/round/bust.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G1868WY
+      module Round
+        class Bust < Engine::Round::Operating
+          def self.short_name
+            'BUST'
+          end
+
+          def name
+            'BUST Round'
+          end
+
+          def select_entities
+            @game.abilities(@game.no_bust, :assign_hexes) ? [@game.no_bust] : []
+          end
+
+          def start_operating
+            entity = @entities[@entity_index]
+            return next_entity! if skip_entity?(entity)
+
+            @current_operator = entity
+            @current_operator_acted = false
+            skip_steps
+            next_entity! if finished?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/round/development.rb
+++ b/lib/engine/game/g_1868_wy/round/development.rb
@@ -6,15 +6,17 @@ module Engine
   module Game
     module G1868WY
       module Round
-        class Operating < Engine::Round::Operating
-          def setup
-            @game.setup_credit_mobilier_for_round
+        class Development < Engine::Round::Operating
+          def self.short_name
+            'DEV'
+          end
 
-            super
+          def name
+            'Development Round'
           end
 
           def select_entities
-            @game.operating_order
+            @game.developing_order
           end
         end
       end


### PR DESCRIPTION
* separate DEV rounds from ORs; DEV rounds derive from ORs, so add a new method in the base `Game`, `final_or_in_set?()`, so that DEV rounds don't incorrectly trigger the end in 1868 Wyoming * in DEV rounds the "minors" (coal and oil companies) operate by placing their development tokens * normally all coal companies go and then oil; there is an async-friendly variant where each player does their coal and oil at once, so you just go through the priority turn order one time instead of twice
* log "privates pay" rounds
* BUST rounds are mostly automatic, but the NO BUST private can lay its token to protect a city that is just about to BUST in the current round
* endgame is triggered by 7-train purchase, and at that point the round structure changes up
* rule changes for player value at the end: unsold private companies do count for their face value, and bankrupt players have 0 value instead of the value of their unsold shares

[#5011]