### PR TITLE
[18SJ] Make it possible to buy multiple "brown" shares from treasury

### DIFF
--- a/lib/engine/game/g_18_sj/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_sj/step/buy_sell_par_shares.rb
@@ -7,6 +7,21 @@ module Engine
     module G18SJ
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
+          def can_buy_any?(entity)
+            (can_buy_any_from_market?(entity) ||
+             can_buy_any_from_ipo?(entity) ||
+             can_buy_any_from_treasury?(entity))
+          end
+
+          def can_buy_any_from_treasury?(entity)
+            @game.corporations.each do |corporation|
+              next unless corporation.ipoed
+              return true if can_buy_shares?(entity, corporation.shares)
+            end
+
+            false
+          end
+
           def can_sell?(entity, bundle)
             super && (@game.oscarian_era || bundle.corporation.floated?)
           end


### PR DESCRIPTION
Fixes #9155

This is unlikely to affect any 18SJ games as it gives the option of buying shares that previous implementation did not allow. So it should be backwards compatible.

If not it is likely broken games can be archived (or contact me to look into this issue).