### PR TITLE
[1880] allows buy from depot after cross buy

### DIFF
--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -80,8 +80,7 @@ module Engine
 
           def can_buy_restored2?(entity)
             @game.phase.available?(restored2_train&.available_on) &&
-            !owns_restored2?(entity) &&
-            @corporations_sold.empty?
+            !owns_restored2?(entity)
           end
 
           def can_buy_restored2_from_depot?(entity)


### PR DESCRIPTION
Fixes #https://github.com/tobymao/18xx/issues/9358

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

removed 
```
&&
   corporations_sold.empty?
```

from lines 83 & 84 of buy_trains.rb, which appear to be what was causing the game to end a corp's turn as soon as it bought a train across from another corp. 

* **Explanation of Change**

This coding was due to a mistranslation in the rules, which was only meant to reconfirm that you can only buy trains across during the Buy Trains step of the game. 