### PR TITLE
fix 1849 dividend view

### DIFF
--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -32,7 +32,7 @@ module Engine
           price = share_price(coordinates).price
           return super if !BLOCKED_UP_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
 
-          @game.log << "#{corporation.name} share price blocked from moving up by phase"
+          @game.log << "#{corporation.name} share price blocked from moving up by phase" if corporation
           coordinates
         end
 
@@ -40,7 +40,7 @@ module Engine
           price = share_price(coordinates).price
           return super if !BLOCKED_RIGHT_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
 
-          @game.log << "#{corporation.name} share price blocked from moving right by phase"
+          @game.log << "#{corporation.name} share price blocked from moving right by phase" if corporation
           coordinates
         end
       end


### PR DESCRIPTION
fix #9078

The fix of stock price movement a month ago introduced an issue where find_relative_share_price calls
right (nil, coordinates). 1849 uses the corp name to log movement, causing a nil exception