### PR TITLE
  [1867] don't allow a Major with no valid home to start; fix Toronto/Montreal starts

### DIFF
--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -463,8 +463,16 @@ module Engine
 
         def home_token_locations(corporation)
           # Can only place home token in cities that have no other tokens.
+          # Minors can go in a disconnected Toronto/Montreal station, but Majors
+          # cannot.
           open_locations = hexes.select do |hex|
-            hex.tile.cities.any? { |city| city.tokenable?(corporation, free: true) && city.tokens.none? }
+            case corporation.type
+            when :minor
+              hex.tile.cities.any? { |c| c.tokenable?(corporation, free: true) && c.tokens.none? }
+            when :major
+              hex.tile.cities.any? { |c| c.tokenable?(corporation, free: true) } &&
+                hex.tile.cities.all? { |c| c.tokens.none? { |t| t&.type == :normal } }
+            end
           end
 
           return open_locations if corporation.type == :minor

--- a/lib/engine/game/g_1867/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1867/step/buy_sell_par_shares.rb
@@ -68,7 +68,11 @@ module Engine
             phase = @game.phase.name.to_i
             if entity.type == :major
               if phase >= MAJOR_PHASE
-                :par
+                if @game.home_token_locations(entity).empty?
+                  'No home token locations are available'
+                else
+                  :par
+                end
               else
                 "Cannot start till phase #{MAJOR_PHASE}"
               end


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/8980

Prior to this fix, 1867 games could select a Major to start with no valid home,
and then be unable to place its home token. They were forced to undo the actions
instead of the game preventing the illegal move, e.g.,
http://18xx.games/game/115992?action=486

This PR changes the UI so that an option to start a Major is not presented, but
it does not change any action validation, so no previous games will break.

1861 already has its own override of `ipo_type`, so those games won't be affected.

From the designer in the comments on https://github.com/tobymao/18xx/issues/8980:

> In 1867, minors may start in unconnected revenue centres in the same hex, but
> majors may not (if one such centre is occupied). Therefore, it should be
> impossible to start a major in Toronto since there is always a CN token in
> it. In principle, a major could start in Montreal (but that would be a bizarre
> situation).

A few 1867 games need pins due to Majors illegally starting in Toronto or
Montreal when another city on those hexes had a token:

`[96823,103457,113060,85612,91793,93176,116910,81411]`