### PR TITLE
[1858] Stock round: exchange and tokening steps

### DIFF
--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -515,7 +515,7 @@ module Engine
         def delete_icons(company)
           icon_name = company.sym.delete('&')
           @hexes.each do |hex|
-            hex.tile.icons.delete_if { |icon| icon.name == icon_name }
+            hex.tile.icons.reject! { |icon| icon.name == icon_name }
           end
         end
 

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -171,13 +171,17 @@ module Engine
             quick_start
             operating_round(1)
           else
+            # The initial stock round isn't *quite* a normal stock round,
+            # you cannot start public companies in the first stock round.
+            # This difference is handled in exchange_corporations().
             stock_round
           end
         end
 
         def stock_round
           Engine::Round::Stock.new(self, [
-            Engine::Step::HomeToken,
+            G1858::Step::Exchange,
+            G1858::Step::HomeToken,
             G1858::Step::BuySellParShares,
           ])
         end
@@ -209,6 +213,54 @@ module Engine
           return entity if entity.minor?
 
           @minors.find { |minor| minor.id == entity.sym }
+        end
+
+        def purchase_company(player, company, price)
+          player.spend(price, @bank) unless price.zero?
+
+          player.companies << company
+          company.owner = player
+
+          minor = private_minor(company)
+          return unless minor # H&G doesn't have an associated minor.
+
+          minor.owner = player
+          minor.float!
+        end
+
+        # Finds the cities that can be tokened by a public company that is
+        # being formed from a private railway company.
+        def reserved_cities(corporation, company)
+          cities.select do |city|
+            # Some cities (Zaragoza, Seville, Córdoba) have two private companies
+            # that share the space, so we need to check that there is an available
+            # space for the corporation to place a token.
+            city.reserved_by?(company) && city.tokenable?(corporation, free: true)
+          end
+        end
+
+        def place_home_token(corporation)
+          return [] if corporation.tokens.any?(&:used)
+
+          super
+        end
+
+        def home_token_locations(corporation)
+          if corporation.companies.empty?
+            # When starting a public company after the start of phase 5 it can
+            # choose any unoccupied city space for its first token.
+            hexes.select do |hex|
+              hex.tile.cities.any? { |city| city.tokenable?(corporation, free: true) }
+            end
+          else
+            # This corporation is being formed from a private company. Its first
+            # token is in one of the city spaces reserved for the private.
+            company = corporation.companies.first
+            home_cities = reserved_cities(corporation, company)
+            raise GameError, "No available token slots for #{company.id}" if home_cities.empty?
+
+            home_cities.map(&:hex)
+          end
         end
 
         # Returns true if the hex is this private railway's home hex.
@@ -389,12 +441,116 @@ module Engine
           minors.sort_by { |m| PRIVATE_ORDER[m.id] } + corporations.sort_by(&:name)
         end
 
+        def exchange_for_partial_presidency?
+          true
+        end
+
+        # Returns true if there is a city token space that is available to be
+        # used by a public company started from this private railway company.
+        # This can only be false for one of the private railway companies that
+        # share reservations on a city (Sevilla, Córdoba or Zaragoza) if the
+        # other company has been used to token that city, and the tile has not
+        # yet been upgraded to green.
+        def company_reservation_available?(company)
+          cities.any? do |city|
+            city.reserved_by?(company) && (city.tokens.compact.size < city.slots)
+          end
+        end
+
+        # Returns the par price for a public company started from a private
+        # railway. Throws an error if called on a private that cannot be used
+        # to start a public company.
+        def par_price(company)
+          unless company.abilities.any? { |ability| ability.type == :exchange }
+            raise GameError, "#{company.sym} cannot start a public company as it does not have a home city"
+          end
+
+          @stock_market.par_prices.max_by do |share_price|
+            share_price.price <= company.value ? share_price.price : 0
+          end
+        end
+
+        def exchange_corporations(exchange_ability)
+          # Can't start public companies in the first stock round.
+          return [] if @turn == 1
+
+          entity = exchange_ability.owner
+          if exchange_ability.corporations == 'ipoed'
+            # A private railway can be exchanged for a share in any public company
+            # that can trace a route to any of the private's home hexes.
+            super.select { |corporation| corporation_private_connected?(corporation, entity) }
+          elsif par_price(entity).price > current_entity.cash
+            # Can't afford to start a public company using this private.
+            []
+          elsif !company_reservation_available?(entity) # rubocop: disable Lint/DuplicateBranch
+            # There is no currently available token space for this company.
+            []
+          else
+            # Can exchange the private railway for any unstarted public company.
+            corporations.reject(&:ipoed)
+          end
+        end
+
+        # Returns true if there is a valid route from any of the corporation's
+        # tokens to any of the private railway's home hexes, or if a token is in
+        # one of the private's home hexes.
+        def corporation_private_connected?(corporation, minor)
+          return false if corporation.closed?
+          return false unless corporation.floated?
+
+          @graph_broad.reachable_hexes(corporation).any? { |hex, _| home_hex?(minor, hex) } ||
+            @graph_metre.reachable_hexes(corporation).any? { |hex, _| home_hex?(minor, hex) } ||
+            corporation.placed_tokens.any? { |token| home_hex?(minor, token.city.hex) }
+        end
+
         def payout_companies
           return if private_closure_round == :in_progress
 
           # Private railways owned by public companies don't pay out.
           exchanged_companies = @companies.select { |company| company.owner&.corporation? }
           super(ignore: exchanged_companies.map(&:id))
+        end
+
+        # Removes all of the icons on the map for a private railway company.
+        def delete_icons(company)
+          icon_name = company.sym.delete('&')
+          @hexes.each do |hex|
+            hex.tile.icons.delete_if { |icon| icon.name == icon_name }
+          end
+        end
+
+        def close_company(company)
+          owner = company.owner
+          message = "#{company.id} closes."
+          unless owner == @bank
+            message += " #{owner.name} receives #{format_currency(company.value)}."
+            @bank.spend(company.value, owner)
+          end
+          company.close!
+          @log << message
+          delete_icons(company)
+        end
+
+        # Closes the private railway companies owned by a public company,
+        # paying their face value to the public company's treasury.
+        def close_companies(corporation)
+          return unless corporation.corporation?
+
+          # The corporation.companies array is modified by company.close!, so we
+          # need to take a copy rather than iterating over original array.
+          companies = corporation.companies.dup
+          companies.each { |company| close_company(company) }
+        end
+
+        # Closes both the company and minor parts of a private railway. Can be
+        # called using either one as its argument.
+        def close_private(entity)
+          company = private_company(entity)
+          minor = private_minor(entity)
+
+          release_stubs(minor)
+          minor&.close!
+          close_company(company)
         end
 
         def entity_can_use_company?(_entity, _company)

--- a/lib/engine/game/g_1858/market.rb
+++ b/lib/engine/game/g_1858/market.rb
@@ -11,6 +11,7 @@ module Engine
         SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :operate
         SELL_MOVEMENT = :left_block_pres
+        SOLD_OUT_INCREASE = false
         MARKET_SHARE_LIMIT = 50
         CERT_LIMIT = { 2 => 21, 3 => 21, 4 => 16, 5 => 13, 6 => 11 }.freeze
         STARTING_CASH = { 2 => 500, 3 => 500, 4 => 375, 5 => 300, 6 => 250 }.freeze
@@ -19,6 +20,10 @@ module Engine
 
         def ipo_name(_entity = nil)
           'Treasury'
+        end
+
+        def can_hold_above_corp_limit?(_entity)
+          true
         end
 
         def issuable_shares(entity)

--- a/lib/engine/game/g_1858/step/dividend.rb
+++ b/lib/engine/game/g_1858/step/dividend.rb
@@ -20,6 +20,7 @@ module Engine
             return if action.entity.minor?
 
             super
+            @game.close_companies(action.entity)
           end
 
           def rust_obsolete_trains!(_entity)

--- a/lib/engine/game/g_1858/step/exchange.rb
+++ b/lib/engine/game/g_1858/step/exchange.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/exchange'
+require_relative 'private_exchange'
+
+module Engine
+  module Game
+    module G1858
+      module Step
+        class Exchange < Engine::Step::Exchange
+          include PrivateExchange
+
+          def actions(entity)
+            if entity.company? || entity.minor?
+              ['buy_shares']
+            else
+              []
+            end
+          end
+
+          def process_buy_shares(action)
+            bundle = action.bundle
+            corporation = bundle.corporation
+            minor = action.entity
+            player = minor.owner
+
+            if !corporation.floated? && !bundle.shares.first.president
+              raise GameError, 'Cannot exchange a private railway ' \
+                               'for a single share of a public company.'
+            end
+
+            acquire_private(corporation, minor)
+            if bundle.percent == 40
+              exchange_for_presidency(bundle, corporation, minor, player)
+              @round.current_actions << action
+            else
+              exchange_for_share(bundle, corporation, minor, player)
+              claim_token(corporation, minor)
+              # Need to add an action to the action log, but this can't be a
+              # buy shares action as that would end the current player's turn.
+              @round.current_actions << Engine::Action::Base.new(minor)
+            end
+          end
+
+          def exchange_for_presidency(bundle, corporation, company, player)
+            raise GameError, "#{corporation.name} cannot be parred" unless @game.can_par?(corporation, player)
+
+            share_price = @game.par_price(company)
+            @game.stock_market.set_par(corporation, share_price)
+            @round.players_bought[player][corporation] += bundle.percent
+            @log << "#{player.name} exchanges #{company.name} and " \
+                    "#{@game.format_currency(share_price.price)} for a " \
+                    "#{bundle.percent}% share of #{corporation.id}"
+            buy_shares(player,
+                       bundle,
+                       exchange: company,
+                       exchange_price: share_price.price,
+                       silent: true)
+            @game.after_par(corporation)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858/step/home_token.rb
+++ b/lib/engine/game/g_1858/step/home_token.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/home_token'
+
+module Engine
+  module Game
+    module G1858
+      module Step
+        class HomeToken < Engine::Step::HomeToken
+          def actions(entity)
+            return [] unless entity == pending_entity
+
+            if entity.placed_tokens.empty?
+              %w[place_token]
+            else
+              %w[place_token pass]
+            end
+          end
+
+          def pass_description
+            'Do not place station token'
+          end
+
+          def process_place_token(action)
+            if action.entity.companies.empty? && action.entity.placed_tokens.empty?
+              # This is a public company floated directly after the start of phase 5.
+              # Home token cost for public companies is twice the city's revenue.
+              city = action.city
+              color = city.tile.color
+              token.price = 2 * city.revenue[color] unless color == :white
+            else
+              # This is a token acquired when a private company is exchanged,
+              # either for the president's certificate or for a share from the
+              # public company's treasury. These tokens are free.
+              token.price = 0
+            end
+
+            super
+          end
+
+          def process_pass(action)
+            super
+            @round.pending_tokens.shift
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858/step/private_exchange.rb
+++ b/lib/engine/game/g_1858/step/private_exchange.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1858
+      module Step
+        # Code shared by both the Exchange and PrivateClosure steps.
+        module PrivateExchange
+          def acquire_private(corporation, entity)
+            player = entity.owner
+
+            company = @game.private_company(entity)
+            minor = @game.private_minor(entity)
+
+            @game.release_stubs(minor)
+            transfer_abilities(minor, company)
+            minor.close!
+            player.companies.delete(company)
+            company.owner = corporation
+            corporation.companies << company
+            @log << "#{corporation.name} acquires #{company.name} from #{player.name}"
+          end
+
+          def transfer_abilities(minor, company)
+            # The ability blocking other entities laying track in the private's
+            # home hexes needs to survive until the private railway closes, so
+            # move it from the minor to the company.
+            blocker = @game.abilities(minor, :blocks_hexes)
+            return unless blocker
+
+            company.add_ability(blocker)
+          end
+
+          def exchange_for_share(bundle, corporation, minor, player)
+            unless @game.corporation_private_connected?(corporation, minor)
+              raise GameError, "#{minor.name} is not connected to #{corporation.full_name}"
+            end
+
+            @game.share_pool.buy_shares(player, bundle, exchange: :free)
+          end
+
+          def claim_token(corporation, minor)
+            return if corporation.unplaced_tokens.empty?
+
+            company = @game.private_company(minor)
+            cities = @game.reserved_cities(corporation, company)
+            return unless cities.any? { |city| city.tokens.compact.size < city.slots }
+
+            @round.pending_tokens << {
+              entity: corporation,
+              hexes: cities.map(&:hex),
+              token: corporation.next_token,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -161,7 +161,19 @@ module Engine
         token.place(self, extra: extra_slot)
         return @extra_tokens << token if extra_slot
 
-        @tokens[get_slot(token.corporation, cheater: cheater)] = token
+        slot = get_slot(token.corporation, cheater: cheater)
+
+        # Special case for 1858 where two private companies can have reservations
+        # in the same city, which only has a single slot on its yellow tile.
+        if (slot == 1) && (normal_slots == 1) && (@reservations.size == 2)
+          # The first of the companies to token the city takes the slot.
+          slot = 0
+          # Switch the reservations so that the other company gets a reserved
+          # slot when the tile is upgraded to green.
+          @reservations.reverse!
+        end
+
+        @tokens[slot] = token
       end
 
       def reset!

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -166,7 +166,8 @@ module Engine
         # Special case for 1858 where two private companies can have reservations
         # in the same city, which only has a single slot on its yellow tile.
         if (slot == 1) && (normal_slots == 1) && (@reservations.size == 2)
-          # The first of the companies to token the city takes the slot.
+          # The company with the reservation for the (not yet created) second
+          # token slot is tokening this city. Put its token in the first slot.
           slot = 0
           # Switch the reservations so that the other company gets a reserved
           # slot when the tile is upgraded to green.


### PR DESCRIPTION
This is the next batch of code for 1858. This is the penultimate chuck of game logic, after this there is just the private closure round to be implemented.

This is the implementation of the stock round exchange and tokening steps.

Private railway companies in 1858 can be exchanged for shares in two different ways:

1. A private with a city in one of its home hexes can be used to start a    new corporation. The par price is taken from the private's face value, with the player paying for half of the president's certificate. The corporation starts with a token in the privates home city (if there are two cities in the private's home hexes then the player gets to choose which one to start in). The corporation becomes the owner of the private company.
2. A private can be exchanged for a treasury share from an existing corporation, if there is a valid route from one of the corporation's tokens to any of the privates home hexes. The corporation may place a token in a city in one of the private's home hexes. The corporation becomes the owner of the private company.

Any privates gained by corporations in this way will close at the end of the corporation's dividend step in the next operating round. The corporation will receive the private's face value as cash to its treasury.

Later in the game, a corporation may be started by simply setting a par price and purchasing the president's certificate. In this case the corporation may start in any open token slot, and pays twice the city's revenue to do this.


### Hacks

There's one place this commit touches common code. This is in `Engine::Part::City.exchange_token`. There are three cities in 1858 which each have two private companies that have a reservation ability for a token slot. However there is only a single slot in these cities before they are upgraded to green. This change to `exchange_token` catches the case where the reservation ability for the non-existent second slot is being used, and switches the two reservations around.