### PR TITLE
[1858] Use sticky icons for private railway home hexes

### DIFF
--- a/lib/engine/game/g_1858/map.rb
+++ b/lib/engine/game/g_1858/map.rb
@@ -80,11 +80,11 @@ module Engine
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2',
             %w[K8] =>
-                    'icon=image:1858/MZ;' \
+                    'icon=image:1858/MZ,sticky:1;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2',
             %w[F17] =>
-                    'icon=image:1858/CS;' \
+                    'icon=image:1858/CS,sticky:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3',
             %w[J11 J13] =>
@@ -130,13 +130,13 @@ module Engine
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5',
             %w[G4] =>
-                    'icon=image:1858/AS;' \
+                    'icon=image:1858/AS,sticky:1;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4',
             %w[J9] =>
-                    'icon=image:1858/MZ;' \
+                    'icon=image:1858/MZ,sticky:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4;' \
@@ -197,7 +197,7 @@ module Engine
                     'border=type:province,edge:4',
             %w[F3] =>
                     'upgrade=cost:80,terrain:mountain;' \
-                    'icon=image:1858/LG;' \
+                    'icon=image:1858/LG,sticky:1;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:5',
@@ -237,7 +237,7 @@ module Engine
 
             %w[E14] =>
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/BCR;',
+                    'icon=image:1858/BCR,sticky:1;',
             %w[C8] =>
                     'upgrade=cost:20,terrain:water;' \
                     'border=type:province,edge:3',
@@ -260,7 +260,7 @@ module Engine
                     'border=type:province,edge:5',
             %w[F15] =>
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/BCR;' \
+                    'icon=image:1858/BCR,sticky:1;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5',
@@ -271,7 +271,7 @@ module Engine
                     'border=type:province,edge:5',
             %w[K6] =>
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/ZP;' \
+                    'icon=image:1858/ZP,sticky:1;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3',
@@ -282,13 +282,13 @@ module Engine
                     'border=type:province,edge:5',
             %w[E12] =>
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/CMP;' \
+                    'icon=image:1858/CMP,sticky:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4',
             %w[F13] =>
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/CMP;' \
+                    'icon=image:1858/CMP,sticky:1;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5',
@@ -310,7 +310,7 @@ module Engine
                     'border=type:province,edge:3',
             %w[B11] =>
                     'town=revenue:0;' \
-                    'icon=image:1858/PL;' \
+                    'icon=image:1858/PL,sticky:1;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:1',
             %w[H15] =>
@@ -323,7 +323,7 @@ module Engine
                     'border=type:province,edge:2',
             %w[I10] =>
                     'town=revenue:0;' \
-                    'icon=image:1858/MZ;' \
+                    'icon=image:1858/MZ,sticky:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3',
             %w[B7 H5] =>
@@ -336,7 +336,7 @@ module Engine
                     'border=type:province,edge:5',
             %w[K4] =>
                     'town=revenue:0;' \
-                    'icon=image:1858/ZP;' \
+                    'icon=image:1858/ZP,sticky:1;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:5',
             %w[I4] =>
@@ -361,19 +361,19 @@ module Engine
                     'border=type:province,edge:3',
             %w[F9] =>
                     'town=revenue:0;' \
-                    'icon=image:1858/MS;' \
+                    'icon=image:1858/MS,sticky:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5',
             %w[F5] =>
                     'town=revenue:0;' \
-                    'icon=image:1858/LG;' \
+                    'icon=image:1858/LG,sticky:1;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5',
             %w[G10] =>
                     'town=revenue:0;' \
-                    'icon=image:1858/MV;' \
+                    'icon=image:1858/MV,sticky:1;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2;' \
@@ -396,26 +396,26 @@ module Engine
             %w[D15] =>
                     'town=revenue:0;' \
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/BCR;' \
+                    'icon=image:1858/BCR,sticky:1;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2',
             %w[B13] =>
                     'town=revenue:0;' \
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/LC;' \
+                    'icon=image:1858/LC,sticky:1;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4',
             %w[D13] =>
                     'town=revenue:0;' \
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/CMP;' \
+                    'icon=image:1858/CMP,sticky:1;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3',
             %w[G12] =>
                     'town=revenue:0;' \
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/CMP;' \
+                    'icon=image:1858/CMP,sticky:1;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3',
@@ -427,7 +427,7 @@ module Engine
             # Double town hexes
             %w[N9] =>
                     'town=revenue:0;town=revenue:0;' \
-                    'icon=image:1858/RT;' \
+                    'icon=image:1858/RT,sticky:1;' \
                     'border=type:province,edge:2',
             %w[H17] =>
                     'town=revenue:0;town=revenue:0;' \
@@ -436,7 +436,8 @@ module Engine
             %w[C4] =>
                     'town=revenue:0;town=revenue:0;' \
                     'upgrade=cost:40,terrain:mountain;' \
-                    'icon=image:1858/SC;icon=image:1858/OV',
+                    'icon=image:1858/SC,sticky:1;' \
+                    'icon=image:1858/OV,sticky:1;',
 
             # City hexes
             %w[C2] =>
@@ -466,7 +467,8 @@ module Engine
             %w[E18] =>
                     'city=revenue:0;label=Y;' \
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/CS;icon=image:1858/SJC;' \
+                    'icon=image:1858/CS,sticky:1;' \
+                    'icon=image:1858/SJC,sticky:1;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3',
             %w[E20] =>
@@ -475,7 +477,8 @@ module Engine
             %w[G18] =>
                     'city=revenue:0;' \
                     'upgrade=cost:20,terrain:water;' \
-                    'icon=image:1858/CM;icon=image:1858/CS',
+                    'icon=image:1858/CM,sticky:1;' \
+                    'icon=image:1858/CS,sticky:1;',
             %w[K18] =>
                     'city=revenue:0;' \
                     'upgrade=cost:20,terrain:water;',
@@ -493,7 +496,8 @@ module Engine
           yellow: {
             %w[L7] =>
                     'city=revenue:30;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0;label=Y;' \
-                    'icon=image:1858/MZ;icon=image:1858/ZP;',
+                    'icon=image:1858/MZ,sticky:1;' \
+                    'icon=image:1858/ZP,sticky:1;',
             %w[H11] =>
                     'city=revenue:40,loc:1;path=a:1,b:_0;' \
                     'city=revenue:40,loc:2.5;path=a:2,b:_1;' \
@@ -503,7 +507,7 @@ module Engine
                     'label=M',
             %w[H13] =>
                     'town=revenue:10;path=a:3,b:_0;path=a:_0,b:5;' \
-                    'icon=image:1858/MA;',
+                    'icon=image:1858/MA,sticky:1;',
             %w[I14] =>
                     'path=a:2,b:5',
           },

--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -43,7 +43,6 @@ module Engine
             @round.gauges_added << new_track_gauge(old_tile, new_tile)
 
             super
-            new_tile.icons = old_tile.icons
           end
 
           def process_lay_tile(action)


### PR DESCRIPTION
Remove the custom code for keeping icons on upgraded tiles, and instead define the icons as being sticky, as there is already code to preserve the icons.

- [x] Branch is derived from the latest `master`
- [x] ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
