### PR TITLE
Don't let players over the cert limit autopass

### DIFF
--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -404,6 +404,9 @@ module Engine
       end
 
       def should_stop_applying_program(entity, program, share_to_buy)
+        # don't let players over the cert limit autopass
+        return "#{entity.name} must sell shares" if must_sell?(entity)
+
         # check for shenanigans, returning the first failure reason it finds
         @round.players_history.each do |other_entity, corporations|
           next if other_entity == entity


### PR DESCRIPTION
Fixes #7142

While #7142 only references 18CZ, this can affect all games.

I repro'd the behavior locally and created a game where illegal passes were happening automatically. With this change applied, the validation script did not break on the game with the illegal actions, since they are "snuck" in with auto_actions, so no pins/etc will be needed.