### PR TITLE
[1848] Shouldn't be able to buy a train from supply after buying from corporation

### DIFF
--- a/lib/engine/game/g_1848/step/buy_train.rb
+++ b/lib/engine/game/g_1848/step/buy_train.rb
@@ -38,6 +38,7 @@ module Engine
             end
             return if entity.share_price.price.zero? # company is closing, not buying train
 
+            @bought_across = !action.train.from_depot?
             super
           end
 
@@ -49,8 +50,10 @@ module Engine
 
           def buyable_trains(entity)
             # Cannot buy 2E if one is already owned, can't by non 2e if at limit. 2E can't be cross bought
+            # Buying another corp's train must be done last (i.e. cannot buy from depot after buying from corp)
             trains_to_buy = at_train_limit?(entity) ? [] : super
             trains_to_buy = trains_to_buy.select(&:from_depot?) unless @game.can_buy_trains
+            trains_to_buy = trains_to_buy.reject(&:from_depot?) if @bought_across
             trains_to_buy = trains_to_buy.reject { |t| t.name == '2E' }
             trains_to_buy << ghan_train if can_buy_2e?(entity)
             trains_to_buy.uniq
@@ -117,6 +120,7 @@ module Engine
 
           def setup
             @round.train_buy_available = true
+            @bought_across = false
             super
           end
 


### PR DESCRIPTION
Fixes #9145

It's possible this could pin games, seems unlikely to be too widespread

> Please minimize the amount of changes to shared `lib/engine` code, if possible

> If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

After buying across a train from another corp, cannot buy from the depot. Implements the rule where buying across from a corp must be the last action of the corp's turn

* **Screenshots**

Before buying across a train:
![Screenshot 2023-04-27 8 37 39 PM](https://user-images.githubusercontent.com/1711810/235048616-bf00f59d-f5f4-4844-91a7-3c3a372c0a00.png)


After buying across a train (cannot buy from depot anymore):
![Screenshot 2023-04-27 6 35 02 PM](https://user-images.githubusercontent.com/1711810/235048447-eeeaef7d-9306-4ce1-a051-c4ea443aad0f.png)


* **Any Assumptions / Hacks**
