### PR TITLE
[1822CA] Implement P10 Winnipeg Station and P21 3-Tile Grant, fix QMOO's home

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1501,7 +1501,7 @@ module Engine
 
       def place_home_token(corporation)
         return unless corporation.next_token # 1882
-        # If a corp has laid it's first token assume it's their home token
+        # If a corp has laid its first token assume its their home token
         return if corporation.tokens.first&.used
 
         hex = hex_by_id(corporation.coordinates)

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -482,6 +482,7 @@ module Engine
 
         MINOR_14_ID = '14'
         MINOR_14_HOME_HEX = 'M38'
+        PENDING_HOME_TOKENERS = [MINOR_14_ID].freeze
 
         PLUS_EXPANSION_BIDBOX_1 = %w[P1 P3 P4 P13 P14 P19].freeze
         PLUS_EXPANSION_BIDBOX_2 = %w[P2 P5 P8 P10 P11 P12 P21].freeze

--- a/lib/engine/game/g_1822/step/pending_token.rb
+++ b/lib/engine/game/g_1822/step/pending_token.rb
@@ -26,7 +26,7 @@ module Engine
                                'tokens in the same city'
             end
 
-            connected = action.entity.id != @game.class::MINOR_14_ID
+            connected = !@game.class::PENDING_HOME_TOKENERS.include?(action.entity.id)
             city.tokens << nil if action.entity.id == @game.class::MINOR_14_ID
             city.tokens << nil unless city.get_slot(action.entity)
             place_token(token.corporation, city, token, connected: connected, extra_action: true,

--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -144,7 +144,24 @@ module Engine
                   'Station slots. Pays company $10 until used. The company does not need to be able to trace a route '\
                   'to Winnipeg to use this property (i.e. any company can use this power to place a token in the '\
                   'Winnipeg hex).',
-            abilities: [],
+            abilities: [
+              {
+                type: 'token',
+                check_tokenable: false,
+                closed_when_used_up: true,
+                connected: false,
+                count: 1,
+                extra_action: true,
+                extra_slot: true,
+                from_owner: false,
+                hexes: ['N16'],
+                owner_type: 'corporation',
+                price: 0,
+                special_only: true,
+                teleport_price: 0,
+                when: 'owning_corp_or_turn',
+              },
+            ],
             color: nil,
           },
           {
@@ -417,6 +434,9 @@ module Engine
                 count: 3,
                 reachable: true,
                 closed_when_used_up: true,
+                special: false,
+                free: true,
+                tiles: [],
                 hexes: %w[A9 B10 B12 B14 B6 B8 C11 C13 C7 C9 D10 D12 D14 D16 D6
                           D8 E15 E7 E9 F10 F12 F6 F8 G11 G13 G17 G7 G9 H10 H12 H14 H16 H6
                           H8 I11 I13 I15 I17 I7 I9 J10 J12 J14 J16 J6 J8 K11 K13 K17 K7 K9
@@ -432,8 +452,6 @@ module Engine
                           AH6 AI11 AI13 AI3 AI5 AI7 AI9 AJ10 AJ12 AJ2 AJ4 AJ6 AJ8 AK11 AK3
                           AK5 AK7 AK9 AL10 AL2 AL4 AL6 AL8 AM3 AM5 AM7 AM9 AN2 AN4 AN6 AO3
                           AO5 AO7 AO9 AP2 AP6 AP8],
-                tiles: %w[1 2 3 4 5 6 7 8 9 55 56 57 58 69 201 202 621 630 631 632 633],
-                free: true,
               },
             ],
             color: nil,
@@ -1693,7 +1711,6 @@ module Engine
             float_percent: 20,
             always_market_price: true,
             coordinates: 'AH8',
-            city: 1,
             color: '#7f3881',
             reservation_color: nil,
             destination_coordinates: 'AA15',

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -33,6 +33,8 @@ module Engine
         COMPANY_5X_REVENUE = 'P9'
         COMPANY_HSBC = nil # Grimsby/Hull Bridge
 
+        COMPANY_WINNIPEG_TOKEN = 'P10'
+
         COMPANIES_BIG_CITY_UPGRADES = %w[P14 P15 P16 P17 P18].freeze
         COMPANIES_EXTRA_TRACK_LAYS = (COMPANIES_BIG_CITY_UPGRADES + %w[P19 P20 P21]).freeze
 
@@ -156,6 +158,7 @@ module Engine
 
         MINOR_14_ID = '13'
         MINOR_14_HOME_HEX = 'AC21'
+        PENDING_HOME_TOKENERS = [MINOR_14_ID, 'QMOO'].freeze
 
         TWO_HOME_CORPORATION = 'CPR'
 
@@ -332,7 +335,7 @@ module Engine
             G1822CA::Step::AssignSawmill,
             G1822::Step::SpecialChoose,
             G1822CA::Step::SpecialTrack,
-            G1822::Step::SpecialToken,
+            G1822CA::Step::SpecialToken,
             G1822CA::Step::Track,
             G1822::Step::DestinationToken,
             G1822::Step::Token,

--- a/lib/engine/game/g_1822_ca/step/special_token.rb
+++ b/lib/engine/game/g_1822_ca/step/special_token.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/special_token'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class SpecialToken < G1822::Step::SpecialToken
+          def actions(entity)
+            if entity.id == @game.class::COMPANY_WINNIPEG_TOKEN &&
+               entity.owner == current_entity &&
+               !available_tokens(entity).empty? &&
+               ability(entity)
+              ['place_token']
+            else
+              []
+            end
+          end
+
+          def available_tokens(entity)
+            if entity.id == @game.class::COMPANY_WINNIPEG_TOKEN && @game.exchange_tokens(entity.owner).positive?
+              [Engine::Token.new(entity.owner)]
+            else
+              []
+            end
+          end
+
+          def process_place_token(action)
+            entity = action.entity.owner
+
+            super
+
+            @game.remove_exchange_token(entity)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_ca/step/special_track.rb
+++ b/lib/engine/game/g_1822_ca/step/special_track.rb
@@ -31,6 +31,12 @@ module Engine
             # Pass privates
             @round.num_laid_track += 1 if @game.class::MOUNTAIN_PASS_COMPANIES.include?(action.entity.id)
           end
+
+          # P21 3-Tile Grant does not need to be consecutive
+          # https://boardgamegeek.com/thread/2449433/article/35135037#35135037
+          def handle_extra_tile_lay_company(ability, entity)
+            super unless entity.id == @game.class::COMPANY_LSR
+          end
         end
       end
     end

--- a/lib/engine/game/g_1822_ca/step/track.rb
+++ b/lib/engine/game/g_1822_ca/step/track.rb
@@ -9,6 +9,18 @@ module Engine
       module Step
         class Track < G1822::Step::Track
           include G1822CA::Tracker
+
+          def process_pass(action)
+            super
+
+            return unless (tile_grant = action.entity.companies.find { |c| c.id == @game.class::COMPANY_LSR })
+            return if tile_grant.closed?
+            return unless (ability = tile_grant.all_abilities[0])
+            return unless ability.used?
+
+            @log << "#{tile_grant.name} closes"
+            tile_grant.close!
+          end
         end
       end
     end


### PR DESCRIPTION
* P10 can teleport an Exchange token into Winnipeg, creating an extra slot
* P21 can close to lay 3 additional yellow tiles, which may be interleaved with the corporation's normal tile lays; if only some if its lays are used it closes at the end of the track step
* fix QMOO's home on the Quebec hex so it is not fixed on a particular city until it first operates

#9376
