### PR TITLE
[1871]  autobuy from market to float

### DIFF
--- a/lib/engine/action/program_buy_shares.rb
+++ b/lib/engine/action/program_buy_shares.rb
@@ -6,7 +6,8 @@ require_relative 'program_enable'
 module Engine
   module Action
     class ProgramBuyShares < ProgramEnable
-      attr_reader :corporation, :until_condition, :from_market, :auto_pass_after
+      attr_accessor :from_market
+      attr_reader :corporation, :until_condition, :auto_pass_after
 
       def initialize(entity, corporation:, until_condition:, from_market: false, auto_pass_after: false)
         super(entity)

--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -186,6 +186,12 @@ module Engine
               @game.can_par?(c, entity) && can_buy?(entity, @game.share_by_id("#{c.name}_0")&.to_bundle)
             end
           end
+
+          # handle auto-floating, since we can only buy from market
+          def activate_program_buy_shares(entity, program)
+            program.from_market = true
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #9282

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

1 - Changes `from_market` to also be writable
2 - Add an override in 1871 to float via a purchase from market

* **Screenshots**

On local, it's `testman3` turn, who sets an auto-action which is immediately executed as it's his turn

Setting auto-action
![Screenshot 2023-07-11 4 05 30 PM](https://github.com/tobymao/18xx/assets/1711810/db6cb287-5fd8-43d4-b255-ef030a53b55b)

Execution of auto-action
![Screenshot 2023-07-11 4 05 01 PM](https://github.com/tobymao/18xx/assets/1711810/6e02c60d-a954-44cb-bb29-eedc0db691d1)

* **Any Assumptions / Hacks**
