### PR TITLE
[1822CA] fix some track and token restrictions

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -278,6 +278,9 @@ module Engine
       # for track and/or cities?
       # :cities for cities, as in  #611 and #63 in 1822
       # :track  for track, as in 18USA
+      # :unlabeled_cities for cities with no special label on their hex; the
+      #     labeled cities in 1822CA don't always add track in all possible
+      #     upgrades
       TILE_UPGRADES_MUST_USE_MAX_EXITS = [].freeze
 
       TILE_COST = 0

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -49,6 +49,9 @@ module Engine
         MOUNTAIN_PASS_COMPANIES = %w[P19 P20].freeze
         MOUNTAIN_PASS_COMPANIES_TO_HEXES = { 'P20' => 'E11', 'P19' => 'F16' }.freeze
 
+        TILE_UPGRADES_MUST_USE_MAX_EXITS = %i[unlabeled_cities].freeze
+        TRACK_RESTRICTION = :permissive
+
         EXTRA_TRAINS = (G1822::Game::EXTRA_TRAINS + %w[G]).freeze
         EXTRA_TRAIN_GRAIN = 'G'
 
@@ -159,6 +162,8 @@ module Engine
         MINOR_14_ID = '13'
         MINOR_14_HOME_HEX = 'AC21'
         PENDING_HOME_TOKENERS = [MINOR_14_ID, 'QMOO'].freeze
+
+        MULTIPLE_TOKENS_ON_SAME_HEX_ALLOWED = true
 
         TWO_HOME_CORPORATION = 'CPR'
 
@@ -335,7 +340,7 @@ module Engine
             G1822CA::Step::SpecialToken,
             G1822CA::Step::Track,
             G1822::Step::DestinationToken,
-            G1822::Step::Token,
+            G1822CA::Step::Token,
             G1822CA::Step::Route,
             G1822::Step::Dividend,
             G1822::Step::BuyTrain,

--- a/lib/engine/game/g_1822_ca/step/token.rb
+++ b/lib/engine/game/g_1822_ca/step/token.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/token'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class Token < G1822::Step::Token
+          def place_token(entity, city, token, check_tokenable:)
+            super(entity,
+                  city,
+                  token,
+                  check_tokenable: check_tokenable,
+                  same_hex_allowed: @game.class::MULTIPLE_TOKENS_ON_SAME_HEX_ALLOWED)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -56,12 +56,12 @@ module Engine
       @routes[corporation]
     end
 
-    def can_token?(corporation, cheater: false)
+    def can_token?(corporation, cheater: false, same_hex_allowed: false)
       tokens = cheater ? @cheater_tokens : @tokens
       return tokens[corporation] if tokens.key?(corporation)
 
       compute(corporation) do |node|
-        if node.tokenable?(corporation, free: true, cheater: cheater)
+        if node.tokenable?(corporation, free: true, cheater: cheater, same_hex_allowed: same_hex_allowed)
           tokens[corporation] = true
           break
         end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -80,7 +80,7 @@ module Engine
       end
 
       def tokenable?(corporation, free: false, tokens: corporation.tokens_by_type, cheater: false,
-                     extra_slot: false, spender: nil)
+                     extra_slot: false, spender: nil, same_hex_allowed: false)
         tokens = Array(tokens)
         @error = :generic
         if !extra_slot && tokens.empty?
@@ -97,7 +97,7 @@ module Engine
             @error = :no_money
             next false
           end
-          if @tile.cities.any? { |c| c.tokened_by?(t.corporation) }
+          if !same_hex_allowed && @tile.cities.any? { |c| c.tokened_by?(t.corporation) }
             @error = :existing_token
             next false
           end
@@ -127,10 +127,16 @@ module Engine
       end
 
       def place_token(corporation, token, free: false, check_tokenable: true, cheater: false,
-                      extra_slot: false, spender: nil)
+                      extra_slot: false, spender: nil, same_hex_allowed: false)
         if check_tokenable && !tokenable?(
-            corporation, free: free, tokens: token, cheater: cheater, extra_slot: extra_slot, spender: spender
-          )
+             corporation,
+             free: free,
+             tokens: token,
+             cheater: cheater,
+             extra_slot: extra_slot,
+             spender: spender,
+             same_hex_allowed: same_hex_allowed
+           )
 
           case @error
           when :no_tokens

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -44,7 +44,7 @@ module Engine
       end
 
       def place_token(entity, city, token, connected: true, extra_action: false,
-                      special_ability: nil, check_tokenable: true, spender: nil)
+                      special_ability: nil, check_tokenable: true, spender: nil, same_hex_allowed: false)
         hex = city.hex
         extra_action ||= special_ability.extra_action if %i[teleport token].include?(special_ability&.type)
 
@@ -79,7 +79,8 @@ module Engine
           extra_slot = ability.extra_slot
         end
         city.place_token(entity, token, free: free, check_tokenable: check_tokenable,
-                                        cheater: cheater, extra_slot: extra_slot, spender: spender)
+                                        cheater: cheater, extra_slot: extra_slot, spender: spender,
+                                        same_hex_allowed: same_hex_allowed)
         unless free
           pay_token_cost(spender || entity, token.price)
           price_log = " for #{@game.format_currency(token.price)}"

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -379,7 +379,10 @@ module Engine
         end.compact
 
         if (!hex.tile.cities.empty? && @game.class::TILE_UPGRADES_MUST_USE_MAX_EXITS.include?(:cities)) ||
-          (hex.tile.cities.empty? && hex.tile.towns.empty? && @game.class::TILE_UPGRADES_MUST_USE_MAX_EXITS.include?(:track))
+           (!hex.tile.cities.empty? &&
+            hex.tile.labels.empty? &&
+            @game.class::TILE_UPGRADES_MUST_USE_MAX_EXITS.include?(:unlabeled_cities)) ||
+           (hex.tile.cities.empty? && hex.tile.towns.empty? && @game.class::TILE_UPGRADES_MUST_USE_MAX_EXITS.include?(:track))
           max_exits(tiles)
         else
           tiles


### PR DESCRIPTION
* let `TILE_UPGRADES_MUST_USE_MAX_EXITS` consider unlabled cities; in 1822CA, upgrading M1 to M3 joins cities up but does not increase value or add new track paths, but is legal * core code modification required to enable this check
* set `TRACK_RESTRICTION`
* allow placing a token in the normal token step in a different city on the same hex where a token is already present * core code modification to plumb `same_hex_allowed` through

https://github.com/tobymao/18xx/issues/9376
