### PR TITLE
[1822] stop P8 ability from working with swamps

### DIFF
--- a/lib/engine/game/g_1822/entities.rb
+++ b/lib/engine/game/g_1822/entities.rb
@@ -150,7 +150,35 @@ module Engine
                   'receives a £20 discount off the cost of all hill and mountain terrain (i.e. NOT off the cost of '\
                   'rough terrain). The private company does not close. Closes if free token taken when acquired. '\
                   'Otherwise, flips when acquired and does not close.',
-            abilities: [],
+            abilities: [
+              {
+                type: 'tile_lay',
+                tiles: [],
+                hexes: %w[
+                  B41 C40 D39 E10 F9 G14 G30 G8 H15 H39 H7 H9 I10 I12 I14 I16 I18
+                  I20 I22 I24 I38 I40 I8 J19 J21 J23 J25 J39 J7 O40
+                ],
+                owner_type: 'corporation',
+                count: 1,
+                closed_when_used_up: true,
+                reachable: true,
+                free: true,
+                special: false,
+                when: 'track',
+              },
+              {
+                type: 'tile_discount',
+                owner_type: 'corporation',
+                discount: 20,
+                terrain: 'hill',
+              },
+              {
+                type: 'tile_discount',
+                owner_type: 'corporation',
+                discount: 20,
+                terrain: 'mountain',
+              },
+            ],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1447,7 +1447,7 @@ module Engine
         end
 
         def company_choices_egr(company, time)
-          return {} if !company.all_abilities.empty? || time != :special_choose
+          return {} if company.all_abilities.size != 3 || time != :special_choose
 
           choices = {}
           choices['token'] = 'Receive a discount token that can be used to pay the full cost of a single '\
@@ -1558,17 +1558,9 @@ module Engine
 
         def company_made_choice_egr(company, choice, time)
           company.desc = company_choices(company, time)[choice]
-          if choice == 'token'
-            # Give the company a free tile lay.
-            ability = Engine::Ability::TileLay.new(type: 'tile_lay', tiles: [], hexes: [], owner_type: 'corporation',
-                                                   count: 1, closed_when_used_up: true, reachable: true, free: true,
-                                                   special: false, when: 'track')
-            company.add_ability(ability)
-          else
-            %w[mountain hill].each do |terrain|
-              ability = Engine::Ability::TileDiscount.new(type: 'tile_discount', discount: 20, terrain: terrain)
-              company.add_ability(ability)
-            end
+          remove_type = choice == 'token' ? :tile_discount : :tile_lay
+          company.all_abilities.dup.each do |ability|
+            company.remove_ability(ability) if ability.type == remove_type
           end
         end
 

--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -103,11 +103,11 @@ module Engine
               return nil
             end
 
-            # If player have choosen the tile lay option on the Edinburgh and Glasgow Railway company,
-            # only rough terrain, hill or mountains are valid hexes
+            # P8 Edinburgh and Glasgow Railway company can
+            # only lay track on hills and mountains
             if @game.must_be_on_terrain?(entity)
               tile_terrain = hex.tile.upgrades.any? do |upgrade|
-                %i[mountain hill swamp].any? { |t| upgrade.terrains.include?(t) }
+                %i[mountain hill].any? { |t| upgrade.terrains.include?(t) }
               end
               return nil unless tile_terrain
             end


### PR DESCRIPTION
Also:

* move ability definitions to config file; when the choice between the one-time or persistent abilities is made, remove the other abilities instead of adding them at the choice time
* list out all valid hill/mountain hexes (list of hexes also valid for 1822MRS and 1822NRS)
* update code comment to say "P8" for easier reference

Fixes #9180