### PR TITLE
don't return nil during spreadsheet rendering

### DIFF
--- a/assets/app/view/game/spreadsheet.rb
+++ b/assets/app/view/game/spreadsheet.rb
@@ -651,7 +651,7 @@ module View
       end
 
       def render_player_loans
-        return unless @game.respond_to?(:player_loans)
+        return '' unless @game.respond_to?(:player_loans)
 
         h(:tr, tr_default_props, [
           h('th.left', 'Loans'),


### PR DESCRIPTION
this is needed to not break w/ Opal 1.6, also good to not throw `undefined` on the DOM in general anyway (basically another case like #9556)

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
