### PR TITLE
clear `selected_company` at the start of rendering for every action

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -40,7 +40,6 @@ module View
             company = @selected_company
             target = @corporation
             store(:selected_corporation, nil, skip: true)
-            store(:selected_company, nil, skip: true)
             process_action(Engine::Action::Assign.new(company, target: target))
           end
         end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -26,6 +26,7 @@ module View
     module Round
       class Operating < Snabberb::Component
         needs :game
+        needs :selected_company, default: nil, store: true
 
         def render
           round = @game.round
@@ -34,6 +35,8 @@ module View
           @current_actions = round.actions_for(entity)
 
           entity = entity.owner if entity.company? && !round.active_entities.one?
+
+          store(:selected_company, nil, skip: true)
 
           convert_track = @step.respond_to?(:conversion?) && @step.conversion?
 
@@ -107,8 +110,8 @@ module View
               }
 
               @step.assignable_corporations(company).each do |corporation|
+                store(:selected_company, company, skip: true)
                 component = View::Game::Corporation.new(@root, corporation: corporation, selected_company: company)
-                component.store(:selected_company, company, skip: true)
                 left << h(:div, props, [component.render])
               end
             end

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -133,7 +133,6 @@ module View
 
           if n_id == o_id + 1
             game_data['actions'] << data
-            store(:selected_company, nil, skip: true)
             store(:game_data, game_data, skip: true)
             store(:game, game.process_action(data))
           else


### PR DESCRIPTION
* the approach in #9527 caused #9563; this reverts that PR

* changing the hex view to match the corporation view, where selected_company is cleared when the action is processed, would work for the current player but would reintroduce #5604

* `View::Game::Round::Operating` sets the selected_company if the step has assignable_corporations, but before this change did not clear the stored state if the step doesn't have any assignable corporations

* fixes #9563
