### PR TITLE
[1868WY] Implement P6 privates - strikebreakers, teapot dome oil

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -261,6 +261,7 @@ module Engine
           @placed_development_tokens = Hash.new { |h, k| h[k] = [] }
           @placed_oil_dt_count = Hash.new(0)
           @busters = {}
+          @teapot_dome_hex_bonus = nil
 
           setup_credit_mobilier
 
@@ -722,6 +723,7 @@ module Engine
           if corporation.floated?
             if corporation.minor? && corporation != union_pacific_coal && corporation != bonanza
               player = corporation.owner
+              statuses << strikebreakers_status if corporation.type == :coal && player == strikebreakers_private.owner
               statuses << 'P3c Frémont discount: $20' if player == fremont.owner
             elsif @round.is_a?(G1868WY::Round::Operating) && corporation.corporation?
               statuses << "Track Points: #{track_points_available(corporation)}"
@@ -1219,6 +1221,7 @@ module Engine
 
           increment_development_token_count(hex)
           @placed_development_tokens[@phase.name] << hex
+          @teapot_dome_hex_bonus = nil if entity == teapot_dome_oil
         end
 
         def destroy_development_token!(token, handle_bust: true)
@@ -1378,6 +1381,8 @@ module Engine
 
           revenue += fort_bonuses(route)[:revenue]
 
+          revenue += teapot_dome_bonuses(route, stops)[:revenue]
+
           revenue
         end
 
@@ -1394,6 +1399,7 @@ module Engine
 
           str += ' + Uranium' if route.stops.any? { |s| uranium_bonus(@phase.name, s.hex).positive? }
           str += fort_bonuses(route)[:description]
+          str += teapot_dome_bonuses(route, route.stops)[:description]
           str
         end
 
@@ -2053,6 +2059,47 @@ module Engine
           @log << "#{company.owner.name} collects #{format_currency(amount)} from #{company.name}; #{reason}"
         end
 
+        def teapot_dome_bonuses(route, stops)
+          return { revenue: 0, description: '' } unless teapot_dome_railroad?(route.corporation)
+
+          revenue = stops.sum do |stop|
+            (boomcity?(stop.tile) && teapot_dome_hex_bonus[stop.hex]) || 0
+          end
+
+          if revenue.positive?
+            { revenue: revenue, description: " + #{teapot_dome_private.sym}" }
+          else
+            { revenue: 0, description: '' }
+          end
+        end
+
+        def teapot_dome_railroad?(corporation)
+          !teapot_dome_private.closed? && corporation.player == teapot_dome_private.player
+        end
+
+        # Returns Hash:
+        #   - keys: Hex
+        #   - values: Int
+        # Int value is the total revenue bonus P6c Teapot Dome Oil Leases
+        # provides to the key Hex. The caller is responsible for ensuring the
+        # bonus only applies to Boom Cities, on routes for RRs with the same
+        # owner as the Teapot Dome private.
+        #
+        # This function is only called when running routes, and is cached so
+        # that the bonuses are not be recomputed with every click on a
+        # route. The cache is busted when the Teapot Dome's owner adds or
+        # removes a token with their oil company.
+        def teapot_dome_hex_bonus
+          @teapot_dome_hex_bonus ||=
+            begin
+              bonus = Hash.new(0)
+              teapot_dome_oil.tokens.each do |token|
+                token.hex.neighbors.each { |_, h| bonus[h] += 5 } if token.used
+              end
+              bonus
+            end
+        end
+
         def check_midwest_oil!(routes)
           return if !midwest_oil || midwest_oil.closed?
           return if !midwest_oil.owned_by_player? && !midwest_oil.owned_by_corporation?
@@ -2077,6 +2124,31 @@ module Engine
             company.close!
             true
           end
+        end
+
+        def setup_strikebreakers!
+          add_coal_development_tokens(strikebreakers_coal, count: 1, sort: true)
+          @log << "#{strikebreakers_private.name} adds 1 Coal DT for each phase to #{strikebreakers_coal.name}'s DTs"
+
+          @strikebreakers_used = (2..7).to_h { |n| [n.to_s, false] }
+        end
+
+        def max_development_tokens(entity)
+          max = @phase.name == '2' ? 2 : 1
+          max += 1 if entity == strikebreakers_coal && !@strikebreakers_used[@phase.name]
+          max
+        end
+
+        def after_strikebreakers
+          @strikebreakers_used[@phase.name] = true
+        end
+
+        def strikebreakers_unused
+          @strikebreakers_used.select { |phase, used| !used && phase.to_i >= @phase.name.to_i }.keys
+        end
+
+        def strikebreakers_status
+          "P6a extra placements: #{strikebreakers_unused.join(',')}"
         end
 
         def fort_bonuses(route)

--- a/lib/engine/game/g_1868_wy/step/dividend.rb
+++ b/lib/engine/game/g_1868_wy/step/dividend.rb
@@ -33,6 +33,21 @@ module Engine
             super
             @game.double_headed_trains = []
           end
+
+          # Teapot Dome: force a float in both JS and Ruby
+          def payout_per_share(entity, revenue)
+            revenue % 10 == 5 ? revenue / 10.0 : super
+          end
+
+          # Teapot Dome: log the fractional amount that will be rounded after
+          # multiplying by share count, i.e., in
+          # Engine::Step::Dividend#dividends_for_entity()
+          def log_payout_shares(entity, revenue, per_share, receivers)
+            return super unless revenue % 10 == 5
+
+            @log << "#{entity.name} pays out #{@game.format_currency(revenue)} = "\
+                    "$#{revenue / 10.0} per share, rounded up (#{receivers})"
+          end
         end
       end
     end

--- a/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
+++ b/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
@@ -71,6 +71,9 @@ module Engine
               @company_choices = nil
               @auctioned_company.close!
               @auctioned_company = nil
+
+              @game.setup_strikebreakers! if company == @game.strikebreakers_private
+
               return
             end
 
@@ -84,6 +87,7 @@ module Engine
             end
 
             company.revenue = 0 if company == @game.lhp_private
+            @game.setup_strikebreakers! if company == @game.strikebreakers_private
 
             @cheapest = @companies.first
             @passed_on_cheapest = {}

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -103,7 +103,9 @@ module Engine
       end
 
       def dividends_for_entity(entity, holder, per_share)
-        # 1817 2 share half pay uses floats, for 18MEX num_shares can be a float for NdM
+        # 1817: 2 share half pay uses floats
+        # 18MEX: num_shares can be a float for NdM
+        # 1868 Wyoming: Teapot Dome private can cause per_share to be a float
         (holder.num_shares_of(entity, ceil: false) * per_share).ceil
       end
 


### PR DESCRIPTION
#5011

P2-P6 each have three different possible companies this finishes the implementation for two of the P6 privates:

- P6a James E Shepperson's Coal Strikebreakers - owning player gets one more coal DT for each color/phase, and gets an extra coal DT placement in the first dev round of each phase
- P6b Teapot Dome Oil Leases - owning player's oil DTs each add $5 total revenue ($0.5 per share) to Boom Cities on its hex or an adjacent hex for that player's corporations