### PR TITLE
[18mag] fix +1 train supporter

### DIFF
--- a/lib/engine/game/g_18_mag/step/special_choose.rb
+++ b/lib/engine/game/g_18_mag/step/special_choose.rb
@@ -52,20 +52,22 @@ module Engine
 
             if distance.is_a?(Numeric)
               town_distance_value = 1
+              city_distance_value = distance
             else
               town_distance = distance.find { |n| n['nodes'] == ['town'] }
+              city_distance_value = distance.find { |n| n['nodes'].include?('city') }['pay']
               town_distance_value = town_distance['pay'] + 1
             end
             @round.ma_plus_train.distance = [
                 {
-                  nodes: %w[city offboard town],
-                  pay: distance,
-                  visit: distance,
-                },
-                {
                   nodes: %w[town],
                   pay: town_distance_value,
                   visit: town_distance_value,
+                },
+                {
+                  nodes: %w[city offboard town],
+                  pay: city_distance_value,
+                  visit: city_distance_value,
                 },
               ]
           end


### PR DESCRIPTION
fixes #9045

one of the supporters converts a train into +1, for example 2+1.
this can combine with the major ability that converts into plus train. (gc major)

Need special logic to handle
2+1 (supporter only)
2+2 (plus train conversion only)
2+3 (supporter and plus train)

added
1- train conversion and train distance use a city_distance_value  in case it's a gc train
2- compute stops needs to use the updated distance, previously used distance without GC. instead of copying the entire content of compute stops i pass a dummy duplicate train with the correct distance (open to other suggestions such as adding a param or copying the entire method)
3- modified route_distance to also work if just supporter is used without gc