### PR TITLE
[1822 family] Fix MUST_SELL_IN_BLOCKS for 1D market games

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -189,6 +189,9 @@ module Engine
         STARTING_CORPORATIONS = %w[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
                                    CNoR CPR GNWR GT GTP GWR ICR NTR PGE QMOO].freeze
 
+        MUST_SELL_IN_BLOCKS = true
+        SELL_MOVEMENT = :left_per_10_if_pres_else_left_one
+
         def setup_game_specific
           # Initialize the stock round choice for P7-Double Cash
           @double_cash_choice = nil

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -49,6 +49,7 @@ module Engine
              360 400 450 500 550 600e],
         ].freeze
 
+        MUST_SELL_IN_BLOCKS = true
         SELL_MOVEMENT = :left_per_10_if_pres_else_left_one
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P6].freeze
         EXTRA_TRAINS = %w[2P P+ LP 3/2P].freeze

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -80,6 +80,7 @@ module Engine
           ]
         end
 
+        MUST_SELL_IN_BLOCKS = true
         SELL_MOVEMENT = :left_per_10_if_pres_else_left_one
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P6].freeze
         EXTRA_TRAIN_PERMANENTS = %w[2P LP].freeze


### PR DESCRIPTION
Fixes #8828

Pins needed for 1822MX and 1822PNW games where shares were not sold in blocks:

```
[83532, 85341, 90838, 94484, 96028, 96507, 100292, 101527, 103539, 103853,
104314, 105097, 106495, 106814, 107499, 108159, 108528, 109165, 112879, 113007,
113207, 117068, 118921]
```