### PR TITLE
[1822CA] Fix M6's home and implement some basic privates

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -270,9 +270,9 @@ module Engine
             Engine::Step::AcquireCompany,
             G1822::Step::DiscardTrain,
             G1822::Step::SpecialChoose,
-            G1822::Step::SpecialTrack,
+            G1822CA::Step::SpecialTrack,
             G1822::Step::SpecialToken,
-            G1822::Step::Track,
+            G1822CA::Step::Track,
             G1822::Step::DestinationToken,
             G1822::Step::Token,
             G1822CA::Step::Route,
@@ -287,6 +287,12 @@ module Engine
 
         def must_remove_town?(entity)
           %w[P29 P30].include?(entity.id)
+        end
+
+        def upgrades_to?(from, to, _special = false, selected_company: nil)
+          return %w[5 6 57].include?(to.name) if from.name == 'AG13' && from.color == :white
+
+          super
         end
       end
     end

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -20,9 +20,20 @@ module Engine
         BIDDING_BOX_START_PRIVATE = 'P1'
 
         PRIVATE_PHASE_REVENUE = %w[P8 P9].freeze
+
+        COMPANY_MTONR = nil # Remove Town; two companies instead of one here
+        COMPANY_LCDR = nil # English Channel
+        COMPANY_EGR = nil # Hill Discount
         COMPANY_DOUBLE_CASH = 'P7'
+        COMPANY_GSWR = nil # River Discount
+        COMPANY_BER = 'P12' # Advanced Tile Lay
+        COMPANY_LSR = 'P21' # Extra Tile Lay
         COMPANY_10X_REVENUE = 'P8'
+        COMPANY_OSTH = 'P11' # Tax Haven
+        COMPANY_LUR = nil # Move Card
+        COMPANY_CHPR = 'P28' # Station Swap
         COMPANY_5X_REVENUE = 'P9'
+        COMPANY_HSBC = nil # Grimsby/Hull Bridge
 
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P6].freeze
 
@@ -251,6 +262,10 @@ module Engine
         def company_tax_haven_bundle(choice); end
         def company_tax_haven_payout(entity, per_share); end
         def num_certs_modification(_entity) = 0
+
+        def must_remove_town?(entity)
+          %w[P29 P30].include?(entity.id)
+        end
       end
     end
   end

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -263,6 +263,28 @@ module Engine
         def company_tax_haven_payout(entity, per_share); end
         def num_certs_modification(_entity) = 0
 
+        def operating_round(round_num)
+          Engine::Round::Operating.new(self, [
+            G1822::Step::PendingToken,
+            G1822::Step::FirstTurnHousekeeping,
+            Engine::Step::AcquireCompany,
+            G1822::Step::DiscardTrain,
+            G1822::Step::SpecialChoose,
+            G1822::Step::SpecialTrack,
+            G1822::Step::SpecialToken,
+            G1822::Step::Track,
+            G1822::Step::DestinationToken,
+            G1822::Step::Token,
+            G1822CA::Step::Route,
+            G1822::Step::Dividend,
+            G1822::Step::BuyTrain,
+            G1822::Step::MinorAcquisition,
+            G1822::Step::PendingToken,
+            G1822::Step::DiscardTrain,
+            G1822::Step::IssueShares,
+          ], round_num: round_num)
+        end
+
         def must_remove_town?(entity)
           %w[P29 P30].include?(entity.id)
         end

--- a/lib/engine/game/g_1822_ca/step/route.rb
+++ b/lib/engine/game/g_1822_ca/step/route.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/route'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class Route < G1822::Step::Route
+          def attach_pullman
+            @orginal_train = @pullman_train.dup
+            distance = train_city_distance(@pullman_train)
+
+            towns = 2 * distance
+
+            @pullman_train.name += "+#{towns}"
+            @pullman_train.distance = [
+              {
+                'nodes' => %w[city offboard],
+                'pay' => distance,
+                'visit' => distance,
+              },
+              {
+                'nodes' => ['town'],
+                'pay' => towns,
+                'visit' => towns,
+              },
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_ca/step/special_track.rb
+++ b/lib/engine/game/g_1822_ca/step/special_track.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/special_track'
+require_relative 'tracker'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class SpecialTrack < G1822::Step::SpecialTrack
+          include G1822CA::Tracker
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_ca/step/track.rb
+++ b/lib/engine/game/g_1822_ca/step/track.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/track'
+require_relative 'tracker'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class Track < G1822::Step::Track
+          include G1822CA::Tracker
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_ca/step/tracker.rb
+++ b/lib/engine/game/g_1822_ca/step/tracker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/tracker'
+
+module Engine
+  module Game
+    module G1822CA
+      module Tracker
+        include G1822::Tracker
+
+        def old_paths_maintained?(hex, tile)
+          if hex.tile.name == 'AG13' && hex.tile.color == :white
+            %w[5 6 57].include?(tile.name)
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -396,10 +396,8 @@ module Engine
 
         return false unless @game.legal_tile_rotation?(entity, hex, tile)
 
-        old_paths = hex.tile.paths
         old_ctedges = hex.tile.city_town_edges
 
-        new_paths = tile.paths
         new_exits = tile.exits
         new_ctedges = tile.city_town_edges
         extra_cities = [0, new_ctedges.size - old_ctedges.size].max
@@ -407,13 +405,19 @@ module Engine
 
         new_exits.all? { |edge| hex.neighbors[edge] } &&
           !(new_exits & hex_neighbors(entity, hex)).empty? &&
-          old_paths.all? { |path| new_paths.any? { |p| path <= p } } &&
+          old_paths_maintained?(hex, tile) &&
           # Count how many cities on the new tile that aren't included by any of the old tile.
           # Make sure this isn't more than the number of new cities added.
           # 1836jr30 D6 -> 54 adds more cities
           extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } } &&
           # 1867: Does every old city correspond to exactly one new city?
           (!multi_city_upgrade || old_ctedges.all? { |oldct| new_ctedges.one? { |newct| (oldct & newct) == oldct } })
+      end
+
+      def old_paths_maintained?(hex, tile)
+        old_paths = hex.tile.paths
+        new_paths = tile.paths
+        old_paths.all? { |path| new_paths.any? { |p| path <= p } }
       end
 
       def legal_tile_rotations(entity_or_entities, hex, tile)


### PR DESCRIPTION
- set override constants from 1822 to correct values for 1822CA's privates
- implement the Pullman, which can hit 2xN towns instead of unlimited towns
- fix laying plain yellow city tiles on the city+town hex (M6's home)
    - extracted a function from `Engine::Step#legal_tile_rotation?` for a more precise override in `G1822CA::Tracker`

 #9376