### PR TITLE
[1822Africa] Fix brown Y tile revenue

### DIFF
--- a/lib/engine/game/g_1822_africa/map.rb
+++ b/lib/engine/game/g_1822_africa/map.rb
@@ -62,13 +62,13 @@ module Engine
             {
               'count' => 2,
               'color' => 'brown',
-              'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=Y',
+              'code' => 'city=revenue:50,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=Y',
             },
           'X2' =>
             {
               'count' => 1,
               'color' => 'brown',
-              'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y',
+              'code' => 'city=revenue:50,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y',
             },
           'GR1' =>
             {


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
Checked all running games and none of them are in brown yet
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes
Y tiles in brown incorrectly had 40 instead of 50 revenue, preventing the upgrade