### PR TITLE
[18NY] Change Text for Forced Salvage of Trains Over Limit on Phase Change

### DIFF
--- a/assets/app/view/game/discard_trains.rb
+++ b/assets/app/view/game/discard_trains.rb
@@ -29,7 +29,7 @@ module View
 
             h('div.margined', train_props, train.name)
           end
-
+          @verb = step.trains(corporation)&.any?(&:salvage) ? 'Salvage' : 'Discard'
           h(:div, block_props, [
             h(Corporation, corporation: corporation),
             h(:div, trains),
@@ -40,7 +40,7 @@ module View
         overflow << h(Map, game: @game) if @game.round.is_a?(Engine::Round::Operating)
 
         h(:div, [
-          h(:h3, 'Discard Trains'),
+          h(:h3, "#{@verb} Trains"),
           *overflow,
         ])
       end

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -135,14 +135,15 @@ module Engine
         ].freeze
 
         TRAINS = [
-          { name: '2H', num: 11, distance: 2, price: 100, rusts_on: '6H' },
-          { name: '4H', num: 6, distance: 4, price: 200, rusts_on: '4DE', events: [{ 'type' => 'float_30' }] },
-          { name: '6H', num: 4, distance: 6, price: 300, rusts_on: 'D', events: [{ 'type' => 'float_40' }] },
+          { name: '2H', num: 11, distance: 2, price: 100, rusts_on: '6H', salvage: 25 },
+          { name: '4H', num: 6, distance: 4, price: 200, rusts_on: '4DE', salvage: 50, events: [{ 'type' => 'float_30' }] },
+          { name: '6H', num: 4, distance: 6, price: 300, rusts_on: 'D', salvage: 75, events: [{ 'type' => 'float_40' }] },
           {
             name: '12H',
             num: 3,
             distance: 12,
             price: 600,
+            salvage: 150,
             events: [{ 'type' => 'float_50' }, { 'type' => 'close_companies' }, { 'type' => 'nyc_formation' },
                      { 'type' => 'capitalization_round', 'when' => 3 }],
           },
@@ -151,6 +152,7 @@ module Engine
             num: 2,
             distance: [{ 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 99, 'multiplier' => 2 }],
             price: 800,
+            salvage: 200,
             events: [{ 'type' => 'float_60' }],
           },
           {
@@ -158,6 +160,7 @@ module Engine
             num: 20,
             distance: 99,
             price: 1000,
+            salvage: 250,
             variants: [
               name: '5DE',
               distance: [{ 'nodes' => %w[city offboard town], 'pay' => 5, 'visit' => 99, 'multiplier' => 2 }],
@@ -830,14 +833,10 @@ module Engine
           entity.remove_ability(stagecoach_token_exchange_ability)
         end
 
-        def salvage_value(train)
-          train.price / 4
-        end
-
         def salvage_train(train)
           owner = train.owner
-          @log << "#{owner.name} salvages a #{train.name} train for #{format_currency(salvage_value(train))}"
-          @bank.spend(salvage_value(train), owner)
+          @log << "#{owner.name} salvages a #{train.name} train for #{format_currency(train.salvage)}"
+          @bank.spend(train.salvage, owner)
           @depot.reclaim_train(train)
         end
 

--- a/lib/engine/game/g_18_ny/step/discard_train.rb
+++ b/lib/engine/game/g_18_ny/step/discard_train.rb
@@ -7,6 +7,10 @@ module Engine
     module G18NY
       module Step
         class DiscardTrain < Engine::Step::DiscardTrain
+          def description
+            'Salvage Train'
+          end
+
           def process_discard_train(action)
             @game.salvage_train(action.train)
           end


### PR DESCRIPTION
Fixes #9128

> Please minimize the amount of changes to shared `lib/engine` code, if possible

> If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Generalizes the 'verb' that is used during a forced "discard train" step

Adds the `salvage` property to 18NY trains, as this is used to determine whether the verb will be "Salvage" or not

* **Screenshots**
Before:
![image](https://user-images.githubusercontent.com/1711810/233761029-ede6097e-7a3a-492f-bfb4-076efc24c503.png)


After:
![Screenshot 2023-04-21 2 32 59 PM](https://user-images.githubusercontent.com/1711810/233760982-15d81a63-90e0-4f9b-a11d-882be87961d3.png)


* **Any Assumptions / Hacks**
