### PR TITLE
[1822Africa] */E train fixes

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -581,6 +581,7 @@ module Engine
                       express_revenue = revenue_for_express(route, stops)
 
                       return express_revenue if train_over_distance?(route)
+                      return super unless includes_two_tokens?(route)
 
                       [super, express_revenue].max
                     end
@@ -607,6 +608,7 @@ module Engine
 
         def runs_as_express?(route)
           return false unless can_be_express?(route.train)
+          return false unless includes_two_tokens?(route)
           return true if train_over_distance?(route)
 
           stops = route.stops
@@ -640,6 +642,16 @@ module Engine
           route_distance = visits.sum(&:visit_cost)
 
           route_distance > train_distance
+        end
+
+        def includes_two_tokens?(route)
+          entity = route.train.owner
+
+          tokened_stops = route.stops.count do |stop|
+            stop.city? && stop.tokened_by?(entity)
+          end
+
+          tokened_stops > 1
         end
 
         def route_train_type(route)

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -575,21 +575,24 @@ module Engine
 
         # This repeats the logic from the base game, but with changes to how */E trains are calculated
         def revenue_for(route, stops)
-          revenue = if route_train_type(route) == :normal
-                      super
-                    else
-                      express_revenue = revenue_for_express(route, stops)
+          revenue = super
+          revenue += destination_bonus_for(route)
 
-                      return express_revenue if train_over_distance?(route)
-                      return super unless includes_two_tokens?(route)
+          return revenue unless can_be_express?(route.train)
+          return revenue unless includes_two_tokens?(route)
 
-                      [super, express_revenue].max
-                    end
+          express_revenue = revenue_for_express(route, stops)
+          express_revenue += destination_bonus_for(route) * self.class::EXPRESS_TRAIN_MULTIPLIER
 
+          [revenue, express_revenue].max
+        end
+
+        def destination_bonus_for(route)
           destination_bonus = destination_bonus(route.routes)
-          revenue += destination_bonus[:revenue] if destination_bonus && destination_bonus[:route] == route
 
-          revenue
+          return destination_bonus[:revenue] if destination_bonus && destination_bonus[:route] == route
+
+          0
         end
 
         def revenue_for_express(route, stops)


### PR DESCRIPTION
Fixes #9476

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

- Fix Express mode being available if only one token is included in the route
- Fix destination bonus only counting once instead of twice for trains in Express mode