### PR TITLE
[1822PNW,MX,CA] fix P16 not counting as a cert

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -246,9 +246,8 @@ module Engine
 
         # Stubbed out because this game doesn't it, but base 22 does
         def company_tax_haven_bundle(choice); end
-
-        # Stubbed out because this game doesn't it, but base 22 does
         def company_tax_haven_payout(entity, per_share); end
+        def num_certs_modification(_entity) = 0
       end
     end
   end

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -496,9 +496,8 @@ module Engine
 
         # Stubbed out because this game doesn't it, but base 22 does
         def company_tax_haven_bundle(choice); end
-
-        # Stubbed out because this game doesn't it, but base 22 does
         def company_tax_haven_payout(entity, per_share); end
+        def num_certs_modification(_entity) = 0
 
         def event_close_ndem!
           @log << '-- Event: Ndem privatizing --'
@@ -743,10 +742,6 @@ module Engine
         end
 
         def finalize_end_game_values; end
-
-        def num_certs_modification(_entity)
-          0
-        end
 
         def reduced_bundle_price_for_market_drop(bundle)
           bundle.share_price = @stock_market.find_share_price(bundle.corporation, [:left] * bundle.num_shares).price

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -676,9 +676,8 @@ module Engine
 
         # Stubbed out because this game doesn't it, but base 22 does
         def company_tax_haven_bundle(choice); end
-
-        # Stubbed out because this game doesn't it, but base 22 does
         def company_tax_haven_payout(entity, per_share); end
+        def num_certs_modification(_entity) = 0
 
         def finalize_end_game_values; end
 


### PR DESCRIPTION
Fixes #8965 

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Override a base 1822 function that handles the way that P16 `Tax Haven` in the base game does not count against certificate limit

* **Screenshots**
![Screenshot 2023-03-04 9 17 56 AM](https://user-images.githubusercontent.com/1711810/222919778-bfab334b-166f-43b7-b8ea-073e762bd02b.png)

* **Any Assumptions / Hacks**

This s.b. generalized in 1822 base code so future games don't have to know about this hack-around