### PR TITLE
[1822Africa] Implement P11 and P12

### DIFF
--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -88,7 +88,7 @@ module Engine
                 hexes: [],
                 tiles: [],
                 consume_tile_lay: false,
-                combo_entities: %w[P9],
+                combo_entities: %w[P9 P11],
               },
             ],
             color: nil,
@@ -128,7 +128,7 @@ module Engine
                 closed_when_used_up: true,
                 hexes: [],
                 tiles: %w[7 8 9 80 81 82 83 544 545 546 60 169],
-                combo_entities: %w[P7],
+                combo_entities: %w[P7 P11],
               },
             ],
             color: nil,
@@ -148,14 +148,32 @@ module Engine
             color: nil,
           },
           {
-            name: 'P11 (Mountain Rebate) [N/A]',
+            name: 'P11 (Mountain Rebate)',
             sym: 'P11',
-            desc: '[NOT YET FUNCTIONAL] '\
-                  'MAJOR/MINOR, Phase 3. After the owning company lays a yellow tile in a mountain hex, '\
-                  'it earns A50 into its treasury. The private company immediately closes.',
+            desc: 'MAJOR/MINOR, Phase 3. The owning company may close this company when it lays a yellow tile '\
+                  'in a mountain hex to earn A50 into its treasury.',
             value: 0,
             revenue: 10,
-            abilities: [],
+            abilities: [
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                when: %w[track special_track],
+                count: 1,
+                reachable: true,
+                closed_when_used_up: true,
+                hexes: %w[G11 G15 H10 H14],
+                tiles: [],
+                combo_entities: %w[P7 P9],
+              },
+              {
+                type: 'tile_income',
+                terrain: 'mountain',
+                income: 50,
+                owner_type: 'corporation',
+                owner_only: true,
+              }
+            ],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -172,20 +172,36 @@ module Engine
                 income: 50,
                 owner_type: 'corporation',
                 owner_only: true,
-              }
+              },
             ],
             color: nil,
           },
           {
-            name: 'P12 (Fast Sahara Building) [N/A]',
+            name: 'P12 (Fast Sahara Building)',
             sym: 'P12',
-            desc: '[NOT YET FUNCTIONAL] '\
-                  'MAJOR/MINOR, Phase 1. The owning company may place any amount of tiles in the hexes marked '\
+            desc: 'MAJOR/MINOR, Phase 1. The owning company may place any amount of yellow tiles in the hexes marked '\
                   'with desert terrain as their normal tile laying step at normal cost. '\
                   'Using this ability closes the private company.',
             value: 0,
             revenue: 10,
-            abilities: [],
+            abilities: [
+              {
+                type: 'tile_lay',
+                hexes: %w[B6 C3 C5 C7 D4 D6 D8 E5 E7 F6 G7],
+                tiles: [],
+                owner_type: 'corporation',
+                when: 'special_track',
+                must_lay_together: true,
+                lay_count: 11,
+                upgrade_count: 0,
+                reachable: true,
+                special: false,
+                connect: false,
+                closed_when_used_up: true,
+                consume_tile_lay: true,
+                combo_entities: %w[P7 P9 P11],
+              },
+            ],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -10,7 +10,7 @@ module Engine
             sym: 'P1',
             desc: 'MAJOR/MINOR, Phase 1. Permanent L-train',
             value: 0,
-            revenue: 10,
+            revenue: 0,
             abilities: [],
             color: nil,
           },
@@ -19,7 +19,7 @@ module Engine
             sym: 'P2',
             desc: 'MAJOR, Phase 2. Permanent 2-train',
             value: 0,
-            revenue: 10,
+            revenue: 0,
             abilities: [],
             color: nil,
           },
@@ -28,7 +28,7 @@ module Engine
             sym: 'P3',
             desc: 'MAJOR, Phase 2. Permanent 2-train',
             value: 0,
-            revenue: 10,
+            revenue: 0,
             abilities: [],
             color: nil,
           },
@@ -37,7 +37,7 @@ module Engine
             sym: 'P4',
             desc: 'MAJOR/MINOR, Phase 3. A "Pullman" carriage that can be added to another train owned by the company.'\
                   ' It converts the train into a + train. Does not count against train limit and does not count '\
-                  'as a train for the purposes of train ownership. Can’t be sold to another company. Does not close.',
+                  'as a train for the purposes of train ownership. Can’t be sold to another company.',
             value: 0,
             revenue: 10,
             abilities: [],
@@ -48,7 +48,7 @@ module Engine
             sym: 'P5',
             desc: 'MAJOR/MINOR, Phase 3. A "Pullman" carriage that can be added to another train owned by the company.'\
                   ' It converts the train into a + train. Does not count against train limit and does not count '\
-                  'as a train for the purposes of train ownership. Can’t be sold to another company. Does not close.',
+                  'as a train for the purposes of train ownership. Can’t be sold to another company.',
             value: 0,
             revenue: 10,
             abilities: [],
@@ -219,7 +219,7 @@ module Engine
                   'If not acquired beforehand, this company closes at the start of Phase 6 and all treasury credits '\
                   'are returned to the bank.',
             value: 0,
-            revenue: 10,
+            revenue: 0,
             abilities: [],
             color: nil,
           },
@@ -242,7 +242,7 @@ module Engine
                   'MAJOR/MINOR, Phase 3. The Safari Bonus can be added to a train owned by the company. '\
                   'It converts the train into a safari train that counts an extra 20 to the earnings for reaching '\
                   'each of the game reserves. Does not count against train limit and does not count as a train '\
-                  'for the purposes of train ownership. Can’t be sold to another company. Does not close.',
+                  'for the purposes of train ownership. Can’t be sold to another company.',
             value: 0,
             revenue: 10,
             abilities: [],

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -64,6 +64,7 @@ module Engine
 
         COMPANY_10X_REVENUE = 'P16'
         COMPANY_REMOVE_TOWN = 'P9'
+        COMPANY_EXTRA_TILE_LAYS = 'P12'
 
         MINOR_BIDBOX_PRICE = 100
         BIDDING_BOX_MINOR_COUNT = 3
@@ -666,6 +667,10 @@ module Engine
 
         def can_be_express?(train)
           train.name[-1] == 'E'
+        end
+
+        def company_ability_extra_track?(company)
+          company.id == self.class::COMPANY_EXTRA_TILE_LAYS
         end
 
         # Stubbed out because this game doesn't use it, but base 22 does

--- a/lib/engine/game/g_1822_africa/map.rb
+++ b/lib/engine/game/g_1822_africa/map.rb
@@ -112,12 +112,12 @@ module Engine
           white: {
             %w[B4 B8 E3 E17 F2 F4 F8 F10 F12 F14 F16 G5 H6 H16 I9] => '',
             %w[B6 C3 C5 C7 D6 E5 E7 F6] => 'upgrade=cost:20,terrain:desert',
-            %w[G11 G15 H14] => 'upgrade=cost:20,terrain:hill',
+            %w[G11 G15 H14] => 'upgrade=cost:20,terrain:mountain',
             %w[A5 A9 D10 E15 G9 I11] => 'town=revenue:0',
             %w[B2 B10 D2 E9 F18 H8 I7] => 'city=revenue:20',
             %w[D4 D8] => 'town=revenue:0;upgrade=cost:20,terrain:desert',
             ['G7'] => 'city=revenue:20;upgrade=cost:20,terrain:desert',
-            ['H10'] => 'city=revenue:20;upgrade=cost:20,terrain:hill',
+            ['H10'] => 'city=revenue:20;upgrade=cost:20,terrain:mountain',
           },
           yellow: {
             %w[E11 E13] => 'city=revenue:20,slots:1;path=a:0,b:_0;path=a:3,b:_0',


### PR DESCRIPTION
### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

Implemented functionality of following privates: 
- **P11**: The owning company may close this company when it lays a yellow tile in a mountain hex to earn A50 into its treasury.
- **P12**: The owning company may place any amount of yellow tiles in the hexes marked with desert terrain as their normal tile laying step at normal cost. Using this ability closes the private company.