### PR TITLE
[1822Africa] Fix auto-pass not disabling in SR x.2

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -673,6 +673,18 @@ module Engine
           company.id == self.class::COMPANY_EXTRA_TILE_LAYS
         end
 
+        # This game has two back-to-back SRs so we need to manually disable auto-pass on round end
+        def check_programmed_actions
+          @programmed_actions.each do |entity, action_list|
+            action_list.reject! do |action|
+              if action&.disable?(self) || action.instance_of?(Engine::Action::ProgramSharePass)
+                player_log(entity, "Programmed action '#{action}' removed due to round change")
+                true
+              end
+            end
+          end
+        end
+
         # Stubbed out because this game doesn't use it, but base 22 does
         def bidbox_minors = []
         def bidbox_concessions = []


### PR DESCRIPTION
Fixes #9482

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

