### PR TITLE
[1822CA] Destinate on a hex with multiple cities

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1768,11 +1768,8 @@ module Engine
           end
         end
 
-        def check_destination_duplicate(entity, hex); end
-
-        def place_destination_token(entity, hex, token)
-          check_destination_duplicate(entity, hex)
-          city = hex.tile.cities.first
+        def place_destination_token(entity, hex, token, city = nil)
+          city ||= destination_city(hex, entity)
           city.place_token(entity, token, free: true, check_tokenable: false, cheater: true)
           hex.tile.icons.reject! { |icon| icon.name == "#{entity.id}_destination" }
 
@@ -1783,6 +1780,10 @@ module Engine
           @graph.clear
 
           @log << "#{entity.name} places its destination token on #{hex.name}"
+        end
+
+        def destination_city(hex, _entity)
+          hex.tile.cities.first
         end
 
         def player_debt(player)
@@ -1949,6 +1950,30 @@ module Engine
           @nothing_sold_in_sr
         end
 
+        # remove non-destination tokens if a corporation has multiple tokens in
+        # one city
+        def remove_extra_tokens!(tile)
+          tile.cities.each do |city|
+            corp_tokens_with_count =
+              city.tokens.each_with_object(Hash.new { |h, k| h[k] = [[], 0] }) do |token, counted_tokens|
+                next unless token
+
+                counted_tokens[token.corporation][0] << token unless token.type == :destination
+                counted_tokens[token.corporation][1] += 1
+              end
+
+            corp_tokens_with_count.each do |corp, (tokens_to_remove, token_count)|
+              (token_count - 1).times do
+                @log << "Extra token for #{corp.name} is returned to their available tokens"
+                token = tokens_to_remove.pop
+                token.remove!
+                # exchange tokens have a price of 0
+                token.price = self.class::TOKEN_PRICE
+              end
+            end
+          end
+        end
+
         private
 
         def find_and_remove_train_by_id(train_id, buyable: true)
@@ -2048,7 +2073,7 @@ module Engine
             dest_hex = hex_by_id(c.destination_coordinates)
             ability = Ability::Base.new(
               type: 'base',
-              description: "Destination: #{dest_hex.location_name} (#{dest_hex.name})",
+              description: destination_description(c),
             )
             c.add_ability(ability)
 
@@ -2064,6 +2089,12 @@ module Engine
               description: 'Places destination token in its first OR'
             ))
           end
+        end
+
+        def destination_description(corporation)
+          dest_hex = hex_by_id(corporation.destination_coordinates)
+
+          "Destination: #{dest_hex.location_name} (#{dest_hex.name})"
         end
 
         def setup_exchange_tokens

--- a/lib/engine/game/g_1822/step/destination_token.rb
+++ b/lib/engine/game/g_1822/step/destination_token.rb
@@ -13,7 +13,7 @@ module Engine
             return [] unless entity == current_entity
             return [] unless can_place_token?(entity)
 
-            ACTIONS
+            self.class::ACTIONS
           end
 
           def auto_actions(entity)
@@ -38,11 +38,11 @@ module Engine
           end
 
           def description
-            'Place the destination token'
+            'Place the Destination Token'
           end
 
           def pass_description
-            'Skip (Destination token)'
+            'Skip (Destination Token)'
           end
 
           def available_hex(entity, hex)
@@ -71,13 +71,14 @@ module Engine
             end
 
             @game.place_destination_token(entity, hex, token)
+            @game.remove_extra_tokens!(hex.tile)
             pass!
           end
 
           def process_pass(action)
             entity = action.entity
             if !@game.loading && destination_node_check?(entity)
-              raise GameError, "You can't skip placing your destination token when you have a connection "\
+              raise GameError, "#{entity.name} cannot skip placing its destination token when it has a connection "\
                                "to #{entity.destination_coordinates}"
             end
 

--- a/lib/engine/game/g_1822/step/tracker.rb
+++ b/lib/engine/game/g_1822/step/tracker.rb
@@ -103,23 +103,7 @@ module Engine
         end
 
         def update_token!(action, entity, tile, old_tile)
-          tile.cities.each do |c|
-            present_corps = []
-            tokens_to_return = []
-            c.tokens.compact.each do |t|
-              if present_corps.include?(t.corporation)
-                tokens_to_return << t
-              else
-                present_corps << t.corporation
-              end
-            end
-            tokens_to_return.compact.each do |t|
-              corp = t.corporation
-              @log << "Extra token for #{corp.name} is returned to the charter"
-              corp.tokens << Engine::Token.new(corp, price: @game.class::TOKEN_PRICE)
-              t.destroy!
-            end
-          end
+          @game.remove_extra_tokens!(tile)
 
           super
         end

--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -1616,6 +1616,7 @@ module Engine
             text_color: 'black',
             reservation_color: nil,
             destination_coordinates: 'N16',
+            destination_exits: [3],
             destination_icon: '1822_ca/GNWR_DEST',
           },
           {
@@ -1631,6 +1632,7 @@ module Engine
             color: '#000000',
             reservation_color: nil,
             destination_coordinates: 'AF12',
+            destination_exits: [0],
             destination_icon: '1822_ca/GT_DEST',
           },
           {
@@ -1675,6 +1677,7 @@ module Engine
             text_color: 'black',
             reservation_color: nil,
             destination_coordinates: 'AH8',
+            destination_exits: [0, 1, 2, 3, 4, 5],
             destination_icon: '1822_ca/ICR_DEST',
           },
           {
@@ -1689,6 +1692,7 @@ module Engine
             color: '#9a6733',
             reservation_color: nil,
             destination_coordinates: 'N16',
+            destination_exits: [5],
             destination_icon: '1822_ca/NTR_DEST',
           },
           {

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -330,7 +330,7 @@ module Engine
             G1822CA::Step::SpecialTrack,
             G1822CA::Step::SpecialToken,
             G1822CA::Step::Track,
-            G1822::Step::DestinationToken,
+            G1822CA::Step::DestinationToken,
             G1822CA::Step::Token,
             G1822CA::Step::Route,
             G1822::Step::Dividend,
@@ -582,6 +582,37 @@ module Engine
             hex.lay(tile)
           end
           @graph.clear
+        end
+
+        # - usually returns a single city
+        # - returns an Array of cities if entity is ICR and Quebec has multiple
+        #   cities with paths
+        def destination_city(hex, entity)
+          return hex.tile.cities[0] unless (exits = entity.destination_exits)
+
+          cities = exits.each_with_object([]) do |exit, cities_|
+            hex.paths[exit].each do |path|
+              next unless (city = path.city)
+
+              cities_ << city unless cities.include?(city)
+            end
+          end
+          cities.one? ? cities[0] : cities
+        end
+
+        def destination_description(corporation)
+          return super unless (exits = corporation.destination_exits)
+
+          dest_hex = hex_by_id(corporation.destination_coordinates)
+          which =
+            if exits.size == 6
+              'Any '
+            elsif exits.one?
+              %w[S SW NW N NE SE][exits[0]] + ' '
+            else
+              ''
+            end
+          "Destination: #{which}#{dest_hex.location_name} (#{dest_hex.name})"
         end
       end
     end

--- a/lib/engine/game/g_1822_ca/step/destination_token.rb
+++ b/lib/engine/game/g_1822_ca/step/destination_token.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/destination_token'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class DestinationToken < G1822::Step::DestinationToken
+          ACTIONS = %w[hex_token place_token pass].freeze
+
+          def setup
+            @connected_destination_nodes = []
+          end
+
+          def auto_actions(entity)
+            return [Engine::Action::Pass.new(entity)] unless destination_node_check?(entity)
+
+            # ICR cannot auto-destinate if it is connected to multiple Quebec cities
+            return if @connected_destination_nodes.size > 1
+
+            destination_hex = @game.hex_by_id(entity.destination_coordinates)
+            if destination_hex.tile.cities.one? || !@game.destination_city(destination_hex, entity).is_a?(Array)
+              [Engine::Action::HexToken.new(entity,
+                                            hex: @game.hex_by_id(entity.destination_coordinates),
+                                            token_type: available_tokens(entity).first.type)]
+            else
+              # if there are multiple Quebec cities and ICR is connected to only
+              # one, it can auto-destinate, but the destination city needs to be
+              # tracked
+              city = @connected_destination_nodes[0]
+              [Engine::Action::PlaceToken.new(entity,
+                                              city: city,
+                                              slot: city.get_slot(entity),
+                                              token_type: available_tokens(entity).first.type)]
+            end
+          end
+
+          def process_hex_token(action)
+            entity = action.entity
+            hex = action.hex
+
+            if !@game.loading && !destination_node_check?(entity)
+              raise GameError, "Can't place the destination token on #{hex.name} "\
+                               'because it is not connected'
+            end
+            if @connected_destination_nodes.size > 1
+              raise GameError, "#{entity.name} is connected to multiple cities on the hex. Click "\
+                               'on the city where it should place its destination token.'
+            end
+
+            super
+          end
+
+          def process_place_token(action)
+            entity = action.entity
+            city = action.city
+            hex = city.hex
+            token = action.token
+            raise GameError, 'Corporation does not have a destination token unused' unless token
+
+            if !@game.loading && !destination_node_check?(entity)
+              raise GameError, "Can't place the destination token on #{hex.name} "\
+                               'because it is not connected'
+            end
+
+            @game.place_destination_token(entity, hex, token, city)
+            @game.remove_extra_tokens!(hex.tile)
+            pass!
+          end
+
+          def destination_node_check?(entity)
+            destination_hex = @game.hex_by_id(entity.destination_coordinates)
+            home_node = entity.tokens.first.city
+
+            destination_nodes = Array(@game.destination_city(destination_hex, entity))
+
+            @connected_destination_nodes = destination_nodes.select do |destination_node|
+              nodes_connected?(destination_node, home_node, entity)
+            end
+
+            !@connected_destination_nodes.empty?
+          end
+
+          def nodes_connected?(node_a, node_b, entity)
+            node_a&.walk(corporation: entity) do |path, _, _|
+              return true if path.nodes.include?(node_b)
+            end
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -1087,14 +1087,6 @@ module Engine
           corporations.delete(minor)
         end
 
-        def check_destination_duplicate(entity, hex)
-          city = hex.tile.cities.first
-          return unless city.tokened_by?(entity)
-
-          @log << "#{entity.name} has an existing token on its destination #{hex.name} and will pick it up as an available token"
-          entity.tokens.find { |t| t.city == city }.remove!
-        end
-
         def after_lay_tile(hex, old_tile, tile)
           hex.neighbors[1].tile.borders.shift if hex.id == 'H13' && tile.exits.include?(1)
           super

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -9,7 +9,7 @@ module Engine
     attr_accessor :coordinates, :color, :text_color
     attr_reader :city, :loans, :logo, :logo_filename, :simple_logo,
                 :operating_history, :tokens, :trains, :destination_icon,
-                :destination_coordinates, :share_price
+                :destination_coordinates, :destination_exits, :share_price
 
     def init_operator(opts)
       @cash = 0
@@ -25,6 +25,7 @@ module Engine
       @color = opts[:color]
       @text_color = opts[:text_color] || '#ffffff'
       @destination_coordinates = opts[:destination_coordinates]
+      @destination_exits = opts[:destination_exits]
       @destination_icon = opts[:destination_icon] ? "/icons/#{opts[:destination_icon]}" : ''
     end
 


### PR DESCRIPTION
* GNWR and NTR destinate in specific cities on the Winnipeg hex, which can have as many as 4 different cities
* GT destinates in a specific city on the Montreal hex
* ICR destinates in any city that it connects to on the Quebec hex; if it is connected to multiple cities when placing its destination token, it gets to choose 
    * in the DestinationToken step, ICR needs to use the `place_token` action so that the chosen city can be tracked without being recomputed by the engine
* `destination_exits` defines which exits are connected to the destination city by a track path; when checking for a destination connection, these exits are used to identify the destination city (or cities, in ICR's case)
* list the cardinal direction for the locations of the destination city/cities on the corporation card, e.g., for GNWR, "Destination: N Winnipeg (N16)"; for ICR "Any Montreal"
* [1822MX, 1822PNW] additional updates for `update_token!`; its logic has been moved into `remove_extra_tokens!` in the game class so that it can also be used in the DestinationToken step, not just in Tracker 
    * in 1822CA, it is possible for a token to be in Winnipeg but not in the destination city, and then after a tile upgrade joins up the cities, the token is in the destination city, so the normal token needs to be removed in that case; it is even technically possible for multiple tokens to need removal at this point
    * call `remove!` instead of destroying the token and creating a new one as in #9495; this does necessitate setting the price to 100, since exchange tokens have a price of 0

#9376
