### PR TITLE
[1868WY] Fix DEV rounds being displayed incorrectly on spreadsheet

### DIFF
--- a/lib/engine/player_info.rb
+++ b/lib/engine/player_info.rb
@@ -13,7 +13,7 @@ module Engine
     end
 
     def round
-      if %w[AR MR OR].include?(round_name)
+      if %w[AR MR OR DEV].include?(round_name)
         "#{round_name} #{turn}.#{round_no}"
       else
         "#{round_name} #{turn}"


### PR DESCRIPTION
[#5011]

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- N/A Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Adds "DEV" as another round short name where there can be multiple rounds. Fixes a bug where one of the DEV rounds' delta values would be the opposite of the preceding OR's value.

* **Screenshots**

Before:

![1868WY DEV before](https://user-images.githubusercontent.com/1045173/235317738-36d09ca2-a96b-43af-904a-0f560c1cb366.png)

After:

![1868WY DEV after](https://user-images.githubusercontent.com/1045173/235317623-90aa601f-8c0a-4bbd-a75b-1abc8f2bd43b.png)