### PR TITLE
[18MEX] set EBUY_OTHER_VALUE to false

### DIFF
--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -29,6 +29,7 @@ module Engine
         CAPITALIZATION = :full
 
         MUST_SELL_IN_BLOCKS = false
+        EBUY_OTHER_VALUE = false
 
         MARKET = [
           %w[60 65 70 75 80p 90p 100 110 120 130 140 150 165 180 200e],

--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -43,12 +43,17 @@ module Engine
         min, max = spend_minmax(action.entity, action.train)
         return if (min..max).cover?(action.price)
 
-        raise GameError, "#{action.entity.name} may not spend "\
-                         "#{@game.format_currency(action.price)} on "\
-                         "#{action.train.owner.name}'s #{action.train.name} "\
-                         'train; may only spend between '\
-                         "#{@game.format_currency(min)} and "\
-                         "#{@game.format_currency(max)}."
+        if max.zero? && !@game.class::EBUY_OTHER_VALUE
+          raise GameError, "#{action.entity.name} may not buy a train from "\
+                           'another corporation.'
+        else
+          raise GameError, "#{action.entity.name} may not spend "\
+                           "#{@game.format_currency(action.price)} on "\
+                           "#{action.train.owner.name}'s #{action.train.name} "\
+                           'train; may only spend between '\
+                           "#{@game.format_currency(min)} and "\
+                           "#{@game.format_currency(max)}."
+        end
       end
 
       def process_buy_train(action)


### PR DESCRIPTION
4.3.4.2, pages 10-11 in rulebook

Fixes #9162

Also update error message for the case where the buying company has no money; in
some 18MEX games, presidents contributed $1 for an EMR cross-buy resulting in
messages like "TM may not spend $1 on MC's 6' train; may only spend between $1
and $0." 