### PR TITLE
"Starting Map" view: clone full game instead of calling `init_hexes`

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -32,7 +32,7 @@ module View
       def render
         return h(:div, []) if (@layout = @game.layout) == :none
 
-        @hexes = @show_starting_map ? @game.init_hexes(@game.companies, @game.corporations) : @game.hexes.dup
+        @hexes = @show_starting_map ? @game.clone([]).hexes : @game.hexes.dup
         @cols = @hexes.reject(&:ignore_for_axes).map(&:x).uniq.sort.map(&:next)
         @rows = @hexes.reject(&:ignore_for_axes).map(&:y).uniq.sort.map(&:next)
         @start_pos = [@cols.first, @rows.first]

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -898,17 +898,6 @@ module Engine
           end.compact
         end
 
-        def init_hexes(_companies, _corporations)
-          hexes = super
-          @corporations.each do |c|
-            if c.destination_coordinates
-              hexes.find { |h| h.id == c.destination_coordinates }.tile.icons <<
-                Part::Icon.new("../#{c.destination_icon}", "#{c.id}_destination")
-            end
-          end
-          hexes
-        end
-
         def init_round
           stock_round
         end
@@ -2009,6 +1998,7 @@ module Engine
             c.tokens << Engine::Token.new(c, logo: "../#{c.destination_icon}.svg",
                                              simple_logo: "../#{c.destination_icon}.svg",
                                              type: :destination)
+            hex_by_id(c.destination_coordinates).tile.icons << Part::Icon.new("../#{c.destination_icon}", "#{c.id}_destination")
           end
         end
 

--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -135,6 +135,14 @@ module Engine
           @mesabi_token_counter = 4
 
           phase_2_companies.each { |c| c.max_price = c.value }
+
+          @corporations.each do |corporation|
+            ability = abilities(corporation, :assign_hexes)
+            next unless ability
+
+            hex = hex_by_id(ability.hexes.first)
+            ability.description = "Edge Token (#{format_currency(ability.cost)}): #{hex.location_name} (#{hex.name})"
+          end
         end
 
         def event_companies_buyable!
@@ -312,21 +320,6 @@ module Engine
 
           @bank.spend(revenue, owner)
           @log << "#{owner.name} collects #{format_currency(revenue)} from #{cm_company.name}"
-        end
-
-        def init_hexes(companies, corporations)
-          hexes = super
-
-          @corporations.each do |corporation|
-            ability = abilities(corporation, :assign_hexes)
-            next unless ability
-
-            hex = hexes.find { |h| h.name == ability.hexes.first }
-
-            ability.description = "Edge Token (#{format_currency(ability.cost)}): #{hex.location_name} (#{hex.name})"
-          end
-
-          hexes
         end
 
         def revenue_for(route, stops)

--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -251,7 +251,7 @@ module Engine
           (@corporations + [@national]).select(&:operated?)
         end
 
-        def add_neutral_tokens(_hexes)
+        def add_neutral_tokens
           # 1861 doesn't have neutral tokens
           @green_tokens = []
         end

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -882,21 +882,21 @@ module Engine
           @final_operating_rounds || super
         end
 
-        def add_neutral_tokens(hexes)
+        def add_neutral_tokens
           @green_tokens = []
           logo = '/logos/1867/neutral.svg'
-          hexes.each do |hex|
+          @hexes.each do |hex|
             case hex.id
             when 'D2'
-              token = Token.new(national, price: 0, logo: logo, simple_logo: logo, type: :neutral)
+              token = Token.new(@national, price: 0, logo: logo, simple_logo: logo, type: :neutral)
               hex.tile.cities.first.exchange_token(token)
               @green_tokens << token
             when 'L12'
-              token = Token.new(national, price: 0, logo: logo, simple_logo: logo, type: :neutral)
+              token = Token.new(@national, price: 0, logo: logo, simple_logo: logo, type: :neutral)
               hex.tile.cities.last.exchange_token(token)
               @green_tokens << token
             when 'F16'
-              hex.tile.cities.first.exchange_token(national.tokens.first)
+              hex.tile.cities.first.exchange_token(@national.tokens.first)
             end
           end
         end
@@ -933,29 +933,20 @@ module Engine
           @hidden_company = company_by_id('3')
 
           # CN corporation only exists to hold tokens
-          @national = national
+          @national = @corporations.find { |c| c.type == :national }
           @national.ipoed = true
           @national.shares.clear
           @national.shares_by_corporation[@national].clear
 
           @national_reservations = self.class::NATIONAL_RESERVATIONS.dup
           @corporations.delete(@national)
+          add_neutral_tokens
 
           # Move green and majors out of the normal list
           @corporations, @future_corporations = @corporations.partition do |corporation|
             corporation.type == :minor && !self.class::GREEN_CORPORATIONS.include?(corporation.id)
           end
           @show_majors = false
-        end
-
-        def national
-          @national ||= @corporations.find { |c| c.type == :national }
-        end
-
-        def init_hexes(_companies, corporations)
-          hexes = super
-          add_neutral_tokens(hexes)
-          hexes
         end
 
         def event_green_minors_available!

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -314,26 +314,20 @@ module Engine
           'Treasury'
         end
 
-        def init_hexes(companies, corporations)
-          hexes = super
-
-          @corporations.each do |corporation|
-            ability = abilities(corporation, :assign_hexes)
-            hex = hexes.find { |h| h.name == ability.hexes.first }
-
-            hex.assign!(corporation)
-            ability.description = "Destination: #{hex.location_name} (#{hex.name})"
-          end
-
-          hexes
-        end
-
         def setup
           @sell_queue = []
           @connection_run = {}
           @reissued = {}
 
           river_company.max_price = river_company.value
+
+          @corporations.each do |corporation|
+            ability = abilities(corporation, :assign_hexes)
+            hex = hex_by_id(ability.hexes.first)
+
+            hex.assign!(corporation)
+            ability.description = "Destination: #{hex.location_name} (#{hex.name})"
+          end
         end
 
         def event_companies_buyable!

--- a/lib/engine/game/g_1894/game.rb
+++ b/lib/engine/game/g_1894/game.rb
@@ -371,6 +371,16 @@ module Engine
           adjust_companies
           remove_extra_french_major_shareholding_companies
 
+          @corporations.each do |corporation|
+            next unless (dest_abilities = Array(abilities(corporation)).select { |a| DESTINATION_ABILITY_TYPES.include?(a.type) })
+
+            dest_abilities.each do |ability|
+              ability.hexes.each do |id|
+                hex_by_id(id).assign!(corporation)
+              end
+            end
+          end
+
           @players.each do |player|
             share_pool.transfer_shares(french_starting_corporation.ipo_shares.last.to_bundle, player)
             share_pool.transfer_shares(belgian_starting_corporation.ipo_shares.last.to_bundle, player)
@@ -380,22 +390,6 @@ module Engine
 
           share_pool.transfer_shares(french_starting_corporation.ipo_shares.last.to_bundle, share_pool)
           share_pool.transfer_shares(belgian_starting_corporation.ipo_shares.last.to_bundle, share_pool)
-        end
-
-        def init_hexes(companies, corporations)
-          hexes = super
-
-          @corporations.each do |corporation|
-            next unless (dest_abilities = Array(abilities(corporation)).select { |a| DESTINATION_ABILITY_TYPES.include?(a.type) })
-
-            dest_hexes = dest_abilities.map(&:hexes).flatten
-
-            hexes
-              .select { |h| dest_hexes.include?(h.name) }
-              .each { |h| h.assign!(corporation) }
-          end
-
-          hexes
         end
 
         def after_buy_company(player, company, price)

--- a/lib/engine/game/g_18_fl/game.rb
+++ b/lib/engine/game/g_18_fl/game.rb
@@ -257,15 +257,9 @@ module Engine
           route.train.variant['name'] == '3E' ? revenue : revenue + (hotels * hotel_value)
         end
 
-        def init_hexes(_companies, corporations)
-          hexes = super
-          place_home_tokens(corporations, hexes)
-          hexes
-        end
-
-        def place_home_tokens(corporations, hexes)
-          corporations.each do |corporation|
-            tile = hexes.find { |hex| hex.coordinates == corporation.coordinates }.tile
+        def setup
+          @corporations.each do |corporation|
+            tile = hex_by_id(corporation.coordinates).tile
             tile.cities[corporation.city || 0].place_token(corporation, corporation.tokens.first, free: true)
           end
         end

--- a/lib/engine/game/g_18_jpt/game.rb
+++ b/lib/engine/game/g_18_jpt/game.rb
@@ -180,22 +180,16 @@ module Engine
             @share_pool,
             ShareBundle.new(tr.shares.dup.reverse.take(3)),
           )
-        end
-
-        def init_hexes(companies, corporations)
-          hexes = super
 
           @corporations.each do |corporation|
             next unless (dest_abilities = Array(abilities(corporation)).select { |a| DESTINATION_ABILITY_TYPES.include?(a.type) })
 
-            dest_hexes = dest_abilities.map(&:hexes).flatten
-
-            hexes
-              .select { |h| dest_hexes.include?(h.name) }
-              .each { |h| h.assign!(corporation) }
+            dest_abilities.each do |ability|
+              ability.hexes.each do |id|
+                hex_by_id(id).assign!(corporation)
+              end
+            end
           end
-
-          hexes
         end
 
         def operating_round(round_num)

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -108,6 +108,11 @@ module Engine
 
         def setup
           super
+
+          %w[a5 a9 G14].each do |id|
+            hex_by_id(id)&.ignore_for_axes = true
+          end
+
           post_setup
         end
 
@@ -128,16 +133,6 @@ module Engine
           companies.reject! { |c| c.sym == 'DC&H' } unless @optional_rules.include?(:dch)
           companies.reject! { |c| c.sym == 'LAT' } unless @optional_rules.include?(:la_title)
           companies
-        end
-
-        def init_hexes(_companies, _corporations)
-          hexes = super
-
-          hexes.each do |hex|
-            hex.ignore_for_axes = true if %w[a5 a9 G14].include?(hex.id)
-          end
-
-          hexes
         end
 
         def num_removals(_group)


### PR DESCRIPTION
* fixes an issue where the map view with "Starting Map" selected can change throughout the game, e.g., [/game/116364?action=0#map](https://18xx.games/game/116364?action=0#map) vs [/game/116364?action=481#map](https://18xx.games/game/116364?action=481#map)
* fixes an issue where toggling "Starting Map" can change the map view at the start of the game, e.g., [/game/116364?action=0#map](https://18xx.games/game/116364?action=0#map)
* moves implementation of `init_hexes` into `setup` for a number of games (all validated, this change doesn't break anything)
    * 1822
    * 1850
    * 1861
    * 1867
    * 1870
    * 1894
    * 18FL
    * 18JPT
    * 18 Los Angeles

Fixes #9001

Other closed issues/PRs which are relevant:

* #3204
* #5274
* #6704
* #8294
* reverts PR #8118 for #3080
* reverts PR #4252 for #4233
* reverts PR #4877 for #4848