### PR TITLE
[18CO] fix rules link

### DIFF
--- a/lib/engine/game/g_18_co/meta.rb
+++ b/lib/engine/game/g_18_co/meta.rb
@@ -15,7 +15,7 @@ module Engine
         GAME_IMPLEMENTER = 'R. Ryan Driskel'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18CO:-Rock-&-Stock'
         GAME_LOCATION = 'Colorado, USA'
-        GAME_RULES_URL = 'https://drive.google.com/open?id=0B3lRHMrbLMG_eEp4elBZZ0toYnM'
+        GAME_RULES_URL = 'https://drive.google.com/file/d/16W5v3w__GW4CzXQ9QeQERYVnbkdRDqg1/view'
 
         PLAYER_RANGE = [3, 6].freeze
         OPTIONAL_RULES = [


### PR DESCRIPTION
Fixes #8918 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Updates the rules link to point to a direct PDF which is accessible anonymously

* **Screenshots**


* **Any Assumptions / Hacks**

We assume that this is the latest version of the rules, this PDF seems to be the only file in the gdrive folder that covers the rules
https://drive.google.com/drive/folders/0B3lRHMrbLMG_eEp4elBZZ0toYnM?resourcekey=0-GDuc0xyk8bJoY8xanSNSCg