### PR TITLE
[feat] Localize deploy date in /about

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,12 +106,12 @@ task :precompile do
 
   # Copy to the pin directory
   git_rev = `git rev-parse --short HEAD`.strip
-  version_datetime = Time.now.strftime('%B %d %Y %H:%M')
+  version_epochtime = Time.now.strftime('%s')
   pin_dir = Assets::OUTPUT_BASE + Assets::PIN_DIR
   File.write(Assets::OUTPUT_BASE + '/assets/version.json', JSON.dump(
     hash: git_rev,
     url: "https://github.com/tobymao/18xx/commit/#{git_rev}",
-    version_datetime: version_datetime,
+    version_epochtime: version_epochtime,
   ))
   FileUtils.mkdir_p(pin_dir)
   assets.pin("#{pin_dir}#{git_rev}.js.gz")

--- a/assets/app/view/about.rb
+++ b/assets/app/view/about.rb
@@ -11,9 +11,10 @@ module View
 
     def render
       @connection&.get('/version.json', '/assets') do |version|
+        version_localtime = Time.at(version['version_epochtime'].to_i)
         link = node_to_s(h(:a, { attrs: { href: version['url'] } }, version['hash']))
         `document.getElementById('version').innerHTML = #{link}`
-        `document.getElementById('version_datetime').innerHTML = #{version['version_datetime']}`
+        `document.getElementById('version_localtime').innerHTML = #{version_localtime}`
       end
 
       message = <<~MESSAGE
@@ -24,7 +25,7 @@ module View
         code on <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. All games are used with express written consent from their respective rights holders. You can find more information about the games on the <a href='https://github.com/tobymao/18xx/wiki'>wiki</a>.
         </p>
 
-        <p>Current version: <span id='version'>unknown</span> deployed at <span id='version_datetime'>unknown</span> (<a href="https://github.com/tobymao/18xx/commits/master">View all recent commits</a>)</p>
+        <p>Current version: <span id='version'>unknown</span> deployed at <span id='version_localtime'>unknown</span> (<a href="https://github.com/tobymao/18xx/commits/master">View all recent commits</a>)</p>
 
         <h2>Conduct Expectations</h2>
 


### PR DESCRIPTION
Fixes #8987

> Please minimize the amount of changes to shared `lib/engine` code, if possible

> If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Refactors the `rake precompile` code to generate an epoch rather than a DateTime object

Stores that epoch in `version.json` that is generated from above

Refactors `about.rb` to pull that new epoch and format it in JS on the client-side

[Time.at()](https://ruby-doc.org/core-2.6.3/Time.html#method-c-at) returns the local time at that epoch with timezone offset
`If a numeric argument is given, the result is in local time.`

* **Screenshots**
![image](https://user-images.githubusercontent.com/1711810/227729251-55269569-c52d-41ff-a186-295b6ef5c0be.png)


* **Any Assumptions / Hacks**
