### PR TITLE
[18AL] Update rules URL in meta.rb

### DIFF
--- a/lib/engine/game/g_18_al/meta.rb
+++ b/lib/engine/game/g_18_al/meta.rb
@@ -13,8 +13,7 @@ module Engine
         GAME_DESIGNER = 'Mark Derrick'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18AL'
         GAME_LOCATION = 'Alabama, USA'
-        # Does not load: GAME_RULES_URL = 'http://www.diogenes.sacramento.ca.us/18AL_Rules_v1_64.pdf'
-        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/37924/18al-rules-v164-booklet'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/80315/18al-rules-v17'
 
         PLAYER_RANGE = [3, 5].freeze
         OPTIONAL_RULES = [


### PR DESCRIPTION
Linked to version 1.7 of the rules (more current). The file is also much easier to read - the 1.64 version was paginated for booklet printing.

Fixes #[PUT_ISSUE_NUMBER_HERE]

> Please minimize the amount of changes to shared `lib/engine` code, if possible

> If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

* **Screenshots**

* **Any Assumptions / Hacks**
