### PR TITLE
1822Africa - Update Tiles, Fix setup private company count

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -331,7 +331,7 @@ module Engine
           @companies.clear
           @companies.concat(minors)
           @companies.concat(concessions)
-          @companies.concat(privates.sort_by! { rand }.take(10))
+          @companies.concat(privates.sort_by! { rand }.take(12))
 
           # Randomize from preset seed to get same order
           @companies.sort_by! { rand }

--- a/lib/engine/game/g_1822_africa/map.rb
+++ b/lib/engine/game/g_1822_africa/map.rb
@@ -5,59 +5,30 @@ module Engine
     module G1822Africa
       module Map
         TILES = {
-          '1' => 1,
-          '2' => 1,
-          '3' => 6,
-          '4' => 6,
-          '5' => 6,
-          '6' => 8,
-          '7' => 'unlimited',
-          '8' => 'unlimited',
-          '9' => 'unlimited',
-          '55' => 1,
-          '56' => 1,
-          '57' => 6,
-          '58' => 6,
-          '69' => 1,
-          '14' => 6,
-          '15' => 6,
-          '80' => 6,
-          '81' => 6,
-          '82' => 8,
-          '83' => 8,
-          '141' => 4,
-          '142' => 4,
-          '143' => 4,
-          '144' => 4,
+          '3' => 1,
+          '4' => 2,
+          '5' => 2,
+          '6' => 4,
+          '7' => 4,
+          '8' => 12,
+          '9' => 7,
+          '57' => 4,
+          '58' => 4,
+          '14' => 2,
+          '15' => 5,
+          '80' => 1,
+          '81' => 2,
+          '82' => 2,
+          '83' => 1,
+          '141' => 1,
+          '142' => 1,
+          '143' => 1,
+          '144' => 1,
           '207' => 2,
           '208' => 1,
-          '619' => 6,
-          '63' => 8,
-          '448' => 'unlimited',
-          '544' => 6,
-          '545' => 6,
-          '546' => 8,
-          '768' =>
-            {
-              'count' => 4,
-              'color' => 'brown',
-              'code' =>
-                'town=revenue:10;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
-            },
-          '767' =>
-            {
-              'count' => 4,
-              'color' => 'brown',
-              'code' =>
-                'town=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0',
-            },
-          '769' =>
-            {
-              'count' => 6,
-              'color' => 'brown',
-              'code' =>
-                'town=revenue:10;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
-            },
+          '619' => 1,
+          '611' => 2,
+          '448' => 5,
           'X1' =>
             {
               'count' => 2,
@@ -143,8 +114,6 @@ module Engine
             ['E19'] => 'junction;path=a:4,b:_0,terminal:1',
             ['G1'] => 'junction;path=a:0,b:_0,terminal:1',
             ['J8'] => 'junction;path=a:2,b:_0,terminal:1',
-            ['D0'] => 'junction;path=a:0,b:_0,terminal:1',
-            ['D12'] => 'junction;path=a:4,b:_0,terminal:1',
           },
         }.freeze
       end


### PR DESCRIPTION

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
- Fixes the number of private companies in the deck setup (should be 12, not 10)
- Revises map tiles to test for use in the physical game (will change back to unlimited plain yellow tiles after playtest period)
- Removes two (now) unnecessary off-map spikes

This will archive almost all existing games due to the deck setup and tile changes and that is okay.