### PR TITLE
[1868WY] remove train variants at discard (like in 1822) instead of on buy

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -351,7 +351,7 @@ module Engine
             G1868WY::Step::Route,
             G1868WY::Step::Dividend,
             G1868WY::Step::DoubleShareProtection,
-            G1868WY::Step::DiscardTrain ,
+            G1868WY::Step::DiscardTrain,
             G1868WY::Step::BuyTrain,
             [G1868WY::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -16,6 +16,7 @@ require_relative 'step/buy_train'
 require_relative 'step/choose'
 require_relative 'step/company_pending_par'
 require_relative 'step/development_token'
+require_relative 'step/discard_train'
 require_relative 'step/dividend'
 require_relative 'step/double_share_protection'
 require_relative 'step/home_token'
@@ -290,7 +291,7 @@ module Engine
 
         def stock_round
           Engine::Round::Stock.new(self, [
-            Engine::Step::DiscardTrain,
+            G1868WY::Step::DiscardTrain,
             G1868WY::Step::Assign,
             G1868WY::Step::ManualCloseCompany,
             G1868WY::Step::HomeToken,
@@ -350,7 +351,7 @@ module Engine
             G1868WY::Step::Route,
             G1868WY::Step::Dividend,
             G1868WY::Step::DoubleShareProtection,
-            Engine::Step::DiscardTrain,
+            G1868WY::Step::DiscardTrain ,
             G1868WY::Step::BuyTrain,
             [G1868WY::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)

--- a/lib/engine/game/g_1868_wy/step/buy_train.rb
+++ b/lib/engine/game/g_1868_wy/step/buy_train.rb
@@ -41,11 +41,6 @@ module Engine
             process_choose_big_boy(action)
           end
 
-          def process_buy_train(action)
-            super
-            action.train.remove_variants!
-          end
-
           def room?(entity, _shell = nil)
             entity.trains.count { |t| !@game.extra_train?(t) } < @game.train_limit(entity)
           end

--- a/lib/engine/game/g_1868_wy/step/discard_train.rb
+++ b/lib/engine/game/g_1868_wy/step/discard_train.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/discard_train'
+
+module Engine
+  module Game
+    module G1868WY
+      module Step
+        class DiscardTrain < Engine::Step::DiscardTrain
+          def process_discard_train(action)
+            super
+            action.train.remove_variants!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- fixes info page issue where after the first train of a type is bought, its row only shows that variant
- hopefully fixes hard-to-reproduce hotseat issue where sometimes buying the plus variant would not actually rust all the other trains

[#5011]
