### PR TITLE
Raise an error if the tile being laid is already on the board

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2083,6 +2083,9 @@ module Engine
 
       def update_tile_lists(tile, old_tile)
         add_extra_tile(tile) if tile.unlimited
+
+        raise GameError, "Cannot lay tile #{tile.id}; it is already on hex #{tile.hex.id}" if tile.hex
+
         @tiles.delete(tile)
         @tiles << old_tile unless old_tile.preprinted
       end

--- a/lib/engine/game/double_sided_tiles.rb
+++ b/lib/engine/game/double_sided_tiles.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../game_error'
+
 # This module is used by games which double sided tiles, providing methods for
 # initializing double-sided tiles and keeping tile lists updated appropriately.
 module DoubleSidedTiles
@@ -14,7 +16,7 @@ module DoubleSidedTiles
       num = by_name[name_a].size
 
       if num != by_name[name_b].size
-        raise GameError, "Sides of double-sided tiles need to have same number (#{name_a}, #{name_b})"
+        raise Engine::GameError, "Sides of double-sided tiles need to have same number (#{name_a}, #{name_b})"
       end
 
       num.times.each do |index|
@@ -40,6 +42,11 @@ module DoubleSidedTiles
           opp_tile.opposite = new_tile
           new_tile.opposite = opp_tile
         end
+      end
+
+      raise Engine::GameError, "Cannot lay tile #{tile.id}; it is already on hex #{tile.hex.id}" if tile.hex
+      if tile.opposite&.hex
+        raise Engine::GameError, "Cannot lay tile #{tile.id}; #{tile.opposite.id} is already on hex #{tile.opposite.hex.id}"
       end
 
       @tiles.delete(tile)


### PR DESCRIPTION
This bug was introduced by #8951, and fixed by #8996, but in between those two, games could be broken and not found when validating #8996 since the tile mismatch could not have any real impact on the game for many actions--in the case of game 115149, the game first misused tiles at action 630 but was not visibly broken until action 1766.

Closes #9026

----

10 of 11 active 18Mag games are impacted; pinning would prevent them from hitting this new exception but cannot prevent encountering the broken behavior seen in #9026.  
Here are the affected games:

`[111821, 113092, 113389, 114853, 115023, 115024, 115139, 115149, 115319, 116143]`

I've pinned them all. Many have triggered the end and may be able to finish, but could still encounter the issues caused by #8951.