### PR TITLE
[1817] clarifies reduce_tokens message

### DIFF
--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -998,7 +998,7 @@ module Engine
               @stock_prices_start_merger = @corporations.to_h { |corp| [corp, corp.share_price] }
               @log << "-- #{round_description('Merger and Conversion', @round.round_num)} --"
               G1817::Round::Merger.new(self, [
-                Engine::Step::ReduceTokens,
+                G1817::Step::ReduceTokens,
                 Engine::Step::DiscardTrain,
                 G1817::Step::PostConversion,
                 G1817::Step::PostConversionLoans,
@@ -1007,7 +1007,7 @@ module Engine
             when G1817::Round::Merger
               @log << "-- #{round_description('Acquisition', @round.round_num)} --"
               G1817::Round::Acquisition.new(self, [
-                Engine::Step::ReduceTokens,
+                G1817::Step::ReduceTokens,
                 G1817::Step::Bankrupt,
                 G1817::Step::CashCrisis,
                 Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_1817/step/reduce_tokens.rb
+++ b/lib/engine/game/g_1817/step/reduce_tokens.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/reduce_tokens'
+
+module Engine
+  module Game
+    module G1817
+      module Step
+        class ReduceTokens < Engine::Step::ReduceTokens
+          def description
+            'Choose token to remove in hexes with multiple tokens, and then remove tokens to drop below limit of '\
+              "#{@game.class::LIMIT_TOKENS_AFTER_MERGER} tokens"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #9371 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Clarifies text for reduce_tokens step to explain that you need to remove duplicate tokens from hexes, even if you're below the 8 token limit.

* **Screenshots**

* **Any Assumptions / Hacks**
