### PR TITLE
[core] allow icons and upgrades to have a `loc` set to specify rendering location, use for DTs in 1868WY

### DIFF
--- a/TILES.md
+++ b/TILES.md
@@ -76,6 +76,9 @@ game config/code:
 - **upgrade**
     - **cost** - *required* - integer
     - **terrain** - `mountain`/`water` - multiple terrain types separated by `|`
+    - **loc** - (currently only supported for `:pointy` layouts) corner to
+      render the upgrade in, `5.5` to be where edges `5` and `0` meet, `0.5` for
+      edges `0` and `1`, and so on
 - **border**
     - **edge** - *required* - integer - which edge to modify
     - **type** - `mountain`/`water`/`impassable` - Border type. If not'
@@ -91,6 +94,9 @@ game config/code:
       upgrade is placed on this hex
     - **blocks_lay** - indicates this tile cannot be laid normally
       but can only be laid by special ability, such as a private company's ability.
+    - **loc** - (currently only supported for `:pointy` layouts) corner to
+      render the upgrade in, `5.5` to be where edges `5` and `0` meet, `0.5` for
+      edges `0` and `1`, and so on
 - **frame**
     - **color** - *required* - the color of the frame
     - **color2** - A second color to display on the frame

--- a/assets/app/view/game/part/base.rb
+++ b/assets/app/view/game/part/base.rb
@@ -6,6 +6,7 @@ module View
       class Base < Snabberb::Component
         needs :region_use
         needs :tile, default: nil
+        needs :loc, default: nil
 
         UPPER_LEFT = [0, 1, 2].freeze
         UPPER_RIGHT = [2, 3, 4].freeze
@@ -152,9 +153,13 @@ module View
         end
 
         def render_location
-          @render_location ||= preferred_render_locations.min_by.with_index do |t, i|
-            [combined_cost(t[:region_weights_in] || t[:region_weights]), i]
-          end
+          @render_location ||=
+            begin
+              locations = @loc ? preferred_render_locations_by_loc : preferred_render_locations
+              locations.min_by.with_index do |t, i|
+                [combined_cost(t[:region_weights_in] || t[:region_weights]), i]
+              end
+            end
         end
 
         # use this method to set instance vars that can be used in the other

--- a/assets/app/view/game/part/icons.rb
+++ b/assets/app/view/game/part/icons.rb
@@ -24,8 +24,12 @@ module View
           end
         end
 
+        def parts_for_loc
+          @icons
+        end
+
         def load_from_tile
-          @icons = @tile.icons.reject(&:large)
+          @icons = @tile.icons.select { |i| !i.large && (i.loc == @loc) }
           @num_cities = @tile.cities.size
         end
 

--- a/assets/app/view/game/part/small_item.rb
+++ b/assets/app/view/game/part/small_item.rb
@@ -6,6 +6,33 @@ module View
   module Game
     module Part
       module SmallItem
+        def preferred_render_locations_by_loc
+          parts = parts_for_loc
+
+          if layout == :pointy
+            case @loc.to_s
+            when '0.5'
+              parts.one? ? [PP_BOTTOM_LEFT_CORNER] : [PP_WIDE_BOTTOM_LEFT_CORNER]
+            when '1.5'
+              parts.one? ? [PP_UPPER_LEFT_CORNER] : [PP_WIDE_UPPER_LEFT_CORNER]
+            when '2.5'
+              parts.one? ? [PP_TOP_CORNER] : [PP_WIDE_TOP_CORNER]
+            when '3.5'
+              parts.one? ? [PP_UPPER_RIGHT_CORNER] : [PP_WIDE_UPPER_RIGHT_CORNER]
+            when '4.5'
+              parts.one? ? [PP_BOTTOM_RIGHT_CORNER] : [PP_WIDE_BOTTOM_RIGHT_CORNER]
+            when '5.5'
+              parts.one? ? [PP_BOTTOM_CORNER] : [PP_WIDE_BOTTOM_CORNER]
+            else
+              @loc = nil
+              preferred_render_locations
+            end
+          else
+            @loc = nil
+            preferred_render_locations
+          end
+        end
+
         P_RIGHT_CORNER = {
           region_weights: Base::RIGHT_CORNER,
           x: 75,
@@ -58,6 +85,24 @@ module View
           region_weights: Base::UPPER_LEFT_CORNER,
           x: -0,
           y: -75,
+        }.freeze
+
+        PP_TOP_LEFT_CORNER = {
+          region_weights: Base::UPPER_LEFT_CORNER,
+          x: -65,
+          y: -37.5,
+        }.freeze
+
+        PP_TOP_RIGHT_CORNER = {
+          region_weights: Base::UPPER_RIGHT_CORNER,
+          x: 65,
+          y: -37.5,
+        }.freeze
+
+        PP_BOTTOM_RIGHT_CORNER = {
+          region_weights: Base::BOTTOM_LEFT_CORNER,
+          x: 65,
+          y: 37.5,
         }.freeze
 
         PP_BOTTOM_LEFT_CORNER = {
@@ -130,6 +175,24 @@ module View
           region_weights: [10, 11, 13, 19],
           x: 0,
           y: 16,
+        }.freeze
+
+        PP_WIDE_UPPER_RIGHT_CORNER = {
+          region_weights: Base::RIGHT_CORNER,
+          x: 52,
+          y: -25,
+        }.freeze
+
+        PP_WIDE_UPPER_LEFT_CORNER = {
+          region_weights: Base::LEFT_CORNER,
+          x: -52,
+          y: -25,
+        }.freeze
+
+        PP_WIDE_BOTTOM_RIGHT_CORNER = {
+          region_weights: [9, 10, 11, 16],
+          x: 52,
+          y: 25,
         }.freeze
 
         PP_WIDE_BOTTOM_LEFT_CORNER = {

--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require 'view/game/part/base'
+require 'view/game/part/small_item'
 
 module View
   module Game
     module Part
       class Upgrade < Base
+        include SmallItem
+
         needs :cost
         needs :terrains, default: []
         needs :size, default: nil
@@ -39,6 +42,11 @@ module View
           x: -50,
           y: -45,
         }.freeze
+        PP_EDGE2 = {
+          region_weights: [0, 5, 6],
+          x: -35,
+          y: -55,
+        }.freeze
 
         P_RIGHT_CORNER = {
           region_weights: [11, 18],
@@ -57,15 +65,31 @@ module View
         TRIANGLE_PATH = '0,20 10,0 20,20'
 
         def preferred_render_locations
-          [
-            P_CENTER,
-            P_TOP_RIGHT_CORNER,
-            P_EDGE2,
-            P_BOTTOM_LEFT_CORNER,
-            P_RIGHT_CORNER,
-            P_LEFT_CORNER,
-            P_BOTTOM_RIGHT_CORNER,
-          ]
+          if layout == :flat
+            [
+              P_CENTER,
+              P_TOP_RIGHT_CORNER,
+              P_EDGE2,
+              P_BOTTOM_LEFT_CORNER,
+              P_RIGHT_CORNER,
+              P_LEFT_CORNER,
+              P_BOTTOM_RIGHT_CORNER,
+            ]
+          else
+            [
+              P_CENTER,
+              PP_TOP_RIGHT_CORNER,
+              PP_EDGE2,
+              PP_BOTTOM_LEFT_CORNER,
+              PP_RIGHT_CORNER,
+              PP_LEFT_CORNER,
+              PP_BOTTOM_RIGHT_CORNER,
+            ]
+          end
+        end
+
+        def parts_for_loc
+          @terrains
         end
 
         def render_part
@@ -91,7 +115,9 @@ module View
 
           children = [cost] + terrain
 
-          h(:g, { attrs: { transform: "#{translate} #{rotation_for_layout}" } }, children)
+          h(:g, { attrs: { transform: rotation_for_layout } }, [
+              h(:g, { attrs: { transform: translate } }, children),
+            ])
         end
 
         def mountain(delta_x: 0, delta_y: 0)

--- a/assets/app/view/game/part/upgrades.rb
+++ b/assets/app/view/game/part/upgrades.rb
@@ -9,6 +9,7 @@ module View
       class Upgrades < Snabberb::Component
         needs :tile
         needs :region_use
+        needs :loc, default: nil
 
         def render
           @tile.upgrades.map do |upgrade|
@@ -19,6 +20,7 @@ module View
               terrains: upgrade.terrains,
               tile: @tile,
               size: upgrade.size,
+              loc: @loc,
             )
           end
         end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -26,6 +26,19 @@ module View
         h(part_class, region_use: @region_use, tile: @tile, **kwargs)
       end
 
+      def render_tile_parts_by_loc(part_class, parts: nil, **kwargs)
+        return [] if !parts || parts.empty?
+
+        loc_to_parts = Hash.new { |h, k| h[k] = [] }
+        parts.each do |part|
+          loc_to_parts[part.loc] << part
+        end
+
+        loc_to_parts.map do |loc, _parts|
+          render_tile_part(part_class, loc: loc, **kwargs)
+        end
+      end
+
       # if false, then the revenue is rendered by Part::Cities or Part::Towns
       def should_render_revenue?
         revenue = @tile.revenue_to_render
@@ -53,6 +66,11 @@ module View
         # modified before being passed on to the next one
         @region_use = Hash.new(0)
 
+        # array of parts to render
+        # - `render_tile_part` is called in the order they impact the region
+        #   usage
+        # - the order of this array determines the order the parts are added to
+        #   the DOM; parts at the end of the array render on top of ealier parts
         children = []
 
         render_revenue = should_render_revenue?
@@ -66,25 +84,31 @@ module View
         if @tile.location_name && @tile.cities.size > 1 && !@tile.hex.hide_location_name
           rendered_loc_name = render_tile_part(Part::LocationName)
         end
-        children << render_tile_part(Part::Revenue) if render_revenue
-        @tile.labels.each { |x| children << render_tile_part(Part::Label, label: x) }
+        revenue = render_tile_part(Part::Revenue) if render_revenue
+        @tile.labels.each { |l| children << render_tile_part(Part::Label, label: l) }
 
-        children << render_tile_part(Part::Upgrades) unless @tile.upgrades.empty?
+        render_tile_parts_by_loc(Part::Upgrades, parts: @tile.upgrades).each { |p| children << p }
         children << render_tile_part(Part::Blocker)
+
         if @tile.location_name && (@tile.cities.size <= 1) && !@tile.hex.hide_location_name
           rendered_loc_name = render_tile_part(Part::LocationName)
         end
-        @tile.reservations.each { |x| children << render_tile_part(Part::Reservation, reservation: x) }
+        @tile.reservations.each { |r| children << render_tile_part(Part::Reservation, reservation: r) }
+
         large, normal = @tile.icons.partition(&:large)
-        children << render_tile_part(Part::Icons) unless normal.empty?
+        render_tile_parts_by_loc(Part::Icons, parts: normal).each { |i| children << i }
         children << render_tile_part(Part::LargeIcons) unless large.empty?
         children << render_tile_part(Part::FutureLabel) if @tile.future_label
 
         children << render_tile_part(Part::Assignments) unless @tile.hex&.assignments&.empty?
-        # borders should always be the top layer
+
+        # these parts should always be on the top layer
+        children << revenue if revenue
         children << borders if borders
         children << render_tile_part(Part::Partitions) unless @tile.partitions.empty?
 
+        # location name and coordinates on top of other "top" layer since they
+        # can be hidden
         children << rendered_loc_name if rendered_loc_name && setting_for(:show_location_names, @game)
         children << render_coords if @show_coords
 

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -612,7 +612,10 @@ module Engine
           hex_ids.each do |hex_id|
             hex = hex_by_id(hex_id)
             hex.tile.icons.find.with_index do |icon, index|
-              hex.tile.icons[index] = Part::Icon.new('1868_wy/uranium', nil, true, false, false) if icon.name == 'uranium_early'
+              if icon.name == 'uranium_early'
+                hex.tile.icons[index] =
+                  Part::Icon.new('1868_wy/uranium', nil, true, false, false, loc: icon.loc)
+              end
             end
             increment_development_token_count(hex)
           end
@@ -884,6 +887,7 @@ module Engine
               if @forts.include?(action.hex.id) && action.tile.color == :yellow
                 icon = action.tile.icons.find { |i| i.name == 'fort' }
                 icon.large = false
+                icon.loc = '2.5'
               end
             end
             update_boomcity_revenue!(action.hex.tile)
@@ -891,6 +895,7 @@ module Engine
             if @forts.include?(action.hex.id) && action.hex.tile.color == :white
               icon = action.hex.tile.icons.find { |i| i.name == 'fort' }
               icon.large = false
+              icon.loc = '2.5'
             end
           end
         end
@@ -1227,7 +1232,10 @@ module Engine
           end
 
           player.spend(cost, @bank) if cost.positive?
-          hex.place_token(token, logo: token.logo, preprinted: false)
+
+          loc = entity == union_pacific_coal || entity == bonanza || entity.type == :oil ? '0.5' : '1.5'
+
+          hex.place_token(token, logo: token.logo, preprinted: false, loc: loc)
 
           increment_development_token_count(hex)
           @placed_development_tokens[@phase.name] << hex

--- a/lib/engine/game/g_1868_wy/map.rb
+++ b/lib/engine/game/g_1868_wy/map.rb
@@ -73,11 +73,11 @@ module Engine
             ['J16'] => 'upgrade=cost:40,terrain:mountain;border=edge:2,type:mountain;border=edge:3,type:mountain;border=edge:4,type:water,cost:30',
             ['J18'] => 'upgrade=cost:40,terrain:mountain;border=edge:2,type:mountain;border=edge:3,type:mountain;border=edge:1,type:water,cost:30',
             ['J10'] => 'upgrade=cost:20,terrain:cow_skull,size:40;border=edge:2,type:mountain;border=edge:3,type:mountain',
-            ['J12'] => 'town=revenue:0,boom:1;upgrade=cost:20,terrain:cow_skull,size:40;'\
+            ['J12'] => 'town=revenue:0,boom:1;upgrade=cost:20,terrain:cow_skull,size:40,loc:2.5;'\
                        'border=edge:2,type:mountain;border=edge:3,type:mountain;'\
-                       'icon=image:1868_wy/uranium_early,sticky:1;icon=image:1868_wy/uranium_early,sticky:1',
-            ['J20'] => 'town=revenue:0,boom:1;upgrade=cost:30,terrain:mountain;'\
-                       'border=edge:2,type:mountain;border=edge:3,type:mountain;icon=image:1868_wy/uranium_early,sticky:1',
+                       'icon=image:1868_wy/uranium_early,sticky:1,loc:4.5;icon=image:1868_wy/uranium_early,sticky:1,loc:4.5',
+            ['J20'] => 'town=revenue:0,boom:1;upgrade=cost:30,terrain:mountain,loc:2.5;'\
+                       'border=edge:2,type:mountain;border=edge:3,type:mountain;icon=image:1868_wy/uranium_early,sticky:1,loc:4.5;',
             ['J22'] =>
     'upgrade=cost:60,terrain:mountain;border=edge:2,type:mountain;border=edge:3,type:mountain;border=edge:4,type:mountain',
             ['J24'] => 'border=edge:0,type:mountain;border=edge:1,type:mountain',

--- a/lib/engine/hex.rb
+++ b/lib/engine/hex.rb
@@ -262,10 +262,10 @@ module Engine
       end
     end
 
-    def place_token(token, logo: nil, blocks_lay: nil, preprinted: true)
+    def place_token(token, logo: nil, blocks_lay: nil, preprinted: true, loc: nil)
       token.place(self)
       @tokens << token
-      icon = Part::Icon.new('', token.corporation.id, true, blocks_lay, preprinted)
+      icon = Part::Icon.new('', token.corporation.id, true, blocks_lay, preprinted, loc: loc)
       icon.image = logo || token.corporation.logo
       @tile.icons << icon
     end

--- a/lib/engine/part/base.rb
+++ b/lib/engine/part/base.rb
@@ -7,7 +7,7 @@ module Engine
     class Base
       include Helper::Type
 
-      attr_accessor :index, :tile
+      attr_accessor :index, :tile, :loc
 
       def id
         @id ||= "#{tile.id}-#{index}"

--- a/lib/engine/part/icon.rb
+++ b/lib/engine/part/icon.rb
@@ -8,10 +8,10 @@ module Engine
     class Icon < Base
       include Ownable
 
-      attr_accessor :preprinted, :image, :large
+      attr_accessor :preprinted, :image, :large, :loc
       attr_reader :name, :sticky
 
-      def initialize(image, name = nil, sticky = true, blocks_lay = nil, preprinted = true, large: false, owner: nil)
+      def initialize(image, name = nil, sticky = true, blocks_lay = nil, preprinted = true, large: false, owner: nil, loc: nil)
         @image = "/icons/#{image}.svg"
         @name = name || image.split('/')[-1]
         @sticky = !!sticky
@@ -19,6 +19,7 @@ module Engine
         @blocks_lay = !!blocks_lay
         @large = !!large
         @owner = owner
+        @loc = loc
       end
 
       def blocks_lay?

--- a/lib/engine/part/upgrade.rb
+++ b/lib/engine/part/upgrade.rb
@@ -7,10 +7,11 @@ module Engine
     class Upgrade < Base
       attr_reader :cost, :terrains, :size
 
-      def initialize(cost, terrains = nil, size = nil)
+      def initialize(cost, terrains = nil, size = nil, loc: nil)
         @cost = cost.to_i
         @terrains = terrains&.map(&:to_sym) || []
         @size = size&.to_i
+        @loc = loc
       end
 
       def upgrade?

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -170,7 +170,7 @@ module Engine
       when 'label'
         Part::Label.new(params)
       when 'upgrade'
-        Part::Upgrade.new(params['cost'], params['terrain']&.split('|'), params['size'])
+        Part::Upgrade.new(params['cost'], params['terrain']&.split('|'), params['size'], loc: params['loc'])
       when 'border'
         Part::Border.new(params['edge'], params['type'], params['cost'], params['color'])
       when 'junction'
@@ -179,7 +179,7 @@ module Engine
         junction
       when 'icon'
         Part::Icon.new(params['image'], params['name'], params['sticky'], params['blocks_lay'],
-                       large: params['large'])
+                       large: params['large'], loc: params['loc'])
       when 'stub'
         Part::Stub.new(params['edge'].to_i)
       when 'partition'


### PR DESCRIPTION
* use new method `preferred_render_locations_by_loc` to render icons and upgrades near the specified corner * only works in `:pointy` layout for now, since 1868WY is only game using it
* put rendered revenue on top of other elements
* [1868WY] specify locs for coal, oil, and uranium development tokens (DTs) to manage crowded hexes; specify some locs for upgrades on starting uranium hexes
* fix transform/translate for upgrades and pointy layouts 
    * this necessitated defining some more part positioning constants in `View::Game::Part::SmallItem` and `View::Game::Part::Upgrade` to avoid changing rendering of terrain upgrade costs in existing pointy-layout games too much

#5011 

----

1868 Wyoming, Jeffrey City (J12) with one coal token, one oil token, two uranium tokens, and two corporation station tokens:

Before:
![before](https://github.com/tobymao/18xx/assets/1045173/48c1eb99-5fa9-47f5-92bb-23d372ef5272)

After:
![after](https://github.com/tobymao/18xx/assets/1045173/8f1244b4-8dfd-4351-af07-13b8ee7b768a)

----

The transform/translate changes did affect other `:pointy` games, e.g., C15 from 1846:

Before:
![1846 C15 before](https://github.com/tobymao/18xx/assets/1045173/c13cbde4-b176-4657-8128-6466db92aec6)

After:
![1846 C15 after](https://github.com/tobymao/18xx/assets/1045173/2089997d-f9ea-40f9-9de6-0172527e8155)

Getting the new positions more exactly the same as the older one makes crowded tiles like 1868WY's worse.