### PR TITLE
[1858] Alternate view for minors

### DIFF
--- a/assets/app/view/game/alternate_corporations.rb
+++ b/assets/app/view/game/alternate_corporations.rb
@@ -510,6 +510,67 @@ module View
           h(:div, { style: { gridColumnStart: 2 } }, [movement_table]),
         ])
       end
+
+      # This is used by 1858 which has private railway companies that act a bit
+      # like minor railways, laying track in operating rounds. This rendering
+      # code is a simplified version of Engine::View::Game::Company.render.
+      def render_private_railway
+        minor = @corporation
+
+        select_minor = lambda do
+          if @selectable
+            selected_corporation = selected? ? nil : minor
+            store(:selected_corporation, selected_corporation)
+          end
+        end
+
+        header_style = {
+          background: minor.color,
+          color: minor.text_color,
+          border: '1px solid',
+          borderRadius: '5px',
+          marginBottom: '0.5rem',
+          fontSize: '90%',
+        }
+        description_style = {
+          margin: '0.5rem 0',
+          fontSize: '80%',
+          textAlign: 'left',
+          fontWeight: 'normal',
+        }
+        value_style = {
+          float: 'left',
+        }
+        revenue_style = {
+          float: 'right',
+        }
+        props = {
+          style: {
+            cursor: 'pointer',
+            boxSizing: 'border-box',
+            padding: '0.5rem',
+            margin: '0.5rem 5px 0 0',
+            textAlign: 'center',
+            fontWeight: 'bold',
+          },
+          on: { click: select_minor },
+        }
+        if selected?
+          props[:style][:backgroundColor] = 'lightblue'
+          props[:style][:color] = 'black'
+          props[:style][:border] = '1px solid'
+        end
+
+        children = [
+          h(:div, { style: header_style }, @game.company_header(minor)),
+          h(:div, minor.full_name),
+          h(:div, { style: description_style }, @game.private_description(minor)),
+          h(:div, { style: value_style }, "Value: #{@game.private_value(minor)}"),
+          h(:div, { style: revenue_style }, "Revenue: #{@game.private_revenue(minor)}"),
+        ]
+
+        h('div.company.card', props, children)
+      end
     end
   end
 end

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -67,6 +67,16 @@ module Engine
           two_player? ? { max_ownership_percent: 70 } : {}
         end
 
+        def corporation_view(entity)
+          return unless entity.minor?
+
+          # Override the default rendering for private railway companies that
+          # are owned by players. These would be rendered as minor companies
+          # (with treasury, trains and revenue). Instead render them in the same
+          # way as private companies that are owned by the bank.
+          'private_railway'
+        end
+
         def option_quick_start?
           optional_rules.include?(:quick_start)
         end
@@ -254,6 +264,18 @@ module Engine
           return entity if entity.minor?
 
           @minors.find { |minor| minor.id == entity.sym }
+        end
+
+        def private_description(minor)
+          private_company(minor).desc
+        end
+
+        def private_revenue(minor)
+          format_currency(private_company(minor).revenue)
+        end
+
+        def private_value(minor)
+          format_currency(private_company(minor).value)
         end
 
         def purchase_company(player, company, price)


### PR DESCRIPTION
The default view for a minor shows:
1. Its name.
2. The trains it owns.
3. The cash in its treasury.
4. Its position in the operating order.
5. The value of its last run.

![minor-default](https://user-images.githubusercontent.com/11144854/232611298-00adf700-eab5-43a9-8ef5-f8b30ff951e1.png)

Most of these are irrelevant for 1858, as the minor parts of the private railway companies can't own trains, don't have a treasury, and don't run routes.

This alternate view makes minors look like companies. This shows more relevant information:
- Revenue.
- Home hexes.
- Whether it can be used to start a corporation (public company).
- Face value.

Making the minors look like companies also helps hide the internal split of private railways into a company and a minor, this does not need to be visible to the player.

![minor-alternate](https://user-images.githubusercontent.com/11144854/232611332-21ff6b6c-5f64-428f-893e-653721ca16cc.png)

This introduces new code into the shared `assets/app/view/game` directory, but it will be ignored by all other games unless they explicitly invoke it from Game::corporation_view.

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`