### PR TITLE
Keep `undefined` out of the DOM when rendering town dots

### DIFF
--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -123,7 +123,9 @@ module View
           children << h(:circle, attrs: dot_attrs)
           children << render_boom if @town.boom
 
-          children << render_revenue if @show_revenue
+          if @show_revenue && (rendered = render_revenue)
+            children << rendered
+          end
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, { key: "#{@town.id}-d" }, children)
         end


### PR DESCRIPTION
`render_revenue` can return `nil` early, and if that's left in the `children` array it dumps `undefined` into the DOM.

Pulling this out of #9544

![Screenshot 2023-09-05 195610](https://github.com/tobymao/18xx/assets/1045173/e82959e2-eea0-4fd7-90a4-3a92d7531919)
