### PR TITLE
[1856] fixes train limit increase for CGR

### DIFF
--- a/lib/engine/game/g_1856/entities.rb
+++ b/lib/engine/game/g_1856/entities.rb
@@ -250,7 +250,7 @@ module Engine
               },
               {
                 type: 'train_limit',
-                increase: 99,
+                increase: 1,
                 description: '3 train limit',
               },
               {

--- a/lib/engine/game/g_1856/entities.rb
+++ b/lib/engine/game/g_1856/entities.rb
@@ -245,7 +245,7 @@ module Engine
             abilities: [
               {
                 type: 'train_buy',
-                description: 'Inter train buy/sell at face value',
+                description: 'Inter-corporation train buy/sell at face value only',
                 face_value: true,
               },
               {


### PR DESCRIPTION
### Before clicking "Create"

- [x ] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

For some reason the train limit increase for the CGR was set to 99 instead of 1. Given how CGR can only buy trains at face value, this is likely unimportant, but regardless, it should be fixed.
