### PR TITLE
1841: Fix EMR player sales, fix bankruptcy

### DIFF
--- a/assets/app/view/game/emergency_money.rb
+++ b/assets/app/view/game/emergency_money.rb
@@ -73,7 +73,7 @@ module View
 
       def render_bankruptcy_option(option)
         resign = lambda do
-          process_action(Engine::Action::Bankrupt.new(entity, type: option))
+          process_action(Engine::Action::Bankrupt.new(entity, option: option))
         end
 
         props = {

--- a/assets/app/view/game/sell_shares.rb
+++ b/assets/app/view/game/sell_shares.rb
@@ -14,7 +14,13 @@ module View
       def render
         step = @game.round.active_step
 
-        buttons = @game.sellable_bundles(@player, @corporation).map do |bundle|
+        bundles = if step.respond_to?(:sellable_bundles)
+                    step.sellable_bundles(@player, @corporation)
+                  else
+                    @game.sellable_bundles(@player, @corporation)
+                  end
+
+        buttons = bundles.map do |bundle|
           sell = lambda do
             process_action(@action.new(
               @player,

--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -1263,7 +1263,6 @@ module Engine
             end
           end
 
-          old_circular = circular_corporations
           shares = from.shares_by_corporation
           shares.keys.each do |corp|
             next if corp == from
@@ -1272,10 +1271,6 @@ module Engine
             @log << "Moving #{shares[corp].size} share(s) of #{corp.name} from #{from.name} to #{target.name} treasury"
             bundle = ShareBundle.new(Array(shares[corp]))
             @share_pool.transfer_shares(bundle, target, allow_president_change: true)
-            update_frozen!
-            next if @merger_tuscan || circular_corporations.none? { |c| !old_circular.include?(c) }
-
-            raise GameError, 'Illegal circular ownership chain is created by this merger. Undo required.'
           end
 
           # cash
@@ -2581,7 +2576,8 @@ module Engine
             return
           end
 
-          @log << "#{player.name} is bankrupt and receives a #{format_currency(BANKRUPTCY_LOAN)} loan form the bank"
+          @log << "#{player.name} is bankrupt and receives a #{format_currency(BANKRUPTCY_LOAN)} loan from the bank"
+          @bank.spend(BANKRUPTCY_LOAN, player)
           @loans[player] += BANKRUPTCY_LOAN
         end
 

--- a/lib/engine/game/g_1841/step/buy_train.rb
+++ b/lib/engine/game/g_1841/step/buy_train.rb
@@ -162,6 +162,12 @@ module Engine
           def issuing_corporation(corp)
             issuable_shares(corp).first&.owner || corp
           end
+
+          def sellable_bundles(player, corp)
+            bundles = @game.sellable_bundles(player, corp)
+            bundles.each { |b| b.share_price = corp.share_price.price / 2.0 }
+            bundles
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #9348 

Common code changes:
UI::SellStock - allow step to override bundle creation. I've tested this w/o the override to make sure I didn't break anything.
UI:EmergencyMoney - fix broken option to Bankrupt action. Only affects 1841.