### PR TITLE
[18Texas] Fixes train discard

### DIFF
--- a/lib/engine/game/g_18_texas/game.rb
+++ b/lib/engine/game/g_18_texas/game.rb
@@ -25,6 +25,7 @@ module Engine
         SELL_AFTER = :operate
         TREASURY_SHARE_LIMIT = 50
         EBUY_OTHER_VALUE = false
+        DISCARDED_TRAINS = :remove
 
         TOKEN_FEE = {
           'T&P' => 140,

--- a/lib/engine/game/g_18_texas/step/discard_train.rb
+++ b/lib/engine/game/g_18_texas/step/discard_train.rb
@@ -9,7 +9,7 @@ module Engine
         class DiscardTrain < Engine::Step::DiscardTrain
           def process_discard_train(action)
             train = action.train
-            @game.remove_train(train)
+            @game.depot.reclaim_train(train)
             @log << "#{action.entity.name} discards #{train.name} and it is removed from the game"
           end
         end


### PR DESCRIPTION
Fixes #9467 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
The game code was not actually removing discarded trains from the company. This corrects that, ensures that they're removed from the game, and displays the message that was initially displayed. 

* **Screenshots**

* **Any Assumptions / Hacks**
