### PR TITLE
Add a :future track type for paths

### DIFF
--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -35,6 +35,11 @@ module View
             width: 2,
             dash: '12',
           },
+          future: {
+            color: '#000000',
+            width: 2,
+            dash: '6',
+          },
         }.freeze
 
         # width here is added to track width
@@ -91,7 +96,7 @@ module View
           # Array<Array<Path>>
           @routes_paths = @routes.map { |route| route.paths_for(@tile.paths) }
 
-          paths_and_stubs = @tile.paths + @tile.stubs
+          paths_and_stubs = @tile.paths + @tile.stubs + @tile.future_paths
           path_indexes = paths_and_stubs.to_h { |p| [p, indexes_for(p)] }
 
           sorted = paths_and_stubs
@@ -127,7 +132,7 @@ module View
             elsif path.offboard
               pass1 << h(TrackOffboard, offboard: path.offboard, path: path, region_use: @region_use,
                                         border_props: border_props, **props)
-            elsif path.track == :thin
+            elsif path.track == :thin || path.track == :future
               pass1 << h(TrackNodePath, tile: @tile, path: path, region_use: @region_use,
                                         pass: 1, border_props: border_props, inner_props: inner_props, **props)
 

--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -36,9 +36,9 @@ module View
             dash: '12',
           },
           future: {
-            color: '#000000',
-            width: 2,
-            dash: '6',
+            color: '#888888',
+            width: 6,
+            dash: '9 3',
           },
         }.freeze
 

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -74,7 +74,9 @@ module View
         children = []
 
         render_revenue = should_render_revenue?
-        children << render_tile_part(Part::Track, routes: @routes) if !@tile.paths.empty? || !@tile.stubs.empty?
+        if !@tile.paths.empty? || !@tile.stubs.empty? || !@tile.future_paths.empty?
+          children << render_tile_part(Part::Track, routes: @routes)
+        end
         children << render_tile_part(Part::Cities, show_revenue: !render_revenue) unless @tile.cities.empty?
 
         children << render_tile_part(Part::Towns, routes: @routes, show_revenue: !render_revenue) unless @tile.towns.empty?

--- a/lib/engine/game/g_1840/map.rb
+++ b/lib/engine/game/g_1840/map.rb
@@ -317,14 +317,62 @@ module Engine
             ['B28'] => 'upgrade=cost:40,terrain:water',
             %w[H10 D18 E17] =>
             'city=revenue:0;city=revenue:0;label=OO',
-            %w[D12 I9] => 'city=revenue:0;upgrade=cost:20;frame=color:#ffa500;icon=image:1840/green_hex',
-            %w[B10 D22] => 'city=revenue:0;upgrade=cost:20;frame=color:#ffa500;icon=image:1840/yellow_hex',
-            %w[E23 F6 I15] => 'city=revenue:0;upgrade=cost:20;frame=color:#ffa500;icon=image:1840/token',
-            %w[C9 E7 H16] => 'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/green_hex',
-            %w[I3 B14 C21] => 'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/red_hex',
-            %w[I7 I13 H12 F12 G23 B16 G19] => 'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/yellow_hex',
-            %w[C13 I5 G5 G21 B20] => 'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/purple_hex',
-            %w[D6 E13 G17] => 'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/token',
+            %w[D12] => 'city=revenue:0;path=track:future,a:3,b:_0;path=track:future,a:5,b:_0;' \
+                       'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/green_hex',
+            %w[I9] => 'city=revenue:0;path=track:future,a:1,b:_0;path=track:future,a:_0,b:4;' \
+                      'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/green_hex',
+            %w[B10] => 'city=revenue:0;path=track:future,a:0,b:_0;path=track:future,a:3,b:_0;' \
+                       'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[D22] => 'city=revenue:0;path=track:future,a:2,b:_0;path=track:future,a:_0,b:5;' \
+                       'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[E23] => 'city=revenue:0;path=track:future,a:2,b:_0;path=track:future,a:_0,b:5;' \
+                       'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/token',
+            %w[F6] => 'city=revenue:0;path=track:future,a:0,b:_0;path=track:future,a:3,b:_0;' \
+                      'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/token',
+            %w[I15] => 'city=revenue:0;path=track:future,a:1,b:_0;path=track:future,a:_0,b:3;' \
+                       'upgrade=cost:20;frame=color:#ffa500;icon=image:1840/token',
+            %w[C9] => 'path=track:future,a:1,b:3;upgrade=cost:20;' \
+                      'frame=color:#ffa500;icon=image:1840/green_hex',
+            %w[E7] => 'path=track:future,a:0,b:2;upgrade=cost:20;' \
+                      'frame=color:#ffa500;icon=image:1840/green_hex',
+            %w[H16] => 'path=track:future,a:0,b:3;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/green_hex',
+            %w[B14] => 'path=track:future,a:0,b:4;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/red_hex',
+            %w[C21] => 'path=track:future,a:2,b:5;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/red_hex',
+            %w[I3] => 'path=track:future,a:1,b:4;upgrade=cost:20;' \
+                      'frame=color:#ffa500;icon=image:1840/red_hex',
+            %w[I7] => 'path=track:future,a:1,b:4;upgrade=cost:20;' \
+                      'frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[I13] => 'path=track:future,a:1,b:4;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[B16] => 'path=track:future,a:1,b:3;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[F12] => 'path=track:future,a:0,b:3;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[H12] => 'path=track:future,a:0,b:2;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[G23] => 'path=track:future,a:1,b:3;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[G19] => 'path=track:future,a:1,b:4;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/yellow_hex',
+            %w[B20] => 'path=track:future,a:2,b:5;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/purple_hex',
+            %w[C13] => 'path=track:future,a:0,b:3;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/purple_hex',
+            %w[G5] => 'path=track:future,a:1,b:3;upgrade=cost:20;' \
+                      'frame=color:#ffa500;icon=image:1840/purple_hex',
+            %w[G21] => 'path=track:future,a:1,b:4;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/purple_hex',
+            %w[I5] => 'path=track:future,a:1,b:4;upgrade=cost:20;' \
+                      'frame=color:#ffa500;icon=image:1840/purple_hex',
+            %w[D6] => 'path=track:future,a:3,b:5;upgrade=cost:20;' \
+                      'frame=color:#ffa500;icon=image:1840/token',
+            %w[E13] => 'path=track:future,a:0,b:2;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/token',
+            %w[G17] => 'path=track:future,a:0,b:4;upgrade=cost:20;' \
+                       'frame=color:#ffa500;icon=image:1840/token',
           },
           yellow: {
 

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -2883,58 +2883,75 @@ module Engine
               # HBE concession route
               %w[
                 B17
-              ] => 'icon=image:1873/HBE,sticky:1',
+              ] => 'icon=image:1873/HBE,sticky:1;'\
+                   'path=track:future,a:0,b:4',
               # GHE concession route
               %w[
                 H19
-              ] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/GHE,sticky:1',
+              ] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/GHE,sticky:1;'\
+                   'path=track:future,a:1,b:3',
               # NWE concession route
               %w[
                 I8
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
+              ] => 'town=revenue:0,style:dot;upgrade=cost:150,terrain:mountain;'\
+                   'icon=image:1873/NWE,sticky:1;'\
+                   'path=track:future,a:0,b:_0;path=track:future,a:3,b:_0;'\
                    'border=edge:2,type:impassable;'\
                    'icon=image:1873/8_open,sticky:1,large:1',
               %w[
                 H7
               ] => 'upgrade=cost:100,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
+                   'path=track:future,a:2,b:4;'\
                    'border=edge:5,type:impassable',
               %w[
                 E6
                 D7
-              ] => 'town=revenue:0;upgrade=cost:50,terrain:mountain;icon=image:1873/NWE,sticky:1',
+              ] => 'town=revenue:0,style:dot;upgrade=cost:50,terrain:mountain;'\
+                   'icon=image:1873/NWE,sticky:1;'\
+                   'path=track:future,a:0,b:_0;path=track:future,a:3,b:_0',
               %w[
                 C8
-              ] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;',
+              ] => 'upgrade=cost:150,terrain:mountain;icon=image:1873/NWE,sticky:1;'\
+                   'path=track:future,a:0,b:3',
               # SHE concession route
               %w[
                 G2
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1;'\
+              ] => 'town=revenue:0,style:dot;upgrade=cost:150,terrain:mountain;'\
+                   'icon=image:1873/SHE,sticky:1;'\
                    'border=edge:4,type:impassable;border=edge:5,type:impassable;'\
+                   'path=track:future,a:0,b:_0;path=track:future,a:3,b:_0;'\
                    'icon=image:1873/9_open,sticky:1,large:1',
               %w[
                 F3
-              ] => 'town=revenue:0;upgrade=cost:150,terrain:mountain;icon=image:1873/SHE,sticky:1',
+              ] => 'town=revenue:0,style:dot;upgrade=cost:150,terrain:mountain;'\
+                   'icon=image:1873/SHE,sticky:1;'\
+                   'path=track:future,a:0,b:_0;path=track:future,a:3,b:_0',
               # KEZ concession route
               %w[
                 H3
               ] => 'upgrade=cost:100,terrain:mountain;icon=image:1873/KEZ,sticky:1;'\
+                   'path=track:future,a:3,b:5;'\
                    'border=edge:2,type:impassable',
               # WBE concession route
               %w[
                 C10
               ] => 'border=edge:5,type:impassable;'\
                    'icon=image:1873/lock;'\
-                   'icon=image:1873/WBE,sticky:1',
+                   'icon=image:1873/WBE,sticky:1;'\
+                   'path=track:future,a:2,b:4',
               %w[
                 C12
-              ] => 'town=revenue:0;border=edge:0,type:impassable;border=edge:5,type:impassable;'\
+              ] => 'town=revenue:0,style:dot;'\
+                   'border=edge:0,type:impassable;border=edge:5,type:impassable;'\
                    'icon=image:1873/lock;'\
-                   'icon=image:1873/WBE,sticky:1',
+                   'icon=image:1873/WBE,sticky:1;'\
+                   'path=track:future,a:1,b:_0;path=track:future,a:4,b:_0',
               %w[
                 C14
-              ] => 'town=revenue:0;border=edge:0,type:impassable;'\
+              ] => 'town=revenue:0,style:dot;border=edge:0,type:impassable;'\
                    'icon=image:1873/lock;'\
-                   'icon=image:1873/WBE,sticky:1',
+                   'icon=image:1873/WBE,sticky:1;'\
+                   'path=track:future,a:1,b:_0;path=track:future,a:5,b:_0',
               # empty tiles
               %w[
                 C18

--- a/lib/engine/game/g_18_sj/map.rb
+++ b/lib/engine/game/g_18_sj/map.rb
@@ -142,21 +142,39 @@ module Engine
             %w[B13 C14] => '',
           },
           white: {
-            %w[A4 C6 D7] => 'icon=image:18_sj/M-S,sticky:1',
-            ['D13'] => 'icon=image:18_sj/G-S,sticky:1',
-            %w[E14 E16 E18 E24 F25 G12] =>
+            %w[A4] => 'path=track:future,a:1,b:5;icon=image:18_sj/M-S,sticky:1',
+            %w[C6 D7] => 'path=track:future,a:2,b:5;icon=image:18_sj/M-S,sticky:1',
+            ['D13'] => 'path=track:future,a:0,b:2;icon=image:18_sj/G-S,sticky:1',
+            %w[E14] => 'path=track:future,a:0,b:4;icon=image:18_sj/L-S,sticky:1',
+            %w[E16 E18] => 'path=track:future,a:1,b:4;icon=image:18_sj/L-S,sticky:1',
+            %w[E24] => 'path=track:future,a:1,b:5;icon=image:18_sj/L-S,sticky:1',
+            %w[F25] => 'path=track:future,a:2,b:5;icon=image:18_sj/L-S,sticky:1',
+            %w[G12] => 'path=track:future,a:1,b:3;icon=image:18_sj/L-S,sticky:1',
+            ['E22'] =>
+              'path=track:future,a:1,b:4;upgrade=cost:75,terrain:mountain;'\
               'icon=image:18_sj/L-S,sticky:1',
-            ['E22'] => 'upgrade=cost:75,terrain:mountain;icon=image:18_sj/L-S,sticky:1',
-            ['B5'] => 'city=revenue:0;icon=image:18_sj/M-S,sticky:1',
+            ['B5'] =>
+              'city=revenue:0;path=track:future,a:2,b:_0;path=track:future,a:5,b:_0;'\
+              'icon=image:18_sj/M-S,sticky:1',
             ['E8'] =>
-              'city=revenue:0;icon=image:18_sj/M-S,sticky:1;icon=image:18_sj/GKB,sticky:1',
-            ['E12'] => 'city=revenue:0;icon=image:18_sj/G-S,sticky:1',
-            %w[F13 E20] => 'city=revenue:0;icon=image:18_sj/L-S,sticky:1',
+              'city=revenue:0;path=track:future,a:2,b:_0;path=track:future,a:5,b:_0;'\
+              'icon=image:18_sj/M-S,sticky:1;icon=image:18_sj/GKB,sticky:1',
+            ['E12'] =>
+              'city=revenue:0;path=track:future,a:0,b:_0;path=track:future,a:3,b:_0;'\
+              'icon=image:18_sj/G-S,sticky:1',
+            %w[E20] =>
+              'city=revenue:0;path=track:future,a:1,b:_0;path=track:future,a:4,b:_0;'\
+              'icon=image:18_sj/L-S,sticky:1',
+            %w[F13] =>
+              'city=revenue:0;path=track:future,a:0,b:_0;path=track:future,a:3,b:_0;'\
+              'icon=image:18_sj/L-S,sticky:1',
             ['C12'] =>
-              'city=revenue:0;border=edge:2,type:mountain,cost:75;icon=image:18_sj/G-S,sticky:1;'\
+              'city=revenue:0;path=track:future,a:2,b:_0;path=track:future,a:5,b:_0;'\
+              'border=edge:2,type:mountain,cost:75;icon=image:18_sj/G-S,sticky:1;'\
               'icon=image:18_sj/GKB,sticky:1',
             ['B11'] =>
-              'city=revenue:0;border=edge:5,type:mountain,cost:75;icon=image:18_sj/G-S,sticky:1',
+              'city=revenue:0;path=track:future,a:2,b:_0;path=track:future,a:5,b:_0;'\
+              'border=edge:5,type:mountain,cost:75;icon=image:18_sj/G-S,sticky:1',
             %w[A12 B19 B21 B23 B25 B27] =>
               'upgrade=cost:75,terrain:mountain',
             ['C30'] => 'upgrade=cost:150,terrain:mountain',
@@ -169,8 +187,12 @@ module Engine
             ['D11'] => 'city=revenue:0;border=edge:2,type:impassable',
             ['D29'] =>
               'city=revenue:0;upgrade=cost:75,terrain:mountain;icon=image:18_sj/M,sticky:1',
-            ['F9'] => 'upgrade=cost:150,terrain:mountain;icon=image:18_sj/M-S,sticky:1',
-            ['F11'] => 'upgrade=cost:75,terrain:mountain;icon=image:18_sj/G-S,sticky:1',
+            ['F9'] =>
+              'path=track:future,a:2,b:5;upgrade=cost:150,terrain:mountain;'\
+              'icon=image:18_sj/M-S,sticky:1',
+            ['F11'] =>
+              'path=track:future,a:0,b:3;upgrade=cost:75,terrain:mountain;'\
+              'icon=image:18_sj/G-S,sticky:1',
           },
           yellow: {
             ['C2'] => 'city=revenue:20;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y;icon=image:port,sticky:1',

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -15,7 +15,7 @@ module Engine
     include Config::Tile
 
     attr_accessor :blocks_lay, :hex, :icons, :index, :legal_rotations, :location_name,
-                  :name, :opposite, :reservations, :upgrades, :color, :future_label
+                  :name, :opposite, :reservations, :upgrades, :color, :future_label, :future_paths
     attr_reader :borders, :cities, :edges, :junction, :nodes, :labels, :parts, :preprinted, :rotation, :stops, :towns,
                 :offboards, :blockers, :city_towns, :unlimited, :stubs, :partitions, :id, :frame, :stripes, :hidden,
                 :hidden_blockers
@@ -210,6 +210,7 @@ module Engine
       @rotation = rotation
       @cities = []
       @paths = []
+      @future_paths = []
       @stubs = []
       @partitions = []
       @towns = []
@@ -602,7 +603,11 @@ module Engine
         elsif part.label?
           @labels << part
         elsif part.path?
-          @paths << part
+          if part.track == :future
+            @future_paths << part
+          else
+            @paths << part
+          end
         elsif part.town?
           @towns << part
           @city_towns << part


### PR DESCRIPTION
Several games have pre-determined routes on the map where track will be built later in the game:

- Harzbahn 1873 has concession routes for the railway companies.
- 1840 has the route for the Stadtbahn companies.
- 18SJ has three mainline routes.

On the physical game boards for these games these are indicated by lines on the map. 18xx.games currently indicates these routes by having icons in the hexes that form the route, but this is less clear as it does not show the edges that the route enters and exits each hex.

This pull adds a :future track type for path tile parts. This gives a dotted line on the game map, allowing the route to be drawn.

Any path tile parts with a track type of :future are not added to the tile's `paths` array, instead they are stored in a separated `future_paths` array. This means that they will not be considered when calculating routes, and are not checked or preserved when a tile is upgraded.

The pull request adds future track to the maps for 1840 (CC: @Zwergenpunk), Harzbahn 1873 (CC: @roseundy) and 18SJ (CC: @perwestling).

Suggestions are welcome for better naming for this track type, or better representation on the map. I'm just creating this as a draft pull request for the moment, to make sure everyone is happy with this before it gets added.


## Screenshots

### 1840 Stadtbahn routes
![image](https://github.com/tobymao/18xx/assets/11144854/cbed2b57-64f2-48db-9bd9-fc49eb58f516)

### 1873 railway concessions
![image](https://github.com/tobymao/18xx/assets/11144854/5ffa026c-d400-48a7-b597-8ce6e8839562)

### 18SJ mainline routes
![image](https://github.com/tobymao/18xx/assets/11144854/0fb1cd11-600a-45d3-ab22-e7627e4b17c0)


## Before clicking create

- [x] Branch is derived from the latest `master`
- [x] ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
