### PR TITLE
Add override for default stock movement when shares sold and make removing closed corp tokens configurable

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -250,6 +250,7 @@ module Engine
       DISCARDED_TRAINS = :discard # discard or remove
       DISCARDED_TRAIN_DISCOUNT = 0 # percent
       CLOSED_CORP_TRAINS_REMOVED = true
+      CLOSED_CORP_TOKENS_REMOVED = true
       CLOSED_CORP_RESERVATIONS_REMOVED = true
 
       MUST_BUY_TRAIN = :route # When must the company buy a train if it doesn't have one (route, never, always)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -250,7 +250,6 @@ module Engine
       DISCARDED_TRAINS = :discard # discard or remove
       DISCARDED_TRAIN_DISCOUNT = 0 # percent
       CLOSED_CORP_TRAINS_REMOVED = true
-      CLOSED_CORP_TOKENS_REMOVED = true
       CLOSED_CORP_RESERVATIONS_REMOVED = true
 
       MUST_BUY_TRAIN = :route # When must the company buy a train if it doesn't have one (route, never, always)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1141,12 +1141,12 @@ module Engine
         self.class::SELL_AFTER == :first ? (@turn > 1 || !@round.stock?) : true
       end
 
-      def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+      def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
         corporation = bundle.corporation
         old_price = corporation.share_price
         was_president = corporation.president?(bundle.owner)
         @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
-        case self.class::SELL_MOVEMENT
+        case movement || self.class::SELL_MOVEMENT
         when :down_share
           bundle.num_shares.times { @stock_market.move_down(corporation) }
         when :down_per_10

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -250,6 +250,7 @@ module Engine
       DISCARDED_TRAINS = :discard # discard or remove
       DISCARDED_TRAIN_DISCOUNT = 0 # percent
       CLOSED_CORP_TRAINS_REMOVED = true
+      CLOSED_CORP_TOKENS_REMOVED = true
       CLOSED_CORP_RESERVATIONS_REMOVED = true
 
       MUST_BUY_TRAIN = :route # When must the company buy a train if it doesn't have one (route, never, always)
@@ -1707,7 +1708,7 @@ module Engine
 
         hexes.each do |hex|
           hex.tile.cities.each do |city|
-            city.tokens.select { |t| t&.corporation == corporation }.each(&:remove!)
+            city.tokens.select { |t| t&.corporation == corporation }.each(&:remove!) if self.class::CLOSED_CORP_TOKENS_REMOVED
 
             if self.class::CLOSED_CORP_RESERVATIONS_REMOVED && city.reserved_by?(corporation)
               city.reservations.delete(corporation)

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -560,7 +560,7 @@ module Engine
           end
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           super
           close_market_shorts
         end

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -508,7 +508,7 @@ module Engine
           @round.entities.insert(@round.entity_index + 1, ndem)
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           return super unless bundle.corporation == corporation_by_id('NDEM')
 
           @share_pool.sell_shares(bundle, allow_president_change: false, swap: swap)

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -274,7 +274,7 @@ module Engine
           revenue
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           @sell_queue << [bundle, bundle.corporation.owner]
 
           @share_pool.sell_shares(bundle)

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -519,7 +519,7 @@ module Engine
           @players.size == 3 ? { max_ownership_percent: 70 } : {}
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           super(bundle, allow_president_change: pres_change_ok?(bundle.corporation), swap: nil)
         end
 

--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -330,7 +330,7 @@ module Engine
           revenue
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           @sell_queue << [bundle, bundle.corporation.owner]
 
           @share_pool.sell_shares(bundle)

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -773,7 +773,7 @@ module Engine
           corporation.operated? && !@no_price_drop_on_sale
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           old_price = corporation.share_price
 

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1190,7 +1190,7 @@ module Engine
           corporation.floated? && !@lner
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           old_price = corporation.share_price
           president_selling = (bundle.owner == corporation.owner)

--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -1302,7 +1302,7 @@ module Engine
           entity.runnable_trains.reject { |t| infrastructure_train?(t) }
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           before_share_price = corporation.share_price
           was_president = corporation.president?(bundle.owner) || bundle.owner == corporation

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -2002,7 +2002,7 @@ module Engine
           after
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           before = before_sell_up(bundle)
           super
           return unless (after = after_sell_up(bundle, before))

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -430,7 +430,7 @@ module Engine
           destination_stop.route_revenue(route.phase, route.train)
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           @sell_queue << [bundle, bundle.corporation.owner]
 
           @share_pool.sell_shares(bundle)

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -1458,7 +1458,7 @@ module Engine
           bundles.select { |bundle| @round.active_step.can_sell?(player, bundle) }
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           old_price = corporation.share_price
 

--- a/lib/engine/game/g_1877_stockholm_tramways/game.rb
+++ b/lib/engine/game/g_1877_stockholm_tramways/game.rb
@@ -271,7 +271,7 @@ module Engine
           @phase.available?(@starting_phase[corporation]) && !@sl
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           old_price = corporation.share_price
 

--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1423,7 +1423,7 @@ module Engine
           @presidents_choice = :triggered
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           old_price = corporation.share_price
           was_president = corporation.president?(bundle.owner)

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -539,7 +539,7 @@ module Engine
           !@phase.status.include?('only_pres_drop')
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           old_price = corporation.share_price
           was_president = corporation.president?(bundle.owner)

--- a/lib/engine/game/g_18_mt/game.rb
+++ b/lib/engine/game/g_18_mt/game.rb
@@ -219,7 +219,7 @@ module Engine
           str
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           corporation = bundle.corporation
           old_price = corporation.share_price
           was_president = corporation.president?(bundle.owner)

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -928,7 +928,7 @@ module Engine
           super
         end
 
-        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil)
+        def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
           return super if bundle.corporation.operated?
 
           @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)


### PR DESCRIPTION
- Add movement kwarg to sell_shares_and_change_price() to allow caller to override default stock movement
- Add  CLOSED_CORP_TOKENS_REMOVED constant