### PR TITLE
21Moon: fix disposal of shares owned by a closing corp

### DIFF
--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -814,7 +814,7 @@ module Engine
           if corporation.corporation?
             corporation.shares_by_corporation.each do |other, _|
               shares = corporation.shares_of(other)
-              shares.each do |share|
+              shares.dup.each do |share|
                 @share_pool.transfer_shares(share.to_bundle, @share_pool)
               end
             end


### PR DESCRIPTION
Fixes #8956 

### Implementation Notes

Fixes the old "deallocating elements of a list while iterating through the list" bug.

No pinning nor archiving required.