### PR TITLE
1822: Add custom route distance strings for Pullman trains and E trains

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2115,6 +2115,26 @@ module Engine
         def port_tile?(hex)
           hex.tile.color == :blue && !hex.tile.cities.empty?
         end
+
+        def pullman_route_distance_str(route)
+          towns = route.visited_stops.count(&:town?)
+          cities = route_distance(route) - towns
+          towns.positive? ? "#{cities}+#{towns}" : cities.to_s
+        end
+
+        def e_route_distance_str(route)
+          corp = route.train.owner
+          total_laid_tokens = corp.tokens.count(&:used)
+          paying_stops = route.visited_stops.count { |stop| stop.tokened_by?(corp) }
+          "#{paying_stops}/#{total_laid_tokens}"
+        end
+
+        def route_distance_str(route)
+          return pullman_route_distance_str(route) if route.train.name[-1] == '+'
+          return e_route_distance_str(route) if route.train.name == 'E'
+
+          super(route)
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Adds an `route_distance_str` implementation to the 1822 base which gives a M+N display for pullman trains (to more easily see if the 5+ can keep on running cities) and a M/N display for E trains (where N is the number of laid tokens for the corporation) to more easily see if the company is running the E train as best as they can
* **Screenshots**
![image](https://github.com/tobymao/18xx/assets/2993555/d5d73eb7-4a47-4e35-bb4a-b52cdc7732cd)
![image](https://github.com/tobymao/18xx/assets/2993555/215ba562-065d-4d94-a640-79565fd78545)
![image](https://github.com/tobymao/18xx/assets/2993555/7ae27d5d-f8d6-4925-b97c-b5dae47bc179)

* **Any Assumptions / Hacks**
Assumes pullmans and only pullmans end in "+" in 22-ish games