### PR TITLE
add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,20 @@
+Fixes #[PUT_ISSUE_NUMBER_HERE]
+
+> Please minimize the amount of changes to shared `lib/engine` code, if possible
+
+> If you are implementing a new game, please break up the changes into multiple PRs for ease of review.
+
+### Before clicking "Create"
+
+- [ ] Branch is derived from the latest `master`
+- [ ] Add the `pins` label if this change will break existing games
+- [ ] Code passes linter with `docker compose exec rack rubocop -a`
+- [ ] Tests pass cleanly with `docker compose exec rack rake`
+
+### Implementation Notes
+
+* **Explanation of Change**
+
+* **Screenshots**
+
+* **Any Assumptions / Hacks**


### PR DESCRIPTION
Goal is to remind ppl to lint their code locally, add `pins` when necessary, and avoid giant PRs / shared code changes

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates