### PR TITLE
Links for known issues

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -143,6 +143,20 @@ class Api < Roda
       render(titles: [game.title], pin: pin,
              game_data: pin ? game.to_h(include_actions: true, logged_in_user_id: user&.id) : game.to_h)
     end
+
+    r.on 'issues', String do |str|
+      label =
+        case str
+        when 'alpha', 'beta', 'production'
+          Engine.issues_labels(str.to_sym)
+        when 'prealpha'
+          '"new games"'
+        else
+          str
+        end
+
+      r.redirect "https://github.com/tobymao/18xx/issues?q=is%3Aissue+is%3Aopen+label%3A#{label}"
+    end
   end
 
   def render_with_games

--- a/assets/app/view/game/game_meta.rb
+++ b/assets/app/view/game/game_meta.rb
@@ -15,6 +15,7 @@ module View
         children.concat(render_implementer)
         children.concat(render_rule_links)
         children.concat(render_optional_rules) if @game.game_instance?
+        children.concat(render_known_issues)
         children.concat(render_more_info)
 
         h(:div, children)
@@ -66,6 +67,10 @@ module View
         return [] if used_optional_rules.empty?
 
         [h(:h3, 'Optional Rules Used'), *used_optional_rules]
+      end
+
+      def render_known_issues
+        [h(:p, [h(:a, { attrs: { href: @game.meta.known_issues_url, target: '_blank' } }, 'Known Issues')])]
       end
 
       def render_more_info

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -43,7 +43,7 @@ module View
 
       inner << h(:div, [
         'Please ',
-        h(:a, { attrs: { href: 'https://github.com/tobymao/18xx/issues/' } }, 'raise a bug report'),
+        h(:a, { attrs: { href: "#{@game.meta.known_issues_url},\"needs triage\"" } }, 'raise a bug report'),
         ' and include ',
         *game_link,
       ])

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -89,4 +89,10 @@ module Engine
       [m.title, candidates]
     end
   end
+
+  def self.issues_labels(dev_stage)
+    GAME_METAS.each_with_object([]) do |meta, labels|
+      labels << meta.label if dev_stage == meta::DEV_STAGE
+    end.sort.uniq.join(',')
+  end
 end

--- a/lib/engine/game/g_1822_mrs/meta.rb
+++ b/lib/engine/game/g_1822_mrs/meta.rb
@@ -19,6 +19,7 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/219065/1822-railways-great-britain-rules'
         GAME_TITLE = '1822MRS'
+        GAME_ISSUE_LABEL = '1822'
         GAME_IS_VARIANT_OF = G1822::Meta
 
         PLAYER_RANGE = [2, 7].freeze

--- a/lib/engine/game/g_1822_nrs/meta.rb
+++ b/lib/engine/game/g_1822_nrs/meta.rb
@@ -19,6 +19,7 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/219065/1822-railways-great-britain-rules'
         GAME_TITLE = '1822NRS'
+        GAME_ISSUE_LABEL = '1822'
         GAME_IS_VARIANT_OF = G1822::Meta
 
         PLAYER_RANGE = [3, 7].freeze

--- a/lib/engine/game/g_1846_two_player_variant/meta.rb
+++ b/lib/engine/game/g_1846_two_player_variant/meta.rb
@@ -20,6 +20,7 @@ module Engine
         }.freeze
         GAME_SUBTITLE = nil
         GAME_TITLE = '1846 2p Variant'
+        GAME_ISSUE_LABEL = '1846'
         GAME_VARIANTS = [].freeze
 
         PLAYER_RANGE = [2, 2].freeze

--- a/lib/engine/game/g_1849_boot/meta.rb
+++ b/lib/engine/game/g_1849_boot/meta.rb
@@ -22,6 +22,7 @@ module Engine
           'Submit Direct Feedback (AAG Contact Form)' => 'https://all-aboardgames.com/pages/order-questions',
         }.freeze
         GAME_TITLE = '1849: Kingdom of the Two Sicilies'
+        GAME_ISSUE_LABEL = '1849'
         GAME_ALIASES = ['1849K2S'].freeze
 
         PLAYER_RANGE = [4, 6].freeze

--- a/lib/engine/game/g_1868_wy/meta.rb
+++ b/lib/engine/game/g_1868_wy/meta.rb
@@ -18,6 +18,7 @@ module Engine
         GAME_LOCATION = 'Wyoming, USA'
         GAME_TITLE = '1868 Wyoming'
         GAME_FULL_TITLE = '1868: Boom and Bust in the Coal Mines and Oil Fields of Wyoming'
+        GAME_ISSUE_LABEL = '1868WY'
 
         PLAYER_RANGE = [3, 5].freeze
 

--- a/lib/engine/game/g_1871/meta.rb
+++ b/lib/engine/game/g_1871/meta.rb
@@ -15,6 +15,7 @@ module Engine
         GAME_SUBTITLE = nil
         GAME_FULL_TITLE = 'The Old Prince 1871'.freeze
         GAME_DROPDOWN_TITLE = 'The Old Prince 1871'.freeze
+        GAME_ISSUE_LABEL = '1871'
 
         GAME_DESIGNER = 'Lucas Boyd'.freeze
         GAME_IMPLEMENTER = 'Christopher Giroir'.freeze

--- a/lib/engine/game/g_1873/meta.rb
+++ b/lib/engine/game/g_1873/meta.rb
@@ -16,6 +16,7 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://docs.google.com/viewer?a=v&pid=sites&srcid=YWxsLWFib2FyZGdhbWVzLmNvbXxhYWdsbGN8Z3g6MThhODUwM2Q3MWUyMmI2Nw'
         GAME_TITLE = 'Harzbahn 1873'
+        GAME_ISSUE_LABEL = '1873'
 
         PLAYER_RANGE = [2, 5].freeze
       end

--- a/lib/engine/game/g_1877/meta.rb
+++ b/lib/engine/game/g_1877/meta.rb
@@ -13,6 +13,7 @@ module Engine
         DEPENDS_ON = '1817'
 
         GAME_TITLE = '1877: Venezuela'
+        GAME_ISSUE_LABEL = '1877'
         GAME_DESIGNER = 'Scott Petersen & Toby Mao'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1877'
         GAME_LOCATION = 'Venezuela'

--- a/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
+++ b/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
@@ -19,6 +19,7 @@ module Engine
         GAME_TITLE = '18Chesapeake: Off the Rails'
         GAME_ALIASES = %w[OTR 18ChesapeakeOTR].freeze
         GAME_IS_VARIANT_OF = G18Chesapeake::Meta
+        GAME_ISSUE_LABEL = '18Chesapeake'
 
         PLAYER_RANGE = [2, 6].freeze
       end

--- a/lib/engine/game/g_18_christmas_eve/meta.rb
+++ b/lib/engine/game/g_18_christmas_eve/meta.rb
@@ -18,6 +18,7 @@ module Engine
         GAME_PUBLISHER = :self_published
         GAME_RULES_URL = 'https://www.dropbox.com/s/on6r5df7vf2pjpt/Rules.pdf?dl=0'
         GAME_TITLE = 'Uncle Lachlan\'s 18 Christmas Eve'
+        GAME_ISSUE_LABEL = '18 Christmas Eve'
 
         PLAYER_RANGE = [2, 6].freeze
       end

--- a/lib/engine/game/g_18_los_angeles/meta.rb
+++ b/lib/engine/game/g_18_los_angeles/meta.rb
@@ -25,6 +25,7 @@ module Engine
         GAME_DISPLAY_TITLE = '18 Los Angeles'
         GAME_FULL_TITLE = '18 Los Angeles: Railroading in the City of Angels 2nd Edition'
         GAME_ALIASES = %w[18LA 18LA_2].freeze
+        GAME_ISSUE_LABEL = '18 Los Angeles'
         GAME_VARIANTS = [
           {
             sym: :first_ed,

--- a/lib/engine/game/g_18_los_angeles1/meta.rb
+++ b/lib/engine/game/g_18_los_angeles1/meta.rb
@@ -24,6 +24,7 @@ module Engine
         GAME_TITLE = '18 Los Angeles'
         GAME_DISPLAY_TITLE = '18 Los Angeles 1'
         GAME_FULL_TITLE = '18 Los Angeles: Railroading in the City of Angels 1st Edition'
+        GAME_ISSUE_LABEL = '18 Los Angeles'
         GAME_IS_VARIANT_OF = G18LosAngeles::Meta
         GAME_ALIASES = ['18LA_1'].freeze
         GAME_VARIANTS = [].freeze

--- a/lib/engine/game/g_18_mt/meta.rb
+++ b/lib/engine/game/g_18_mt/meta.rb
@@ -14,6 +14,7 @@ module Engine
         GAME_DESIGNER = 'R. Ryan Driskel'
         GAME_LOCATION = 'Montana, USA'
         GAME_TITLE = '18MT: Big Sky Barons'
+        GAME_ISSUE_LABEL = '18MT'
         GAME_RULES_URL = {
           'Wiki Rules Highlights' => 'https://github.com/tobymao/18xx/wiki/18MT:-Big-Sky-Barons',
           'Contact Ryan on the 18xx Slack' => 'https://app.slack.com/client/T67762LUR/C012K0CNY5C',

--- a/lib/engine/game/g_18_ny_1e/meta.rb
+++ b/lib/engine/game/g_18_ny_1e/meta.rb
@@ -17,6 +17,7 @@ module Engine
         GAME_RULES_URL = 'https://drive.google.com/file/d/0B1SWz2pNe2eAWG9NRVYzS3FUc28/view?resourcekey=0-4MvZ7w-dGc_esikxhR8rvw'.freeze
         GAME_TITLE = '18NY 1st Edition'.freeze
         GAME_VARIANTS = [].freeze
+        GAME_ISSUE_LABEL = '18NY'
 
         def self.fs_name
           @fs_name ||= 'g_18_ny_1e'

--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -13,6 +13,7 @@ module Engine
         DEPENDS_ON = '18 Los Angeles'
 
         GAME_TITLE = '18 Tokaido'
+        GAME_ISSUE_LABEL = '18Tokaido'
         GAME_DESIGNER = 'Douglas Triggs'
         GAME_LOCATION = 'Central Japan'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Tokaido'

--- a/lib/engine/game/g_18_zoo/meta.rb
+++ b/lib/engine/game/g_18_zoo/meta.rb
@@ -23,6 +23,7 @@ module Engine
           'FAQ' =>
             'https://boardgamegeek.com/thread/2661280/faq',
         }.freeze
+        GAME_ISSUE_LABEL = '18ZOO'
 
         OPTIONAL_RULES = [
           {

--- a/lib/engine/game/g_rolling_stock/meta.rb
+++ b/lib/engine/game/g_rolling_stock/meta.rb
@@ -11,6 +11,8 @@ module Engine
         DEV_STAGE = :production
 
         GAME_TITLE = 'Rolling Stock'
+        GAME_ISSUE_LABEL = 'RollingStock'
+
         GAME_DESIGNER = 'Björn Rabenstein'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'http://rabenste.in/rollingstock/rules.pdf'

--- a/lib/engine/game/g_rolling_stock_stars/meta.rb
+++ b/lib/engine/game/g_rolling_stock_stars/meta.rb
@@ -19,6 +19,7 @@ module Engine
         GAME_RULES_URL = 'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/RSS.pdf'
         GAME_SUBTITLE = nil
         GAME_TITLE = 'Rolling Stock Stars'
+        GAME_ISSUE_LABEL = 'RollingStock'
 
         PLAYER_RANGE = [2, 6].freeze
 

--- a/lib/engine/game/meta.rb
+++ b/lib/engine/game/meta.rb
@@ -16,6 +16,7 @@ module Engine
       GAME_SUBTITLE = nil
       GAME_FULL_TITLE = nil # defaults to "GAME_DISPLAY_TITLE", then "GAME_TITLE: GAME_SUBTITLE"; used in "Game Info" section
       GAME_DROPDOWN_TITLE = nil # new game dropdown, defaults to GAME_DISPLAY_TITLE + location and dev stage if applicable
+      GAME_ISSUE_LABEL = nil # the GitHub label used to organize issues for this title, defaults to GAME_TITLE
 
       # real game metadata
       GAME_DESIGNER = nil
@@ -68,6 +69,19 @@ module Engine
             self::GAME_FULL_TITLE ||
             self::GAME_DISPLAY_TITLE ||
             [title, self::GAME_SUBTITLE].compact.join(': ')
+        end
+
+        def label
+          @label ||=
+            begin
+              label = self::GAME_ISSUE_LABEL || title
+              label = %("#{label}") if label.include?(' ')
+              label
+            end
+        end
+
+        def known_issues_url
+          "https://github.com/tobymao/18xx/issues?q=is%3Aissue+is%3Aopen+label%3A#{label}"
         end
 
         def fs_name


### PR DESCRIPTION
* add "Known Issues" link to info page for each game, which will open GitHub
  with the appropriate label selected
    * games with a different label tag than their `title` must set
    `GAME_ISSUE_LABEL` in their `Meta`, e.g., "The Old Prince 1871" simply uses
    "1871" for its issues
* update the 'raise a bug report' link on broken games to go to the issues page
  and search for two labels: the active game, and "needs triage", maximizing the
  chances of the user seeing if their bug has already been reported
* add new routes, `/issues/<dev_stage>`, to redirect to the GitHub issues page
  with labels for all games matching the entered dev stage, so it's easy to find
  a production isssue to work on