### PR TITLE
[1822Africa] Add 5/E and 6/E trains

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -82,6 +82,8 @@ module Engine
         COMPANY_CHPR = nil
         COMPANY_5X_REVENUE = nil
         COMPANY_HSBC = nil
+        FRANCE_HEX = nil
+        ENGLISH_CHANNEL_HEX = nil
         BIDDING_BOX_START_PRIVATE = nil
         BIDDING_BOX_START_MINOR = nil
         DOUBLE_HEX = [].freeze
@@ -508,6 +510,19 @@ module Engine
           entity.id == self.class::COMPANY_REMOVE_TOWN
         end
 
+        def train_help(entity, runnable_trains, _routes)
+          help = super
+
+          hybrid_trains = runnable_trains.any? { |t| can_be_express?(t) }
+
+          if hybrid_trains
+            help << '5/E and 6/E trains can run either as usual, or as Express. '\
+                    "Express trains run unlimited distance, only count cities that have a #{entity.name} token "\
+                    'and double the revenue.'
+          end
+
+          help
+        end
         # Stubbed out because this game doesn't use it, but base 22 does
         def bidbox_minors = []
         def bidbox_concessions = []

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -55,6 +55,8 @@ module Engine
 
         EXTRA_TRAINS = %w[2P P+ LP].freeze
         EXTRA_TRAIN_PERMANENTS = %w[2P LP].freeze
+        EXPRESS_TRAIN_MULTIPLIER = 2
+
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5].freeze
         PRIVATE_MAIL_CONTRACTS = [].freeze # Stub
         PRIVATE_PHASE_REVENUE = %w[P16].freeze
@@ -523,6 +525,134 @@ module Engine
 
           help
         end
+
+        # This repeats the logic from the base game because our determination of train type is based on route
+        def check_overlap(routes)
+          # Tracks by e-train and normal trains
+          tracks_by_type = Hash.new { |h, k| h[k] = [] }
+
+          # Check local train not use the same token more then one time
+          local_cities = []
+
+          routes.each do |route|
+            local_cities.concat(route.visited_stops.select(&:city?)) if route.train.local? && !route.chains.empty?
+
+            route.paths.each do |path|
+              a = path.a
+              b = path.b
+
+              tracks = tracks_by_type[route_train_type(route)]
+              tracks << [path.hex, a.num, path.lanes[0][1]] if a.edge?
+              tracks << [path.hex, b.num, path.lanes[1][1]] if b.edge?
+
+              if b.edge? && a.town? && (nedge = a.tile.preferred_city_town_edges[a]) && nedge != b.num
+                tracks << [path.hex, a, path.lanes[0][1]]
+              end
+              if a.edge? && b.town? && (nedge = b.tile.preferred_city_town_edges[b]) && nedge != a.num
+                tracks << [path.hex, b, path.lanes[1][1]]
+              end
+            end
+          end
+
+          tracks_by_type.each do |_type, tracks|
+            tracks.group_by(&:itself).each do |k, v|
+              raise GameError, "Route can't reuse track on #{k[0].id}" if v.size > 1
+            end
+          end
+
+          local_cities.group_by(&:itself).each do |k, v|
+            raise GameError, "Local train can only use each token on #{k.hex.id} once" if v.size > 1
+          end
+        end
+
+        def compute_other_paths(routes, route)
+          routes.flat_map do |r|
+            next if r == route || route_train_type(route) != route_train_type(r)
+
+            r.paths
+          end
+        end
+
+        # This repeats the logic from the base game, but with changes to how */E trains are calculated
+        def revenue_for(route, stops)
+          revenue = if route_train_type(route) == :normal
+                      super
+                    else
+                      express_revenue = revenue_for_express(route, stops)
+
+                      return express_revenue if train_over_distance?(route)
+
+                      [super, express_revenue].max
+                    end
+
+          destination_bonus = destination_bonus(route.routes)
+          revenue += destination_bonus[:revenue] if destination_bonus && destination_bonus[:route] == route
+
+          revenue
+        end
+
+        def revenue_for_express(route, stops)
+          entity = route.train.owner
+
+          stops.sum do |stop|
+            next 0 unless stop.city?
+
+            if stop.tokened_by?(entity)
+              stop.route_base_revenue(route.phase, route.train) * self.class::EXPRESS_TRAIN_MULTIPLIER
+            else
+              0
+            end
+          end
+        end
+
+        def runs_as_express?(route)
+          return false unless can_be_express?(route.train)
+          return true if train_over_distance?(route)
+
+          stops = route.stops
+
+          normal_revenue = G1822::Game.instance_method(:revenue_for).bind_call(self, route, stops)
+          express_revenue = revenue_for_express(route, stops)
+
+          express_revenue > normal_revenue
+        end
+
+        def revenue_str(route)
+          str = super
+
+          str += ' [Express]' if runs_as_express?(route)
+
+          str
+        end
+
+        def check_distance(route, visits, train = nil)
+          return if can_be_express?(route.train)
+
+          super
+        end
+
+        def train_over_distance?(route)
+          train_distance = route.train.distance
+          visits = route.visited_stops
+
+          return false unless train_distance.is_a?(Numeric)
+
+          route_distance = visits.sum(&:visit_cost)
+
+          route_distance > train_distance
+        end
+
+        def route_train_type(route)
+          return :normal unless can_be_express?(route.train)
+          return :express if runs_as_express?(route)
+
+          :normal
+        end
+
+        def can_be_express?(train)
+          train.name[-1] == 'E'
+        end
+
         # Stubbed out because this game doesn't use it, but base 22 does
         def bidbox_minors = []
         def bidbox_concessions = []


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

#### Explanation of Change
5/E and 6/E trains in this game can either run normally, or as Express (infinite distance, only count tokened locations, but double the revenue).
- The implementation counts the revenue from running these trains normally and as Express on submitted route, compares the revenue and selects running mode based on which revenue is higher. 
- If selected route exceeds the distance of the train, Express mode is used
- If a Pullman car is attached to */E train, it runs as a normal train
- */E train running in Express mode can use same track as any other normal train (even other */E train running in normal mode)

#### Screenshots
Note that "6/E" train in this image runs as Express:

<img width="1150" alt="Screenshot 2023-08-25 at 23 41 29" src="https://github.com/tobymao/18xx/assets/576786/3ee95eab-4560-4ff4-b5df-4632f22320ae">

#### Any Assumptions / Hacks
The `check_overlap` function is copied from 1822 implementation mostly without changes because my function for determining train type depends on the route, and in 1822 only on train name
