### PR TITLE
[1846] bad player count: raise error instead of returning early out of setup

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -268,7 +268,9 @@ module Engine
           @second_tokens_in_green = {}
 
           # When creating a game the game will not have enough to start
-          return unless @players.size.between?(*self.class::PLAYER_RANGE)
+          unless (player_count = @players.size).between?(*self.class::PLAYER_RANGE)
+            raise GameError, "#{self.class::GAME_TITLE} does not support #{player_count} players"
+          end
 
           if first_edition?
             remove_icons(self.class::BOOMTOWN_HEXES, self.class::ABILITY_ICONS['BT'])


### PR DESCRIPTION
`routes/game.rb` does halt with a 400 error if the player count is wrong when a multiplayer game is starting, and no other games have this logic, so maybe it could be deleted instead? OTOH this should prevent #9222 from occurring again.

Close #9222