### PR TITLE
1841: Merger fixes

### DIFF
--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -1370,10 +1370,10 @@ module Engine
           tp = total_percent(entity, @merger_corpa, @merger_corpb)
           pres_share = @merger_target.shares_of(@merger_target).find(&:president)
           if @merger_state == :exchange_pass1
-            if tp >= 40 || !pres_share || !entity.player || !afford_upgrade_to_pres?(entity, tp, @merger_target)
+            if tp >= 40 || !pres_share || !entity.player? || !afford_upgrade_to_pres?(entity, tp, @merger_target)
               merger_do_exchange(:no)
             else
-              # ask to see if they want to upgrade to president's share
+              # ask to see if the player wants to upgrade to president's share
               @round.pending_options << {
                 title: @merger_title,
                 entity: entity,

--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -1202,9 +1202,11 @@ module Engine
         end
 
         def merger_values(corpa, corpb)
-          if corpa.type == :major && corpa.share_price.price > 250 && corpa.share_price.price > 250
+          raise GameError, 'Both corporations must be the same type' unless corpa.type == corpb.type
+
+          if corpa.type == :major && corpa.share_price.price > 250 && corpb.share_price.price > 250
             #  both majors are above 250
-            return [corpa.share_price, corpb.share_price].sort if corpa.share_price.price != corpb.share_price.price
+            return [corpa.share_price, corpb.share_price].sort_by(&:price) if corpa.share_price.price != corpb.share_price.price
 
             return [corpa.share_price]
           end
@@ -1230,6 +1232,9 @@ module Engine
           @merger_target = target
           @merger_tuscan = tuscan_merge
           @merger_decider = tuscan_merge ? @tuscan_merge_decider : corpa.player
+          @merger_title = tuscan_merge ? 'Tuscan Merge - ' : ''
+          @merger_title += "Merging #{corpa.name} with #{corpb.name} to form #{target.name}: "
+
           @log << if tuscan_merge
                     "-- Tuscan Merge: #{corpa.name} and #{corpb.name} will merge and form #{target.name} --"
                   else
@@ -1242,6 +1247,7 @@ module Engine
           end
           # player must choose share price
           @round.pending_options << {
+            title: @merger_title,
             entity: @merger_tuscan ? @tuscan_merge_decider : corpa,
             type: :price,
             share_prices: share_prices,
@@ -1326,11 +1332,14 @@ module Engine
           @merger_target.floated = true
           @merger_target.share_price = share_price
 
+          @merger_share_holders = merger_share_holder_list(@merger_corpa, @merger_corpb, 10)
+
+          @merger_sh_list = @merger_share_holders.select { |sh| total_percent(sh, @merger_corpa, @merger_corpb) >= 20 }
+
           # move assets (except for tokens) to the target
           move_assets(@merger_corpa, @merger_corpb, @merger_target)
           move_assets(@merger_corpb, @merger_corpa, @merger_target)
 
-          @merger_sh_list = merger_share_holder_list(@merger_corpa, @merger_corpb, 20)
           if @merger_corpa.type == :major
             @merger_state = :exchange_pass1
             merger_next_exchange
@@ -1361,14 +1370,16 @@ module Engine
           tp = total_percent(entity, @merger_corpa, @merger_corpb)
           pres_share = @merger_target.shares_of(@merger_target).find(&:president)
           if @merger_state == :exchange_pass1
-            if tp >= 40 || !pres_share || !entity.player? || !afford_upgrade_to_pres?(entity, tp, @merger_target)
+            if tp >= 40 || !pres_share || !entity.player || !afford_upgrade_to_pres?(entity, tp, @merger_target)
               merger_do_exchange(:no)
             else
               # ask to see if they want to upgrade to president's share
               @round.pending_options << {
+                title: @merger_title,
                 entity: entity,
                 type: :upgrade,
                 percent: tp,
+                old_shares: (entity.shares_of(@merger_corpa) + entity.shares_of(@merger_corpb)).sort_by(&:percent).reverse,
                 target: @merger_target,
                 choices: %i[pres no],
               }
@@ -1394,9 +1405,11 @@ module Engine
             else
               # ask to see if they want to buy into a pres share or full share
               @round.pending_options << {
+                title: @merger_title,
                 entity: entity,
                 type: :upgrade,
                 percent: tp,
+                old_shares: (entity.shares_of(@merger_corpa) + entity.shares_of(@merger_corpb)).sort_by(&:percent).reverse,
                 target: @merger_target,
                 choices: options,
               }
@@ -1505,7 +1518,7 @@ module Engine
             # start 2nd pass of exchanges
             #
             @merger_state = :exchange_pass2
-            @merger_sh_list = merger_share_holder_list(@merger_corpa, @merger_corpb, 10)
+            @merger_sh_list = @merger_share_holders.select { |sh| total_percent(sh, @merger_corpa, @merger_corpb) >= 10 }
             if !@merger_sh_list.empty?
               merger_next_exchange
             else
@@ -1841,7 +1854,14 @@ module Engine
             return share_offer_next
           end
 
+          title = if @secession_state
+                    'Ferdinandea Secession: '
+                  else
+                    "#{@tranform_tuscan ? 'Tuscan Merge - ' : ''}Transforming #{@transform_corp}: "
+                  end
+
           @round.pending_options << {
+            title: title,
             entity: entity,
             type: :share_offer,
             target: @share_offer_corp,
@@ -2050,6 +2070,7 @@ module Engine
             else
               # ask decider which corp current president of IRSFF wants to be president of
               @round.pending_options << {
+                title: 'Ferdinandea Secession: ',
                 entity: old.player ? old_owner : @secession_decider,
                 type: :pick_exchange_pres,
                 share_owner: old_owner,
@@ -2160,6 +2181,7 @@ module Engine
 
           if a_avail && b_avail && entity.player
             @round.pending_options << {
+              title: 'Ferdinandea Secession: ',
               entity: entity,
               type: :pick_exchange_corp,
               share_owner: entity,
@@ -2169,6 +2191,7 @@ module Engine
             @round.clear_cache!
           elsif a_avail && b_avail && entity == @share_pool
             @round.pending_options << {
+              title: 'Ferdinandea Secession: ',
               entity: @secession_decider,
               type: :pick_exchange_corp,
               share_owner: entity,
@@ -2259,6 +2282,7 @@ module Engine
           end
 
           @round.pending_options << {
+            title: 'Ferdinandea Secession: ',
             entity: corp.player ? corp : @secession_decider,
             type: :offer_again,
             corp: corp,

--- a/lib/engine/game/g_1841/step/choose_option.rb
+++ b/lib/engine/game/g_1841/step/choose_option.rb
@@ -51,6 +51,22 @@ module Engine
             pending_option[:share_owner]
           end
 
+          def pending_title
+            pending_option[:title] || ''
+          end
+
+          def pending_target
+            pending_option[:target]
+          end
+
+          def pending_percent
+            pending_option[:percent]
+          end
+
+          def pending_old_shares
+            pending_option[:old_shares]
+          end
+
           def pending_option
             @round.pending_options&.first || {}
           end
@@ -66,15 +82,38 @@ module Engine
           end
 
           def choice_name
-            return 'Choose share price' if pending_type == :price
-            return "Optional share purchase by #{pending_entity.name}" if pending_type == :share_offer
-            return "Choose president share for #{pending_share_owner.name}" if pending_type == :pick_exchange_pres
-            if pending_type == :pick_exchange_corp
-              return "Choose share that #{pending_share_owner.name} will exchange an IRSFF share for"
+            case pending_type
+            when :price
+              pending_title + 'Choose share price for new corporation'
+            when :share_offer
+              pending_title + "Optional purchase of a share of #{pending_target.name} by #{pending_entity.name}"
+            when :pick_exchange_pres
+              pending_title + "Choose corporation to exchange of IRSFF president share for #{pending_share_owner.name}"
+            when :pick_exchange_corp
+              pending_title + "Choose share that #{pending_share_owner.name} will exchange an IRSFF share for"
+            when :offer_again
+              pending_title + "Perform another share purchase round for #{pending_corp.name}?"
+            when :upgrade
+              if pending_percent == 10
+                pending_title + "Decision for outgoing 10% share of #{pending_old_shares[0].corporation.name}"\
+                                " owned by #{pending_entity.name}"
+              elsif pending_percent == 20 && pending_old_shares[0].president
+                pending_title + "Decision for outgoing president share of #{pending_old_shares[0].corporation.name}"\
+                                " owned by #{pending_entity.name}"
+              elsif pending_percent == 20 && pending_old_shares[0].corporation == pending_old_shares[1].corporation
+                pending_title + "Decision for outgoing two 10% shares of #{pending_old_shares[0].corporation.name}"\
+                                " owned by #{pending_entity.name}"
+              elsif pending_percent == 20
+                pending_title + "Decision for outgoing 10% share of #{pending_old_shares[0].corporation.name} and"\
+                                " 10% share of #{pending_old_shares[1].corporation.name} both owned by #{pending_entity.name}"
+              else
+                # must be 30%
+                pending_title + "Decision for outgoing president share of #{pending_old_shares[0].corporation.name} and"\
+                                " 10% share of #{pending_old_shares[1].corporation.name} both owned by #{pending_entity.name}"
+              end
+            else
+              pending_title
             end
-            return "Perform another share purchase round for #{pending_corp.name}?" if pending_type == :offer_again
-
-            'Decision for exchange of stocks in merger'
           end
 
           def choices
@@ -86,31 +125,28 @@ module Engine
               }
             when :upgrade
               opts = {}
-              target = pending_option[:target]
-              percent = pending_option[:percent]
               if pending_choices.include?(:pres)
-                opts[:pres] = "Upgrade to the president's share of #{target.name}. "\
-                              "Cost: #{@game.format_currency(@game.pres_upgrade_cost(percent, target))}"
+                opts[:pres] = "Upgrade to the president's share of #{pending_target.name}. "\
+                              "Cost: #{@game.format_currency(@game.pres_upgrade_cost(pending_percent, pending_target))}"
               end
               if pending_choices.include?(:full)
-                opts[:full] = "Upgrade to a full share of #{target.name}. "\
-                              "Cost: #{@game.format_currency(@game.full_upgrade_cost(target))}"
+                opts[:full] = "Upgrade to a full share of #{pending_target.name}. "\
+                              "Cost: #{@game.format_currency(@game.full_upgrade_cost(pending_target))}"
               end
               if pending_choices.include?(:cash)
-                opts[:cash] = "No exchange for #{target.name} "\
-                              "and receive: #{@game.format_currency(@game.full_upgrade_cost(target))}"
+                opts[:cash] = "No exchange for #{pending_target.name} "\
+                              "and receive: #{@game.format_currency(@game.full_upgrade_cost(pending_target))}"
               end
               if pending_choices.include?(:no)
-                opts[:no] = "Don't upgrade to the president's share of #{target.name}, "\
+                opts[:no] = "Don't upgrade to the president's share of #{pending_target.name}, "\
                             'just receive a normal share'
               end
               opts
             when :share_offer
-              target = pending_option[:target]
-              price = @game.format_currency(target.share_price.price)
+              price = @game.format_currency(pending_target.share_price.price)
               {
                 no: 'Pass',
-                yes: "Buy one share of #{target.name} for #{price}",
+                yes: "Buy one share of #{pending_target.name} for #{price}",
               }
             when :pick_exchange_pres, :pick_exchange_corp
               corpa = pending_option[:corpa]

--- a/lib/engine/game/g_1841/step/choose_option.rb
+++ b/lib/engine/game/g_1841/step/choose_option.rb
@@ -88,7 +88,7 @@ module Engine
             when :share_offer
               pending_title + "Optional purchase of a share of #{pending_target.name} by #{pending_entity.name}"
             when :pick_exchange_pres
-              pending_title + "Choose corporation to exchange of IRSFF president share for #{pending_share_owner.name}"
+              pending_title + "Choose corporation to exchange IRSFF president share for #{pending_share_owner.name}"
             when :pick_exchange_corp
               pending_title + "Choose share that #{pending_share_owner.name} will exchange an IRSFF share for"
             when :offer_again


### PR DESCRIPTION
Fixes #9351 

This also fixes an additional problem with mergers I discovered while testing this fix. This is an edge case where corp A owns corp B owns corp C, and A and C merge. Since I didn't construct the list of shareholders until after I moved A and C's stock into the new corp, corp B was left out since it was owned by the new corp and no entities owned the new corp yet. The solution is to generate the list of shareholders before transferring any stock.

While I was at it, I made the UI for mergers, secessions and transformations more user friendly - it was pretty terse before.