### PR TITLE
add build date to /about

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,10 +106,12 @@ task :precompile do
 
   # Copy to the pin directory
   git_rev = `git rev-parse --short HEAD`.strip
+  version_datetime = Time.now.strftime('%B %d %Y %H:%M')
   pin_dir = Assets::OUTPUT_BASE + Assets::PIN_DIR
   File.write(Assets::OUTPUT_BASE + '/assets/version.json', JSON.dump(
     hash: git_rev,
     url: "https://github.com/tobymao/18xx/commit/#{git_rev}",
+    version_datetime: version_datetime,
   ))
   FileUtils.mkdir_p(pin_dir)
   assets.pin("#{pin_dir}#{git_rev}.js.gz")

--- a/assets/app/view/about.rb
+++ b/assets/app/view/about.rb
@@ -13,6 +13,7 @@ module View
       @connection&.get('/version.json', '/assets') do |version|
         link = node_to_s(h(:a, { attrs: { href: version['url'] } }, version['hash']))
         `document.getElementById('version').innerHTML = #{link}`
+        `document.getElementById('version_datetime').innerHTML = #{version['version_datetime']}`
       end
 
       message = <<~MESSAGE
@@ -23,7 +24,7 @@ module View
         code on <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. All games are used with express written consent from their respective rights holders. You can find more information about the games on the <a href='https://github.com/tobymao/18xx/wiki'>wiki</a>.
         </p>
 
-        <p>Current version <span id='version'>unknown</span> (<a href="https://github.com/tobymao/18xx/commits/master">recent commits</a>).</p>
+        <p>Current version: <span id='version'>unknown</span> deployed at <span id='version_datetime'>unknown</span> (<a href="https://github.com/tobymao/18xx/commits/master">View all recent commits</a>)</p>
 
         <h2>Conduct Expectations</h2>
 


### PR DESCRIPTION
Adds date that `precompile` was run to /about

![Screenshot 2023-03-05 9 50 45 PM](https://user-images.githubusercontent.com/1711810/223034130-cc9be149-1538-4d03-9d8d-e87f55720dea.png)
