### PR TITLE
[1822CA] fix some meta info, finish 2p-specific implementation

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -175,8 +175,10 @@ module Engine
       # down_block -- down one row per block
       # left_share -- left one column per share
       # left_share_pres -- left one column per share if president
-      # left_block_pres -- left one column per block if president
       # left_block -- one row per block
+      # down_block_pres -- down one row per block if president
+      # left_block_pres -- left one column per block if president
+      # left_per_10_if_pres_else_left_one -- left_share_pres + left_block
       # none -- don't drop price
       SELL_MOVEMENT = :down_share
 
@@ -1143,12 +1145,16 @@ module Engine
         self.class::SELL_AFTER == :first ? (@turn > 1 || !@round.stock?) : true
       end
 
+      def sell_movement
+        self.class::SELL_MOVEMENT
+      end
+
       def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
         corporation = bundle.corporation
         old_price = corporation.share_price
         was_president = corporation.president?(bundle.owner)
         @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
-        case movement || self.class::SELL_MOVEMENT
+        case movement || sell_movement
         when :down_share
           bundle.num_shares.times { @stock_market.move_down(corporation) }
         when :down_per_10
@@ -1179,7 +1185,7 @@ module Engine
         else
           raise NotImplementedError
         end
-        log_share_price(corporation, old_price) if self.class::SELL_MOVEMENT != :none
+        log_share_price(corporation, old_price) if sell_movement != :none
       end
 
       def sold_out_increase?(_corporation)

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -33,11 +33,11 @@ module Engine
 
         BANK_CASH = 12_000
 
-        CERT_LIMIT = { 3 => 26, 4 => 20, 5 => 16, 6 => 13, 7 => 11 }.freeze
+        CERT_LIMIT = { 2 => 40, 3 => 26, 4 => 20, 5 => 16, 6 => 13, 7 => 11 }.freeze
 
         EBUY_OTHER_VALUE = false
 
-        STARTING_CASH = { 3 => 700, 4 => 525, 5 => 420, 6 => 350, 7 => 300 }.freeze
+        STARTING_CASH = { 2 => 1000, 3 => 700, 4 => 525, 5 => 420, 6 => 350, 7 => 300 }.freeze
 
         CAPITALIZATION = :incremental
 

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -211,7 +211,6 @@ module Engine
                                    CNoR CPR GNWR GT GTP GWR ICR NTR PGE QMOO].freeze
 
         MUST_SELL_IN_BLOCKS = true
-        SELL_MOVEMENT = :left_per_10_if_pres_else_left_one
 
         def setup_game_specific
           # Initialize the stock round choice for P7-Double Cash
@@ -274,7 +273,7 @@ module Engine
           @company_trains['P2'] = find_and_remove_train_by_id('LP-0', buyable: false)
         end
 
-        # Stubbed out because this game doesn't it, but base 22 does
+        # Stubbed out because this game doesn't use it, but base 22 does
         def company_tax_haven_bundle(choice); end
         def company_tax_haven_payout(entity, per_share); end
         def num_certs_modification(_entity) = 0
@@ -314,6 +313,10 @@ module Engine
 
         def company_ability_extra_track?(company)
           self.class::COMPANIES_EXTRA_TRACK_LAYS.include?(company.id)
+        end
+
+        def sell_movement
+          @sell_movement ||= @players.size == 2 ? :left_share_pres : :left_per_10_if_pres_else_left_one
         end
 
         def routes_subsidy(routes)

--- a/lib/engine/game/g_1822_ca/meta.rb
+++ b/lib/engine/game/g_1822_ca/meta.rb
@@ -14,14 +14,17 @@ module Engine
 
         GAME_SUBTITLE = 'The Railways of Canada'
         GAME_DESIGNER = 'Robert Lecuyer'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1822'
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1822CA'
         GAME_LOCATION = 'Canada'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/219065/1822-railways-great-britain-rules'
+        GAME_RULES_URL = {
+          'Rules' => 'https://boardgamegeek.com/filepage/238950/1822ca-rules',
+          '2-player Scenarios' => 'https://boardgamegeek.com/thread/2591186/1822ca-2-player-scenarios',
+        }.freeze
         GAME_TITLE = '1822CA'
         GAME_ISSUE_LABEL = '1822CA'
 
-        PLAYER_RANGE = [3, 7].freeze
+        PLAYER_RANGE = [2, 7].freeze
 
         GAME_VARIANTS = [
           {

--- a/lib/engine/game/g_1822_ca_ers/meta.rb
+++ b/lib/engine/game/g_1822_ca_ers/meta.rb
@@ -18,6 +18,10 @@ module Engine
         GAME_TITLE = '1822CA ERS'
         GAME_DISPLAY_TITLE = '1822CA: Eastern Regional Scenario'
         GAME_LOCATION = 'Eastern Canada'
+        GAME_RULES_URL = {
+          'Rules' => 'https://boardgamegeek.com/filepage/238950/1822ca-rules',
+          '2-player Scenarios' => 'https://boardgamegeek.com/thread/2591186/1822ca-2-player-scenarios',
+        }.freeze
 
         PLAYER_RANGE = [2, 5].freeze
       end

--- a/lib/engine/game/g_1822_ca_wrs/meta.rb
+++ b/lib/engine/game/g_1822_ca_wrs/meta.rb
@@ -18,6 +18,10 @@ module Engine
         GAME_TITLE = '1822CA WRS'
         GAME_DISPLAY_TITLE = '1822CA: Western Regional Scenario'
         GAME_LOCATION = 'Western Canada'
+        GAME_RULES_URL = {
+          'Rules' => 'https://boardgamegeek.com/filepage/238950/1822ca-rules',
+          '2-player Scenarios' => 'https://boardgamegeek.com/thread/2591186/1822ca-2-player-scenarios',
+        }.freeze
 
         PLAYER_RANGE = [2, 5].freeze
       end


### PR DESCRIPTION
* add setup for full 1822CA from the [2p thread on BGG](https://boardgamegeek.com/thread/2591186/1822ca-2-player-scenarios)
* implement the sell_movement being different for 2p than other player counts * update comments for `SELL_MOVEMENT` in the base game class to include all implemented options, in the same order in which they appear in the `case` block
* fix meta links

#9376

(holding as a draft until rake passes)
