### PR TITLE
[1849] Fix 8253 - Allow up movement when blocked from blue zone

### DIFF
--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -40,12 +40,10 @@ module Engine
           price = share_price(coordinates).price
 
           # Special case rule: Stock marker UP if not in blue zone
-          if !@game.phase.status.include?('blue_zone') && BLOCKED_RIGHT_PRICES.include?(price)
-            return up(corporation, coordinates)
-          elsif !BLOCKED_RIGHT_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
-            return super
-          end
-
+          return up(corporation, coordinates) if !@game.phase.status.include?('blue_zone') && BLOCKED_RIGHT_PRICES.include?(price)
+            
+          return super if !BLOCKED_RIGHT_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
+            
           @game.log << "#{corporation.name} share price blocked from moving right by phase" if corporation
           coordinates
         end

--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -38,7 +38,14 @@ module Engine
 
         def right(corporation, coordinates)
           price = share_price(coordinates).price
-          return super if !BLOCKED_RIGHT_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
+
+          # Lower two blocked right prices push stock marker UP if not in blue zone
+          if !@game.phase.status.include?('blue_zone') && BLOCKED_RIGHT_PRICES.slice(0, 2).include?(price)
+            @game.log << "#{corporation.name} share price blocked from moving right by phase; moves up instead" if corporation
+            return up(corporation, coordinates)
+          elsif !BLOCKED_RIGHT_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
+            return super
+          end
 
           @game.log << "#{corporation.name} share price blocked from moving right by phase" if corporation
           coordinates

--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -40,10 +40,12 @@ module Engine
           price = share_price(coordinates).price
 
           # Special case rule: Stock marker UP if not in blue zone
-          return up(corporation, coordinates) if !@game.phase.status.include?('blue_zone') && BLOCKED_RIGHT_PRICES.include?(price)
-            
+          return up(corporation, coordinates) if
+            !@game.phase.status.include?('blue_zone') &&
+            BLOCKED_RIGHT_PRICES.include?(price)
+
           return super if !BLOCKED_RIGHT_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
-            
+
           @game.log << "#{corporation.name} share price blocked from moving right by phase" if corporation
           coordinates
         end

--- a/lib/engine/game/g_1849/stock_market.rb
+++ b/lib/engine/game/g_1849/stock_market.rb
@@ -39,9 +39,8 @@ module Engine
         def right(corporation, coordinates)
           price = share_price(coordinates).price
 
-          # Lower two blocked right prices push stock marker UP if not in blue zone
-          if !@game.phase.status.include?('blue_zone') && BLOCKED_RIGHT_PRICES.slice(0, 2).include?(price)
-            @game.log << "#{corporation.name} share price blocked from moving right by phase; moves up instead" if corporation
+          # Special case rule: Stock marker UP if not in blue zone
+          if !@game.phase.status.include?('blue_zone') && BLOCKED_RIGHT_PRICES.include?(price)
             return up(corporation, coordinates)
           elsif !BLOCKED_RIGHT_PRICES.include?(price) || @game.phase.status.include?('blue_zone')
             return super


### PR DESCRIPTION
Fixes #8253

First time using CodeSpaces, not sure why it made an empty commit!

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
