### PR TITLE
Call City.remove_reservation from Ability::Reservation.teardown

### DIFF
--- a/lib/engine/ability/reservation.rb
+++ b/lib/engine/ability/reservation.rb
@@ -16,7 +16,7 @@ module Engine
       end
 
       def teardown
-        tile.cities[@city].reservations.delete(owner) if tile
+        tile.cities[@city].remove_reservation!(owner) if tile
       end
     end
   end

--- a/spec/lib/engine/round/operating_spec.rb
+++ b/spec/lib/engine/round/operating_spec.rb
@@ -753,7 +753,7 @@ module Engine
               )
             )
 
-            expect(city.reservations).to eq([])
+            expect(city.reservations.compact).to eq([])
           end
 
           it 'is removed when a corporation buys in the C&WI' do
@@ -765,7 +765,7 @@ module Engine
               )
             )
 
-            expect(city.reservations).to eq([])
+            expect(city.reservations.compact).to eq([])
           end
         end
 


### PR DESCRIPTION
In `Ability::Reservation.teardown` the reservation was being removed by calling `City.reservations.delete`. This could trigger a bug if there were other reservations and also tokens in a city with multiple slots.

The bug appears if:
- The city has two slots, which are reserved by companies P1 and P2.
- A corporation has used P1's ability to place a token in slot 0.
- The city's reservations will be `[P1, P2]`, so P2 has a reservation on the open slot.
- If P1 closes, `Ability::Reservation.teardown` will call `City.reservations.delete(P1)`, changing the reservations array to be [P2], so P2's reservation is now for slot 0, which already has a token, and slot 1 is no longer reserved.
- By calling `City.remove_reservation!(P1)` instead, the reservations array will become `[nil, P2]`, so P2's reservation is preserved.

A couple of 1846 tests are tweaked, as the reservations array returned is `[nil]` instead of `[]` after this change. I looked at adding code to `City.remove_reservation` to trim any trailing nil values off the reservations array, but this broke different tests.

Fixes ollybh/18xx#62.

- [x] Branch is derived from the latest `master`
- [x] ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`