### PR TITLE
[1868WY] Implement P5b and small fixes for other privates

### DIFF
--- a/lib/engine/game/g_1868_wy/entities.rb
+++ b/lib/engine/game/g_1868_wy/entities.rb
@@ -303,8 +303,8 @@ module Engine
             value: 100,
             revenue: 20,
             abilities: [{ type: 'close', on_phase: '6' }],
-            desc: 'Buyer or auction winner chooses one of "General Jack" (three '\
-                  'time use, 3 free tile laying actions), Credit Foncier of America (earn money '\
+            desc: 'Buyer or auction winner chooses one of "General Jack" '\
+                  '(three free tile laying actions), Credit Foncier of America (earn money '\
                   'for each tile lay), or Pacific Railroad Acts of 1862 and 1864 (terrain costs '\
                   'are halved, including for DTs when player-owned)',
           },
@@ -340,8 +340,8 @@ module Engine
             abilities: [{ type: 'close', on_phase: '6' },
                         { type: 'revenue_change', revenue: 0o0, when: 'sold' },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'Owning Railroad Company is paid per tile it places: $40/city, $30/Boomtown or '\
-                  'Boom City, $10/yellow town. $20 revenue is only paid while owned by a player. Closes at phase 6.',
+            desc: 'Owning Railroad Company is paid per yellow tile it places: $40/city, $30/Boomtown or '\
+                  'Boom City, $10/town. $20 revenue is only paid while owned by a player. Closes at phase 6.',
           },
           {
             name: 'P5c Pacific Railroad Acts of 1862 and 1864',

--- a/lib/engine/game/g_1868_wy/step/stock_round_action.rb
+++ b/lib/engine/game/g_1868_wy/step/stock_round_action.rb
@@ -38,13 +38,13 @@ module Engine
           end
 
           def actions(entity)
-            return %w[buy_shares] if can_exchange?(entity)
+            return %w[buy_shares] if entity == @exchanger && can_exchange?(entity)
             return [] unless entity == current_entity
             return ['sell_shares'] if must_sell?(entity)
 
             actions = []
             actions << 'sell_shares' if can_sell_any?(entity)
-            actions << 'buy_shares' if can_buy_any?(entity)
+            actions << 'buy_shares' if can_buy_any?(entity) || can_exchange?(entity)
             actions << 'par' if can_ipo_any?(entity)
             actions << 'place_token' if can_token?(entity)
             actions << 'pass' unless actions.empty?
@@ -86,8 +86,7 @@ module Engine
 
           def can_exchange?(entity, bundle = nil)
             return false if bought? || sold?
-            return false unless entity == @exchanger
-            return false unless @game.abilities(entity, :exchange)
+            return false if entity != @exchanger.owner && !(entity == @exchanger && current_entity == @exchanger.owner)
 
             bundle ||= @game.up_double_share.to_bundle
             can_gain?(entity.owner, bundle, exchange: true)


### PR DESCRIPTION
#5011

Finishes up implementation for the last few privates.

- P5b Credit Foncier of America - owning corporation gets money per yellow tile it lays, amount depends on type of tile
    - this PR: full implementation
- P5c Pacific RR Acts of 1862 and 1864 - terrain discount
    - this PR: show on owning corp's card via status array
- P9 Laramie, Hahn's Peak & Pacific Railway (LHP) - becomes a permanent 2+1 train at phase 5, which can be assigned to a corporation at that time if it was not already bought in
    - this PR: fix assignment at phase 5
- P11 Oakes and Oliver Ames, Jr - can be exchanged for the special UP double share
    - this PR: fix skipping P11 owner in stock round when exchanging P11 is their only valid stock round action