### PR TITLE
[18TN Implements triple yellow variant

### DIFF
--- a/lib/engine/game/g_18_tn/meta.rb
+++ b/lib/engine/game/g_18_tn/meta.rb
@@ -18,6 +18,13 @@ module Engine
         GAME_RULES_URL = 'https://drive.google.com/file/d/1r0qnCWW-Qf9ETyXV_jIfHcnn9O5cJcmC/view?usp=sharing'
 
         PLAYER_RANGE = [3, 5].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :triple_yellow_first_or,
+            short_name: 'Extra yellow',
+            desc: 'Allow corporations to lay 3 yellow tiles their first OR',
+          },
+        ].freeze
       end
     end
   end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

Implements the official rules variant to allow a third yellow track lay on a corporation's first operating turn. 
