### PR TITLE
[1888] fix diesel buy-on

### DIFF
--- a/lib/engine/game/g_1888/game.rb
+++ b/lib/engine/game/g_1888/game.rb
@@ -133,7 +133,6 @@ module Engine
             distance: 999,
             price: 900,
             num: 17,
-            available_on: '6',
             discount: { '4' => 200, '5' => 200, '6' => 200 },
           },
         ].freeze


### PR DESCRIPTION
Fixes #9357

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Diesels are only buyable after all the 6's

* **Screenshots**

![Screenshot 2023-08-09 7 04 23 PM](https://github.com/tobymao/18xx/assets/1711810/680793c5-cee5-46f8-958e-d3966a8382f5)


* **Any Assumptions / Hacks**
