### PR TITLE
[1817] Volatility-variant private "Inventor" pays too much on 6 train purchase

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1950,9 +1950,9 @@ module Engine
       end
 
       def rust(train)
+        train.rusted = true
         remove_train(train)
         train.owner = nil
-        train.rusted = true
       end
 
       def num_corp_trains(entity)

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -871,15 +871,8 @@ module Engine
         end
 
         def remove_train(train)
-          from_depot = train.from_depot?
+          inventor_payout(train)
           super
-
-          return unless inventor_private&.owner&.corporation?
-          return if train.rusted || !from_depot || @depot.trains.find { |t| t.name == train.name } != train
-          return unless (payout = inventor_payout(train)).positive?
-
-          @log << "#{inventor_private.owner.name} collects #{format_currency(payout)} from #{inventor_private.name}"
-          @bank.spend(payout, inventor_private.owner)
         end
 
         def loan_shark_private
@@ -925,8 +918,13 @@ module Engine
         end
 
         def inventor_payout(train)
+          return unless inventor_private&.owner&.corporation?
+
           @payouts ||= { '2' => 20, '3' => 30, '4' => 40, '5' => 50, '6' => 60, '7' => 70, '8' => 80 }
-          @payouts[train.name] || 0
+          return unless (payout = @payouts.delete(train.name))
+
+          @log << "#{inventor_private.owner.name} collects #{format_currency(payout)} from #{inventor_private.name}"
+          @bank.spend(payout, inventor_private.owner)
         end
 
         private

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -873,8 +873,9 @@ module Engine
         def remove_train(train)
           from_depot = train.from_depot?
           super
+
           return unless inventor_private&.owner&.corporation?
-          return if !from_depot || @depot.trains.find { |t| t.name == train.name } != train
+          return if train.rusted || !from_depot || @depot.trains.find { |t| t.name == train.name } != train
           return unless (payout = inventor_payout(train)).positive?
 
           @log << "#{inventor_private.owner.name} collects #{format_currency(payout)} from #{inventor_private.name}"
@@ -924,7 +925,7 @@ module Engine
         end
 
         def inventor_payout(train)
-          @payouts ||= { '2' => 20, '2+' => 0, '3' => 30, '4' => 40, '5' => 50, '6' => 60, '7' => 70, '8' => 80 }
+          @payouts ||= { '2' => 20, '3' => 30, '4' => 40, '5' => 50, '6' => 60, '7' => 70, '8' => 80 }
           @payouts[train.name] || 0
         end
 


### PR DESCRIPTION
Fixes #8988

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**


- Sets the `rusted` flag on trains before `remove_train()` is called, as within that function it was not possible to check the `rusted` state otherwise. This behavior was causing a bug as described here https://github.com/tobymao/18xx/issues/8988#issuecomment-1467477512

-  Also Removes an un-necessary "2+ trains provide zero revenue" definition from the lookup hash, since the calling function returns zero anyway if the train type is not in the hash

* **Screenshots**
![Screenshot 2023-03-14 12 06 21 AM](https://user-images.githubusercontent.com/1711810/224930509-25e91205-8ed5-424e-b9c1-1d2c7bab401b.png)

* **Any Assumptions / Hacks**

We assume that `remove_train` will operate correctly if the train is already marked as rusted