### PR TITLE
1841: always clear both graphs

### DIFF
--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -352,16 +352,11 @@ module Engine
         end
 
         def select_track_graph
-          old_graph = @selected_graph
           @selected_graph = if @phase.name.to_i == 2
                               @region_graph
                             else
                               @graph
                             end
-          return if old_graph == @selected_graph
-
-          @region_graph.clear
-          @graph.clear
         end
 
         def select_token_graph
@@ -376,15 +371,15 @@ module Engine
           @region_graph
         end
 
-        def clear_graph_for_entity(entity)
-          super
-          token_graph_for_entity(entity).clear
+        def clear_graph_for_entity(_entity)
+          @graph.clear
+          @region_graph.clear
           @border_paths = nil
         end
 
-        def clear_token_graph_for_entity(entity)
-          super
-          graph_for_entity(entity).clear
+        def clear_token_graph_for_entity(_entity)
+          @graph.clear
+          @region_graph.clear
           @border_paths = nil
         end
 

--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -377,10 +377,8 @@ module Engine
           @border_paths = nil
         end
 
-        def clear_token_graph_for_entity(_entity)
-          @graph.clear
-          @region_graph.clear
-          @border_paths = nil
+        def clear_token_graph_for_entity(entity)
+          clear_graph_for_entity(entity)
         end
 
         def event_phase4_regions!


### PR DESCRIPTION
This is a better fix for #9474 

It took me a while, but I root-caused why the above bug only failed on the server and not with validate_json - even with strict:true.

The prior fix works, but this is potentially more robust.