### PR TITLE
1841: Add player to player share and concession purchases

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -11,6 +11,9 @@ module View
       include Actionable
 
       needs :corporation
+      needs :selected_corporation, default: nil, store: true
+      needs :flexible_player, default: nil, store: true
+      needs :flexible_corporation, default: nil, store: true
 
       def render
         @step = @game.round.active_step
@@ -135,16 +138,39 @@ module View
       end
 
       def render_other_player_shares
-        @corporation.player_share_holders.keys.reject { |sh| sh == @current_entity }.flat_map do |sh|
-          shares = sh.shares_of(@corporation).select(&:buyable).group_by(&:percent).values.map(&:first)
-          shares.sort_by(&:percent).reverse.map do |share|
-            next unless @step.can_buy?(@current_entity, share.to_bundle)
+        if @step.respond_to?(:flexible_buy?) && @step.flexible_buy?(@current_entity)
+          if @flexible_player && @flexible_corporation != @selected_corporation
+            store(:flexible_corporation, nil, skip: true)
+            store(:flexible_player, nil)
+          end
+          @corporation.player_share_holders.keys.reject { |sh| sh == @current_entity }.select(&:player?).flat_map do |sh|
+            next unless @step.flexible_can_buy_any_shares?(@current_entity, sh.shares_of(@corporation))
 
-            h(Button::BuyShare,
-              share: share,
-              entity: @current_entity,
-              percentages_available: shares.group_by(&:percent).size,
-              source: sh.name)
+            update_player = lambda do
+              store(:flexible_corporation, @corporation, skip: true)
+              store(:flexible_player, sh)
+            end
+
+            button_props = {
+              attrs: {
+                type: :button,
+              },
+              on: { click: update_player },
+            }
+            h(:button, button_props, "Buy Shares from #{sh.name}")
+          end
+        else
+          @corporation.player_share_holders.keys.reject { |sh| sh == @current_entity }.flat_map do |sh|
+            shares = sh.shares_of(@corporation).select(&:buyable).group_by(&:percent).values.map(&:first)
+            shares.sort_by(&:percent).reverse.map do |share|
+              next unless @step.can_buy?(@current_entity, share.to_bundle)
+
+              h(Button::BuyShare,
+                share: share,
+                entity: @current_entity,
+                percentages_available: shares.group_by(&:percent).size,
+                source: sh.name)
+            end
           end
         end
       end

--- a/assets/app/view/game/flexible_buy.rb
+++ b/assets/app/view/game/flexible_buy.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+require 'view/game/button/buy_share'
+
+module View
+  module Game
+    class FlexibleBuy < Snabberb::Component
+      include Actionable
+
+      needs :flexible_player, default: nil, store: true
+      needs :flexible_corporation, default: nil, store: true
+
+      def render
+        @step = @game.round.active_step
+        @current_entity = @step.current_entity
+
+        children = []
+
+        bundles = @step.flexible_bundles(@current_entity, @flexible_player, @flexible_corporation)
+        children << render_flexible_bundles(bundles) unless bundles.empty?
+
+        h(:div, children)
+      end
+
+      def render_flexible_bundles(bundles)
+        lines = []
+        lines << h(:h3, "#{@flexible_corporation.name} shares owned by #{@flexible_player.name}:")
+
+        header = h(:thead, [h(:tr, [
+            h(:th, 'Percent'),
+            h(:th, 'Value'),
+            h(:th, 'Price'),
+            h(:th, 'Buy'),
+          ])])
+
+        rows = bundles.map.with_index do |bundle, _idx|
+          input_props = {
+            style: {
+              height: '1.5rem',
+              width: '3rem',
+              padding: '0 0 0 0.2rem',
+              margin: '0',
+            },
+            attrs: {
+              type: 'number',
+              min: 1,
+              max: @current_entity.cash,
+              value: 1,
+              size: @current_entity.cash.to_s.size + 2,
+            },
+          }
+          input = h('input.no_margin', input_props)
+
+          buy_shares_click = lambda do
+            price = input.JS['elm'].JS['value'].to_i
+            price_percent = bundle.corporation.type == :major ? 10 : 20
+            share_price = (price * price_percent / bundle.percent).to_i
+            return unless @step.flexible_can_buy_shares?(@current_entity, bundle.shares, price)
+
+            buy_shares = lambda do
+              process_action(
+                Engine::Action::BuyShares.new(
+                  @current_entity,
+                  shares: bundle.shares,
+                  percent: bundle.percent,
+                  share_price: share_price,
+                  total_price: price
+                )
+              )
+            end
+            check_consent(@current_entity, @flexible_player, buy_shares)
+          end
+
+          button = h('button.no_margin', { on: { click: buy_shares_click } }, 'Buy')
+
+          h(:tr, [
+            h(:td, "#{bundle.percent}%"),
+            h(:td, @game.format_currency(bundle.price)),
+            h(:td, [input]),
+            h(:td, [button]),
+          ])
+        end
+
+        table_props = {
+          style: {
+            color: 'black',
+            border: '1px solid',
+          },
+        }
+
+        lines << h(:table, table_props, [header, h(:tbody, rows)])
+        h(:div, lines)
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -23,6 +23,7 @@ module View
         needs :last_player, default: nil, store: true
         needs :corporation_to_par, default: nil, store: true
         needs :show_other_players, default: nil, store: true
+        needs :flexible_player, default: nil, store: true
 
         def render
           round = @game.round
@@ -55,6 +56,7 @@ module View
           children = []
 
           children << h(Choose) if @current_actions.include?('choose') && @step.choice_available?(@current_entity)
+          children << h(FlexibleBuy) if @current_actions.include?('buy_shares') && @flexible_player
 
           if @step.respond_to?(:must_sell?) && @step.must_sell?(@current_entity)
             children << if @game.num_certs(@current_entity) > @game.cert_limit(@current_entity)

--- a/lib/engine/action/buy_shares.rb
+++ b/lib/engine/action/buy_shares.rb
@@ -5,15 +5,17 @@ require_relative 'base'
 module Engine
   module Action
     class BuyShares < Base
-      attr_reader :entity, :bundle, :swap, :purchase_for, :borrow_from
+      attr_reader :entity, :bundle, :swap, :purchase_for, :borrow_from, :total_price
 
-      def initialize(entity, shares:, share_price: nil, percent: nil, swap: nil, purchase_for: nil, borrow_from: nil)
+      def initialize(entity, shares:, share_price: nil, percent: nil, swap: nil, purchase_for: nil,
+                     borrow_from: nil, total_price: nil)
         super(entity)
         @bundle = ShareBundle.new(Array(shares), percent)
         @bundle.share_price = share_price
         @swap = swap
         @purchase_for = purchase_for
         @borrow_from = borrow_from
+        @total_price = total_price
       end
 
       def self.h_to_args(h, game)
@@ -24,6 +26,7 @@ module Engine
           swap: game.share_by_id(h['swap']),
           purchase_for: game.get(h['purchase_for_type'], h['purchase_for']),
           borrow_from: game.get(h['borrow_from_type'], h['borrow_from']),
+          total_price: h['total_price'],
         }
       end
 
@@ -37,6 +40,7 @@ module Engine
           'purchase_for' => @purchase_for&.id,
           'borrow_from_type' => type_s(@borrow_from),
           'borrow_from' => @borrow_from&.id,
+          'total_price' => @total_price,
         }
       end
     end

--- a/lib/engine/game/g_1841/map.rb
+++ b/lib/engine/game/g_1841/map.rb
@@ -351,6 +351,8 @@ module Engine
         HISTORICAL_CITIES = %w[F8 F16 H4 J6 M3 R14 P12 Q11].freeze
         VENETO = %w[H12 G13 F14 G15 F16 D16 D14 C15].freeze
         TUSCAN_TOKEN_HEXES = %w[Q11 R14].freeze
+        LUGANO = 'C7'
+        FIRENZE = 'R14'
 
         AXES = { x: :number, y: :letter }.freeze
       end

--- a/lib/engine/game/g_1841/meta.rb
+++ b/lib/engine/game/g_1841/meta.rb
@@ -18,7 +18,24 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1841'
 
         PLAYER_RANGE = [3, 8].freeze
-        OPTIONAL_RULES = [].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :p2p_purchases,
+            short_name: 'Player to player purchases',
+            desc: 'Allow players to buy stock/concessions directly from other players',
+          },
+          {
+            sym: :lite,
+            short_name: '1841lite map and rules',
+            desc: 'Smaller map, train roster, and bank for a shorter game',
+            players: [3, 4, 5, 6],
+          },
+          {
+            sym: :version_1,
+            short_name: 'Version 1',
+            desc: 'Original auction, map and corporations',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_1841/round/stock.rb
+++ b/lib/engine/game/g_1841/round/stock.rb
@@ -29,6 +29,14 @@ module Engine
             end
             @game.finish_stock_round
           end
+
+          def sold_out?(corporation)
+            super && !@game.frozen?(corporation)
+          end
+
+          def corporations_to_move_price
+            @game.corporations.select(&:floated?)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1841/step/base_buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1841/step/base_buy_sell_par_shares.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+require_relative '../../../step/share_buying'
+require_relative '../../../action/buy_shares'
+require_relative '../../../action/par'
+require_relative 'corp_start'
+
+module Engine
+  module Game
+    module G1841
+      module Step
+        class BaseBuySellParShares < Engine::Step::BuySellParShares
+          include CorpStart
+          def description
+            'Sell then Buy Shares or Concessions'
+          end
+
+          def round_state
+            super.merge({ corp_started: nil })
+          end
+
+          def setup
+            super
+            @round.corp_started = nil
+          end
+
+          def can_buy_any_from_player?(_entity)
+            false
+          end
+
+          def can_buy_multiple?(entity, corporation, _owner)
+            @round.current_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation } &&
+              entity.percent_of(corporation) < 40
+          end
+
+          def can_buy?(entity, bundle)
+            return unless bundle
+            return unless bundle.buyable
+            return if bundle.owner.corporation? && bundle.owner != bundle.corporation # can't buy non-IPO shares in treasury
+            return if bundle.owner.player? && entity.player? && !@game.allow_player2player_sales?
+            return if bundle.owner.player? && entity.corporation?
+
+            super
+          end
+
+          def can_gain?(entity, bundle, exchange: false)
+            return if !bundle || !entity
+
+            corporation = bundle.corporation
+
+            # can't exceed cert limit
+            (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity)) &&
+              # can't allow player to control too much
+              ((@game.player_controlled_percentage(entity,
+                                                   corporation) + bundle.common_percent) <= corporation.max_ownership_percent)
+          end
+
+          def can_dump?(entity, bundle)
+            super && (!bundle.presidents_share || @game.pres_change_ok?(bundle.corporation))
+          end
+
+          def pass!
+            super
+            post_share_pass_step! if @round.corp_started
+          end
+
+          def log_pass(entity)
+            return super unless @round.corp_started
+
+            @log << "#{entity.name} declines to purchase additional shares of #{@round.corp_started.name}"
+          end
+
+          def can_sell_any_of_corporation?(entity, corporation)
+            bundles = @game.bundles_for_corporation(entity, corporation).reject { |b| b.corporation == entity }
+            bundles.any? { |bundle| can_sell?(entity, bundle) }
+          end
+
+          # include anti-trust rule
+          def must_sell?(entity)
+            return false unless can_sell_any?(entity)
+            return true if @game.num_certs(entity) > @game.cert_limit(entity)
+
+            player = @game.controller(entity)
+            @game.corporations.any? do |corp|
+              (@game.player_controlled_percentage(player, corp) > corp.max_ownership_percent) &&
+                can_sell_any_of_corporation?(entity, corp)
+            end
+          end
+
+          def sell_shares(entity, shares, swap: nil)
+            old_circular = @game.circular_corporations
+            raise GameError, "Cannot sell shares of #{shares.corporation.name}" if !can_sell?(entity, shares) && !swap
+
+            @round.players_sold[shares.owner][shares.corporation] = :now
+            @game.sell_shares_and_change_price(shares, swap: swap,
+                                                       allow_president_change: @game.pres_change_ok?(shares.corporation))
+            @game.update_frozen!
+            @round.recalculate_order if @round.respond_to?(:recalculate_order)
+            return if @game.circular_corporations.none? { |c| !old_circular.include?(c) }
+
+            raise GameError, 'Cannot sell if it causes a circular chain of ownership'
+          end
+
+          def process_buy_shares(action)
+            old_circular = @game.circular_corporations
+            @round.players_bought[action.entity][action.bundle.corporation] += action.bundle.percent
+            @round.bought_from_ipo = true if action.bundle.owner.corporation?
+            buy_shares(action.purchase_for || action.entity, action.bundle,
+                       swap: action.swap, borrow_from: action.borrow_from,
+                       allow_president_change: @game.pres_change_ok?(action.bundle.corporation))
+            track_action(action, action.bundle.corporation)
+            @game.update_frozen!
+            return if @game.circular_corporations.none? { |c| !old_circular.include?(c) }
+
+            raise GameError, 'Cannot purchase if it causes a circular chain of ownership'
+          end
+
+          def get_par_prices(entity, corp)
+            return super if corp.type == :major
+
+            @game
+              .stock_market
+              .par_prices
+              .select { |p| p.type == :par && p.price * 2 <= entity.cash }
+          end
+
+          def process_par(action)
+            @round.corp_started = action.corporation
+            super
+          end
+
+          def visible_corporations
+            @game.sorted_corporations.reject { |c| c.closed? || (@game.historical?(c) && !@game.startable?(c)) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1841/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1841/step/buy_sell_par_shares.rb
@@ -1,148 +1,165 @@
 # frozen_string_literal: true
 
-require_relative '../../../step/buy_sell_par_shares'
-require_relative '../../../step/share_buying'
-require_relative '../../../action/buy_shares'
-require_relative '../../../action/par'
-require_relative 'corp_start'
+require_relative 'base_buy_sell_par_shares'
 
 module Engine
   module Game
     module G1841
       module Step
-        class BuySellParShares < Engine::Step::BuySellParShares
-          include CorpStart
-          def description
-            'Sell then Buy Shares or Concessions'
+        class BuySellParShares < BaseBuySellParShares
+          def flexible_buy?(entity)
+            entity&.player? && @game.allow_player2player_sales?
           end
 
-          def round_state
-            super.merge({ corp_started: nil })
+          def can_buy_any_from_player?(entity)
+            return false unless flexible_buy?(entity)
+            return false unless entity.cash.positive?
+            return false if bought?
+
+            @game.players.reject { |p| p == entity }.any? { |p| flexible_can_buy_any_shares?(entity, p.shares) }
           end
 
-          def setup
-            super
-            @round.corp_started = nil
-          end
+          def flexible_can_buy_any_shares?(entity, shares)
+            return false if shares.empty?
 
-          # FIXME
-          def purchasable_companies(_entity)
-            []
-          end
+            shares.each do |share|
+              next if entity == share.owner || @round.players_sold[entity][share.corporation]
+              next if share.president && !@game.pres_change_ok?(share.corporation)
+              next unless can_gain?(entity, share.to_bundle)
 
-          def can_buy_multiple?(entity, corporation, _owner)
-            @round.current_actions.any? { |x| x.is_a?(Action::Par) && x.corporation == corporation } &&
-              entity.percent_of(corporation) < 40
-          end
-
-          def can_buy?(entity, bundle)
-            return unless bundle
-            return unless bundle.buyable
-            return if bundle.owner.corporation? && bundle.owner != bundle.corporation # can't buy non-IPO shares in treasury
-            return if bundle.owner.player? && entity.player? && !@game.allow_player2player_sales?
-            return if bundle.owner.player? && entity.corporation?
-
-            super
-          end
-
-          def can_gain?(entity, bundle, exchange: false)
-            return if !bundle || !entity
-
-            corporation = bundle.corporation
-
-            # can't exceed cert limit
-            (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity)) &&
-              # can't allow player to control too much
-              ((@game.player_controlled_percentage(entity,
-                                                   corporation) + bundle.common_percent) <= corporation.max_ownership_percent)
-          end
-
-          def can_dump?(entity, bundle)
-            super && (!bundle.presidents_share || @game.pres_change_ok?(bundle.corporation))
-          end
-
-          def pass!
-            super
-            post_share_pass_step! if @round.corp_started
-          end
-
-          def log_pass(entity)
-            return super unless @round.corp_started
-
-            @log << "#{entity.name} declines to purchase additional shares of #{@round.corp_started.name}"
-          end
-
-          def can_sell_any_of_corporation?(entity, corporation)
-            bundles = @game.bundles_for_corporation(entity, corporation).reject { |b| b.corporation == entity }
-            bundles.any? { |bundle| can_sell?(entity, bundle) }
-          end
-
-          # include anti-trust rule
-          def must_sell?(entity)
-            return false unless can_sell_any?(entity)
-            return true if @game.num_certs(entity) > @game.cert_limit(entity)
-
-            player = @game.controller(entity)
-            @game.corporations.any? do |corp|
-              (@game.player_controlled_percentage(player, corp) > corp.max_ownership_percent) &&
-                can_sell_any_of_corporation?(entity, corp)
+              return true
             end
+            false
           end
 
-          def sell_shares(entity, shares, swap: nil)
-            old_circular = @game.circular_corporations
-            raise GameError, "Cannot sell shares of #{shares.corporation.name}" if !can_sell?(entity, shares) && !swap
+          def flexible_bundles(buyer, owner, corporation)
+            shares = owner.shares_of(corporation).sort_by(&:percent)
+            shares.reject! { |s| s.president && !@game.pres_change_ok?(corporation) }
+            bundles = @game.all_bundles_for_corporation(owner, corporation, shares: shares)
+            bundles.select { |bundle| can_sell_to_player?(buyer, owner, bundle) }
+          end
 
-            @round.players_sold[shares.owner][shares.corporation] = :now
-            @game.sell_shares_and_change_price(shares, swap: swap,
-                                                       allow_president_change: @game.pres_change_ok?(shares.corporation))
-            @game.update_frozen!
-            @round.recalculate_order if @round.respond_to?(:recalculate_order)
-            return if @game.circular_corporations.none? { |c| !old_circular.include?(c) }
+          def can_sell_to_player?(buyer, owner, bundle)
+            return unless bundle
+            return false if owner != bundle.owner
+            return true unless (pres = bundle.presidents_share)
+            return true if bundle.percent >= pres.percent # new owner can take presidency
 
-            raise GameError, 'Cannot sell if it causes a circular chain of ownership'
+            # we are dealing with a partial pres share, somebody better have
+            # enough take the presidency
+            sh = bundle.corporation.player_share_holders(corporate: true)
+            return true if sh[buyer]&.positive? # buyer just needs 1 share
+
+            (sh.reject { |k, _| k == owner }.values.max || 0) >= pres.percent
+          end
+
+          def flexible_can_buy_shares?(entity, shares, price)
+            return false if shares.empty? || entity.cash < price || bought?
+            return false if @round.players_sold[entity][shares[0].corporation]
+
+            pres = shares.find(&:president)
+            return false if pres && !@game.pres_change_ok?(pres.corporation)
+
+            can_gain?(entity, ShareBundle.new(shares))
           end
 
           def process_buy_shares(action)
+            return super unless action.bundle.owner.player?
+
+            # player to player purchase
+            #
             old_circular = @game.circular_corporations
-            @round.players_bought[action.entity][action.bundle.corporation] += action.bundle.percent
-            @round.bought_from_ipo = true if action.bundle.owner.corporation?
-            buy_shares(action.purchase_for || action.entity, action.bundle,
-                       swap: action.swap, borrow_from: action.borrow_from,
-                       allow_president_change: @game.pres_change_ok?(action.bundle.corporation))
-            track_action(action, action.bundle.corporation)
+            entity = action.entity
+            price = action.total_price
+            bundle = action.bundle
+            owner = bundle.owner
+            corporation = bundle.corporation
+            raise GameError, 'Not enough cash for purchase' unless entity.cash >= price
+            raise GameError, 'Cannot purchase these shares' unless flexible_can_buy_shares?(entity, bundle.shares, price)
+
+            # can't use share_pool.buy_shares since it uses bundle.share_price
+            @log << "#{entity.name} buys a #{bundle.percent}% share"\
+                    " of #{corporation.name} from #{owner.name} for #{@game.format_currency(price)}"
+
+            @game.share_pool.transfer_shares(bundle,
+                                             entity,
+                                             spender: entity,
+                                             receiver: owner,
+                                             price: price,
+                                             allow_president_change: @game.pres_change_ok?(corporation))
+
+            track_action(action, corporation)
             @game.update_frozen!
             return if @game.circular_corporations.none? { |c| !old_circular.include?(c) }
 
             raise GameError, 'Cannot purchase if it causes a circular chain of ownership'
           end
 
-          def get_par_prices(entity, corp)
-            return super if corp.type == :major
+          def company_president_share(company)
+            corp = @game.corporation_by_id(company&.sym)
+            return nil unless corp
 
-            @game
-              .stock_market
-              .par_prices
-              .select { |p| p.type == :par && p.price * 2 <= entity.cash }
+            owner = company.owner
+            owner = @game.share_pool if owner == @game.bank
+            owner.shares_of(corp).find(&:president)
           end
 
-          def process_par(action)
-            @round.corp_started = action.corporation
-            super
+          def purchasable_companies(entity)
+            return [] if bought? || !entity.cash.positive? || !@game.allow_player2player_sales?
+
+            @game.companies.select { |c| !c.closed? && c.owner.player? && can_buy_company?(entity, c) }
           end
 
-          def visible_corporations
-            @game.corporations.reject { |c| c.closed? || (@game.historical?(c) && !@game.startable?(c)) }
+          def buyable_bank_owned_companies(entity)
+            return [] if bought? || @game.phase.name.to_i < 3
+
+            @game.companies.select { |c| !c.closed? && c.owner == @game.bank && can_buy_company?(entity, c) }
           end
 
+          # this works for both buying from the bank as well as players
           def can_buy_company?(player, company)
-            !bought? && super
+            return false unless player.player?
+            return false if company.closed?
+            return false unless (owner = company.owner)
+            return false if owner.player? && !@game.allow_player2player_sales?
+            return false if !owner.player? && @game.phase.name.to_i < 3
+
+            # can afford?
+            pres = company_president_share(company)
+            pres_value = pres ? pres.corporation.share_price.price * 2 : 0
+            price = owner.player? ? 1 : company.value + pres_value
+            return false unless player.cash >= price
+
+            # can take pres share?
+            return true unless pres
+
+            can_gain?(player, pres.to_bundle)
           end
 
           def process_buy_company(action)
+            entity = action.entity
+            company = action.company
+            price = action.price
+            owner = company.owner
+
+            # increase price when bought from bank to account for president's share
+            pres = company_president_share(company)
+            extra = pres && !owner.player? ? pres.corporation.share_price.price * 2 : 0
+
+            raise GameError, "Not enough cash to buy #{action.company.name}" unless entity.cash >= (price + extra)
+            raise GameError, "Cannot buy #{action.company.name}" unless can_buy_company?(entity, company)
+
             super
-            @round.last_to_act = action.entity.player
-            @round.current_actions << action
+
+            return unless pres
+
+            if extra.positive?
+              @log << "#{entity.name} pays the bank for the president's share of #{pres.corporation.name}"
+              entity.spend(extra, @game.bank)
+            end
+            @log << "#{entity.name} takes the president's share and becomes president of #{pres.corporation.name}"
+            @game.share_pool.transfer_shares(pres.to_bundle, entity, allow_president_change: false)
+            pres.corporation.owner = entity
           end
         end
       end

--- a/lib/engine/game/g_1841/step/corporate_buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1841/step/corporate_buy_sell_par_shares.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require_relative 'buy_sell_par_shares'
+require_relative 'base_buy_sell_par_shares'
 
 module Engine
   module Game
     module G1841
       module Step
-        class CorporateBuySellParShares < BuySellParShares
+        class CorporateBuySellParShares < BaseBuySellParShares
           def actions(entity)
             return [] if @game.done_this_round[entity]
 
@@ -89,6 +89,14 @@ module Engine
           def process_sell_shares(action)
             super
             @round.recalculate_order
+          end
+
+          def purchaseable_companies(_entity)
+            []
+          end
+
+          def buyable_bank_owned_companies(_entity)
+            []
           end
         end
       end

--- a/lib/engine/game/g_1841/step/token.rb
+++ b/lib/engine/game/g_1841/step/token.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G1841
+      module Step
+        class Token < Engine::Step::Token
+          def process_place_token(action)
+            raise GameError, 'That location is reserved for SFMA' unless @game.check_token_hex(action.entity, action.city.hex)
+
+            super
+          end
+
+          def tokener_available_hex(entity, hex)
+            super && @game.check_token_hex(entity, hex)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -282,8 +282,14 @@ module Engine
       # previous president if they haven't sold the president's share
       # give the president the president's share
       # if the owner only sold half of their president's share, take one away
-      transfer_to = @game.sold_shares_destination(corporation) == :corporation ? corporation : self
-      swap_to = previous_president.percent_of(corporation) >= presidents_share.percent ? previous_president : transfer_to
+      if owner.player? && to_entity.player? && bundle.presidents_share
+        # special case when doing a player-to-player purchase of the president's share
+        transfer_to = to_entity
+        swap_to = to_entity
+      else
+        transfer_to = @game.sold_shares_destination(corporation) == :corporation ? corporation : self
+        swap_to = previous_president.percent_of(corporation) >= presidents_share.percent ? previous_president : transfer_to
+      end
 
       change_president(presidents_share, swap_to, president, previous_president)
 


### PR DESCRIPTION
### Implementation Notes

* **Explanation of Change**

This adds player to player stock purchases, as well as player to player and bank owned concession purchases. Concessions always come with the president's share of the corresponding corporation.

It also fixes a few bugs found during live testing.

This adds/changes the following common elements:

Engine::SharePool - add code to handle president changes for certain player to player purchases
Engine::Action::BuyShares - add new optional parameter - total_price, because there was no way to set a total bundle price except by setting the share_price for individual shares - which because of rounding may not add up to the correct value

UI::Round::Stock - support for new FlexibleBuy element
UI::BuySellShares - support for new FlexibleBuy element. Adds buttons that when clicked will cause the stock round to call FlexibleBuy
UI::FlexibleBuy - new UI element to support player to player stock purchases with player supplied prices. I struggled with the naming of this, but setted on "Flexible" because of the player being able to set the price for the bundle.

* **Screenshots**
![FlexibleBuy](https://github.com/tobymao/18xx/assets/8494213/3048cb7f-329e-4a00-a8b2-68b7638bb4c6)



* **Any Assumptions / Hacks**
