### PR TITLE
Harzbahn hex variant

### DIFF
--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -234,6 +234,13 @@ module Engine
           5 => 200,
         }.freeze
 
+        OPTION_REMOVE_HEXES = ['F7'].freeze
+        OPTION_ADD_HEXES = {
+          ['F7'] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;'\
+                    'path=a:3,b:_1,track:narrow;upgrade=cost:50,terrain:mountain;'\
+                    'icon=image:1873/11_open,sticky:1,large:1',
+        }.freeze
+
         def location_name(coord)
           @location_names ||= game_location_names
 
@@ -3103,6 +3110,26 @@ module Engine
             Action::ProgramHarzbahnDraftPass,
             Action::ProgramIndependentMines,
           ]
+        end
+
+        def aag_variant?
+          @aag_variant ||= @optional_rules&.include?(:aag_variant)
+        end
+
+        def optional_hexes
+          return self.class::HEXES unless aag_variant?
+
+          new_hexes = {}
+          HEXES.keys.each do |color|
+            new_map = self.class::HEXES[color].transform_keys do |coords|
+              coords - OPTION_REMOVE_HEXES
+            end
+            OPTION_ADD_HEXES.each { |coords, tile_str| new_map[coords] = tile_str } if color == :green
+
+            new_hexes[color] = new_map
+          end
+
+          new_hexes
         end
       end
     end

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -237,7 +237,7 @@ module Engine
         OPTION_REMOVE_HEXES = ['F7'].freeze
         OPTION_ADD_HEXES = {
           ['F7'] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;'\
-                    'path=a:3,b:_1,track:narrow;upgrade=cost:50,terrain:mountain;'\
+                    'path=a:3,b:_1,track:narrow;upgrade=cost:100,terrain:mountain;'\
                     'icon=image:1873/11_open,sticky:1,large:1',
         }.freeze
 

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -2877,277 +2877,144 @@ module Engine
           ]
         end
 
-        def game_hexes
-          {
-            white: {
-              # HBE concession route
-              %w[
-                B17
-              ] => 'icon=image:1873/HBE,sticky:1',
-              # GHE concession route
-              %w[
-                H19
-              ] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/GHE,sticky:1',
-              # NWE concession route
-              %w[
-                I8
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
-                   'border=edge:2,type:impassable;'\
-                   'icon=image:1873/8_open,sticky:1,large:1',
-              %w[
-                H7
-              ] => 'upgrade=cost:100,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
-                   'border=edge:5,type:impassable',
-              %w[
-                E6
-                D7
-              ] => 'town=revenue:0;upgrade=cost:50,terrain:mountain;icon=image:1873/NWE,sticky:1',
-              %w[
-                C8
-              ] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;',
-              # SHE concession route
-              %w[
-                G2
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1;'\
-                   'border=edge:4,type:impassable;border=edge:5,type:impassable;'\
-                   'icon=image:1873/9_open,sticky:1,large:1',
-              %w[
-                F3
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1',
-              # KEZ concession route
-              %w[
-                H3
-              ] => 'upgrade=cost:100,terrain:mountain;icon=image:1873/KEZ,sticky:1;'\
-                   'border=edge:2,type:impassable',
-              # WBE concession route
-              %w[
-                C10
-              ] => 'border=edge:5,type:impassable;'\
-                   'icon=image:1873/lock;'\
-                   'icon=image:1873/WBE,sticky:1',
-              %w[
-                C12
-              ] => 'town=revenue:0;border=edge:0,type:impassable;border=edge:5,type:impassable;'\
-                   'icon=image:1873/lock;'\
-                   'icon=image:1873/WBE,sticky:1',
-              %w[
-                C14
-              ] => 'town=revenue:0;border=edge:0,type:impassable;'\
-                   'icon=image:1873/lock;'\
-                   'icon=image:1873/WBE,sticky:1',
-              # empty tiles
-              %w[
-                C18
-                D19
-              ] => '',
-              # no towns
-              %w[
-                B15
-              ] => 'upgrade=cost:50,terrain:mountain',
-              %w[
-                G8
-                H11
-              ] => 'upgrade=cost:100,terrain:mountain',
-              %w[
-                E12
-              ] => 'upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable',
-              %w[
-                E14
-                G10
-                G18
-                H5
-                H15
-                I12
-              ] => 'upgrade=cost:150,terrain:mountain',
-              # towns
-              %w[
-                D5
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;border=edge:0,type:impassable',
-              %w[
-                D11
-              ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable;'\
-                   'border=edge:2,type:impassable;border=edge:3,type:impassable;'\
-                   'icon=image:1873/4_open,sticky:1,large:1',
-              %w[
-                D13
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;'\
-                   'border=edge:2,type:impassable;border=edge:3,type:impassable;'\
-                   'icon=image:1873/5_open,sticky:1,large:1',
-              %w[
-                D17
-              ] => 'town=revenue:0;',
-              %w[
-                E8
-              ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:4,type:impassable;'\
-                   'icon=image:1873/1_open,sticky:1,large:1',
-              %w[
-                E10
-              ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable;'\
-                   'border=edge:4,type:impassable;'\
-                   'icon=image:1873/6_open,sticky:1,large:1',
-              %w[
-                E16
-                G12
-                G14
-              ] => 'town=revenue:0;upgrade=cost:50,terrain:mountain',
-              %w[
-                F9
-                G16
-              ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain',
-              %w[
-                I14
-              ] => 'town=revenue:0;upgrade=cost:50,terrain:mountain;'\
-                   'icon=image:1873/7_open,sticky:1,large:1',
-              %w[
-                I16
-              ] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;'\
-                   'icon=image:1873/3_open,sticky:1,large:1',
-            },
-            yellow: {
-              %w[
-                D9
-              ] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                   'border=edge:4,type:impassable;frame=color:#800080;'\
-                   'icon=image:1873/10_open,sticky:1,large:1',
-              %w[
-                D15
-              ] => 'city=revenue:40,slots:2;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;'\
-                   'path=a:5,b:_0,track:narrow;label=B;frame=color:#800080;'\
-                   'icon=image:1873/12_open,sticky:1,large:1',
-              %w[
-                E4
-              ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                   'border=edge:3,type:impassable;frame=color:#800080;'\
-                   'icon=image:1873/2_open,sticky:1,large:1',
-              %w[
-                F11
-              ] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                   'frame=color:#800080;'\
-                   'icon=image:1873/SM_open,sticky:1,large:1',
-              %w[
-                G4
-              ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                   'border=edge:1,type:impassable;border=edge:3,type:impassable;frame=color:#800080;'\
-                   'icon=image:1873/14_open,sticky:1,large:1',
-            },
-            green: {
-              %w[
-                B19
-              ] => 'city=revenue:60;path=a:1,b:_0,track:narrow;path=a:2,b:_0;path=a:5,b:_0;'\
-                   'frame=color:#800080;label=HQG',
-              %w[
-                C16
-              ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:2,b:_0,track:narrow;'\
-                   'path=a:3,b:_0,track:narrow',
-              %w[
-                E20
-              ] => 'city=revenue:60;path=a:1,b:_0,track:narrow;path=a:0,b:_0;path=a:3,b:_0;'\
-                   'frame=color:#800080;label=HQG',
-              %w[
-                F5
-              ] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
-                   'path=a:3,b:_1,track:narrow;path=a:5,b:_1,track:narrow;'\
-                   'upgrade=cost:50,terrain:mountain;border=edge:0,type:impassable',
-              %w[
-                F7
-              ] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;'\
-                   'path=a:3,b:_1,track:narrow;upgrade=cost:50,terrain:mountain;'\
-                   'icon=image:1873/11_open,sticky:1,large:1',
-              %w[
-                G6
-              ] => 'city=revenue:40;path=a:2,b:_0,track:narrow;upgrade=cost:100,terrain:mountain;'\
-                   'path=a:5,b:_0,track:narrow;frame=color:#800080',
-              %w[
-                G20
-              ] => 'city=revenue:60;path=a:0,b:_0,track:narrow;path=a:2,b:_0;path=a:5,b:_0;'\
-                   'frame=color:#800080;label=HQG',
-              %w[
-                H13
-              ] => 'city=revenue:40;path=a:2,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
-                   'upgrade=cost:50,terrain:mountain;frame=color:#800080',
-              %w[
-                H17
-              ] => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
-                   'path=a:5,b:_0,track:narrow;upgrade=cost:100,terrain:mountain',
-            },
-            gray: {
-              %w[
-                A18
-              ] => 'path=a:5,b:2,terminal:1',
-              %w[
-                B9
-              ] => 'city=slots:2,revenue:yellow_60|green_80|brown_120|gray_150;'\
-                   'path=a:1,b:_0;path=a:4,b:_0;path=a:0,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
-                   'frame=color:#800080',
-              %w[
-                B13
-              ] => 'city=slots:2,revenue:yellow_30|green_70|brown_60|gray_60;'\
-                   'path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
-                   'frame=color:#800080;icon=image:1873/ZW_open,sticky:1,large:1',
-              %w[
-                C4
-              ] => 'city=revenue:yellow_50|green_80|brown_120|gray_150;path=a:5,b:_0,track:narrow',
-              %w[
-                C6
-              ] => 'town=revenue:0;path=a:0,b:_0,track:narrow;'\
-                   'icon=image:1873/SBC6_open,sticky:1,large:1',
-              %w[
-                E18
-              ] => 'city=revenue:30,slots:2;path=a:1,b:_0,track:narrow;'\
-                   'path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
-                   'icon=image:1873/PM_open,sticky:1,large:1',
-              %w[
-                F15
-              ] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
-                   'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080;'\
-                   'icon=image:1873/15_open,sticky:1,large:1',
-              %w[
-                H9
-              ] => 'city=revenue:30,slots:2;path=a:0,b:_0,track:narrow;'\
-                   'path=a:1,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
-                   'icon=image:1873/SBH9_open,sticky:1,large:1',
-              %w[
-                H21
-              ] => 'path=a:2,b:5,terminal:1',
-              %w[
-                I2
-              ] => 'city=revenue:yellow_40|green_50|brown_80|gray_120;path=a:1,b:_0;'\
-                   'path=a:2,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080',
-              %w[
-                I4
-              ] => 'city=revenue:yellow_40|green_50|brown_80|gray_120;path=a:1,b:_0;'\
-                   'path=a:2,b:_0,track:narrow;path=a:5,b:_0;frame=color:#800080',
-              %w[
-                I18
-              ] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
-                   'path=a:2,b:_0,track:narrow;frame=color:#800080;'\
-                   'icon=image:1873/13_open,sticky:1,large:1',
-              %w[
-                J7
-              ] => 'city=revenue:yellow_60|green_80|brown_120|gray_180;path=a:1,b:_0;'\
-                   'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080',
-              # implicit tiles
-              %w[
-                C20
-              ] => 'path=a:2,b:5',
-              %w[
-                D21
-              ] => 'path=a:2,b:0',
-              %w[
-                F17
-              ] => 'path=a:1,b:4',
-              %w[
-                F19
-              ] => 'path=a:1,b:3;path=a:5,b:3',
-              %w[
-                H1
-              ] => 'path=a:5,b:3,track:narrow',
-              %w[
-                J5
-              ] => 'path=a:2,b:4',
-            },
-          }
-        end
+        HEXES = {
+          white: {
+            # HBE concession route
+            ['B17'] => 'icon=image:1873/HBE,sticky:1',
+            # GHE concession route
+            ['H19'] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/GHE,sticky:1',
+            # NWE concession route
+            ['I8'] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
+                      'border=edge:2,type:impassable;'\
+                      'icon=image:1873/8_open,sticky:1,large:1',
+            ['H7'] => 'upgrade=cost:100,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
+                      'border=edge:5,type:impassable',
+            %w[E6 D7] => 'town=revenue:0;upgrade=cost:50,terrain:mountain;icon=image:1873/NWE,sticky:1',
+            ['C8'] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;',
+            # SHE concession route
+            ['G2'] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1;'\
+                      'border=edge:4,type:impassable;border=edge:5,type:impassable;'\
+                      'icon=image:1873/9_open,sticky:1,large:1',
+            ['F3'] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1',
+            # KEZ concession route
+            ['H3'] => 'upgrade=cost:100,terrain:mountain;icon=image:1873/KEZ,sticky:1;'\
+                      'border=edge:2,type:impassable',
+            # WBE concession route
+            ['C10'] => 'border=edge:5,type:impassable;'\
+                       'icon=image:1873/lock;'\
+                       'icon=image:1873/WBE,sticky:1',
+            ['C12'] => 'town=revenue:0;border=edge:0,type:impassable;border=edge:5,type:impassable;'\
+                       'icon=image:1873/lock;'\
+                       'icon=image:1873/WBE,sticky:1',
+            ['C14'] => 'town=revenue:0;border=edge:0,type:impassable;'\
+                       'icon=image:1873/lock;'\
+                       'icon=image:1873/WBE,sticky:1',
+            # empty tiles
+            %w[C18 D19] => '',
+            # no towns
+            ['B15'] => 'upgrade=cost:50,terrain:mountain',
+            %w[G8 H11] => 'upgrade=cost:100,terrain:mountain',
+            ['E12'] => 'upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable',
+            %w[E14 G10 G18 H5 H15 I12] => 'upgrade=cost:150,terrain:mountain',
+            # towns
+            ['D5'] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;border=edge:0,type:impassable',
+            ['D11'] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable;'\
+                       'border=edge:2,type:impassable;border=edge:3,type:impassable;'\
+                       'icon=image:1873/4_open,sticky:1,large:1',
+            ['D13'] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;'\
+                       'border=edge:2,type:impassable;border=edge:3,type:impassable;'\
+                       'icon=image:1873/5_open,sticky:1,large:1',
+            ['D17'] => 'town=revenue:0;',
+            ['E8'] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:4,type:impassable;'\
+                      'icon=image:1873/1_open,sticky:1,large:1',
+            ['E10'] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;border=edge:1,type:impassable;'\
+                       'border=edge:4,type:impassable;'\
+                       'icon=image:1873/6_open,sticky:1,large:1',
+            %w[E16 G12 G14] => 'town=revenue:0;upgrade=cost:50,terrain:mountain',
+            %w[F9 G16] => 'town=revenue:0;upgrade=cost:100,terrain:mountain',
+            ['I14'] => 'town=revenue:0;upgrade=cost:50,terrain:mountain;'\
+                       'icon=image:1873/7_open,sticky:1,large:1',
+            ['I16'] => 'town=revenue:0;upgrade=cost:100,terrain:mountain;'\
+                       'icon=image:1873/3_open,sticky:1,large:1',
+          },
+          yellow: {
+            ['D9'] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
+                      'border=edge:4,type:impassable;frame=color:#800080;'\
+                      'icon=image:1873/10_open,sticky:1,large:1',
+            ['D15'] => 'city=revenue:40,slots:2;path=a:1,b:_0,track:narrow;path=a:3,b:_0,track:narrow;'\
+                       'path=a:5,b:_0,track:narrow;label=B;frame=color:#800080;'\
+                       'icon=image:1873/12_open,sticky:1,large:1',
+            ['E4'] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
+                      'border=edge:3,type:impassable;frame=color:#800080;'\
+                      'icon=image:1873/2_open,sticky:1,large:1',
+            ['F11'] => 'city=revenue:30;path=a:5,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
+                       'frame=color:#800080;'\
+                       'icon=image:1873/SM_open,sticky:1,large:1',
+            ['G4'] => 'city=revenue:30;path=a:0,b:_0,track:narrow;upgrade=cost:50,terrain:mountain;'\
+                      'border=edge:1,type:impassable;border=edge:3,type:impassable;frame=color:#800080;'\
+                      'icon=image:1873/14_open,sticky:1,large:1',
+          },
+          green: {
+            ['B19'] => 'city=revenue:60;path=a:1,b:_0,track:narrow;path=a:2,b:_0;path=a:5,b:_0;'\
+                       'frame=color:#800080;label=HQG',
+            ['C16'] => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:2,b:_0,track:narrow;'\
+                       'path=a:3,b:_0,track:narrow',
+            ['E20'] => 'city=revenue:60;path=a:1,b:_0,track:narrow;path=a:0,b:_0;path=a:3,b:_0;'\
+                       'frame=color:#800080;label=HQG',
+            ['F5'] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
+                      'path=a:3,b:_1,track:narrow;path=a:5,b:_1,track:narrow;'\
+                      'upgrade=cost:50,terrain:mountain;border=edge:0,type:impassable',
+            ['F7'] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0,track:narrow;'\
+                      'path=a:3,b:_1,track:narrow;upgrade=cost:50,terrain:mountain;'\
+                      'icon=image:1873/11_open,sticky:1,large:1',
+            ['G6'] => 'city=revenue:40;path=a:2,b:_0,track:narrow;upgrade=cost:100,terrain:mountain;'\
+                      'path=a:5,b:_0,track:narrow;frame=color:#800080',
+            ['G20'] => 'city=revenue:60;path=a:0,b:_0,track:narrow;path=a:2,b:_0;path=a:5,b:_0;'\
+                       'frame=color:#800080;label=HQG',
+            ['H13'] => 'city=revenue:40;path=a:2,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
+                       'upgrade=cost:50,terrain:mountain;frame=color:#800080',
+            ['H17'] => 'city=revenue:30;path=a:0,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
+                       'path=a:5,b:_0,track:narrow;upgrade=cost:100,terrain:mountain',
+          },
+          gray: {
+            ['A18'] => 'path=a:5,b:2,terminal:1',
+            ['B9'] => 'city=slots:2,revenue:yellow_60|green_80|brown_120|gray_150;'\
+                      'path=a:1,b:_0;path=a:4,b:_0;path=a:0,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
+                      'frame=color:#800080',
+            ['B13'] => 'city=slots:2,revenue:yellow_30|green_70|brown_60|gray_60;'\
+                       'path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;'\
+                       'frame=color:#800080;icon=image:1873/ZW_open,sticky:1,large:1',
+            ['C4'] => 'city=revenue:yellow_50|green_80|brown_120|gray_150;path=a:5,b:_0,track:narrow',
+            ['C6'] => 'town=revenue:0;path=a:0,b:_0,track:narrow;'\
+                      'icon=image:1873/SBC6_open,sticky:1,large:1',
+            ['E18'] => 'city=revenue:30,slots:2;path=a:1,b:_0,track:narrow;'\
+                       'path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
+                       'icon=image:1873/PM_open,sticky:1,large:1',
+            ['F15'] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
+                       'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080;'\
+                       'icon=image:1873/15_open,sticky:1,large:1',
+            ['H9'] => 'city=revenue:30,slots:2;path=a:0,b:_0,track:narrow;'\
+                      'path=a:1,b:_0,track:narrow;path=a:4,b:_0,track:narrow;'\
+                      'icon=image:1873/SBH9_open,sticky:1,large:1',
+            ['H21'] => 'path=a:2,b:5,terminal:1',
+            ['I2'] => 'city=revenue:yellow_40|green_50|brown_80|gray_120;path=a:1,b:_0;'\
+                      'path=a:2,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080',
+            ['I4'] => 'city=revenue:yellow_40|green_50|brown_80|gray_120;path=a:1,b:_0;'\
+                      'path=a:2,b:_0,track:narrow;path=a:5,b:_0;frame=color:#800080',
+            ['I18'] => 'city=revenue:yellow_30|green_40|brown_60|gray_70;'\
+                       'path=a:2,b:_0,track:narrow;frame=color:#800080;'\
+                       'icon=image:1873/13_open,sticky:1,large:1',
+            ['J7'] => 'city=revenue:yellow_60|green_80|brown_120|gray_180;path=a:1,b:_0;'\
+                      'path=a:3,b:_0,track:narrow;path=a:4,b:_0;frame=color:#800080',
+            # implicit tiles
+            ['C20'] => 'path=a:2,b:5',
+            ['D21'] => 'path=a:2,b:0',
+            ['F17'] => 'path=a:1,b:4',
+            ['F19'] => 'path=a:1,b:3;path=a:5,b:3',
+            ['H1'] => 'path=a:5,b:3,track:narrow',
+            ['J5'] => 'path=a:2,b:4',
+          },
+        }.freeze
 
         def game_phases
           [

--- a/lib/engine/game/g_1873/meta.rb
+++ b/lib/engine/game/g_1873/meta.rb
@@ -19,6 +19,13 @@ module Engine
         GAME_ISSUE_LABEL = '1873'
 
         PLAYER_RANGE = [2, 5].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :aag_variant,
+            short_name: 'AAG variant map',
+            desc: 'Increases terrain cost of F7 to 100 ℳ',
+          },
+        ].freeze
       end
     end
   end


### PR DESCRIPTION
Fixes #8837

Adds variant option to make F7 terrain cost 100, as in the AAG printing and approved by the game designer on bug 8837 comments 