### PR TITLE
41: Blind Bidding

### DIFF
--- a/assets/app/view/game/blind_bid.rb
+++ b/assets/app/view/game/blind_bid.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'view/game/actionable'
+
+module View
+  module Game
+    class BlindBid < Snabberb::Component
+      include Actionable
+
+      def render
+        @round = @game.round
+        @current_entity = @round.current_entity
+        @step = @round.active_step
+        @current_actions = @step.current_actions
+
+        choices = @step.blind_choices(@current_entity)
+        @count = choices.size
+        max = @step.blind_max(@current_entity)
+
+        input = {}
+        rows = choices.map.with_index do |entity, idx|
+          label = @step.blind_label(entity)
+
+          input[idx] = h('input.no_margin',
+                         style: {
+                           height: '1.6rem',
+                           width: '4rem',
+                           padding: '0 0 0 0.2rem',
+                           margin: '0',
+                         },
+                         attrs: {
+                           type: 'number',
+                           min: 0,
+                           max: max,
+                           value: 0,
+                           size: max.to_s.size + 2,
+                         })
+          h(:tr, [
+            h(:td, [label]),
+            h(:td, [input[idx]]),
+          ])
+        end
+
+        click = lambda do
+          amounts = input.keys.map { |k| input[k].JS['elm'].JS['value'].to_i }
+          process_action(Engine::Action::BlindBid.new(
+                           @game.current_entity,
+                           bids: amounts,
+                         ))
+        end
+
+        button = h('button', { style: { padding: '0.2rem 0.2rem' }, on: { click: click } }, 'Enter Bid')
+
+        table_props = {
+          style: {
+            color: 'black',
+            border: '1px solid',
+          },
+        }
+
+        h(:div, [
+          h(:table, table_props, [h(:tbody, rows)]),
+          button,
+        ])
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -6,6 +6,7 @@ require 'view/game/par'
 require 'view/game/par_chart'
 require 'view/game/players'
 require 'view/game/stock_market'
+require 'view/game/blind_bid'
 
 module View
   module Game
@@ -132,7 +133,11 @@ module View
             },
           }
 
-          children = [h(Company, company: company, bids: @step.bids[company])]
+          children = if show_bids?(company)
+                       [h(Company, company: company, bids: @step.bids[company])]
+                     else
+                       [h(Company, company: company)]
+                     end
           children << render_input(company) if @selected_company == company
           h(:div, props, children)
         end
@@ -204,6 +209,7 @@ module View
         end
 
         def render_turn_bid
+          return h(BlindBid) if @current_actions.include?('blind_bid')
           return if !@current_actions.include?('bid') || @step.auctioning != :turn
 
           if @step.respond_to?(:bid_choices)
@@ -479,6 +485,10 @@ module View
           return nil unless show
 
           h(StockMarket, game: @game, show_bank: false)
+        end
+
+        def show_bids?(company)
+          @step.respond_to?(:show_bids?) ? @step.show_bids?(company) : !@step.bids[company].empty?
         end
       end
     end

--- a/lib/engine/action/blind_bid.rb
+++ b/lib/engine/action/blind_bid.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class BlindBid < Base
+      attr_reader :bids
+
+      def initialize(entity, bids: [])
+        super(entity)
+        @bids = bids
+      end
+
+      def self.h_to_args(h, _game)
+        {
+          bids: h['bids']&.map(&:to_i),
+        }
+      end
+
+      def args_to_h
+        {
+          'bids' => @bids,
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1841/round/operating.rb
+++ b/lib/engine/game/g_1841/round/operating.rb
@@ -36,11 +36,6 @@ module Engine
             next_entity! unless @game.finished
           end
 
-          def next_entity!
-            after_operating(@entities[@entity_index])
-            super unless @game.finished
-          end
-
           def start_operating
             return if @game.finished
 
@@ -54,7 +49,7 @@ module Engine
             super
           end
 
-          def after_operating(entity)
+          def after_end_of_turn(entity)
             return unless entity&.corporation?
 
             @game.done_operating!(entity)
@@ -70,8 +65,9 @@ module Engine
 
             return unless @game.circular?(entity)
 
-            # for circular ownership, sell shares of controlling corps
-            entity.corporate_shares.select { |s| @game.in_chain?(entity, s.corporation) }.each do |share|
+            # for circular ownership, sell shares of corps that were in chain when it became frozen
+            # circular will remain set as long as corp is frozen
+            entity.corporate_shares.select { |s| @game.in_cicular_chain?(entity, s.corporation) }.each do |share|
               @game.sell_shares_and_change_price(share.to_bundle, allow_president_change: true)
             end
             @game.update_frozen!

--- a/lib/engine/game/g_1841/step/blind_auction.rb
+++ b/lib/engine/game/g_1841/step/blind_auction.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/waterfall_auction'
+
+module Engine
+  module Game
+    module G1841
+      module Step
+        class BlindAuction < Engine::Step::WaterfallAuction
+          MIN_BID = 20
+
+          def actions(entity)
+            return [] if @companies.empty?
+            return ['blind_bid'] if entity == current_entity && @initial_bids < @game.players.size
+
+            correct = false
+
+            active_auction do |_company, bids|
+              correct = next_bid(bids).entity == entity
+            end
+
+            correct || entity == current_entity ? ACTIONS : []
+          end
+
+          def setup
+            setup_auction
+            @companies = @game.companies.dup
+            @cheapest = @companies.first
+            @bidders = Hash.new { |h, k| h[k] = [] }
+            @initial_bids = 0
+            @bid_list = Hash.new { |h, k| h[k] = [] }
+            @player_total = {}
+            @player_bids = {}
+          end
+
+          def blind_choices(_entity)
+            @companies
+          end
+
+          def blind_label(entity)
+            entity.sym
+          end
+
+          def blind_max(entity)
+            entity.cash
+          end
+
+          def validate_blind_bid(entity, bids)
+            total = 0
+            bids.each do |b|
+              if b.positive? && b < MIN_BID
+                raise GameError, "Non-zero bids must be a minimum of #{@game.format_currency(MIN_BID)}"
+              end
+
+              total += b
+            end
+            raise GameError, "Total bid cannot be more than  #{@game.format_currency(entity.cash)}" if total > entity.cash
+
+            @player_total[entity] = total
+          end
+
+          def add_blind_bid(entity, company, price)
+            return unless price.positive?
+
+            bid = Action::Bid.new(entity, price: price, company: company)
+            @bids[company] << bid
+            @bidders[company] |= [entity]
+          end
+
+          def can_auction?(_company)
+            true
+          end
+
+          def show_bids
+            @log << 'Bids:'
+            @companies.each do |c|
+              @log << "#{c.sym}: #{@bid_list[c].join(' | ')}"
+            end
+          end
+
+          def reorder_players
+            current_order = @game.players.dup
+            @game.players.sort_by! do |player|
+              sort_values = [@player_total[player]]
+              sort_values.concat(@player_bids[player])
+              sort_values << current_order.index(player)
+              sort_values
+            end.reverse
+            @log << '-- New player order: --'
+            @game.players.each.with_index do |p, idx|
+              pd = idx.zero? ? ' - Priority Deal -' : ''
+              @log << "#{p.name}#{pd}"
+            end
+          end
+
+          def remove_nulls
+            @companies.dup.each do |c|
+              @companies.delete(c) if @bids[c].empty?
+            end
+          end
+
+          def remove_winners_and_losers
+            @companies.dup.each do |c|
+              bids = @bids[c]
+              prices = bids.map(&:price)
+              highest = prices.max
+              count = prices.count { |p| p == highest }
+              if count == 1
+                winning_bid = @bids[c].find { |bid| bid.price == highest }
+                @bids.delete(c)
+                buy_company(winning_bid.entity, c, highest)
+                next
+              end
+
+              # remove any lower bids
+              @bids[c].reject! { |b| b.price < highest }
+            end
+          end
+
+          def process_blind_bid(action)
+            entity = action.entity
+            bids = action.bids
+            validate_blind_bid(entity, bids)
+            action.entity.unpass!
+
+            @player_bids[entity] = bids
+            bids.each.with_index do |b, idx|
+              company = @companies[idx]
+              @bid_list[company] << b
+              add_blind_bid(entity, company, b)
+            end
+            @log << "#{entity.name} has placed bid"
+            @round.next_entity_index!
+
+            @initial_bids += 1
+            return unless @initial_bids >= @game.players.size
+
+            # done with blind bidding. Move to waterfall auction if needed
+            show_bids
+            remove_nulls
+            remove_winners_and_losers
+            reorder_players
+            resolve_bids
+          end
+
+          def show_companies
+            @initial_bids < @game.players.size
+          end
+
+          def show_bids?(_company)
+            @initial_bids >= @game.players.size
+          end
+
+          def next_bid(bids)
+            bids.min_by { |b| [b.price, @game.players.find_index(b.entity)] }
+          end
+
+          def active_entities
+            active_auction do |_, bids|
+              return [next_bid(bids).entity]
+            end
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Implementation Notes

* **Explanation of Change**

This adds a new auction type: Blind Bidding, for the version 1 rules of 1841
It also finishes the automatic selling of stock for corporations that were frozen due to a circular chain of ownership

This finishes all planned functionality for 1841

Common code changes:

UI::BlindBid - new auction type and action
UI::Round::Auction - use BlindBid, and hide bids for companies when blind bidding
Engine::Action::BlindBid - new action for blind bids 

* **Screenshots**
A blind bid:
![41_blind_bid](https://github.com/tobymao/18xx/assets/8494213/6e24af73-0371-48a6-be16-403e0e36cbd4)


* **Any Assumptions / Hacks**
