### PR TITLE
[1822Africa] Fix share movement on issue

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -429,7 +429,7 @@ module Engine
             G1822Africa::Step::MinorAcquisition,
             G1822::Step::PendingToken,
             G1822::Step::DiscardTrain,
-            G1822::Step::IssueShares,
+            G1822Africa::Step::IssueShares,
           ], round_num: round_num)
         end
 

--- a/lib/engine/game/g_1822_africa/step/issue_shares.rb
+++ b/lib/engine/game/g_1822_africa/step/issue_shares.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/issue_shares'
+
+module Engine
+  module Game
+    module G1822Africa
+      module Step
+        class IssueShares < Engine::Game::G1822::Step::IssueShares
+          def process_sell_shares(action)
+            @game.share_pool.sell_shares(action.bundle)
+            old_price = action.entity.share_price
+            action.bundle.shares.size.times { @game.stock_market.move_left(action.entity) }
+            @game.log_share_price(action.entity, old_price)
+            pass!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

When issuing shares stock price only moved left one step regardless of the number of shares issues.
Correct behavior is to move one step per share issues.

This change **may** break existing games if they had share issuing
