### PR TITLE
[18EU] Checks consent for reserved hexes

### DIFF
--- a/lib/engine/game/g_18_eu/entities.rb
+++ b/lib/engine/game/g_18_eu/entities.rb
@@ -130,8 +130,8 @@ module Engine
                 from: %w[ipo market],
               },
               {
-                type: 'blocks_hexes',
-                owner_type: nil,
+                type: 'blocks_hexes_consent',
+                owner_type: 'player',
                 hexes: ['C8'],
               },
             ],
@@ -155,8 +155,8 @@ module Engine
                 from: %w[ipo market],
               },
               {
-                type: 'blocks_hexes',
-                owner_type: nil,
+                type: 'blocks_hexes_consent',
+                owner_type: 'player',
                 hexes: ['B11'],
               },
             ],
@@ -240,8 +240,8 @@ module Engine
                 from: %w[ipo market],
               },
               {
-                type: 'blocks_hexes',
-                owner_type: nil,
+                type: 'blocks_hexes_consent',
+                owner_type: 'player',
                 hexes: ['I6'],
               },
             ],
@@ -305,8 +305,8 @@ module Engine
                 from: %w[ipo market],
               },
               {
-                type: 'blocks_hexes',
-                owner_type: nil,
+                type: 'blocks_hexes_consent',
+                owner_type: 'player',
                 hexes: %w[F19 F21],
               },
             ],


### PR DESCRIPTION
Fixes #8508

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

No pins should be required, since hexes were previously blocked.

* **Explanation of Change**

changed 'blocks_hexes' to 'blocks_hexes_consent', as rule 4.6 says you can ignore hex reservations with the consent of the owner of that minor.

Issue #8508 originally was reporting that a minor was able to lay a tile on a reserved hex. This was not actually a bug, since  both minors were held by the same player so consent was implied. The code already made an exception to disregard the reservation if the owners were the same. I left that code in place so that players will not be asked to confirm consent from themselves.
