### PR TITLE
18Dixie: Cannot sell shares until a corporation has operated

### DIFF
--- a/lib/engine/game/g_18_dixie/game.rb
+++ b/lib/engine/game/g_18_dixie/game.rb
@@ -51,6 +51,7 @@ module Engine
                                                                            'ICG may form on purchase of first 5D '\
                                                                            'if SCL not formed'],
                                               }).freeze
+        SELL_AFTER = :operate
         SELL_BUY_ORDER = :sell_buy_sell
         STARTING_CASH = { 3 => 700, 4 => 525, 5 => 425, 6 => 375 }.freeze
         TILE_RESERVATION_BLOCKS_OTHERS = :always


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Set the flag so that shares can only be sold once a corporation has operated
* **Screenshots**

* **Any Assumptions / Hacks**
