### PR TITLE
[1822CA, 1822MX] if a city has multiple tokens from one corp, return extra to charter

### DIFF
--- a/lib/engine/game/g_1822/step/tracker.rb
+++ b/lib/engine/game/g_1822/step/tracker.rb
@@ -101,6 +101,28 @@ module Engine
         def upgraded_track?(from, _to, _hex)
           from.color != :white
         end
+
+        def update_token!(action, entity, tile, old_tile)
+          tile.cities.each do |c|
+            present_corps = []
+            tokens_to_return = []
+            c.tokens.compact.each do |t|
+              if present_corps.include?(t.corporation)
+                tokens_to_return << t
+              else
+                present_corps << t.corporation
+              end
+            end
+            tokens_to_return.compact.each do |t|
+              corp = t.corporation
+              @log << "Extra token for #{corp.name} is returned to the charter"
+              corp.tokens << Engine::Token.new(corp, price: @game.class::TOKEN_PRICE)
+              t.destroy!
+            end
+          end
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/game/g_1822_mx/step/track.rb
+++ b/lib/engine/game/g_1822_mx/step/track.rb
@@ -97,26 +97,6 @@ module Engine
             super
           end
 
-          def update_token!(action, entity, tile, old_tile)
-            tile.cities.each do |c|
-              present_corps = []
-              tokens_to_delete = []
-              c.tokens.compact.each do |t|
-                if present_corps.include?(t.corporation)
-                  tokens_to_delete << t
-                else
-                  present_corps << t.corporation
-                end
-              end
-              tokens_to_delete.compact.each do |t|
-                @log << "Extra token for #{t.corporation.name} is removed"
-                t.destroy!
-              end
-            end
-
-            super
-          end
-
           def ndem_acting_player
             @ndem_tile_layers&.first
           end


### PR DESCRIPTION
* in previous 1822MX implementation, the extra token was simply destroyed instead of being returned

Fixes #9494

#9376