### PR TITLE
update game.shares to utilize both corporation and player shares 

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -929,7 +929,7 @@ module Engine
       end
 
       def shares
-        @corporations.flat_map(&:shares)
+        @corporations.flat_map(&:shares) + @players.flat_map(&:shares)
       end
 
       def share_prices

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -929,7 +929,7 @@ module Engine
       end
 
       def shares
-        @corporations.flat_map(&:shares) + @players.flat_map(&:shares)
+        @corporations.flat_map(&:shares) + @players.flat_map(&:shares) + @share_pool.shares
       end
 
       def share_prices


### PR DESCRIPTION
if update_cache is called on shares it doesn't wipe out shares currently in players hands


- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

