### PR TITLE
[1847 AE] Nationalization

### DIFF
--- a/lib/engine/game/g_1847_ae/entities.rb
+++ b/lib/engine/game/g_1847_ae/entities.rb
@@ -186,14 +186,13 @@ module Engine
                   'Automatically exchanged at the beginning of the first stock round in Phase 5+5. '\
                   'May not be sold to a corporation. ',
             sym: 'MNR',
-            abilities: [{ type: 'no_buy' },
-                        {
-                          type: 'exchange',
-                          corporations: ['HLB'],
-                          owner_type: 'player',
-                          when: 'owning_player_sr_turn',
-                          from: %w[reserved],
-                        }],
+            abilities: [{
+              type: 'exchange',
+              corporations: ['HLB'],
+              owner_type: 'player',
+              when: 'owning_player_sr_turn',
+              from: %w[reserved],
+            }],
           },
           {
             name: 'Saarland Coal Mines',
@@ -204,14 +203,13 @@ module Engine
                   'Automatically exchanged at the beginning of the first stock round in Phase 5+5. '\
                   'May not be sold to a corporation. ',
             sym: 'SCR',
-            abilities: [{ type: 'no_buy' },
-                        {
-                          type: 'exchange',
-                          corporations: ['Saar'],
-                          owner_type: 'player',
-                          when: 'owning_player_sr_turn',
-                          from: %w[reserved],
-                        }],
+            abilities: [{
+              type: 'exchange',
+              corporations: ['Saar'],
+              owner_type: 'player',
+              when: 'owning_player_sr_turn',
+              from: %w[reserved],
+            }],
           },
           {
             name: 'Völklinger Iron Works',
@@ -222,14 +220,13 @@ module Engine
                   'Automatically exchanged at the beginning of the first stock round in Phase 5+5. '\
                   'May not be sold to a corporation. ',
             sym: 'VIW',
-            abilities: [{ type: 'no_buy' },
-                        {
-                          type: 'exchange',
-                          corporations: ['Saar'],
-                          owner_type: 'player',
-                          when: 'owning_player_sr_turn',
-                          from: %w[reserved],
-                        }],
+            abilities: [{
+              type: 'exchange',
+              corporations: ['Saar'],
+              owner_type: 'player',
+              when: 'owning_player_sr_turn',
+              from: %w[reserved],
+            }],
           },
         ].freeze
 

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -38,7 +38,7 @@ module Engine
         B_HEXES = %w[I3 I13].freeze
 
         DOUBLE_TOWN_TILES = %w[1 55 56 69].freeze
-        DOUBLE_STLOT_GREEN_CITIES = %w[14 15]
+        DOUBLE_SLOT_GREEN_CITIES = %w[14 15].freeze
 
         MARKET = [
           ['', '', '', '', '130', '150', '170', '190', '210', '230', '255', '285', '315', '350', '385', '420'],
@@ -323,7 +323,7 @@ module Engine
           return to.name == '204' if from.hex.tile.name == '69'
 
           # double slot green cities don't upgrade
-          return false if DOUBLE_STLOT_GREEN_CITIES.include?(from.hex.tile.name)
+          return false if DOUBLE_SLOT_GREEN_CITIES.include?(from.hex.tile.name)
 
           super
         end

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -30,6 +30,8 @@ module Engine
         CERT_LIMIT = { 3 => 16, 4 => 12, 5 => 9 }.freeze
         STARTING_CASH = { 3 => 500, 4 => 390, 5 => 320 }.freeze
 
+        COMPANIES_PURCHASABLE_BY_CORPORATIONS = %w[R K W H].freeze
+
         LAST_TRANCH_CORPORATIONS = %w[NDB M N RNB].freeze
 
         COAL_HEXES = %w[G7 H6].freeze
@@ -326,6 +328,15 @@ module Engine
           return false if DOUBLE_SLOT_GREEN_CITIES.include?(from.hex.tile.name)
 
           super
+        end
+
+        def purchasable_companies(entity = nil)
+          return super unless entity&.corporation?
+
+          @companies.select do |company|
+            company.owner&.player? && entity != company.owner && !abilities(company, :no_buy) &&
+            COMPANIES_PURCHASABLE_BY_CORPORATIONS.include?(company.id)
+          end
         end
 
         def action_processed(action)

--- a/lib/engine/game/g_1847_ae/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1847_ae/step/buy_sell_par_shares.rb
@@ -15,7 +15,7 @@ module Engine
             # nationalization - must own 70% of the corporation and pay 150% of CMV
             if bundle.owner.player?
               return false unless can_nationalize?(entity, bundle.corporation)
-              
+
               return entity.cash >= nationalization_price(bundle.price)
             end
 
@@ -43,8 +43,8 @@ module Engine
 
             corporation = bundle.corporation
 
-            return false if exchange && !@game.can_corporation_have_investor_shares_exchanged?(corporation)    
-    
+            return false if exchange && !@game.can_corporation_have_investor_shares_exchanged?(corporation)
+
             corporation.holding_ok?(entity, bundle.common_percent) &&
               (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity))
           end
@@ -52,17 +52,17 @@ module Engine
           def can_buy_any_from_player?(entity)
             return false if bought?
 
-            a = @game.corporations.any? { |c| can_nationalize?(entity, c) && entity.cash >= nationalization_price(c.share_price.price) }
-
-            return a
+            @game.corporations.select(&:floated?).any? do |corporation|
+              can_nationalize?(entity, corporation) && entity.cash >= nationalization_price(corporation.share_price.price)
+            end
           end
-          
+
           def can_nationalize?(player, corporation)
-            return player.num_shares_of(corporation) >= 4
+            player.num_shares_of(corporation) >= 7
           end
 
           def nationalization_price(price)
-            return (price * 1.5).ceil
+            (price * 1.5).ceil
           end
 
           def process_buy_shares(action)

--- a/lib/engine/game/g_1847_ae/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1847_ae/step/buy_sell_par_shares.rb
@@ -46,7 +46,7 @@ module Engine
             return false if exchange && !@game.can_corporation_have_investor_shares_exchanged?(corporation)
 
             corporation.holding_ok?(entity, bundle.common_percent) &&
-              (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity))
+              (exchange || @game.num_certs(entity) < @game.cert_limit(entity))
           end
 
           def can_buy_any_from_player?(entity)
@@ -74,10 +74,10 @@ module Engine
             price = nationalization_price(bundle.price)
             owner = bundle.owner
             corporation = bundle.corporation
+
             raise GameError, 'Cannot nationalize this corporation' unless can_nationalize?(player, corporation)
             raise GameError, 'Not enough cash for nationalization' unless player.cash >= price
 
-            # can't use share_pool.buy_shares since it uses bundle.share_price
             @log << "-- Nationalization: #{player.name} buys a #{bundle.percent}% share"\
                     " of #{corporation.name} from #{owner.name} for #{@game.format_currency(price)} --"
 

--- a/lib/engine/game/g_1847_ae/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1847_ae/step/buy_sell_par_shares.rb
@@ -7,7 +7,18 @@ module Engine
     module G1847AE
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
+          def get_par_prices(_entity, corporation)
+            [corporation.par_price]
+          end
+
           def can_buy?(entity, bundle)
+            # nationalization - must own 70% of the corporation and pay 150% of CMV
+            if bundle.owner.player?
+              return false unless can_nationalize?(entity, bundle.corporation)
+              
+              return entity.cash >= nationalization_price(bundle.price)
+            end
+
             return false unless super
 
             bundle = bundle.to_bundle
@@ -27,14 +38,56 @@ module Engine
             true
           end
 
-          def get_par_prices(_entity, corporation)
-            [corporation.par_price]
+          def can_gain?(entity, bundle, exchange: false)
+            return false if !bundle || !entity
+
+            corporation = bundle.corporation
+
+            return false if exchange && !@game.can_corporation_have_investor_shares_exchanged?(corporation)    
+    
+            corporation.holding_ok?(entity, bundle.common_percent) &&
+              (!corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity))
           end
 
-          def can_gain?(entity, bundle, exchange: false)
-            return false if exchange && !@game.can_corporation_have_investor_shares_exchanged?(bundle.corporation)
+          def can_buy_any_from_player?(entity)
+            return false if bought?
 
-            super(entity, bundle, exchange: exchange)
+            a = @game.corporations.any? { |c| can_nationalize?(entity, c) && entity.cash >= nationalization_price(c.share_price.price) }
+
+            return a
+          end
+          
+          def can_nationalize?(player, corporation)
+            return player.num_shares_of(corporation) >= 4
+          end
+
+          def nationalization_price(price)
+            return (price * 1.5).ceil
+          end
+
+          def process_buy_shares(action)
+            return super unless action.bundle.owner.player?
+
+            # nationalization
+            player = action.entity
+            bundle = action.bundle
+            price = nationalization_price(bundle.price)
+            owner = bundle.owner
+            corporation = bundle.corporation
+            raise GameError, 'Cannot nationalize this corporation' unless can_nationalize?(player, corporation)
+            raise GameError, 'Not enough cash for nationalization' unless player.cash >= price
+
+            # can't use share_pool.buy_shares since it uses bundle.share_price
+            @log << "-- Nationalization: #{player.name} buys a #{bundle.percent}% share"\
+                    " of #{corporation.name} from #{owner.name} for #{@game.format_currency(price)} --"
+
+            @game.share_pool.transfer_shares(bundle,
+                                             player,
+                                             spender: player,
+                                             receiver: owner,
+                                             price: price)
+
+            track_action(action, corporation)
           end
         end
       end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

- Nationalization allows a player that owns at least 70% of a corporation to buy a share from another player, for 150% of the current market value, without asking them for permission. 
- Investor companies are purchasable by players but not by corporations.
