### PR TITLE
[1822PNW] fix L/2 train roster variants

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -384,6 +384,13 @@ module Engine
         optional_rules
       end
 
+      def check_optional_rules!
+        min_players = @players.size
+        max_players = @players.size
+        error_string = meta.check_options(@optional_rules, min_players, max_players)&.[](:error)
+        raise OptionError, error_string if error_string
+      end
+
       def setup_optional_rules; end
 
       def log_optional_rules
@@ -568,8 +575,9 @@ module Engine
 
         init_company_abilities
 
-        setup_optional_rules
+        check_optional_rules!
         log_optional_rules
+        setup_optional_rules
         setup
         @round.setup
 

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -570,6 +570,14 @@ module Engine
           setup_tokencity_tiles
         end
 
+        def setup_optional_rules
+          if @optional_rules&.include?(:remove_three_ls)
+            remove_l_trains(3)
+          elsif @optional_rules&.include?(:remove_two_ls)
+            remove_l_trains(2)
+          end
+        end
+
         def remove_l_trains(num_trains)
           @log << "#{num_trains} L/2 train(s) have been discarded"
           num_trains.times { @depot.remove_train(@depot.upcoming.first) }

--- a/lib/engine/game/g_1822_pnw/meta.rb
+++ b/lib/engine/game/g_1822_pnw/meta.rb
@@ -23,26 +23,21 @@ module Engine
         PLAYER_RANGE = [3, 5].freeze
         OPTIONAL_RULES = [
           {
-            sym: :one_less_l,
-            short_name: 'One less L/2 train',
-            desc: 'Game starts with one less L/2 train (Playtest Trial)',
+            sym: :remove_two_ls,
+            short_name: 'Remove two L/2 trains',
           },
           {
-            sym: :two_less_ls,
-            short_name: 'Two less L/2 trains',
-            desc: 'Game starts with two less L/2 trains.  Takes priority over earlier options. (Playtest Trial)',
-          },
-          {
-            sym: :three_less_ls,
-            short_name: 'Three less L/2 trains',
-            desc: 'Game starts with three less L/2 trains.  Takes priority over earlier options. (Playtest Trial)',
-          },
-          {
-            sym: :four_less_ls,
-            short_name: 'Four less L/2 trains',
-            desc: 'Game starts with four less L/2 trains.  Takes priority over earlier options. (Playtest Trial)',
+            sym: :remove_three_ls,
+            short_name: 'Remove three L/2 trains',
           },
         ].freeze
+
+        def self.check_options(options, _min_players, _max_players)
+          optional_rules = (options || []).map(&:to_sym)
+          return if !optional_rules.include?(:remove_two_ls) || !optional_rules.include?(:remove_three_ls)
+
+          { error: 'Cannot use both L/2 Train Roster Adjustment Variants' }
+        end
       end
     end
   end


### PR DESCRIPTION
The current variants for reducing the number of L/2 trains are not functional. This PR replaces the four non-functional variants with two new ones that match the variants in the latest version of the rulebook.

* four variants were implemented in #8380, merged on 2022-09-26
* the variants were announced [on BGG][0] on 2022-10-03
* the implementation for the variants was deleted in #8443, merged on 2022-10-15, but the `OPTIONAL_RULES` remained in `G1822PNW::Meta`; since this was deployed, 1822PNW games could be created with a variant for fewer L/2 trains selected, but the setup was not actually changed
* the latest (dated 2023-02-22) [draft rules][1] show variants for removing two or three L/2 trains (Chapter 11, page 28)
* since this implementation uses different names for the optional rules, old games created with the non-functional optional rules will not need pins

[0]: https://boardgamegeek.com/thread/2945245/how-many-l2-trains
[1]: https://boardgamegeek.com/thread/2890404/1822pnw-public-rules-review

----

This cannot be deployed without https://github.com/tobymao/18xx/pull/9206, but they didn't have overlapping code so I split them up
