### PR TITLE
[1868WY] various small fixes

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -230,18 +230,7 @@ module Engine
           '619' => '619b',
         }.freeze
 
-        def dotify(tile)
-          tile.towns.each { |town| town.style = :dot }
-          tile
-        end
-
-        def init_tiles
-          super.each { |tile| dotify(tile) }
-        end
-
-        def init_hexes(companies, corporations)
-          super.each { |hex| dotify(hex.tile) }
-        end
+        TOKEN_PRICES_AFTER_BUST = [80, 60, 40].freeze
 
         def ipo_name(_entity = nil)
           'Treasury'
@@ -629,15 +618,18 @@ module Engine
           @track_points_used = Hash.new(0)
         end
 
-        def status_str(corporation)
-          return unless corporation.floated?
+        def status_array(corporation)
+          statuses = []
 
-          if corporation.minor?
-            player = corporation.owner
-            "#{player.name} Cash: #{format_currency(player.cash)}"
-          else
-            "Track Points: #{track_points_available(corporation)}"
+          if corporation.floated?
+            if @round.is_a?(G1868WY::Round::Operating) && corporation.corporation?
+              statuses << "Track Points: #{track_points_available(corporation)}"
+            end
+          elsif !@all_corps_available && (stack = @corp_stacks.find { |s| s.last == corporation }) && stack.size > 1
+            statuses << "Next: #{stack.map(&:name).reverse.slice(1, 4).join(', ')}"
           end
+
+          statuses.empty? ? nil : statuses
         end
 
         def hell_on_wheels
@@ -922,15 +914,21 @@ module Engine
           @players.map.with_index do |player, index|
             coal_company = Engine::Minor.new(
               type: :coal,
-              sym: "Coal-#{index + 1}",
-              name: "#{player.name} Coal",
+              sym: "Coal-#{self.class::LETTERS[index]}",
+              name: self.class::COAL_COMPANY_NAMES[index],
               logo: '1868_wy/coal',
               tokens: [],
               color: :black,
               abilities: [{ type: 'no_buy', owner_type: 'player' }],
             )
+            add_coal_development_tokens(coal_company)
             coal_company.owner = player
             coal_company.float!
+
+            def coal_company.cash
+              player.cash
+            end
+
             coal_company
           end
         end
@@ -1154,11 +1152,19 @@ module Engine
         def upgrades_to?(from, to, special = false, selected_company: nil)
           return false unless boomer?(from) == boomer?(to)
 
-          if (upgrades = TILE_UPGRADES[from.name])
-            upgrades.include?(to.name)
+          case from.name
+          when 'YG'
+            to.name == 'GG'
+          when 'YL'
+            to.name == 'GL'
           else
             super
           end
+        end
+
+        # green crossing track with "$20" label
+        def upgrades_to_correct_label?(from, to)
+          (%w[8 9].include?(from.name) && to.label&.to_s == '$20') || super
         end
 
         def upgrade_cost(tile, hex, entity, spender)
@@ -1185,16 +1191,43 @@ module Engine
         end
 
         def revenue_for(route, stops)
-          stops.sum do |stop|
-            if stop.city? && stop.boom
-              dtc = @development_token_count[stop.hex]
-              next BUSTED_REVENUE[stop.hex.tile.color] if dtc < DTC_BOOMCITY
+          revenue = super
 
-              gets_bonus = dtc >= DTC_REVENUE
+          revenue += east_west_bonus(stops)[:revenue]
+
+          revenue += spike_route_bonuses(route, stops)[:revenue]
+          revenue
+        end
+
+        def revenue_str(route)
+          str = super
+          ew_bonus = east_west_bonus(route.stops)[:description]
+          str += " + #{ew_bonus}" if ew_bonus
+
+          spike_bonus = spike_route_bonuses(route, route.stops)[:description]
+          str += " + #{spike_bonus}" if spike_bonus
+
+          str += ' + Uranium' if route.stops.any? { |s| uranium_bonus(@phase.name, s.hex).positive? }
+          str
+        end
+
+        def east_west_bonus(stops)
+          bonus = { revenue: 0 }
+
+          east = stops.find { |stop| stop.groups.include?('E') && stop.tile.label&.to_s == 'E' }
+          west = stops.find { |stop| stop.groups.include?('W') && stop.tile.label&.to_s == 'W' }
+
+          if east && west
+            east_rev = east.tile.icons.sum { |icon| icon.name.to_i }
+            west_rev = west.tile.icons.sum { |icon| icon.name.to_i }
+
+            if !east_rev.zero? && !west_rev.zero?
+              bonus[:revenue] += east_rev + west_rev
+              bonus[:description] = 'E/W'
             end
-
-            stop.route_revenue(route.phase, route.train) + (gets_bonus ? BOOMING_REVENUE_BONUS : 0)
           end
+
+          bonus
         end
 
         def decrement_development_token_count(tokened_hex)
@@ -1255,7 +1288,7 @@ module Engine
 
           corporations = tokens.map do |token|
             token.remove!
-            token.corporation
+            reprice_tokens!(token.corporation)
           end
 
           if corporations.empty?
@@ -1265,6 +1298,13 @@ module Engine
             dpr.coordinates = '' if corporations.include?(dpr) && dpr.tokens.count(&:used).zero?
             " Tokens are returned: #{corporations.map(&:name).join(' and ')}" unless corporations.empty?
           end
+        end
+
+        def reprice_tokens!(corporation)
+          corporation.tokens.reject(&:used).reverse.each_with_index do |token, index|
+            token.price = TOKEN_PRICES_AFTER_BUST[index]
+          end
+          corporation
         end
 
         def to_ghost_town!(hex)
@@ -1683,8 +1723,6 @@ module Engine
         end
 
         def event_close_ames_brothers!
-          return if ames_bros.closed?
-
           player = ames_bros.owner
           cash = union_pacific.share_price.price * 2
           @log << "Company #{ames_bros.name} closes."
@@ -1814,8 +1852,6 @@ module Engine
         end
 
         def event_close_no_bust!
-          return if !no_bust || no_bust.closed?
-
           @log << "-- Event: #{no_bust.name} closes, removing the NO BUST token --"
           hex = @no_bust_hex
           hex.remove_assignment!(no_bust.id)
@@ -1860,12 +1896,12 @@ module Engine
         def event_close_privates!
           case @phase.name
           when '5'
-            event_close_ames_brothers!
+            event_close_ames_brothers! unless ames_bros.closed?
           when '7'
-            event_close_pure_oil!
+            event_close_pure_oil! unless pure_oil.closed?
           when '8'
-            event_close_big_boy!
-            event_close_no_bust!
+            event_close_big_boy! unless big_boy_private.closed?
+            event_close_no_bust! unless no_bust.closed?
           end
         end
       end

--- a/lib/engine/game/g_1868_wy/golden_spike.rb
+++ b/lib/engine/game/g_1868_wy/golden_spike.rb
@@ -7,7 +7,7 @@ module Engine
         SPIKE = {
           northern: {
             start_desc: 'an Eastern offboard',
-            start_hex_ids: %w[E27 F28 K27 M27 N26],
+            start_hex_ids: %w[C27 E27 G27 K27 M27 N26],
             end_hex_meta: {
               'A9' => {
                 exits: [1],

--- a/lib/engine/game/g_1868_wy/map.rb
+++ b/lib/engine/game/g_1868_wy/map.rb
@@ -110,7 +110,7 @@ module Engine
                        'path=a:_0,b:0;path=a:_0,b:1;path=a:_0,b:5;icon=image:1868_wy/120',
             ['A15'] => 'offboard=groups:Billings,revenue:yellow_10|green_20|brown_30|gray_30,groups:W;'\
                        'path=a:_0,b:1;path=a:_0,b:5;icon=image:1868_wy/60',
-            ['A23'] => 'offboard=revenue:yellow_40|green_30|brown_20|gray_20;path=a:_0,b:5;icon=image:1868_wy/fort,sticky:1',
+            ['A23'] => 'offboard=revenue:yellow_40|green_30|brown_20|gray_20;path=a:_0,b:0;path=a:_0,b:5;icon=image:1868_wy/fort,sticky:1',
             ['E27'] => 'offboard=revenue:yellow_10|green_20|brown_30|gray_40,groups:E;'\
                        'path=a:_0,b:1;label=E;icon=image:1868_wy/10;',
             ['E1'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_50,groups:W;'\
@@ -129,9 +129,9 @@ module Engine
             ['B4'] => 'border=edge:0;border=edge:1;border=edge:5',
             ['C3'] => 'border=edge:0;border=edge:2;border=edge:3;border=edge:4;border=edge:5',
             ['C5'] => 'border=edge:0;border=edge:1;border=edge:2;border=edge:3;'\
-                      'border=edge:5;town=revenue:yellow_20|green_30|brown_30|gray_40,loc:4.5;path=a:_0,b:4',
+                      'border=edge:5;town=style:dot,revenue:yellow_20|green_30|brown_30|gray_40,loc:4.5;path=a:_0,b:4',
             ['D2'] => 'border=edge:3;border=edge:4',
-            ['D4'] => 'border=edge:1;border=edge:2;border=edge:3;town=revenue:yellow_20|green_30|brown_30|gray_40,loc:0;'\
+            ['D4'] => 'border=edge:1;border=edge:2;border=edge:3;town=style:dot,revenue:yellow_20|green_30|brown_30|gray_40,loc:0;'\
                       'path=a:_0,b:0',
           },
           purple: {
@@ -145,7 +145,7 @@ module Engine
           gray: {
             %w[B6 C15 D6 D8 E9 F4 F6 H2 H8 L18 M15] => '',
             %w[A17 G7] => 'offboard=revenue:0;path=a:_0,b:0',
-            ['A1'] => 'town=revenue:0;path=a:_0,b:4;icon=image:1868_wy/golden_spike',
+            ['A1'] => 'town=style:dot,revenue:0;path=a:_0,b:4;icon=image:1868_wy/golden_spike,large:1',
             %w[C7 E5] => 'path=a:1,b:4',
             %w[D16 K1] => 'offboard=revenue:0;path=a:_0,b:3',
             ['E3'] => 'junction;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0',
@@ -156,7 +156,7 @@ module Engine
             ['G3'] => 'path=a:2,b:4',
             ['I1'] => 'offboard=revenue:0;path=a:_0,b:4;path=a:_0,b:5;',
             ['M19'] => 'town=revenue:10;path=a:_0,b:0;path=a:_0,b:4',
-            ['L0'] => 'town=revenue:0,loc:5;junction;path=a:_0,b:5;path=a:_1,b:4,terminal:1;icon=image:1868_wy/golden_spike',
+            ['L0'] => 'town=style:dot,revenue:0,loc:5;junction;path=a:_0,b:5;path=a:_1,b:4,terminal:1;icon=image:1868_wy/golden_spike,large:1',
           },
         }.freeze
 
@@ -209,17 +209,17 @@ module Engine
           'YL' => {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'city=revenue:0,loc:1;town=revenue:10,loc:center;path=a:_1,b:2;path=a:_1,b:4;label=L',
+            'code' => 'city=revenue:0,loc:1;town=revenue:10,loc:center,style:dot;path=a:_1,b:2;path=a:_1,b:4;label=L',
           },
           'YG' => {
             'count' => 1,
             'color' => 'yellow',
-            'code' => 'city=revenue:0,loc:0;town=revenue:10,loc:center;path=a:_1,b:2;path=a:_1,b:4;label=G',
+            'code' => 'city=revenue:0,loc:0;town=revenue:10,loc:center,style:dot;path=a:_1,b:2;path=a:_1,b:4;label=G',
           },
           '5b' => {
             'count' => 'unlimited',
             'color' => 'yellow',
-            'code' => 'town=revenue:10,boom:1,loc:center;path=a:_0,b:0;path=a:_0,b:1',
+            'code' => 'town=revenue:10,boom:1,loc:center,style:dot;path=a:_0,b:0;path=a:_0,b:1',
           },
           '5B' => {
             'count' => 'unlimited',
@@ -229,7 +229,7 @@ module Engine
           '6b' => {
             'count' => 'unlimited',
             'color' => 'yellow',
-            'code' => 'town=revenue:10,boom:1,loc:center;path=a:_0,b:0;path=a:_0,b:2',
+            'code' => 'town=revenue:10,boom:1,loc:center,style:dot;path=a:_0,b:0;path=a:_0,b:2',
           },
           '6B' => {
             'count' => 'unlimited',
@@ -239,7 +239,7 @@ module Engine
           '57b' => {
             'count' => 'unlimited',
             'color' => 'yellow',
-            'code' => 'town=revenue:10,boom:1,loc:center;path=a:_0,b:0;path=a:_0,b:3',
+            'code' => 'town=revenue:10,boom:1,loc:center,style:dot;path=a:_0,b:0;path=a:_0,b:3',
           },
           '57B' => {
             'count' => 'unlimited',
@@ -503,39 +503,6 @@ module Engine
             'code' => 'offboard=groups:Billings,revenue:yellow_30|green_40|brown_50|gray_60,groups:W;'\
                       'path=a:_0,b:3;path=a:_0,b:4;label=W;icon=image:1868_wy/50;',
           },
-        }.freeze
-
-        TILE_UPGRADES = {
-          # hard-coded to work with the custom tiles with
-          # the special $20 upgrade cost and label: 16 19 20
-          '8' => %w[16 17 19 21 22],
-          '9' => %w[18 19 20],
-
-          # town + city -> city
-          'YG' => ['GG'],
-          'YL' => ['GL'],
-
-          # Green -> Brown Boomtown
-          '12b' => %w[448b 450b],
-          '13b' => %w[450b],
-          '205b' => %w[449b 448b 450b],
-          '206b' => %w[449b 448b 450b],
-
-          # Green -> Brown Boom City
-          '12B' => %w[448B 450B],
-          '13B' => %w[450B],
-          '205B' => %w[449B 448B 450B],
-          '206B' => %w[449B 448B 450B],
-
-          # Brown -> Gray Boomtown
-          '449b' => ['51b'],
-          '448b' => ['51b'],
-          '450b' => ['51b'],
-
-          # Brown -> Gray Boom City
-          '449B' => ['51B'],
-          '448B' => ['51B'],
-          '450B' => ['51B'],
         }.freeze
 
         BOOMTOWN_TO_BOOMCITY_TILES = {

--- a/lib/engine/game/g_1868_wy/step/track.rb
+++ b/lib/engine/game/g_1868_wy/step/track.rb
@@ -33,10 +33,9 @@ module Engine
           end
 
           def legal_tile_rotation?(entity, hex, tile)
-            if (upgrades = @game.class::TILE_UPGRADES[hex.tile.name]) && upgrades.include?(tile.name)
-              (hex.tile.exits & tile.exits == hex.tile.exits) &&
-                tile.exits.all? { |edge| hex.neighbors[edge] } &&
-                !(tile.exits & hex_neighbors(entity, hex)).empty?
+            case tile.name
+            when 'YL', 'YG', 'GL', 'GG'
+              tile.rotation.zero?
             else
               super
             end

--- a/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
+++ b/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
@@ -64,9 +64,10 @@ module Engine
             if @choosing
               company.owner = player
               player.companies << company
-              @log << "#{player.name} chooses #{company.name}, closing #{@auctioned_company.name}"
+              @log << "#{player.name} chooses #{company.name}, closing the other #{@auctioned_company.sym} companies"
               @choosing = false
               @choosing_player = nil
+              @company_choices.each { |c| c.close! unless c == company }
               @company_choices = nil
               @auctioned_company.close!
               @auctioned_company = nil


### PR DESCRIPTION
* map/tile tweaks:

    * embiggen spike icons
    * new track on A23
    * get rid of `dotify`, just use `style:dot` now
        * used for boomtowns to always use dots and appear in center of tile, as
          opposed to regular towns with the classic rectangle
    * fix `legal_tile_rotation?` for green $20 tiles and L/G tiles; the "L" and
      "G" tiles have only one legal rotation in yellow and green, but the logic
      that was using `TILE_UPGRADES` was leaking into the green tiles that cost
      $20 to lay, allowing upgrades that actually rerouted track;
      `TILE_UPGRADES` also is no longer needed for boom tiles, so it can be
      removed entirely

* routes:

    * remove boom city calculation from `revenue_for`, that is now done directly
      on the city's revenue
    * string for uranium bonus; actual value is done directly on the city's
      revenue
    * east-west bonuses
    * golden/northern spike bonuses
    * fix northern spike route starting hexes

* status array:

    * show corporations coming up in the stacks
    * some private company abilities will be shown in upcoming PRs; use an array
      instead of string so that they can all be shown

* coal companies:

    * fix displayed name
    * display player cash as the company cash instead of displaying cash in the
      status

* after BUST returns tokens, reprice the tokens so they always fill up the most expensive slots first (`TOKEN_PRICES_AFTER_BUST` and `reprice_tokens!`)

* closing privates:

    * in the auction, when one of the three available privates is chosen for
      P2-P6, close the companies that were not chosen
    * only call event methods for closing specific private companies if the
      company is not already closed

#5011