### PR TITLE
Rolling Stock: one more ipo fix

### DIFF
--- a/lib/engine/game/g_rolling_stock/step/ipo_company.rb
+++ b/lib/engine/game/g_rolling_stock/step/ipo_company.rb
@@ -40,9 +40,12 @@ module Engine
               buy_and_issue(player, company, share_price, corporation, 1)
             elsif share_price.price * 2 >= company.value
               buy_and_issue(player, company, share_price, corporation, 2)
-            else
+            elsif share_price.price * 3 >= company.value
               # we should only get here in RS not RSS
               buy_and_issue(player, company, share_price, corporation, 3)
+            else
+              # we should only get here in RS not RSS
+              buy_and_issue(player, company, share_price, corporation, 4)
             end
 
             corporation.companies << company
@@ -89,8 +92,10 @@ module Engine
               par_price - company.value
             elsif par_price * 2 >= company.value
               (par_price * 2) - company.value
-            else
+            elsif par_price * 3 >= company.value
               (par_price * 3) - company.value
+            else
+              (par_price * 4) - company.value
             end
           end
 


### PR DESCRIPTION
Fixes #9212 

### Implementation Notes

Fix to allow purchase of 4 shares during an IPO. The failing case represents the worst difference between max company value and min par price.

I thought about using a ceiling function and making the code cleaner, but I remembered there have been rounding issues with Opal/JS.

No pins needed.
