### PR TITLE
Fix `update_tile_lists` for double-sided tiles

### DIFF
--- a/lib/engine/game/double_sided_tiles.rb
+++ b/lib/engine/game/double_sided_tiles.rb
@@ -27,13 +27,13 @@ module DoubleSidedTiles
     end
   end
 
-  def update_tile_lists!(tile, old_tile)
+  def update_tile_lists(tile, old_tile)
     if tile.opposite == old_tile
       unused_tiles.delete(tile)
       unused_tiles << old_tile
     else
       if tile.unlimited
-        add_extra_tile(tile)
+        new_tile = add_extra_tile(tile)
 
         if (opp_name = tile.opposite&.name) && !new_tile.opposite
           opp_tile = tile_by_id("#{opp_name}-#{new_tile.index}") || add_extra_tile(tile_by_id("#{opp_name}-0"))


### PR DESCRIPTION
Fixes some problems from #8951:

* the new tile returned from `add_extra_tile` was not being captured, so
  `new_tile` was actually not defined on the subsequent `if` check

* the method was named `update_tile_lists!` but the base method it overrides
  does not have an exclamation point; originally the 18Carolinas code and 18Mag
  code did call it with the exclamation point but that call was removed in #8951

I think 18Carolinas and 18Mag didn't break since their double-sided tiles are
all limited in count.