### PR TITLE
Clear `selected_company` when processing an action received from server

### DIFF
--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -133,6 +133,7 @@ module View
 
           if n_id == o_id + 1
             game_data['actions'] << data
+            store(:selected_company, nil, skip: true)
             store(:game_data, game_data, skip: true)
             store(:game, game.process_action(data))
           else


### PR DESCRIPTION
In #5604, when an 1846 player makes their Steamboat Company assignments and the OR begins, their opponents won't see hexes available for the active corporation, because the Steamboat is still in their UI state as the `selected_company`.

Fixes #5604
