### PR TITLE
[1822MX] fix `active?` for NdeM in track step to stop excessive logging

### DIFF
--- a/lib/engine/game/g_1822_mx/step/track.rb
+++ b/lib/engine/game/g_1822_mx/step/track.rb
@@ -24,9 +24,11 @@ module Engine
           end
 
           def active?
-            return super unless current_entity == @game.ndem
-
-            !@ndem_tile_layers.empty? || !acted
+            if current_entity == @game.ndem
+              super && (!@ndem_tile_layers.empty? || !acted)
+            else
+              super
+            end
           end
 
           def pass!


### PR DESCRIPTION
Fixes #8096

This lets the track step be properly skipped, which stops logging "NDEM skips lay/upgrade track" after it runs trains and during the auction for its station tokens, as described in #8096.

Validated against all 1822MX games, this change caused no breakages.