### PR TITLE
[18Rhl] Fix illegal route

### DIFF
--- a/lib/engine/game/g_18_rhl/game.rb
+++ b/lib/engine/game/g_18_rhl/game.rb
@@ -698,6 +698,10 @@ module Engine
           last = visits.last
           rge = rge_train?(route)
 
+          if route.hexes.uniq.size == 1 && RHINE_METROPOLIS_HEXES.include?(first.hex.id)
+            raise GameError, 'Route cannot consist of only one Rhine metropolis'
+          end
+
           if rge
             if !rge_terminus?(first) && !rge_terminus?(last)
               raise GameError, 'Route for 8 trains must begin and/or end in an RGE hex'


### PR DESCRIPTION
Fixes #8774 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Raise an error when a route consists of only a Rhine metropolis city.

This may break existing games, so `pins` is needed.


