### PR TITLE
[1858] Don't check graph in Step::BuySellParShares.actions

### DIFF
--- a/lib/engine/game/g_1858/step/private_exchange.rb
+++ b/lib/engine/game/g_1858/step/private_exchange.rb
@@ -32,7 +32,7 @@ module Engine
           end
 
           def exchange_for_share(bundle, corporation, minor, player)
-            unless @game.corporation_private_connected?(corporation, minor)
+            if !@game.loading && !@game.corporation_private_connected?(corporation, minor)
               raise GameError, "#{minor.name} is not connected to #{corporation.full_name}"
             end
 


### PR DESCRIPTION
The call to `can_exchange_any?` in `Step::BuySellParShares.actions` was leading to a call to `@game.corporation_private_connected?` which uses the game graph. This will be slowing down loading the game history, so this commit adds a simplified check which is just checking that shares are available for the exchange.

When the game is being run interactively, `auto_actions` will check the game graph to see if any exchanges are actually possible, and pass if not.

- [x] Branch is derived from the latest `master`
- [x] ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`