### PR TITLE
[1822, 1822CA] match up lanes of different width, simplify France hex

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -384,8 +384,6 @@ module Engine
         LONDON_HEX = 'M38'
         ENGLISH_CHANNEL_HEX = 'P43'
         FRANCE_HEX = 'Q44'
-        FRANCE_HEX_BROWN_TILE = 'offboard=revenue:yellow_0|green_60|brown_90|gray_120,visit_cost:0;'\
-                                'path=a:2,b:_0,lanes:2'
 
         COMPANY_MTONR = 'P2'
         COMPANY_LCDR = 'P5'
@@ -1310,8 +1308,6 @@ module Engine
 
           # If we upgraded the english channel to brown, upgrade france as well since we got 2 lanes to france.
           return if hex.name != self.class::ENGLISH_CHANNEL_HEX || tile.color != :brown
-
-          upgrade_france_to_brown
         end
 
         def bank_companies(prefix)
@@ -1840,12 +1836,6 @@ module Engine
 
         def train_type(train)
           train.name == 'E' ? :etrain : :normal
-        end
-
-        def upgrade_france_to_brown
-          france_tile = Engine::Tile.from_code(self.class::FRANCE_HEX, :gray, self.class::FRANCE_HEX_BROWN_TILE)
-          france_tile.location_name = 'France'
-          hex_by_id(self.class::FRANCE_HEX).tile = france_tile
         end
 
         def upgrade_minor_14_home_hex(hex)

--- a/lib/engine/game/g_1822/map.rb
+++ b/lib/engine/game/g_1822/map.rb
@@ -499,7 +499,7 @@ module Engine
               'city=revenue:yellow_30|green_40|brown_50|gray_60,slots:2;path=a:0,b:_0,terminal:1;'\
               'path=a:1,b:_0,terminal:1',
             ['Q44'] =>
-              'offboard=revenue:yellow_0|green_60|brown_90|gray_120,visit_cost:0;path=a:2,b:_0',
+              'offboard=revenue:yellow_0|green_60|brown_90|gray_120,visit_cost:0;path=a:2,b:_0,lanes:2',
           },
           blue: {
             %w[L11 J43 Q36 Q42 R31] =>

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -180,16 +180,33 @@ module Engine
       end
 
       # return true if facing exits on adjacent tiles match up taking lanes into account
-      # TBD: support titles where lanes of different sizes can connect
       def lane_match?(lanes0, lanes1)
-        lanes0 &&
-          lanes1 &&
-          lanes1[LANE_WIDTH] == lanes0[LANE_WIDTH] &&
+        return false unless lanes0
+        return false unless lanes1
+
+        if lanes1[LANE_WIDTH] == lanes0[LANE_WIDTH]
           lanes1[LANE_INDEX] == lane_invert(lanes0)[LANE_INDEX]
+        else
+          lane_match_different_sizes?(lanes0, lanes1)
+        end
       end
 
       def lane_invert(lane)
         [lane[LANE_WIDTH], lane[LANE_WIDTH] - lane[LANE_INDEX] - 1]
+      end
+
+      # the important part of matching lanes of different sizes is to just use
+      # the larger width when doing the inverted comparison; the delta just
+      # allows the smaller-lane side to be more centered, i.e., it makes 1 lane
+      # match up with the middle of 3 lanes
+      def lane_match_different_sizes?(lanes0, lanes1)
+        lanes_a, lanes_b = [lanes0, lanes1].sort
+
+        larger_width = lanes_b[LANE_WIDTH]
+        delta = ((lanes_b[LANE_WIDTH] - lanes_a[LANE_WIDTH]) / 2).to_i
+        new_index = lanes_a[LANE_INDEX] + delta
+
+        [larger_width, new_index][LANE_INDEX] == lane_invert(lanes_b)[LANE_INDEX]
       end
 
       def path?


### PR DESCRIPTION
* fixes Windsor-Detroit and Hamilton-Buffalo in 1822CA
* change France in 1822 to always have 2 lanes, now that 1 lane can run into the two; remove code around "upgrading" France


#9376