### PR TITLE
1860: Implements Re-use Of Hexes variant

### DIFF
--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -986,7 +986,7 @@ module Engine
         end
 
         def check_other(route)
-          check_hex_reentry(route)
+          check_hex_reentry(route) unless @optional_rules&.include?(:re_enter_hexes)
           check_home_token(current_entity, route.routes) unless route.routes.empty?
           check_intersection(route.routes) unless route.routes.empty?
         end

--- a/lib/engine/game/g_1860/meta.rb
+++ b/lib/engine/game/g_1860/meta.rb
@@ -39,6 +39,11 @@ module Engine
             short_name: 'First edition rules and map',
             desc: 'Use all of the first edition rules (smaller map, original insolvency, no skipping towns)',
           },
+          {
+            sym: :re_enter_hexes,
+            short_name: 'Re-enter hexes',
+            desc: 'Routes may enter the same hex more than once, so long as no track is re-used.',
+          },
         ].freeze
       end
     end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

Implements the Re-use Of Hexes variant from the official rules, allowing trains to reenter a hex as long as no track is reused. 

![image](https://github.com/tobymao/18xx/assets/26125362/03a1ece0-c6a7-4650-b9d4-ce96843360ce)
