### PR TITLE
[18RHL] Correct lay of special tile 949

### DIFF
--- a/lib/engine/game/g_18_rhl/step/track.rb
+++ b/lib/engine/game/g_18_rhl/step/track.rb
@@ -21,6 +21,7 @@ module Engine
 
           def check_track_restrictions!(entity, old_tile, new_tile)
             return if FOUR_SPOKERS_TO.include?(new_tile.name)
+            return if @game.optional_promotion_tiles && old_tile.name == '929' && new_tile.name == '949'
 
             super
           end


### PR DESCRIPTION
Duisburg title, when using optional promotion tiles, need special handling as it adds a town.

Right now this tile can only be placed in one orientation; attempts to make is possible to rotate were not successful.

Fixes #8654
