### PR TITLE
1841: EMR for tokens

### DIFF
--- a/assets/app/view/game/cash_crisis.rb
+++ b/assets/app/view/game/cash_crisis.rb
@@ -29,33 +29,47 @@ module View
 
       def corporation_cash_crisis(entity, funds_required)
         actions = @game.round.actions_for(entity)
-        owner = entity.owner
+        owner = entity.player
         owner_actions = @game.round.actions_for(owner)
         step = @game.round.active_step
 
         children = []
 
         if actions.include?('sell_shares')
+          if step.respond_to?(:show_cash?) && step.show_cash?(entity)
+            children << h('div.margined', "#{entity.name} has #{step.available_cash_str(entity)}")
+          end
+
           bundle = step.issuable_shares(entity).max_by(&:price)
-          children << h('div.margined', "#{entity.name} can issue shares to raise up to #{@game.format_currency(bundle.price)}.")
+          issue_verb = step.respond_to?(:issue_verb) ? step.issue_verb(entity) : 'issue'
+          children << h('div.margined',
+                        "#{entity.name} can #{issue_verb} shares to raise up to #{@game.format_currency(bundle.price)}.")
         end
         if actions.include?('take_loan')
           num_loans = @game.num_emergency_loans(entity, funds_required)
           children << h('div.margined',
                         "#{entity.name} can take loans to raise #{@game.format_currency(@game.loan_value(entity) * num_loans)}.")
         end
-        children << h('div.margined',
-                      "#{owner.name} must contribute #{@game.format_currency(funds_required)} to payoff #{entity.name}'s debt.")
-        children << h('div.margined', "#{owner.name} has #{@game.format_currency(owner.cash)} in cash.")
-        cash_in_stocks = @game.liquidity(owner, emergency: true) - owner.cash
-        children << h('div.margined', "#{owner.name} has #{@game.format_currency(cash_in_stocks)} in sellable shares.")
+        if president_may_contribute?(entity)
+          owner_funds = step.respond_to?(:owner_funds) ? step.owner_funds(entity) : funds_required
+          children << h('div.margined',
+                        "#{owner.name} must contribute #{@game.format_currency(owner_funds)} to payoff #{entity.name}'s debt.")
+          children << h('div.margined', "#{owner.name} has #{@game.format_currency(owner.cash)} in cash.")
+          cash_in_stocks = @game.liquidity(owner, emergency: true) - owner.cash
+          children << h('div.margined', "#{owner.name} has #{@game.format_currency(cash_in_stocks)} in sellable shares.")
 
-        children << h(IssueShares, entity: entity) if actions.include?('sell_shares')
-        children << h(Loans, corporation: entity) if actions.include?('take_loan')
-        children << h('div.margined', [payoff_debt_button(owner)]) if owner_actions.include?('payoff_debt')
-        children.concat(render_emergency_money_raising(owner)) if owner_actions.include?('sell_shares')
+          children << h(IssueShares, entity: entity) if actions.include?('sell_shares')
+          children << h(Loans, corporation: entity) if actions.include?('take_loan')
+          children << h('div.margined', [payoff_debt_button(owner)]) if owner_actions.include?('payoff_debt')
+          children.concat(render_emergency_money_raising(owner)) if owner_actions.include?('sell_shares')
+        end
 
         children
+      end
+
+      def president_may_contribute?(entity)
+        step = @game.round.active_step
+        step.respond_to?(:president_may_contribute?) ? step.president_may_contribute?(entity) : true
       end
 
       def payoff_debt_button(entity)

--- a/assets/app/view/game/cash_crisis.rb
+++ b/assets/app/view/game/cash_crisis.rb
@@ -42,8 +42,9 @@ module View
 
           bundle = step.issuable_shares(entity).max_by(&:price)
           issue_verb = step.respond_to?(:issue_verb) ? step.issue_verb(entity) : 'issue'
+          issuable_cash = step.respond_to?(:issuable_cash) ? step.issuable_cash(entity) : bundle.price
           children << h('div.margined',
-                        "#{entity.name} can #{issue_verb} shares to raise up to #{@game.format_currency(bundle.price)}.")
+                        "#{entity.name} can #{issue_verb} shares to raise up to #{@game.format_currency(issuable_cash)}.")
         end
         if actions.include?('take_loan')
           num_loans = @game.num_emergency_loans(entity, funds_required)

--- a/lib/engine/game/g_1841/step/bankrupt.rb
+++ b/lib/engine/game/g_1841/step/bankrupt.rb
@@ -70,9 +70,24 @@ module Engine
 
             @game.declare_bankrupt(player, option)
 
-            # let the company off the hook (for this round)
-            @game.done_operating!(corp)
-            @game.done_this_round[corp] = true
+            if @round.token_emr_entity
+              # went bankrupt because of a L.50 token! => in rules limbo
+              # just give the company a stupid token and move on
+              #
+              @log << "Giving #{corp.name} a discounted token due to bankruptcy"
+              corp << Token.new(corp, price: 0)
+              corp.spend(corp.cash, @game.bank) if corp.cash.positive?
+
+              @round.token_emr_entity = nil
+              @round.token_emr_amount = 0
+
+              @game.transform_finish if @game.transform_state
+            else
+              # went bankrupt because of a train purchase
+              # let the company off the hook (for this round)
+              @game.done_operating!(corp)
+              @game.done_this_round[corp] = true
+            end
             @round.clear_cache!
           end
         end

--- a/lib/engine/game/g_1841/step/buy_new_tokens.rb
+++ b/lib/engine/game/g_1841/step/buy_new_tokens.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/base'
+require_relative 'emergency_assist'
 
 module Engine
   module Game
     module G1841
       module Step
         class BuyNewTokens < Engine::Step::Base
+          include EmergencyAssist
+
           def actions(entity)
             return [] unless entity == pending_entity
 
@@ -62,8 +65,13 @@ module Engine
 
             case type
             when :start
-              @game.purchase_tokens!(entity, num, total)
+              @game.purchase_tokens!(entity, num, total) # should never need token_emegency_money
             when :transform
+              if entity.cash < total
+                sweep_cash(entity, entity.player, total)
+                raise GameError, "#{entity.name} does not have #{format_currency(total_cost)} for token" if entity.cash < total
+              end
+
               @game.purchase_additional_tokens!(entity, num, total)
               @game.transform_finish
             end

--- a/lib/engine/game/g_1841/step/emergency_assist.rb
+++ b/lib/engine/game/g_1841/step/emergency_assist.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1841
+      module Step
+        module EmergencyAssist
+          def sweep_cash(entity, seller, cost)
+            return if entity == seller
+
+            @game.chain_of_control(entity).each do |controller|
+              needed = [cost - entity.cash, 0].max
+              amount = [needed, controller.cash].min
+              if amount.positive?
+                @log << "Sweeping #{@game.format_currency(amount)} from #{controller.name} to #{entity.name} (EMR)"
+                controller.spend(amount, entity)
+              end
+              break if controller == seller
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1841/step/token_emergency_money.rb
+++ b/lib/engine/game/g_1841/step/token_emergency_money.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/emergency_money'
+require_relative 'emergency_assist'
+
+module Engine
+  module Game
+    module G1841
+      module Step
+        class TokenEmergencyMoney < Engine::Step::Base
+          include Engine::Step::EmergencyMoney
+          include EmergencyAssist
+
+          def actions(entity)
+            return [] if entity != active_entity && entity != active_entity&.player
+            return ['sell_shares'] if can_sell_shares?(entity)
+
+            []
+          end
+
+          def round_state
+            {
+              token_emr_entity: nil,
+              token_emr_amount: 0,
+            }
+          end
+
+          def setup
+            super
+            @round.token_emr_entity = nil
+            @round.token_emr_amount = 0
+          end
+
+          def description
+            'Token Emergency Money Raising'
+          end
+
+          def cash_crisis?
+            true
+          end
+
+          def active?
+            active_entity
+          end
+
+          def active_entity
+            @round.token_emr_entity
+          end
+
+          def active_entities
+            [@round.token_emr_entity]
+          end
+
+          def needed_cash(_entity)
+            @round.token_emr_amount
+          end
+
+          def can_sell?(_entity, bundle)
+            @game.emr_can_sell?(active_entity, bundle)
+          end
+
+          def issuable_shares(entity)
+            return [] unless entity.corporation?
+
+            @game.emergency_issuable_bundles(entity, needed_cash(entity))
+          end
+
+          def can_sell_shares?(entity)
+            return issuable_shares(entity).any? if entity.corporation?
+
+            entity.cash < needed_cash(entity)
+          end
+
+          def show_cash?(_entity)
+            true
+          end
+
+          def available_cash(corp)
+            @game.emergency_cash_before_issuing(corp, needed_cash(corp))
+          end
+
+          def available_cash_str(corp)
+            str = @game.format_currency(corp.cash)
+            avail = available_cash(corp)
+            str += " (#{@game.format_currency(avail)} EMR cash is available)" if avail > corp.cash
+            str
+          end
+
+          def issuing_corporation(corp)
+            issuable_shares(corp).first&.owner || corp
+          end
+
+          def president_may_contribute?(corp)
+            @game.emergency_cash_before_issuing(corp, needed_cash(corp)) < needed_cash(corp)
+          end
+
+          def issue_verb(_entity)
+            'sell'
+          end
+
+          def issue_text(entity)
+            bundles = issuable_shares(entity)
+            owner = bundles&.first&.owner
+
+            str = "#{owner.name} EMR Sell Shares"
+            str += " (for #{entity.name})" if owner != entity
+            str
+          end
+
+          def owner_funds(entity)
+            [needed_cash(entity) - @game.emergency_issuable_funds(entity), 0].max
+          end
+
+          def process_sell_shares(action)
+            seller = action.bundle.owner
+            corp = action.bundle.corporation
+            raise GameError, "Cannot sell shares of #{corp.name}" unless can_sell?(action.entity, action.bundle)
+
+            if @game.emergency_cash_before_selling(active_entity, needed_cash(active_entity)) >= needed_cash(active_entity)
+              raise GameError, 'Did not need to sell shares'
+            end
+
+            @game.sell_shares_and_change_price(action.bundle, allow_president_change: @game.pres_change_ok?(corp))
+            @game.update_frozen!
+            sweep_cash(active_entity, seller, needed_cash(active_entity))
+
+            if @game.emergency_cash_before_selling(active_entity, needed_cash(active_entity)) >= needed_cash(active_entity)
+              @round.token_emr_entity = nil
+              @round.token_emr_amount = 0
+              @round.clear_cache!
+            end
+
+            @round.recalculate_order if @round.respond_to?(:recalculate_order)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1841/step/token_emergency_money.rb
+++ b/lib/engine/game/g_1841/step/token_emergency_money.rb
@@ -108,6 +108,10 @@ module Engine
             str
           end
 
+          def issuable_cash(entity)
+            @game.emergency_issuable_cash(entity)
+          end
+
           def owner_funds(entity)
             [needed_cash(entity) - @game.emergency_issuable_funds(entity), 0].max
           end


### PR DESCRIPTION
### Implementation Notes

* **Explanation of Change**

* Finishes the last case of EMR: a token purchase after transforming a minor into a major. Unlike other token purchases (when forming a corp), this is the only one that potentially requires more than just issuing IPO shares to cover it.

**Common Code Changes**
* UI::CashCrisis - much like the changes to UI::BuyTrains, I had to customize somewhat for the whole corps owning corps deal. I did test this on 18NY and I don't appear to have broken anything

* **Screenshots**
![token_emr](https://github.com/tobymao/18xx/assets/8494213/efb4324d-3bce-4705-b5bc-252951609eac)


* **Any Assumptions / Hacks**
