### PR TITLE
[18MEX] Change Copper Canyon's town style to `:rect`, make it orange

### DIFF
--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -695,8 +695,8 @@ module Engine
         end
 
         def upgrades_to?(from, to, _special = false, selected_company: nil)
-          # Copper Canyon cannot be upgraded
-          return false if from.name == '470'
+          # Copper Canyon uses a special orange color
+          return true if from.name == 'F5' && to.name == '470'
 
           super
         end

--- a/lib/engine/game/g_18_mex/map.rb
+++ b/lib/engine/game/g_18_mex/map.rb
@@ -46,9 +46,9 @@ module Engine
           '470' =>
           {
             'count' => 1,
-            'color' => 'yellow',
+            'color' => 'orange',
             'code' =>
-            'town=revenue:20,loc:0;path=a:0,b:_0;path=a:3,b:_0;path=a:3,b:4;path=a:4,b:_0;label=CC',
+            'town=revenue:20,loc:0,style:rect;path=a:0,b:_0;path=a:3,b:_0;path=a:3,b:4;path=a:4,b:_0;label=CC',
           },
           '471' => 1,
           '472' => 1,


### PR DESCRIPTION
Fixes #7765

Before:

![Copper Canyon before](https://github.com/tobymao/18xx/assets/1045173/84c59d17-6c8a-4eac-a765-ae6448ca6768)

After:
![Copper Canyon tile](https://github.com/tobymao/18xx/assets/1045173/51d7b591-4cc7-4394-9ba7-3e253b7dbd5a)

----

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`