### PR TITLE
[18CZ] fix `potential_company_cash`

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -752,10 +752,10 @@ module Engine
 
         # extra cash available if the corporation sells a company to the bank
         def potential_company_cash(entity)
-          if @phase.status.include?('can_buy_companies') && entity.corporation? && entity.cash.positive?
+          if @phase.status.include?('can_buy_companies') && entity.corporation?
             @companies.reduce(0) do |memo, company|
               memo +
-                if company.owned_by_player?
+                if company.owned_by_player? && entity.cash.positive?
                   company.value - 1
                 elsif company.owner == entity
                   company.value


### PR DESCRIPTION
If the currently active corporation has no cash, they can still gain cash from a company by simply selling it, so move the check for positive cash into the loop on the condition looking at player-owned companies.

[Fixes #8409]