### PR TITLE
add new constant to show currency symbol for upgrade costs on tiles

### DIFF
--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -12,6 +12,7 @@ module View
         needs :cost
         needs :terrains, default: []
         needs :size, default: nil
+        needs :formatter, default: nil
 
         P_CENTER = {
           region_weights: CENTER,
@@ -93,7 +94,7 @@ module View
         end
 
         def render_part
-          cost = h('text.number', { attrs: { fill: 'black' } }, @cost)
+          cost = h('text.number', { attrs: { fill: 'black' } }, @formatter ? @formatter.call(@cost) : @cost)
 
           delta_x = -(size / 2)
 

--- a/assets/app/view/game/part/upgrades.rb
+++ b/assets/app/view/game/part/upgrades.rb
@@ -10,6 +10,7 @@ module View
         needs :tile
         needs :region_use
         needs :loc, default: nil
+        needs :formatter, default: nil
 
         def render
           @tile.upgrades.map do |upgrade|
@@ -21,6 +22,7 @@ module View
               tile: @tile,
               size: upgrade.size,
               loc: @loc,
+              formatter: @formatter,
             )
           end
         end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -89,7 +89,11 @@ module View
         revenue = render_tile_part(Part::Revenue) if render_revenue
         @tile.labels.each { |l| children << render_tile_part(Part::Label, label: l) }
 
-        render_tile_parts_by_loc(Part::Upgrades, parts: @tile.upgrades).each { |p| children << p }
+        render_tile_parts_by_loc(
+          Part::Upgrades,
+          parts: @tile.upgrades,
+          formatter: @game && @game.class::FORMAT_UPGRADES_ON_HEXES ? ->(cost) { @game.format_currency(cost) } : nil,
+        ).each { |p| children << p }
         children << render_tile_part(Part::Blocker)
 
         if @tile.location_name && (@tile.cities.size <= 1) && !@tile.hex.hide_location_name

--- a/assets/app/view/tiles.rb
+++ b/assets/app/view/tiles.rb
@@ -52,7 +52,8 @@ module View
       top_text: nil,
       fixture_id: nil,
       fixture_title: nil,
-      action: nil
+      action: nil,
+      game: nil
     )
       block_props = {
         style: {
@@ -115,6 +116,7 @@ module View
                   role: :tile_page,
                   unavailable: unavailable,
                   clickable: clickable,
+                  game: game,
                 ),
               ]),
             ]),
@@ -138,7 +140,8 @@ module View
       unavailable: nil,
       clickable: false,
       extra_children_a: [],
-      extra_children_b: []
+      extra_children_b: [],
+      game: nil
     )
       block_props = {
         style: {
@@ -164,6 +167,7 @@ module View
               role: :tile_page,
               unavailable: unavailable,
               clickable: clickable,
+              game: game,
             ),
           ]),
         ])

--- a/assets/app/view/tiles_page.rb
+++ b/assets/app/view/tiles_page.rb
@@ -142,6 +142,7 @@ module View
         scale: scale,
         rotations: rotations,
         hex_coordinates: hex_coordinates,
+        game: game,
         **kwargs,
       )
     end
@@ -186,6 +187,7 @@ module View
           tile: tile,
           location_name: tile.location_name,
           hex_coordinates: tile.name,
+          game: game,
         )
       end
 
@@ -200,6 +202,7 @@ module View
               num: tiles_.size,
               rotations: @rotations,
               location_name: @location_name,
+              game: game,
             )
           end
         else
@@ -213,6 +216,7 @@ module View
                 num: all_tiles[name].size,
                 rotations: @rotations,
                 location_name: @location_name,
+                game: game,
               )
             else
               name_a, name_b = group
@@ -224,7 +228,8 @@ module View
                 layout: game.layout,
                 tile_a: tile_a,
                 tile_b: tile_b,
-                num: all_tiles[name_a].size
+                num: all_tiles[name_a].size,
+                game: game,
               )
             end
           end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -110,6 +110,7 @@ module Engine
       BANK_CASH = 12_000
 
       CURRENCY_FORMAT_STR = '$%s'
+      FORMAT_UPGRADES_ON_HEXES = false
 
       STARTING_CASH = {}.freeze
 

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -144,6 +144,7 @@ module Engine
         ].freeze
 
         CURRENCY_FORMAT_STR = '$%s'
+        FORMAT_UPGRADES_ON_HEXES = true
 
         EXCHANGE_TOKENS = {
           'CNoR' => 3,


### PR DESCRIPTION
Robert Lecuyer gave me some feedback on the 1822CA map, he pointed out the lack of currency symbol on the upgrades. That is standard across 18xx.games, but in the physical games it is standard to show the currency symbol for the upgrade costs.

Sometimes we show minor/corporation names on the hexes to show they'll eventually have a home on that tile; in 1822CA, those minors just have numbers for names, so it's good to have some distinction between the minor and the upgrade cost; here's Toronto, home to Minor 13 and costs $20 to upgrade:

![1822CA AC12](https://github.com/tobymao/18xx/assets/1045173/535ace26-f1ae-4efb-9673-c52abc70d6cb)

This PR adds a flag to show the currency symbol on the hex. I defaulted to false, only setting it true for 1822CA. I imagine adding another character will cause a lot of new overlap problems, so I'm leaving it as "opt-in" for now.