### PR TITLE
[1822CA, 1822] allow Tax Haven to buy additional shares

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -529,6 +529,9 @@ module Engine
         STARTING_CORPORATIONS_PLUS = %w[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
                                         30 LNWR GWR LBSCR SECR CR MR LYR NBR SWR NER].freeze
 
+        # can the tax haven private own multiple shares?
+        TAX_HAVEN_MULTIPLE = false
+
         TOKEN_PRICE = 100
 
         TRACK_PLAIN = %w[7 8 9 80 81 82 83 544 545 546 60 169].freeze
@@ -540,7 +543,7 @@ module Engine
 
         UPGRADE_COST_L_TO_2 = 80
 
-        attr_reader :minor_14_city_exit
+        attr_reader :minor_14_city_exit, :tax_haven
         attr_accessor :bidding_token_per_player, :player_debts
 
         def bank_sort(corporations)
@@ -665,8 +668,9 @@ module Engine
 
           if company.id == self.class::COMPANY_OSTH && company.owner&.player? && @tax_haven.value.positive?
             company.value = @tax_haven.value
-            share = @tax_haven.shares.first
-            return "(#{share.corporation.name})"
+            cash = format_currency(@tax_haven.cash)
+            shares = @tax_haven.shares.map { |s| s.corporation.name }.join(',')
+            return "(#{cash}; #{shares})"
           end
 
           nil
@@ -1497,12 +1501,15 @@ module Engine
         end
 
         def company_choices_osth(company, time)
-          return {} if @tax_haven.value.positive? || !company.owner&.player? || time != :stock_round
+          return {} if @tax_haven.value.positive? && !company_tax_haven_can_own_multiple?
+          return {} if !company.owner&.player? || time != :stock_round || @round.tax_haven_bought
 
           choices = {}
           @corporations.select { |c| c.type == :major }.each do |corporation|
             price = corporation.share_price&.price || 0
             next unless price.positive?
+            next if @tax_haven.num_shares_of(corporation).positive?
+            next if price > tax_haven_spender(company).cash
 
             if corporation.num_ipo_shares.positive?
               choices["#{corporation.id}_ipo"] = "#{corporation.id} IPO (#{format_currency(price)})"
@@ -1592,16 +1599,28 @@ module Engine
         end
 
         def company_made_choice_osth(company, choice)
-          spender = company.owner
+          spender = tax_haven_spender(company)
           bundle = company_tax_haven_bundle(choice)
           corporation = bundle.corporation
           floated = corporation.floated?
           receiver = bundle.owner == @share_pool ? @bank : corporation
           @share_pool.transfer_shares(bundle, @tax_haven, spender: spender, receiver: receiver,
                                                           price: bundle.price, allow_president_change: false)
-          @log << "#{spender.name} spends #{format_currency(bundle.price)} and tax haven gains a share of "\
-                  "#{corporation.name}."
+
+          if spender == @tax_haven
+            from = choice.split('_')[1] == 'ipo' ? 'Treasury' : 'market'
+            @log << "Tax Haven (#{company.owner.name}) buys a 10% share of #{corporation.name} from the #{from} for #{format_currency(bundle.price)}"
+          else
+            @log << "#{spender.name} spends #{format_currency(bundle.price)} and Tax Haven gains a share of "\
+                    "#{corporation.name}."
+          end
           float_corporation(corporation) if corporation.floatable && floated != corporation.floated?
+        end
+
+        def tax_haven_spender(company)
+          return company.owner if !company_tax_haven_can_own_multiple? || @tax_haven.value.zero?
+
+          @tax_haven
         end
 
         def company_tax_haven_bundle(choice)
@@ -1619,6 +1638,10 @@ module Engine
 
           @bank.spend(amount, @tax_haven)
           @log << "#{entity.name} pays out #{format_currency(amount)} to tax haven"
+        end
+
+        def company_tax_haven_can_own_multiple?
+          self.class::TAX_HAVEN_MULTIPLE || @optional_rules&.include?(:tax_haven_multiple)
         end
 
         def destination_bonus(routes)

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1609,10 +1609,11 @@ module Engine
 
           if spender == @tax_haven
             from = choice.split('_')[1] == 'ipo' ? 'Treasury' : 'market'
-            @log << "Tax Haven (#{company.owner.name}) buys a 10% share of #{corporation.name} from the #{from} for #{format_currency(bundle.price)}"
+            @log << "Tax Haven (#{company.owner.name}) buys a 10% share of #{corporation.name} "\
+                    "from the #{from} for #{format_currency(bundle.price)}"
           else
-            @log << "#{spender.name} spends #{format_currency(bundle.price)} and Tax Haven gains a share of "\
-                    "#{corporation.name}."
+            @log << "#{spender.name} spends #{format_currency(bundle.price)} and Tax Haven gains "\
+                    "a share of #{corporation.name}."
           end
           float_corporation(corporation) if corporation.floatable && floated != corporation.floated?
         end

--- a/lib/engine/game/g_1822/meta.rb
+++ b/lib/engine/game/g_1822/meta.rb
@@ -40,6 +40,11 @@ module Engine
             desc: '6 more minors and 3 more privates. The privates are categorized into blue (bidbox 1), '\
                   'dark grey (bidbox 2) and gold (bidbox 3) stacks.',
           },
+          {
+            sym: :tax_haven_multiple,
+            short_name: 'Tax Haven Variant',
+            desc: 'P16 (Tax Haven) can use the cash it accumulates to buy 1 share per SR. Cannot own multiple shares of one corporation.',
+          },
         ].freeze
       end
     end

--- a/lib/engine/game/g_1822/meta.rb
+++ b/lib/engine/game/g_1822/meta.rb
@@ -43,7 +43,8 @@ module Engine
           {
             sym: :tax_haven_multiple,
             short_name: 'Tax Haven Variant',
-            desc: 'P16 (Tax Haven) can use the cash it accumulates to buy 1 share per SR. Cannot own multiple shares of one corporation.',
+            desc: 'P16 (Tax Haven) can use the cash it accumulates to buy 1 share per SR. Cannot '\
+                  'own multiple shares of one corporation.',
           },
         ].freeze
       end

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -151,14 +151,17 @@ module Engine
             end
 
             bundle = @game.company_tax_haven_bundle(action.choice)
-            entity = action.entity.owner
-            if available_cash(entity) < bundle.price || @round.players_sold[entity][bundle.corporation]
+            player = action.entity.owner
+            spender = @game.tax_haven_spender(action.entity)
+            if available_cash(spender) < bundle.price || @round.players_sold[player][bundle.corporation] || @round.tax_haven_bought
               raise GameError, "Can't buy a share of #{bundle&.corporation&.name}"
             end
 
+            @round.tax_haven_bought = true
+
             @game.company_made_choice(action.entity, action.choice, :stock_round)
             track_action(action, action.entity)
-            log_pass(entity)
+            log_pass(player)
             pass!
           end
 
@@ -270,6 +273,14 @@ module Engine
 
             log_pass(entity)
             pass!
+          end
+
+          def round_state
+            super.merge(
+              {
+                tax_haven_bought: false,
+              }
+            )
           end
         end
       end

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -10,6 +10,14 @@ module Engine
         class BuySellParShares < Engine::Step::BuySellParShares
           include BidboxAuction
 
+          def round_state
+            super.merge(
+              {
+                tax_haven_bought: false,
+              }
+            )
+          end
+
           def actions(entity)
             return ['choose_ability'] unless choices_ability(entity).empty?
             return [] unless entity == current_entity
@@ -153,7 +161,9 @@ module Engine
             bundle = @game.company_tax_haven_bundle(action.choice)
             player = action.entity.owner
             spender = @game.tax_haven_spender(action.entity)
-            if available_cash(spender) < bundle.price || @round.players_sold[player][bundle.corporation] || @round.tax_haven_bought
+            if available_cash(spender) < bundle.price ||
+               @round.players_sold[player][bundle.corporation] ||
+               @round.tax_haven_bought
               raise GameError, "Can't buy a share of #{bundle&.corporation&.name}"
             end
 
@@ -273,14 +283,6 @@ module Engine
 
             log_pass(entity)
             pass!
-          end
-
-          def round_state
-            super.merge(
-              {
-                tax_haven_bought: false,
-              }
-            )
           end
         end
       end

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -227,6 +227,8 @@ module Engine
         STARTING_CORPORATIONS = %w[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
                                    CNoR CPR GNWR GT GTP GWR ICR NTR PGE QMOO].freeze
 
+        TAX_HAVEN_MULTIPLE = true
+
         MUST_SELL_IN_BLOCKS = true
 
         TRAINS = (G1822::Game::TRAINS + [
@@ -320,11 +322,6 @@ module Engine
           @company_trains['P26'] = find_and_remove_train_by_id('G-0', buyable: false)
           @company_trains['P27'] = find_and_remove_train_by_id('G-1', buyable: false)
         end
-
-        # Stubbed out because this game doesn't use it, but base 22 does
-        def company_tax_haven_bundle(choice); end
-        def company_tax_haven_payout(entity, per_share); end
-        def num_certs_modification(_entity) = 0
 
         def operating_round(round_num)
           Engine::Round::Operating.new(self, [


### PR DESCRIPTION
This is a base rule in 1822CA, and an official variant in 1822 (page 28, rule 11.1.2).

This allows the Tax Haven private to use the cash it has accumulated to buy one share per stock round, but it can never buy a second share of a corporation.

#9376