### PR TITLE
Fix ZigZig end movement for 60 and 62

### DIFF
--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -404,7 +404,7 @@ module Engine
         end
 
         def init_stock_market
-          StockMarket.new(self.class::MARKET, [], zigzag: true)
+          StockMarket.new(self.class::MARKET, [], zigzag: true, ledge_movement: true)
         end
 
         def new_auction_round

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -995,7 +995,7 @@ module Engine
         end
 
         def init_stock_market
-          StockMarket.new(self.class::MARKET, [], zigzag: true)
+          StockMarket.new(self.class::MARKET, [], zigzag: true, ledge_movement: true)
         end
 
         def init_round

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -5,13 +5,12 @@ require_relative 'stock_movement'
 
 module Engine
   class StockMarket
-    attr_reader :market, :par_prices, :has_close_cell, :zigzag, :ledge_movement
+    attr_reader :market, :par_prices, :has_close_cell, :zigzag
 
     def initialize(market, unlimited_types, multiple_buy_types: [], zigzag: nil, ledge_movement: nil)
       @par_prices = []
       @has_close_cell = false
       @zigzag = zigzag
-      @ledge_movement = ledge_movement
       @market = market.map.with_index do |row, r_index|
         row.map.with_index do |code, c_index|
           price = SharePrice.from_code(code,
@@ -32,7 +31,7 @@ module Engine
 
       @movement =
         if @zigzag
-          ZigZagMovement.new(@market, @ledge_movement)
+          ZigZagMovement.new(@market, ledge_movement)
         elsif one_d?
           OneDimensionalMovement.new(@market)
         else

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -5,12 +5,13 @@ require_relative 'stock_movement'
 
 module Engine
   class StockMarket
-    attr_reader :market, :par_prices, :has_close_cell, :zigzag
+    attr_reader :market, :par_prices, :has_close_cell, :zigzag, :ledge_movement
 
-    def initialize(market, unlimited_types, multiple_buy_types: [], zigzag: nil)
+    def initialize(market, unlimited_types, multiple_buy_types: [], zigzag: nil, ledge_movement: nil)
       @par_prices = []
       @has_close_cell = false
       @zigzag = zigzag
+      @ledge_movement = ledge_movement
       @market = market.map.with_index do |row, r_index|
         row.map.with_index do |code, c_index|
           price = SharePrice.from_code(code,
@@ -31,7 +32,7 @@ module Engine
 
       @movement =
         if @zigzag
-          ZigZagMovement.new(@market)
+          ZigZagMovement.new(@market, @ledge_movement)
         elsif one_d?
           OneDimensionalMovement.new(@market)
         else

--- a/lib/engine/stock_movement.rb
+++ b/lib/engine/stock_movement.rb
@@ -83,15 +83,33 @@ module Engine
   end
 
   class ZigZagMovement < BaseMovement
+    attr_reader :ledge_movement
+
+    def initialize(market, ledge_movement)
+      @market = market
+      @ledge_movement = ledge_movement
+      super(market)
+    end
+
     def left(coordinates)
       r, c = coordinates
-      c -= 2 if c - 2 >= 0
+      if ledge_movement
+        c -= 2
+        c = 0 if c.negative?
+      elsif c - 2 >= 0
+        c -= 2
+      end
       [r, c]
     end
 
     def right(coordinates)
       r, c = coordinates
-      c += 2 if c + 2 < @market[r].size
+      if ledge_movement
+        c += 2
+        c = @market[r].size - 1 if c >= @market[r].size
+      elsif c + 2 < @market[r].size
+        c += 2
+      end
       [r, c]
     end
 


### PR DESCRIPTION
Fixes #8979 

> Please minimize the amount of changes to shared `lib/engine` code, if possible

Have to touch stock_market and stock_movement

> If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

### Before clicking "Create"

- [*] Branch is derived from the latest `master`
- [*] Add the `pins` label if this change will break existing games
- [*] Code passes linter with `docker compose exec rack rubocop -a`
- [*] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

1860 and 1862 have different rules than 18CZ and EUS when reaching either end of the "ZigZag" row.

* **Screenshots**

* **Any Assumptions / Hacks**
