### PR TITLE
1841: allow purchase of president cert directly from share pool

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -84,7 +84,8 @@ module View
       def render_market_shares
         @pool_shares.map do |share|
           next unless @step.can_buy?(@current_entity, share.to_bundle)
-          if share.to_bundle.presidents_share && @pool_shares.size > 1 && !@game.can_buy_presidents_share_directly_from_market?
+          if share.to_bundle.presidents_share && @pool_shares.size > 1 &&
+              !@game.can_buy_presidents_share_directly_from_market?(share.corporation)
             next
           end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1120,7 +1120,7 @@ module Engine
         end
       end
 
-      def can_buy_presidents_share_directly_from_market?
+      def can_buy_presidents_share_directly_from_market?(_corporation)
         false
       end
 

--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -307,7 +307,7 @@ module Engine
 
         # only allow president shares in market on EMR/Frozen
         def init_share_pool
-          SharePool.new(self, allow_president_sale: true)
+          SharePool.new(self, allow_president_sale: true, no_rebundle_president_buy: true)
         end
 
         # load non-standard corporation info
@@ -2742,6 +2742,10 @@ module Engine
           end
 
           super
+        end
+
+        def can_buy_presidents_share_directly_from_market?(corporation)
+          (@phase.name.to_i >= 4) || !historical?(corporation)
         end
       end
     end

--- a/lib/engine/game/g_18_ny/game.rb
+++ b/lib/engine/game/g_18_ny/game.rb
@@ -497,7 +497,7 @@ module Engine
           true
         end
 
-        def can_buy_presidents_share_directly_from_market?
+        def can_buy_presidents_share_directly_from_market?(_corporation)
           true
         end
 

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -10,11 +10,12 @@ module Engine
     include Entity
     include ShareHolder
 
-    def initialize(game, allow_president_sale: false)
+    def initialize(game, allow_president_sale: false, no_rebundle_president_buy: false)
       @game = game
       @bank = game.bank
       @log = game.log
       @allow_president_sale = allow_president_sale
+      @no_rebundle_president_buy = no_rebundle_president_buy
     end
 
     def name
@@ -32,7 +33,7 @@ module Engine
     def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil,
                    allow_president_change: true, silent: nil, borrow_from: nil)
       bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
-      if @allow_president_sale && bundle.presidents_share && bundle.owner == self
+      if @allow_president_sale && !@no_rebundle_president_buy && bundle.presidents_share && bundle.owner == self
         bundle = ShareBundle.new(bundle.shares, bundle.corporation.share_percent)
       end
 


### PR DESCRIPTION
Fixes #9379 

Common code changes:
Engine::SharePool - add parameter to avoid re-bundling when pres cert is bought
Engine::Game::Base - add parameter to can_buy_presidents_share_directly_from_market? method
UI::BuySellShares - use parameter for can_buy_presidents_share_directly_from_market?

Also, modified 18NY to add parameter to can_buy_presidents_share_directly_from_market? method