### PR TITLE
[1882] make EMR optional if only route is to fishing exit

### DIFF
--- a/lib/engine/game/g_1882/game.rb
+++ b/lib/engine/game/g_1882/game.rb
@@ -197,7 +197,7 @@ module Engine
             Engine::Step::Route,
             Engine::Step::Dividend,
             Engine::Step::DiscardTrain,
-            Engine::Step::BuyTrain,
+            G1882::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
         end
@@ -356,6 +356,10 @@ module Engine
 
         def token_ability_from_owner_usable?(_ability, _corporation)
           true
+        end
+
+        def fishing_exit
+          @fishing_exit ||= hex_by_id('B6')
         end
       end
     end

--- a/lib/engine/game/g_1882/step/buy_train.rb
+++ b/lib/engine/game/g_1882/step/buy_train.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1882
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def actions(entity)
+            return %w[sell_shares] if entity == current_entity&.owner && can_ebuy_sell_shares?(current_entity)
+
+            return [] if entity != current_entity
+            return %w[buy_train] if must_buy_train?(entity)
+            return %w[buy_train pass] if can_buy_train?(entity)
+
+            []
+          end
+
+          def president_may_contribute?(entity, _shell = nil)
+            entity.trains.empty? &&
+              (@game.graph.route_info(entity)&.dig(:route_train_purchase) ||
+               @game.graph.reachable_hexes(entity).include?(@game.fishing_exit))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #7775

In the base code, `president_may_contribute?` points to the Game class's `must_buy_train?`; the 1882 override takes just what it needs from that and adds the exception to allow, but not require, EMR with a route to the fishing exit: https://github.com/tobymao/18xx/blob/a77c96dd939b0d8ce999933b40664e9f03171e0d/lib/engine/game/base.rb#L1214-L1219

Validated all 1882 games and got no breakages, as expected, since this only adds a possible action to a step where `pass` was already possible.