### PR TITLE
removes "No shorts" comment from phase 8 info

### DIFF
--- a/lib/engine/game/g_1817_de/game.rb
+++ b/lib/engine/game/g_1817_de/game.rb
@@ -121,7 +121,6 @@ module Engine
             on: '8',
             train_limit: 2,
             tiles: %i[yellow green brown gray],
-            status: ['no_new_shorts'],
             operating_rounds: 2,
             corporation_sizes: [10],
           },


### PR DESCRIPTION
Fixes #8903

Removes "no new shorts" status from phase 8, since 18DE doesn't have shorts. 