### PR TITLE
[1822CA] P19-P20 free Mountain Pass privates

### DIFF
--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -343,7 +343,21 @@ module Engine
                   'Pass (CP) and ignore the terrain fee. This tile placement counts as the company’s full track '\
                   'laying step. Closed when used. The CP hex is not reserved; any company may pay to lay a tile '\
                   'there irrespective of the ownership of P19.',
-            abilities: [],
+            abilities: [
+              {
+                hexes: %w[F16],
+                tiles: %w[7 8 9],
+                type: 'tile_lay',
+                when: %w[track special_track],
+                owner_type: 'corporation',
+                free: true,
+                special: false,
+                count: 1,
+                reachable: true,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
+              },
+            ],
             color: nil,
           },
           {
@@ -355,7 +369,21 @@ module Engine
                   'Pass (YP) and ignore the terrain fee. This tile placement counts as the company’s full track '\
                   'laying step. Closed when used. The YP hex is not reserved; any company may pay to lay a tile '\
                   'there irrespective of the ownership of P20.',
-            abilities: [],
+            abilities: [
+              {
+                hexes: %w[E11],
+                tiles: %w[7 8 9],
+                type: 'tile_lay',
+                when: %w[track special_track],
+                owner_type: 'corporation',
+                free: true,
+                special: false,
+                count: 1,
+                reachable: true,
+                consume_tile_lay: true,
+                closed_when_used_up: true,
+              },
+            ],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -42,6 +42,11 @@ module Engine
         PRIVATE_REMOVE_REVENUE = %w[P1 P5 P6 P7 P14 P15 P16 P17 P18 P22 P23 P24 P25 P26 P27 P28].freeze
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P6].freeze
 
+        MOUNTAIN_PASS_HEXES = %w[E11 F16].freeze
+        MOUNTAIN_PASS_TILES = %w[7 8 9].freeze
+        MOUNTAIN_PASS_COMPANIES = %w[P19 P20].freeze
+        MOUNTAIN_PASS_COMPANIES_TO_HEXES = { 'P20' => 'E11', 'P19' => 'F16' }.freeze
+
         COMPANY_SHORT_NAMES = {
           'P1' => 'P1 (5-Train)',
           'P2' => 'P2 (Perm. L Train)',
@@ -329,6 +334,10 @@ module Engine
 
         def routes_subsidy(routes)
           super + small_mail_contract_subsidy(routes)
+        end
+
+        def upgrades_to_correct_label?(from, to)
+          super || (MOUNTAIN_PASS_HEXES.include?(from.hex.id) && MOUNTAIN_PASS_TILES.include?(to.name))
         end
 
         def small_mail_contract_subsidy(routes)

--- a/lib/engine/game/g_1822_ca/step/special_track.rb
+++ b/lib/engine/game/g_1822_ca/step/special_track.rb
@@ -15,6 +15,14 @@ module Engine
 
             super
           end
+
+          def process_lay_tile(action)
+            super
+
+            # cannot lay a second yellow after using one of the P19-P20 Mountain
+            # Pass privates
+            @round.num_laid_track += 1 if @game.class::MOUNTAIN_PASS_COMPANIES.include?(action.entity.id)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1822_ca/step/tracker.rb
+++ b/lib/engine/game/g_1822_ca/step/tracker.rb
@@ -15,6 +15,22 @@ module Engine
             super
           end
         end
+
+        def abilities(entity, **kwargs, &block)
+          ability = super
+
+          # P19-P20 Mountain Pass privates
+          if ability && @game.class::MOUNTAIN_PASS_COMPANIES.include?(entity.id)
+            # consume full turn's tile lay
+            return if @round.num_laid_track.positive?
+
+            # useless if someone's already paid for the mountain pass
+            hex = @game.hex_by_id(@game.class::MOUNTAIN_PASS_COMPANIES_TO_HEXES[entity.id])
+            return unless hex.tile.color == :white
+          end
+
+          ability
+        end
       end
     end
   end


### PR DESCRIPTION
* P19-P20 can lay a yellow in their respective mountain pass hex for free
* uses up the owning Major's full normal tile laying action, i.e., another lay yellow may not be laid before or after, unless with another private ability like the 3-Tile Grant
* if another Major pays for the mountain pass, the private cannot be used, but continues to make its revenue
* fix laying in labeled mountain pass hexes with normal track actions by overriding `upgrades_to_correct_label?`

https://github.com/tobymao/18xx/issues/9376
