### PR TITLE
[1822Africa] Fix express trains running over the distance

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -594,6 +594,8 @@ module Engine
           express_revenue = revenue_for_express(route, stops)
           express_revenue += destination_bonus_for(route) * self.class::EXPRESS_TRAIN_MULTIPLIER
 
+          return express_revenue if train_over_distance?(route)
+
           [revenue, express_revenue].max
         end
 


### PR DESCRIPTION
Fixes #9550

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

*/E train running over the distance were using express mode, but still calculating the best possible revenue. So it could be that such a train runs for 10-20 stops, treats itself as express, but gets revenue as a diesel)

**This will definitely archive some games**
