### PR TITLE
[1847 AE] Two track actions on first operation

### DIFF
--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -126,7 +126,7 @@ module Engine
                                { 'nodes' => %w[city offboard town], 'pay' => 3, 'visit' => 3 }],
                     price: 300,
                     rusts_on: '5+5',
-                    num: 3,
+                    num: 2,
                   },
                   {
                     name: '4',


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

- In two first phases corporations may lay two yellow tracks
- On its very first operation, a corporation may perform two track actions
