### PR TITLE
[1858] Remove graph call from Step::Track.actions

### DIFF
--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -9,7 +9,6 @@ module Engine
         class Track < Engine::Step::Track
           def actions(entity)
             return [] unless entity == current_entity
-            return [] if !entity.minor? && !entity.corporation?
 
             ACTIONS
           end

--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -10,9 +10,15 @@ module Engine
           def actions(entity)
             return [] unless entity == current_entity
             return [] if !entity.minor? && !entity.corporation?
-            return [] unless can_lay_tile?(entity)
 
             ACTIONS
+          end
+
+          def auto_actions(entity)
+            return unless entity.minor?
+            return if can_lay_tile?(entity)
+
+            [Engine::Action::Pass.new(entity)]
           end
 
           def round_state


### PR DESCRIPTION
The call to `can_lay_tile?` in the actions method meant that the graph had to be evaluated whilst a game's history is loaded, increasing the amount of work to be done.

This call has been removed from actions and instead `auto_actions` is used to generate a pass if it is not possible for a minor to lay any track.

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`