### PR TITLE
[18EU] Allows minor exchange above 60%

### DIFF
--- a/lib/engine/game/g_18_eu/step/minor_exchange.rb
+++ b/lib/engine/game/g_18_eu/step/minor_exchange.rb
@@ -81,6 +81,13 @@ module Engine
 
           @game.maybe_discard_pullman(destination)
         end
+
+        def can_gain?(entity, bundle, exchange: false)
+          return if !bundle || !entity
+          return true if exchange
+
+          super
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #9283

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes
I don't think this will require pins, since previously players wouldn't have had the choice to exchange at this point. 

* **Explanation of Change**
Allows players to exchange a minor for a share of a corp they already own 60% of. Player will still have to sell down to 60% at next legal opportunity, as per the last paragraph of rule 4.2.

* **Screenshots**

![image](https://github.com/tobymao/18xx/assets/26125362/39629c67-fb33-408a-b275-deab3c5a9e81)

