### PR TITLE
[1846] In track and token step, highlight tokenable hexes

### DIFF
--- a/lib/engine/step/token.rb
+++ b/lib/engine/step/token.rb
@@ -25,7 +25,7 @@ module Engine
       end
 
       def available_hex(entity, hex)
-        @game.token_graph_for_entity(entity).reachable_hexes(entity)[hex]
+        tokener_available_hex(entity, hex)
       end
 
       def process_place_token(action)

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -154,6 +154,10 @@ module Engine
         city_string = hex.tile.cities.size > 1 ? " city #{city.index}" : ''
         raise GameError, "Cannot place token on #{hex.name}#{city_string} because it is not connected"
       end
+
+      def tokener_available_hex(entity, hex)
+        @game.token_graph_for_entity(entity).reachable_hexes(entity)[hex]
+      end
     end
   end
 end

--- a/lib/engine/step/track_and_token.rb
+++ b/lib/engine/step/track_and_token.rb
@@ -68,9 +68,10 @@ module Engine
       end
 
       def available_hex(entity, hex)
-        return super if can_lay_tile?(entity)
+        return true if can_lay_tile?(entity) && tracker_available_hex(entity, hex)
+        return true if can_place_token?(entity) && tokener_available_hex(entity, hex)
 
-        @game.graph.reachable_hexes(entity)[hex]
+        false
       end
     end
   end


### PR DESCRIPTION
Fixes #9112

Screenshots from the hotseat game shared in that bug; NYC has laid a tile upgrade, and can still place a token in Chicago or Cleveland, or lay a yellow tile in South Bend. The new behavior incorporates the normal Token step behavior, where all reachable hexes are highlighted.

Before:

![Screenshot 2023-04-16 015019](https://user-images.githubusercontent.com/1045173/232283275-73984093-0b91-4e7b-8e39-121a6a05a7f8.png)

After:


![Screenshot 2023-04-16 015112](https://user-images.githubusercontent.com/1045173/232283279-170503ad-0bf4-4a90-8c9e-4fd7b89f7c98.png)
