### PR TITLE
[1858] performance improvements and fixes

### DIFF
--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -23,9 +23,8 @@ module Engine
             # Exchanging a private company for a share certificate from the
             # company treasury is also a sell action, but this is handled
             # through the companies' abilities rather than these actions.
-            # Converting a corporation from 5 to 10 shares is also a sell
-            # action. This is handled in corporation_actions.
             actions << 'sell_shares' if can_sell_any?(entity)
+            actions << 'convert' if can_convert_any?(entity)
 
             # Buy actions.
             # Starting a public company by exchanging a private company for the
@@ -109,6 +108,10 @@ module Engine
           def can_convert?(corporation)
             (corporation.owner == current_entity) && (corporation.type == :'5-share') &&
               corporation.floated? && !bought?
+          end
+
+          def can_convert_any?(_entity)
+            @game.corporations.any? { |corporation| can_convert?(corporation) }
           end
 
           def can_gain?(entity, share, exchange: false)

--- a/lib/engine/game/g_1858/step/token.rb
+++ b/lib/engine/game/g_1858/step/token.rb
@@ -143,6 +143,15 @@ module Engine
             entity.tokens_by_type
           end
 
+          def auto_actions(entity)
+            return if entity.minor?
+            return if (@game.graph_broad.can_token?(entity) ||
+                       @game.graph_metre.can_token?(entity)) &&
+                      (min_token_price(entity) <= buying_power(entity))
+
+            [Engine::Action::Pass.new(entity)]
+          end
+
           # Finds all the cities that a corporation could place a token in.
           # Does not consider whether the corporation can afford to place the token.
           def tokenable_cities(corporation)
@@ -157,11 +166,14 @@ module Engine
           end
 
           def can_place_token?(entity)
+            # Don't check for any legal token placements here, or whether the
+            # corporation can afford the actual token cost here. This would
+            # require the game graph to be consulted, which slows down game
+            # loading. Instead auto_actions are used to pass token placement
+            # if no token can be placed.
             current_entity == entity &&
               !@round.tokened &&
-              !available_tokens(entity).empty? &&
-              (@game.graph_broad.can_token?(entity) || @game.graph_metre.can_token?(entity)) &&
-              (min_token_price(entity) <= buying_power(entity))
+              !available_tokens(entity).empty?
           end
 
           # Calculate the token cost from the number of provincial borders

--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -15,7 +15,7 @@ module Engine
 
           def auto_actions(entity)
             return unless entity.minor?
-            return if can_lay_tile?(entity)
+            return if can_lay_tile?(entity, check_graph: true)
 
             [Engine::Action::Pass.new(entity)]
           end
@@ -55,7 +55,11 @@ module Engine
             entity = action.entity
             spender = entity.minor? ? entity.owner : nil
             lay_tile_action(action, spender: spender)
-            pass! unless can_lay_tile?(entity)
+            # Automatically pass if another tile cannot be placed. Do not check
+            # whether there are any legal tile placements as this slows down
+            # loading games (Graph.compute would be called), just whether the
+            # current operator has another tile placement available.
+            pass! unless can_lay_tile?(entity, check_graph: false)
           end
 
           def potential_tiles(entity, hex)
@@ -66,11 +70,12 @@ module Engine
             tiles.reject { |tile| tile.paths.map(&:track).include?(:narrow) }
           end
 
-          def can_lay_tile?(entity)
+          def can_lay_tile?(entity, check_graph: true)
             # Don't check whether the company has enough cash to pay for the tile
             # lay as this can be paid by the company president.
             action = get_tile_lay(entity)
             return false unless action
+            return true unless check_graph
 
             # Check whether there are any hexes where track can be laid. After a
             # couple of operating rounds many of the private railway companies

--- a/public/logos/1858/AS.svg
+++ b/public/logos/1858/AS.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">A&amp;S</text></svg>

--- a/public/logos/1858/BCR.svg
+++ b/public/logos/1858/BCR.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;CR</text></svg>

--- a/public/logos/1858/BM.svg
+++ b/public/logos/1858/BM.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">B&amp;M</text></svg>

--- a/public/logos/1858/CB.svg
+++ b/public/logos/1858/CB.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;B</text></svg>

--- a/public/logos/1858/CM.svg
+++ b/public/logos/1858/CM.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;M</text></svg>

--- a/public/logos/1858/CMP.svg
+++ b/public/logos/1858/CMP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">CM&amp;P</text></svg>

--- a/public/logos/1858/CS.svg
+++ b/public/logos/1858/CS.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">C&amp;S</text></svg>

--- a/public/logos/1858/HG.svg
+++ b/public/logos/1858/HG.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">H&amp;G</text></svg>

--- a/public/logos/1858/LC.svg
+++ b/public/logos/1858/LC.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">L&amp;C</text></svg>

--- a/public/logos/1858/LG.svg
+++ b/public/logos/1858/LG.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">L&amp;G</text></svg>

--- a/public/logos/1858/MA.svg
+++ b/public/logos/1858/MA.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;A</text></svg>

--- a/public/logos/1858/MC.svg
+++ b/public/logos/1858/MC.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;C</text></svg>

--- a/public/logos/1858/MS.svg
+++ b/public/logos/1858/MS.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;S</text></svg>

--- a/public/logos/1858/MV.svg
+++ b/public/logos/1858/MV.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;V</text></svg>

--- a/public/logos/1858/MZ.svg
+++ b/public/logos/1858/MZ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">M&amp;Z</text></svg>

--- a/public/logos/1858/OV.svg
+++ b/public/logos/1858/OV.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">O&amp;V</text></svg>

--- a/public/logos/1858/PL.svg
+++ b/public/logos/1858/PL.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">P&amp;L</text></svg>

--- a/public/logos/1858/RT.svg
+++ b/public/logos/1858/RT.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">R&amp;T</text></svg>

--- a/public/logos/1858/SC.svg
+++ b/public/logos/1858/SC.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="green"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">S&amp;C</text></svg>

--- a/public/logos/1858/SJC.svg
+++ b/public/logos/1858/SJC.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">SJ&amp;C</text></svg>

--- a/public/logos/1858/VJ.svg
+++ b/public/logos/1858/VJ.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">V&amp;J</text></svg>

--- a/public/logos/1858/ZP.svg
+++ b/public/logos/1858/ZP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="yellow"/><text x="4" y="5.4" text-anchor="middle" font-weight="700" font-size="3" font-family="Arial" fill="#000000">Z&amp;P</text></svg>


### PR DESCRIPTION
A few more fixes for 1858. Nothing is touched in shared code.

- Improve loading speed by stopping the game graph from being computed during the game load process. I'd already got rid of most of the calls into the game graph, but missed a couple of places where this was happening:
    - When checking if there is a route to an available token slot, and the token could be afforded. Neither of these are checked in `Step::Token.actions` any more, instead `auto_actions` are used to pass the token-laying step if there is no legal token placement option.
    - When checking whether another tile lay action is possible after a tile had been laid. Now we just check whether there is another tile lay action allowed, if there is then a new track step will occur, and `auto_actions` will pass if a minor (private railway) cannot lay more track.
- If a player's only legal action on a share turn was to convert a five-share company into a ten-share company then their turn was being skipped. This has been fixed.
- Add back the private railway company logos that were removed in commit 5d7d59cdc. These *are* needed, for the logos shown next to the minors in the operating round order.


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
~~Add the `pins` label if this change will break existing games~~