### PR TITLE
fixes impassable edge 5 border on hex I21

### DIFF
--- a/lib/engine/game/g_18_ny/map.rb
+++ b/lib/engine/game/g_18_ny/map.rb
@@ -265,7 +265,7 @@ module Engine
             %w[F6] => 'border=edge:3,type:water,cost:40;upgrade=cost:60,terrain:mountain',
             %w[F8] => 'border=edge:4,type:impassable;upgrade=cost:60,terrain:mountain',
             %w[H18] => 'border=edge:4,type:water,cost:80',
-            %w[I21] => 'border=edge:1,type:water,cost:80',
+            %w[I21] => 'border=edge:1,type:water,cost:80;border=edge:5,type:impassable',
             %w[B12] => 'town=revenue:0',
             %w[C11] => 'town=revenue:0',
             %w[C23] => 'town=revenue:0',

--- a/lib/engine/game/g_18_ny_1e/map.rb
+++ b/lib/engine/game/g_18_ny_1e/map.rb
@@ -265,7 +265,7 @@ module Engine
             %w[F6] => 'border=edge:3,type:water,cost:40;upgrade=cost:60,terrain:mountain',
             %w[F8] => 'border=edge:4,type:impassable;upgrade=cost:60,terrain:mountain',
             %w[H18] => 'border=edge:4,type:water,cost:80',
-            %w[I21] => 'border=edge:1,type:water,cost:80',
+            %w[I21] => 'border=edge:1,type:water,cost:80;border=edge:5,type:impassable',
             %w[B12] => 'town=revenue:0',
             %w[C11] => 'town=revenue:0',
             %w[C23] => 'town=revenue:0',


### PR DESCRIPTION
Fixes #9189 

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

added `border=edge:5,type:impassable` to hex I21 in both editions of 18NY map files
