### PR TITLE
[1822Africa] Implement P13 (Station Swap)

### DIFF
--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -218,10 +218,9 @@ module Engine
             color: nil,
           },
           {
-            name: 'P13 (Station Swap) [N/A]',
+            name: 'P13 (Station Swap)',
             sym: 'P13',
-            desc: '[NOT YET FUNCTIONAL] '\
-                  'MAJOR, Phase 5. Station Marker Swap. Allows the owning company to move a token from the exchange '\
+            desc: 'MAJOR, Phase 5. Station Marker Swap. Allows the owning company to move a token from the exchange '\
                   'token area of its charter to the available token area, or vice versa. '\
                   'This company closes when its power is exercised.',
             value: 0,

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -68,6 +68,7 @@ module Engine
         COMPANY_10X_REVENUE = 'P16'
         COMPANY_REMOVE_TOWN = 'P9'
         COMPANY_EXTRA_TILE_LAYS = %w[P7 P12].freeze
+        COMPANY_TOKEN_SWAP = 'P13'
 
         GAME_RESERVE_TILE = 'GR'
         GAME_RESERVE_MULTIPLIER = 5
@@ -89,7 +90,6 @@ module Engine
         COMPANY_LSR = nil
         COMPANY_OSTH = nil
         COMPANY_LUR = nil
-        COMPANY_CHPR = nil
         COMPANY_5X_REVENUE = nil
         COMPANY_HSBC = nil
         FRANCE_HEX = nil
@@ -325,7 +325,7 @@ module Engine
         @bidbox_cache = []
         @bidbox_companies_size = false
 
-        def init_companies(players)
+        def init_companies(_players)
           game_companies.map do |company|
             Company.new(**company)
           end.compact
@@ -734,6 +734,22 @@ module Engine
                 true
               end
             end
+          end
+        end
+
+        def company_choices(company, time)
+          case company.id
+          when self.class::COMPANY_TOKEN_SWAP
+            company_choices_chpr(company, time)
+          else
+            {}
+          end
+        end
+
+        def company_made_choice(company, choice, _time)
+          case company.id
+          when self.class::COMPANY_TOKEN_SWAP
+            company_made_choice_chpr(company, choice)
           end
         end
 


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

This is implemented already in 1822 but I forgot it for some reason.
Also fixed a private selection bug where only first 12 privates of 18 were always in the game.