### PR TITLE
1841: Stock Market

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -85,7 +85,7 @@ module View
       end
 
       CROSSHATCH_TYPES = %i[par_overlap convert_range].freeze
-      BORDER_TYPES = %i[max_price].freeze
+      BORDER_TYPES = %i[max_price max_price_1].freeze
 
       def cell_style(box_style, types)
         normal_types = types.reject { |t| BORDER_TYPES.include?(t) }
@@ -103,7 +103,7 @@ module View
 
         unless (types & BORDER_TYPES).empty?
           style[:borderRightWidth] = "#{BORDER * 4}px"
-          style[:borderRightColor] = COLOR_MAP[:purple]
+          style[:borderRightColor] = @game.class::STOCKMARKET_COLORS[(types & BORDER_TYPES).first]
           style[:width] = "#{WIDTH_TOTAL - (2 * PAD) - (2 * BORDER) - 3}px"
         end
         if color == :black

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -146,6 +146,7 @@ module Engine
         repar: :gray,
         ignore_one_sale: :green,
         safe_par: :white,
+        max_price: :purple,
       }.freeze
 
       MIN_BID_INCREMENT = 5

--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -4,6 +4,7 @@ require_relative '../base'
 require_relative 'meta'
 require_relative 'entities'
 require_relative 'map'
+require_relative 'stock_market'
 
 module Engine
   module Game
@@ -48,14 +49,14 @@ module Engine
         TRACK_RESTRICTION = :semi_restrictive
 
         MARKET = [
-          %w[72 83 95 107 120 133 147 164 182 202 224 248 276 306 340p 377 419 465 516],
-          %w[63 72 82 93 104 116 128 142 158 175 195 216p 240 266 295 328 365 404 449],
-          %w[57 66 75 84 95 105 117 129 144p 159 177 196 218 242 269 298 331 367 408],
-          %w[54 62 71 80 90 100p 111 123 137 152 169 187 208 230 256 284],
-          %w[52 59 68p 77 86 95 106 117 130 145 160 178 198 219],
-          %w[47 54 62 70 78 87 96 107 118 131 146 162 180],
-          %w[41 47 54 61 68 75 84 93 103 114 127 141],
-          %w[34 39 45 50 57 63 70 77 86 95 106],
+          %w[72 83 95 107 120 133 147 164 182 202 224m 248 276 306 340x 377n 419 465 516],
+          %w[63 72 82 93 104 116 128 142 158 175 195m 216x 240 266 295 328n 365 404 449],
+          %w[57 66 75 84 95 105 117 129 144p 159 177m 196 218 242 269 298n 331 367 408],
+          %w[54 62 71 80 90 100p 111 123 137 152 169m 187 208 230 256 284n],
+          %w[52 59 68p 77 86 95 106 117 130 145 160m 178 198 219],
+          %w[47 54 62 70 78 87 96 107 118 131 146m 162 180],
+          %w[41 47 54 61 68 75 84 93 103 114 127m 141],
+          %w[34 39 45 50 57 63 70 77 86 95 106m],
           %w[27 31 36 40 45 50 56 62 69 76],
           %w[21 24 27 31 35 39 43 48 53],
           %w[16 18 20 23 26 29 32 35],
@@ -63,17 +64,14 @@ module Engine
           %w[8 9 10 11 13 14],
         ].freeze
 
-        MARKET_TEXT = {
-          par: 'Par value',
-          no_cert_limit: 'Corporation shares do not count towards cert limit',
-          unlimited: 'Corporation shares can be held above 60%',
-          multiple_buy: 'Can buy more than one share in the corporation per turn',
-          close: 'Corporation closes',
-          endgame: 'End game trigger',
-          liquidation: 'Liquidation',
-          repar: 'Minor company value',
-          ignore_one_sale: 'Ignore first share sold when moving price',
-        }.freeze
+        MARKET_TEXT = Base::MARKET_TEXT.merge(par_1: 'Major Corporation Par',
+                                              par: 'Major/Minor Corporation Par',
+                                              max_price: 'Maximum price for a minor',
+                                              max_price_1: 'Maximum price before phase 8').freeze
+
+        STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(par_1: :green,
+                                                            max_price: :orange,
+                                                            max_price_1: :blue).freeze
 
         PHASES = [
           {
@@ -222,6 +220,11 @@ module Engine
             corp = @corporations.find { |m| m.name == cm[:sym] }
             [corp, { historical: cm[:historical], startable: cm[:startable] }]
           end
+        end
+
+        def init_stock_market
+          G1841::StockMarket.new(game_market, self.class::CERT_LIMIT_TYPES,
+                                 multiple_buy_types: self.class::MULTIPLE_BUY_TYPES, game: self)
         end
 
         def setup

--- a/lib/engine/game/g_1841/stock_market.rb
+++ b/lib/engine/game/g_1841/stock_market.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1841
+      class StockMarket < Engine::StockMarket
+        def initialize(market, unlimited_types, multiple_buy_types: [], zigzag: nil, ledge_movement: nil, game: nil)
+          @game = game
+          super(market, unlimited_types, multiple_buy_types: multiple_buy_types, zigzag: zigzag, ledge_movement: ledge_movement)
+        end
+
+        def right(corporation, coordinates)
+          if (corporation&.type == :minor && corporation&.share_price&.types&.include?(:max_price)) ||
+              (@game.phase.name.to_i < 8 && corporation&.share_price&.types&.include?(:max_price_1))
+            up(corporation, coordinates)
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/share_price.rb
+++ b/lib/engine/share_price.rb
@@ -23,6 +23,7 @@ module Engine
       'w' => :par_3,
       'C' => :convert_range,
       'm' => :max_price,
+      'n' => :max_price_1,
       'u' => :phase_limited,
       'B' => :pays_bonus,
       'W' => :pays_bonus_1,
@@ -32,7 +33,7 @@ module Engine
     }.freeze
 
     # Types which are info only and shouldn't
-    NON_HIGHLIGHT_TYPES = %i[par safe_par par_1 par_2 par_3 par_overlap safe_par convert_range max_price repar].freeze
+    NON_HIGHLIGHT_TYPES = %i[par safe_par par_1 par_2 par_3 par_overlap safe_par convert_range max_price max_price_1 repar].freeze
 
     # Types which count as par
     PAR_TYPES = %i[par par_overlap par_1 par_2 par_3].freeze


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

This finishes implementing the 1841 stock market. It required adding a 2nd 'max_price' stock attribute. One is if minors (as in 1861/1867), the other is for pre-phase 8.

* **Explanation of Change**

Borrowed the approach 1861/1867 took with redefining the stock market "right" method. 1841 needs to pass in the game to it's stock market in order to check the current phase.

**Common code:**
Engine::SharePrice: added :max_price_1
UI::StockMarket: added max_price_1, added flexible border colors for :max_price and :max_price_1
Engine::Game::Base: added default color for :max_price

* **Screenshots**
![41_stock_market](https://github.com/tobymao/18xx/assets/8494213/7d728b86-5a27-49ad-a4e8-eb8cfc27bca8)

* **Any Assumptions / Hacks**
