### PR TITLE
Add CitiesPlusTOwnsRouteDistanceStr module to 1841 

### DIFF
--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -5,12 +5,14 @@ require_relative 'meta'
 require_relative 'entities'
 require_relative 'map'
 require_relative 'stock_market'
+require_relative '../cities_plus_towns_route_distance_str'
 
 module Engine
   module Game
     module G1841
       class Game < Game::Base
         include_meta(G1841::Meta)
+        include CitiesPlusTownsRouteDistanceStr
         include Entities
         include Map
 


### PR DESCRIPTION
Since towns are friendly in the game

Small visual improvement to 1841

### Implementation Notes

* **Explanation of Change**
Since towns are friendly in 1841 I am adding the CitiesPlusTownsDistanceStr that several other games with friendly towns (like 18Mex) use to get a "M+N" route distance display

* **Screenshots**
![image](https://github.com/tobymao/18xx/assets/2993555/ab80d799-3fc9-46ce-bd95-5ca0b4595a27)

!Warning!
I didn't run `rack rake` locally before sending this out, I'm running it now though

--update--
I ran `rack rake` locally and all tests passed