### PR TITLE
[1880] Fix OO hex tile reservations

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -198,9 +198,7 @@ module Engine
       # do tile reservations completely block other companies?
       # :never -- token can be placed as long as there is a city space for existing tile reservations
       # :always -- token cannot be placed until tile reservation resolved
-      # :yellow_only -- token cannot be placed while tile is yellow or until the tile reservation is resolved
-      # :oo_only -- token cannot be places while the tile has two or more seperate cities (OO tile),
-      #             if and when the cities merge into one, regular reservation rules apply.
+      # :single_slot_cities -- token cannot be placed if tile contains single slot cities.
       TILE_RESERVATION_BLOCKS_OTHERS = :never
 
       COMPANIES = [].freeze

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -198,7 +198,7 @@ module Engine
       # do tile reservations completely block other companies?
       # :never -- token can be placed as long as there is a city space for existing tile reservations
       # :always -- token cannot be placed until tile reservation resolved
-      # :single_slot_cities -- token cannot be placed if tile contains single slot cities.
+      # :single_slot_cities -- token cannot be placed if tile contains any single slot cities
       TILE_RESERVATION_BLOCKS_OTHERS = :never
 
       COMPANIES = [].freeze

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -21,7 +21,7 @@ module Engine
                     :foreign_investors_operate, :rocket_train
 
         TRACK_RESTRICTION = :permissive
-        TILE_RESERVATION_BLOCKS_OTHERS = :oo_only
+        TILE_RESERVATION_BLOCKS_OTHERS = :single_slot_cities
         TILE_UPGRADES_MUST_USE_MAX_EXITS = %i[cities].freeze
         HOME_TOKEN_TIMING = :operating_round
         SELL_BUY_ORDER = :sell_buy

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -375,8 +375,7 @@ module Engine
       return false if @reservations.empty?
 
       if @reservation_blocks == :always ||
-        (@reservation_blocks == :yellow_only && @color == :yellow) ||
-        (@reservation_blocks == :oo_only && @cities.size > 1)
+        (@reservation_blocks == :single_slot_cities && @cities.any? { |city| city.slots.size == 1 })
         !@reservations.include?(corporation)
       else
         @reservations.count { |x| corporation != x } >= @cities.sum(&:available_slots)

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -375,7 +375,7 @@ module Engine
       return false if @reservations.empty?
 
       if @reservation_blocks == :always ||
-        (@reservation_blocks == :single_slot_cities && @cities.any? { |city| city.slots.size == 1 })
+        (@reservation_blocks == :single_slot_cities && @cities.any? { |city| city.slots == 1 })
         !@reservations.include?(corporation)
       else
         @reservations.count { |x| corporation != x } >= @cities.sum(&:available_slots)


### PR DESCRIPTION
The current fix in #8871 assumes all tiles with more than one city is an OO. This is not a valid way to identify an OO city. There are many games with more than one extra city on a tile that is not an OO tile and thus the name of the feature is incorrect.

This fix attempts to provide a clearer blocking mechanism that can be reused without providing unexpected behavior.

Also removed yellow_only as it was added for 1880 and not used by any other game.