### PR TITLE
[1846] fixes single/double quote in two company descriptions

### DIFF
--- a/lib/engine/game/g_1846/entities.rb
+++ b/lib/engine/game/g_1846/entities.rb
@@ -168,9 +168,9 @@ module Engine
             name: 'Michigan Central',
             value: 40,
             revenue: 15,
-            desc: "The owning corporation may lay up to two extra $0 cost yellow tiles in the MC's '\
-'reserved hexes (B10, B12). The owning corporation does not need to be connected to those hexes. '\
-'If two tiles are laid, they must connect to each other.",
+            desc: "The owning corporation may lay up to two extra $0 cost yellow tiles in the MC's "\
+                  'reserved hexes (B10, B12). The owning corporation does not need to be connected to those hexes. '\
+                  'If two tiles are laid, they must connect to each other.',
             sym: 'MC',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: %w[B10 B12] },
                         {
@@ -189,9 +189,9 @@ module Engine
             name: 'Ohio & Indiana',
             value: 40,
             revenue: 15,
-            desc: "The owning corporation may lay up to two extra $0 cost yellow tiles in the O&I''\
-'s reserved hexes (F14, F16). The owning corporation does not need to be connected to those hexes. '\
-'If two tiles are laid, they must connect to each other.",
+            desc: "The owning corporation may lay up to two extra $0 cost yellow tiles in the O&I's "\
+                  'reserved hexes (F14, F16). The owning corporation does not need to be connected to those hexes. '\
+                  'If two tiles are laid, they must connect to each other.',
             sym: 'O&I',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: %w[F14 F16] },
                         {


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Two private company descriptions had errors in the way they used single and double quotations.
Corrected indentation on those entries too. 

* **Screenshots**
Before: 
![image](https://user-images.githubusercontent.com/26125362/235272310-6f822321-fc83-4d78-a493-b962e7b11db1.png)
![image](https://user-images.githubusercontent.com/26125362/235272319-0981d96d-7d88-4325-bbc4-c79260c0e555.png)

* **Any Assumptions / Hacks**
None. 
