### PR TITLE
Raise an error if the tile being laid (or its opposite) is already on the board

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2084,6 +2084,9 @@ module Engine
       def update_tile_lists(tile, old_tile)
         add_extra_tile(tile) if tile.unlimited
 
+        # TileSelector creates "fake" A1 hexes that are attached to the tiles,
+        # so here we need to check that tile.hex actually belongs to the Game
+        # object
         if (hex = tile.hex) && (hex == hex_by_id(hex.id))
           raise GameError,
                 "Cannot lay tile #{tile.id}; it is already on hex #{tile.hex.id}"

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2083,6 +2083,12 @@ module Engine
 
       def update_tile_lists(tile, old_tile)
         add_extra_tile(tile) if tile.unlimited
+
+        if (hex = tile.hex) && (hex == hex_by_id(hex.id))
+          raise GameError,
+                "Cannot lay tile #{tile.id}; it is already on hex #{tile.hex.id}"
+        end
+
         @tiles.delete(tile)
         @tiles << old_tile unless old_tile.preprinted
       end

--- a/lib/engine/game/double_sided_tiles.rb
+++ b/lib/engine/game/double_sided_tiles.rb
@@ -44,6 +44,9 @@ module DoubleSidedTiles
         end
       end
 
+      # TileSelector creates "fake" A1 hexes that are attached to the tiles,
+      # so here we need to check that tile.hex actually belongs to the Game
+      # object
       if (hex = tile.hex) && (hex == hex_by_id(hex.id))
         raise Engine::GameError,
               "Cannot lay tile #{tile.id}; it is already on hex #{tile.hex.id}"

--- a/lib/engine/game/double_sided_tiles.rb
+++ b/lib/engine/game/double_sided_tiles.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../game_error'
+
 # This module is used by games which double sided tiles, providing methods for
 # initializing double-sided tiles and keeping tile lists updated appropriately.
 module DoubleSidedTiles
@@ -14,7 +16,7 @@ module DoubleSidedTiles
       num = by_name[name_a].size
 
       if num != by_name[name_b].size
-        raise GameError, "Sides of double-sided tiles need to have same number (#{name_a}, #{name_b})"
+        raise Engine::GameError, "Sides of double-sided tiles need to have same number (#{name_a}, #{name_b})"
       end
 
       num.times.each do |index|
@@ -40,6 +42,14 @@ module DoubleSidedTiles
           opp_tile.opposite = new_tile
           new_tile.opposite = opp_tile
         end
+      end
+
+      if (hex = tile.hex) && (hex == hex_by_id(hex.id))
+        raise Engine::GameError,
+              "Cannot lay tile #{tile.id}; it is already on hex #{tile.hex.id}"
+      end
+      if (hex = tile.opposite&.hex) && hex == hex_by_id(hex.id)
+        raise Engine::GameError, "Cannot lay tile #{tile.id}; #{tile.opposite.id} is already on hex #{tile.opposite.hex.id}"
       end
 
       @tiles.delete(tile)


### PR DESCRIPTION
It's #9029 again, but the error is only raised if the tile's hex is the hex from the game. Tiles need to be assigned an `A1` hex belonging to the TileSelector (this is why #9029 broke everyone's games), so it's not enough to check whether a tile has a hex, we need to check if that hex is the game's hex.