### PR TITLE
[1847 AE] Add draft and  the ramaining companies

### DIFF
--- a/lib/engine/game/g_1847_ae/entities.rb
+++ b/lib/engine/game/g_1847_ae/entities.rb
@@ -7,13 +7,46 @@ module Engine
       module Entities
         COMPANIES = [
           {
+            name: 'Pfälzische Ludwigsbahn presidency',
+            value: 172,
+            revenue: 0,
+            desc: 'Comes with the President\'s certificate of Pfälzische Ludwigsbahn (L). '\
+                  'Closes immediately.',
+            sym: 'PLP',
+            abilities: [{ type: 'shares', shares: 'L_0' }],
+          },
+          {
+            name: 'Saarbrücker Private Railway',
+            value: 190,
+            revenue: 15,
+            desc: 'Comes with the president\'s certificate of Saarbrücker Eisenbahn (Saar). '\
+                  'May not be sold to a corporation. '\
+                  'Closes when Saar buys its first train.',
+            sym: 'SPR',
+            abilities: [{ type: 'shares', shares: 'Saar_0' }],
+          },
+          {
+            name: 'Locomotive Firm Krauss & Co.',
+            value: 130,
+            revenue: 0,
+            desc: 'Every OR, first time a train is purchased from supply, this pays revenue '\
+                  'equal to 10% of the train\'s cost and the stock price marker is moved right. '\
+                  'If no train is purchased from supply in OR, no revenue is paid and the stock '\
+                  'price marker is moved left. '\
+                  'May not be sold to a corporation. '\
+                  'May be sold to or purchased from the market. '\
+                  'Never closes.',
+            sym: 'LFKC',
+            abilities: [{ type: 'shares', shares: 'Saar_0' }],
+          },
+          {
             name: 'Rammelsbach',
             value: 150,
             revenue: 30,
             min_price: 100,
             max_price: 200,
-            desc: 'May be sold to a corporation for 100 to 200M. '\
-                  'Revenue increases to 50M when a tile is laid in D9. '\
+            desc: 'Revenue increases to 50M when a tile is laid in D9. '\
+                  'May be sold to a corporation for 100 to 200M. '\
                   'Never closes.',
             sym: 'R',
           },
@@ -23,13 +56,15 @@ module Engine
             revenue: 5,
             min_price: 15,
             max_price: 40,
-            desc: 'May be sold to a corporation for 15 to 40M. '\
-                  'Owning corporation may close this company to place a yellow tile on '\
+            desc: 'Owning corporation may close this company to place a yellow tile on '\
                   'a mountain hex for free, in addition to normal track action. '\
-                  'Otherwise closes in Phase 6E.',
+                  'Otherwise closes in Phase 6E. '\
+                  'May be sold to a corporation for 15 to 40M. '\
+                  'Comes with a share of Pfälzische Ludwigsbahn (L).',
             sym: 'K',
             abilities: [
               { type: 'close', on_phase: '6E' },
+              { type: 'shares', shares: 'L_1' },
               {
                 type: 'tile_lay',
                 hexes: %w[B4
@@ -62,7 +97,7 @@ module Engine
                 closed_when_used_up: true,
                 special: false,
               },
-],
+            ],
           },
           {
             name: 'Hochstätten',
@@ -70,13 +105,15 @@ module Engine
             revenue: 15,
             min_price: 40,
             max_price: 120,
-            desc: 'May be sold to a corporation for 40 to 120M. '\
-                  'Owning corporation may close this company to place a yellow tile on '\
+            desc: 'Owning corporation may close this company to place a yellow tile on '\
                   'a mountain hex for free, in addition to normal track action. '\
-                  'Otherwise closes in Phase 6E.',
+                  'Otherwise closes in Phase 6E. '\
+                  'May be sold to a corporation for 40 to 120M. '\
+                  'Comes with a share of Pfälzische Ludwigsbahn (L).',
             sym: 'H',
             abilities: [
               { type: 'close', on_phase: '6E' },
+              { type: 'shares', shares: 'L_2' },
               {
                 type: 'tile_lay',
                 hexes: %w[B4
@@ -109,7 +146,7 @@ module Engine
                 closed_when_used_up: true,
                 special: false,
               },
-],
+            ],
           },
           {
             name: 'Weidenthal',
@@ -117,12 +154,14 @@ module Engine
             revenue: 10,
             min_price: 25,
             max_price: 75,
-            desc: 'May be sold to a corporation for 25 to 75M. '\
-                  'Owning corporation may close this company to place a token '\
-                  'for half price. Otherwise closes in Phase 6E.',
+            desc: 'Owning corporation may close this company to place a token for half the price.'\
+                  'Otherwise closes in Phase 6E. '\
+                  'May be sold to a corporation for 25 to 75M. '\
+                  'Comes with a share of Pfälzische Ludwigsbahn (L).',
             sym: 'W',
             abilities: [
               { type: 'close', on_phase: '6E' },
+              { type: 'shares', shares: 'L_3' },
               {
                 type: 'token',
                 owner_type: 'corporation',
@@ -134,7 +173,7 @@ module Engine
                 from_owner: true,
                 closed_when_used_up: true,
               },
-],
+            ],
           },
           {
             name: 'Main-Neckar-Railway',
@@ -142,7 +181,8 @@ module Engine
             revenue: 20,
             desc: 'May be exchanged for an Investor share of the Hessische Ludwigsbahn (HLB), '\
                   'instead of buying a share, during a stock round in Phase 3+3 or later. ' \
-                  'Automatically exchanged at the beginning of the first stock round in Phase 5+5.',
+                  'Automatically exchanged at the beginning of the first stock round in Phase 5+5. '\
+                  'May not be sold to a corporation. ',
             sym: 'MNR',
             abilities: [{ type: 'no_buy' },
                         {
@@ -159,7 +199,8 @@ module Engine
             revenue: 15,
             desc: 'May be exchanged for an Investor share of the Saarbrücker Eisenbahn (Saar), '\
                   'instead of buying a share, during a stock round in Phase 3+3 or later. ' \
-                  'Automatically exchanged at the beginning of the first stock round in Phase 5+5.',
+                  'Automatically exchanged at the beginning of the first stock round in Phase 5+5. '\
+                  'May not be sold to a corporation. ',
             sym: 'SCR',
             abilities: [{ type: 'no_buy' },
                         {
@@ -176,7 +217,8 @@ module Engine
             revenue: 20,
             desc: 'May be exchanged for an Investor share of the Saarbrücker Eisenbahn (Saar), '\
                   'instead of buying a share, during a stock round in Phase 3+3 or later. ' \
-                  'Automatically exchanged at the beginning of the first stock round in Phase 5+5.',
+                  'Automatically exchanged at the beginning of the first stock round in Phase 5+5. '\
+                  'May not be sold to a corporation. ',
             sym: 'VIW',
             abilities: [{ type: 'no_buy' },
                         {

--- a/lib/engine/game/g_1847_ae/entities.rb
+++ b/lib/engine/game/g_1847_ae/entities.rb
@@ -12,8 +12,8 @@ module Engine
             revenue: 30,
             min_price: 100,
             max_price: 200,
-            desc: 'May be sold to a corporation for 100 to 200 M. '\
-                  'Revenue increases to 50 when a tile is laid in D9. '\
+            desc: 'May be sold to a corporation for 100 to 200M. '\
+                  'Revenue increases to 50M when a tile is laid in D9. '\
                   'Never closes.',
             sym: 'R',
           },
@@ -23,7 +23,7 @@ module Engine
             revenue: 5,
             min_price: 15,
             max_price: 40,
-            desc: 'May be sold to a corporation for 15 to 40 M. '\
+            desc: 'May be sold to a corporation for 15 to 40M. '\
                   'Owning corporation may close this company to place a yellow tile on '\
                   'a mountain hex for free, in addition to normal track action. '\
                   'Otherwise closes in Phase 6E.',
@@ -70,7 +70,7 @@ module Engine
             revenue: 15,
             min_price: 40,
             max_price: 120,
-            desc: 'May be sold to a corporation for 40 to 120 M. '\
+            desc: 'May be sold to a corporation for 40 to 120M. '\
                   'Owning corporation may close this company to place a yellow tile on '\
                   'a mountain hex for free, in addition to normal track action. '\
                   'Otherwise closes in Phase 6E.',
@@ -117,7 +117,7 @@ module Engine
             revenue: 10,
             min_price: 25,
             max_price: 75,
-            desc: 'May be sold to a corporation for 25 to 75 M. '\
+            desc: 'May be sold to a corporation for 25 to 75M. '\
                   'Owning corporation may close this company to place a token '\
                   'for half price. Otherwise closes in Phase 6E.',
             sym: 'W',

--- a/lib/engine/game/g_1847_ae/entities.rb
+++ b/lib/engine/game/g_1847_ae/entities.rb
@@ -37,7 +37,6 @@ module Engine
                   'May be sold to or purchased from the market. '\
                   'Never closes.',
             sym: 'LFKC',
-            abilities: [{ type: 'shares', shares: 'Saar_0' }],
           },
           {
             name: 'Rammelsbach',

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -188,8 +188,7 @@ module Engine
         def new_draft_round
           @log << "-- Draft Round #{@turn} -- "
           G1847AE::Round::Draft.new(self,
-                                    [G1847AE::Step::Draft],
-                                    first_to_act_index: @draft_last_acting_index,)
+                                    [G1847AE::Step::Draft],)
         end
 
         def next_round!

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -185,6 +185,10 @@ module Engine
           corporation_by_id('HLB')
         end
 
+        def r
+          company_by_id('R')
+        end
+
         def init_share_pool
           G1847AE::SharePool.new(self)
         end
@@ -237,6 +241,15 @@ module Engine
         # Cannot build in E9 before Phase 5
         def can_build_in_e9?
           ['5', '5+5', '6E', '6+6'].include?(@phase.current[:name])
+        end
+
+        def action_processed(action)
+          super
+
+          return if r.revenue == 50 || !action.is_a?(Action::LayTile) || action.hex.id != 'E9'
+
+          r.revenue = 50
+          @log << "Tile laid in E9 - #{r.name}'s revenue increased to 50M"
         end
       end
     end

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -243,7 +243,6 @@ module Engine
 
         def setup
           # Place L's home station in case there is a "short OR" during draft
-          puts l.coordinates
           hex = hex_by_id(l.coordinates)
           tile = hex&.tile
           tile.cities.first.place_token(l, l.next_token)

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -160,6 +160,12 @@ module Engine
                                     reverse_order: true,)
         end
 
+        def new_draft_round
+          @log << "-- Draft Round #{@turn} -- "
+          G1847AE::Round::Draft.new(self,
+                                    [G1847AE::Step::Draft],)
+        end
+
         def stock_round
           Engine::Round::Stock.new(self, [
             G1847AE::Step::Exchange,
@@ -183,12 +189,6 @@ module Engine
             Engine::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
-        end
-
-        def new_draft_round
-          @log << "-- Draft Round #{@turn} -- "
-          G1847AE::Round::Draft.new(self,
-                                    [G1847AE::Step::Draft],)
         end
 
         def next_round!

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -205,6 +205,10 @@ module Engine
             end
         end
 
+        def l
+          corporation_by_id('L')
+        end
+
         def saar
           corporation_by_id('Saar')
         end
@@ -239,6 +243,12 @@ module Engine
         end
 
         def setup
+          # Place L's home station in case there is a "short OR" during draft
+          puts l.coordinates
+          hex = hex_by_id(l.coordinates)
+          tile = hex&.tile
+          tile.cities.first.place_token(l, l.next_token)
+
           # Reserve investor shares and add money for them to treasury
           [saar.shares[1], saar.shares[2], hlb.shares[1]].each { |s| s.buyable = false }
           saar.cash += saar.par_price.price * 2

--- a/lib/engine/game/g_1847_ae/round/draft.rb
+++ b/lib/engine/game/g_1847_ae/round/draft.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/draft'
+
+module Engine
+  module Game
+    module G1847AE
+      module Round
+        class Draft < Engine::Round::Draft
+          def initialize(game, steps, **opts)
+            super
+
+            return unless @game.draft_first_round_finished
+
+            @entity_index = @game.draft_last_acting_index
+            @game.draft_last_acting_index = nil
+          end
+
+          def next_entity_index!
+            if @entity_index == @entities.size - 1 && !@game.draft_first_round_finished
+              @entities.reverse!
+              @game.draft_first_round_finished = true
+            end
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1847_ae/round/draft.rb
+++ b/lib/engine/game/g_1847_ae/round/draft.rb
@@ -12,11 +12,16 @@ module Engine
 
             return unless @game.draft_first_round_finished
 
-            @entity_index = @game.draft_last_acting_index
-            @game.draft_last_acting_index = nil
+            # Continue the previous round of draft, the index to last acting person
+            if !@game.draft_last_acting_index.nil?
+              @entities.rotate!(@game.draft_last_acting_index)
+              @game.draft_last_acting_index = nil
+            end
           end
 
           def next_entity_index!
+            puts 'next_entity_index'
+            # First round of draft is perforemd in reverse player order
             if @entity_index == @entities.size - 1 && !@game.draft_first_round_finished
               @entities.reverse!
               @game.draft_first_round_finished = true

--- a/lib/engine/game/g_1847_ae/step/draft.rb
+++ b/lib/engine/game/g_1847_ae/step/draft.rb
@@ -88,13 +88,15 @@ module Engine
             @log << "#{player.name} buys #{company.name} for #{@game.format_currency(price)}"
 
             company.abilities.each do |ability|
-                next unless ability.type == :shares
+              next unless ability.type == :shares
 
-                ability.shares.each do |share|
-                    @game.share_pool.buy_shares(player, share, exchange: :free)
-                end
+              # Give related share to the player and give money for the share to the corporation
+              ability.shares.each do |share|
+                @game.share_pool.buy_shares(player, share, exchange: :free)
+                share.corporation.cash += share.corporation.par_price.price * share.percent / 10
+              end
             end
-            
+
             # PLP company is only a temporary holder for the L presidency
             company.close! if company.id == 'PLP'
 

--- a/lib/engine/game/g_1847_ae/step/draft.rb
+++ b/lib/engine/game/g_1847_ae/step/draft.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1847AE
+      module Step
+        class Draft < Engine::Step::Base
+          attr_reader :companies, :choices, :grouped_companies
+
+          ACTIONS = %w[bid pass].freeze
+
+          def setup
+            @companies = @game.companies.select { |c| c.owner.nil? }
+            @companies = @companies.sort_by { |item| [item.revenue, item.value] }
+          end
+
+          def available
+            @companies
+          end
+
+          def may_purchase?(_company)
+            true
+          end
+
+          def auctioning; end
+
+          def bids
+            {}
+          end
+
+          def visible?
+            true
+          end
+
+          def players_visible?
+            true
+          end
+
+          def tiered_auction_companies
+            @companies.group_by(&:revenue).values
+          end
+
+          def name
+            'Draft'
+          end
+
+          def description
+            'Draft Private Companies'
+          end
+
+          def finished?
+            finished = @companies.empty? || entities.all?(&:passed?)
+
+            if finished && @game.draft_last_acting_index.nil?
+              # If not all companies are purchased, the draft will be coninuted after a "short OR".
+              # We have to store the index of the last player to have acted, so we can continue with next in order.
+              @game.draft_finished = @companies.empty?
+              @game.draft_last_acting_index = @round.entity_index
+            end
+
+            finished
+          end
+
+          def actions(entity)
+            return [] if finished?
+
+            unless @companies.any? { |c| current_entity.cash >= min_bid(c) }
+              @log << "#{current_entity.name} has no valid actions and passes"
+              return []
+            end
+
+            entity == current_entity ? ACTIONS : []
+          end
+
+          def process_bid(action)
+            company = action.company
+            player = action.entity
+            price = action.price
+
+            company.owner = player
+            player.companies << company
+            player.spend(price, @game.bank)
+
+            @companies.delete(company)
+
+            @log << "#{player.name} buys #{company.name} for #{@game.format_currency(price)}"
+
+            entities.each(&:unpass!)
+            @round.next_entity_index!
+            action_finalized
+          end
+
+          def process_pass(action)
+            @log << "#{action.entity.name} passes"
+            action.entity.pass!
+            @round.next_entity_index!
+            action_finalized
+          end
+
+          def action_finalized
+            return unless finished?
+
+            @round.reset_entity_index!
+          end
+
+          def committed_cash(_player, _show_hidden = false)
+            0
+          end
+
+          def min_bid(company)
+            return unless company
+
+            company.value
+          end
+
+          def skip!
+            current_entity.pass!
+            @round.next_entity_index!
+            action_finalized
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1847_ae/step/draft.rb
+++ b/lib/engine/game/g_1847_ae/step/draft.rb
@@ -87,6 +87,17 @@ module Engine
 
             @log << "#{player.name} buys #{company.name} for #{@game.format_currency(price)}"
 
+            company.abilities.each do |ability|
+                next unless ability.type == :shares
+
+                ability.shares.each do |share|
+                    @game.share_pool.buy_shares(player, share, exchange: :free)
+                end
+            end
+            
+            # PLP company is only a temporary holder for the L presidency
+            company.close! if company.id == 'PLP'
+
             entities.each(&:unpass!)
             @round.next_entity_index!
             action_finalized

--- a/lib/engine/game/g_1847_ae/step/draft.rb
+++ b/lib/engine/game/g_1847_ae/step/draft.rb
@@ -12,7 +12,7 @@ module Engine
           ACTIONS = %w[bid pass].freeze
 
           def setup
-            @companies = @game.companies.select { |c| c.owner.nil? }
+            @companies = @game.companies.select { |c| c.owner.nil? && !c.closed? }
             @companies = @companies.sort_by { |item| [item.revenue, item.value] }
           end
 
@@ -20,6 +20,10 @@ module Engine
             @companies
           end
 
+          def active?
+            true
+          end
+          
           def may_purchase?(_company)
             true
           end

--- a/lib/engine/game/g_1847_ae/step/track.rb
+++ b/lib/engine/game/g_1847_ae/step/track.rb
@@ -10,7 +10,7 @@ module Engine
           def available_hex(entity, hex)
             return nil if (hex.id == 'E9') && !@game.can_build_in_e9?
 
-            super(entity, hex)
+            super
           end
         end
       end

--- a/lib/engine/round/draft.rb
+++ b/lib/engine/round/draft.rb
@@ -6,8 +6,11 @@ module Engine
   module Round
     class Draft < Base
       def initialize(game, steps, **opts)
+        # reverse_order: 4, 3, 2, 1; 4, 3, 2, 1; ...
         @reverse_order = opts[:reverse_order] || false
+        # snake_order: 1, 2, 3, 4; 4, 3, 2, 1; 1, 2, 3, 4; 4, ...
         @snake_order = opts[:snake_order] || false
+        # rotating_order: 1, 2, 3, 4; 2, 3, 4, 1; 3, 4, 1, 2; ...
         @rotating_order = opts[:rotating_order] || false
         @snaking_up = true
 


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Companies are drafted in the following order: Player4, 3, 2, 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, ...
If all players pass and there are still undrafted companies, a short OR takes place in which companies pay revenue and the L corporation operates if it is floated (5 of its shares are held by players).
