### PR TITLE
Partially revert 4c65c1f, move changes to 1880 code

### DIFF
--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -455,7 +455,7 @@ module Engine
 
         def operating_round(round_num)
           G1880::Round::Operating.new(self, [
-            Engine::Step::HomeToken,
+            G1880::Step::HomeToken,
             G1880::Step::RocketPurchaseTrain,
             Engine::Step::Exchange,
             Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_1880/step/home_token.rb
+++ b/lib/engine/game/g_1880/step/home_token.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/home_token'
+
+module Engine
+  module Game
+    module G1880
+      module Step
+        class HomeToken < Engine::Step::HomeToken
+          def active_entities
+            @round.pending_tokens&.map { |token| token[:entity] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/home_token.rb
+++ b/lib/engine/step/home_token.rb
@@ -43,10 +43,6 @@ module Engine
         @round.pending_tokens&.first || {}
       end
 
-      def active_entities
-        @round.pending_tokens&.map { |token| token[:entity] }
-      end
-
       def description
         if current_entity != token.corporation
           "Place #{token.corporation.name} Home Token"


### PR DESCRIPTION
Fixes #8952.

The changes introduced by commit 4c65c1f to `lib/engine/step/home_token.rb` had changed game behaviour in 1867. The home token for a minor needs to be placed before the minor has a president (at the start of its auction), previously the player was the active entity during the home token step, this had changed it to be the presidentless minor.

This removes this change and instead puts it in a G1880 subclass.

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

I don't believe that this change will break any existing 1867 games. The recent behaviour is that anyone can place the token for the minor that is being auctioned, but the action produced is the same regardless of who chooses where the token goes.

@bentziaxl Can you check that this is OK for 1880? I can't see why it wouldn't work, but I've not done any more testing than running rake.