### PR TITLE
[1868WY] oil companies and P8 pure oil camp

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -192,6 +192,12 @@ module View
           return process_action(Engine::Action::Assign.new(@entity, target: @hex)) if @actions.include?('assign')
 
           step = @game.round.active_step
+          if @actions.include?('remove_hex_token') && @hex.tokens.find { |t| t.corporation == @entity }
+            return process_action(Engine::Action::RemoveHexToken.new(
+              @entity,
+              hex: @hex,
+            ))
+          end
           if @actions.include?('hex_token')
             return if step.available_tokens(@entity).empty?
 

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -173,10 +173,11 @@ module View
         end
 
         def render_boom
+          radius_addend = @reservation || @token ? 3.2 : 0.8
           h(:circle, attrs: {
               transform: translate.to_s,
               stroke: @color,
-              r: @boom_radius ||= 10 * (0.8 + (route_prop(0, :width).to_i / 40)),
+              r: @boom_radius ||= 10 * (radius_addend + (route_prop(0, :width).to_i / 40)),
               'stroke-width': 2,
               'stroke-dasharray': 6,
             })

--- a/lib/engine/action/remove_hex_token.rb
+++ b/lib/engine/action/remove_hex_token.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class RemoveHexToken < Base
+      attr_reader :hex
+
+      def initialize(entity, hex:)
+        super(entity)
+        @hex = hex
+      end
+
+      def self.h_to_args(h, game)
+        {
+          hex: game.hex_by_id(h['hex']),
+        }
+      end
+
+      def args_to_h
+        {
+          'hex' => @hex.id,
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/entities.rb
+++ b/lib/engine/game/g_1868_wy/entities.rb
@@ -451,8 +451,8 @@ module Engine
                 ],
               },
             ],
-            desc: 'Comes with a Boomtown token that may be placed during any OR '\
-                  'anywhere track may be placed. Once it\'s a Boom City, it may '\
+            desc: 'Comes with a Boomtown token that may be placed (when owned by a Railroad) '\
+                  'during any OR anywhere track may be placed. Once it\'s a Boom City, it may '\
                   'only be tokened by the owning Railroad Company. Closes at '\
                   'phase 7, removing Boomtown/City and station token, and tile '\
                   'becomes a Ghost Town.',

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -5,6 +5,7 @@ require_relative 'entities'
 require_relative 'golden_spike'
 require_relative 'map'
 require_relative 'meta'
+require_relative 'oil_companies'
 require_relative 'share_pool'
 require_relative 'trains'
 require_relative 'round/bust'
@@ -44,6 +45,7 @@ module Engine
         include Trains
         include CreditMobilier
         include GoldenSpike
+        include OilCompanies
 
         # Engine::Game includes
         include CompanyPriceUpToFace
@@ -160,8 +162,27 @@ module Engine
         UP_PRESIDENTS_SHARE = 'UP_0'
         UP_DOUBLE_SHARE = 'UP_7'
 
+        # privates
         ASSIGNMENT_TOKENS = {
           'P6c' => '/icons/1868_wy/no_bust.svg',
+          'P8' => '/icons/1868_wy/pure_oil.svg',
+        }.freeze
+        PURE_OIL_CAMP_TILES = {
+          '7' => '5b',
+          '8' => '6b',
+          '9' => '57b',
+          '14' => '14b',
+          '17' => '14b',
+          '20' => '14b',
+          '626' => '14b',
+          '15' => '15b',
+          '16' => '15b',
+          '18' => '15b',
+          '625' => '15b',
+          '19' => '619b',
+          '21' => '619b',
+          '22' => '619b',
+          '619' => '619b',
         }.freeze
 
         def dotify(tile)
@@ -221,6 +242,8 @@ module Engine
           union_pacific.shares.last.buyable = false
           up_double_share.double_cert = true
           @up_double_share_protection = {}
+
+          @pure_oil_hex = nil
 
           @lhp_train = find_and_remove_train_by_id('2+1-0', buyable: false)
           @lhp_train_pending = false
@@ -440,6 +463,13 @@ module Engine
           @endgame_triggered = true
           @operating_rounds = @round.round_num
           @final_turn = @turn + 1
+        end
+
+        def event_close_pure_oil!
+          @log << "Company #{pure_oil.name} closes"
+          pure_oil.close!
+          @pure_oil_hex&.remove_assignment!(pure_oil.id)
+          to_ghost_town!(@pure_oil_hex)
         end
 
         def event_close_big_boy!
@@ -898,6 +928,12 @@ module Engine
             new_tile = boomcity_tile(tile.name)
             boom_bust_autoreplace_tile!(new_tile, tile)
           end
+
+          if hex.assigned?(pure_oil.id)
+            token = hex.tokens.first
+            hex.remove_token(token)
+            hex.tile.add_reservation!(pure_oil.owner, 0, 0)
+          end
         end
 
         def boomcity_increase_revenue!(hex)
@@ -1042,11 +1078,16 @@ module Engine
           hex.tile.location_name = GHOST_TOWN_NAME
 
           gt_tile_name = GHOST_TOWN_TILE[hex.tile.name]
+          if hex.tile.preprinted
+            hex.remove_assignment!(pure_oil.id) if hex.assigned?(pure_oil.id)
+            return
+          end
           gt_tile = @tiles.find { |t| t.name == gt_tile_name.to_s && !t.hex }
 
           boom_bust_autoreplace_tile!(gt_tile, hex.tile)
 
           @development_hexes << hex
+          hex.remove_assignment!(pure_oil.id) if hex.assigned?(pure_oil.id)
         end
 
         def boomcity_to_boomtown!(hex)
@@ -1069,6 +1110,18 @@ module Engine
             tile = boomtown_tile(hex.tile.name)
             boom_bust_autoreplace_tile!(tile, hex.tile)
           end
+
+          return unless hex.assigned?(pure_oil.id)
+
+          corp = pure_oil.corporation
+          token = Token.new(
+            corp,
+            price: 0,
+            logo: corp.logo,
+            simple_logo: corp.simple_logo,
+            type: :boomcity_reservation,
+          )
+          hex.place_token(token, logo: token.simple_logo, preprinted: false)
         end
 
         def final_or_in_set?(round)
@@ -1254,6 +1307,56 @@ module Engine
             dpr
           else
             super
+          end
+        end
+
+        def place_pure_oil(hex)
+          pure_oil = pure_oil
+          type = @development_token_count[hex] < DTC_BOOMCITY ? :boomtown : :boomcity
+
+          @pure_oil_hex = hex
+
+          if hex.tile.color == :white
+            revenue = '0'
+            opts = { boom: true }
+
+            if type == :boomtown
+              town = Part::Town.new(revenue, **opts)
+              town.tile = hex.tile
+              hex.tile.towns << town
+            else
+              city = Part::City.new(revenue, **opts)
+              city.tile = hex.tile
+              hex.tile.cities << city
+            end
+          else
+            tile_name = PURE_OIL_CAMP_TILES[hex.tile.name]
+            tile_name = tile_name.upcase if type == :boomcity
+            tile = tiles.find { |t| t.name == tile_name }
+
+            rotation = -1
+            tile.rotate!(rotation += 1) until (hex.tile.exits - tile.exits).empty? || rotation > 5
+
+            update_tile_lists(tile, hex.tile)
+            hex.lay(tile)
+            update_boomcity_revenues!(tile, hex.tile)
+
+            case type
+            when :boomtown
+              corp = pure_oil.corporation
+              token = Token.new(
+                corp,
+                price: 0,
+                logo: corp.logo,
+                simple_logo: corp.simple_logo,
+                type: :boomcity_reservation,
+              )
+              hex.place_token(token, logo: token.simple_logo, preprinted: false)
+
+            when :boomcity
+              tile.add_reservation!(pure_oil.owner, 0, 0)
+              @log << "#{hex.name} reserved for #{pure_oil.owner.name}"
+            end
           end
         end
 
@@ -1546,6 +1649,8 @@ module Engine
           case @phase.name
           when '5'
             event_close_ames_brothers!
+          when '7'
+            event_close_pure_oil!
           when '8'
             event_close_big_boy!
             event_close_no_bust!

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -374,7 +374,7 @@ module Engine
             G1868WY::Step::Route,
             G1868WY::Step::Dividend,
             G1868WY::Step::DoubleShareProtection,
-            G1868WY::Step::DiscardTrain ,
+            G1868WY::Step::DiscardTrain,
             G1868WY::Step::BuyTrain,
             [G1868WY::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
@@ -929,11 +929,11 @@ module Engine
             boom_bust_autoreplace_tile!(new_tile, tile)
           end
 
-          if hex.assigned?(pure_oil.id)
-            token = hex.tokens.first
-            hex.remove_token(token)
-            hex.tile.add_reservation!(pure_oil.owner, 0, 0)
-          end
+          return unless hex.assigned?(pure_oil.id)
+
+          token = hex.tokens.first
+          hex.remove_token(token)
+          hex.tile.add_reservation!(pure_oil.owner, 0, 0)
         end
 
         def boomcity_increase_revenue!(hex)
@@ -1311,7 +1311,6 @@ module Engine
         end
 
         def place_pure_oil(hex)
-          pure_oil = pure_oil
           type = @development_token_count[hex] < DTC_BOOMCITY ? :boomtown : :boomcity
 
           @pure_oil_hex = hex

--- a/lib/engine/game/g_1868_wy/oil_companies.rb
+++ b/lib/engine/game/g_1868_wy/oil_companies.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1868WY
+      module OilCompanies
+        OIL_COMPANY_NAMES = [
+          'Standard Oil',
+          'Empire State Oil',
+          'Consolidated Royalty Oil Company',
+          'Argo Oil Corporation',
+          'Petroleum Maatschappij Salt Creek',
+        ].freeze
+
+        def event_oil_companies_available!
+          @log << '-- Event: Oil Companies now available --'
+          @oil_companies.each(&:float!)
+        end
+
+        def init_oil_companies
+          @players.map.with_index do |player, index|
+            sym = "Oil-#{self.class::LETTERS[index]}"
+            oil_company = Engine::Minor.new(
+              type: :oil,
+              sym: sym,
+              name: self.class::OIL_COMPANY_NAMES[index],
+              logo: "1868_wy/#{sym}",
+              tokens: [],
+              color: :black,
+              abilities: [{ type: 'no_buy', owner_type: 'player' }],
+            )
+            3.times { new_oil_token!(oil_company) }
+            oil_company.owner = player
+
+            def oil_company.cash
+              player.cash
+            end
+
+            oil_company
+          end
+        end
+
+        def new_oil_token!(oil_company)
+          oil_company.tokens << Token.new(
+            oil_company,
+            price: 0,
+            type: :development,
+          )
+        end
+
+        def remove_oil_development_token!(token)
+          entity = token.corporation
+          player = entity.player
+          hex = token.hex
+          token.destroy!
+          decrement_development_token_count(hex)
+          handle_bust!
+          new_oil_token!(entity)
+          @log << "#{player.name} removes a Development Token from #{hex.id}"
+          @teapot_dome_hex_bonus = nil if entity == teapot_dome_oil
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy/step/assign.rb
+++ b/lib/engine/game/g_1868_wy/step/assign.rb
@@ -34,6 +34,8 @@ module Engine
                 else
                   %w[assign]
                 end
+              when @game.pure_oil
+                %w[assign] if @game.abilities(entity, :assign_hexes)
               when @game.lhp_private
                 %w[assign pass] if @game.lhp_train_pending?
               end
@@ -45,6 +47,9 @@ module Engine
             when @game.no_bust
               super
               @game.place_no_bust(action.target)
+            when @game.pure_oil
+              super
+              @game.place_pure_oil(action.target)
             when @game.lhp_private
               @game.convert_lhp_train!(action.target)
             end

--- a/lib/engine/game/g_1868_wy/step/manual_close_company.rb
+++ b/lib/engine/game/g_1868_wy/step/manual_close_company.rb
@@ -36,7 +36,7 @@ module Engine
             when @game.big_boy_private
               @game.event_close_big_boy!
             when @game.pure_oil
-              @game.event_close_pure_oil_camp!
+              @game.event_close_pure_oil!
             when @game.no_bust
               @game.event_close_no_bust!
             end

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -261,16 +261,16 @@ module Engine
       end
     end
 
-    def place_token(token, logo: nil, preprinted: true)
+    def place_token(token, logo: nil, blocks_lay: nil, preprinted: true)
       token.place(self)
       @tokens << token
-      icon = Part::Icon.new('', token.corporation.id, true, false, preprinted)
+      icon = Part::Icon.new('', token.corporation.id, true, blocks_lay, preprinted)
       icon.image = logo || token.corporation.logo
       @tile.icons << icon
     end
 
     def remove_token(token)
-      @tile.icons.delete(@tile.icons.find { |_name| token.corporation.id })
+      @tile.icons.delete(@tile.icons.find { |icon| icon.name == token.corporation.id })
       @tokens.delete(token)
     end
 

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -91,7 +91,8 @@ module Engine
           token.corporation.tokens << token
           @log << "#{tokener} places a neutral token on #{hex.name}#{price_log}"
         else
-          @log << "#{tokener} places a token on #{hex.name} (#{hex.location_name})#{price_log}"
+          hex_description = hex.location_name ? "#{hex.name} (#{hex.location_name}) " : "#{hex.name} "
+          @log << "#{tokener} places a token on #{hex_description}#{price_log}"
         end
 
         @round.tokened = true unless extra_action


### PR DESCRIPTION
* oil companies are minors like coal companies, placing development tokens; oil companies can also remove their hex tokens as an action
* P8 adds a Boomtown to a chosen hex 
    * if the hex booms, the Boomtown becomes a Boom City that is reserved for the owner of P8
* update rendering so the boomed dashed line renders outside of the city circle

[#5011]