### PR TITLE
[1822CA] Implement P14-P18, "big city" upgrades and a few more config-only privates

### DIFF
--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -70,7 +70,7 @@ module Engine
 
               next unless ability_.type == :tile_lay
 
-              if ability_.count <= 0 && ability_.closed_when_used_up
+              if ability_.closed_when_used_up && ability_.count <= 0
                 @log << "#{ability_.owner.name} closes"
                 ability_.owner.close!
               end
@@ -272,7 +272,7 @@ module Engine
           end
 
           def hex_neighbors(entity, hex)
-            @game.graph_for_entity(entity).connected_hexes(entity)[hex]
+            @game.graph_for_entity(entity).connected_hexes(entity)[hex] || []
           end
 
           # Extra Tile Lay abilities need to be used either entirely before

--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -210,7 +210,19 @@ module Engine
                   'tile placement. This tile placement is in addition to the company’s normal tile placement(s), but '\
                   'happens during the company’s tile laying step. Does not close. Minor may place yellow or green '\
                   'only. The company upgrading the city must be connected to it in order to exercise the private company.',
-            abilities: [],
+            abilities: [
+              {
+                hexes: %w[AC21],
+                tiles: %w[T1 T2 T3 T4 T5 T6 T7],
+                type: 'tile_lay',
+                when: %w[track special_track],
+                owner_type: 'corporation',
+                free: true,
+                special: false,
+                count_per_or: 1,
+                reachable: true,
+              },
+            ],
             color: nil,
           },
           {
@@ -222,7 +234,19 @@ module Engine
                   'tile placement. This tile placement is in addition to the company’s normal tile placement(s), but '\
                   'happens during the company’s tile laying step. Does not close. Minor may place yellow or green '\
                   'only. The company upgrading the city must be connected to it in order to exercise the private company.',
-            abilities: [],
+            abilities: [
+              {
+                hexes: %w[AE15],
+                tiles: %w[O1 O2 O3 O4 O5 O6 O7 O8],
+                type: 'tile_lay',
+                when: %w[track special_track],
+                owner_type: 'corporation',
+                free: true,
+                special: false,
+                count_per_or: 1,
+                reachable: true,
+              },
+            ],
             color: nil,
           },
           {
@@ -234,7 +258,19 @@ module Engine
                   'tile placement. This tile placement is in addition to the company’s normal tile placement(s), but '\
                   'happens during the company’s tile laying step. Does not close. Minor may place yellow or green '\
                   'only. The company upgrading the city must be connected to it in order to exercise the private company.',
-            abilities: [],
+            abilities: [
+              {
+                hexes: %w[AF12],
+                tiles: %w[M1 M2 M3 M4 M5 M6 M7],
+                type: 'tile_lay',
+                when: %w[track special_track],
+                owner_type: 'corporation',
+                free: true,
+                special: false,
+                count_per_or: 1,
+                reachable: true,
+              },
+            ],
             color: nil,
           },
           {
@@ -246,7 +282,19 @@ module Engine
                   'tile placement. This tile placement is in addition to the company’s normal tile placement(s), but '\
                   'happens during the company’s tile laying step. Does not close. Minor may place yellow or green '\
                   'only. The company upgrading the city must be connected to it in order to exercise the private company.',
-            abilities: [],
+            abilities: [
+              {
+                hexes: %w[AH8],
+                tiles: %w[Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8],
+                type: 'tile_lay',
+                when: %w[track special_track],
+                owner_type: 'corporation',
+                free: true,
+                special: false,
+                count_per_or: 1,
+                reachable: true,
+              },
+            ],
             color: nil,
           },
           {
@@ -258,7 +306,19 @@ module Engine
                   'tile placement. This tile placement is in addition to the company’s normal tile placement(s), but '\
                   'happens during the company’s tile laying step. Does not close. Minor may place yellow or green '\
                   'only. The company upgrading the city must be connected to it in order to exercise the private company.',
-            abilities: [],
+            abilities: [
+              {
+                hexes: %w[N16],
+                tiles: %w[W1 W2 W3 W4 W5 W6 W7],
+                type: 'tile_lay',
+                when: %w[track special_track],
+                owner_type: 'corporation',
+                free: true,
+                special: false,
+                count_per_or: 1,
+                reachable: true,
+              },
+            ],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -19,8 +19,6 @@ module Engine
         BIDDING_BOX_START_CONCESSION = 'C2'
         BIDDING_BOX_START_PRIVATE = 'P1'
 
-        PRIVATE_PHASE_REVENUE = %w[P8 P9].freeze
-
         COMPANY_MTONR = nil # Remove Town; two companies instead of one here
         COMPANY_LCDR = nil # English Channel
         COMPANY_EGR = nil # Hill Discount
@@ -35,6 +33,12 @@ module Engine
         COMPANY_5X_REVENUE = 'P9'
         COMPANY_HSBC = nil # Grimsby/Hull Bridge
 
+        COMPANIES_BIG_CITY_UPGRADES = %w[P14 P15 P16 P17 P18].freeze
+        COMPANIES_EXTRA_TRACK_LAYS = (COMPANIES_BIG_CITY_UPGRADES + %w[P19 P20 P21]).freeze
+
+        PRIVATE_MAIL_CONTRACTS = %w[P22 P23].freeze
+        PRIVATE_PHASE_REVENUE = %w[P8 P9].freeze
+        PRIVATE_REMOVE_REVENUE = %w[P1 P5 P6 P7 P14 P15 P16 P17 P18 P22 P23 P24 P25 P26 P27 P28].freeze
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P6].freeze
 
         COMPANY_SHORT_NAMES = {
@@ -293,6 +297,10 @@ module Engine
           return %w[5 6 57].include?(to.name) if from.name == 'AG13' && from.color == :white
 
           super
+        end
+
+        def company_ability_extra_track?(company)
+          self.class::COMPANIES_EXTRA_TRACK_LAYS.include?(company.id)
         end
       end
     end

--- a/lib/engine/game/g_1822_ca/step/special_track.rb
+++ b/lib/engine/game/g_1822_ca/step/special_track.rb
@@ -9,6 +9,12 @@ module Engine
       module Step
         class SpecialTrack < G1822::Step::SpecialTrack
           include G1822CA::Tracker
+
+          def actions(entity)
+            return [] unless entity.company?
+
+            super
+          end
         end
       end
     end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -400,24 +400,46 @@ module Engine
 
         new_exits = tile.exits
         new_ctedges = tile.city_town_edges
-        extra_cities = [0, new_ctedges.size - old_ctedges.size].max
+        added_cities = [0, new_ctedges.size - old_ctedges.size].max
         multi_city_upgrade = tile.cities.size > 1 && hex.tile.cities.size > 1
 
-        new_exits.all? { |edge| hex.neighbors[edge] } &&
-          !(new_exits & hex_neighbors(entity, hex)).empty? &&
-          old_paths_maintained?(hex, tile) &&
-          # Count how many cities on the new tile that aren't included by any of the old tile.
-          # Make sure this isn't more than the number of new cities added.
-          # 1836jr30 D6 -> 54 adds more cities
-          extra_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } } &&
-          # 1867: Does every old city correspond to exactly one new city?
-          (!multi_city_upgrade || old_ctedges.all? { |oldct| new_ctedges.one? { |newct| (oldct & newct) == oldct } })
+        all_new_exits_valid = new_exits.all? { |edge| hex.neighbors[edge] }
+        return false unless all_new_exits_valid
+
+        entity_reaches_a_new_exit = !(new_exits & hex_neighbors(entity, hex)).empty?
+        return false unless entity_reaches_a_new_exit
+
+        return false unless old_paths_maintained?(hex, tile)
+
+        # Count how many cities on the new tile that aren't included by any of the old tile.
+        # Make sure this isn't more than the number of new cities added.
+        # 1836jr30 D6 -> 54 adds more cities
+        valid_added_city_count = added_cities >= new_ctedges.count { |newct| old_ctedges.all? { |oldct| (newct & oldct).none? } }
+        return false unless valid_added_city_count
+
+        # 1867: Does every old city correspond to exactly one new city?
+        old_cities_map_to_new =
+          !multi_city_upgrade ||
+          old_ctedges.all? { |oldct| new_ctedges.one? { |newct| (oldct & newct) == oldct } }
+        return false unless old_cities_map_to_new
+
+        return false unless city_sizes_maintained(hex, tile)
+
+        true
       end
 
       def old_paths_maintained?(hex, tile)
         old_paths = hex.tile.paths
         new_paths = tile.paths
         old_paths.all? { |path| new_paths.any? { |p| path <= p } }
+      end
+
+      # 1822CA: some big cities have a mix of 2-slot and 1-slot cities; don't
+      # reduce slots in a city
+      def city_sizes_maintained(hex, tile)
+        return true unless hex.tile.cities.map(&:normal_slots).uniq.size > 1
+
+        hex.city_map_for(tile).all? { |old_c, new_c| new_c.normal_slots >= old_c.normal_slots }
       end
 
       def legal_tile_rotations(entity_or_entities, hex, tile)


### PR DESCRIPTION
* Refactor `Step::Tracker#legal_tile_rotation?` for readability and deubgger-friendliness
* Don't allow a 2-slot city to "upgrade" to a 1-slot city * Extract function to create the old->new city map in Engine::Hex
* Prevent some nil reference errors in `G1822::Step::SpecialTrack`

#9376

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

* **Screenshots**

* **Any Assumptions / Hacks**

Assumption: no implemented games need to upgrade a city to one with fewer token slots