### PR TITLE
[1880] fix 6e route issue

### DIFF
--- a/assets/app/view/game/par_chart.rb
+++ b/assets/app/view/game/par_chart.rb
@@ -39,7 +39,7 @@ module View
 
         cash = @current_entity.cash
         prices = @step.get_par_prices(@current_entity, @corporation_to_par)
-        prices.map! { |sp| "#{@game.format_currency(sp.price)} (#{(cash / sp.price.to_f).floor} shares)" }
+        prices.map! { |sp| "#{@game.format_currency(sp.price)} (#{[(cash / sp.price.to_f).floor, 10].min} shares)" }
         text = "#{@current_entity.name} can par #{@corporation_to_par.name} at #{prices.join(', ')}"
         h(:div, props, text)
       end

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -196,7 +196,7 @@ module Engine
                     price: 450,
                     rusts_on: '8E',
                     num: 5,
-                    events: [{ 'type' => 'float_40' }, { 'type' => 'permit_c' }],
+                    events: [{ 'type' => 'permit_c' }],
                   },
                   {
                     name: '6',
@@ -683,10 +683,15 @@ module Engine
 
             unless stops.find { |stop| stop.tokened_by?(route.corporation) }
               stops.pop
-              stops << sorted_stops.find { |stop| stop.tokened_by?(route.corporation) }
+              tokened_stop = sorted_stops.find { |stop| stop.tokened_by?(route.corporation) }
+              stops << tokened_stop if tokened_stop
             end
 
-            stops << sorted_stops.select { |stop| trans_siberian_hexes.include?(stop.hex) } if trans_siberian_bonus?(sorted_stops)
+            if trans_siberian_bonus?(sorted_stops)
+              stops.concat(sorted_stops.select do |stop|
+                             trans_siberian_hexes.include?(stop.hex)
+                           end)
+            end
 
             stops.uniq!
           end


### PR DESCRIPTION
fixes #9038: 
removes the extra float_40 event on 4+4.
sets min of shares purchasable and 10

fixes #9034 