### PR TITLE
Allow consent checks to be required for choose actions

### DIFF
--- a/assets/app/view/game/choose.rb
+++ b/assets/app/view/game/choose.rb
@@ -26,18 +26,26 @@ module View
 
         choice_buttons = choices.map do |choice, label|
           label ||= choice
-          click = lambda do
-            process_action(Engine::Action::Choose.new(
-              @game.current_entity,
-              choice: choice,
-            ))
+          process_choose = lambda do
+            choose = lambda do
+              process_action(Engine::Action::Choose.new(
+                @game.current_entity,
+                choice: choice,
+              ))
+            end
+
+            if (consenter = @game.consenter_for_choice(@game.current_entity, choice, label))
+              check_consent(@game.current_entity, consenter, choose)
+            else
+              choose.call
+            end
           end
 
           props = {
             style: {
               padding: '0.2rem 0.2rem',
             },
-            on: { click: click },
+            on: { click: process_choose },
           }
           h('button', props, label)
         end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1227,6 +1227,12 @@ module Engine
       # means that consent is not required.
       def consenter_for_buy_shares(_entity, _bundle); end
 
+      # A hook to allow a game to request a consent check for a choose action.
+      # If consent is needed then this method should return the player that
+      # needs to consent to this action. Returning nil or false means that
+      # consent is not required.
+      def consenter_for_choice(_entity, _choice, _label); end
+
       def can_run_route?(entity)
         graph_for_entity(entity).route_info(entity)&.dig(:route_available)
       end

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -344,6 +344,17 @@ module Engine
           bundle.corporation.owner
         end
 
+        # Consent for a share exchange in the private closure round is needed
+        # if the corporation whose share is being taken is not run by the same
+        # player as the private railway company being exchanged, and the share
+        # is from the corporation's treasury.
+        def consenter_for_choice(minor, choice, _label)
+          return if choice['from'] == 'market'
+
+          corporation = @corporations.find { |c| c.id == choice['corporation'] }
+          corporation.owner unless corporation.owner == minor.owner
+        end
+
         def tile_lays(entity)
           entity.corporation? ? TILE_LAYS : MINOR_TILE_LAYS
         end

--- a/lib/engine/game/g_1858/step/private_closure.rb
+++ b/lib/engine/game/g_1858/step/private_closure.rb
@@ -43,27 +43,18 @@ module Engine
           end
 
           def choices
-            choices = []
+            choices = {}
             exchange_corporations(current_entity).each do |corporation|
-              choices << choice_text(corporation, 'treasury') if corporation.num_treasury_shares.positive?
-              choices << choice_text(corporation, 'market') if corporation.num_market_shares.positive?
+              add_choice(choices, corporation, 'treasury') if corporation.num_treasury_shares.positive?
+              add_choice(choices, corporation, 'market') if corporation.num_market_shares.positive?
             end
             choices
           end
 
-          def choice_text(corporation, share_location)
-            "#{corporation.id} #{share_location} share"
-          end
-
-          # Returns a hash with two items:
-          #   corporation: the corporation object
-          #   location: a string, either 'treasury' or 'market'
-          def decode_choice(choice_text)
-            /(?<corp_id>.*) (?<location>.*) share/ =~ choice_text
-            {
-              corporation: @game.corporations.find { |corp| corp.id == corp_id },
-              location: location,
-            }
+          def add_choice(choices, corporation, location)
+            k = { 'corporation' => corporation.id, 'from' => location }
+            v = "#{corporation.id} #{location} share"
+            choices[k] = v
           end
 
           def share_chosen(corporation, share_location)
@@ -75,9 +66,9 @@ module Engine
           end
 
           def process_choose(action)
-            choice = decode_choice(action.choice)
-            corporation = choice[:corporation]
-            share_location = choice[:location]
+            choice = action.choice
+            corporation = @game.corporations.find { |c| c.id == choice['corporation'] }
+            share_location = choice['from']
             minor = action.entity
             company = @game.private_company(minor)
             player = company.owner


### PR DESCRIPTION
The 1858 private closure round is implemented using choose actions: for each private railway company, the player is shown a set of buttons with the shares that the private can be exchanged for. If a treasury share is chosen, for a corporation whose president is another player, then we need to check that consent has been received for this exchange.

This pull request adds a `Game::Base::consenter_for_choice` method. If that method returns a player then a consent check will occur. The default implementation of this method is to return nil, which means that no consent checks are needed.

This PR also tidies up 1858's use of choose actions, so that structured information is stored as the choice, instead of storing the button label text.

- [x] Branch is derived from the latest `master`
- ~~[ ] Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`