### PR TITLE
Refactor stock movement into separate classes per market type

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -260,7 +260,7 @@ module View
                 align = { left: 0, bottom: 0 }
                 arrow = '⭣'
               # last cell on right, not top row
-              elsif !row_i.zero? && @game.stock_market.right_ledge?(row_i, col_i)
+              elsif !row_i.zero? && @game.stock_market.right_ledge?([row_i, col_i])
                 align = { right: 0, top: 0 }
                 arrow = '⭡'
               else

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -752,7 +752,7 @@ module Engine
           return if corporation.owner == @share_pool
 
           @owner_when_liquidated[corporation] = corporation.owner
-          @stock_market.move(corporation, 0, 0, force: true)
+          @stock_market.move(corporation, [0, 0], force: true)
         end
 
         def train_help(_entity, _runnable_trains, routes)

--- a/lib/engine/game/g_1817/step/conversion.rb
+++ b/lib/engine/game/g_1817/step/conversion.rb
@@ -110,7 +110,7 @@ module Engine
             initial_size = corporation.total_shares
             share_price = new_share_price(corporation, target)
             price = share_price.price
-            @game.stock_market.move(corporation, *share_price.coordinates)
+            @game.stock_market.move(corporation, share_price.coordinates)
 
             @log << "#{corporation.name} merges with #{target.name} "\
                     "at share price #{@game.format_currency(price)} receiving #{receiving.join(', ')}"

--- a/lib/engine/game/g_1822/stock_market.rb
+++ b/lib/engine/game/g_1822/stock_market.rb
@@ -9,13 +9,13 @@ module Engine
         def move_up(corporation)
           r, c = corporation.share_price.coordinates
 
-          if r.positive? && share_price(r - 1, c)
+          if r.positive? && share_price([r - 1, c])
             r -= 1
           else
             r += 1
             c += 1
           end
-          move(corporation, r, c)
+          move(corporation, [r, c])
         end
       end
     end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -612,7 +612,7 @@ module Engine
             if @loans.empty?
               @log << "There are no more loans available to force buy a train, #{entity.name} goes into receivership"
               r, _c = entity.share_price.coordinates
-              @stock_market.move(entity, r, 0)
+              @stock_market.move(entity, [r, 0])
               break
             end
             loan = @loans.first

--- a/lib/engine/game/g_1848/stock_market.rb
+++ b/lib/engine/game/g_1848/stock_market.rb
@@ -9,8 +9,8 @@ module Engine
       class StockMarket < Engine::StockMarket
         def move_down(corporation)
           r, c = corporation.share_price.coordinates
-          r += 1 if r + 1 < @market.size && r + 1 != G1848::Game::BOE_ROW && share_price(r + 1, c)
-          move(corporation, r, c)
+          r += 1 if r + 1 < @market.size && r + 1 != G1848::Game::BOE_ROW && share_price([r + 1, c])
+          move(corporation, [r, c])
         end
       end
     end

--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -9,7 +9,7 @@ module Engine
         BLOCKED_RIGHT_PRICES = [218, 240, 276].freeze
         BLOCKED_UP_PRICES = [230].freeze
 
-        def move(corp, row, column, force: false)
+        def move(corp, coordinates, force: false)
           super
           return if corp.reached_max_value || !corp.share_price.end_game_trigger?
 
@@ -19,7 +19,8 @@ module Engine
           @game.max_value_reached = true
         end
 
-        def right_ledge?(r, c)
+        def right_ledge?(coordinates)
+          r, c = coordinates
           price = @market.dig(r, c).price
           return false if BLOCKED_UP_PRICES.include?(price) && !@game.phase.status.include?('blue_zone')
           return true if BLOCKED_RIGHT_PRICES.include?(price) && !@game.phase.status.include?('blue_zone')

--- a/lib/engine/game/g_1856/stock_market.rb
+++ b/lib/engine/game/g_1856/stock_market.rb
@@ -6,12 +6,12 @@ module Engine
       class StockMarket < Engine::StockMarket
         attr_writer :game
 
-        def move(corporation, row, column, force: false)
+        def move(corporation, coordinates, force: false)
           return super if corporation != @game.national
           # National may not move unless it's owned a permanent train
           return unless @game.national_ever_owned_permanent
 
-          share_price = share_price(row, column)
+          share_price = share_price(coordinates)
           # National may never close.
           return super unless share_price.types.include?(:close)
 

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -780,7 +780,7 @@ module Engine
           @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
           num_shares = bundle.num_shares
           num_shares -= 1 if corporation.share_price.type == :ignore_one_sale
-          num_shares.times { @stock_market.move_left(corporation) } if selling_movement?(corporation)
+          num_shares.times { @stock_market.move_down(corporation) } if selling_movement?(corporation)
           log_share_price(corporation, old_price)
           check_bankruptcy!(corporation)
         end

--- a/lib/engine/game/g_1860/step/dividend.rb
+++ b/lib/engine/game/g_1860/step/dividend.rb
@@ -63,18 +63,18 @@ module Engine
             if revenue.positive?
               curr_price = entity.share_price.price
               if revenue >= curr_price && revenue < 2 * curr_price
-                { share_direction: :right, share_times: 2 }
+                { share_direction: :right, share_times: 1 }
               elsif revenue >= 2 * curr_price && revenue < 3 * curr_price
-                { share_direction: :right, share_times: 4 }
+                { share_direction: :right, share_times: 2 }
               elsif revenue >= 3 * curr_price && revenue < 4 * curr_price
-                { share_direction: :right, share_times: 6 }
+                { share_direction: :right, share_times: 3 }
               elsif revenue >= 4 * curr_price
-                { share_direction: :right, share_times: 8 }
+                { share_direction: :right, share_times: 4 }
               else
                 {}
               end
             else
-              { share_direction: :left, share_times: 2 }
+              { share_direction: :left, share_times: 1 }
             end
           end
 
@@ -100,10 +100,6 @@ module Engine
 
             @log << "#{entity.name} pays out #{@game.format_currency(revenue)} = "\
                     "#{@game.format_currency(per_share)} (#{receivers})"
-          end
-
-          def movement_str(times, dir)
-            "#{times / 2} #{dir}"
           end
         end
       end

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1201,7 +1201,7 @@ module Engine
             num_shares -= 1 if corporation.share_price.type == :ignore_one_sale
             num_shares -= 2 if corporation.share_price.type == :ignore_two_sales
           end
-          num_shares.times { @stock_market.move_left(corporation) } if selling_movement?(corporation)
+          num_shares.times { @stock_market.move_down(corporation) } if selling_movement?(corporation)
           log_share_price(corporation, old_price)
           check_bankruptcy!(corporation)
         end

--- a/lib/engine/game/g_1862/step/dividend.rb
+++ b/lib/engine/game/g_1862/step/dividend.rb
@@ -136,18 +136,18 @@ module Engine
             if revenue.positive?
               curr_price = entity.share_price.price
               if revenue >= curr_price && revenue < 2 * curr_price
-                { share_direction: :right, share_times: 2 }
+                { share_direction: :right, share_times: 1 }
               elsif revenue >= 2 * curr_price && revenue < 3 * curr_price
-                { share_direction: :right, share_times: 4 }
+                { share_direction: :right, share_times: 2 }
               elsif revenue >= 3 * curr_price && revenue < 4 * curr_price
-                { share_direction: :right, share_times: 6 }
+                { share_direction: :right, share_times: 3 }
               elsif revenue >= 4 * curr_price
-                { share_direction: :right, share_times: 8 }
+                { share_direction: :right, share_times: 4 }
               else
                 {}
               end
             else
-              { share_direction: :left, share_times: 2 }
+              { share_direction: :left, share_times: 1 }
             end
           end
 
@@ -162,10 +162,6 @@ module Engine
           def hudson(entity, revenue, subsidy)
             diff = hudson_delta(entity, revenue)
             { corporation: subsidy - diff, per_share: payout_per_share(entity, revenue + diff) }
-          end
-
-          def movement_str(times, dir)
-            "#{times / 2} #{dir}"
           end
 
           def handle_warranties!(entity)

--- a/lib/engine/game/g_1866/step/single_item_auction.rb
+++ b/lib/engine/game/g_1866/step/single_item_auction.rb
@@ -308,7 +308,7 @@ module Engine
                 minor = @game.corporation_by_id(minor_id)
 
                 par_rows = @game.class::MINOR_NATIONAL_PAR_ROWS[minor_id]
-                share_price = @game.stock_market.share_price(par_rows[0], par_rows[1])
+                share_price = @game.stock_market.share_price([par_rows[0], par_rows[1]])
 
                 # Find the right spot on the stock market
                 @game.stock_market.set_par(minor, share_price)

--- a/lib/engine/game/g_1866/stock_market.rb
+++ b/lib/engine/game/g_1866/stock_market.rb
@@ -14,7 +14,7 @@ module Engine
           else
             r += 1
           end
-          move(corporation, r, c) if share_price(r, c)
+          move(corporation, [r, c]) if share_price([r, c])
         end
 
         def move_up(corporation)
@@ -26,7 +26,7 @@ module Engine
             r += 1
             c += 1
           end
-          move(corporation, r, c) if share_price(r, c)
+          move(corporation, [r, c]) if share_price([r, c])
         end
       end
     end

--- a/lib/engine/game/g_1867/stock_market.rb
+++ b/lib/engine/game/g_1867/stock_market.rb
@@ -16,7 +16,7 @@ module Engine
             r += 1
             c += 1
           end
-          move(corporation, r, c)
+          move(corporation, [r, c])
         end
 
         def move_right(corporation)

--- a/lib/engine/game/g_1868_wy/step/double_share_protection.rb
+++ b/lib/engine/game/g_1868_wy/step/double_share_protection.rb
@@ -145,8 +145,7 @@ module Engine
                   ''
                 end
 
-              row, col = protect[:new_price].coordinates
-              @game.stock_market.move(@game.union_pacific, row, col)
+              @game.stock_market.move(@game.union_pacific, protect[:new_price].coordinates)
               @game.log_share_price(@game.union_pacific, old_price)
 
               if protect[:cash]

--- a/lib/engine/game/g_1868_wy/stock_market.rb
+++ b/lib/engine/game/g_1868_wy/stock_market.rb
@@ -9,13 +9,13 @@ module Engine
         def move_up(corporation)
           r, c = corporation.share_price.coordinates
 
-          if r.positive? && share_price(r - 1, c)
+          if r.positive? && share_price([r - 1, c])
             r -= 1
           else
             r += 1
             c += 1
           end
-          move(corporation, r, c)
+          move(corporation, [r, c])
         end
       end
     end

--- a/lib/engine/game/g_1870/stock_market.rb
+++ b/lib/engine/game/g_1870/stock_market.rb
@@ -13,7 +13,14 @@ module Engine
           move_down(corporation)
         end
 
-        def right_ledge?(r, c)
+        def move_right(corporation)
+          return move_up(corporation) if right_ledge?(corporation.share_price.coordinates)
+
+          super
+        end
+
+        def right_ledge?(coordinates)
+          r, c = coordinates
           super || (@market.dig(r, c).type != :ignore_one_sale && @market.dig(r, c + 1)&.type == :ignore_one_sale)
         end
       end

--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -118,8 +118,8 @@ module Engine
           mainline.full_name = mainline.full_name[0..-2] + 'ML'
           mainline.float_percent = 50
           shortline.full_name = shortline.full_name[0..-2] + 'SL'
-          stock_market.set_par(mainline, stock_market.share_price(1, 1))
-          stock_market.set_par(shortline, stock_market.share_price(2, 1))
+          stock_market.set_par(mainline, stock_market.share_price([1, 1]))
+          stock_market.set_par(shortline, stock_market.share_price([2, 1]))
 
           # Mainline and Shortline tokens start on the board
           @hexes.each do |hex|
@@ -417,15 +417,15 @@ module Engine
 
         # Events to remove pars on certain trains
         def event_remove_smv_80!
-          stock_market.remove_par!(stock_market.share_price(3, 1))
+          stock_market.remove_par!(stock_market.share_price([3, 1]))
         end
 
         def event_remove_smv_74!
-          stock_market.remove_par!(stock_market.share_price(4, 1))
+          stock_market.remove_par!(stock_market.share_price([4, 1]))
         end
 
         def event_remove_smv_65!
-          stock_market.remove_par!(stock_market.share_price(5, 1))
+          stock_market.remove_par!(stock_market.share_price([5, 1]))
         end
 
         # Handle tile upgrades. Differences from base include:

--- a/lib/engine/game/g_18_co/stock_market.rb
+++ b/lib/engine/game/g_18_co/stock_market.rb
@@ -10,10 +10,10 @@ module Engine
         def move_up(corporation)
           r, c = corporation.share_price.coordinates
 
-          if r - 1 >= 0 && share_price(r - 1, c)
+          if r - 1 >= 0 && share_price([r - 1, c])
             r -= 1
-            move(corporation, r, c)
-          elsif share_price(r, c + 1)
+            move(corporation, [r, c])
+          elsif share_price([r, c + 1])
             move_right(corporation)
           end
         end

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -37,7 +37,7 @@ module Engine
         TRACK_RESTRICTION = :permissive
 
         SELL_BUY_ORDER = :sell_buy
-        SELL_MOVEMENT = :left_block
+        SELL_MOVEMENT = :down_block
         MARKET_SHARE_LIMIT = 1000 # notionally unlimited shares in market
 
         MUST_BUY_TRAIN = :always
@@ -806,7 +806,7 @@ module Engine
 
         def maximum_share_price_change(entity)
           position = entity.share_price.coordinates.last
-          return 4 if position.odd? # movement on the top row is capped only by the market's end
+          return 2 if position.odd? # movement on the top row is capped only by the market's end
 
           MARKET[0].size - 2 - position
         end

--- a/lib/engine/game/g_18_cz/step/dividend.rb
+++ b/lib/engine/game/g_18_cz/step/dividend.rb
@@ -12,20 +12,16 @@ module Engine
           end
 
           def share_price_change(entity, revenue = 0)
-            return { share_direction: :left, share_times: 2 } unless revenue.positive?
+            return { share_direction: :left, share_times: 1 } unless revenue.positive?
 
             max_moves = @game.maximum_share_price_change(entity)
-            times = (max_moves < 2 ? max_moves : 2)
-            times = (max_moves < 4 ? max_moves : 4) if entity.type == :large
+            times = (max_moves < 2 ? max_moves : 1)
+            times = (max_moves < 4 ? max_moves : 2) if entity.type == :large
             { share_direction: :right, share_times: times }
           end
 
           def corporation_dividends(_entity, _per_share)
             0
-          end
-
-          def movement_str(times, dir)
-            "#{times / 2} #{dir}"
           end
         end
       end

--- a/lib/engine/game/g_18_ireland/step/merge.rb
+++ b/lib/engine/game/g_18_ireland/step/merge.rb
@@ -100,7 +100,7 @@ module Engine
             new_column = @round.merging.map { |p| p.share_price.coordinates.last }.min
             # Find the top most price
             new_row = @round.merging.map { |p| p.share_price.coordinates.first }.min
-            @game.stock_market.share_price(new_row, new_column)
+            @game.stock_market.share_price([new_row, new_column])
           end
 
           def finish_merge(entity)

--- a/lib/engine/game/g_18_new_england/game.rb
+++ b/lib/engine/game/g_18_new_england/game.rb
@@ -278,16 +278,16 @@ module Engine
 
         def lookup_minor_price(p, row)
           @stock_market.market[row].size.times do |i|
-            next unless @stock_market.share_price(row, i)
-            return @stock_market.share_price(row, i) if @stock_market.share_price(row, i).price == p
+            next unless @stock_market.share_price([row, i])
+            return @stock_market.share_price([row, i]) if @stock_market.share_price([row, i]).price == p
           end
         end
 
         def lookup_par_price(p)
           @stock_market.market[MAJOR_ROW].size.times do |i|
-            next unless @stock_market.share_price(MAJOR_ROW, i)
-            return @stock_market.share_price(MAJOR_ROW, i) if @stock_market.share_price(MAJOR_ROW, i).price == p
-            return @stock_market.share_price(MAJOR_ROW, i - 1) if @stock_market.share_price(MAJOR_ROW, i).price > p
+            next unless @stock_market.share_price([MAJOR_ROW, i])
+            return @stock_market.share_price([MAJOR_ROW, i]) if @stock_market.share_price([MAJOR_ROW, i]).price == p
+            return @stock_market.share_price([MAJOR_ROW, i - 1]) if @stock_market.share_price([MAJOR_ROW, i]).price > p
           end
         end
 

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -753,21 +753,21 @@ module Engine
           r, c = current.coordinates
 
           # assumes that current is not at either limit of market
-          right = @stock_market.share_price(r, c + 1)
-          left = @stock_market.share_price(r, c - 1)
+          right = @stock_market.share_price([r, c + 1])
+          left = @stock_market.share_price([r, c - 1])
 
           if book >= market_cap(corporation, current) && book < market_cap(corporation, right)
             diff = 1
             target = right
           elsif book >= market_cap(corporation, right)
             diff = 2
-            target = right.end_game_trigger? ? right : @stock_market.share_price(r, c + 2)
+            target = right.end_game_trigger? ? right : @stock_market.share_price([r, c + 2])
           elsif book < market_cap(corporation, current) && book >= market_cap(corporation, left)
             diff = -1
             target = left
           else
             diff = -2
-            target = left.price.zero? ? left : @stock_market.share_price(r, c - 2)
+            target = left.price.zero? ? left : @stock_market.share_price([r, c - 2])
           end
 
           actual = find_new_price(current, target, diff)
@@ -782,8 +782,7 @@ module Engine
 
         def move_to_right(corporation)
           old_price = corporation.share_price.price
-          r, c = next_price_to_right(corporation.share_price).coordinates
-          @stock_market.move(corporation, r, c)
+          @stock_market.move(corporation, next_price_to_right(corporation.share_price).coordinates)
           new_price = corporation.share_price.price
           @log << "#{corporation.name} share price increases to #{format_currency(new_price)}" unless old_price == new_price
         end
@@ -792,14 +791,13 @@ module Engine
           new_price = price
           while !new_price.end_game_trigger? && (!new_price.corporations.empty? || new_price == price)
             r, c = new_price.coordinates
-            new_price = @stock_market.share_price(r, c + 1)
+            new_price = @stock_market.share_price([r, c + 1])
           end
           new_price
         end
 
         def move_to_left(corporation)
-          r, c = next_price_to_left(corporation.share_price).coordinates
-          @stock_market.move(corporation, r, c)
+          @stock_market.move(corporation, next_price_to_left(corporation.share_price).coordinates)
           new_price = corporation.share_price.price
           @log << "#{corporation.name} share price decreases to #{format_currency(new_price)}"
           close_corporation(corporation) if new_price.zero?
@@ -809,7 +807,7 @@ module Engine
           new_price = price
           while new_price.price != 0 && (!new_price.corporations.empty? || new_price == price)
             r, c = new_price.coordinates
-            new_price = @stock_market.share_price(r, c - 1)
+            new_price = @stock_market.share_price([r, c - 1])
           end
           new_price
         end
@@ -818,36 +816,35 @@ module Engine
           r, c = price.coordinates
           return nil if (c - 1).negative?
 
-          @stock_market.share_price(r, c - 1)
+          @stock_market.share_price([r, c - 1])
         end
 
         def two_prices_to_left(price)
           r, c = price.coordinates
           return nil if (c - 2).negative?
 
-          @stock_market.share_price(r, c - 2)
+          @stock_market.share_price([r, c - 2])
         end
 
         def one_price_to_right(price)
           r, c = price.coordinates
           return nil if c + 1 >= @stock_market.market[r].size
 
-          @stock_market.share_price(r, c + 1)
+          @stock_market.share_price([r, c + 1])
         end
 
         def two_prices_to_right(price)
           r, c = price.coordinates
           return nil if c + 2 >= @stock_market.market[r].size
 
-          @stock_market.share_price(r, c + 2)
+          @stock_market.share_price([r, c + 2])
         end
 
         def move_to_price(corporation, new_price)
           current_price = corporation.share_price
           return if current_price.price == new_price.price
 
-          r, c = new_price.coordinates
-          @stock_market.move(corporation, r, c)
+          @stock_market.move(corporation, new_price.coordinates)
           dir = new_price.price > current_price.price ? 'increases' : 'decreases'
           @log << "#{corporation.name} share price #{dir} to #{format_currency(new_price.price)}"
           close_corporation(corporation) if new_price.price.zero?

--- a/lib/engine/game/g_rolling_stock_stars/game.rb
+++ b/lib/engine/game/g_rolling_stock_stars/game.rb
@@ -132,18 +132,18 @@ module Engine
           r, c = current.coordinates
 
           # assumes that current is not at either limit of market
-          right = @stock_market.share_price(r, c + 1)
-          left = @stock_market.share_price(r, c - 1)
+          right = @stock_market.share_price([r, c + 1])
+          left = @stock_market.share_price([r, c - 1])
 
           diff = corporation_stars(corporation, cash) - target_stars(corporation)
           diff = [[diff, 2].min, -2].max
 
           target = if diff > -2 && diff < 2
-                     @stock_market.share_price(r, c + diff)
+                     @stock_market.share_price([r, c + diff])
                    elsif diff == 2
-                     right.end_game_trigger? ? right : @stock_market.share_price(r, c + 2)
+                     right.end_game_trigger? ? right : @stock_market.share_price([r, c + 2])
                    else
-                     left.price.zero? ? left : @stock_market.share_price(r, c - 2)
+                     left.price.zero? ? left : @stock_market.share_price([r, c - 2])
                    end
 
           actual = find_new_price(current, target, diff)

--- a/lib/engine/stock_movement.rb
+++ b/lib/engine/stock_movement.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Engine
+  class BaseMovement
+    def initialize(market)
+      @market = market
+    end
+
+    def share_price(coordinates)
+      row, column = coordinates
+      @market[row]&.[](column)
+    end
+
+    def left(coordinates)
+      raise NotImplementedError
+    end
+
+    def right(coordinates)
+      raise NotImplementedError
+    end
+
+    def down(coordinates)
+      raise NotImplementedError
+    end
+
+    def up(coordinates)
+      raise NotImplementedError
+    end
+  end
+
+  class TwoDimensionalMovement < BaseMovement
+    def left(coordinates)
+      r, c = coordinates
+      if c.positive? && share_price([r, c - 1])
+        [r, c - 1]
+      else
+        down(coordinates)
+      end
+    end
+
+    def right(coordinates)
+      r, c = coordinates
+      if c + 1 >= @market[r].size
+        up(coordinates)
+      else
+        [r, c + 1]
+      end
+    end
+
+    def down(coordinates)
+      r, c = coordinates
+      r += 1 if r + 1 < @market.size
+      [r, c]
+    end
+
+    def up(coordinates)
+      r, c = coordinates
+      r -= 1 if r - 1 >= 0
+      [r, c]
+    end
+  end
+
+  class OneDimensionalMovement < BaseMovement
+    def left(coordinates)
+      r, c = coordinates
+      c -= 1 if c - 1 >= 0
+      [r, c]
+    end
+
+    def right(coordinates)
+      r, c = coordinates
+      c += 1 if c + 1 < @market[r].size
+      [r, c]
+    end
+
+    def down(coordinates)
+      left(coordinates)
+    end
+
+    def up(coordinates)
+      right(coordinates)
+    end
+  end
+
+  class ZigZagMovement < BaseMovement
+    def left(coordinates)
+      r, c = coordinates
+      c -= 2 if c - 2 >= 0
+      [r, c]
+    end
+
+    def right(coordinates)
+      r, c = coordinates
+      c += 2 if c + 2 < @market[r].size
+      [r, c]
+    end
+
+    def down(coordinates)
+      r, c = coordinates
+      c -= 1 if c.positive?
+      [r, c]
+    end
+
+    def up(coordinates)
+      r, c = coordinates
+      c += 1 if c + 1 < @market[r].size
+      [r, c]
+    end
+  end
+end

--- a/spec/lib/engine/round/stock_spec.rb
+++ b/spec/lib/engine/round/stock_spec.rb
@@ -234,7 +234,7 @@ module Engine
       end
 
       it 'director can buy two shares from ipo in gray' do
-        market.move(corp_0, 12, 0, force: true)
+        market.move(corp_0, [12, 0], force: true)
         expect(corp_0.share_price.type).to eq(:unlimited)
 
         market_share = corp_0.shares.first
@@ -252,7 +252,7 @@ module Engine
       end
 
       it 'cannot buy stocks from second company after buying one gray' do
-        market.move(corp_0, 12, 0, force: true)
+        market.move(corp_0, [12, 0], force: true)
         expect(corp_0.share_price.type).to eq(:unlimited)
 
         subject.process_action(Engine::Action::BuyShares.new(player_0, shares: corp_0.shares.first))
@@ -261,7 +261,7 @@ module Engine
       end
 
       it 'corporation share price goes up if in gray at end of stock round' do
-        market.move(corp_0, 12, 0, force: true)
+        market.move(corp_0, [12, 0], force: true)
         expect(corp_0.share_price.type).to eq(:unlimited)
 
         # Sell out corp
@@ -294,7 +294,7 @@ module Engine
       end
 
       it 'corporation share price goes up 3 times if in gray, 80% owned by director, and sold out' do
-        market.move(corp_0, 12, 0, force: true)
+        market.move(corp_0, [12, 0], force: true)
         expect(corp_0.share_price.type).to eq(:unlimited)
 
         # Owner to 80%


### PR DESCRIPTION
- Introduce stock movement class for each type of stock market
- Remove zigzag market workarounds from being based on a 1d market, in 1860, 1862, and 18CZ
- Some methods took coordinates ([r, c]) and others r, c. Standardize on coordinates
