### PR TITLE
1858 fixes

### DIFF
--- a/lib/engine/game/g_1858/entities.rb
+++ b/lib/engine/game/g_1858/entities.rb
@@ -596,7 +596,7 @@ module Engine
             logo: '1858/BM',
             coordinates: %w[O8],
             abilities: [
-              { type: 'blocks_hexes', hexes: %w[O8] },
+              { type: 'blocks_hexes', hexes: %w[O8], hidden: true },
               {
                 type: 'exchange',
                 owner_type: 'player',
@@ -653,7 +653,7 @@ module Engine
             logo: '1858/VJ',
             coordinates: %w[L13],
             abilities: [
-              { type: 'blocks_hexes', hexes: %w[L13] },
+              { type: 'blocks_hexes', hexes: %w[L13], hidden: true },
               {
                 type: 'exchange',
                 owner_type: 'player',
@@ -672,7 +672,7 @@ module Engine
             logo: '1858/RT',
             coordinates: %w[N9],
             abilities: [
-              { type: 'blocks_hexes', hexes: %w[N9] },
+              { type: 'blocks_hexes', hexes: %w[N9], hidden: true },
               {
                 type: 'exchange',
                 owner_type: 'player',
@@ -806,7 +806,7 @@ module Engine
             logo: '1858/CB',
             coordinates: %w[I2],
             abilities: [
-              { type: 'blocks_hexes', hexes: %w[I2] },
+              { type: 'blocks_hexes', hexes: %w[I2], hidden: true },
               {
                 type: 'exchange',
                 owner_type: 'player',
@@ -920,7 +920,7 @@ module Engine
             logo: '1858/MS',
             coordinates: %w[F9],
             abilities: [
-              { type: 'blocks_hexes', hexes: %w[F9] },
+              { type: 'blocks_hexes', hexes: %w[F9], hidden: true },
               {
                 type: 'exchange',
                 owner_type: 'player',

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -50,19 +50,6 @@ module Engine
           { lay: true, upgrade: true, cost: 20, cannot_reuse_same_hex: true },
         ].freeze
 
-        def init_optional_rules(optional_rules)
-          rules = super
-
-          # Quick start variant doesn't work for two players.
-          rules -= [:quick_start] if two_player?
-
-          # The alternate set of private packets can only be used with the
-          # quick start variant.
-          rules -= [:set_b] unless rules.include?(:quick_start)
-
-          rules
-        end
-
         def corporation_opts
           two_player? ? { max_ownership_percent: 70 } : {}
         end
@@ -78,11 +65,11 @@ module Engine
         end
 
         def option_quick_start?
-          optional_rules.include?(:quick_start)
+          optional_rules.include?(:quick_start_a) || optional_rules.include?(:quick_start_b)
         end
 
         def option_quick_start_packets
-          if optional_rules.include?(:set_b)
+          if optional_rules.include?(:quick_start_b)
             QUICK_START_PACKETS_B
           else
             QUICK_START_PACKETS_A

--- a/lib/engine/game/g_1858/map.rb
+++ b/lib/engine/game/g_1858/map.rb
@@ -466,32 +466,39 @@ module Engine
             # City hexes
             %w[C2] =>
                     'city=revenue:0;' \
-                    'path=track:future,a:0,b:_0',
+                    'path=track:future,a:0,b:_0;' \
+                    'icon=image:1858/SC,sticky:1;',
             %w[H19] =>
                     'city=revenue:0',
             %w[B5] =>
                     'city=revenue:0;' \
                     'path=track:future,a:4,b:_0;' \
+                    'icon=image:1858/OV,sticky:1;' \
                     'border=type:province,edge:0;',
             %w[I2] =>
                     'city=revenue:0;' \
+                    'icon=image:1858/CB,sticky:1;' \
                     'border=type:province,edge:1',
             %w[G8] =>
                     'city=revenue:0;' \
                     'path=track:future,a:0,b:_0;' \
+                    'icon=image:1858/MV,sticky:1;' \
                     'border=type:province,edge:1;' \
                     'border=type:province,edge:2',
             %w[B9] =>
                     'city=revenue:0;label=Y;' \
                     'future_label=label:P,color:brown;' \
                     'path=track:future,a:0,b:_0;' \
+                    'icon=image:1858/PL,sticky:1;' \
                     'upgrade=cost:20,terrain:water;',
             %w[G20] =>
                     'city=revenue:0;label=Y;' \
                     'path=track:future,a:3,b:_0;' \
+                    'icon=image:1858/CM,sticky:1;' \
                     'upgrade=cost:20,terrain:water',
             %w[L13] =>
                     'city=revenue:0;label=Y;' \
+                    'icon=image:1858/VJ,sticky:1;' \
                     'upgrade=cost:20,terrain:water;',
             %w[E18] =>
                     'city=revenue:0;label=Y;' \
@@ -505,6 +512,7 @@ module Engine
             %w[E20] =>
                     'city=revenue:0;' \
                     'path=track:future,a:3,b:_0;' \
+                    'icon=image:1858/SJC,sticky:1;' \
                     'upgrade=cost:20,terrain:water;',
             %w[G18] =>
                     'city=revenue:0;' \
@@ -516,10 +524,12 @@ module Engine
             %w[K18] =>
                     'city=revenue:0;' \
                     'path=track:future,a:_0,b:5;' \
+                    'icon=image:1858/MC,sticky:1;' \
                     'upgrade=cost:20,terrain:water;',
             %w[H3] =>
                     'city=revenue:0;' \
                     'path=track:future,a:1,b:_0;' \
+                    'icon=image:1858/AS,sticky:1;' \
                     'upgrade=cost:40,terrain:mountain;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:1;' \
@@ -527,7 +537,8 @@ module Engine
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5',
             %w[O8] =>
-                    'city=revenue:0;label=B;',
+                    'city=revenue:0;label=B;' \
+                    'icon=image:1858/BM,sticky:1;',
           },
           yellow: {
             %w[L7] =>
@@ -550,6 +561,7 @@ module Engine
           green: {
             %w[A14] =>
                     'city=revenue:40,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=L;' \
+                    'icon=image:1858/LC,sticky:1;' \
                     'border=type:impassable,edge:5',
           },
           red: {

--- a/lib/engine/game/g_1858/meta.rb
+++ b/lib/engine/game/g_1858/meta.rb
@@ -20,18 +20,27 @@ module Engine
 
         OPTIONAL_RULES = [
           {
-            sym: :quick_start,
-            short_name: 'Quick start',
+            sym: :quick_start_a,
+            short_name: 'Quick start, set A',
             desc: 'The yellow private companies are given to players in ' \
                   'randomly assigned batches, instead of being auctioned.',
+            players: (3..6).to_a,
           },
           {
-            sym: :set_b,
+            sym: :quick_start_b,
             short_name: 'Quick start, set B',
             desc: 'Different sets of private companies for four players ' \
                   'in the quick start variant.',
+            players: (3..6).to_a,
           },
         ].freeze
+
+        def self.check_options(options, _min_players, _max_players)
+          optional_rules = (options || []).map(&:to_sym)
+          return if !optional_rules.include?(:quick_start_a) || !optional_rules.include?(:quick_start_b)
+
+          { error: 'Cannot choose both quick start variants.' }
+        end
       end
     end
   end

--- a/lib/engine/game/g_1858/meta.rb
+++ b/lib/engine/game/g_1858/meta.rb
@@ -15,6 +15,8 @@ module Engine
         GAME_LOCATION = 'Iberia'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://docs.google.com/viewer?a=v&pid=sites&srcid=YWxsLWFib2FyZGdhbWVzLmNvbXxhYWdsbGN8Z3g6NGJmNDUwZjAyOTYwZDJhMg'
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1858'
+        GAME_IMPLEMENTER = 'Oliver Burnett-Hall'
 
         PLAYER_RANGE = [2, 6].freeze
 
@@ -35,12 +37,7 @@ module Engine
           },
         ].freeze
 
-        def self.check_options(options, _min_players, _max_players)
-          optional_rules = (options || []).map(&:to_sym)
-          return if !optional_rules.include?(:quick_start_a) || !optional_rules.include?(:quick_start_b)
-
-          { error: 'Cannot choose both quick start variants.' }
-        end
+        MUTEX_RULES = [%i[quick_start_a quick_start_b]].freeze
       end
     end
   end

--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -85,6 +85,16 @@ module Engine
             true # Show bank owned private companies before public companies
           end
 
+          def visible_corporations
+            # Don't show public companies in the first stock round, only the
+            # private railway companies can be purchased.
+            if @game.turn == 1
+              @game.sorted_corporations.select { |c| c.type == :minor }
+            else
+              @game.sorted_corporations.reject(&:closed?)
+            end
+          end
+
           def process_par(action)
             super
             pass!

--- a/lib/engine/game/g_1858/step/token.rb
+++ b/lib/engine/game/g_1858/step/token.rb
@@ -179,6 +179,15 @@ module Engine
             token.price = token_cost(entity, city)
           end
 
+          def process_place_token(action)
+            # token_cost_override! is only called from the game view. When the
+            # game is being loaded we need to restore the saved token cost from
+            # the action, otherwise the default cost of Pt20 for a token will
+            # be used.
+            action.token.price = action.cost
+            super
+          end
+
           def borders_crossed(hex1, hex2)
             DISTANCES[hex1.coordinates][hex2.coordinates]
           end

--- a/public/icons/1858/AS.svg
+++ b/public/icons/1858/AS.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">A&amp;S</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">A&amp;S</text></svg>

--- a/public/icons/1858/BCR.svg
+++ b/public/icons/1858/BCR.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;CR</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;CR</text></svg>

--- a/public/icons/1858/BM.svg
+++ b/public/icons/1858/BM.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;M</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;M</text></svg>

--- a/public/icons/1858/CB.svg
+++ b/public/icons/1858/CB.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;B</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;B</text></svg>

--- a/public/icons/1858/CM.svg
+++ b/public/icons/1858/CM.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;M</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;M</text></svg>

--- a/public/icons/1858/CS.svg
+++ b/public/icons/1858/CS.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;S</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;S</text></svg>

--- a/public/icons/1858/LC.svg
+++ b/public/icons/1858/LC.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">L&amp;C</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">L&amp;C</text></svg>

--- a/public/icons/1858/MA.svg
+++ b/public/icons/1858/MA.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;A</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;A</text></svg>

--- a/public/icons/1858/MC.svg
+++ b/public/icons/1858/MC.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;C</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;C</text></svg>

--- a/public/icons/1858/MV.svg
+++ b/public/icons/1858/MV.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;V</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;V</text></svg>

--- a/public/icons/1858/MZ.svg
+++ b/public/icons/1858/MZ.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;Z</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;Z</text></svg>

--- a/public/icons/1858/PL.svg
+++ b/public/icons/1858/PL.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">P&amp;L</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">P&amp;L</text></svg>

--- a/public/icons/1858/RT.svg
+++ b/public/icons/1858/RT.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">R&amp;T</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">R&amp;T</text></svg>

--- a/public/icons/1858/SJC.svg
+++ b/public/icons/1858/SJC.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">SJ&amp;C</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">SJ&amp;C</text></svg>

--- a/public/icons/1858/VJ.svg
+++ b/public/icons/1858/VJ.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">V&amp;J</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">V&amp;J</text></svg>

--- a/public/icons/1858/ZP.svg
+++ b/public/icons/1858/ZP.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">Z&amp;P</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#e4d200"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">Z&amp;P</text></svg>

--- a/public/logos/1858/AS.svg
+++ b/public/logos/1858/AS.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">A&amp;S</text></svg>

--- a/public/logos/1858/BCR.svg
+++ b/public/logos/1858/BCR.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;CR</text></svg>

--- a/public/logos/1858/BM.svg
+++ b/public/logos/1858/BM.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;M</text></svg>

--- a/public/logos/1858/CB.svg
+++ b/public/logos/1858/CB.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;B</text></svg>

--- a/public/logos/1858/CM.svg
+++ b/public/logos/1858/CM.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;M</text></svg>

--- a/public/logos/1858/CMP.svg
+++ b/public/logos/1858/CMP.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">CM&amp;P</text></svg>

--- a/public/logos/1858/CS.svg
+++ b/public/logos/1858/CS.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;S</text></svg>

--- a/public/logos/1858/HG.svg
+++ b/public/logos/1858/HG.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">H&amp;G</text></svg>

--- a/public/logos/1858/LC.svg
+++ b/public/logos/1858/LC.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">L&amp;C</text></svg>

--- a/public/logos/1858/LG.svg
+++ b/public/logos/1858/LG.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">L&amp;G</text></svg>

--- a/public/logos/1858/MA.svg
+++ b/public/logos/1858/MA.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;A</text></svg>

--- a/public/logos/1858/MC.svg
+++ b/public/logos/1858/MC.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;C</text></svg>

--- a/public/logos/1858/MS.svg
+++ b/public/logos/1858/MS.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;S</text></svg>

--- a/public/logos/1858/MV.svg
+++ b/public/logos/1858/MV.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;V</text></svg>

--- a/public/logos/1858/MZ.svg
+++ b/public/logos/1858/MZ.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;Z</text></svg>

--- a/public/logos/1858/OV.svg
+++ b/public/logos/1858/OV.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">O&amp;V</text></svg>

--- a/public/logos/1858/PL.svg
+++ b/public/logos/1858/PL.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">P&amp;L</text></svg>

--- a/public/logos/1858/RT.svg
+++ b/public/logos/1858/RT.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">R&amp;T</text></svg>

--- a/public/logos/1858/SC.svg
+++ b/public/logos/1858/SC.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">S&amp;C</text></svg>

--- a/public/logos/1858/SJC.svg
+++ b/public/logos/1858/SJC.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">SJ&amp;C</text></svg>

--- a/public/logos/1858/VJ.svg
+++ b/public/logos/1858/VJ.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">V&amp;J</text></svg>

--- a/public/logos/1858/ZP.svg
+++ b/public/logos/1858/ZP.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">Z&amp;P</text></svg>


### PR DESCRIPTION
Various small fixes for 1858, getting it ready to go to alpha status.

There's one game-breaking bug that is fixed in this: `token_cost_override!` is used to calculate the cost of a token based on the distance between tokens, but that method wasn't being called when a game was loaded. This meant that the default cost of a token (Pt20) was always used when a game was loaded. This is now fixed, so the proper cost is always used.

There are also various small changes:

- Better selection of optional rules, using `MUTEX_RULES` and player ranges.
- Corporations are hidden in the first stock round.
- Tidying up the map, hiding blocker abilities.
- Darker yellow icons, with better contrast to yellow hexes.
- Removed unused logo files. 

Before clicking commit:

- [x] Branch is derived from the latest `master`
- ~~[ ] Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`