### PR TITLE
Improve 1822 family destination information, allow hiding location name

### DIFF
--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -63,13 +63,17 @@ module View
 
         borders = render_tile_part(Part::Borders) if @tile.borders.any?(&:type)
         # OO tiles have different rules...
-        rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && @tile.cities.size > 1
+        if @tile.location_name && @tile.cities.size > 1 && !@tile.hex.hide_location_name
+          rendered_loc_name = render_tile_part(Part::LocationName)
+        end
         children << render_tile_part(Part::Revenue) if render_revenue
         @tile.labels.each { |x| children << render_tile_part(Part::Label, label: x) }
 
         children << render_tile_part(Part::Upgrades) unless @tile.upgrades.empty?
         children << render_tile_part(Part::Blocker)
-        rendered_loc_name = render_tile_part(Part::LocationName) if @tile.location_name && (@tile.cities.size <= 1)
+        if @tile.location_name && (@tile.cities.size <= 1) && !@tile.hex.hide_location_name
+          rendered_loc_name = render_tile_part(Part::LocationName)
+        end
         @tile.reservations.each { |x| children << render_tile_part(Part::Reservation, reservation: x) }
         large, normal = @tile.icons.partition(&:large)
         children << render_tile_part(Part::Icons) unless normal.empty?

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -215,6 +215,7 @@ module Engine
       PHASES = [].freeze
 
       LOCATION_NAMES = {}.freeze
+      HEXES_HIDE_LOCATION_NAMES = {}.freeze
 
       TRACK_RESTRICTION = :semi_restrictive
 
@@ -2337,7 +2338,8 @@ module Engine
               # name the location (city/town)
               location_name = location_name(coord)
 
-              Hex.new(coord, layout: layout, axes: axes, tile: tile, location_name: location_name)
+              Hex.new(coord, layout: layout, axes: axes, tile: tile, location_name: location_name,
+                             hide_location_name: self.class::HEXES_HIDE_LOCATION_NAMES[coord])
             end
           end
         end.flatten.compact

--- a/lib/engine/game/g_1822_mx/map.rb
+++ b/lib/engine/game/g_1822_mx/map.rb
@@ -53,6 +53,7 @@ module Engine
           'M26' => 'Poza Rica Jalapa',
           'M36' => 'Campeche',
           'N17' => 'Manzanillo',
+          'N23' => 'Mexico City',
           'N25' => 'Tlaxcala Puebla',
           'N27' => 'Veracruz',
           'N33' => 'Ciudad del Carmen',
@@ -65,6 +66,7 @@ module Engine
           'P31' => 'Tuxtla Gutierrez',
           'Q34' => 'Guatemala',
         }.freeze
+        HEXES_HIDE_LOCATION_NAMES = { 'N23' => true }.freeze
 
         LAYOUT = :pointy
 

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -8,7 +8,7 @@ module Engine
 
     attr_accessor :x, :y, :ignore_for_axes, :location_name
     attr_reader :coordinates, :empty, :layout, :neighbors, :all_neighbors, :tile, :original_tile, :tokens,
-                :column, :row
+                :column, :row, :hide_location_name
 
     DIRECTIONS = {
       flat: {
@@ -73,7 +73,7 @@ module Engine
     # x and y map to the double coordinate system
     # layout is :pointy or :flat
     def initialize(coordinates, layout: nil, axes: nil, tile: Tile.for('blank'),
-                   location_name: nil, empty: false)
+                   location_name: nil, hide_location_name: false, empty: false)
       @coordinates = coordinates
       @layout = layout
       @axes = axes
@@ -82,6 +82,7 @@ module Engine
       @all_neighbors = {}
       @location_name = location_name
       tile.location_name = location_name
+      @hide_location_name = hide_location_name
       @original_tile = @tile = tile
       @tile.hex = self
       @activations = []


### PR DESCRIPTION
* [1822 family] make destinations more clear/accessible, fixes #9135 and fixes #5248
    * make destination ability more concise
    * add home token ability 
    * add new ability for corporations like LNWR that get their destination for free, instead of including it in the too-long destination ability description
* in 1822MX, on the N23 hex, "Mexico City" is currently not rendered on the map, presumably to avoid excess clutter; add mechanism to have the location name saved but not rendered, so that it will remain off the rendered map, but will be visible for corporations with a home there

#### Screenshots

Before:

![before](https://user-images.githubusercontent.com/1045173/233807526-4c8911ba-5407-4ba0-8627-8fb998124cd8.png)

After:

![Screenshot 2023-04-22 153029](https://user-images.githubusercontent.com/1045173/233807534-92f9e7bc-043d-4088-809a-bca0ebed9861.png)
