### PR TITLE
1841: EMR and Bankruptcy

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -16,7 +16,7 @@ module View
       needs :active_shell, default: nil, store: true
 
       def render_president_contributions
-        player = @corporation.owner
+        player = corp_owner(@corporation)
         owner = nil
         if @game.class::EBUY_OWNER_MUST_HELP
           owner = @game.acting_for_entity(player)
@@ -32,7 +32,7 @@ module View
                                else
                                  discounted_train(@depot.min_depot_train, @depot.min_depot_price).first
                                end
-        cash = @corporation.cash + player.cash
+        cash = available_cash(@corporation) + player.cash
         share_funds_required = cheapest_train_price - cash
         share_funds_allowed = if @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST
                                 share_funds_required
@@ -190,7 +190,7 @@ module View
 
         available = @step.buyable_trains(@corporation).group_by(&:owner)
         depot_trains = available.delete(@depot) || []
-        other_corp_trains = available.sort_by { |c, _| c.owner == @corporation.owner ? 0 : 1 }
+        other_corp_trains = available.sort_by { |c, _| corp_owner(c) == corp_owner(@corporation) ? 0 : 1 }
         children = []
 
         @must_buy_train = @step.must_buy_train?(@corporation)
@@ -263,12 +263,13 @@ module View
         children << h(:h3, 'Remaining Trains')
         children << remaining_trains
 
-        children << h(:div, "#{@corporation.name} has #{@game.format_currency(@corporation.cash)}.")
+        children << h(:div, "#{@corporation.name} has #{available_cash_str(@corporation)}.")
         if @step.issuable_shares(@corporation).any? &&
            (issuable_cash = @game.emergency_issuable_cash(@corporation)).positive?
           issue_verb = 'issue'
           issue_verb = @step.issue_verb(@corporation) if @step.respond_to?(:issue_verb)
-          issue_str = "#{@corporation.name} can #{issue_verb} shares to raise up to #{@game.format_currency(issuable_cash)}"
+          issue_str = "#{issuing_corporation(@corporation).name} can #{issue_verb} shares"\
+                      " to raise up to #{@game.format_currency(issuable_cash)}"
           if @step.must_issue_before_ebuy?(@corporation)
             issue_str += " (the corporation must #{issue_verb} shares before the president may contribute)"
           end
@@ -301,7 +302,7 @@ module View
       def discounted_train(train, price)
         entity = @corporation
 
-        if @selected_company && [@corporation, @corporation.owner].include?(@selected_company.owner) \
+        if @selected_company && [@corporation, corp_owner(@corporation)].include?(@selected_company.owner) \
           && @step.respond_to?(:ability_timing)
           @game.abilities(@selected_company, :train_discount, time: @step.ability_timing) do |ability|
             if ability.trains.empty? || ability.trains.include?(train.name)
@@ -438,7 +439,7 @@ module View
                 ))
               end
 
-              if other_owner(other) == @corporation.owner
+              if other_owner(other) == corp_owner(@corporation)
                 if !@corporation.loans.empty? &&
                    !@game.interest_paid?(@corporation) &&
                    !@game.can_pay_interest?(@corporation, -price)
@@ -460,7 +461,7 @@ module View
 
             count = group.size
 
-            real_name = other_owner(other) != other.owner ? " [#{other_owner(other).name}]" : ''
+            real_name = other_owner(other) != corp_owner(other) ? " [#{other_owner(other).name}]" : ''
 
             train_props = { style: {} }
             unless @game.able_to_operate?(corporation, group[0], name)
@@ -468,10 +469,10 @@ module View
               train_props[:style][:backgroundColor] = color
               train_props[:style][:color] = contrast_on(color)
             end
-            line = if @show_other_players || other_owner(other) == @corporation.owner
+            line = if @show_other_players || other_owner(other) == corp_owner(@corporation)
                      [h(:div, train_props, name),
                       h('div.nowrap', train_props,
-                        "#{other.name} (#{count > 1 ? "#{count}, " : ''}#{other.owner.name}#{real_name})"),
+                        "#{other.name} (#{count > 1 ? "#{count}, " : ''}#{corp_owner(other).name}#{real_name})"),
                       input,
                       h('button.no_margin', { on: { click: buy_train_click } }, 'Buy')]
                    else
@@ -526,6 +527,22 @@ module View
       # need to abstract due to corporations owning minors owning trains
       def other_owner(other)
         @step.respond_to?(:real_owner) ? @step.real_owner(other) : other.owner
+      end
+
+      def corp_owner(corp)
+        @step.respond_to?(:corp_owner) ? @step.corp_owner(corp) : corp.owner
+      end
+
+      def available_cash(corp)
+        @step.respond_to?(:available_cash) ? @step.available_cash(corp) : corp.cash
+      end
+
+      def available_cash_str(corp)
+        @step.respond_to?(:available_cash_str) ? @step.available_cash_str(corp) : @game.format_currency(corp.cash)
+      end
+
+      def issuing_corporation(corp)
+        @step.respond_to?(:issuing_corporation) ? @step.issuing_corporation(corp) : corp
       end
 
       def price_range(train)

--- a/assets/app/view/game/emergency_money.rb
+++ b/assets/app/view/game/emergency_money.rb
@@ -33,7 +33,12 @@ module View
 
         if @game.round.actions_for(entity).include?('bankrupt') &&
            @game.can_go_bankrupt?(player, @corporation)
-          children << render_bankruptcy
+          b_options = @game.bankruptcy_options(player)
+          if b_options.empty?
+            children << render_bankruptcy
+          else
+            b_options.each { |o| children << render_bankruptcy_option(o) }
+          end
         end
         children
       end
@@ -64,6 +69,21 @@ module View
         }
 
         h(:button, props, 'Declare Bankruptcy')
+      end
+
+      def render_bankruptcy_option(option)
+        resign = lambda do
+          process_action(Engine::Action::Bankrupt.new(entity, type: option))
+        end
+
+        props = {
+          style: {
+            width: 'max-content',
+          },
+          on: { click: resign },
+        }
+
+        h(:button, props, @game.bankruptcy_button_text(option))
       end
 
       private

--- a/lib/engine/action/bankrupt.rb
+++ b/lib/engine/action/bankrupt.rb
@@ -5,6 +5,24 @@ require_relative 'base'
 module Engine
   module Action
     class Bankrupt < Base
+      attr_reader :option
+
+      def initialize(entity, option: nil)
+        super(entity)
+        @type = type
+      end
+
+      def self.h_to_args(h, _game)
+        {
+          option: h['option'],
+        }
+      end
+
+      def args_to_h
+        {
+          'option' => @option,
+        }
+      end
     end
   end
 end

--- a/lib/engine/action/bankrupt.rb
+++ b/lib/engine/action/bankrupt.rb
@@ -9,7 +9,7 @@ module Engine
 
       def initialize(entity, option: nil)
         super(entity)
-        @type = type
+        @option = option
       end
 
       def self.h_to_args(h, _game)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2207,6 +2207,10 @@ module Engine
         corporations.select(&:receivership?)
       end
 
+      def bankruptcy_options(_entity)
+        []
+      end
+
       private
 
       def init_graph

--- a/lib/engine/game/g_1841/step/bankrupt.rb
+++ b/lib/engine/game/g_1841/step/bankrupt.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/bankrupt'
+
+module Engine
+  module Game
+    module G1841
+      module Step
+        class Bankrupt < Engine::Step::Bankrupt
+          def process_bankrupt(action)
+            corp = action.entity
+            player = corp.player
+            option = action.option
+
+            @log << "-- #{player.name} goes bankrupt and sells remaining shares --"
+
+            # validate after emergency issuing to fix the math in the exception message
+            unless @game.can_go_bankrupt?(player, corp)
+              buying_power = @game.format_currency(@game.total_emr_buying_power(player, corp))
+              price = @game.format_currency(@game.depot.min_depot_price)
+
+              msg = "Cannot go bankrupt. #{corp.name}'s cash plus #{player.name}'s cash and "\
+                    "sellable shares total #{buying_power}, and the cheapest train in the "\
+                    "Depot costs #{price}."
+
+              raise GameError, msg
+            end
+
+            # next the president sells all normally allowed shares at half price
+            player.shares_by_corporation(sorted: true).each do |corporation, _|
+              next unless corporation.share_price # if a corporation has not parred
+              next unless (bundle = @game.sellable_bundles(player, corporation).max_by(&:price))
+
+              bundle.share_price = corporation.share_price.price / 2.0
+              @game.sell_shares_and_change_price(bundle)
+            end
+
+            # finally, the president sells all their shares at half price, regardless of
+            # 50% and presidency restrictions, not changing any share prices
+            player.shares_by_corporation(sorted: true).each do |corporation, shares|
+              next unless corporation.share_price # if a corporation has not parred
+              next if shares.empty?
+
+              bundle = ShareBundle.new(shares)
+              bundle.share_price = corporation.share_price.price / 2.0
+              if @game.historical?(corporation) && @game.phase.name.to_i < 4
+                # deal with selling a historical corp
+                @game.share_pool.sell_shares(bundle, allow_president_change: false)
+                if bundle.presidents_share
+                  # dumped a historical corp presidency
+                  corporation.owner = @game.share_pool
+                end
+              else
+                @game.share_pool.sell_shares(bundle, allow_president_change: true)
+              end
+              @game.update_frozen!
+            end
+
+            if player.cash.positive?
+              @log << "#{player.name} transfers #{@game.format_currency(player.cash)} to #{corp.name}"
+              player.spend(player.cash, corp)
+            end
+
+            # move any concessions to bank
+            player.companies.dup.each do |company|
+              player.companies.delete(company)
+              company.owner = @game.bank
+              @log << "#{company.name} concession is moved to the bank"
+            end
+
+            @game.declare_bankrupt(player, option)
+
+            # let the company off the hook (for this round)
+            @game.done_operating!(corp)
+            @game.done_this_round[corp] = true
+            @round.clear_cache!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1841/step/buy_new_tokens.rb
+++ b/lib/engine/game/g_1841/step/buy_new_tokens.rb
@@ -58,12 +58,11 @@ module Engine
             total = price(num)
             type = pending_type
             entity = pending_entity
-            price = pending_price
             @round.buy_tokens.shift
 
             case type
             when :start
-              @game.purchase_tokens!(entity, num, price)
+              @game.purchase_tokens!(entity, num, total)
             when :transform
               @game.purchase_additional_tokens!(entity, num, total)
               @game.transform_finish

--- a/lib/engine/game/g_1841/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1841/step/buy_sell_par_shares.rb
@@ -97,6 +97,7 @@ module Engine
             @game.sell_shares_and_change_price(shares, swap: swap,
                                                        allow_president_change: @game.pres_change_ok?(shares.corporation))
             @game.update_frozen!
+            @round.recalculate_order if @round.respond_to?(:recalculate_order)
             return if @game.circular_corporations.none? { |c| !old_circular.include?(c) }
 
             raise GameError, 'Cannot sell if it causes a circular chain of ownership'

--- a/lib/engine/game/g_1841/step/buy_train.rb
+++ b/lib/engine/game/g_1841/step/buy_train.rb
@@ -44,10 +44,6 @@ module Engine
             must_buy_train?(corporation) && ebuy_president_can_contribute?(corporation)
           end
 
-          # def must_issue_before_ebuy?(corporation)
-          #  super
-          # end
-
           def issuable_shares(entity)
             return [] unless must_buy_train?(entity)
 

--- a/lib/engine/game/g_1841/step/buy_train.rb
+++ b/lib/engine/game/g_1841/step/buy_train.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G1841
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def actions(entity)
+            return [] unless can_entity_buy_train?(entity)
+            return ['sell_shares'] if entity == current_entity&.player && can_ebuy_sell_shares?(current_entity)
+            return [] if entity != current_entity
+            return %w[buy_train sell_shares] if must_sell_shares?(entity)
+            return %w[buy_train] if must_buy_train?(entity)
+            return %w[buy_train pass] if can_buy_train?(entity)
+
+            []
+          end
+
+          def setup
+            super
+            @emr_triggered = false
+          end
+
+          def can_entity_buy_train?(entity)
+            !@game.done_this_round[entity]
+          end
+
+          def must_sell_shares?(corporation)
+            return false unless must_buy_train?(corporation)
+            return false unless @game.emergency_cash_before_issuing(corporation) < @game.depot.min_depot_price
+
+            must_issue_before_ebuy?(corporation)
+          end
+
+          def ebuy_president_can_contribute?(corporation)
+            return false unless @game.emergency_cash_before_issuing(corporation) < @game.depot.min_depot_price
+
+            !must_issue_before_ebuy?(corporation)
+          end
+
+          def president_may_contribute?(corporation)
+            must_buy_train?(corporation) && ebuy_president_can_contribute?(corporation)
+          end
+
+          # def must_issue_before_ebuy?(corporation)
+          #  super
+          # end
+
+          def issuable_shares(entity)
+            return [] unless must_buy_train?(entity)
+
+            super
+          end
+
+          def buyable_trains(entity)
+            return super unless @emr_triggered
+
+            [@game.depot.min_depot_train(entity)]
+          end
+
+          def train_vatiant_helper(train, _entity)
+            variants = train.variants.values
+            return variants if train.owned_by_corporation?
+
+            # variants.reject! { |v| entity.cash < v[:price] } if must_issue_before_ebuy?(entity)
+            variants
+          end
+
+          def can_sell?(_entity, bundle)
+            @game.emr_can_sell?(current_entity, bundle)
+          end
+
+          def sweep_cash(entity, seller, train_cost)
+            @emr_triggered = true
+            return if entity == seller
+
+            @game.chain_of_control(entity).each do |controller|
+              needed = [train_cost - entity.cash, 0].max
+              amount = [needed, controller.cash].min
+              if amount.positive?
+                @log << "Sweeping #{@game.format_currency(amount)} from #{controller.name} to #{entity.name} (EMR)"
+                controller.spend(amount, entity)
+              end
+              break if controller == seller
+            end
+          end
+
+          def process_buy_train(action)
+            entity = action.entity
+            price = action.price
+            player = entity.player
+            raise GameError, 'Cannot purchase with selling shares' unless issuable_shares(entity).empty?
+
+            if @emr_triggered && action.train.owner != @game.depot
+              raise GameError, 'Must purchase first train from depot after EMR'
+            end
+
+            if entity.cash < price
+              sweep_cash(entity, player, price)
+
+              if entity.cash < price
+                raise GameError, "#{entity.name} has #{@game.format_currency(entity.cash)} and cannot afford train"
+              end
+            end
+
+            super
+            @emr_triggered = false
+          end
+
+          def track_action(action, corporation)
+            @round.last_to_act = action.entity.player
+            @round.current_actions << action
+            @round.players_history[action.entity.player][corporation] << action
+          end
+
+          def process_sell_shares(action)
+            seller = action.bundle.owner
+            corp = action.bundle.corporation
+            raise GameError, "Cannot sell shares of #{corp.name}" unless can_sell?(action.entity, action.bundle)
+            raise GameError, 'Train puchase not required. Cannot sell shares' unless must_buy_train?(current_entity)
+
+            @game.sell_shares_and_change_price(action.bundle, allow_president_change: @game.pres_change_ok?(corp))
+            @game.update_frozen!
+            sweep_cash(current_entity, seller, @game.depot.min_depot_price)
+            track_action(action, action.bundle.corporation)
+            @round.recalculate_order if @round.respond_to?(:recalculate_order)
+          end
+
+          def issue_text(entity)
+            bundles = issuable_shares(entity)
+            owner = bundles&.first&.owner
+
+            str = "#{owner.name} EMR Sell Shares"
+            str += " (for #{entity.name})" if owner != entity
+            str
+          end
+
+          def issue_verb(_entity)
+            'sell'
+          end
+
+          def issue_corp_name(bundle)
+            return 'IPO' if bundle.corporation == bundle.owner
+
+            bundle.corporation.name
+          end
+
+          def real_owner(corp)
+            corp.player
+          end
+
+          def corp_owner(corp)
+            corp.player
+          end
+
+          def available_cash(corp)
+            @game.emergency_cash_before_issuing(corp)
+          end
+
+          def available_cash_str(corp)
+            str = @game.format_currency(corp.cash)
+            avail = available_cash(corp)
+            str += " (#{@game.format_currency(avail)} EMR cash is available)" if avail > corp.cash
+            str
+          end
+
+          def issuing_corporation(corp)
+            issuable_shares(corp).first&.owner || corp
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1841/step/corporate_buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1841/step/corporate_buy_sell_par_shares.rb
@@ -7,6 +7,12 @@ module Engine
     module G1841
       module Step
         class CorporateBuySellParShares < BuySellParShares
+          def actions(entity)
+            return [] if @game.done_this_round[entity]
+
+            super
+          end
+
           def description
             'Corporate Sell then Buy Shares'
           end

--- a/lib/engine/game/g_1841/step/merge.rb
+++ b/lib/engine/game/g_1841/step/merge.rb
@@ -8,7 +8,7 @@ module Engine
       module Step
         class Merge < Engine::Step::Base
           def actions(entity)
-            return [] if !entity.corporation? || entity != current_entity
+            return [] if !entity.corporation? || entity != current_entity || @game.done_this_round[entity]
             return [] unless @game.mergeable?(entity)
             return [] if target_corporations.empty?
             return [] if @merge_target
@@ -25,7 +25,7 @@ module Engine
           end
 
           def auto_actions(entity)
-            return super if @merging
+            return super if @merging || !@round.pending_tokens.empty? || !@round.buy_tokens.empty?
 
             return [Engine::Action::Pass.new(entity)] if mergeable_candidates(entity).empty?
 

--- a/lib/engine/game/g_1841/step/remove_tokens.rb
+++ b/lib/engine/game/g_1841/step/remove_tokens.rb
@@ -67,6 +67,8 @@ module Engine
 
           def pass!
             super
+            return unless active?
+
             @round.pending_removals.shift
             @game.finish_merge
           end

--- a/lib/engine/game/g_1841/step/track.rb
+++ b/lib/engine/game/g_1841/step/track.rb
@@ -68,7 +68,7 @@ module Engine
             end
 
             # if we are here, must be an upgraded city/town
-            new_tile.nodes each do |n|
+            new_tile.nodes.each do |n|
               railheads.each do |t|
                 return t if graph.connected_nodes_by_token(entity, t.city).include?(n)
               end

--- a/lib/engine/game/g_1841/step/transform.rb
+++ b/lib/engine/game/g_1841/step/transform.rb
@@ -8,7 +8,7 @@ module Engine
       module Step
         class Transform < Engine::Step::Base
           def actions(entity)
-            return [] if !entity.corporation? || entity != current_entity
+            return [] if !entity.corporation? || entity != current_entity || @game.done_this_round[entity]
             return [] if @xform_target
             return [] unless @game.transformable?(entity)
             return [] if target_corporations.empty?


### PR DESCRIPTION
### Implementation Notes

* **Explanation of Change**

This implements the EMR and Bankruptcy rules for 1841.

EMR is complicated because of the possibility of corporations selling treasury shares as well as IPO shares as part of EMR and also because multiple corporations can be involved before a player, given the fact that corporations may own corporations.

Bankruptcy is a little more complicated than usual because 1841 specifies two ways a player may bankrupt.

**Common Code Changes**
* lib/engine/game/base - add support for multiple bankruptcy options
* UI::emergency_money - add support for multiple bankruptcy options
* UI::buy_trains - generalized corporation ownership, corporate funds available and corporation owning the shares to be sold
* lib/action/action/bankrupt - add an optional, um, option.

* **Screenshots**

**EMR 1**
![EMR_1](https://github.com/tobymao/18xx/assets/8494213/e3e8f82e-1b32-4ff3-afcb-91f2878422f3)

**EMR 2**
![EMR_2](https://github.com/tobymao/18xx/assets/8494213/59b630c4-0d4c-4b51-88a3-7c9e4a350015)

**EMR 3**
![EMR_3](https://github.com/tobymao/18xx/assets/8494213/5d338e08-f727-4beb-b850-bfb423454d73)

**EMR 4**
![EMR_4](https://github.com/tobymao/18xx/assets/8494213/11abf962-fa20-470e-a5a7-aa541ac10d36)

**EMR 5**
![EMR_5](https://github.com/tobymao/18xx/assets/8494213/7dff8903-6037-4beb-a008-45ebcecb214b)

**Bankruptcy Choices**
![bankrupt_buttons](https://github.com/tobymao/18xx/assets/8494213/e4cc51a9-b515-4728-926d-05555b806aa8)


* **Any Assumptions / Hacks**
