### PR TITLE
[1822MX] don't allow bidding on NdeM token for a Major with token on same hex

### DIFF
--- a/lib/engine/game/g_1822_mx/step/auction_ndem_tokens.rb
+++ b/lib/engine/game/g_1822_mx/step/auction_ndem_tokens.rb
@@ -77,7 +77,7 @@ module Engine
           def corp_can_purchase_token?(corporation, token)
             corporation.cash >= @available_ndem_tokens[token] &&
             !@game.exchange_tokens(corporation).zero? &&
-            !token.city.tokened_by?(corporation)
+            token.hex.tile.cities.none? { |c| c.tokened_by?(corporation) }
           end
 
           def player_can_purchase_token?(player, token)


### PR DESCRIPTION
Fixes #8574

Not all games violating the rule are caught by the validation script because of how auto actions work, e.g., in game 106013, the player who shouldn't have been allowed to bid passed on their turn, so no breaking action occurred. 

Pins:

```
[88732, 92280, 92703, 92821, 93434, 94482, 94484, 98864, 99158, 100237, 100302,
101009, 101954, 102436, 105374, 105993, 106814, 107617, 111006, 111383, 114266,
115540]
```