### PR TITLE
Disable create game button when incompatible optional rules are selected

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -32,7 +32,6 @@ module View
 
     def render_create_button(check_options: true)
       error = check_options &&
-              selected_game_or_variant.respond_to?(:check_options) &&
               selected_game_or_variant.check_options(@optional_rules, @min_players, @max_players)&.[](:error)
       (render_button('Create', { style: { margin: '0.5rem 1rem 1rem 0' }, attrs: { disabled: !!error } }) { submit })
     end
@@ -286,8 +285,7 @@ module View
         h(:ul, ul_props, [*game_variants, *optional_rules]),
       ]
 
-      checked_options = selected_game_or_variant.respond_to?(:check_options) &&
-        selected_game_or_variant.check_options(@optional_rules, @min_players, @max_players)
+      checked_options = selected_game_or_variant.check_options(@optional_rules, @min_players, @max_players)
       if checked_options
         if (info = checked_options[:info])
           children.concat(

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -30,13 +30,20 @@ module View
     needs :min_players, default: nil, store: true
     needs :max_players, default: nil, store: true
 
+    def render_create_button(check_options: true)
+      error = check_options &&
+              selected_game_or_variant.respond_to?(:check_options) &&
+              selected_game_or_variant.check_options(@optional_rules, @min_players, @max_players)&.[](:error)
+      (render_button('Create', { style: { margin: '0.5rem 1rem 1rem 0' }, attrs: { disabled: !!error } }) { submit })
+    end
+
     def render_content
       @label_style = { display: 'block' }
 
       inputs = [mode_selector]
 
       if @mode == :json
-        inputs << (render_button('Create', { style: { margin: '0.5rem 1rem 1rem 0' } }) { submit })
+        inputs << render_create_button(check_options: false)
         inputs << render_upload_button
         inputs << render_input(
           '',
@@ -58,7 +65,7 @@ module View
       else
         if selected_game_or_variant
           update_player_range(selected_game_or_variant)
-          inputs << (render_button('Create', { style: { margin: '0.5rem 1rem 1rem 0' } }) { submit })
+          inputs << render_create_button
           inputs << h(:h2, selected_game_or_variant.meta.full_title)
           inputs << render_inputs
 
@@ -274,23 +281,35 @@ module View
         },
       }
 
-      info = selected_game_or_variant.respond_to?(:check_options) &&
-        selected_game_or_variant.check_options(@optional_rules, @min_players, @max_players)
+      children = [
+        h(:h4, 'Game Variants / Optional Rules'),
+        h(:ul, ul_props, [*game_variants, *optional_rules]),
+      ]
 
-      if info
-        h(:div, [
-          h(:h4, 'Game Variants / Optional Rules'),
-          h(:ul, ul_props, [*game_variants, *optional_rules]),
-          h(:h4, 'Option Info/Errors'),
-          h(:div, info),
-          h(:br),
-        ])
-      else
-        h(:div, [
-          h(:h4, 'Game Variants / Optional Rules'),
-          h(:ul, ul_props, [*game_variants, *optional_rules]),
-        ])
+      checked_options = selected_game_or_variant.respond_to?(:check_options) &&
+        selected_game_or_variant.check_options(@optional_rules, @min_players, @max_players)
+      if checked_options
+        if (info = checked_options[:info])
+          children.concat(
+            [
+              h(:h4, 'Option Info'),
+              h(:div, info),
+              h(:br),
+            ]
+          )
+        end
+        if (error = checked_options[:error])
+          children.concat(
+            [
+              h(:h4, 'Option Errors'),
+              h(:div, error),
+              h(:br),
+            ]
+          )
+        end
       end
+
+      h(:div, children)
     end
 
     def render_upload_button
@@ -378,18 +397,12 @@ module View
       game_params[:seed] = game_params[:seed].to_i
       game_params[:seed] = nil if (game_params[:seed]).zero?
 
-      if @mode == :multi
-        begin
-          return create_game(game_params)
-        rescue Engine::OptionError => e
-          return store(:flash_opts, e.message)
-        end
-      end
+      return create_game(game_params) if @mode == :multi
 
       players = game_params
-        .select { |k, _| k.start_with?('player_') }
-        .values
-        .map { |name| name.gsub(/\s+/, ' ').strip }
+                  .select { |k, _| k.start_with?('player_') }
+                  .values
+                  .map { |name| name.gsub(/\s+/, ' ').strip }
 
       return store(:flash_opts, 'Cannot have duplicate player names') if players.uniq.size != players.size
 
@@ -406,6 +419,13 @@ module View
           },
         }
         game_data[:settings][:seed] = game_params[:seed] if game_params[:seed]
+      end
+
+      checked_options = Engine.meta_by_title(game_data[:title])
+                          .check_options(game_data[:settings][:optional_rules],
+                                         game_data[:min_players], game_data[:max_players])
+      if (options_error_msg = checked_options&.[](:error))
+        return store(:flash_opts, "game_data Optional Rules Error: #{options_error_msg}")
       end
 
       create_hotseat(

--- a/assets/app/view/form.rb
+++ b/assets/app/view/form.rb
@@ -77,9 +77,10 @@ module View
       )
     end
 
-    def render_button(text, style: {}, &block)
+    def render_button(text, style: {}, attrs: {}, &block)
       props = {
         attrs: {
+          **attrs,
           type: :button,
         },
         style: {

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -153,17 +153,17 @@ module Engine
           if optional_rules.empty?
             case max_players
             when 2
-              return 'No Unit(s) selected. Will use Unit 3 based on player count'
+              return { info: 'No Unit(s) selected. Will use Unit 3 based on player count' }
             when 3
-              return 'No Unit(s) selected. Will use Unit 2 based on player count'
+              return { info: 'No Unit(s) selected. Will use Unit 2 based on player count' }
             when 4, 5
-              return 'No Unit(s) selected. Will use Unit 1 based on player count'
+              return { info: 'No Unit(s) selected. Will use Unit 1 based on player count' }
             when 6, 7
-              return 'No Unit(s) selected. Will use Units 1+2 based on player count'
+              return { info: 'No Unit(s) selected. Will use Units 1+2 based on player count' }
             when 8
-              return 'No Unit(s) selected. Will use Units 1+2+3 based on player count'
+              return { info: 'No Unit(s) selected. Will use Units 1+2+3 based on player count' }
             else
-              return 'No Unit(s) selected. Will use Units 1+2+3 and R1+R2+R3 based on player count'
+              return { info: 'No Unit(s) selected. Will use Units 1+2+3 and R1+R2+R3 based on player count' }
             end
           end
 
@@ -199,21 +199,25 @@ module Engine
           regionals[3] = true if optional_rules.include?(:r3)
 
           if !units[1] && !units[2] && !units[3] && !optional_rules.empty?
-            return 'Must select at least one Unit if using other options'
+            return { error: 'Must select at least one Unit if using other options' }
           end
-          return 'Cannot combine Units 1 and 3 without Unit 2' if units[1] && !units[2] && units[3]
-          return 'Cannot add Regionals without Unit 1' if !regionals.keys.empty? && !units[1]
-          return 'Cannot add K5 without Unit 2' if kits[5] && !units[2]
-          return 'Cannot add K7 without Unit 1' if kits[7] && !units[1]
-          return 'K2 not supported with just Unit 3' if kits[2] && !units[1] && !units[2] && units[3]
-          return 'K2 not supported without K3' if kits[2] && !kits[3]
-          return 'Cannot use extra Unit 3 trains without Unit 3' if !units[3] && optional_rules.include?(:u3p)
-          return 'Cannot use K1 or K6 with D1' if (kits[1] || kits[6]) && optional_rules.include?(:d1)
-          return 'Cannot use both bank options' if optional_rules.include?(:big_bank) && optional_rules.include?(:strict_bank)
-          return 'Variant DB1 not useful in a Unit 2 only game' if !units[1] && !units[3] && optional_rules.include?(:db1)
-          return 'Variant DB2 is for Unit 1' if !units[1] && optional_rules.include?(:db2)
-          return 'Variant DB3 is for Unit 3' if !units[3] && optional_rules.include?(:db3)
-          return 'Unit 4 requires Unit 3' if units4 && !units[3]
+          return { error: 'Cannot combine Units 1 and 3 without Unit 2' } if units[1] && !units[2] && units[3]
+          return { error: 'Cannot add Regionals without Unit 1' } if !regionals.keys.empty? && !units[1]
+          return { error: 'Cannot add K5 without Unit 2' } if kits[5] && !units[2]
+          return { error: 'Cannot add K7 without Unit 1' } if kits[7] && !units[1]
+          return { error: 'K2 not supported with just Unit 3' } if kits[2] && !units[1] && !units[2] && units[3]
+          return { error: 'K2 not supported without K3' } if kits[2] && !kits[3]
+          return { error: 'Cannot use extra Unit 3 trains without Unit 3' } if !units[3] && optional_rules.include?(:u3p)
+          return { error: 'Cannot use K1 or K6 with D1' } if (kits[1] || kits[6]) && optional_rules.include?(:d1)
+          if optional_rules.include?(:big_bank) && optional_rules.include?(:strict_bank)
+            return { error: 'Cannot use both bank options' }
+          end
+          if !units[1] && !units[3] && optional_rules.include?(:db1)
+            return { error: 'Variant DB1 not useful in a Unit 2 only game' }
+          end
+          return { error: 'Variant DB2 is for Unit 1' } if !units[1] && optional_rules.include?(:db2)
+          return { error: 'Variant DB3 is for Unit 3' } if !units[3] && optional_rules.include?(:db3)
+          return { error: 'Unit 4 requires Unit 3' } if units4 && !units[3]
 
           nil
         end

--- a/lib/engine/game/g_1888/meta.rb
+++ b/lib/engine/game/g_1888/meta.rb
@@ -36,7 +36,7 @@ module Engine
 
         def self.check_options(options, _min_players, _max_players)
           optional_rules = (options || []).map(&:to_sym)
-          return 'WARNING: No option selected. Will use North map with prototype rules' if optional_rules.empty?
+          return { info: 'WARNING: No option selected. Will use North map with prototype rules' } if optional_rules.empty?
         end
 
         def self.min_players(optional_rules, _num_players)

--- a/lib/engine/game/g_18_gb/meta.rb
+++ b/lib/engine/game/g_18_gb/meta.rb
@@ -40,8 +40,10 @@ module Engine
           two_player_map = optional_rules.include?(:two_player_ew) ? 'East-West' : 'North-South'
           four_player_setup = optional_rules.include?(:four_player_alt) ? 'Alternative' : 'Standard'
 
-          "The 2P #{two_player_map} map will be used if the game is started with 2 players. The 4P #{four_player_setup} setup " \
-            'will be used if the game is started with 4 players.'
+          {
+            info: "The 2P #{two_player_map} map will be used if the game is started with 2 players. The "\
+                  "4P #{four_player_setup} setup will be used if the game is started with 4 players.",
+          }
         end
       end
     end

--- a/lib/engine/game/meta.rb
+++ b/lib/engine/game/meta.rb
@@ -126,6 +126,8 @@ module Engine
             self::GAME_IMPLEMENTER,
           ].compact.flat_map { |c| c.upcase.split(/[:, ]+/) }.uniq
         end
+
+        def check_options(_options, _min_players, _max_players); end
       end
     end
   end


### PR DESCRIPTION
Old behavior with bad set of optional rules selected:

* multiplayer: can create a game table, no error until starting the game
* hotseat: taken to error page
* JSON: taken to error page

New behavior with bad set:

* multiplayer and hotseat: 'Create' button is disabled
* JSON: error message flashes and user stays on the page