### PR TITLE
[1822CA] P26-P27 Grain Trains, grain elevators, and ports

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1361,7 +1361,7 @@ module Engine
           h['nodes'].each { |type| type_info[type] << info }
         end
 
-        grouped = visits.group_by(&:type)
+        grouped = visits.group_by { |v| stop_type(v, train) }
 
         grouped.sort_by { |t, _| type_info[t].size }.each do |type, group|
           num = group.sum(&:visit_cost)
@@ -1416,7 +1416,7 @@ module Engine
 
             next unless stops.all? do |stop|
               row = distance.index.with_index do |h, i|
-                h['nodes'].include?(stop.type) && types_used[i] < h['pay']
+                h['nodes'].include?(stop_type(stop, train)) && types_used[i] < h['pay']
               end
 
               types_used[row] += 1 if row
@@ -1436,6 +1436,10 @@ module Engine
         end
 
         []
+      end
+
+      def stop_type(stop, _train)
+        stop.type
       end
 
       def visited_stops(route)

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -680,13 +680,15 @@ module Engine
         end
 
         def crowded_corps
-          @crowded_corps ||= corporations.select do |c|
-            trains = c.trains.count { |t| !extra_train?(t) }
-            crowded = trains > train_limit(c)
-            crowded |= extra_train_permanent_count(c) > 1
-            crowded |= pullman_train_count(c) > 1
-            crowded
-          end
+          @crowded_corps ||= corporations.select { |c| crowded_corp?(c) }
+        end
+
+        def crowded_corp?(corp)
+          trains = corp.trains.count { |t| !extra_train?(t) }
+          crowded = trains > train_limit(corp)
+          crowded |= extra_train_permanent_count(corp) > 1
+          crowded |= pullman_train_count(corp) > 1
+          crowded
         end
 
         def discountable_trains_for(corporation)
@@ -1926,6 +1928,8 @@ module Engine
 
         def find_and_remove_train_by_id(train_id, buyable: true)
           train = train_by_id(train_id)
+          return unless train
+
           @depot.remove_train(train)
           train.buyable = buyable
           train.reserved = true

--- a/lib/engine/game/g_1822/step/route.rb
+++ b/lib/engine/game/g_1822/step/route.rb
@@ -11,14 +11,22 @@ module Engine
             return [] if !entity.operator? || @game.route_trains(entity).empty? || !@game.can_run_route?(entity)
             return [] if entity.corporation? && entity.type == :minor && only_e_train?(entity)
 
-            @pullman_train ||= nil
             actions = ACTIONS.dup
-            actions << 'choose' if !@pullman_train && find_pullman_train(entity) && !pullman_train_choices(entity).empty?
+            actions << 'choose' if choosing?(entity)
             actions
           end
 
+          def choosing?(entity)
+            choosing_pullman?(entity)
+          end
+
+          def choosing_pullman?(entity)
+            @pullman_train ||= nil
+            !@pullman_train && find_pullman_train(entity) && !pullman_train_choices(entity).empty?
+          end
+
           def attach_pullman
-            @orginal_train = @pullman_train.dup
+            @pullman_original_train = @pullman_train.dup
             distance = train_city_distance(@pullman_train)
             @pullman_train.name += '+'
             @pullman_train.distance = [
@@ -36,7 +44,7 @@ module Engine
           end
 
           def choice_name
-            'Choose which train you want to attach your pullman carriage train'
+            'Attach pullman (P+) to a train'
           end
 
           def choices
@@ -48,10 +56,10 @@ module Engine
           end
 
           def detach_pullman
-            @pullman_train.name = @orginal_train.name
-            @pullman_train.distance = @orginal_train.distance
+            @pullman_train.name = @pullman_original_train.name
+            @pullman_train.distance = @pullman_original_train.distance
 
-            @orginal_train = nil
+            @pullman_original_train = nil
             @pullman_train = nil
           end
 
@@ -72,7 +80,7 @@ module Engine
           def process_choose(action)
             entity = action.entity
             @pullman_train = pullman_train_choices(entity)[action.choice.to_i]
-            @log << "#{entity.id} chooses to attach the pullman to the #{@pullman_train.name} train"
+            @log << "#{entity.id} attaches the pullman to a #{@pullman_train.name} train"
 
             attach_pullman
           end

--- a/lib/engine/game/g_1822_ca/step/discard_train.rb
+++ b/lib/engine/game/g_1822_ca/step/discard_train.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/discard_train'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class DiscardTrain < G1822::Step::DiscardTrain
+          def trains(corporation)
+            return corporation.trains.select { |t| @game.grain_train?(t) } if @game.grain_train_count(corporation) > 1
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_ca/step/route.rb
+++ b/lib/engine/game/g_1822_ca/step/route.rb
@@ -7,8 +7,89 @@ module Engine
     module G1822CA
       module Step
         class Route < G1822::Step::Route
+          CHOICE_SKIP = 'None'
+
+          TRAIN_STR = {
+            pullman: 'pullman',
+            grain: 'grain train',
+          }.freeze
+
+          def setup
+            @choosing = nil
+            @skipped = { pullman: false, grain: false }
+
+            @game.train_with_pullman = @pullman_train = nil
+            @game.train_with_grain = @grain_train = nil
+          end
+
+          def choosing?(entity)
+            @choosing =
+              if choosing_pullman?(entity)
+                :pullman
+              elsif choosing_grain_train?(entity)
+                :grain
+              end
+          end
+
+          def choice_name
+            case @choosing
+            when :pullman
+              super
+            when :grain
+              'Attach grain train (G) to a train'
+            else
+              ''
+            end
+          end
+
+          def choices
+            choices = { CHOICE_SKIP => CHOICE_SKIP }
+            train_choices =
+              case @choosing
+              when :pullman
+                super
+              when :grain
+                grain_train_choices(current_entity).each_with_index.with_object({}) do |(train, index), c|
+                  c[index.to_s] = "#{train.name} train"
+                end
+              else
+                raise GameError, 'Unexpected value for @choosing when calling `choices`'
+              end
+            choices.merge!(train_choices)
+            choices
+          end
+
+          def process_choose(action)
+            entity = action.entity
+
+            if action.choice == CHOICE_SKIP
+              @skipped[@choosing] = true
+              @log << "#{entity.id} skips attaching #{TRAIN_STR[@choosing]}"
+              return
+            end
+
+            case @choosing
+            when :pullman
+              super
+              @game.train_with_pullman = @pullman_train
+            when :grain
+              @grain_train = grain_train_choices(entity)[action.choice.to_i]
+              @game.train_with_grain = @grain_train
+              @log << "#{entity.id} attaches the grain train to a #{@grain_train.name} train"
+              attach_grain_train
+            else
+              raise GameError, 'Unexpected value for @choosing when processing action "choose"'
+            end
+          end
+
+          def process_run_routes(action)
+            super
+
+            detach_grain_train if @grain_train
+          end
+
           def attach_pullman
-            @orginal_train = @pullman_train.dup
+            @pullman_original_train = @pullman_train.dup
             distance = train_city_distance(@pullman_train)
 
             towns = 2 * distance
@@ -16,16 +97,77 @@ module Engine
             @pullman_train.name += "+#{towns}"
             @pullman_train.distance = [
               {
-                'nodes' => %w[city offboard],
-                'pay' => distance,
-                'visit' => distance,
-              },
-              {
                 'nodes' => ['town'],
                 'pay' => towns,
                 'visit' => towns,
               },
+              {
+                'nodes' => %w[city offboard town],
+                'pay' => distance,
+                'visit' => distance,
+              },
             ]
+          end
+
+          def detach_pullman
+            super
+            @game.train_with_pullman = @pullman = nil
+          end
+
+          def choosing_pullman?(entity)
+            !@skipped[:pullman] && super
+          end
+
+          def choosing_grain_train?(entity)
+            @grain_train ||= nil
+            !@skipped[:grain] && !@grain_train && find_grain_train(entity) && !grain_train_choices(entity).empty?
+          end
+
+          def find_grain_train(entity)
+            entity.trains.find { |t| @game.grain_train?(t) }
+          end
+
+          def grain_train_choices(entity)
+            @game.route_trains(entity).reject do |t|
+              t.name == @game.class::E_TRAIN || t == @pullman_train
+            end
+          end
+
+          def attach_grain_train
+            @grain_original_train = @grain_train.dup
+
+            grain_distance = {
+              'nodes' => [@game.class::GRAIN_ELEVATOR_TYPE],
+              'pay' => @game.class::GRAIN_ELEVATOR_COUNT,
+              'visit' => @game.class::GRAIN_ELEVATOR_COUNT,
+            }
+            original_distance =
+              if @grain_train.distance.is_a?(Numeric)
+                [
+                  {
+                    'nodes' => %w[city offboard town],
+                    'pay' => @grain_train.distance,
+                    'visit' => @grain_train.distance,
+                  },
+                ]
+              else
+                @grain_train.distance
+              end
+            @grain_train.distance = [grain_distance, *original_distance]
+
+            # allows selecting routes in the UI with more than 2 stops, if
+            # attached to the LP
+            @grain_train.no_local = true
+
+            @grain_train.name += (@grain_train.name[-1] == 'P' ? '-G' : 'G')
+          end
+
+          def detach_grain_train
+            @grain_train.name = @grain_original_train.name
+            @grain_train.no_local = false
+
+            @grain_original_train = nil
+            @game.train_with_grain = @grain_train = nil
           end
         end
       end

--- a/lib/engine/game/g_1822_ca_wrs/game.rb
+++ b/lib/engine/game/g_1822_ca_wrs/game.rb
@@ -24,6 +24,26 @@ module Engine
           'PGE' => 3,
         }.freeze
 
+        TRAINS = (G1822CA::Scenario::TRAINS + [
+          {
+            name: 'G',
+            distance: [
+              {
+                'nodes' => ['city'],
+                'pay' => 99,
+                'visit' => 99,
+              },
+              {
+                'nodes' => ['town'],
+                'pay' => 99,
+                'visit' => 99,
+              },
+            ],
+            num: 2,
+            price: 0,
+          },
+        ]).freeze
+
         def init_companies(players)
           game_companies.map do |company|
             next if players.size < (company[:min_players] || 0)

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -8,7 +8,7 @@ module Engine
     include Ownable
 
     attr_accessor :obsolete, :events, :variants, :obsolete_on, :rusted, :rusts_on, :index, :name,
-                  :distance, :reserved
+                  :distance, :reserved, :no_local
     attr_reader :available_on, :discount, :multiplier, :sym, :variant, :requires_token, :ever_operated, :operated, :salvage
     attr_writer :buyable
 


### PR DESCRIPTION
Grain trains can attach to regular trains in order to earn revenue at grain elevators without counting the town as a stop. All standard trains except E-trains can earn bonuses at grain elevators, and an extra bonus if the route includes a grain elevator and a port.

Any train except an E-train can attach a grain train. This is done in the Route step. If a Major owns both a pullman and a grain train, the pullman is attached (or skipped) first.

Details on the revenue bonus rules can be found on page 21 in the [rulebook](https://boardgamegeek.com/filepage/238950/1822ca-rules):

* the table in rule 5.11.27 covers most of it
* 5.11.25 shows the port limit 

Very small, semi-related changes also included here:

* reorder pullman's distance to fix it counting stops; this was broken when enough towns were added since it was originally copied from 1822 pullmans, which have no limit to the number of towns
* after the train object is created, rename the "5P" train to "5"; the different id/name is useful in setup, but once a Major owns the train it is just like any other 5-train (and IMO looks better when renamed from attaching the pullman or grain train)

Core changes:

* extract new method `stop_type()` in `Game::Base`, so that grain elevator towns could be treated as the new type `grain_elevator` instead of `town` for grain trains
* in `Engine::Train`, added `attr_accessor :no_local` so it could be toggled when attaching a grain train; this was necessary for the LP-G train to select more than 2 stops

#9376