### PR TITLE
Only allow valid playercounts

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -392,6 +392,8 @@ module View
       return if !selected_game_or_variant && @mode != :json
 
       game_params = params
+      title = selected_game_or_variant.title
+      game_params[:max_players] = @max_p[title] if game_params[:max_players].to_i <= 0
       game_params[:seed] = game_params[:seed].to_i
       game_params[:seed] = nil if (game_params[:seed]).zero?
 
@@ -499,13 +501,12 @@ module View
         max_players = (val = max_players_elm&.value.to_i).zero? ? nil : val
         min_players = (val = min_players_elm&.value.to_i).zero? ? nil : val
       end
-
       if max_players
         max_players = [max_players, max_p].min
+        max_players = [max_players, min_p].max
         if selected_game_or_variant.respond_to?(:min_players)
           min_p = selected_game_or_variant.min_players(@optional_rules, max_players)
         end
-        max_players_elm&.value = max_players
       end
 
       if min_players


### PR DESCRIPTION
Fixes #9233

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Attempting to set a bogus `max_players` (i.e. less than the game supports, or zero/negative) will now result in a game where `max_players` is set to the maximum that the game supports


* **Screenshots**

* **Any Assumptions / Hacks**

I had to (possibly redundantly) check and correct `max_players` at submit-time, since it didn't seem like the `max_players` set in `update_inputs()` would be correctly modified, otherwise