### PR TITLE
[1868WY] Finish implementing DPR home, fix Pure Oil, update Ames Bros wording

### DIFF
--- a/lib/engine/game/g_1868_wy/entities.rb
+++ b/lib/engine/game/g_1868_wy/entities.rb
@@ -494,7 +494,7 @@ module Engine
                           when: 'owning_player_sr_turn',
                           from: %i[reserved],
                         }],
-            desc: 'May be exchanged for the Ames Brothers double share of the Union '\
+            desc: 'May be exchanged for the Ames Brothers 20% share of the Union '\
                   'Pacific Railroad as an action in a stock round. No RR Buy-in. Closes '\
                   'on share exchange or at phase 5.',
           },

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -733,6 +733,14 @@ module Engine
             statuses << "Next: #{stack.map(&:name).reverse.slice(1, 4).join(', ')}"
           end
 
+          if corporation == dpr
+            if dpr_first_home_status == :placed && dpr.tokens.count(&:used).zero? && !home_token_locations(corporation).empty?
+              statuses << 'Choose new home as an SR action'
+            elsif !dpr_first_home_status && home_token_locations(corporation).empty?
+              statuses << 'Cannot par: no home token location available'
+            end
+          end
+
           statuses.empty? ? nil : statuses
         end
 

--- a/lib/engine/game/g_1868_wy/step/assign.rb
+++ b/lib/engine/game/g_1868_wy/step/assign.rb
@@ -87,6 +87,16 @@ module Engine
           end
 
           def log_skip(_entity); end
+
+          def available_hex(entity, hex)
+            available = super
+
+            if entity == @game.pure_oil
+              available && %i[white yellow].include?(hex.tile.color)
+            else
+              available
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
#5011

### DPR home

Some parts of DPR's home are already done, such as its operations being skipped automatically if it has no home token.

Implemented here:

* if DPR started during full cap part of game (phase 5+), their home token is reserved instead of immediately placed
* if all their tokens are in Boom Cities which end up BUSTing, they can place a new home token in the stock round
* add note about home token to status array for corp card

### Pure Oil company

Recent rule change: the token can only be used on blank (white) or yellow hexes/tiles

### Ames Bros wording

Recent change: the rulebook and components will now refer to the special share as a "20% share" instead of "double share".

-----

The implementation is now alpha-ready, but the designer and publisher want to hold off on making it available. Last target I heard was matching it up with when the physical copies from the [MAINLINE kickstarter](https://www.kickstarter.com/projects/traxx-mainline/mainline-magazine-spring-2023-issue) are shipping out.