### PR TITLE
[1848] make end text more clear

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -165,6 +165,12 @@ module Engine
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or, custom: :full_or }.freeze
 
+        GAME_END_DESCRIPTION_REASON_MAP_TEXT = {
+          bank: 'Bank Broken',
+          stock_market: 'Corporation hit max stock value or Bank of England has given 16 or more loans',
+          custom: 'Fifth corporation is in receivership',
+        }.freeze
+
         PHASES = [{ name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 1 },
                   {
                     name: '3',


### PR DESCRIPTION
Fixes #9452

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Override the built-in endgame descriptions

1848 uses a `stock_market` price trigger at 260 to determine whether BoE has hit 16 loans, since it only moves up when a loan is taken. This avoids having to make a custom check, but also means we have to override the base description for that endgame check

Note that the base hash is immutable so we have to redeclare it here

* **Screenshots**
![Screenshot 2023-08-24 11 13 38 AM](https://github.com/tobymao/18xx/assets/1711810/b51e4115-cb57-4a6a-a10c-f41c37384b11)


* **Any Assumptions / Hacks**
